### PR TITLE
DBZ-29 Changed MySQL connector to be able to hide, truncate, and mask specific columns

### DIFF
--- a/debezium-core/src/main/java/io/debezium/function/Predicates.java
+++ b/debezium-core/src/main/java/io/debezium/function/Predicates.java
@@ -5,127 +5,79 @@
  */
 package io.debezium.function;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import io.debezium.util.Strings;
 
 /**
+ * Utilities for constructing various predicates.
  * @author Randall Hauch
  *
  */
 public class Predicates {
 
-
     /**
-     * Generate a whitelist filter/predicate that allows only those values that <em>are</em> included in the supplied input.
+     * Generate a predicate function that for any supplied string returns {@code true} if <i>any</i> of the regular expressions in
+     * the supplied comma-separated list matches the predicate parameter.
      * 
-     * @param input the input string
-     * @param splitter the function that splits the input into multiple items; may not be null
-     * @param factory the factory for creating string items into filter matches; may not be null
-     * @return the predicate that returns {@code true} if and only if the argument to the predicate matches (with
-     *         {@link Object#equals(Object) equals(...)} one of the objects parsed from the input; never null
+     * @param regexPatterns the comma-separated regular expression pattern (or literal) strings; may not be null
+     * @return the predicate function that performs the matching
      */
-    public static <T> Predicate<T> whitelist(String input, Function<String, String[]> splitter, Function<String, T> factory) {
-        if ( input == null ) return (str)->false;
-        Set<T> matches = new HashSet<>();
-        for (String item : splitter.apply(input)) {
-            T obj = factory.apply(item);
-            if ( obj != null ) matches.add(obj);
-        }
-        return matches::contains;
+    public static Predicate<String> includes(String regexPatterns) {
+        return includes(regexPatterns, (str) -> str);
     }
 
     /**
-     * Generate a whitelist filter/predicate that allows only those values that <em>are</em> included in the supplied input.
+     * Generate a predicate function that for any supplied string returns {@code true} if <i>none</i> of the regular
+     * expressions in the supplied comma-separated list matches the predicate parameter.
      * 
-     * @param input the input string
-     * @param delimiter the character used to delimit the items in the input
-     * @param factory the factory for creating string items into filter matches; may not be null
-     * @return the predicate that returns {@code true} if and only if the argument to the predicate matches (with
-     *         {@link Object#equals(Object) equals(...)} one of the objects parsed from the input; never null
+     * @param regexPatterns the comma-separated regular expression pattern (or literal) strings; may not be null
+     * @return the predicate function that performs the matching
      */
-    public static <T> Predicate<T> whitelist(String input, char delimiter, Function<String, T> factory) {
-        return whitelist(input, (str) -> str.split("[" + delimiter + "]"), factory);
+    public static Predicate<String> excludes(String regexPatterns) {
+        return includes(regexPatterns).negate();
     }
 
     /**
-     * Generate a whitelist filter/predicate that allows only those values that <em>are</em> included in the supplied
-     * comma-separated input.
+     * Generate a predicate function that for any supplied parameter returns {@code true} if <i>any</i> of the regular expressions
+     * in the supplied comma-separated list matches the predicate parameter in a case-insensitive manner.
      * 
-     * @param input the input string
-     * @param factory the factory for creating string items into filter matches; may not be null
-     * @return the predicate that returns {@code true} if and only if the argument to the predicate matches (with
-     *         {@link Object#equals(Object) equals(...)} one of the objects parsed from the input; never null
+     * @param regexPatterns the comma-separated regular expression pattern (or literal) strings; may not be null
+     * @param conversion the function that converts each predicate-supplied value to a string that can be matched against the
+     *            regular expressions; may not be null
+     * @return the predicate function that performs the matching
      */
-    public static <T> Predicate<T> whitelist(String input, Function<String, T> factory) {
-        return whitelist(input, (str) -> str.split("[\\,]"), factory);
+    public static <T> Predicate<T> includes(String regexPatterns, Function<T, String> conversion) {
+        Set<Pattern> patterns = Strings.listOfRegex(regexPatterns,Pattern.CASE_INSENSITIVE);
+        return (t) -> {
+            String str = conversion.apply(t);
+            for ( Pattern p : patterns ) {
+                if ( p.matcher(str).matches()) return true;
+            }
+            return false;
+        };
     }
 
     /**
-     * Generate a whitelist filter/predicate that allows only those values that <em>are</em> included in the supplied
-     * comma-separated input.
+     * Generate a predicate function that for any supplied parameter returns {@code true} if <i>none</i> of the regular
+     * expressions in the supplied comma-separated list matches the predicate parameter.
      * 
-     * @param input the input string
-     * @return the predicate that returns {@code true} if and only if the argument to the predicate matches (with
-     *         {@link Object#equals(Object) equals(...)} one of the objects parsed from the input; never null
+     * @param regexPatterns the comma-separated regular expression pattern (or literal) strings; may not be null
+     * @param conversion the function that converts each predicate-supplied value to a string that can be matched against the
+     *            regular expressions; may not be null
+     * @return the predicate function that performs the matching
      */
-    public static Predicate<String> whitelist(String input) {
-        return whitelist(input, (str) -> str);
-    }
-
-    /**
-     * Generate a blacklist filter/predicate that allows only those values that are <em>not</em> included in the supplied input.
-     * 
-     * @param input the input string
-     * @param splitter the function that splits the input into multiple items; may not be null
-     * @param factory the factory for creating string items into filter matches; may not be null
-     * @return the predicate that returns {@code true} if and only if the argument to the predicate matches (with
-     *         {@link Object#equals(Object) equals(...)} one of the objects parsed from the input; never null
-     */
-    public static <T> Predicate<T> blacklist(String input, Function<String, String[]> splitter, Function<String, T> factory) {
-        return whitelist(input, splitter, factory).negate();
-    }
-
-    /**
-     * Generate a blacklist filter/predicate that allows only those values that are <em>not</em> included in the supplied input.
-     * 
-     * @param input the input string
-     * @param delimiter the character used to delimit the items in the input
-     * @param factory the factory for creating string items into filter matches; may not be null
-     * @return the predicate that returns {@code true} if and only if the argument to the predicate matches (with
-     *         {@link Object#equals(Object) equals(...)} one of the objects parsed from the input; never null
-     */
-    public static <T> Predicate<T> blacklist(String input, char delimiter, Function<String, T> factory) {
-        return whitelist(input, delimiter, factory).negate();
-    }
-
-    /**
-     * Generate a blacklist filter/predicate that allows only those values that are <em>not</em> included in the supplied comma-separated input.
-     * 
-     * @param input the input string
-     * @param factory the factory for creating string items into filter matches; may not be null
-     * @return the predicate that returns {@code true} if and only if the argument to the predicate matches (with
-     *         {@link Object#equals(Object) equals(...)} one of the objects parsed from the input; never null
-     */
-    public static <T> Predicate<T> blacklist(String input, Function<String, T> factory) {
-        return whitelist(input, factory).negate();
-    }
-    /**
-     * Generate a blacklist filter/predicate that allows only those values that are <em>not</em> included in the supplied comma-separated input.
-     * 
-     * @param input the input string
-     * @return the predicate that returns {@code true} if and only if the argument to the predicate matches (with
-     *         {@link Object#equals(Object) equals(...)} one of the objects parsed from the input; never null
-     */
-    public static Predicate<String> blacklist(String input) {
-        return whitelist(input).negate();
+    public static <T> Predicate<T> excludes(String regexPatterns, Function<T, String> conversion) {
+        return includes(regexPatterns, conversion).negate();
     }
 
     public static <R> Predicate<R> not(Predicate<R> predicate) {
         return predicate.negate();
     }
-    
+
     public static <T> Predicate<T> notNull() {
         return new Predicate<T>() {
             @Override
@@ -134,8 +86,8 @@ public class Predicates {
             }
         };
     }
-    
+
     private Predicates() {
     }
-    
+
 }

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -33,8 +33,8 @@ import io.debezium.relational.ColumnEditor;
 import io.debezium.relational.TableEditor;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
-import io.debezium.relational.Tables.ColumnFilter;
-import io.debezium.relational.Tables.TableFilter;
+import io.debezium.relational.Tables.ColumnNameFilter;
+import io.debezium.relational.Tables.TableNameFilter;
 import io.debezium.util.Collect;
 import io.debezium.util.Strings;
 
@@ -359,7 +359,7 @@ public class JdbcConnection implements AutoCloseable {
      * @throws SQLException if an error occurs while accessing the database metadata
      */
     public void readSchema(Tables tables, String databaseCatalog, String schemaNamePattern,
-                           TableFilter tableFilter, ColumnFilter columnFilter) throws SQLException {
+                           TableNameFilter tableFilter, ColumnNameFilter columnFilter) throws SQLException {
         DatabaseMetaData metadata = conn.getMetaData();
 
         // Read the metadata for the table columns ...
@@ -369,11 +369,11 @@ public class JdbcConnection implements AutoCloseable {
                 String catalogName = rs.getString(1);
                 String schemaName = rs.getString(2);
                 String tableName = rs.getString(3);
-                if (tableFilter == null || tableFilter.test(catalogName, schemaName, tableName)) {
+                if (tableFilter == null || tableFilter.matches(catalogName, schemaName, tableName)) {
                     TableId tableId = new TableId(catalogName, schemaName, tableName);
                     List<Column> cols = columnsByTable.computeIfAbsent(tableId, name -> new ArrayList<>());
                     String columnName = rs.getString(4);
-                    if (columnFilter == null || columnFilter.test(catalogName, schemaName, tableName, columnName)) {
+                    if (columnFilter == null || columnFilter.matches(catalogName, schemaName, tableName, columnName)) {
                         ColumnEditor column = Column.editor().name(columnName);
                         column.jdbcType(rs.getInt(5));
                         column.typeName(rs.getString(6));

--- a/debezium-core/src/main/java/io/debezium/relational/ColumnId.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnId.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import io.debezium.annotation.Immutable;
+import io.debezium.util.Strings;
+
+/**
+ * Unique identifier for a column in a database table.
+ * 
+ * @author Randall Hauch
+ */
+@Immutable
+public final class ColumnId implements Comparable<ColumnId> {
+    
+    /**
+     * Create the map of predicate functions that specify which columns are to be included.
+     * <p>
+     * Qualified column names are comma-separated strings that are each {@link #parse(String) parsed} into {@link ColumnId} objects.
+     * 
+     * @param columnBlacklist the comma-separated string listing the qualified names of the columns to be explicitly disallowed;
+     *            may be null
+     * @return the predicate function; never null
+     */
+    public static Map<TableId,Predicate<Column>> filter(String columnBlacklist) {
+        Set<ColumnId> columnExclusions = columnBlacklist == null ? null : Strings.listOf(columnBlacklist, ColumnId::parse);
+        Map<TableId,Set<String>> excludedColumnNamesByTable = new HashMap<>();
+        columnExclusions.forEach(columnId->{
+            excludedColumnNamesByTable.compute(columnId.tableId(), (tableId,columns)->{
+                if ( columns == null ) columns = new HashSet<String>();
+                columns.add(columnId.columnName().toLowerCase());
+                return columns;
+            });
+        });
+        Map<TableId,Predicate<Column>> exclusionFilterByTable= new HashMap<>();
+        excludedColumnNamesByTable.forEach((tableId,excludedColumnNames)->{
+            exclusionFilterByTable.put(tableId, (col)->!excludedColumnNames.contains(col.name().toLowerCase()));
+        });
+        return exclusionFilterByTable;
+    }
+    
+    /**
+     * Parse the supplied string delimited with a period ({@code .}) character, extracting the last segment into a column name
+     * and the prior segments into the TableID.
+     * 
+     * @param str the input string
+     * @return the column ID, or null if it could not be parsed
+     */
+    public static ColumnId parse(String str) {
+        return parse(str, '.', true);
+    }
+
+    /**
+     * Parse the supplied string delimited with the specified delimiter character, extracting the last segment into a column name
+     * and the prior segments into the TableID.
+     * 
+     * @param str the input string
+     * @param delimiter the delimiter between parts
+     * @param useCatalogBeforeSchema {@code true} if the parsed string contains only 2 items and the first should be used as
+     *            the catalog and the second as the table name, or {@code false} if the first should be used as the schema and the
+     *            second
+     *            as the table name
+     * @return the column ID, or null if it could not be parsed
+     */
+    public static ColumnId parse(String str, char delimiter, boolean useCatalogBeforeSchema) {
+        String[] parts = str.split("[\\" + delimiter + "]");
+        if ( parts.length < 2 ) return null;
+        TableId tableId = TableId.parse(parts, parts.length - 1, useCatalogBeforeSchema);
+        if ( tableId == null ) return null;
+        return new ColumnId(tableId,parts[parts.length-1]);
+    }
+
+    private final TableId tableId;
+    private final String columnName;
+    private final String id;
+
+    /**
+     * Create a new column identifier.
+     * 
+     * @param tableId the identifier of the table; may not be null
+     * @param columnName the name of the column; may not be null
+     */
+    public ColumnId(TableId tableId, String columnName) {
+        this.tableId = tableId;
+        this.columnName = columnName;
+        assert this.tableId != null;
+        assert this.columnName != null;
+        this.id = columnId(this.tableId,this.columnName);
+    }
+
+    /**
+     * Create a new column identifier.
+     * 
+     * @param catalogName the name of the database catalog that contains the table; may be null if the JDBC driver does not
+     *            show a schema for this table
+     * @param schemaName the name of the database schema that contains the table; may be null if the JDBC driver does not
+     *            show a schema for this table
+     * @param tableName the name of the table; may not be null
+     * @param columnName the name of the column; may not be null
+     */
+    public ColumnId(String catalogName, String schemaName, String tableName, String columnName) {
+        this(new TableId(catalogName,schemaName,tableName),columnName);
+    }
+
+    /**
+     * Get the identifier for the table that owns this column.
+     * 
+     * @return the table identifier; never null
+     */
+    public TableId tableId() {
+        return tableId;
+    }
+
+    /**
+     * Get the name of the JDBC catalog.
+     * 
+     * @return the catalog name, or null if the table does not belong to a catalog
+     */
+    public String catalog() {
+        return tableId.catalog();
+    }
+
+    /**
+     * Get the name of the JDBC schema.
+     * 
+     * @return the JDBC schema name, or null if the table does not belong to a JDBC schema
+     */
+    public String schema() {
+        return tableId.schema();
+    }
+
+    /**
+     * Get the name of the table.
+     * 
+     * @return the table name; never null
+     */
+    public String table() {
+        return tableId.table();
+    }
+
+    /**
+     * Get the name of the table.
+     * 
+     * @return the table name; never null
+     */
+    public String columnName() {
+        return columnName;
+    }
+
+    @Override
+    public int compareTo(ColumnId that) {
+        if (this == that) return 0;
+        return this.id.compareTo(that.id);
+    }
+
+    public int compareToIgnoreCase(ColumnId that) {
+        if (this == that) return 0;
+        return this.id.compareToIgnoreCase(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof ColumnId) {
+            return this.compareTo((ColumnId) obj) == 0;
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return id;
+    }
+
+    private static String columnId(TableId tableId, String columnName) {
+        return tableId.toString() + "." + columnName;
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/relational/ColumnMapper.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+/**
+ * A factory for a function used to map values of a column.
+ * 
+ * @author Randall Hauch
+ */
+@FunctionalInterface
+public interface ColumnMapper {
+
+    /**
+     * Create for the given column a function that maps values.
+     * 
+     * @param column the column description; never null
+     * @return the function that converts the value; may be null
+     */
+    ValueConverter create(Column column);
+
+}

--- a/debezium-core/src/main/java/io/debezium/relational/ColumnMappers.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnMappers.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+import io.debezium.annotation.Immutable;
+import io.debezium.function.Predicates;
+import io.debezium.util.Strings;
+
+/**
+ * A set of {@link ColumnMapper} objects for columns.
+ * 
+ * @author Randall Hauch
+ */
+@Immutable
+public class ColumnMappers {
+
+    /**
+     * Obtain a new {@link Builder builder} for a table selection predicate.
+     * 
+     * @return the builder; never null
+     */
+    public static Builder create() {
+        return new Builder();
+    }
+
+    /**
+     * A builder of {@link Selectors}.
+     * 
+     * @author Randall Hauch
+     */
+    public static class Builder {
+
+        private final List<MapperRule> rules = new ArrayList<>();
+
+        /**
+         * Set a mapping function for the columns with fully-qualified names that match the given comma-separated list of regular
+         * expression patterns.
+         * 
+         * @param fullyQualifiedColumnNames the comma-separated list of fully-qualified column names; may not be null
+         * @param mapper the column mapping function that will be used to map actual values into values used in the output record;
+         *            null if an existing mapping function should be removed
+         * @return this object so that methods can be chained together; never null
+         */
+        public Builder map(String fullyQualifiedColumnNames, ColumnMapper mapper) {
+            Predicate<ColumnId> columnMatcher = Predicates.includes(fullyQualifiedColumnNames, ColumnId::toString);
+            rules.add(new MapperRule(columnMatcher, mapper));
+            return this;
+        }
+
+        /**
+         * Set a mapping function for the columns with fully-qualified names that match the given comma-separated list of regular
+         * expression patterns.
+         * 
+         * @param fullyQualifiedColumnNames the comma-separated list of fully-qualified column names; may not be null
+         * @param mapperClass the Java class that implements {@code BiFunction<Column, Object, Object>} and that
+         *            will be used to map actual values into values used in the output record; may not be null
+         * @return this object so that methods can be chained together; never null
+         */
+        public Builder map(String fullyQualifiedColumnNames, Class<ColumnMapper> mapperClass) {
+            return map(fullyQualifiedColumnNames, instantiateMapper(mapperClass));
+        }
+
+        /**
+         * Truncate to a maximum length the string values for each of the columns with the fully-qualified names.
+         * Only columns {@link String} values can be truncated.
+         * 
+         * @param fullyQualifiedColumnNames the comma-separated list of fully-qualified column names; may not be null
+         * @param maxLength the maximum number of characters to appear in the value
+         * @return this object so that methods can be chained together; never null
+         */
+        public Builder truncateStrings(String fullyQualifiedColumnNames, int maxLength) {
+            return map(fullyQualifiedColumnNames, (column) -> {
+                return (value) -> {
+                    if (value instanceof String) {
+                        String str = (String) value;
+                        if (str.length() > maxLength) return str.substring(0, maxLength);
+                    }
+                    return value;
+                };
+            });
+        }
+
+        /**
+         * Use a string of the specified number of '*' characters to mask the string values for each of the columns with
+         * fully-qualified names that match the given comma-separated list of regular expression patterns.
+         * 
+         * @param fullyQualifiedColumnNames the comma-separated list of fully-qualified column names; may not be null
+         * @param numberOfChars the number of mask characters to be used in the mask value
+         * @return this object so that methods can be chained together; never null
+         */
+        public Builder maskStrings(String fullyQualifiedColumnNames, int numberOfChars) {
+            return maskStrings(fullyQualifiedColumnNames, numberOfChars, '*');
+        }
+
+        /**
+         * Use a string of the specified number of characters to mask the string values for each of the columns with
+         * fully-qualified names that match the given comma-separated list of regular expression patterns.
+         * 
+         * @param fullyQualifiedColumnNames the comma-separated list of fully-qualified column names; may not be null
+         * @param numberOfChars the number of mask characters to be used in the mask value
+         * @param maskChar the character to be used; may not be null
+         * @return this object so that methods can be chained together; never null
+         */
+        public Builder maskStrings(String fullyQualifiedColumnNames, int numberOfChars, char maskChar) {
+            return maskStrings(fullyQualifiedColumnNames, Strings.createString(maskChar, numberOfChars));
+        }
+
+        /**
+         * Use the specified string to mask the string values for each of the columns with
+         * fully-qualified names that match the given comma-separated list of regular expression patterns.
+         * 
+         * @param fullyQualifiedColumnNames the comma-separated list of fully-qualified column names; may not be null
+         * @param maskValue the value to be used in place of the actual value; may not be null
+         * @return this object so that methods can be chained together; never null
+         */
+        public Builder maskStrings(String fullyQualifiedColumnNames, String maskValue) {
+            return map(fullyQualifiedColumnNames, (column) -> {
+                switch (column.jdbcType()) {
+                    case Types.CHAR: // variable-length
+                    case Types.VARCHAR: // variable-length
+                    case Types.LONGVARCHAR: // variable-length
+                    case Types.CLOB: // variable-length
+                    case Types.NCHAR: // fixed-length
+                    case Types.NVARCHAR: // fixed-length
+                    case Types.LONGNVARCHAR: // fixed-length
+                    case Types.NCLOB: // fixed-length
+                    case Types.DATALINK:
+                        return (input) -> maskValue;
+                    default:
+                        return (input) -> input;
+                }
+            });
+        }
+
+        /**
+         * Set a mapping function for the columns with fully-qualified names that match the given comma-separated list of regular
+         * expression patterns.
+         * 
+         * @param fullyQualifiedColumnNames the comma-separated list of fully-qualified column names; may not be null
+         * @param mapperClassName the name of the Java class that implements {@code BiFunction<Column, Object, Object>} and that
+         *            will be used to map actual values into values used in the output record; null if
+         *            an existing mapping function should be removed
+         * @return this object so that methods can be chained together; never null
+         */
+        @SuppressWarnings("unchecked")
+        public Builder map(String fullyQualifiedColumnNames, String mapperClassName) {
+            Class<ColumnMapper> mapperClass = null;
+            if (mapperClassName != null) {
+                try {
+                    mapperClass = (Class<ColumnMapper>) getClass().getClassLoader().loadClass(mapperClassName);
+                } catch (ClassNotFoundException e) {
+                    throw new ConnectException("Unable to find column mapper class " + mapperClassName + ": " + e.getMessage(), e);
+                } catch (ClassCastException e) {
+                    throw new ConnectException(
+                            "Column mapper class must implement " + ColumnMapper.class + " but does not: " + e.getMessage(),
+                            e);
+                }
+            }
+            return map(fullyQualifiedColumnNames, mapperClass);
+        }
+
+        /**
+         * Build the {@link Predicate} that determines whether a table identified by a given {@link TableId} is to be included.
+         * 
+         * @return the table selection predicate; never null
+         */
+        public ColumnMappers build() {
+            return new ColumnMappers(rules);
+        }
+    }
+
+    private final List<MapperRule> rules;
+
+    private ColumnMappers(List<MapperRule> rules) {
+        assert rules != null;
+        this.rules = new ArrayList<>(rules);
+    }
+
+    /**
+     * Get the value mapping function for the given column.
+     * 
+     * @param table the table to which the column belongs; may not be null
+     * @param column the column; may not be null
+     * @return the mapping function, or null if there is no mapping function
+     */
+    public ValueConverter mapperFor(Table table, Column column) {
+        return mapperFor(table.id(),column);
+    }
+
+    /**
+     * Get the value mapping function for the given column.
+     * 
+     * @param tableId the identifier of the table to which the column belongs; may not be null
+     * @param column the column; may not be null
+     * @return the mapping function, or null if there is no mapping function
+     */
+    public ValueConverter mapperFor(TableId tableId, Column column) {
+        ColumnId id = new ColumnId(tableId, column.name());
+        Optional<MapperRule> matchingRule = rules.stream().filter(rule -> rule.matches(id)).findFirst();
+        if (matchingRule.isPresent()) {
+            return matchingRule.get().mapper.create(column);
+        }
+        return null;
+    }
+
+    @Immutable
+    protected static final class MapperRule {
+        protected final Predicate<ColumnId> predicate;
+        protected final ColumnMapper mapper;
+
+        protected MapperRule(Predicate<ColumnId> predicate, ColumnMapper mapper) {
+            this.predicate = predicate;
+            this.mapper = mapper;
+        }
+
+        protected boolean matches(ColumnId id) {
+            return predicate.test(id);
+        }
+    }
+
+    protected static <T> T instantiateMapper(Class<T> clazz) {
+        try {
+            return clazz.newInstance();
+        } catch (InstantiationException e) {
+            throw new ConnectException("Unable to instantiate column mapper class " + clazz.getName() + ": " + e.getMessage(), e);
+        } catch (IllegalAccessException e) {
+            throw new ConnectException("Unable to access column mapper class " + clazz.getName() + ": " + e.getMessage(), e);
+        }
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/relational/Selectors.java
+++ b/debezium-core/src/main/java/io/debezium/relational/Selectors.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import java.util.function.Predicate;
+
+import io.debezium.annotation.Immutable;
+import io.debezium.function.Predicates;
+
+/**
+ * Define predicates determines whether tables or columns should be used. The predicates use rules to determine which tables
+ * and columns are included or excluded.
+ * <p>
+ * Because tables can be included and excluded based upon their fully-qualified names and based upon the database names, this
+ * class defines a {@link #tableSelector() builder} to collect the various regular expression patterns the predicate(s) will use
+ * to determine which columns and tables are included. The builder is then used to
+ * {@link TableSelectionPredicateBuilder#build() build} the immutable table selection predicate.
+ * <p>
+ * By default all columns in included tables will be selected, except when they are specifically excluded using regular
+ * expressions that match the columns' fully-qualified names. Therefore, the predicate is constructed using a simple
+ * {@link #excludeColumns(String) static method}.
+ * 
+ * @author Randall Hauch
+ */
+@Immutable
+public class Selectors {
+    
+    /**
+     * Obtain a new {@link TableSelectionPredicateBuilder builder} for a table selection predicate.
+     * 
+     * @return the builder; never null
+     */
+    public static TableSelectionPredicateBuilder tableSelector() {
+        return new TableSelectionPredicateBuilder();
+    }
+
+    /**
+     * A builder of {@link Selectors}.
+     * 
+     * @author Randall Hauch
+     */
+    public static class TableSelectionPredicateBuilder {
+        private Predicate<String> dbInclusions;
+        private Predicate<String> dbExclusions;
+        private Predicate<TableId> tableInclusions;
+        private Predicate<TableId> tableExclusions;
+
+        /**
+         * Specify the names of the databases that should be included. This method will override previously included and
+         * {@link #excludeDatabases(String) excluded} databases.
+         * 
+         * @param databaseNames the comma-separated list of database names to include; may be null or empty
+         * @return this builder so that methods can be chained together; never null
+         */
+        public TableSelectionPredicateBuilder includeDatabases(String databaseNames) {
+            if (databaseNames == null || databaseNames.trim().isEmpty()) {
+                dbInclusions = null;
+            } else {
+                dbInclusions = Predicates.includes(databaseNames);
+            }
+            return this;
+        }
+
+        /**
+         * Specify the names of the databases that should be excluded. This method will override previously {@link
+         * #excludeDatabases(String) excluded} databases, although {@link #includeDatabases(String) including databases} overrides
+         * exclusions.
+         * 
+         * @param databaseNames the comma-separated list of database names to exclude; may be null or empty
+         * @return this builder so that methods can be chained together; never null
+         */
+        public TableSelectionPredicateBuilder excludeDatabases(String databaseNames) {
+            if (databaseNames == null || databaseNames.trim().isEmpty()) {
+                dbExclusions = null;
+            } else {
+                dbExclusions = Predicates.excludes(databaseNames);
+            }
+            return this;
+        }
+
+        /**
+         * Specify the names of the tables that should be included. This method will override previously included and
+         * {@link #excludeTables(String) excluded} table names.
+         * <p>
+         * Note that any specified tables that are in an {@link #excludeDatabases(String) excluded database} will not be included.
+         * 
+         * @param fullyQualifiedTableNames the comma-separated list of fully-qualified table names to include; may be null or
+         *            empty
+         * @return this builder so that methods can be chained together; never null
+         */
+        public TableSelectionPredicateBuilder includeTables(String fullyQualifiedTableNames) {
+            if (fullyQualifiedTableNames == null || fullyQualifiedTableNames.trim().isEmpty()) {
+                tableInclusions = null;
+            } else {
+                tableInclusions = Predicates.includes(fullyQualifiedTableNames, TableId::toString);
+            }
+            return this;
+        }
+
+        /**
+         * Specify the names of the tables that should be excluded. This method will override previously {@link
+         * #excludeDatabases(String) excluded} tables, although {@link #includeTables(String) including tables} overrides
+         * exclusions.
+         * <p>
+         * Note that any specified tables that are in an {@link #excludeDatabases(String) excluded database} will not be included.
+         * 
+         * @param fullyQualifiedTableNames the comma-separated list of fully-qualified table names to exclude; may be null or
+         *            empty
+         * @return this builder so that methods can be chained together; never null
+         */
+        public TableSelectionPredicateBuilder excludeTables(String fullyQualifiedTableNames) {
+            if (fullyQualifiedTableNames == null || fullyQualifiedTableNames.trim().isEmpty()) {
+                tableExclusions = null;
+            } else {
+                tableExclusions = Predicates.excludes(fullyQualifiedTableNames, TableId::toString);
+            }
+            return this;
+        }
+
+        /**
+         * Build the {@link Predicate} that determines whether a table identified by a given {@link TableId} is to be included.
+         * 
+         * @return the table selection predicate; never null
+         * @see #includeDatabases(String)
+         * @see #excludeDatabases(String)
+         * @see #includeTables(String)
+         * @see #excludeTables(String)
+         */
+        public Predicate<TableId> build() {
+            Predicate<TableId> tableFilter = tableInclusions != null ? tableInclusions : tableExclusions;
+            Predicate<String> dbFilter = dbInclusions != null ? dbInclusions : dbExclusions;
+            if (dbFilter != null) {
+                if (tableFilter != null) {
+                    return (id) -> dbFilter.test(id.catalog()) && tableFilter.test(id);
+                }
+                return (id) -> dbFilter.test(id.catalog());
+            }
+            if (tableFilter != null) {
+                return tableFilter;
+            }
+            return (id) -> true;
+        }
+    }
+
+    /**
+     * Build the {@link Predicate} that determines whether a column identified by a given {@link ColumnId} is to be included,
+     * using the given comma-separated regular expression patterns defining which columns (if any) should be <i>excluded</i>.
+     * <p>
+     * Note that this predicate is completely independent of the table selection predicate, so it is expected that this predicate
+     * be used only <i>after</i> the table selection predicate determined the table containing the column(s) is to be used.
+     * 
+     * @param fullyQualifiedTableNames the comma-separated list of fully-qualified table names to exclude; may be null or
+     *            empty
+     * @return this builder so that methods can be chained together; never null
+     */
+    public static Predicate<ColumnId> excludeColumns(String fullyQualifiedTableNames) {
+        return Predicates.excludes(fullyQualifiedTableNames, ColumnId::toString);
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/relational/Tables.java
+++ b/debezium-core/src/main/java/io/debezium/relational/Tables.java
@@ -32,7 +32,7 @@ public class Tables {
      * A filter for tables.
      */
     @FunctionalInterface
-    public static interface TableFilter {
+    public static interface TableNameFilter {
         /**
          * Determine whether the named table should be included.
          * 
@@ -43,14 +43,14 @@ public class Tables {
          * @param tableName the name of the table
          * @return {@code true} if the table should be included, or {@code false} if the table should be excluded
          */
-        boolean test(String catalogName, String schemaName, String tableName);
+        boolean matches(String catalogName, String schemaName, String tableName);
     }
 
     /**
      * A filter for columns.
      */
     @FunctionalInterface
-    public static interface ColumnFilter {
+    public static interface ColumnNameFilter {
         /**
          * Determine whether the named column should be included in the table's {@link Schema} definition.
          * 
@@ -62,7 +62,7 @@ public class Tables {
          * @param columnName the name of the column
          * @return {@code true} if the table should be included, or {@code false} if the table should be excluded
          */
-        boolean test(String catalogName, String schemaName, String tableName, String columnName);
+        boolean matches(String catalogName, String schemaName, String tableName, String columnName);
     }
 
     private final FunctionalReadWriteLock lock = FunctionalReadWriteLock.reentrant();

--- a/debezium-core/src/main/java/io/debezium/relational/ValueConverter.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ValueConverter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+/**
+ * A function that converts from a column data value into another value.
+ */
+@FunctionalInterface
+public interface ValueConverter {
+    /**
+     * Convert the column's data value.
+     * 
+     * @param data the column data value
+     * @return the new data value
+     */
+    Object convert(Object data);
+    
+    /**
+     * Obtain a {@link ValueConverter} that passes through values.
+     * @return the pass-through {@link ValueConverter}; never null
+     */
+    public static ValueConverter passthrough() {
+        return (data)->data;
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/util/Strings.java
+++ b/debezium-core/src/main/java/io/debezium/util/Strings.java
@@ -9,8 +9,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.regex.Pattern;
 
 import io.debezium.annotation.ThreadSafe;
 
@@ -22,6 +26,70 @@ import io.debezium.annotation.ThreadSafe;
  */
 @ThreadSafe
 public final class Strings {
+
+    /**
+     * Generate the set of values that are included in the list.
+     * 
+     * @param input the input string
+     * @param splitter the function that splits the input into multiple items; may not be null
+     * @param factory the factory for creating string items into filter matches; may not be null
+     * @return the list of objects included in the list; never null
+     */
+    public static <T> Set<T> listOf(String input, Function<String, String[]> splitter, Function<String, T> factory) {
+        if ( input == null ) return Collections.emptySet();
+        Set<T> matches = new HashSet<>();
+        for (String item : splitter.apply(input)) {
+            T obj = factory.apply(item);
+            if ( obj != null ) matches.add(obj);
+        }
+        return matches;
+    }
+
+    /**
+     * Generate the set of values that are included in the list delimited by the given delimiter.
+     * 
+     * @param input the input string
+     * @param delimiter the character used to delimit the items in the input
+     * @param factory the factory for creating string items into filter matches; may not be null
+     * @return the list of objects included in the list; never null
+     */
+    public static <T> Set<T> listOf(String input, char delimiter, Function<String, T> factory) {
+        return listOf(input,(str) -> str.split("[" + delimiter + "]"),factory);
+    }
+
+    /**
+     * Generate the set of values that are included in the list separated by commas.
+     * 
+     * @param input the input string
+     * @param factory the factory for creating string items into filter matches; may not be null
+     * @return the list of objects included in the list; never null
+     */
+    public static <T> Set<T> listOf(String input, Function<String, T> factory) {
+        return listOf(input,',',factory);
+    }
+
+    /**
+     * Generate the set of regular expression {@link Pattern}s that are specified in the string containing comma-separated
+     * regular expressions.
+     * 
+     * @param input the input string with comma-separated regular expressions
+     * @return the list of regular expression {@link Pattern}s included in the list; never null
+     */
+    public static Set<Pattern> listOfRegex(String input) {
+        return listOf(input,',',Pattern::compile);
+    }
+
+    /**
+     * Generate the set of regular expression {@link Pattern}s that are specified in the string containing comma-separated
+     * regular expressions.
+     * 
+     * @param input the input string with comma-separated regular expressions
+     * @param regexFlags the flags for {@link Pattern#compile(String, int) compiling regular expressions}
+     * @return the list of regular expression {@link Pattern}s included in the list; never null
+     */
+    public static Set<Pattern> listOfRegex(String input, int regexFlags) {
+        return listOf(input,',',(str)->Pattern.compile(str,regexFlags));
+    }
 
     /**
      * Represents a predicate (boolean-valued function) of one character argument.

--- a/debezium-core/src/test/java/io/debezium/config/ConfigurationTest.java
+++ b/debezium-core/src/test/java/io/debezium/config/ConfigurationTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.config;
+
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Randall Hauch
+ *
+ */
+public class ConfigurationTest {
+
+    private Configuration config;
+    
+    @Before
+    public void beforeEach() {
+        config = Configuration.create().with("A", "a")
+                .with("B", "b")
+                .with("1", 1)
+                .build();
+    }
+    
+    @Test
+    public void shouldConvertFromProperties() {
+        Properties props = new Properties();
+        props.setProperty("A", "a");
+        props.setProperty("B", "b");
+        props.setProperty("1", "1");
+        config = Configuration.from(props);
+        assertThat(config.getString("A")).isEqualTo("a");
+        assertThat(config.getString("B")).isEqualTo("b");
+        assertThat(config.getString("1")).isEqualTo("1");
+        assertThat(config.getInteger("1")).isEqualTo(1);    // converts
+        assertThat(config.getBoolean("1")).isNull();    // not a boolean
+    }
+    
+    @Test
+    public void shouldCallFunctionOnEachMatchingFieldUsingRegex() {
+        config = Configuration.create()
+                .with("column.truncate.to.-10.chars", "should-not-be-matched")
+                .with("column.truncate.to.10.chars", "10-chars")
+                .with("column.truncate.to.20.chars", "20-chars")
+                .with("column.mask.with.20.chars", "20-mask")
+                .with("column.mask.with.0.chars", "0-mask")
+                .with("column.mask.with.chars", "should-not-be-matched")
+                .build();
+        
+        // Use a regex that captures an integer using a regex group ...
+        AtomicInteger counter = new AtomicInteger();
+        config.forEachMatchingFieldNameWithInteger("column\\.truncate\\.to\\.(\\d+)\\.chars",(value,n)->{
+            counter.incrementAndGet();
+            assertThat(value).isEqualTo(Integer.toString(n) + "-chars");
+        });
+        assertThat(counter.get()).isEqualTo(2);
+        
+        // Use a regex that captures an integer using a regex group ...
+        counter.set(0);
+        config.forEachMatchingFieldNameWithInteger("column.mask.with.(\\d+).chars",(value,n)->{
+            counter.incrementAndGet();
+            assertThat(value).isEqualTo(Integer.toString(n) + "-mask");
+        });
+        assertThat(counter.get()).isEqualTo(2);
+        
+        // Use a regex that matches the name but also uses a regex group ...
+        counter.set(0);
+        config.forEachMatchingFieldName("column.mask.with.(\\d+).chars",(name,value)->{
+            counter.incrementAndGet();
+            assertThat(name).startsWith("column.mask.with.");
+            assertThat(name).endsWith(".chars");
+            assertThat(value).endsWith("-mask");
+        });
+        assertThat(counter.get()).isEqualTo(2);
+        
+        // Use a regex that matches all of our fields ...
+        counter.set(0);
+        config.forEachMatchingFieldName("column.*",(name,value)->{
+            counter.incrementAndGet();
+            assertThat(name).startsWith("column.");
+            assertThat(name).endsWith(".chars");
+            assertThat(value).isNotNull();
+        });
+        assertThat(counter.get()).isEqualTo(6);
+    }
+
+}

--- a/debezium-core/src/test/java/io/debezium/function/PredicatesTest.java
+++ b/debezium-core/src/test/java/io/debezium/function/PredicatesTest.java
@@ -17,8 +17,21 @@ import static org.fest.assertions.Assertions.assertThat;
 public class PredicatesTest {
 
     @Test
-    public void shouldWhitelistCommaSeparatedIntegers() {
-        Predicate<Integer> p = Predicates.whitelist("1,2,3,4,5",',', Integer::parseInt);
+    public void shouldMatchCommaSeparatedRegexIncludes() {
+        Predicate<String> p = Predicates.includes("1.*5,30");
+        assertThat(p.test("30")).isTrue();
+        assertThat(p.test("1005")).isTrue();
+        assertThat(p.test("105")).isTrue();
+        assertThat(p.test("15")).isTrue();
+        assertThat(p.test("215")).isFalse();
+        assertThat(p.test("150")).isFalse();
+        assertThat(p.test("015")).isFalse();
+        assertThat(p.test("5")).isFalse();
+    }
+
+    @Test
+    public void shouldMatchCommaSeparatedLiteralIncludes() {
+        Predicate<Integer> p = Predicates.includes("1,2,3,4,5", (i)->i.toString());
         assertThat(p.test(1)).isTrue();
         assertThat(p.test(2)).isTrue();
         assertThat(p.test(3)).isTrue();
@@ -30,8 +43,8 @@ public class PredicatesTest {
     }
 
     @Test
-    public void shouldBlacklistCommaSeparatedIntegers() {
-        Predicate<Integer> p = Predicates.blacklist("1,2,3,4,5",',', Integer::parseInt);
+    public void shouldMatchCommaSeparatedLiteralExcludes() {
+        Predicate<Integer> p = Predicates.excludes("1,2,3,4,5", (i)->i.toString());
         assertThat(p.test(1)).isFalse();
         assertThat(p.test(2)).isFalse();
         assertThat(p.test(3)).isFalse();

--- a/debezium-core/src/test/java/io/debezium/relational/ColumnMappersTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/ColumnMappersTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import java.sql.Types;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import io.debezium.util.Strings;
+
+/**
+ * @author Randall Hauch
+ */
+public class ColumnMappersTest {
+
+    private TableId tableId = new TableId("db", null, "A");
+    private Column column;
+    private Column column2;
+    private Column column3;
+    private ColumnMappers mappers;
+    private ValueConverter converter;
+    private String fullyQualifiedNames;
+
+    @Before
+    public void beforeEach() {
+        column = Column.editor().name("firstName").jdbcType(Types.VARCHAR).typeName("VARCHAR").position(1).create();
+        column2 = Column.editor().name("lastName").jdbcType(Types.VARCHAR).typeName("VARCHAR").position(2).create();
+        column3 = Column.editor().name("otherColumn").jdbcType(Types.VARCHAR).typeName("VARCHAR").position(3).create();
+        fullyQualifiedNames = tableId + "." + column.name() + ","
+                + tableId + "." + column3.name() + ",";
+    }
+
+    @Test
+    public void shouldNotFindMapperForUnmatchedColumn() {
+        mappers = ColumnMappers.create().truncateStrings(fullyQualifiedNames, 10).build();
+        converter = mappers.mapperFor(tableId, column2);
+        assertThat(converter).isNull();
+    }
+
+    @Test
+    public void shouldTruncateStrings() {
+        mappers = ColumnMappers.create().truncateStrings(fullyQualifiedNames.toUpperCase(), 10).build(); // inexact case
+        converter = mappers.mapperFor(tableId, column);
+        assertThat(converter).isNotNull();
+        assertThat(converter.convert("12345678901234567890").toString()).isEqualTo("1234567890");
+        assertThat(converter.convert("12345678901234567890").toString().length()).isEqualTo(10);
+        assertThat(converter.convert("12345678901").toString()).isEqualTo("1234567890");
+        assertThat(converter.convert("12345678901").toString().length()).isEqualTo(10);
+        assertThat(converter.convert("1234567890").toString()).isEqualTo("1234567890");
+        assertThat(converter.convert("1234567890").toString().length()).isEqualTo(10);
+        assertThat(converter.convert("123456789").toString()).isEqualTo("123456789");
+        assertThat(converter.convert("123456789").toString().length()).isEqualTo(9);
+        assertThat(converter.convert(null)).isNull();   // null values are unaltered
+    }
+
+    @Test
+    public void shouldMaskStringsToFixedLength() {
+        String maskValue = "**********";
+        mappers = ColumnMappers.create().maskStrings(fullyQualifiedNames, maskValue.length()).build(); // exact case
+        converter = mappers.mapperFor(tableId, column);
+        assertThat(converter).isNotNull();
+        assertThat(converter.convert("12345678901234567890")).isEqualTo(maskValue);
+        assertThat(converter.convert("12345678901")).isEqualTo(maskValue);
+        assertThat(converter.convert("1234567890")).isEqualTo(maskValue);
+        assertThat(converter.convert("123456789")).isEqualTo(maskValue);
+        assertThat(converter.convert(null)).isEqualTo(maskValue); // null values are masked, too
+    }
+
+    @Test
+    public void shouldMaskStringsToFixedNumberOfSpecifiedCharacters() {
+        char maskChar = '=';
+        String maskValue = Strings.createString(maskChar, 10);
+        mappers = ColumnMappers.create().maskStrings(fullyQualifiedNames, maskValue.length(), maskChar).build();
+        converter = mappers.mapperFor(tableId, column);
+        assertThat(converter).isNotNull();
+        assertThat(converter.convert("12345678901234567890")).isEqualTo(maskValue);
+        assertThat(converter.convert("12345678901")).isEqualTo(maskValue);
+        assertThat(converter.convert("1234567890")).isEqualTo(maskValue);
+        assertThat(converter.convert("123456789")).isEqualTo(maskValue);
+        assertThat(converter.convert(null)).isEqualTo(maskValue); // null values are masked, too
+    }
+
+    @Test
+    public void shouldMaskStringsWithSpecificValue() {
+        String maskValue = "*-*-*-*-*";
+        mappers = ColumnMappers.create().maskStrings(fullyQualifiedNames, maskValue).build(); // exact case
+        converter = mappers.mapperFor(tableId, column);
+        assertThat(converter).isNotNull();
+        assertThat(converter.convert("12345678901234567890")).isEqualTo(maskValue);
+        assertThat(converter.convert("12345678901")).isEqualTo(maskValue);
+        assertThat(converter.convert("1234567890")).isEqualTo(maskValue);
+        assertThat(converter.convert("123456789")).isEqualTo(maskValue);
+        assertThat(converter.convert(null)).isEqualTo(maskValue); // null values are masked, too
+    }
+
+    @Test
+    public void shouldMapValuesUsingColumnMapperInstance() {
+        RepeatingColumnMapper mapper = new RepeatingColumnMapper();
+        mappers = ColumnMappers.create().map(fullyQualifiedNames, mapper).build();
+        converter = mappers.mapperFor(tableId, column);
+        assertThat(converter).isNotNull();
+        assertThat(converter.convert("1234")).isEqualTo("12341234");
+        assertThat(converter.convert("a")).isEqualTo("aa");
+        assertThat(converter.convert(null)).isNull();
+    }
+
+    @Test
+    public void shouldMapValuesUsingFunctionByClassName() {
+        mappers = ColumnMappers.create().map(fullyQualifiedNames, RepeatingColumnMapper.class.getName()).build();
+        converter = mappers.mapperFor(tableId, column);
+        assertThat(converter).isNotNull();
+        assertThat(converter.convert("1234")).isEqualTo("12341234");
+        assertThat(converter.convert("a")).isEqualTo("aa");
+        assertThat(converter.convert(null)).isNull();
+    }
+
+    public static class RepeatingColumnMapper implements ColumnMapper {
+        @Override
+        public ValueConverter create(Column column) {
+            return (value) -> value == null ? null : value.toString() + value.toString();
+        }
+    }
+
+}

--- a/debezium-core/src/test/java/io/debezium/relational/SelectorsTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/SelectorsTest.java
@@ -14,13 +14,30 @@ import static org.fest.assertions.Assertions.assertThat;
 /**
  * @author Randall Hauch
  */
-public class TableIdTest {
+public class SelectorsTest {
 
     private Predicate<TableId> filter;
 
     @Test
+    public void shouldCreateFilterWithAllLists() {
+        filter = Selectors.tableSelector()
+                          .includeDatabases("connector_test")
+                          .excludeDatabases("")
+                          .includeTables("")
+                          .excludeTables("")
+                          .build();
+        assertAllowed(filter, "connector_test", "A");
+        assertAllowed(filter, "connector_test", "B");
+        assertNotAllowed(filter, "other_test", "A");
+        assertNotAllowed(filter, "other_test", "B");
+    }
+
+    @Test
     public void shouldCreateFilterWithDatabaseWhitelistAndTableWhitelist() {
-        filter = TableId.filter("db1,db2", null, "db1.A,db1.B,db2.C", null);
+        filter = Selectors.tableSelector()
+                          .includeDatabases("db1,db2")
+                          .includeTables("db1\\.A,db1\\.B,db2\\.C")
+                          .build();
 
         assertAllowed(filter, "db1", "A");
         assertAllowed(filter, "db1", "B");
@@ -38,7 +55,10 @@ public class TableIdTest {
 
     @Test
     public void shouldCreateFilterWithDatabaseWhitelistAndTableBlacklist() {
-        filter = TableId.filter("db1,db2", null, null, "db1.A,db1.B,db2.C");
+        filter = Selectors.tableSelector()
+                          .includeDatabases("db1,db2")
+                          .excludeTables("db1\\.A,db1\\.B,db2\\.C")
+                          .build();
 
         assertNotAllowed(filter, "db1", "A");
         assertNotAllowed(filter, "db1", "B");
@@ -56,7 +76,10 @@ public class TableIdTest {
 
     @Test
     public void shouldCreateFilterWithDatabaseBlacklistAndTableWhitelist() {
-        filter = TableId.filter(null,"db3,db4", "db1.A,db1.B,db2.C", null);
+        filter = Selectors.tableSelector()
+                          .excludeDatabases("db3,db4")
+                          .includeTables("db1\\.A,db1\\.B,db2\\.C")
+                          .build();
 
         assertAllowed(filter, "db1", "A");
         assertAllowed(filter, "db1", "B");
@@ -74,7 +97,10 @@ public class TableIdTest {
 
     @Test
     public void shouldCreateFilterWithDatabaseBlacklistAndTableBlacklist() {
-        filter = TableId.filter(null,"db3,db4", null, "db1.A,db1.B,db2.C");
+        filter = Selectors.tableSelector()
+                          .excludeDatabases("db3,db4")
+                          .excludeTables("db1\\.A,db1\\.B,db2\\.C")
+                          .build();
 
         assertNotAllowed(filter, "db1", "A");
         assertNotAllowed(filter, "db1", "B");
@@ -92,7 +118,9 @@ public class TableIdTest {
 
     @Test
     public void shouldCreateFilterWithNoDatabaseFilterAndTableWhitelist() {
-        filter = TableId.filter(null, null, "db1.A,db1.B,db2.C", null);
+        filter = Selectors.tableSelector()
+                          .includeTables("db1\\.A,db1\\.B,db2\\.C")
+                          .build();
 
         assertAllowed(filter, "db1", "A");
         assertAllowed(filter, "db1", "B");
@@ -110,7 +138,9 @@ public class TableIdTest {
 
     @Test
     public void shouldCreateFilterWithNoDatabaseFilterAndTableBlacklist() {
-        filter = TableId.filter(null, null, null, "db1.A,db1.B,db2.C");
+        filter = Selectors.tableSelector()
+                          .excludeTables("db1\\.A,db1\\.B,db2\\.C")
+                          .build();
 
         assertNotAllowed(filter, "db1", "A");
         assertNotAllowed(filter, "db1", "B");
@@ -128,7 +158,9 @@ public class TableIdTest {
 
     @Test
     public void shouldCreateFilterWithDatabaseWhitelistAndNoTableFilter() {
-        filter = TableId.filter("db1,db2", null, null, null);
+        filter = Selectors.tableSelector()
+                          .includeDatabases("db1,db2")
+                          .build();
 
         assertAllowed(filter, "db1", "A");
         assertAllowed(filter, "db2", "A");
@@ -138,7 +170,9 @@ public class TableIdTest {
 
     @Test
     public void shouldCreateFilterWithDatabaseBlacklistAndNoTableFilter() {
-        filter = TableId.filter(null, "db1,db2", null, null);
+        filter = Selectors.tableSelector()
+                          .excludeDatabases("db1,db2")
+                          .build();
 
         assertNotAllowed(filter, "db1", "A");
         assertNotAllowed(filter, "db2", "A");

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -58,7 +58,7 @@ public abstract class AbstractConnectorTest implements Testing {
     private CountDownLatch latch;
 
     @Before
-    public final void initializeConnectorTestFramework() throws Exception {
+    public final void initializeConnectorTestFramework() {
         resetBeforeEachTest();
         consumedLines = new ArrayBlockingQueue<>(getMaximumEnqueuedRecordCount());
         Testing.Files.delete(OFFSET_STORE_PATH);


### PR DESCRIPTION
Changes the MySQL connector to use regular expressions in the database and table blacklist/whitelists, and adds support for excluding, truncating, and masking certain columns.

### Using regular expression patterns
Changed the MySQL connector to use comma-separated lists of regular expressions for the database and table whitelist/blacklists. Literals are still accepted and will match fully-qualified table names, although the `.` character used as a delimiter is also a special character in regular expressions and therefore may need to be escaped (e.g., preceded by a double backslash (`\\`) or surrounded by square brackets) to more carefully match fully-qualified table names.

### Excluding columns
Added several new configuration properties for the MySQL connector that instruct it to hide, truncate, and/or mask certain columns. The properties' values are all lists of regular expressions or literal fully-qualified column names. For example, the following configuration property:

    column.blacklist=server.users.picture,server.users.other

will cause the connector to leave out of change event messages for the `server.users` table those fields that correspond to the `picture` and `others` columns. 

Excluding columns in change events can help prevent dissemination of sensitive information.

### Masking columns
An alternative to excluding/blacklisting columns is _masking_ them. The following configuration property:

    column.mask.with.10.chars=server\\.users\\.(\\w*email)

will cause the connector to mask in the change event messages for the `server.users` table all values for columns whose name ends in `email`. The values will be replaced in this case with a constant string of 10 asterisk (`*`) characters, even when the email value is null. Although this example used a mask of 10 characters, any positive length can be specified; separate properties should be used when different mask lengths are required. 

Masking columns in change events can help prevent dissemination of sensitive information.

### Truncating columns
It is also possible to truncate string values of specific columns to reduce the potential size of change events. The following configuration property:

    column.truncate.to.120.chars=server[.]users[.](description|biography)

is an example that shows how to configure the connector to truncate to at most 120 characters the values of the `description` and `biography` columns in the change event messages for the `server.users` table. Although this example used a limit of 120 characters, any positive length can be specified; separate properties should be used when different lengths are required. Note how the `.` delimiter in the fully-qualified names is escaped since that same character is a special character in regular expressions; this escaping of the `.` characters may not be required in all cases, but it is recommended.