### PR TITLE
DBZ-17 Added plugin distribution ZIP for MySQL and other connectors

### DIFF
--- a/debezium-assembly-descriptors/pom.xml
+++ b/debezium-assembly-descriptors/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-parent</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>debezium-assembly-descriptors</artifactId>
+    <name>Debezium Assembly Descriptors</name>
+    <build>
+        <plugins>
+            <plugin>
+                <!-- We don't want to run this -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>non-existant</phase>
+                    </execution>
+                    <execution>
+                        <id>attach-test-sources</id>
+                        <phase>non-existant</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!-- We don't want to create a test JAR -->
+                        <id>test-jar</id>
+                        <phase>non-existant</phase>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/debezium-assembly-descriptors/src/main/resources/assemblies/connector-distribution.xml
+++ b/debezium-assembly-descriptors/src/main/resources/assemblies/connector-distribution.xml
@@ -1,0 +1,47 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <id>plugin</id>
+  <formats>
+    <format>tar.gz</format>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <dependencySets>
+      <dependencySet>
+          <outputDirectory>${project.artifactId}</outputDirectory>
+          <unpack>false</unpack>
+          <scope>runtime</scope>
+          <useProjectArtifact>false</useProjectArtifact>
+          <excludes>
+              <exclude>${project.groupId}:${project.artifactId}:*</exclude>
+              <!-- Exclude all Kafka APIs and their dependencies, since they will be available in the runtime -->
+              <exclude>org.apache.kafka:*</exclude>
+              <exclude>org.xerial.snappy:*</exclude>
+              <exclude>net.jpountz.lz4:*</exclude>
+          </excludes>
+      </dependencySet>
+      <dependencySet>
+          <outputDirectory>${project.artifactId}</outputDirectory>
+          <unpack>false</unpack>
+          <includes>
+              <include>${project.groupId}:${project.artifactId}:*</include>
+          </includes>
+      </dependencySet>
+  </dependencySets>
+  <fileSets>
+    <fileSet>
+      <!-- Get the files from the top-level directory, which should be above the connectors -->
+      <directory>${project.basedir}/..</directory>
+      <outputDirectory>${project.artifactId}</outputDirectory>
+      <includes>
+        <include>README*</include>
+        <include>CHANGELOG*</include>
+        <include>CONTRIBUTE*</include>
+        <include>COPYRIGHT*</include>
+        <include>LICENSE*</include>
+      </includes>
+      <useDefaultExcludes>true</useDefaultExcludes>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -246,6 +246,36 @@
     Define several profiles for working with different Docker images (or no Docker whatsoever)
     -->
     <profiles>
+        <profile>
+            <id>assembly</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <finalName>${project.artifactId}-${project.version}</finalName>
+                                    <attach>true</attach>  <!-- we want attach & deploy these to Maven -->
+                                    <descriptorRefs>
+                                        <descriptorRef>connector-distribution</descriptorRef>
+                                    </descriptorRefs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
       <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             Do not perform any Docker-related functionality
             To use, specify "-DskipITs" on the Maven command line.

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -1,9 +1,4 @@
 <?xml version="1.0"?>
-<!--
-  ~ Copyright 2014 Red Hat, Inc. and/or its affiliates.
-  ~
-  ~ Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
-  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                    http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
@@ -84,7 +79,7 @@
         <!--
         By default, we should use the default Docker image. This propery is changed with different profiles.
         -->
-        <docker.image>debezium-mysql57-server</docker.image>
+        <docker.image>debezium/mysql57-it-server</docker.image>
         <docker.skip>false</docker.skip>
     </properties>
     <build>
@@ -100,13 +95,16 @@
                 <images>
                   <image>
                     <!-- A custom Docker image built on top of an "optimized" MySQL installation. -->
-                    <name>debezium-mysql57-server</name>
+                    <name>debezium/mysql57-it-server</name>
                     <alias>database</alias>
                     <build>
                       <assembly>
                         <basedir>/docker-entrypoint-initdb.d</basedir>
                         <dockerFileDir>${project.basedir}/src/test/docker</dockerFileDir>
                       </assembly>
+                      <tags>
+                        <tag>${docker.image.tag}</tag>
+                      </tags>
                     </build>
                     <run>
                       <namingStrategy>alias</namingStrategy>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -1,9 +1,4 @@
 <?xml version="1.0"?>
-<!--
-  ~ Copyright 2014 Red Hat, Inc. and/or its affiliates.
-  ~
-  ~ Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
-  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                    http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -1,9 +1,4 @@
 <?xml version="1.0"?>
-<!--
-  ~ Copyright 2014 Red Hat, Inc. and/or its affiliates.
-  ~
-  ~ Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
-  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                    http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>

--- a/debezium-embedded/pom.xml
+++ b/debezium-embedded/pom.xml
@@ -1,9 +1,4 @@
 <?xml version="1.0"?>
-<!--
-  ~ Copyright 2014 Red Hat, Inc. and/or its affiliates.
-  ~
-  ~ Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
-  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                    http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>

--- a/debezium-kafka-connect/pom.xml
+++ b/debezium-kafka-connect/pom.xml
@@ -1,9 +1,4 @@
 <?xml version="1.0"?>
-<!--
-  ~ Copyright 2014 Red Hat, Inc. and/or its affiliates.
-  ~
-  ~ Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
-  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                    http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
     </properties>
     <modules>
         <module>support/checkstyle</module>
+        <module>debezium-assembly-descriptors</module>
         <module>debezium-core</module>
         <module>debezium-embedded</module>
         <module>debezium-connector-mysql</module>
@@ -347,6 +348,24 @@
                     <groupId>org.jolokia</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
                     <version>${version.docker.maven.plugin}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.debezium</groupId>
+                            <artifactId>debezium-assembly-descriptors</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                    </dependencies>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>single</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,4 @@
 <?xml version="1.0"?>
-<!--
-  ~ Copyright 2014 Red Hat, Inc. and/or its affiliates.
-  ~
-  ~ Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
-  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" 
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -52,7 +47,6 @@
 
         <!-- Major dependencies -->
         <version.jackson>2.4.0</version.jackson>
-        <version.kafka>0.9.0.0</version.kafka>
 
         <!-- Logging -->
         <version.org.slf4j>1.7.2</version.org.slf4j>
@@ -76,10 +70,11 @@
         <version.google.formatter.plugin>0.3.1</version.google.formatter.plugin>
         <version.docker.maven.plugin>0.13.9</version.docker.maven.plugin>
 
-       <!-- Dockerfiles -->
+        <!-- Dockerfiles -->
         <docker.maintainer>Debezium community</docker.maintainer>
+        <docker.image.tag>0.1</docker.image.tag>
 
-       <!-- Kafka -->
+        <!-- Kafka -->
         <version.kafka>0.9.0.0</version.kafka>
         <version.kafka.scala>2.11</version.kafka.scala>
         <version.scala>2.11.7</version.scala>


### PR DESCRIPTION
The MySQL connector module now creates during the `assembly` profile two distribution files, `debezium-connector-mysql-<version>-plugin.tar.gz` and `debezium-connector-mysql-<version>-plugin.zip`. Either of these artifacts can be used to add the necessary JAR files for the module into a Kafka Connect service.

These archives contain the module's JAR plus any dependencies required by the module, except for any Kafka Connect API and implementation-related artifacts that are to be provided by the Kafka Connect service.