### PR TITLE
DBZ-26 Corrected how MySQL table info is recovered from db history upon connector restart

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -204,6 +204,7 @@ public final class MySqlConnectorTask extends SourceTask {
                 logger.info("Recovering MySQL connector '{}' database schemas from history stored in {}", serverName, dbHistory);
                 DdlParser ddlParser = new MySqlDdlParser();
                 dbHistory.recover(source.partition(), source.offset(), tables, ddlParser);
+                tableConverters.loadTables();
                 logger.debug("Recovered MySQL connector '{}' database schemas: {}", serverName, tables.subset(tableFilter));
             } catch (Throwable t) {
                 throw new ConnectException("Failure while recovering database schemas", t);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -17,6 +17,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -67,6 +68,8 @@ public final class MySqlConnectorTask extends SourceTask {
                                                                              "slave_relay_log_info", "slave_master_info",
                                                                              "slave_worker_info", "gtid_executed",
                                                                              "server_cost", "engine_cost");
+    private final Set<String> BUILT_IN_DB_NAMES = Collect.unmodifiableSet("mysql", "performance_schema");
+
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final TopicSelector topicSelector;
 
@@ -81,6 +84,7 @@ public final class MySqlConnectorTask extends SourceTask {
     private int maxBatchSize;
     private String serverName;
     private Metronome metronome;
+    private final AtomicBoolean running = new AtomicBoolean(false);
 
     // Used in the methods that process events ...
     private final SourceInfo source = new SourceInfo();
@@ -122,6 +126,7 @@ public final class MySqlConnectorTask extends SourceTask {
                                                                                                                  // prefix
         this.dbHistory.configure(dbHistoryConfig); // validates
         this.dbHistory.start();
+        this.running.set(true);
 
         // Read the configuration ...
         final String user = config.getString(MySqlConnectorConfig.USER);
@@ -145,7 +150,9 @@ public final class MySqlConnectorTask extends SourceTask {
                                                         config.getString(MySqlConnectorConfig.TABLE_WHITELIST),
                                                         config.getString(MySqlConnectorConfig.TABLE_BLACKLIST));
         if (config.getBoolean(MySqlConnectorConfig.TABLES_IGNORE_BUILTIN)) {
-            Predicate<TableId> ignoreBuiltins = (id) -> !BUILT_IN_TABLE_NAMES.contains(id.table().toLowerCase());
+            Predicate<TableId> ignoreBuiltins = (id) -> {
+                return !BUILT_IN_TABLE_NAMES.contains(id.table().toLowerCase()) && !BUILT_IN_DB_NAMES.contains(id.catalog().toLowerCase());
+            };
             tableFilter = ignoreBuiltins.or(tableFilter);
         }
 
@@ -197,7 +204,7 @@ public final class MySqlConnectorTask extends SourceTask {
                 logger.info("Recovering MySQL connector '{}' database schemas from history stored in {}", serverName, dbHistory);
                 DdlParser ddlParser = new MySqlDdlParser();
                 dbHistory.recover(source.partition(), source.offset(), tables, ddlParser);
-                logger.debug("Recovered MySQL connector '{}' database schemas: {}", serverName, tables);
+                logger.debug("Recovered MySQL connector '{}' database schemas: {}", serverName, tables.subset(tableFilter));
             } catch (Throwable t) {
                 throw new ConnectException("Failure while recovering database schemas", t);
             }
@@ -229,7 +236,7 @@ public final class MySqlConnectorTask extends SourceTask {
     @Override
     public List<SourceRecord> poll() throws InterruptedException {
         logger.trace("Polling for events from MySQL server '{}'", serverName);
-        while (events.drainTo(batchEvents, maxBatchSize - batchEvents.size()) == 0 || batchEvents.isEmpty()) {
+        while (running.get() && (events.drainTo(batchEvents, maxBatchSize - batchEvents.size()) == 0 || batchEvents.isEmpty())) {
             // No events to process, so sleep for a bit ...
             metronome.pause();
         }
@@ -263,6 +270,8 @@ public final class MySqlConnectorTask extends SourceTask {
                     source.setRowInEvent(0);
                 }
             }
+            
+            if ( !running.get()) break;
 
             // If there is a handler for this event, forward the event to it ...
             EventHandler handler = eventHandlers.get(eventType);
@@ -272,6 +281,12 @@ public final class MySqlConnectorTask extends SourceTask {
         }
         logger.trace("Completed processing {} events from MySQL server '{}'", serverName);
 
+        if (!this.running.get()) {
+            // We're supposed to stop, so return nothing that we might have already processed
+            // so that no records get persisted if DB history has already been stopped ...
+            return null;
+        }
+
         // We've processed them all, so clear the batch and return the records ...
         assert batchEvents.isEmpty();
         return records;
@@ -280,6 +295,10 @@ public final class MySqlConnectorTask extends SourceTask {
     @Override
     public void stop() {
         try {
+            // Signal to the 'poll()' method that it should stop what its doing ...
+            this.running.set(false);
+
+            // Flush and stop the database history ...
             logger.debug("Stopping database history for MySQL server '{}'", serverName);
             dbHistory.stop();
         } catch (Throwable e) {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/TableConverters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/TableConverters.java
@@ -76,6 +76,15 @@ final class TableConverters {
         Predicate<TableId> knownTables = (id) -> !unknownTableIds.contains(id); // known if not unknown
         this.tableFilter = tableFilter != null ? tableFilter.and(knownTables) : knownTables;
     }
+    
+    public void loadTables() {
+        // Create TableSchema instances for any existing table ...
+        this.tables.tableIds().forEach(id->{
+            Table table = this.tables.forTable(id);
+            TableSchema schema = schemaBuilder.create(table, false);
+            tableSchemaByTableId.put(id, schema);
+        });
+    }
 
     public void updateTableCommand(Event event, SourceInfo source, Consumer<SourceRecord> recorder) {
         QueryEventData command = event.getData();

--- a/debezium-core/src/main/java/io/debezium/relational/Tables.java
+++ b/debezium-core/src/main/java/io/debezium/relational/Tables.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.apache.kafka.connect.data.Schema;
 
@@ -312,6 +313,19 @@ public class Tables {
             return this.tablesByTableId.equals(that.tablesByTableId);
         }
         return false;
+    }
+
+    public Tables subset(Predicate<TableId> filter) {
+        if (filter == null) return this;
+        return lock.read(() -> {
+            Tables result = new Tables();
+            tablesByTableId.forEach((tableId, table) -> {
+                if (filter.test(tableId)) {
+                    result.overwriteTable(table);
+                }
+            });
+            return result;
+        });
     }
 
     @Override

--- a/debezium-core/src/test/java/io/debezium/util/Testing.java
+++ b/debezium-core/src/test/java/io/debezium/util/Testing.java
@@ -47,7 +47,7 @@ public interface Testing {
         }
 
         public static void disable() {
-            enabled = true;
+            enabled = false;
         }
 
         public static boolean isEnabled() {

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -469,7 +469,7 @@ public final class EmbeddedEngine implements Runnable {
 
             long started = clock.currentTimeInMillis();
             long timeout = started + commitTimeoutMs;
-            offsetWriter.beginFlush();
+            if ( !offsetWriter.beginFlush() ) return;
             Future<Void> flush = offsetWriter.doFlush(this::completedFlush);
             if (flush == null) return; // no offsets to commit ...
 

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -83,9 +83,7 @@ public abstract class AbstractConnectorTest implements Testing {
             if (engine != null && engine.isRunning()) {
                 engine.stop();
                 try {
-                    while (!engine.await(5, TimeUnit.SECONDS)) {
-                        // Wait for connector to stop completely ...
-                    }
+                    engine.await(5, TimeUnit.SECONDS);
                 } catch (InterruptedException e) {
                     Thread.interrupted();
                 }
@@ -96,6 +94,15 @@ public abstract class AbstractConnectorTest implements Testing {
                 try {
                     while (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
                         // wait for completion ...
+                    }
+                } catch (InterruptedException e) {
+                    Thread.interrupted();
+                }
+            }
+            if (engine != null && engine.isRunning()) {
+                try {
+                    while (!engine.await(5, TimeUnit.SECONDS)) {
+                        // Wait for connector to stop completely ...
                     }
                 } catch (InterruptedException e) {
                     Thread.interrupted();


### PR DESCRIPTION
Corrected the logic of the MySQL connector upon restart to properly recover the table information from the database history, and changed one of the integration tests to verify the correct behavior. 

Also corrected the embedded connector framework (which is used in the integration tests) to properly shut down the connectors, and changed the MySQL connector to return from `poll()` when the connector is stopped. Several log statements were improved.