### PR TITLE
DBZ-61 Improved MySQL connector's handling of binary values

### DIFF
--- a/debezium-connector-mysql/src/test/docker/init/setup.sql
+++ b/debezium-connector-mysql/src/test/docker/init/setup.sql
@@ -172,3 +172,24 @@ VALUES (default, '2016-01-16', 1001, 1, 102),
        (default, '2016-02-18', 1004, 3, 109),
        (default, '2016-02-19', 1002, 2, 106),
        (default, '2016-02-21', 1003, 1, 107);
+
+
+
+# ----------------------------------------------------------------------------------------------------------------
+# DATABASE:  regression_test
+# ----------------------------------------------------------------------------------------------------------------
+# The integration test for this database expects to scans all of the binlog events associated with this database
+# without error or problems. The integration test does not modify any records in this database, so this script
+# must contain all operations to these tables.
+#
+CREATE DATABASE regression_test;
+USE regression_test;
+
+# DBZ-61 handle binary value recorded as hex string value
+CREATE TABLE t1464075356413_testtable6 (
+  pk_column int auto_increment NOT NULL,
+  varbinary_col varbinary(20) NOT NULL,
+  PRIMARY KEY(pk_column)
+);
+INSERT INTO t1464075356413_testtable6 (pk_column, varbinary_col)
+VALUES(default, 0x4D7953514C)

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import java.nio.file.Path;
+import java.sql.SQLException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.relational.history.FileDatabaseHistory;
+import io.debezium.util.Testing;
+
+/**
+ * @author Randall Hauch
+ */
+public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
+
+    private static final Path DB_HISTORY_PATH = Testing.Files.createTestingPath("file-db-history-regression.txt").toAbsolutePath();
+
+    private Configuration config;
+
+    @Before
+    public void beforeEach() {
+        stopConnector();
+        initializeConnectorTestFramework();
+        Testing.Files.delete(DB_HISTORY_PATH);
+    }
+
+    @After
+    public void afterEach() {
+        try {
+            stopConnector();
+        } finally {
+            Testing.Files.delete(DB_HISTORY_PATH);
+        }
+    }
+
+    @Test
+    public void shouldConsumeAllEventsFromDatabaseUsingBinlogAndNoSnapshot() throws SQLException, InterruptedException {
+        // Use the DB configuration to define the connector's configuration ...
+        config = Configuration.create()
+                              .with(MySqlConnectorConfig.HOSTNAME, System.getProperty("database.hostname"))
+                              .with(MySqlConnectorConfig.PORT, System.getProperty("database.port"))
+                              .with(MySqlConnectorConfig.USER, "snapper")
+                              .with(MySqlConnectorConfig.PASSWORD, "snapperpass")
+                              .with(MySqlConnectorConfig.SERVER_ID, 18765)
+                              .with(MySqlConnectorConfig.SERVER_NAME, "regression")
+                              .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
+                              .with(MySqlConnectorConfig.DATABASE_WHITELIST, "regression_test")
+                              .with(MySqlConnectorConfig.DATABASE_HISTORY, FileDatabaseHistory.class)
+                              .with(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
+                              .with(MySqlConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.toString())
+                              .with(FileDatabaseHistory.FILE_PATH, DB_HISTORY_PATH)
+                              .with("database.useSSL",false) // eliminates MySQL driver warning about SSL connections
+                              .build();
+        // Start the connector ...
+        start(MySqlConnector.class, config);
+        
+        // ---------------------------------------------------------------------------------------------------------------
+        // Consume all of the events due to startup and initialization of the database
+        // ---------------------------------------------------------------------------------------------------------------
+        //Testing.Debug.enable();
+        SourceRecords records = consumeRecordsByTopic(2+1);   // 2 schema change record, 1 insert
+        stopConnector();
+        assertThat(records).isNotNull();
+        assertThat(records.recordsForTopic("regression").size()).isEqualTo(2);
+        assertThat(records.recordsForTopic("regression.regression_test.t1464075356413_testtable6").size()).isEqualTo(1);
+        assertThat(records.topics().size()).isEqualTo(2);
+        assertThat(records.databaseNames().size()).isEqualTo(1);
+        assertThat(records.ddlRecordsForDatabase("regression_test").size()).isEqualTo(2);
+        assertThat(records.ddlRecordsForDatabase("connector_test")).isNull();
+        assertThat(records.ddlRecordsForDatabase("readbinlog_test")).isNull();
+        records.ddlRecordsForDatabase("regression_test").forEach(this::print);
+
+        // Check that all records are valid, can be serialized and deserialized ...
+        records.forEach(this::validate);
+    }
+
+}

--- a/debezium-core/src/main/java/io/debezium/data/SchemaUtil.java
+++ b/debezium-core/src/main/java/io/debezium/data/SchemaUtil.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.data;
 
+import java.nio.ByteBuffer;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
@@ -169,6 +171,11 @@ public class SchemaUtil {
                     appendFirst(field.name(), s.get(field));
                 }
                 sb.append('}');
+            } else if (obj instanceof ByteBuffer) {
+                ByteBuffer b = (ByteBuffer) obj;
+                sb.append('"').append(Base64.getEncoder().encode(b.array())).append('"');
+            } else if (obj instanceof byte[]) {
+                sb.append('"').append(Base64.getEncoder().encode((byte[])obj)).append('"');
             } else if (obj instanceof Map<?, ?>) {
                 Map<?, ?> map = (Map<?, ?>) obj;
                 sb.append('{');


### PR DESCRIPTION
Binary values read from the MySQL binlog may include strings, in which case they need to be converted to binary values.

Interestingly, work on this uncovered [KAFKA-3803](https://issues.apache.org/jira/browse/KAFKA-3803) whereby Kafka Connect's `Struct.equals` method does not properly handle comparing `byte[]` values. Upon researching the problem and potentially supplying a patch, it was discovered that the Kafka Connect codebase and the Avro converter all use `ByteBuffer` objects rather than `byte[]`. Consequently, the Debezium code that converts JDBC values to Kafka Connect values was changed to return `ByteBuffer` objects rather than `byte[]` objects.

Unfortunately, the JSON converter rehydrates objects with just `byte[]`, so that still means that Debezium's `VerifyRecords` logic cannot rely upon `Struct.equals` for comparison, and instead needs custom logic.