### PR TITLE
DBZ-53 NPE in integration tests because of faulty "append" logic for …

### DIFF
--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -331,7 +331,7 @@ public abstract class AbstractConnectorTest implements Testing {
             }
             sb.append('}');
         }
-        if (obj instanceof Struct) {
+        else if (obj instanceof Struct) {
             Struct s = (Struct) obj;
             sb.append('{');
             boolean first = true;


### PR DESCRIPTION
…AbstractConnectorTest