### PR TITLE
DBZ-64 Added Avro Converter to record verification utilities

### DIFF
--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -25,12 +25,6 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-connect-avro-converter</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -73,6 +67,10 @@
         <dependency>
             <groupId>org.easytesting</groupId>
             <artifactId>fest-assert</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-avro-converter</artifactId>
         </dependency>
     </dependencies>
     <properties>

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
@@ -59,20 +59,23 @@ public class MySqlSchema {
     private final DatabaseHistory dbHistory;
     private final TableSchemaBuilder schemaBuilder;
     private final DdlChanges ddlChanges;
+    private final String serverName;
     private Tables tables;
 
     /**
      * Create a schema component given the supplied {@link MySqlConnectorConfig MySQL connector configuration}.
      * 
      * @param config the connector configuration, which is presumed to be valid
+     * @param serverName the name of the server
      */
-    public MySqlSchema(Configuration config) {
+    public MySqlSchema(Configuration config, String serverName) {
         this.filters = new Filters(config);
         this.ddlParser = new MySqlDdlParser(false);
         this.tables = new Tables();
         this.ddlChanges = new DdlChanges(this.ddlParser.terminator());
         this.ddlParser.addListener(ddlChanges);
         this.schemaBuilder = new TableSchemaBuilder();
+        this.serverName = serverName;
 
         // Create and configure the database history ...
         this.dbHistory = config.getInstance(MySqlConnectorConfig.DATABASE_HISTORY, DatabaseHistory.class);
@@ -247,7 +250,7 @@ public class MySqlSchema {
         // Create TableSchema instances for any existing table ...
         this.tables.tableIds().forEach(id -> {
             Table table = this.tables.forTable(id);
-            TableSchema schema = schemaBuilder.create(table, filters.columnFilter(), filters.columnMappers());
+            TableSchema schema = schemaBuilder.create(serverName,table, filters.columnFilter(), filters.columnMappers());
             tableSchemaByTableId.put(id, schema);
         });
     }
@@ -317,7 +320,7 @@ public class MySqlSchema {
             if (table == null) { // removed
                 tableSchemaByTableId.remove(tableId);
             } else {
-                TableSchema schema = schemaBuilder.create(table, filters.columnFilter(), filters.columnMappers());
+                TableSchema schema = schemaBuilder.create(serverName, table, filters.columnFilter(), filters.columnMappers());
                 tableSchemaByTableId.put(tableId, schema);
             }
         });

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -48,7 +48,7 @@ public final class MySqlTaskContext {
         this.source.setServerName(serverName());
 
         // Set up the MySQL schema ...
-        this.dbSchema = new MySqlSchema(config);
+        this.dbSchema = new MySqlSchema(config, serverName());
         this.dbSchema.start();
 
         // Set up the record processor ...
@@ -108,7 +108,11 @@ public final class MySqlTaskContext {
     }
 
     public String serverName() {
-        return config.getString(MySqlConnectorConfig.SERVER_NAME);
+        String serverName = config.getString(MySqlConnectorConfig.SERVER_NAME);
+        if ( serverName == null ) {
+            serverName = hostname() + ":" + port();
+        }
+        return serverName;
     }
 
     public String username() {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RecordMakers.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RecordMakers.java
@@ -161,7 +161,7 @@ public class RecordMakers {
 
         String topicName = topicSelector.getTopic(id);
         Envelope envelope = Envelope.defineSchema()
-                                    .withName(topicName)
+                                    .withName(topicName + ".Envelope")
                                     .withRecord(schema.schemaFor(id).valueSchema())
                                     .withSource(SourceInfo.SCHEMA)
                                     .build();

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/Configurator.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/Configurator.java
@@ -77,7 +77,8 @@ public class Configurator {
     }
 
     public MySqlSchema createSchemas() {
-        return new MySqlSchema(configBuilder.build());
+        Configuration config = configBuilder.build();
+        return new MySqlSchema(config,config.getString(MySqlConnectorConfig.SERVER_NAME));
     }
 
 }

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -71,6 +71,11 @@
             <artifactId>connect-file</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-avro-converter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/debezium-core/src/main/java/io/debezium/data/SchemaUtil.java
+++ b/debezium-core/src/main/java/io/debezium/data/SchemaUtil.java
@@ -30,6 +30,16 @@ public class SchemaUtil {
      * @param field the field; may not be null
      * @return the JSON string representation
      */
+    public static String asString(Object field) {
+        return new RecordWriter().append(field).toString();
+    }
+
+    /**
+     * Obtain a JSON string representation of the specified field.
+     * 
+     * @param field the field; may not be null
+     * @return the JSON string representation
+     */
     public static String asString(Field field) {
         return new RecordWriter().append(field).toString();
     }

--- a/debezium-core/src/main/java/io/debezium/relational/TableSchemaBuilder.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableSchemaBuilder.java
@@ -105,11 +105,12 @@ public class TableSchemaBuilder {
      * <p>
      * This is equivalent to calling {@code create(table,false)}.
      * 
+     * @param schemaPrefix the prefix added to the table identifier to construct the schema names; may be null if there is no prefix
      * @param table the table definition; may not be null
      * @return the table schema that can be used for sending rows of data for this table to Kafka Connect; never null
      */
-    public TableSchema create(Table table) {
-        return create(table, null, null);
+    public TableSchema create(String schemaPrefix, Table table) {
+        return create(schemaPrefix, table, null, null);
     }
 
     /**
@@ -120,18 +121,20 @@ public class TableSchemaBuilder {
      * <p>
      * This is equivalent to calling {@code create(table,false)}.
      * 
+     * @param schemaPrefix the prefix added to the table identifier to construct the schema names; may be null if there is no prefix
      * @param table the table definition; may not be null
      * @param filter the filter that specifies whether columns in the table should be included; may be null if all columns
      *            are to be included
      * @param mappers the mapping functions for columns; may be null if none of the columns are to be mapped to different values
      * @return the table schema that can be used for sending rows of data for this table to Kafka Connect; never null
      */
-    public TableSchema create(Table table, Predicate<ColumnId> filter, ColumnMappers mappers) {
+    public TableSchema create(String schemaPrefix, Table table, Predicate<ColumnId> filter, ColumnMappers mappers) {
+        if ( schemaPrefix == null ) schemaPrefix = "";
         // Build the schemas ...
         final TableId tableId = table.id();
         final String tableIdStr = tableId.toString();
-        SchemaBuilder valSchemaBuilder = SchemaBuilder.struct().name(tableIdStr);
-        SchemaBuilder keySchemaBuilder = SchemaBuilder.struct().name(tableIdStr + "/pk");
+        SchemaBuilder valSchemaBuilder = SchemaBuilder.struct().name(schemaPrefix + tableIdStr + ".Value");
+        SchemaBuilder keySchemaBuilder = SchemaBuilder.struct().name(schemaPrefix + tableIdStr + ".Key");
         AtomicBoolean hasPrimaryKey = new AtomicBoolean(false);
         table.columns().forEach(column -> {
             if (table.isPrimaryKeyColumn(column.name())) {

--- a/debezium-core/src/test/java/io/debezium/relational/TableSchemaBuilderTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/TableSchemaBuilderTest.java
@@ -19,6 +19,7 @@ import static org.fest.assertions.Assertions.assertThat;
 
 public class TableSchemaBuilderTest {
 
+    private final String prefix = "";
     private final TableId id = new TableId("catalog", "schema", "table");
     private final Object[] data = new Object[] { "c1value", 3.142d, java.sql.Date.valueOf("2001-10-31"), 4 };
     private Table table;
@@ -68,19 +69,19 @@ public class TableSchemaBuilderTest {
 
     @Test(expected = NullPointerException.class)
     public void shouldFailToBuildTableSchemaFromNullTable() {
-        new TableSchemaBuilder().create(null);
+        new TableSchemaBuilder().create(prefix,null);
     }
 
     @Test
     public void shouldBuildTableSchemaFromTable() {
-        schema = new TableSchemaBuilder().create(table);
+        schema = new TableSchemaBuilder().create(prefix,table);
         assertThat(schema).isNotNull();
     }
 
     @Test
     public void shouldBuildTableSchemaFromTableWithoutPrimaryKey() {
         table = table.edit().setPrimaryKeyNames().create();
-        schema = new TableSchemaBuilder().create(table);
+        schema = new TableSchemaBuilder().create(prefix,table);
         assertThat(schema).isNotNull();
         // Check the keys ...
         assertThat(schema.keySchema()).isNull();

--- a/pom.xml
+++ b/pom.xml
@@ -50,13 +50,14 @@
         <!-- Kafka and it's dependencies MUST reflect what the Kafka version uses -->
         <version.kafka>0.9.0.1</version.kafka>
         <version.kafka.scala>2.11</version.kafka.scala>
-        <version.confluent.platform>2.1.0-alpha1</version.confluent.platform>
         <version.scala>2.11.7</version.scala>
         <version.curator>2.4.0</version.curator>
         <version.zookeeper>3.4.6</version.zookeeper>
         <version.jackson>2.5.4</version.jackson>
         <version.org.slf4j>1.7.6</version.org.slf4j>
         <version.log4j>1.2.17</version.log4j>
+        <!-- check new release version at https://github.com/confluentinc/schema-registry/releases -->
+        <version.confluent.platform>3.0.0</version.confluent.platform>
 
         <!-- Databases -->
         <version.postgresql.driver>9.4-1205-jdbc42</version.postgresql.driver>
@@ -185,7 +186,6 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-avro-converter</artifactId>
-                <!-- check new release version at https://github.com/confluentinc/schema-registry/releases -->
                 <version>${version.confluent.platform}</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
The `VerifyRecord` utility class has methods that will verify a `SourceRecord`, and is used in many of our integration tests to check whether records are constructed in a valid manner. The utility already checks whether the records can be serialized and deserialized using the JSON converter (provided with Kafka Connect); this change also checks with the Avro Converter (which produces much smaller records and is more suitable for production).

Note that version 3.0.0 of the Confluent Avro Converter is required; version 2.1.0-alpha1 could not properly handle complex Schema objects with optional fields (see https://github.com/confluentinc/schema-registry/pull/280).

Also, the names of the Kafka Connect schemas used in MySQL source records has changed.

1. The record's envelope Schema used to be "_{serverName}_._{database}_._{table}_" but is now "_{serverName}_._{database}_._{table}_.Envelope".
2. The Schema for record keys used to be named "_{database}_._{table}_/pk", but the `/` character is not valid within a Avro name, and has been changed to "_{serverName}_._{database}_._{table}_.Key".
3. The Schema for record values used to be named "_{database}_._{table}_", but to better fit with the other Schema names it has been changed to "_{serverName}_._{database}_._{table}_.Value".

Thus, all of the Schemas for a single database table have the same Avro namespace "_{serverName}_._{database}_._{table}_" with Avro schema names of "Envelope", "Key", and "Value".

All unit and integration tests pass.