### PR TITLE
DBZ-58 Added MDC logging contexts to connector

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -60,7 +60,7 @@ public final class MySqlConnectorTask extends SourceTask {
             throw new ConnectException("Error configuring an instance of " + getClass().getSimpleName() + "; check the logs for details");
         }
 
-        // Create the task and set our running flag ...
+        // Create and start the task context ...
         this.taskContext = new MySqlTaskContext(config);
         this.taskContext.start();
 
@@ -133,13 +133,13 @@ public final class MySqlConnectorTask extends SourceTask {
 
     @Override
     public List<SourceRecord> poll() throws InterruptedException {
-        logger.trace("Polling for events from MySQL connector");
+        logger.trace("Polling for events");
         return currentReader.poll();
     }
 
     @Override
     public void stop() {
-        logger.info("Stopping MySQL Connector");
+        logger.info("Stopping MySQL connector task");
         // We need to explicitly stop both readers, in this order. If we were to instead call 'currentReader.stop()', there
         // is a chance without synchronization that we'd miss the transition and stop only the snapshot reader. And stopping both
         // is far simpler and more efficient than synchronizing ...
@@ -155,7 +155,7 @@ public final class MySqlConnectorTask extends SourceTask {
                 } catch (Throwable e) {
                     logger.error("Unexpected error shutting down the database history and/or closing JDBC connections", e);
                 } finally {
-                    logger.info("Stopped connector to MySQL server '{}'", taskContext.serverName());
+                    logger.info("Connector task successfully stopped");
                 }
             }
         }

--- a/debezium-connector-mysql/src/test/resources/log4j.properties
+++ b/debezium-connector-mysql/src/test/resources/log4j.properties
@@ -2,7 +2,7 @@
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p     %m (%c)%n
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p  %X{dbz.connectorType}|%X{dbz.connectorName}|%X{dbz.connectorContext}  %m   [%c]%n
 
 # Root logger option
 log4j.rootLogger=INFO, stdout

--- a/debezium-core/src/main/java/io/debezium/util/LoggingContext.java
+++ b/debezium-core/src/main/java/io/debezium/util/LoggingContext.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import java.util.Map;
+
+import org.slf4j.MDC;
+
+/**
+ * A utility that provides a consistent set of properties for the Mapped Diagnostic Context (MDC) properties used by Debezium
+ * components.
+ * 
+ * @author Randall Hauch
+ * @since 0.2
+ */
+public class LoggingContext {
+
+    /**
+     * The key for the connector type MDC property.
+     */
+    public static final String CONNECTOR_TYPE = "dbz.connectorType";
+    /**
+     * The key for the connector logical name MDC property.
+     */
+    public static final String CONNECTOR_NAME = "dbz.connectorName";
+    /**
+     * The key for the connector context name MDC property.
+     */
+    public static final String CONNECTOR_CONTEXT = "dbz.connectorContext";
+
+    private LoggingContext() {
+    }
+    
+    /**
+     * A snapshot of an MDC context that can be {@link #restore()}.
+     */
+    public static final class PreviousContext {
+        private final Map<String,String> context;
+        @SuppressWarnings("unchecked")
+        protected PreviousContext() {
+            context = MDC.getCopyOfContextMap();
+        }
+        /**
+         * Restore this logging context.
+         */
+        public void restore() {
+            for ( Map.Entry<String, String> entry : context.entrySet() ) {
+                MDC.put(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
+    /**
+     * Configure for a connector the logger's Mapped Diagnostic Context (MDC) properties for the thread making this call.
+     * 
+     * @param connectorType the type of connector; may not be null
+     * @param connectorName the name of the connector; may not be null
+     * @param contextName the name of the context; may not be null
+     * @return the previous MDC context; never null
+     * @throws IllegalArgumentException if any of the parameters are null
+     */
+    public static PreviousContext forConnector(String connectorType, String connectorName, String contextName) {
+        if (connectorType == null) throw new IllegalArgumentException("The MDC value for the connector type may not be null");
+        if (connectorName == null) throw new IllegalArgumentException("The MDC value for the connector name may not be null");
+        if (contextName == null) throw new IllegalArgumentException("The MDC value for the connector context may not be null");
+        PreviousContext previous = new PreviousContext();
+        MDC.put(CONNECTOR_TYPE, connectorType);
+        MDC.put(CONNECTOR_NAME, connectorName);
+        MDC.put(CONNECTOR_CONTEXT, contextName);
+        return previous;
+    }
+    
+    /**
+     * Run the supplied function in the temporary connector MDC context, and when complete always return the MDC context to its
+     * state before this method was called.
+     * 
+     * @param connectorType the type of connector; may not be null
+     * @param connectorName the logical name of the connector; may not be null
+     * @param contextName the name of the context; may not be null
+     * @param operation the function to run in the new MDC context; may not be null
+     * @throws IllegalArgumentException if any of the parameters are null
+     */
+    public static void temporarilyForConnector(String connectorType, String connectorName, String contextName, Runnable operation) {
+        if (connectorType == null) throw new IllegalArgumentException("The MDC value for the connector type may not be null");
+        if (connectorName == null) throw new IllegalArgumentException("The MDC value for the connector name may not be null");
+        if (contextName == null) throw new IllegalArgumentException("The MDC value for the connector context may not be null");
+        if (operation == null) throw new IllegalArgumentException("The operation may not be null");
+        PreviousContext previous = new PreviousContext();
+        try {
+            forConnector(connectorType,connectorName,contextName);
+            operation.run();
+        } finally {
+            previous.restore();
+        }
+    }
+    
+}


### PR DESCRIPTION
Changed the MySQL connector to make use of MDC logging contexts, which allow thread-specific parameters that can be written out on every log line by simply changing the logging configuration (e.g., Log4J configuration file).

We adopt a convention for all Debezium connectors with the following MDC properties:

* `dbz.connectorType` - the type of connector, which would be a single well-known value for each connector (e.g., "MySQL" for the MySQL connector)
* `dbz.connectorName` - the name of the connector, which for the MySQL connector is simply the value of the `server.name` property (e.g., the logical name for the MySQL server/cluster). Unfortunately, Kafka Connect does not give us its name for the connector.
* `dbz.connectorContext` - the name of the thread or context, which is "task" for the sole MySQL connector task, "snapshot" for the thread started by the snapshot reader, and "binlog" for the thread started by the binlog reader.

Different logging frameworks have their own way of using MDC properties. In a Log4J configuration, for example, simply use `%X{name}` in the logger's layout, where "name" is one of the properties listed above (or another MDC property).