### PR TITLE
DBZ-73, DBZ-76 Corrected how binlog coordinates are recorded and put into change events

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -107,7 +107,7 @@ public final class MySqlConnectorTask extends SourceTask {
             if (taskContext.isSnapshotNeverAllowed()) {
                 // We're not allowed to take a snapshot, so instead we have to assume that the binlog contains the
                 // full history of the database.
-                source.setBinlogFilename("");// start from the beginning of the binlog
+                source.setBinlogStartPoint("", 0L);// start from the beginning of the binlog
             } else {
                 // We are allowed to use snapshots, and that is the best way to start ...
                 startWithSnapshot = true;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -186,9 +186,11 @@ public class SnapshotReader extends AbstractReader {
             sql.set("SHOW MASTER STATUS");
             mysql.query(sql.get(), rs -> {
                 if (rs.next()) {
-                    source.setBinlogFilename(rs.getString(1));
-                    source.setBinlogPosition(rs.getLong(2));
-                    source.setGtidSet(rs.getString(5));// GTID set, may be null, blank, or contain a GTID set
+                    String binlogFilename = rs.getString(1);
+                    long binlogPosition = rs.getLong(2);
+                    String gtidSet = rs.getString(5);// GTID set, may be null, blank, or contain a GTID set
+                    source.setBinlogStartPoint(binlogFilename, binlogPosition);
+                    source.setGtidSet(gtidSet);
                     source.startSnapshot();
                 }
             });

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/BinlogReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/BinlogReaderIT.java
@@ -114,7 +114,7 @@ public class BinlogReaderIT {
         config = simpleConfig().build();
         context = new MySqlTaskContext(config);
         context.start();
-        context.source().setBinlogFilename(""); // start from beginning
+        context.source().setBinlogStartPoint("",0L); // start from beginning
         reader = new BinlogReader(context);
 
         // Start reading the binlog ...
@@ -173,7 +173,7 @@ public class BinlogReaderIT {
         config = simpleConfig().with(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES, true).build();
         context = new MySqlTaskContext(config);
         context.start();
-        context.source().setBinlogFilename(""); // start from beginning
+        context.source().setBinlogStartPoint("",0L); // start from beginning
         reader = new BinlogReader(context);
 
         // Start reading the binlog ...

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSchemaTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSchemaTest.java
@@ -60,8 +60,7 @@ public class MySqlSchemaTest {
         mysql.start();
 
         // Testing.Print.enable();
-        source.setBinlogFilename("binlog-001");
-        source.setBinlogPosition(400);
+        source.setBinlogStartPoint("binlog-001",400);
         mysql.applyDdl(source, "db1", readFile("ddl/mysql-products.ddl"), this::printStatements);
 
         // Check that we have tables ...
@@ -81,11 +80,10 @@ public class MySqlSchemaTest {
                      .createSchemas();
         mysql.start();
 
-        source.setBinlogFilename("binlog-001");
-        source.setBinlogPosition(400);
+        source.setBinlogStartPoint("binlog-001",400);
         mysql.applyDdl(source, "mysql", readFile("ddl/mysql-test-init-5.7.ddl"), this::printStatements);
 
-        source.setBinlogPosition(1000);
+        source.setBinlogStartPoint("binlog-001",1000);
         mysql.applyDdl(source, "db1", readFile("ddl/mysql-products.ddl"), this::printStatements);
 
         // Check that we have tables ...
@@ -107,11 +105,10 @@ public class MySqlSchemaTest {
                      .createSchemas();
         mysql.start();
 
-        source.setBinlogFilename("binlog-001");
-        source.setBinlogPosition(400);
+        source.setBinlogStartPoint("binlog-001",400);
         mysql.applyDdl(source, "mysql", readFile("ddl/mysql-test-init-5.7.ddl"), this::printStatements);
 
-        source.setBinlogPosition(1000);
+        source.setBinlogStartPoint("binlog-001",1000);
         mysql.applyDdl(source, "db1", readFile("ddl/mysql-products.ddl"), this::printStatements);
 
         // Check that we have tables ...


### PR DESCRIPTION
Fixes two issues with how the binlog coordinates are handled.

The first, DBZ-73, fixes how the offsets are recording the _next_ binlog coordinates within the offsets, which is fine for single-row events but which can result in dropped events should Kafka Connect flush the offset of some but not all of the rows before the Kafka Connect crashes. Upon restart, the offset contains the binlog coordinates for the _next_ event, so any of the last rows from the previous events will be lost.

With this fix, the offset used with all but the last row (in the binlog event) has the binlog coordinates of the current event, with the event row number set to be the next row that needs to be processed. The offset for the last row will have the binlog coordinates of the next event.

The second issue, DBZ-76, is somewhat related: the `source` field of the change events has the binlog coordinates of the _next_ issue. The fix involves putting the binlog coordinates for the _current_ event into the `source` field.

Both of these issues are related and influenced a fix that could address both problems. Essentially, the `SourceInfo` is now recording the previous and next position, and the next and previous row numbers. The offset is created with parameters that specify the row number and the total number of rows, so this method correctly adjusts the binlog coordinates of the offset. The `struct` field produces the value for the `source` field, and it is always using the previous position and previous row number that reflect the change event in which it is used.