### PR TITLE
DBZ-55 Corrected filtering of DDL statements based upon affected database

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -301,7 +301,7 @@ public class MySqlDdlParserTest {
         parser.parse(readFile("ddl/mysql-test-statements.ddl"), tables);
         Testing.print(tables);
         assertThat(tables.size()).isEqualTo(6);
-        assertThat(listener.total()).isEqualTo(49);
+        assertThat(listener.total()).isEqualTo(62);
         // listener.forEach(this::printEvent);
     }
 
@@ -316,7 +316,7 @@ public class MySqlDdlParserTest {
     public void shouldParseMySql56InitializationStatements() {
         parser.parse(readLines(1, "ddl/mysql-test-init-5.6.ddl"), tables);
         assertThat(tables.size()).isEqualTo(85); // 1 table
-        assertThat(listener.total()).isEqualTo(112);
+        assertThat(listener.total()).isEqualTo(118);
         listener.forEach(this::printEvent);
     }
 
@@ -324,7 +324,7 @@ public class MySqlDdlParserTest {
     public void shouldParseMySql57InitializationStatements() {
         parser.parse(readLines(1, "ddl/mysql-test-init-5.7.ddl"), tables);
         assertThat(tables.size()).isEqualTo(123);
-        assertThat(listener.total()).isEqualTo(125);
+        assertThat(listener.total()).isEqualTo(132);
         listener.forEach(this::printEvent);
     }
 

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/DdlChanges.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/DdlChanges.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational.ddl;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.debezium.annotation.NotThreadSafe;
+
+/**
+ * A {@link DdlParserListener} that accumulates changes, allowing them to be consumed in the same order by database.
+ * 
+ * @author Randall Hauch
+ */
+@NotThreadSafe
+public class DdlChanges implements DdlParserListener {
+
+    private final String terminator;
+    private final List<Event> events = new ArrayList<>();
+    private final Set<String> databaseNames = new HashSet<>();
+
+    /**
+     * Create a new changes object with ';' as the terminator token.
+     */
+    public DdlChanges() {
+        this(null);
+    }
+
+    /**
+     * Create a new changes object with the designated terminator token.
+     * 
+     * @param terminator the token used to terminate each statement; may be null
+     */
+    public DdlChanges(String terminator) {
+        this.terminator = terminator != null ? terminator : ";";
+    }
+
+    /**
+     * Clear all accumulated changes.
+     * 
+     * @return this object for method chaining; never null
+     */
+    public DdlChanges reset() {
+        events.clear();
+        databaseNames.clear();
+        return this;
+    }
+
+    @Override
+    public void handle(Event event) {
+        events.add(event);
+        databaseNames.add(getDatabase(event));
+    }
+
+    /**
+     * Consume the events in the same order they were {@link #handle(io.debezium.relational.ddl.DdlParserListener.Event) recorded},
+     * but grouped by database name. Multiple sequential statements that were applied to the same database are grouped together.
+     * @param consumer the consumer
+     */
+    public void groupStatementStringsByDatabase(DatabaseStatementStringConsumer consumer) {
+        groupEventsByDatabase((DatabaseEventConsumer)(dbName,eventList)->{
+            StringBuilder statements = new StringBuilder();
+            eventList.forEach(event->{
+                statements.append(event.statement());
+                statements.append(terminator);
+            });
+            consumer.consume(dbName, statements.toString());
+        });
+    }
+
+    /**
+     * Consume the events in the same order they were {@link #handle(io.debezium.relational.ddl.DdlParserListener.Event) recorded},
+     * but grouped by database name. Multiple sequential statements that were applied to the same database are grouped together.
+     * @param consumer the consumer
+     */
+    public void groupStatementsByDatabase(DatabaseStatementConsumer consumer) {
+        groupEventsByDatabase((DatabaseEventConsumer)(dbName,eventList)->{
+            List<String> statements = new ArrayList<>();
+            eventList.forEach(event->statements.add(event.statement()));
+            consumer.consume(dbName, statements);
+        });
+    }
+
+    /**
+     * Consume the events in the same order they were {@link #handle(io.debezium.relational.ddl.DdlParserListener.Event) recorded},
+     * but grouped by database name. Multiple sequential statements that were applied to the same database are grouped together.
+     * @param consumer the consumer
+     */
+    public void groupEventsByDatabase(DatabaseEventConsumer consumer) {
+        if ( isEmpty() ) return;
+        if ( databaseNames.size() <= 1 ) {
+            consumer.consume(databaseNames.iterator().next(), events);
+            return;
+        }
+        List<Event> dbEvents = new ArrayList<>();
+        String currentDatabase = null;
+        for (Event event : events) {
+            String dbName = getDatabase(event);
+            if (currentDatabase == null || dbName.equals(currentDatabase)) {
+                currentDatabase = dbName;
+                // Accumulate the statement ...
+                dbEvents.add(event);
+            } else {
+                // Submit the statements ...
+                consumer.consume(currentDatabase, dbEvents);
+            }
+        }
+    }
+
+    protected String getDatabase(Event event) {
+        switch (event.type()) {
+            case CREATE_TABLE:
+            case ALTER_TABLE:
+            case DROP_TABLE:
+                TableEvent tableEvent = (TableEvent) event;
+                return tableEvent.tableId().catalog();
+            case CREATE_INDEX:
+            case DROP_INDEX:
+                TableIndexEvent tableIndexEvent = (TableIndexEvent) event;
+                return tableIndexEvent.tableId().catalog();
+            case CREATE_DATABASE:
+            case ALTER_DATABASE:
+            case DROP_DATABASE:
+                DatabaseEvent dbEvent = (DatabaseEvent) event;
+                return dbEvent.databaseName();
+        }
+        assert false : "Should never happen";
+        return null;
+    }
+    
+    public boolean isEmpty() {
+        return events.isEmpty();
+    }
+    
+    public boolean applyToMoreDatabasesThan( String name ) {
+        return databaseNames.contains(name) ? databaseNames.size() > 1 : databaseNames.size() > 0;
+    }
+    
+    @Override
+    public String toString() {
+        return events.toString();
+    }
+
+    public static interface DatabaseEventConsumer {
+        void consume(String databaseName, List<Event> events);
+    }
+
+    public static interface DatabaseStatementConsumer {
+        void consume(String databaseName, List<String> ddlStatements);
+    }
+
+    public static interface DatabaseStatementStringConsumer {
+        void consume(String databaseName, String ddlStatements);
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/DdlParserSql2003.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/DdlParserSql2003.java
@@ -131,9 +131,36 @@ public class DdlParserSql2003 extends DdlParser {
         } else if (tokens.matches("VIEW") || tokens.matches("RECURSIVE", "VIEW")) {
             parseCreateView(marker);
             debugParsed(marker);
+        } else if (tokens.matchesAnyOf("DATABASE", "SCHEMA")) {
+            parseCreateDatabase(marker);
         } else {
             parseCreateUnknown(marker);
         }
+    }
+
+    protected void parseCreateDatabase(Marker start) {
+        tokens.consumeAnyOf("DATABASE","SCHEMA");
+        tokens.canConsume("IF","NOT","EXISTS");
+        String dbName = tokens.consume();
+        consumeRemainingStatement(start);
+        signalCreateDatabase(dbName, start);
+        debugParsed(start);
+    }
+
+    protected void parseAlterDatabase(Marker start) {
+        tokens.consumeAnyOf("DATABASE","SCHEMA");
+        String dbName = tokens.consume();
+        consumeRemainingStatement(start);
+        signalAlterDatabase(dbName, null, start);
+        debugParsed(start);
+    }
+
+    protected void parseDropDatabase(Marker start) {
+        tokens.consumeAnyOf("DATABASE","SCHEMA");
+        tokens.canConsume("IF","EXISTS");
+        String dbName = tokens.consume();
+        signalDropDatabase(dbName, start);
+        debugParsed(start);
     }
 
     protected void parseCreateTable(Marker start) {
@@ -555,6 +582,8 @@ public class DdlParserSql2003 extends DdlParser {
         if (tokens.matches("TABLE") || tokens.matches("IGNORE", "TABLE")) {
             parseAlterTable(marker);
             debugParsed(marker);
+        } else if (tokens.matchesAnyOf("DATABASE", "SCHEMA")) {
+            parseAlterDatabase(marker);
         } else {
             parseAlterUnknown(marker);
         }
@@ -659,6 +688,8 @@ public class DdlParserSql2003 extends DdlParser {
         } else if (tokens.matches("VIEW")) {
             parseDropView(marker);
             debugParsed(marker);
+        } else if (tokens.matchesAnyOf("DATABASE", "SCHEMA")) {
+            parseDropDatabase(marker);
         } else {
             parseDropUnknown(marker);
         }

--- a/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
@@ -40,7 +40,7 @@ public interface DatabaseHistory {
      * @param position the point in history where these DDL changes were made, which may be used when
      *            {@link #recover(Map, Map, Tables, DdlParser) recovering} the schema to some point in history; may not be
      *            null
-     * @param databaseName the name of the database whose schema is being changed; may not be null
+     * @param databaseName the name of the database whose schema is being changed; may be null
      * @param schema the current definition of the database schema; may not be null
      * @param ddl the DDL statements that describe the changes to the database schema; may not be null
      */

--- a/debezium-core/src/test/java/io/debezium/relational/ddl/DdlChangesTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/ddl/DdlChangesTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational.ddl;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import io.debezium.relational.Tables;
+import io.debezium.relational.ddl.DdlParserListener.EventType;
+
+public class DdlChangesTest {
+
+    private DdlChanges changes;
+    private DdlParser parser;
+    private Tables tables;
+
+    @Before
+    public void beforeEach() {
+        changes = new DdlChanges();
+        parser = new DdlParserSql2003();
+        parser.addListener(changes);
+        tables = new Tables();
+    }
+
+    @Test
+    public void shouldParseMultipleStatementsWithDefaultDatabase() {
+        parser.setCurrentSchema("mydb");
+        String ddl = "CREATE TABLE foo ( " + System.lineSeparator()
+                + " c1 INTEGER NOT NULL, " + System.lineSeparator()
+                + " c2 VARCHAR(22) " + System.lineSeparator()
+                + "); " + System.lineSeparator()
+                + "-- This is a comment" + System.lineSeparator()
+                + "DROP TABLE foo;" + System.lineSeparator();
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(0); // table created and dropped
+
+        changes.groupEventsByDatabase((dbName, list) -> {
+            assertThat(dbName).isEqualTo("mydb");
+            assertThat(list.size()).isEqualTo(2);
+            assertThat(list.get(0).type()).isEqualTo(EventType.CREATE_TABLE);
+            assertThat(list.get(1).type()).isEqualTo(EventType.DROP_TABLE);
+        });
+    }
+
+    @Test
+    public void shouldParseMultipleStatementsWithFullyQualifiedDatabase() {
+        parser.setCurrentSchema("mydb");
+        String ddl = "CREATE TABLE other.foo ( " + System.lineSeparator()
+                + " c1 INTEGER NOT NULL, " + System.lineSeparator()
+                + " c2 VARCHAR(22) " + System.lineSeparator()
+                + "); " + System.lineSeparator()
+                + "-- This is a comment" + System.lineSeparator()
+                + "DROP TABLE other.foo;" + System.lineSeparator();
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(0); // table created and dropped
+
+        changes.groupEventsByDatabase((dbName, list) -> {
+            assertThat(dbName).isEqualTo("other");
+            assertThat(list.size()).isEqualTo(2);
+            assertThat(list.get(0).type()).isEqualTo(EventType.CREATE_TABLE);
+            assertThat(list.get(1).type()).isEqualTo(EventType.DROP_TABLE);
+        });
+    }
+
+    @Test
+    public void shouldParseMultipleStatementsWithNoCurrentSchemaAndFullyQualifiedDatabase() {
+        String ddl = "CREATE TABLE other.foo ( " + System.lineSeparator()
+                + " c1 INTEGER NOT NULL, " + System.lineSeparator()
+                + " c2 VARCHAR(22) " + System.lineSeparator()
+                + "); " + System.lineSeparator()
+                + "-- This is a comment" + System.lineSeparator()
+                + "DROP TABLE other.foo;" + System.lineSeparator();
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(0); // table created and dropped
+
+        for (int i = 0; i != 5; ++i) {
+            changes.groupEventsByDatabase((dbName, list) -> {
+                assertThat(dbName).isEqualTo("other");
+                assertThat(list.size()).isEqualTo(2);
+                assertThat(list.get(0).type()).isEqualTo(EventType.CREATE_TABLE);
+                assertThat(list.get(1).type()).isEqualTo(EventType.DROP_TABLE);
+            });
+        }
+
+        changes.reset();
+        changes.groupEventsByDatabase((dbName, list) -> {
+            fail("Should not have any changes");
+        });
+    }
+
+}

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -273,6 +273,10 @@ public abstract class AbstractConnectorTest implements Testing {
                 if (recordConsumer != null) {
                     recordConsumer.accept(record);
                 }
+                if ( Testing.Debug.isEnabled() ) {
+                    Testing.debug("Consumed record " + recordsConsumed + " / " + numberOfRecords + " (" + (numberOfRecords-recordsConsumed) + " more)");
+                    debug(record);
+                }
             }
         }
         return recordsConsumed;
@@ -501,6 +505,17 @@ public abstract class AbstractConnectorTest implements Testing {
         SchemaAndValue keyWithSchema = null;
         SchemaAndValue valueWithSchema = null;
         try {
+            // The key should never be null ...
+            assertThat(record.key()).isNotNull();
+            assertThat(record.keySchema()).isNotNull();
+            
+            // If the value is not null there must be a schema; otherwise, the schema should also be null ...
+            if ( record.value() == null ) {
+                assertThat(record.valueSchema()).isNull();
+            } else {
+                assertThat(record.valueSchema()).isNotNull();
+            }
+            
             // First serialize and deserialize the key ...
             byte[] keyBytes = keyJsonConverter.fromConnectData(record.topic(), record.keySchema(), record.key());
             keyJson = keyJsonDeserializer.deserialize(record.topic(), keyBytes);
@@ -538,7 +553,7 @@ public abstract class AbstractConnectorTest implements Testing {
         }
     }
 
-    protected void print(SourceRecord record) {
+    protected String printToString(SourceRecord record) {
         StringBuilder sb = new StringBuilder("SourceRecord{");
         sb.append("sourcePartition=").append(record.sourcePartition());
         sb.append(", sourceOffset=").append(record.sourceOffset());
@@ -549,7 +564,15 @@ public abstract class AbstractConnectorTest implements Testing {
         sb.append(", value=");
         append(record.value(), sb);
         sb.append("}");
-        Testing.print(sb.toString());
+        return sb.toString();
+    }
+
+    protected void print(SourceRecord record) {
+        Testing.print(printToString(record));
+    }
+
+    protected void debug(SourceRecord record) {
+        Testing.debug(printToString(record));
     }
 
     protected void printJson(SourceRecord record) {


### PR DESCRIPTION
Previously, the DDL statements were being filtered and recorded based upon the name of the database that appeared in the binlog. That database name, however, is actually the name of the database to which the client submitting the operation is connected, and is not necessarily the database _affected_ by the operation (e.g., when an operation includes a fully-qualified table name not in the connected-to database).

With these changes, the table/database _affected_ by the DDL statements is now being used to filter the recording of the statements. The order of the DDL statements in the binlog is still maintained, but since each DDL statement can apply to a separate database, the DDL statements are batched (in the same original order) based upon the affected database. For example, two statements affecting `db1` will get batched together into one schema change record, followed by one statement affecting `db2` as a second schema change record, followed by another statement affecting `db1` as a third schema record. Of course, if `db2` is excluded for some reason from the connector's configuration, then that second schema change record would not be written.

To determine the _affected_ database for each DDL statement required changes to the DDL parsing framework. Although a listener mechanism was recently added, this PR adds a reusable listener implementation that accumulates 1 or more DDL statements and allows the caller (in this case the MySQL connector) to consume the sequences of statements and the database names to which they apply. Consecutive statements that apply to the same database are grouped/batched together. The MySQL connector uses this to process each QUERY event in the binlog, which may contain 1 or more DDL statements. The MySQL DDL parser was also enhanced to properly parse and handle `CREATE DATABASE`, `ALTER DATABASE`, and `DROP DATABASE` statements, since the parser needs to identify the affected database for these statements so they can be properly filtered.

Meanwhile, this change does not affect how the _database history_ records the statements: it still records them exactly as submitted without regard to filtering and using a single record for each separate binlog QUERY event. IOW, the _database history_ continues to record every DDL statement in the same order as found in the binlog, and all DDL statements found in a single binlog event are written atomically  to the history stream. However, this commit does change the order that the database history and schema change records are written, so that the latter are now first and the database history is written second. Under nominal operation each is written exactly once, but the database history records are now written _after_ any schema change record so that, upon recovery after failure, no schema change records are lost (and instead have at-least-once delivery guarantees).