### PR TITLE
DBZ-79 Changed public methods in GtidSet to reflect the MySQL Binary Log Connector's class

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -194,7 +194,7 @@ public final class MySqlConnectorTask extends SourceTask {
             // GTIDs are enabled, and we used them previously ...
             GtidSet gtidSet = new GtidSet(gtidStr);
             GtidSet availableGtidSet = new GtidSet(knownGtidSet());
-            if ( gtidSet.isSubsetOf(availableGtidSet)) {
+            if ( gtidSet.isContainedWithin(availableGtidSet)) {
                 return true;
             }
             logger.info("Connector last known GTIDs are {}, but MySQL has {}",gtidSet,availableGtidSet);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
@@ -503,7 +503,7 @@ final class SourceInfo {
                     return true;
                 }
                 // The GTIDs are not an exact match, so figure out if recorded is a subset of the desired ...
-                return recordedGtidSet.isSubsetOf(desiredGtidSet);
+                return recordedGtidSet.isContainedWithin(desiredGtidSet);
             }
             // The desired position did use GTIDs while the recorded did not use GTIDs. So, we assume that the
             // recorded position is older since GTIDs are often enabled but rarely disabled. And if they are disabled,

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/GtidSetTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/GtidSetTest.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.connector.mysql;
 
+import java.util.LinkedList;
+
 import org.junit.Test;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -84,14 +86,14 @@ public class GtidSetTest {
     
     protected void asertFirstInterval( String uuid, int start, int end) {
         UUIDSet set = gtids.forServerWithId(uuid);
-        Interval interval = set.getFirstInterval();
+        Interval interval = set.getIntervals().iterator().next();
         assertThat(interval.getStart()).isEqualTo(start);
         assertThat(interval.getEnd()).isEqualTo(end);
     }
     
     protected void asertLastInterval( String uuid, int start, int end) {
         UUIDSet set = gtids.forServerWithId(uuid);
-        Interval interval = set.getLastInterval();
+        Interval interval = new LinkedList<>(set.getIntervals()).getLast();
         assertThat(interval.getStart()).isEqualTo(start);
         assertThat(interval.getEnd()).isEqualTo(end);
     }


### PR DESCRIPTION
Removed several of the `GtidSet` convenience methods that are not in the [improved](https://github.com/shyiko/mysql-binlog-connector-java/pull/100) `com.github.shyiko.mysql.binlog.GtidSet` class. Getting these out of our API will make it easier to reuse the improved `com.github.shyiko.mysql.binlog.GtidSet` class.