### PR TITLE
DBZ-57 Support CHARSET alias for CHARACTER SET

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
@@ -80,6 +80,10 @@ public class MySqlDdlParser extends DdlParser {
         dataTypes.register(Types.BLOB, "VARCHAR(L) BINARY [CHARACTER SET charset_name] [COLLATE collation_name]");
         dataTypes.register(Types.VARCHAR, "CHAR[(L)] [CHARACTER SET charset_name] [COLLATE collation_name]");
         dataTypes.register(Types.VARCHAR, "VARCHAR(L) [CHARACTER SET charset_name] [COLLATE collation_name]");
+        dataTypes.register(Types.BLOB, "CHAR[(L)] BINARY [CHARSET charset_name] [COLLATE collation_name]");
+        dataTypes.register(Types.BLOB, "VARCHAR(L) BINARY [CHARSET charset_name] [COLLATE collation_name]");
+        dataTypes.register(Types.VARCHAR, "CHAR[(L)] [CHARSET charset_name] [COLLATE collation_name]");
+        dataTypes.register(Types.VARCHAR, "VARCHAR(L) [CHARSET charset_name] [COLLATE collation_name]");
         dataTypes.register(Types.CHAR, "BINARY[(L)]");
         dataTypes.register(Types.VARBINARY, "VARBINARY(L)");
         dataTypes.register(Types.BLOB, "TINYBLOB");
@@ -96,6 +100,16 @@ public class MySqlDdlParser extends DdlParser {
         dataTypes.register(Types.VARCHAR, "LONGTEXT [CHARACTER SET charset_name] [COLLATE collation_name]");
         dataTypes.register(Types.CHAR, "ENUM(...) [CHARACTER SET charset_name] [COLLATE collation_name]");
         dataTypes.register(Types.CHAR, "SET(...) [CHARACTER SET charset_name] [COLLATE collation_name]");
+        dataTypes.register(Types.BLOB, "TINYTEXT BINARY [CHARSET charset_name] [COLLATE collation_name]");
+        dataTypes.register(Types.BLOB, "TEXT BINARY [CHARSET charset_name] [COLLATE collation_name]");
+        dataTypes.register(Types.BLOB, "MEDIUMTEXT BINARY [CHARSET charset_name] [COLLATE collation_name]");
+        dataTypes.register(Types.BLOB, "LONGTEXT BINARY [CHARSET charset_name] [COLLATE collation_name]");
+        dataTypes.register(Types.VARCHAR, "TINYTEXT [CHARSET charset_name] [COLLATE collation_name]");
+        dataTypes.register(Types.VARCHAR, "TEXT [CHARSET charset_name] [COLLATE collation_name]");
+        dataTypes.register(Types.VARCHAR, "MEDIUMTEXT [CHARSET charset_name] [COLLATE collation_name]");
+        dataTypes.register(Types.VARCHAR, "LONGTEXT [CHARSET charset_name] [COLLATE collation_name]");
+        dataTypes.register(Types.CHAR, "ENUM(...) [CHARSET charset_name] [COLLATE collation_name]");
+        dataTypes.register(Types.CHAR, "SET(...) [CHARSET charset_name] [COLLATE collation_name]");
         dataTypes.register(Types.OTHER, "JSON");
     }
 
@@ -839,12 +853,16 @@ public class MySqlDdlParser extends DdlParser {
             newTableName.accept(newTableId);
         } else if (tokens.canConsume("ORDER", "BY")) {
             consumeCommaSeparatedValueList(start); // this should not affect the order of the columns in the table
-        } else if (tokens.canConsume("CONVERT", "TO", "CHARACTER", "SET")) {
+        } else if (tokens.canConsume("CONVERT", "TO", "CHARACTER", "SET")
+                || tokens.canConsume("CONVERT", "TO", "CHARSET")) {
             tokens.consume(); // charset name
             if (tokens.canConsume("COLLATE")) {
                 tokens.consume(); // collation name
             }
-        } else if (tokens.canConsume("CHARACTER", "SET") || tokens.canConsume("DEFAULT", "CHARACTER", "SET")) {
+        } else if (tokens.canConsume("CHARACTER", "SET")
+                || tokens.canConsume("CHARSET")
+                || tokens.canConsume("DEFAULT", "CHARACTER", "SET")
+                || tokens.canConsume("DEFAULT", "CHARSET")) {
             tokens.canConsume('=');
             tokens.consume(); // charset name
             if (tokens.canConsume("COLLATE")) {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -28,7 +28,7 @@ import io.debezium.util.IoUtil;
 import io.debezium.util.Testing;
 
 public class MySqlDdlParserTest {
-    
+
     private DdlParser parser;
     private Tables tables;
     private SimpleDdlParserListener listener;
@@ -109,6 +109,32 @@ public class MySqlDdlParserTest {
     }
 
     @Test
+    public void shouldParseCreateTableStatementWithMultipleColumnsForPrimaryKey() {
+        String ddl = "CREATE TABLE shop ("
+                + " id BIGINT(20) NOT NULL AUTO_INCREMENT,"
+                + " version BIGINT(20) NOT NULL,"
+                + " name VARCHAR(255) NOT NULL,"
+                + " owner VARCHAR(255) NOT NULL,"
+                + " phone_number VARCHAR(255) NOT NULL,"
+                + " primary key (id, name)"
+                + " );";
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(1);
+        Table foo = tables.forTable(new TableId(null, null, "shop"));
+        assertThat(foo).isNotNull();
+        assertThat(foo.columnNames()).containsExactly("id", "version", "name", "owner", "phone_number");
+        assertThat(foo.primaryKeyColumnNames()).containsExactly("id", "name");
+        assertColumn(foo, "id", "BIGINT", Types.BIGINT, 20, -1, false, true, true);
+        assertColumn(foo, "version", "BIGINT", Types.BIGINT, 20, -1, false, false, false);
+        assertColumn(foo, "name", "VARCHAR", Types.VARCHAR, 255, -1, false, false, false);
+        assertColumn(foo, "owner", "VARCHAR", Types.VARCHAR, 255, -1, false, false, false);
+        assertColumn(foo, "phone_number", "VARCHAR", Types.VARCHAR, 255, -1, false, false, false);
+
+        parser.parse("DROP TABLE shop", tables);
+        assertThat(tables.size()).isEqualTo(0);
+    }
+
+    @Test
     public void shouldParseCreateUserTable() {
         String ddl = "CREATE TABLE IF NOT EXISTS user (   Host char(60) binary DEFAULT '' NOT NULL, User char(32) binary DEFAULT '' NOT NULL, Select_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Insert_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Update_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Delete_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Create_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Drop_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Reload_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Shutdown_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Process_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, File_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Grant_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, References_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Index_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Alter_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Show_db_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Super_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Create_tmp_table_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Lock_tables_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Execute_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Repl_slave_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Repl_client_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Create_view_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Show_view_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Create_routine_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Alter_routine_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Create_user_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Event_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Trigger_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, Create_tablespace_priv enum('N','Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, ssl_type enum('','ANY','X509', 'SPECIFIED') COLLATE utf8_general_ci DEFAULT '' NOT NULL, ssl_cipher BLOB NOT NULL, x509_issuer BLOB NOT NULL, x509_subject BLOB NOT NULL, max_questions int(11) unsigned DEFAULT 0  NOT NULL, max_updates int(11) unsigned DEFAULT 0  NOT NULL, max_connections int(11) unsigned DEFAULT 0  NOT NULL, max_user_connections int(11) unsigned DEFAULT 0  NOT NULL, plugin char(64) DEFAULT 'mysql_native_password' NOT NULL, authentication_string TEXT, password_expired ENUM('N', 'Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, password_last_changed timestamp NULL DEFAULT NULL, password_lifetime smallint unsigned NULL DEFAULT NULL, account_locked ENUM('N', 'Y') COLLATE utf8_general_ci DEFAULT 'N' NOT NULL, PRIMARY KEY Host (Host,User) ) engine=MyISAM CHARACTER SET utf8 COLLATE utf8_bin comment='Users and global privileges';";
         parser.parse(ddl, tables);
@@ -121,7 +147,7 @@ public class MySqlDdlParserTest {
         parser.parse("DROP TABLE user", tables);
         assertThat(tables.size()).isEqualTo(0);
     }
-    
+
     @Test
     public void shouldParseCreateTableStatementWithSignedTypes() {
         String ddl = "CREATE TABLE foo ( " + System.lineSeparator()
@@ -239,19 +265,19 @@ public class MySqlDdlParserTest {
         Testing.print(tables);
         assertThat(tables.size()).isEqualTo(6);
         assertThat(listener.total()).isEqualTo(49);
-        //listener.forEach(this::printEvent);
+        // listener.forEach(this::printEvent);
     }
 
     @Test
     public void shouldParseSomeLinesFromCreateStatements() {
-        parser.parse(readLines(189,"ddl/mysql-test-create.ddl"), tables);
+        parser.parse(readLines(189, "ddl/mysql-test-create.ddl"), tables);
         assertThat(tables.size()).isEqualTo(39);
         assertThat(listener.total()).isEqualTo(120);
     }
 
     @Test
     public void shouldParseMySql56InitializationStatements() {
-        parser.parse(readLines(1,"ddl/mysql-test-init-5.6.ddl"), tables);
+        parser.parse(readLines(1, "ddl/mysql-test-init-5.6.ddl"), tables);
         assertThat(tables.size()).isEqualTo(85); // 1 table
         assertThat(listener.total()).isEqualTo(112);
         listener.forEach(this::printEvent);
@@ -259,21 +285,21 @@ public class MySqlDdlParserTest {
 
     @Test
     public void shouldParseMySql57InitializationStatements() {
-        parser.parse(readLines(1,"ddl/mysql-test-init-5.7.ddl"), tables);
+        parser.parse(readLines(1, "ddl/mysql-test-init-5.7.ddl"), tables);
         assertThat(tables.size()).isEqualTo(123);
         assertThat(listener.total()).isEqualTo(125);
         listener.forEach(this::printEvent);
     }
-    
-    protected void printEvent( Event event ) {
+
+    protected void printEvent(Event event) {
         Testing.print(event);
     }
 
-    protected String readFile( String classpathResource ) {
-        try ( InputStream stream = getClass().getClassLoader().getResourceAsStream(classpathResource); ) {
+    protected String readFile(String classpathResource) {
+        try (InputStream stream = getClass().getClassLoader().getResourceAsStream(classpathResource);) {
             assertThat(stream).isNotNull();
             return IoUtil.read(stream);
-        } catch ( IOException e ) {
+        } catch (IOException e) {
             fail("Unable to read '" + classpathResource + "'");
         }
         assert false : "should never get here";
@@ -283,21 +309,22 @@ public class MySqlDdlParserTest {
     /**
      * Reads the lines starting with a given line number from the specified file on the classpath. Any lines preceding the
      * given line number will be included as empty lines, meaning the line numbers will match the input file.
+     * 
      * @param startingLineNumber the 1-based number designating the first line to be included
      * @param classpathResource the path to the file on the classpath
      * @return the string containing the subset of the file contents; never null but possibly empty
      */
-    protected String readLines( int startingLineNumber, String classpathResource ) {
-        try ( InputStream stream = getClass().getClassLoader().getResourceAsStream(classpathResource); ) {
+    protected String readLines(int startingLineNumber, String classpathResource) {
+        try (InputStream stream = getClass().getClassLoader().getResourceAsStream(classpathResource);) {
             assertThat(stream).isNotNull();
             StringBuilder sb = new StringBuilder();
             AtomicInteger counter = new AtomicInteger();
-            IoUtil.readLines(stream,line->{
+            IoUtil.readLines(stream, line -> {
                 if (counter.incrementAndGet() >= startingLineNumber) sb.append(line);
                 sb.append(System.lineSeparator());
             });
             return sb.toString();
-        } catch ( IOException e ) {
+        } catch (IOException e) {
             fail("Unable to read '" + classpathResource + "'");
         }
         assert false : "should never get here";

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -139,6 +139,85 @@ public class MySqlDdlParserTest {
     }
 
     @Test
+    public void shouldParseCreateTableStatementWithCharacterSetForTable() {
+        String ddl = "CREATE TABLE t ( col1 VARCHAR(25) ) DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci; ";
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(1);
+        Table t = tables.forTable(new TableId(null, null, "t"));
+        assertThat(t).isNotNull();
+        assertThat(t.columnNames()).containsExactly("col1");
+        assertThat(t.primaryKeyColumnNames()).isEmpty();
+        assertColumn(t, "col1", "VARCHAR", Types.VARCHAR, 25, -1, true, false, false);
+
+        ddl = "CREATE TABLE t2 ( col1 VARCHAR(25) ) DEFAULT CHARSET utf8 DEFAULT COLLATE utf8_general_ci; ";
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(2);
+        Table t2 = tables.forTable(new TableId(null, null, "t2"));
+        assertThat(t2).isNotNull();
+        assertThat(t2.columnNames()).containsExactly("col1");
+        assertThat(t2.primaryKeyColumnNames()).isEmpty();
+        assertColumn(t2, "col1", "VARCHAR", Types.VARCHAR, 25, -1, true, false, false);
+
+        ddl = "CREATE TABLE t3 ( col1 VARCHAR(25) ) CHARACTER SET utf8 COLLATE utf8_general_ci; ";
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(3);
+        Table t3 = tables.forTable(new TableId(null, null, "t3"));
+        assertThat(t3).isNotNull();
+        assertThat(t3.columnNames()).containsExactly("col1");
+        assertThat(t3.primaryKeyColumnNames()).isEmpty();
+        assertColumn(t3, "col1", "VARCHAR", Types.VARCHAR, 25, -1, true, false, false);
+
+        ddl = "CREATE TABLE t4 ( col1 VARCHAR(25) ) CHARSET utf8 COLLATE utf8_general_ci; ";
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(4);
+        Table t4 = tables.forTable(new TableId(null, null, "t4"));
+        assertThat(t4).isNotNull();
+        assertThat(t4.columnNames()).containsExactly("col1");
+        assertThat(t4.primaryKeyColumnNames()).isEmpty();
+        assertColumn(t4, "col1", "VARCHAR", Types.VARCHAR, 25, -1, true, false, false);
+    }
+
+    @Test
+    public void shouldParseCreateTableStatementWithCharacterSetForColumns() {
+        String ddl = "CREATE TABLE t ( col1 VARCHAR(25) CHARACTER SET greek ); ";
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(1);
+        Table t = tables.forTable(new TableId(null, null, "t"));
+        assertThat(t).isNotNull();
+        assertThat(t.columnNames()).containsExactly("col1");
+        assertThat(t.primaryKeyColumnNames()).isEmpty();
+        assertColumn(t, "col1", "VARCHAR CHARACTER SET greek", Types.VARCHAR, 25, -1, true, false, false);
+    }
+
+    @Test
+    public void shouldParseAlterTableStatementThatAddsCharacterSetForColumns() {
+        String ddl = "CREATE TABLE t ( col1 VARCHAR(25) ); ";
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(1);
+        Table t = tables.forTable(new TableId(null, null, "t"));
+        assertThat(t).isNotNull();
+        assertThat(t.columnNames()).containsExactly("col1");
+        assertThat(t.primaryKeyColumnNames()).isEmpty();
+        assertColumn(t, "col1", "VARCHAR", Types.VARCHAR, 25, -1, true, false, false);
+
+        ddl = "ALTER TABLE t MODIFY col1 VARCHAR(50) CHARACTER SET greek;";
+        parser.parse(ddl, tables);
+        Table t2 = tables.forTable(new TableId(null, null, "t"));
+        assertThat(t2).isNotNull();
+        assertThat(t2.columnNames()).containsExactly("col1");
+        assertThat(t2.primaryKeyColumnNames()).isEmpty();
+        assertColumn(t2, "col1", "VARCHAR CHARACTER SET greek", Types.VARCHAR, 50, -1, true, false, false);
+
+        ddl = "ALTER TABLE t MODIFY col1 VARCHAR(75) CHARSET utf8;";
+        parser.parse(ddl, tables);
+        Table t3 = tables.forTable(new TableId(null, null, "t"));
+        assertThat(t3).isNotNull();
+        assertThat(t3.columnNames()).containsExactly("col1");
+        assertThat(t3.primaryKeyColumnNames()).isEmpty();
+        assertColumn(t3, "col1", "VARCHAR CHARSET utf8", Types.VARCHAR, 75, -1, true, false, false);
+    }
+
+    @Test
     public void shouldParseGrantStatement() {
         String ddl = "GRANT ALL PRIVILEGES ON `mysql`.* TO 'mysqluser'@'%'";
         parser.parse(ddl, tables);


### PR DESCRIPTION
Two unit tests are added and they show that the existing MySQL DDL parser properly handles column definitions of the form `... VARCHAR(50) CHARACTER SET utf8 ...`. Note that the [MySQL documentation](http://dev.mysql.com/doc/refman/5.7/en/charset-column.html) makes no mention of supporting `CHARSET`.