### PR TITLE
DBZ-73, DBZ-77 Added offset tests and fix for incomplete snapshot bug (for 0.2.x)

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RecordMakers.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RecordMakers.java
@@ -179,7 +179,7 @@ public class RecordMakers {
                 if (value != null || key != null) {
                     Schema keySchema = tableSchema.keySchema();
                     Map<String, ?> partition = source.partition();
-                    Map<String, ?> offset = source.offset(rowNumber, numberOfRows);
+                    Map<String, ?> offset = source.offsetForRow(rowNumber, numberOfRows);
                     Struct origin = source.struct();
                     SourceRecord record = new SourceRecord(partition, offset, topicName, partitionNum,
                             keySchema, key, envelope.schema(), envelope.read(value, origin, ts));
@@ -198,7 +198,7 @@ public class RecordMakers {
                 if (value != null || key != null) {
                     Schema keySchema = tableSchema.keySchema();
                     Map<String, ?> partition = source.partition();
-                    Map<String, ?> offset = source.offset(rowNumber, numberOfRows);
+                    Map<String, ?> offset = source.offsetForRow(rowNumber, numberOfRows);
                     Struct origin = source.struct();
                     SourceRecord record = new SourceRecord(partition, offset, topicName, partitionNum,
                             keySchema, key, envelope.schema(), envelope.create(value, origin, ts));
@@ -220,7 +220,7 @@ public class RecordMakers {
                     Struct valueBefore = tableSchema.valueFromColumnData(before);
                     Schema keySchema = tableSchema.keySchema();
                     Map<String, ?> partition = source.partition();
-                    Map<String, ?> offset = source.offset(rowNumber, numberOfRows);
+                    Map<String, ?> offset = source.offsetForRow(rowNumber, numberOfRows);
                     Struct origin = source.struct();
                     if (key != null && !Objects.equals(key, oldKey)) {
                         // The key has indeed changed, so first send a create event ...
@@ -260,7 +260,7 @@ public class RecordMakers {
                 if (value != null || key != null) {
                     Schema keySchema = tableSchema.keySchema();
                     Map<String, ?> partition = source.partition();
-                    Map<String, ?> offset = source.offset(rowNumber, numberOfRows);
+                    Map<String, ?> offset = source.offsetForRow(rowNumber, numberOfRows);
                     Struct origin = source.struct();
                     // Send a delete message ...
                     SourceRecord record = new SourceRecord(partition, offset, topicName, partitionNum,

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
@@ -161,12 +161,14 @@ final class SourceInfo {
     /**
      * Set the current row number within a given event, and then get the Kafka Connect detail about the source "offset", which
      * describes the position within the source where we have last read.
+     * <p>
+     * This method should always be called before {@link #struct()}.
      * 
      * @param eventRowNumber the 0-based row number within the event being processed
      * @param totalNumberOfRows the total number of rows within the event being processed
      * @return a copy of the current offset; never null
      */
-    public Map<String, ?> offset(int eventRowNumber, int totalNumberOfRows) {
+    public Map<String, ?> offsetForRow(int eventRowNumber, int totalNumberOfRows) {
         if (eventRowNumber < (totalNumberOfRows - 1)) {
             // This is not the last row, so our offset should record the next row to be used ...
             this.lastEventRowNumber = eventRowNumber;
@@ -180,7 +182,7 @@ final class SourceInfo {
         return offsetUsingPosition(nextBinlogPosition);
     }
 
-    private Map<String, ?> offsetUsingPosition( long binlogPosition ) {
+    private Map<String, ?> offsetUsingPosition(long binlogPosition) {
         Map<String, Object> map = new HashMap<>();
         if (serverId != 0) map.put(SERVER_ID_KEY, serverId);
         if (binlogTimestampSeconds != 0) map.put(TIMESTAMP_KEY, binlogTimestampSeconds);
@@ -209,6 +211,8 @@ final class SourceInfo {
     /**
      * Get a {@link Struct} representation of the source {@link #partition()} and {@link #offset()} information. The Struct
      * complies with the {@link #SCHEMA} for the MySQL connector.
+     * <p>
+     * This method should always be called after {@link #offsetForRow(int, int)}.
      * 
      * @return the source partition and offset {@link Struct}; never null
      * @see #schema()
@@ -284,8 +288,8 @@ final class SourceInfo {
     public void setEventPosition(long positionOfCurrentEvent, long eventSizeInBytes) {
         this.lastBinlogPosition = positionOfCurrentEvent;
         this.nextBinlogPosition = positionOfCurrentEvent + eventSizeInBytes;
-        this.nextEventRowNumber = 0;
-        this.lastEventRowNumber = 0;
+        // Don't set anything else, since the row numbers are set in the offset(int,int) method called at least once
+        // for each processed event
     }
 
     /**
@@ -338,6 +342,7 @@ final class SourceInfo {
             nextEventRowNumber = (int) longOffsetValue(sourceOffset, BINLOG_EVENT_ROW_NUMBER_OFFSET_KEY);
             lastBinlogPosition = nextBinlogPosition;
             lastEventRowNumber = nextEventRowNumber;
+            snapshot = booleanOffsetValue(sourceOffset, SNAPSHOT_KEY);
         }
     }
 
@@ -350,6 +355,13 @@ final class SourceInfo {
         } catch (NumberFormatException e) {
             throw new ConnectException("Source offset '" + key + "' parameter value " + obj + " could not be converted to a long");
         }
+    }
+
+    private boolean booleanOffsetValue(Map<String, ?> values, String key) {
+        Object obj = values.get(key);
+        if (obj == null) return false;
+        if (obj instanceof Boolean) return ((Boolean) obj).booleanValue();
+        return Boolean.parseBoolean(obj.toString());
     }
 
     /**

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
@@ -7,9 +7,16 @@ package io.debezium.connector.mysql;
 
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.avro.Schema;
+import org.apache.kafka.connect.data.Struct;
 import org.fest.assertions.GenericAssert;
+import org.junit.Before;
 import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
 
 import io.confluent.connect.avro.AvroData;
 import io.debezium.document.Document;
@@ -18,6 +25,318 @@ public class SourceInfoTest {
 
     private static int avroSchemaCacheSize = 1000;
     private static final AvroData avroData = new AvroData(avroSchemaCacheSize);
+    private static final String FILENAME = "mysql-bin.00001";
+    private static final String GTID_SET = "gtid-set"; // can technically be any string
+    private static final String SERVER_NAME = "my-server"; // can technically be any string
+
+    private SourceInfo source;
+
+    @Before
+    public void beforeEach() {
+        source = new SourceInfo();
+    }
+
+    @Test
+    public void shouldStartSourceInfoFromZeroBinlogCoordinates() {
+        source.setBinlogStartPoint(FILENAME, 0);
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(0);
+        assertThat(source.lastBinlogPosition()).isEqualTo(0);
+        assertThat(source.nextEventRowNumber()).isEqualTo(0);
+        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.isSnapshotInEffect()).isFalse();
+    }
+
+    @Test
+    public void shouldStartSourceInfoFromNonZeroBinlogCoordinates() {
+        source.setBinlogStartPoint(FILENAME, 100);
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(100);
+        assertThat(source.lastBinlogPosition()).isEqualTo(100);
+        assertThat(source.nextEventRowNumber()).isEqualTo(0);
+        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.isSnapshotInEffect()).isFalse();
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Test reading the offset map and recovering the proper SourceInfo state
+    // -------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldRecoverSourceInfoFromOffsetWithZeroBinlogCoordinates() {
+        sourceWith(offset(0, 0));
+        assertThat(source.gtidSet()).isNull();
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(0);
+        assertThat(source.lastBinlogPosition()).isEqualTo(0);
+        assertThat(source.nextEventRowNumber()).isEqualTo(0);
+        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.isSnapshotInEffect()).isFalse();
+    }
+
+    @Test
+    public void shouldRecoverSourceInfoFromOffsetWithNonZeroBinlogCoordinates() {
+        sourceWith(offset(100, 0));
+        assertThat(source.gtidSet()).isNull();
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(100);
+        assertThat(source.lastBinlogPosition()).isEqualTo(100);
+        assertThat(source.nextEventRowNumber()).isEqualTo(0);
+        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.isSnapshotInEffect()).isFalse();
+    }
+
+    @Test
+    public void shouldRecoverSourceInfoFromOffsetWithZeroBinlogCoordinatesAndNonZeroRow() {
+        sourceWith(offset(0, 5));
+        assertThat(source.gtidSet()).isNull();
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(0);
+        assertThat(source.lastBinlogPosition()).isEqualTo(0);
+        assertThat(source.nextEventRowNumber()).isEqualTo(5);
+        assertThat(source.lastEventRowNumber()).isEqualTo(5);
+        assertThat(source.isSnapshotInEffect()).isFalse();
+    }
+
+    @Test
+    public void shouldRecoverSourceInfoFromOffsetWithNonZeroBinlogCoordinatesAndNonZeroRow() {
+        sourceWith(offset(100, 5));
+        assertThat(source.gtidSet()).isNull();
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(100);
+        assertThat(source.lastBinlogPosition()).isEqualTo(100);
+        assertThat(source.nextEventRowNumber()).isEqualTo(5);
+        assertThat(source.lastEventRowNumber()).isEqualTo(5);
+        assertThat(source.isSnapshotInEffect()).isFalse();
+    }
+
+    @Test
+    public void shouldRecoverSourceInfoFromOffsetWithZeroBinlogCoordinatesAndSnapshot() {
+        sourceWith(offset(0, 0, true));
+        assertThat(source.gtidSet()).isNull();
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(0);
+        assertThat(source.lastBinlogPosition()).isEqualTo(0);
+        assertThat(source.nextEventRowNumber()).isEqualTo(0);
+        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.isSnapshotInEffect()).isTrue();
+    }
+
+    @Test
+    public void shouldRecoverSourceInfoFromOffsetWithNonZeroBinlogCoordinatesAndSnapshot() {
+        sourceWith(offset(100, 0, true));
+        assertThat(source.gtidSet()).isNull();
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(100);
+        assertThat(source.lastBinlogPosition()).isEqualTo(100);
+        assertThat(source.nextEventRowNumber()).isEqualTo(0);
+        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.isSnapshotInEffect()).isTrue();
+    }
+
+    @Test
+    public void shouldRecoverSourceInfoFromOffsetWithZeroBinlogCoordinatesAndNonZeroRowAndSnapshot() {
+        sourceWith(offset(0, 5, true));
+        assertThat(source.gtidSet()).isNull();
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(0);
+        assertThat(source.lastBinlogPosition()).isEqualTo(0);
+        assertThat(source.nextEventRowNumber()).isEqualTo(5);
+        assertThat(source.lastEventRowNumber()).isEqualTo(5);
+        assertThat(source.isSnapshotInEffect()).isTrue();
+    }
+
+    @Test
+    public void shouldRecoverSourceInfoFromOffsetWithNonZeroBinlogCoordinatesAndNonZeroRowAndSnapshot() {
+        sourceWith(offset(100, 5, true));
+        assertThat(source.gtidSet()).isNull();
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(100);
+        assertThat(source.lastBinlogPosition()).isEqualTo(100);
+        assertThat(source.nextEventRowNumber()).isEqualTo(5);
+        assertThat(source.lastEventRowNumber()).isEqualTo(5);
+        assertThat(source.isSnapshotInEffect()).isTrue();
+    }
+
+    @Test
+    public void shouldStartSourceInfoFromBinlogCoordinatesWithGtidsAndZeroBinlogCoordinates() {
+        sourceWith(offset(GTID_SET, 0, 0, false));
+        assertThat(source.gtidSet()).isEqualTo(GTID_SET);
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(0);
+        assertThat(source.lastBinlogPosition()).isEqualTo(0);
+        assertThat(source.nextEventRowNumber()).isEqualTo(0);
+        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.isSnapshotInEffect()).isFalse();
+    }
+
+    @Test
+    public void shouldStartSourceInfoFromBinlogCoordinatesWithGtidsAndZeroBinlogCoordinatesAndNonZeroRow() {
+        sourceWith(offset(GTID_SET, 0, 5, false));
+        assertThat(source.gtidSet()).isEqualTo(GTID_SET);
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(0);
+        assertThat(source.lastBinlogPosition()).isEqualTo(0);
+        assertThat(source.nextEventRowNumber()).isEqualTo(5);
+        assertThat(source.lastEventRowNumber()).isEqualTo(5);
+        assertThat(source.isSnapshotInEffect()).isFalse();
+    }
+
+    @Test
+    public void shouldStartSourceInfoFromBinlogCoordinatesWithGtidsAndNonZeroBinlogCoordinates() {
+        sourceWith(offset(GTID_SET, 100, 0, false));
+        assertThat(source.gtidSet()).isEqualTo(GTID_SET);
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(100);
+        assertThat(source.lastBinlogPosition()).isEqualTo(100);
+        assertThat(source.nextEventRowNumber()).isEqualTo(0);
+        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.isSnapshotInEffect()).isFalse();
+    }
+
+    @Test
+    public void shouldStartSourceInfoFromBinlogCoordinatesWithGtidsAndNonZeroBinlogCoordinatesAndNonZeroRow() {
+        sourceWith(offset(GTID_SET, 100, 5, false));
+        assertThat(source.gtidSet()).isEqualTo(GTID_SET);
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(100);
+        assertThat(source.lastBinlogPosition()).isEqualTo(100);
+        assertThat(source.nextEventRowNumber()).isEqualTo(5);
+        assertThat(source.lastEventRowNumber()).isEqualTo(5);
+        assertThat(source.isSnapshotInEffect()).isFalse();
+    }
+
+    @Test
+    public void shouldStartSourceInfoFromBinlogCoordinatesWithGtidsAndZeroBinlogCoordinatesAndSnapshot() {
+        sourceWith(offset(GTID_SET, 0, 0, true));
+        assertThat(source.gtidSet()).isEqualTo(GTID_SET);
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(0);
+        assertThat(source.lastBinlogPosition()).isEqualTo(0);
+        assertThat(source.nextEventRowNumber()).isEqualTo(0);
+        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.isSnapshotInEffect()).isTrue();
+    }
+
+    @Test
+    public void shouldStartSourceInfoFromBinlogCoordinatesWithGtidsAndZeroBinlogCoordinatesAndNonZeroRowAndSnapshot() {
+        sourceWith(offset(GTID_SET, 0, 5, true));
+        assertThat(source.gtidSet()).isEqualTo(GTID_SET);
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(0);
+        assertThat(source.lastBinlogPosition()).isEqualTo(0);
+        assertThat(source.nextEventRowNumber()).isEqualTo(5);
+        assertThat(source.lastEventRowNumber()).isEqualTo(5);
+        assertThat(source.isSnapshotInEffect()).isTrue();
+    }
+
+    @Test
+    public void shouldStartSourceInfoFromBinlogCoordinatesWithGtidsAndNonZeroBinlogCoordinatesAndSnapshot() {
+        sourceWith(offset(GTID_SET, 100, 0, true));
+        assertThat(source.gtidSet()).isEqualTo(GTID_SET);
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(100);
+        assertThat(source.lastBinlogPosition()).isEqualTo(100);
+        assertThat(source.nextEventRowNumber()).isEqualTo(0);
+        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.isSnapshotInEffect()).isTrue();
+    }
+
+    @Test
+    public void shouldStartSourceInfoFromBinlogCoordinatesWithGtidsAndNonZeroBinlogCoordinatesAndNonZeroRowAndSnapshot() {
+        sourceWith(offset(GTID_SET, 100, 5, true));
+        assertThat(source.gtidSet()).isEqualTo(GTID_SET);
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.nextBinlogPosition()).isEqualTo(100);
+        assertThat(source.lastBinlogPosition()).isEqualTo(100);
+        assertThat(source.nextEventRowNumber()).isEqualTo(5);
+        assertThat(source.lastEventRowNumber()).isEqualTo(5);
+        assertThat(source.isSnapshotInEffect()).isTrue();
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Test advancing SourceInfo state (similar to how the BinlogReader uses it)
+    // -------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldAdvanceSourceInfoFromNonZeroPositionAndRowZeroForEventsWithOneRow() {
+        sourceWith(offset(100, 0));
+        handleNextEvent(200, 10, withRowCount(1));
+        handleNextEvent(220, 10, withRowCount(1));
+        handleNextEvent(250, 50, withRowCount(1));
+    }
+
+    @Test
+    public void shouldAdvanceSourceInfoFromNonZeroPositionAndRowZeroForEventsWithMultipleRow() {
+        sourceWith(offset(100, 0));
+        handleNextEvent(200, 10, withRowCount(3));
+        handleNextEvent(220, 10, withRowCount(4));
+        handleNextEvent(250, 50, withRowCount(6));
+        handleNextEvent(300, 20, withRowCount(1));
+        handleNextEvent(350, 20, withRowCount(3));
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Utility methods
+    // -------------------------------------------------------------------------------------
+
+    protected int withRowCount(int rowCount) {
+        return rowCount;
+    }
+
+    protected void handleNextEvent(long positionOfEvent, long eventSize, int rowCount) {
+        source.setEventPosition(positionOfEvent, eventSize);
+        for (int i = 0; i != rowCount; ++i) {
+            // Get the offset for this row (always first!) ...
+            Map<String, ?> offset = source.offsetForRow(i, rowCount);
+            if ((i + 1) < rowCount) {
+                // This is not the last row, so the next binlog position should be for next row in this event ...
+                assertThat(offset.get(SourceInfo.BINLOG_POSITION_OFFSET_KEY)).isEqualTo(positionOfEvent);
+                assertThat(offset.get(SourceInfo.BINLOG_EVENT_ROW_NUMBER_OFFSET_KEY)).isEqualTo(i+1);
+            } else {
+                // This is the last row, so the next binlog position should be for first row in next event ...
+                assertThat(offset.get(SourceInfo.BINLOG_POSITION_OFFSET_KEY)).isEqualTo(positionOfEvent + eventSize);
+                assertThat(offset.get(SourceInfo.BINLOG_EVENT_ROW_NUMBER_OFFSET_KEY)).isEqualTo(0);
+            }
+            assertThat(offset.get(SourceInfo.BINLOG_FILENAME_OFFSET_KEY)).isEqualTo(FILENAME);
+            if ( source.gtidSet() != null ) {
+                assertThat(offset.get(SourceInfo.GTID_SET_KEY)).isEqualTo(source.gtidSet());
+            }
+            // Get the source struct for this row (always second), which should always reflect this row in this event ...
+            Struct recordSource = source.struct();
+            assertThat(recordSource.getInt64(SourceInfo.BINLOG_POSITION_OFFSET_KEY)).isEqualTo(positionOfEvent);
+            assertThat(recordSource.getInt32(SourceInfo.BINLOG_EVENT_ROW_NUMBER_OFFSET_KEY)).isEqualTo(i);
+            assertThat(recordSource.getString(SourceInfo.BINLOG_FILENAME_OFFSET_KEY)).isEqualTo(FILENAME);
+            if ( source.gtidSet() != null ) {
+                assertThat(recordSource.getString(SourceInfo.GTID_SET_KEY)).isEqualTo(source.gtidSet());
+            }
+        }
+    }
+
+    protected Map<String, String> offset(long position, int row) {
+        return offset(null, position, row, false);
+    }
+
+    protected Map<String, String> offset(long position, int row, boolean snapshot) {
+        return offset(null, position, row, snapshot);
+    }
+
+    protected Map<String, String> offset(String gtidSet, long position, int row, boolean snapshot) {
+        Map<String, String> offset = new HashMap<>();
+        offset.put(SourceInfo.BINLOG_FILENAME_OFFSET_KEY, FILENAME);
+        offset.put(SourceInfo.BINLOG_POSITION_OFFSET_KEY, Long.toString(position));
+        offset.put(SourceInfo.BINLOG_EVENT_ROW_NUMBER_OFFSET_KEY, Integer.toString(row));
+        if (gtidSet != null) offset.put(SourceInfo.GTID_SET_KEY, gtidSet);
+        if (snapshot) offset.put(SourceInfo.SNAPSHOT_KEY, Boolean.TRUE.toString());
+        return offset;
+    }
+
+    protected SourceInfo sourceWith(Map<String, String> offset) {
+        source = new SourceInfo();
+        source.setOffset(offset);
+        source.setServerName(SERVER_NAME);
+        return source;
+    }
 
     /**
      * When we want to consume SinkRecord which generated by debezium-connector-mysql, it should not
@@ -32,30 +351,31 @@ public class SourceInfoTest {
 
     @Test
     public void shouldConsiderPositionsWithSameGtidSetsAsSame() {
-        assertPositionWithGtids("IdA:1-5").isAtOrBefore(positionWithGtids("IdA:1-5"));  // same, single
+        assertPositionWithGtids("IdA:1-5").isAtOrBefore(positionWithGtids("IdA:1-5")); // same, single
         assertPositionWithGtids("IdA:1-5,IdB:1-20").isAtOrBefore(positionWithGtids("IdA:1-5,IdB:1-20")); // same, multiple
         assertPositionWithGtids("IdA:1-5,IdB:1-20").isAtOrBefore(positionWithGtids("IdB:1-20,IdA:1-5")); // equivalent
     }
 
     @Test
     public void shouldConsiderPositionsWithSameGtidSetsAndSnapshotAsSame() {
-        assertPositionWithGtids("IdA:1-5",true).isAtOrBefore(positionWithGtids("IdA:1-5",true));  // same, single
-        assertPositionWithGtids("IdA:1-5,IdB:1-20",true).isAtOrBefore(positionWithGtids("IdA:1-5,IdB:1-20",true)); // same, multiple
-        assertPositionWithGtids("IdA:1-5,IdB:1-20",true).isAtOrBefore(positionWithGtids("IdB:1-20,IdA:1-5",true)); // equivalent
+        assertPositionWithGtids("IdA:1-5", true).isAtOrBefore(positionWithGtids("IdA:1-5", true)); // same, single
+        assertPositionWithGtids("IdA:1-5,IdB:1-20", true).isAtOrBefore(positionWithGtids("IdA:1-5,IdB:1-20", true)); // same,
+                                                                                                                     // multiple
+        assertPositionWithGtids("IdA:1-5,IdB:1-20", true).isAtOrBefore(positionWithGtids("IdB:1-20,IdA:1-5", true)); // equivalent
     }
 
     @Test
     public void shouldOrderPositionWithGtidAndSnapshotBeforePositionWithSameGtidButNoSnapshot() {
-        assertPositionWithGtids("IdA:1-5",true).isAtOrBefore(positionWithGtids("IdA:1-5"));  // same, single
-        assertPositionWithGtids("IdA:1-5,IdB:1-20",true).isAtOrBefore(positionWithGtids("IdA:1-5,IdB:1-20")); // same, multiple
-        assertPositionWithGtids("IdA:1-5,IdB:1-20",true).isAtOrBefore(positionWithGtids("IdB:1-20,IdA:1-5")); // equivalent
+        assertPositionWithGtids("IdA:1-5", true).isAtOrBefore(positionWithGtids("IdA:1-5")); // same, single
+        assertPositionWithGtids("IdA:1-5,IdB:1-20", true).isAtOrBefore(positionWithGtids("IdA:1-5,IdB:1-20")); // same, multiple
+        assertPositionWithGtids("IdA:1-5,IdB:1-20", true).isAtOrBefore(positionWithGtids("IdB:1-20,IdA:1-5")); // equivalent
     }
 
     @Test
     public void shouldOrderPositionWithoutGtidAndSnapshotAfterPositionWithSameGtidAndSnapshot() {
-        assertPositionWithGtids("IdA:1-5",false).isAfter(positionWithGtids("IdA:1-5",true));  // same, single
-        assertPositionWithGtids("IdA:1-5,IdB:1-20",false).isAfter(positionWithGtids("IdA:1-5,IdB:1-20",true)); // same, multiple
-        assertPositionWithGtids("IdA:1-5,IdB:1-20",false).isAfter(positionWithGtids("IdB:1-20,IdA:1-5",true)); // equivalent
+        assertPositionWithGtids("IdA:1-5", false).isAfter(positionWithGtids("IdA:1-5", true)); // same, single
+        assertPositionWithGtids("IdA:1-5,IdB:1-20", false).isAfter(positionWithGtids("IdA:1-5,IdB:1-20", true)); // same, multiple
+        assertPositionWithGtids("IdA:1-5,IdB:1-20", false).isAfter(positionWithGtids("IdB:1-20,IdA:1-5", true)); // equivalent
     }
 
     @Test
@@ -107,16 +427,16 @@ public class SourceInfoTest {
                                SourceInfo.BINLOG_EVENT_ROW_NUMBER_OFFSET_KEY, row);
     }
 
-    protected PositionAssert assertThat(Document position) {
+    protected PositionAssert assertThatDocument(Document position) {
         return new PositionAssert(position);
     }
 
     protected PositionAssert assertPositionWithGtids(String gtids) {
-        return assertThat(positionWithGtids(gtids));
+        return assertThatDocument(positionWithGtids(gtids));
     }
 
     protected PositionAssert assertPositionWithGtids(String gtids, boolean snapshot) {
-        return assertThat(positionWithGtids(gtids, snapshot));
+        return assertThatDocument(positionWithGtids(gtids, snapshot));
     }
 
     protected PositionAssert assertPositionWithoutGtids(String filename, int position, int row) {
@@ -124,7 +444,7 @@ public class SourceInfoTest {
     }
 
     protected PositionAssert assertPositionWithoutGtids(String filename, int position, int row, boolean snapshot) {
-        return assertThat(positionWithoutGtids(filename, position, row, snapshot));
+        return assertThatDocument(positionWithoutGtids(filename, position, row, snapshot));
     }
 
     protected static class PositionAssert extends GenericAssert<PositionAssert, Document> {

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -7,6 +7,7 @@ package io.debezium.embedded;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -333,6 +334,10 @@ public abstract class AbstractConnectorTest implements Testing {
 
         public void forEach(Consumer<SourceRecord> consumer) {
             records.forEach(consumer);
+        }
+        
+        public List<SourceRecord> allRecordsInOrder() {
+            return Collections.unmodifiableList(records);
         }
 
         public void print() {


### PR DESCRIPTION
Added unit tests that verify the behavior of the MySQL connector's `SourceInfo` component. This testing reveal an issue with how offsets were being recorded at the end of a snapshot ([DBZ-77](https://issues.jboss.org/browse/DBZ-77)). The second commit corrects this problem by utilizing the recently-added logic for different offset and `source` field information on the very last record produced during the snapshot.