### PR TITLE
DBZ-13 Changed Maven build to attach JavaDoc JARs to each module

### DIFF
--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -210,6 +210,7 @@
                 </executions>
                 <configuration>
                     <skipTests>${skipITs}</skipTests>
+                    <enableAssertions>true</enableAssertions>
                     <systemPropertyVariables>
                         <!-- Make these available to the tests via system properties -->
                         <database.hostname>${docker.host.address}</database.hostname>

--- a/debezium-core/src/main/java/io/debezium/document/Value.java
+++ b/debezium-core/src/main/java/io/debezium/document/Value.java
@@ -15,7 +15,7 @@ import java.util.function.LongConsumer;
 import io.debezium.annotation.Immutable;
 
 /**
- * A value in a {@link Document} or {@link Array}. Note that {@link #compareTo(Value)} might perform literal comparisons;
+ * A value in a {@link Document} or {@link Array}. Note that {@link Value#compareTo} might perform literal comparisons;
  * to perform semantic comparisons, use {@link #comparable()} to obtain a wrapped value with semantic comparison capability.
  * 
  * @author Randall Hauch
@@ -204,7 +204,7 @@ public interface Value extends Comparable<Value> {
 
     /**
      * Get a Value representation that will allow semantic comparison of values, rather than the literal comparison normally
-     * performed by {@link #compareTo(Value)}.
+     * performed by {@link #compareTo}.
      * 
      * @return the Value that will perform semantic comparisons; never null
      */

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/DdlParser.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/DdlParser.java
@@ -243,7 +243,7 @@ public class DdlParser {
     }
 
     /**
-     * Parse the a DDL line comment. This is generally called by {@link #parseNextStatement(Marker)} for line comments that appear
+     * Parse the a DDL line comment. This is generally called by {@link #parseNextStatement} for line comments that appear
      * between other DDL statements, and is not typically called for comments that appear <i>within</i> DDL statements.
      * 
      * @param marker the start of the statement; never null
@@ -694,7 +694,7 @@ public class DdlParser {
 
     /**
      * Returns the tables keyed by their aliases that appear in a SELECT clause's "FROM" list. This method handles the
-     * {@link #canConsumeJoin(Marker) various standard joins}.
+     * {@link #canConsumeJoin various standard joins}.
      * 
      * @param start the start of the statement
      * @return the map of resolved tables keyed by the alias (or table name) used in the SELECT statement; never null but possibly

--- a/debezium-core/src/test/java/io/debezium/kafka/ZookeeperServer.java
+++ b/debezium-core/src/test/java/io/debezium/kafka/ZookeeperServer.java
@@ -139,7 +139,7 @@ public class ZookeeperServer {
      * Set the basic time unit in milliseconds used by ZooKeeper. It is used to do heartbeats and the minimum session timeout will
      * be twice the tickTime.
      * 
-     * @param tickTime the desired value, or non-positive if the default of {@value #DEFAULT_TICK_TIME} be used
+     * @param tickTime the desired value, or non-positive if the default of {@link #DEFAULT_TICK_TIME} be used
      * @return this instance to allow chaining methods; never null
      */
     public ZookeeperServer setTickTime(int tickTime) {

--- a/pom.xml
+++ b/pom.xml
@@ -380,6 +380,7 @@
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
                     <pushChanges>false</pushChanges>
+                    <releaseProfiles>docs,assembly,release-sign-artifacts</releaseProfiles>
                 </configuration>
             </plugin>
             <plugin>
@@ -499,7 +500,6 @@
                 <skipLongRunningTests>false</skipLongRunningTests>
             </properties>
         </profile>
-
         <profile>
             <id>performance</id>
             <properties>
@@ -527,10 +527,15 @@
                         </configuration>
                         <executions>
                             <execution>
-                                <id>build-aggregate</id>
-                                <phase>package</phase>
+                                <id>attach-javadocs</id>
                                 <goals>
-                                    <goal>aggregate</goal>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>attach-test-javadocs</id>
+                                <goals>
+                                    <goal>test-jar</goal>
                                 </goals>
                             </execution>
                         </executions>
@@ -564,27 +569,5 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>checkstyle</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>checkstyle</name>
-                </property>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                    </plugins>
-                </pluginManagement>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-checkstyle-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
-
 </project>


### PR DESCRIPTION
Modified the 'docs' profile to build and attach JavaDoc JARs for each module's source and test source artifacts. The profile will be automatically used when releasing. 

Also made minor changes to the code to eliminate several JavaDoc warnings.