### PR TITLE
DBZ-71 Corrected MySQL connector plugin archives and upgraded MySQL JDBC driver

### DIFF
--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -28,6 +28,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+        </dependency>
 
         <!-- Testing -->
         <dependency>
@@ -44,11 +48,6 @@
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-embedded</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <version.postgresql.driver>9.4-1205-jdbc42</version.postgresql.driver>
         <version.postgresql.server>9.4</version.postgresql.server>
         <version.mysql.server>5.7</version.mysql.server>
-        <version.mysql.driver>5.1.38</version.mysql.driver>
+        <version.mysql.driver>5.1.39</version.mysql.driver>
         <version.mysql.binlog>0.3.1</version.mysql.binlog>
 
         <!-- Testing -->


### PR DESCRIPTION
Corrected the MySQL connector plugin to include the MySQL JDBC driver, which was only used in tests in 0.1. Also upgraded the MySQL JDBC driver from 5.1.38 to 5.1.39, which is the latest available.