### PR TITLE
Removed duplicate versions in POMs

### DIFF
--- a/debezium-assembly-descriptors/pom.xml
+++ b/debezium-assembly-descriptors/pom.xml
@@ -8,7 +8,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-assembly-descriptors</artifactId>
-    <version>0.2-SNAPSHOT</version>
     <name>Debezium Assembly Descriptors</name>
     <build>
         <plugins>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -8,7 +8,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-connector-mysql</artifactId>
-    <version>0.2-SNAPSHOT</version>
     <name>Debezium Connector for MySQL</name>
     <packaging>jar</packaging>
 

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -8,7 +8,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-core</artifactId>
-    <version>0.2-SNAPSHOT</version>
     <name>Debezium Core</name>
     <packaging>jar</packaging>
     <dependencies>

--- a/debezium-embedded/pom.xml
+++ b/debezium-embedded/pom.xml
@@ -8,7 +8,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-embedded</artifactId>
-    <version>0.2-SNAPSHOT</version>
     <name>Debezium Embedded</name>
     <packaging>jar</packaging>
     <dependencies>


### PR DESCRIPTION
The version specifications in child modules are not require when they are the same as the parent.