### PR TITLE
DBZ-52 Added top-level container structure to all messages

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -87,6 +87,7 @@ public final class MySqlConnectorTask extends SourceTask {
     private int maxBatchSize;
     private String serverName;
     private Metronome metronome;
+    private final Clock clock = Clock.system();
     private final AtomicBoolean running = new AtomicBoolean(false);
 
     // Used in the methods that process events ...
@@ -176,8 +177,8 @@ public final class MySqlConnectorTask extends SourceTask {
 
         // Set up our handlers for specific kinds of events ...
         tables = new Tables();
-        tableConverters = new TableConverters(topicSelector, dbHistory, includeSchemaChanges, tables, tableFilter, columnFilter,
-                columnMappers);
+        tableConverters = new TableConverters(topicSelector, dbHistory, includeSchemaChanges, clock,
+                                              tables, tableFilter, columnFilter, columnMappers);
         eventHandlers.put(EventType.ROTATE, tableConverters::rotateLogs);
         eventHandlers.put(EventType.TABLE_MAP, tableConverters::updateTableMetadata);
         eventHandlers.put(EventType.QUERY, tableConverters::updateTableCommand);

--- a/debezium-core/src/main/java/io/debezium/data/Envelope.java
+++ b/debezium-core/src/main/java/io/debezium/data/Envelope.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.data;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+/**
+ * An immutable descriptor for the structure of Debezium message envelopes. An {@link Envelope} can be created for each message
+ * schema using the {@link #defineSchema()} builder, and once created can generate {@link Struct} objects representing CREATE,
+ * READ, UPDATE, and DELETE messages that conform to that schema.
+ * 
+ * @author Randall Hauch
+ */
+public final class Envelope {
+
+    /**
+     * The constants for the values for the {@link FieldName#OPERATION operation} field in the message envelope.
+     */
+    public static final class Operation {
+        /**
+         * The operation that read the current state of a record, most typically during snapshots.
+         */
+        public static final String READ = "r";
+        /**
+         * An operation that resulted in a new record being created in the source.
+         */
+        public static final String CREATE = "c";
+        /**
+         * An operation that resulted in an existing record being updated in the source.
+         */
+        public static final String UPDATE = "u";
+        /**
+         * An operation that resulted in an existing record being removed from or deleted in the source.
+         */
+        public static final String DELETE = "d";
+    }
+
+    /**
+     * The constants for the names of the fields in the message envelope.
+     */
+    public static final class FieldName {
+        /**
+         * The {@code before} field is used to store the state of a record before an operation.
+         */
+        public static final String BEFORE = "before";
+        /**
+         * The {@code after} field is used to store the state of a record after an operation.
+         */
+        public static final String AFTER = "after";
+        /**
+         * The {@code op} field is used to store the kind of operation on a record.
+         */
+        public static final String OPERATION = "op";
+        /**
+         * The {@code origin} field is used to store the information about the source of a record, including the
+         * Kafka Connect partition and offset information.
+         */
+        public static final String SOURCE = "source";
+        /**
+         * The {@code ts} field is used to store the information about the local time at which the connector processed/generated
+         * the event. Note that the accuracy of the timestamp is not defined, and the values may not always be monotonically
+         * increasing.
+         */
+        public static final String TIMESTAMP = "ts";
+    }
+
+    /**
+     * Flag that specifies whether the {@link FieldName#OPERATION} field is required within the envelope.
+     */
+    public static final int VERSION = 1;
+
+    /**
+     * Flag that specifies whether the {@link FieldName#OPERATION} field is required within the envelope.
+     */
+    public static final boolean OPERATION_REQUIRED = true;
+
+    /**
+     * The immutable set of all {@link FieldName}s.
+     */
+    public static final Set<String> ALL_FIELD_NAMES;
+
+    static {
+        Set<String> fields = new HashSet<>();
+        fields.add(FieldName.OPERATION);
+        fields.add(FieldName.TIMESTAMP);
+        fields.add(FieldName.BEFORE);
+        fields.add(FieldName.AFTER);
+        fields.add(FieldName.SOURCE);
+        ALL_FIELD_NAMES = Collections.unmodifiableSet(fields);
+    }
+
+    /**
+     * A builder of an envelope schema.
+     */
+    public static interface Builder {
+        /**
+         * Define the {@link Schema} used in the {@link FieldName#BEFORE} and {@link FieldName#AFTER} fields.
+         * 
+         * @param schema the schema of the records, used in the {@link FieldName#BEFORE} and {@link FieldName#AFTER} fields; may
+         *            not be null
+         * @return this builder so methods can be chained; never null
+         */
+        default Builder withRecord(Schema schema) {
+            return withSchema(schema, FieldName.BEFORE, FieldName.AFTER);
+        }
+
+        /**
+         * Define the {@link Schema} used in the {@link FieldName#SOURCE} field.
+         * 
+         * @param sourceSchema the schema of the {@link FieldName#SOURCE} field; may not be null
+         * @return this builder so methods can be chained; never null
+         */
+        default Builder withSource(Schema sourceSchema) {
+            return withSchema(sourceSchema, FieldName.SOURCE);
+        }
+
+        /**
+         * Define the {@link Schema} used for an arbitrary field in the envelope.
+         * 
+         * @param fieldNames the names of the fields that this schema should be used with; may not be null
+         * @param fieldSchema the schema of the new optional field; may not be null
+         * @return this builder so methods can be chained; never null
+         */
+        Builder withSchema(Schema fieldSchema, String... fieldNames);
+
+        /**
+         * Define the name for the schema.
+         * 
+         * @param name the name
+         * @return this builder so methods can be chained; never null
+         */
+        Builder withName(String name);
+
+        /**
+         * Define the documentation for the schema.
+         * 
+         * @param doc the documentation
+         * @return this builder so methods can be chained; never null
+         */
+        Builder withDoc(String doc);
+
+        /**
+         * Create the message envelope descriptor.
+         * 
+         * @return the envelope schema; never null
+         */
+        Envelope build();
+    }
+
+    public static Builder defineSchema() {
+        return new Builder() {
+            private SchemaBuilder builder = SchemaBuilder.struct();
+            private Set<String> missingFields = new HashSet<>();
+
+            @Override
+            public Builder withSchema(Schema fieldSchema, String... fieldNames) {
+                for (String fieldName : fieldNames) {
+                    builder.field(fieldName, fieldSchema);
+                }
+                return this;
+            }
+
+            @Override
+            public Builder withName(String name) {
+                builder.name(name);
+                return this;
+            }
+
+            @Override
+            public Builder withDoc(String doc) {
+                builder.doc(doc);
+                return this;
+            }
+
+            @Override
+            public Envelope build() {
+                builder.field(FieldName.OPERATION, OPERATION_REQUIRED ? Schema.STRING_SCHEMA : Schema.OPTIONAL_STRING_SCHEMA);
+                builder.field(FieldName.TIMESTAMP, Schema.OPTIONAL_INT64_SCHEMA);
+                builder.version(VERSION);
+                checkFieldIsDefined(FieldName.OPERATION, OPERATION_REQUIRED);
+                checkFieldIsDefined(FieldName.BEFORE, false);
+                checkFieldIsDefined(FieldName.AFTER, false);
+                checkFieldIsDefined(FieldName.SOURCE, false);
+                if (!missingFields.isEmpty()) {
+                    throw new IllegalStateException("The envelope schema is missing field(s) " + String.join(", ", missingFields));
+                }
+                return new Envelope(builder.build());
+            }
+
+            private void checkFieldIsDefined(String fieldName, boolean required) {
+                if (builder.field(fieldName) == null) missingFields.add(fieldName);
+            }
+        };
+    }
+
+    private final Schema schema;
+
+    private Envelope(Schema schema) {
+        this.schema = schema;
+    }
+
+    /**
+     * Get the {@link Schema} describing the message envelopes and their content.
+     * 
+     * @return the schema; never null
+     */
+    public Schema schema() {
+        return schema;
+    }
+
+    /**
+     * Generate a {@link Operation#READ read} message with the given information.
+     * 
+     * @param record the state of the record as read; may not be null
+     * @param source the information about the source that was read; may be null
+     * @param timestamp the timestamp for this message; may be null
+     * @return the read message; never null
+     */
+    public Struct read(Struct record, Struct source, Long timestamp) {
+        Struct struct = new Struct(schema);
+        struct.put(FieldName.OPERATION, Operation.READ);
+        struct.put(FieldName.AFTER, record);
+        if (source != null) struct.put(FieldName.SOURCE, source);
+        if (timestamp != null) struct.put(FieldName.TIMESTAMP, timestamp);
+        return struct;
+    }
+
+    /**
+     * Generate a {@link Operation#CREATE read} message with the given information.
+     * 
+     * @param record the state of the record after creation; may not be null
+     * @param source the information about the source where the creation occurred; may be null
+     * @param timestamp the timestamp for this message; may be null
+     * @return the create message; never null
+     */
+    public Struct create(Struct record, Struct source, Long timestamp) {
+        Struct struct = new Struct(schema);
+        struct.put(FieldName.OPERATION, Operation.CREATE);
+        struct.put(FieldName.AFTER, record);
+        if (source != null) struct.put(FieldName.SOURCE, source);
+        if (timestamp != null) struct.put(FieldName.TIMESTAMP, timestamp);
+        return struct;
+    }
+
+    /**
+     * Generate an {@link Operation#UPDATE update} message with the given information.
+     * 
+     * @param before the state of the record before the update; may be null
+     * @param after the state of the record after the update; may not be null
+     * @param source the information about the source where the update occurred; may be null
+     * @param timestamp the timestamp for this message; may be null
+     * @return the update message; never null
+     */
+    public Struct update(Struct before, Struct after, Struct source, Long timestamp) {
+        Struct struct = new Struct(schema);
+        struct.put(FieldName.OPERATION, Operation.UPDATE);
+        if (before != null) struct.put(FieldName.BEFORE, before);
+        struct.put(FieldName.AFTER, after);
+        if (source != null) struct.put(FieldName.SOURCE, source);
+        if (timestamp != null) struct.put(FieldName.TIMESTAMP, timestamp);
+        return struct;
+    }
+
+    /**
+     * Generate an {@link Operation#DELETE delete} message with the given information.
+     * 
+     * @param before the state of the record before the delete; may be null
+     * @param source the information about the source where the deletion occurred; may be null
+     * @param timestamp the timestamp for this message; may be null
+     * @return the delete message; never null
+     */
+    public Struct delete(Struct before, Struct source, Long timestamp) {
+        Struct struct = new Struct(schema);
+        struct.put(FieldName.OPERATION, Operation.DELETE);
+        if (before != null) struct.put(FieldName.BEFORE, before);
+        if (source != null) struct.put(FieldName.SOURCE, source);
+        if (timestamp != null) struct.put(FieldName.TIMESTAMP, timestamp);
+        return struct;
+    }
+
+}

--- a/debezium-core/src/main/java/io/debezium/data/SchemaUtil.java
+++ b/debezium-core/src/main/java/io/debezium/data/SchemaUtil.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.data;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.Struct;
+
+/**
+ * Utilities for obtaining JSON string representations of {@link Schema}, {@link Struct}, and {@link Field} objects.
+ * 
+ * @author Randall Hauch
+ */
+public class SchemaUtil {
+
+    private SchemaUtil() {
+    }
+
+    /**
+     * Obtain a JSON string representation of the specified field.
+     * 
+     * @param field the field; may not be null
+     * @return the JSON string representation
+     */
+    public static String asString(Field field) {
+        StringBuilder sb = new StringBuilder();
+        append(field, sb);
+        return sb.toString();
+    }
+
+    /**
+     * Obtain a JSON string representation of the specified {@link Struct}.
+     * 
+     * @param struct the {@link Struct}; may not be null
+     * @return the JSON string representation
+     */
+    public static String asString(Struct struct) {
+        StringBuilder sb = new StringBuilder();
+        append(struct, sb);
+        return sb.toString();
+    }
+
+    /**
+     * Obtain a JSON string representation of the specified {@link Schema}.
+     * 
+     * @param schema the {@link Schema}; may not be null
+     * @return the JSON string representation
+     */
+    public static String asString(Schema schema) {
+        StringBuilder sb = new StringBuilder();
+        append(schema, sb);
+        return sb.toString();
+    }
+
+    protected static void append(Object obj, StringBuilder sb) {
+        if (obj == null) {
+            sb.append("null");
+        } else if (obj instanceof Schema) {
+            Schema schema = (Schema) obj;
+            sb.append('{');
+            if (schema.name() != null) {
+                appendFirst(sb, "name", schema.name());
+                appendAdditional(sb, "type", schema.type());
+            } else {
+                appendFirst(sb, "type", schema.type());
+            }
+            appendAdditional(sb, "optional", schema.isOptional());
+            if (schema.doc() != null) appendAdditional(sb, "doc", schema.doc());
+            if (schema.version() != null) appendAdditional(sb, "version", schema.version());
+            switch (schema.type()) {
+                case STRUCT:
+                    appendAdditional(sb, "fields", schema.fields());
+                    break;
+                case MAP:
+                    appendAdditional(sb, "key", schema.keySchema());
+                    appendAdditional(sb, "value", schema.valueSchema());
+                    break;
+                case ARRAY:
+                    appendAdditional(sb, "value", schema.valueSchema());
+                    break;
+                default:
+            }
+            sb.append('}');
+        } else if (obj instanceof Struct) {
+            Struct s = (Struct) obj;
+            sb.append('{');
+            boolean first = true;
+            for (Field field : s.schema().fields()) {
+                if (first)
+                    first = false;
+                else
+                    sb.append(", ");
+                appendFirst(sb, field.name(), s.get(field));
+            }
+            sb.append('}');
+        } else if (obj instanceof Map<?, ?>) {
+            Map<?, ?> map = (Map<?, ?>) obj;
+            sb.append('{');
+            boolean first = true;
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if (first)
+                    first = false;
+                else
+                    sb.append(", ");
+                sb.append("{ ");
+                appendFirst(sb, "key", entry.getKey());
+                appendAdditional(sb, "value", entry.getValue());
+                sb.append(" } ");
+            }
+            sb.append('}');
+        } else if (obj instanceof List<?>) {
+            List<?> list = (List<?>) obj;
+            sb.append('[');
+            boolean first = true;
+            for (Object value : list) {
+                if (first)
+                    first = false;
+                else
+                    sb.append(", ");
+                append(value, sb);
+            }
+            sb.append(']');
+        } else if (obj instanceof Field) {
+            Field f = (Field) obj;
+            sb.append('{');
+            appendFirst(sb, "name", f.name());
+            appendAdditional(sb, "index", f.index());
+            appendAdditional(sb, "schema", f.schema());
+            sb.append('}');
+        } else if (obj instanceof String) {
+            sb.append('"').append(obj.toString()).append('"');
+        } else if (obj instanceof Type) {
+            sb.append('"').append(obj.toString()).append('"');
+        } else {
+            sb.append(obj.toString());
+        }
+    }
+
+    protected static void appendFirst(StringBuilder sb, String name, Object value) {
+        append(name, sb);
+        sb.append(" : ");
+        append(value, sb);
+    }
+
+    protected static void appendAdditional(StringBuilder sb, String name, Object value) {
+        sb.append(", ");
+        append(name, sb);
+        sb.append(" : ");
+        append(value, sb);
+    }
+
+}

--- a/debezium-core/src/main/java/io/debezium/relational/TableSchemaBuilder.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableSchemaBuilder.java
@@ -145,7 +145,7 @@ public class TableSchemaBuilder {
                 addField(valSchemaBuilder, column, mapper);
             }
         });
-        Schema valSchema = valSchemaBuilder.build();
+        Schema valSchema = valSchemaBuilder.optional().build();
         Schema keySchema = hasPrimaryKey.get() ? keySchemaBuilder.build() : null;
 
         // Create the generators ...

--- a/debezium-core/src/test/java/io/debezium/data/EnvelopeTest.java
+++ b/debezium-core/src/test/java/io/debezium/data/EnvelopeTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.data;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Randall Hauch
+ *
+ */
+public class EnvelopeTest {
+
+    @Test
+    public void shouldBuildWithSimpleOptionalTypesForBeforeAndAfter() {
+        Envelope env = Envelope.defineSchema()
+                               .withName("someName")
+                               .withRecord(Schema.OPTIONAL_STRING_SCHEMA)
+                               .withSource(Schema.OPTIONAL_INT64_SCHEMA)
+                               .build();
+        assertThat(env.schema()).isNotNull();
+        assertThat(env.schema().name()).isEqualTo("someName");
+        assertThat(env.schema().doc()).isNull();
+        assertOptionalField(env, Envelope.FieldName.AFTER, Schema.OPTIONAL_STRING_SCHEMA);
+        assertOptionalField(env, Envelope.FieldName.BEFORE, Schema.OPTIONAL_STRING_SCHEMA);
+        assertOptionalField(env, Envelope.FieldName.SOURCE, Schema.OPTIONAL_INT64_SCHEMA);
+        assertRequiredField(env, Envelope.FieldName.OPERATION, Schema.STRING_SCHEMA);
+    }
+
+    protected void assertRequiredField(Envelope env, String fieldName, Schema expectedSchema) {
+        assertField(env.schema().field(fieldName),fieldName,expectedSchema, false);
+    }
+
+    protected void assertOptionalField(Envelope env, String fieldName, Schema expectedSchema) {
+        assertField(env.schema().field(fieldName),fieldName,expectedSchema, true);
+    }
+
+    protected void assertField(Field field, String fieldName, Schema expectedSchema, boolean optional) {
+        assertThat(field.name()).isEqualTo(fieldName);
+        Schema schema = field.schema();
+        assertThat(schema.name()).isEqualTo(expectedSchema.name());
+        assertThat(schema.doc()).isEqualTo(expectedSchema.doc());
+        assertThat(schema.parameters()).isEqualTo(expectedSchema.parameters());
+        assertThat(schema.version()).isEqualTo(expectedSchema.version());
+        assertThat(schema.isOptional()).isEqualTo(optional);
+        switch (expectedSchema.type()) {
+            case STRUCT:
+                for (Field f : expectedSchema.fields()) {
+                    assertField(schema.field(f.name()),f.name(),f.schema(),f.schema().isOptional());
+                }
+                break;
+            default:
+        }
+    }
+
+}


### PR DESCRIPTION
The new envelope Struct contains fields for the local time at which the connector processed the event, the kind of operation (e.g., read, insert, update, or delete), the state of the record before and after the change, and the information about the event source. The latter two items are connector-specific. The timestamp is merely the time using the connector's process clock, and no guarantees are provided about accuracy, monotonicity, or relationship to the original source event.

The envelope structure is now used as the value for each event message in the MySQL connector; they keys of the event messages remain unchanged. Note that to facilitate Kafka log compaction (which requires a null value), a delete event containing the envelope with details about the deletion is followed by a "tombstone" event that contains the same key but null value.

An example of a message value with this new envelope is as follows:

```
{
    "schema" : {
      "type" : "struct",
      "fields" : [ {
        "type" : "struct",
        "fields" : [ {
          "type" : "int32",
          "optional" : false,
          "name" : "org.apache.kafka.connect.data.Date",
          "version" : 1,
          "field" : "order_date"
        }, {
          "type" : "int32",
          "optional" : false,
          "field" : "purchaser"
        }, {
          "type" : "int32",
          "optional" : false,
          "field" : "quantity"
        }, {
          "type" : "int32",
          "optional" : false,
          "field" : "product_id"
        } ],
        "optional" : true,
        "name" : "connector_test.orders",
        "field" : "before"
      }, {
        "type" : "struct",
        "fields" : [ {
          "type" : "int32",
          "optional" : false,
          "name" : "org.apache.kafka.connect.data.Date",
          "version" : 1,
          "field" : "order_date"
        }, {
          "type" : "int32",
          "optional" : false,
          "field" : "purchaser"
        }, {
          "type" : "int32",
          "optional" : false,
          "field" : "quantity"
        }, {
          "type" : "int32",
          "optional" : false,
          "field" : "product_id"
        } ],
        "optional" : true,
        "name" : "connector_test.orders",
        "field" : "after"
      }, {
        "type" : "struct",
        "fields" : [ {
          "type" : "string",
          "optional" : false,
          "field" : "server"
        }, {
          "type" : "string",
          "optional" : false,
          "field" : "file"
        }, {
          "type" : "int64",
          "optional" : false,
          "field" : "pos"
        }, {
          "type" : "int32",
          "optional" : false,
          "field" : "row"
        } ],
        "optional" : false,
        "name" : "io.debezium.connector.mysql.Source",
        "field" : "source"
      }, {
        "type" : "string",
        "optional" : false,
        "field" : "op"
      }, {
        "type" : "int64",
        "optional" : true,
        "field" : "ts"
      } ],
      "optional" : false,
      "name" : "kafka-connect-2.connector_test.orders",
      "version" : 1
    },
    "payload" : {
      "before" : null,
      "after" : {
        "order_date" : 16852,
        "purchaser" : 1003,
        "quantity" : 1,
        "product_id" : 107
      },
      "source" : {
        "server" : "kafka-connect-2",
        "file" : "mysql-bin.000002",
        "pos" : 2887680,
        "row" : 4
      },
      "op" : "c",
      "ts" : 1463437199134
    }
}
```
Notice how the Schema is significantly larger, since it must describe all of the envelope's fields even when those fields are not used. In this case, the event signifies that a record was created as the 4th record of a single event recorded in the binlog.