### PR TITLE
DBZ-22 Adapted to the Docker Maven Plugin's move to Fabric8 community

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <version.war.plugin>2.5</version.war.plugin>
         <version.codehaus.helper.plugin>1.8</version.codehaus.helper.plugin>
         <version.google.formatter.plugin>0.3.1</version.google.formatter.plugin>
-        <version.docker.maven.plugin>0.13.9</version.docker.maven.plugin>
+        <version.docker.maven.plugin>0.14.1</version.docker.maven.plugin>
 
         <!-- Dockerfiles -->
         <docker.maintainer>Debezium community</docker.maintainer>
@@ -345,7 +345,7 @@
                     <version>${version.google.formatter.plugin}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.jolokia</groupId>
+                    <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
                     <version>${version.docker.maven.plugin}</version>
                 </plugin>


### PR DESCRIPTION
As of today, the `org.jolokia:docker-maven-plugin` has moved into the Fabric8 community and changed its Maven groupID to `io.fabric8`. This PR changes the groupID and also upgrades the release number from 0.13.9 to 0.14.1 (the latest). The plugins [change log](https://github.com/fabric8io/docker-maven-plugin/blob/master/doc/changelog.md) is available.