### PR TITLE
DBZ-45 Confirmed and tested support for 'before' and 'after' states in UPDATE events

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
@@ -439,6 +439,13 @@ public class MySqlDdlParser extends DdlParser {
             // Obtain the column editor ...
             String columnName = tokens.consume();
             parseCreateColumn(start, table, columnName);
+            
+            // ALTER TABLE allows reordering the columns after the definition ...
+            if (tokens.canConsume("FIRST")) {
+                table.reorderColumn(columnName, null);
+            } else if (tokens.canConsume("AFTER")) {
+                table.reorderColumn(columnName, tokens.consume());
+            }
         }
     }
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -244,6 +244,43 @@ public class MySqlDdlParserTest {
     }
 
     @Test
+    public void shouldParseAlterTableStatementAddColumns() {
+        String ddl = "CREATE TABLE t ( col1 VARCHAR(25) ); ";
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(1);
+        Table t = tables.forTable(new TableId(null, null, "t"));
+        assertThat(t).isNotNull();
+        assertThat(t.columnNames()).containsExactly("col1");
+        assertThat(t.primaryKeyColumnNames()).isEmpty();
+        assertColumn(t, "col1", "VARCHAR", Types.VARCHAR, 25, -1, true, false, false);
+        assertThat(t.columnWithName("col1").position()).isEqualTo(1);
+
+        ddl = "ALTER TABLE t ADD col2 VARCHAR(50) NOT NULL;";
+        parser.parse(ddl, tables);
+        Table t2 = tables.forTable(new TableId(null, null, "t"));
+        assertThat(t2).isNotNull();
+        assertThat(t2.columnNames()).containsExactly("col1","col2");
+        assertThat(t2.primaryKeyColumnNames()).isEmpty();
+        assertColumn(t2, "col1", "VARCHAR", Types.VARCHAR, 25, -1, true, false, false);
+        assertColumn(t2, "col2", "VARCHAR", Types.VARCHAR, 50, -1, false, false, false);
+        assertThat(t2.columnWithName("col1").position()).isEqualTo(1);
+        assertThat(t2.columnWithName("col2").position()).isEqualTo(2);
+
+        ddl = "ALTER TABLE t ADD col3 FLOAT NOT NULL AFTER col1;";
+        parser.parse(ddl, tables);
+        Table t3 = tables.forTable(new TableId(null, null, "t"));
+        assertThat(t3).isNotNull();
+        assertThat(t3.columnNames()).containsExactly("col1","col3", "col2");
+        assertThat(t3.primaryKeyColumnNames()).isEmpty();
+        assertColumn(t3, "col1", "VARCHAR", Types.VARCHAR, 25, -1, true, false, false);
+        assertColumn(t3, "col3", "FLOAT", Types.FLOAT, -1, -1, false, false, false);
+        assertColumn(t3, "col2", "VARCHAR", Types.VARCHAR, 50, -1, false, false, false);
+        assertThat(t3.columnWithName("col1").position()).isEqualTo(1);
+        assertThat(t3.columnWithName("col3").position()).isEqualTo(2);
+        assertThat(t3.columnWithName("col2").position()).isEqualTo(3);
+    }
+
+    @Test
     public void shouldParseGrantStatement() {
         String ddl = "GRANT ALL PRIVILEGES ON `mysql`.* TO 'mysqluser'@'%'";
         parser.parse(ddl, tables);


### PR DESCRIPTION
Adds integration test logic to verify that UPDATE events include both `before` and `after` states (previously added as part of DBZ-52), to verify that altering a table does not generate events for the rows in that table, and that the `before` and `after` states (read from the binlog) are always defined in terms of the _current_ table schema. IOW, no special logic is needed to handle a 'before' state that has different columns than defined in the current table's definition.

Also added support for properly handling an ALTER TABLE statement that adds columns AFTER another existing column. This error was discovered during aforementioned testing.