### PR TITLE
Corrected build to look for updated output of alt-mysql container

### DIFF
--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -215,7 +215,7 @@
                         <color>magenta</color>
                       </log>
                       <wait>
-                        <log>socket: \'/var/run/mysqld/mysqld\.sock\'  port: 3306  MySQL Community Server \(GPL\)</log>
+                        <log>MySQL init process done. Ready for start up.</log>
                         <time>30000</time>
                       </wait>
                     </run>


### PR DESCRIPTION
The `mysql:5.7` docker image was recently updated and changed its output to be more like `mysql/mysql-server:5.7`. This broke our build since our build looks for specific lines in the output to know when the server has completed initialization. Simply changing the pattern corrects the problem.