### PR TITLE
DBZ-44 Generate a tombstone for old key when row's key is changed

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/TableConverters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/TableConverters.java
@@ -307,6 +307,17 @@ final class TableConverters {
                                 keySchema, key, valueSchema, value);
                         recorder.accept(record);
                     }
+
+                    // Check whether the key for this record changed in the update ...
+                    Object oldKey = converter.createKey(before, includedColumns);
+                    if ( key != null && !Objects.equals(key, oldKey)) {
+                        // The key has indeed changed, so also send a delete/tombstone event for the old key ...
+                        value = converter.deleted(before, includedColumnsBefore);
+                        if ( value == null ) valueSchema = null;
+                        SourceRecord record = new SourceRecord(source.partition(), source.offset(row), topic, partition,
+                                keySchema, oldKey, valueSchema, value);
+                        recorder.accept(record);
+                    }
                 }
             } else if (logger.isDebugEnabled()) {
                 logger.debug("Skipping update row event: {}", event);

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -318,6 +318,35 @@ public abstract class AbstractConnectorTest implements Testing {
         assertThat(consumedLines.isEmpty()).isTrue();
     }
 
+    protected void assertKey(SourceRecord record, String pkField, int pk) {
+        Struct key = (Struct) record.key();
+        assertThat(key.get(pkField)).isEqualTo(pk);
+    }
+
+    protected void assertTombstone(SourceRecord record) {
+        assertThat(record.key()).isNotNull();
+        assertThat(record.keySchema()).isNotNull();
+        assertThat(record.value()).isNull();
+        assertThat(record.valueSchema()).isNull();
+    }
+
+    protected void assertTombstone(SourceRecord record, String pkField, int pk) {
+        assertKey(record,pkField,pk);
+        assertTombstone(record);
+    }
+
+    protected void assertInsert(SourceRecord record, String pkField, int pk) {
+        assertKey(record,pkField,pk);
+        assertThat(record.key()).isNotNull();
+        assertThat(record.keySchema()).isNotNull();
+        assertThat(record.value()).isNotNull();
+        assertThat(record.valueSchema()).isNotNull();
+    }
+
+    protected void assertUpdate(SourceRecord record, String pkField, int pk) {
+        assertInsert(record,pkField,pk);    // currently the same as an insert
+    }
+
     protected void print(SourceRecord record) {
         StringBuilder sb = new StringBuilder("SourceRecord{");
         sb.append("sourcePartition=").append(record.sourcePartition());
@@ -399,8 +428,7 @@ public abstract class AbstractConnectorTest implements Testing {
                 append(field.schema(), sb);
             }
             sb.append('}');
-        }
-        if (obj instanceof Struct) {
+        } else if (obj instanceof Struct) {
             Struct s = (Struct) obj;
             sb.append('{');
             boolean first = true;


### PR DESCRIPTION
When a row is updated in the database and the primary/unique key for that table is changed, the MySQL connector continues to generate an update event with the new key and new value, but now also generates a _tombstone event_ for the old key. This ensures that when a Kafka topic is compacted, all prior events with the old key will (eventually) be removed. It also ensures that consumers see that the row represented by the old key has been removed.