### PR TITLE
DBZ-94 Added support for copying very large tables during snapshot

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -268,6 +268,15 @@ public class MySqlConnectorConfig {
                                                       .withDescription("Frequency in milliseconds to wait for new change events to appear after receiving no events. Defaults to 1 second (1000 ms).")
                                                       .withDefault(TimeUnit.SECONDS.toMillis(1))
                                                       .withValidation(Field::isPositiveInteger);
+    
+    public static final Field ROW_COUNT_FOR_STREAMING_RESULT_SETS = Field.create("min.row.count.to.stream.results")
+                                                                         .withDisplayName("Stream result set larger than")
+                                                                         .withType(Type.LONG)
+                                                                         .withWidth(Width.MEDIUM)
+                                                                         .withImportance(Importance.LOW)
+                                                                         .withDescription("The number of rows a table must contain to stream results rather than pull all into memory during snapshots. Defaults to 1,000.")
+                                                                         .withDefault(1_000)
+                                                                         .withValidation(Field::isPositiveInteger);
 
     /**
      * The database history class is hidden in the {@link #configDef()} since that is designed to work with a user interface,

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -102,6 +102,10 @@ public final class MySqlTaskContext extends MySqlJdbcContext {
     public long pollIntervalInMillseconds() {
         return config.getLong(MySqlConnectorConfig.POLL_INTERVAL_MS);
     }
+    
+    public long rowCountForLargeTable() {
+        return config.getLong(MySqlConnectorConfig.ROW_COUNT_FOR_STREAMING_RESULT_SETS);
+    }
 
     public boolean includeSchemaChangeRecords() {
         return config.getBoolean(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RecordMakers.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RecordMakers.java
@@ -81,6 +81,20 @@ public class RecordMakers {
     }
 
     /**
+     * Determine if there is a record maker for the given table.
+     * 
+     * @param tableId the identifier of the table
+     * @return {@code true} if there is a {@link #forTable(TableId, BitSet, BlockingConsumer) record maker}, or {@code false}
+     * if there is none
+     */
+    public boolean hasTable(TableId tableId) {
+        Long tableNumber = tableNumbersByTableId.get(tableId);
+        if ( tableNumber == null ) return false;
+        Converter converter = convertersByTableNumber.get(tableNumber);
+        return converter != null;
+    }
+
+    /**
      * Obtain the record maker for the given table, using the specified columns and sending records to the given consumer.
      * 
      * @param tableNumber the {@link #assign(long, TableId) assigned table number} for which records are to be produced

--- a/debezium-core/src/main/java/io/debezium/function/BufferedBlockingConsumer.java
+++ b/debezium-core/src/main/java/io/debezium/function/BufferedBlockingConsumer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.function;
+
+import java.util.function.Function;
+
+/**
+ * A {@link BlockingConsumer} that retains a maximum number of values in a buffer before sending them to
+ * a delegate consumer. Note that any buffered values may need to be {@link #flush() flushed} periodically.
+ * <p>
+ * This maintains the same order of the values.
+ * 
+ * @param <T> the type of the input to the operation
+ * @author Randall Hauch
+ */
+public interface BufferedBlockingConsumer<T> extends BlockingConsumer<T> {
+
+    /**
+     * Flush all of the buffered values to the delegate.
+     * 
+     * @throws InterruptedException if the thread is interrupted while this consumer is blocked
+     */
+    public default void flush() throws InterruptedException {
+        flush(t -> t);
+    }
+
+    /**
+     * Flush all of the buffered values to the delegate by first running each buffered value through the given function
+     * to generate a new value to be flushed to the delegate consumer.
+     * 
+     * @param function the function to apply to the values that are flushed
+     * @throws InterruptedException if the thread is interrupted while this consumer is blocked
+     */
+    public void flush(Function<T, T> function) throws InterruptedException;
+
+    /**
+     * Get a {@link BufferedBlockingConsumer} that buffers just the last value seen by the consumer.
+     * When another value is then added to the consumer, this buffered consumer will push the prior value into the delegate
+     * and buffer the latest.
+     * <p>
+     * The resulting consumer is not threadsafe.
+     * 
+     * @param delegate the delegate to which values should be flushed; may not be null
+     * @return the blocking consumer that buffers a single value at a time; never null
+     */
+    public static <T> BufferedBlockingConsumer<T> bufferLast(BlockingConsumer<T> delegate) {
+        return new BufferedBlockingConsumer<T>() {
+            private T last;
+
+            @Override
+            public void accept(T t) throws InterruptedException {
+                if (last != null) delegate.accept(last);
+                last = t;
+            }
+
+            @Override
+            public void flush(Function<T, T> function) throws InterruptedException {
+                if (last != null) {
+                    try {
+                        delegate.accept(function.apply(last));
+                    } finally {
+                        last = null;
+                    }
+                }
+            }
+        };
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -27,8 +27,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
@@ -275,8 +277,22 @@ public class JdbcConnection implements AutoCloseable {
      * @see #execute(Operations)
      */
     public JdbcConnection query(String query, ResultSetConsumer resultConsumer) throws SQLException {
+        return query(query,conn->conn.createStatement(),resultConsumer);
+    }
+
+    /**
+     * Execute a SQL query.
+     * 
+     * @param query the SQL query
+     * @param statementFactory the function that should be used to create the statement from the connection; may not be null
+     * @param resultConsumer the consumer of the query results
+     * @return this object for chaining methods together
+     * @throws SQLException if there is an error connecting to the database or executing the statements
+     * @see #execute(Operations)
+     */
+    public JdbcConnection query(String query, StatementFactory statementFactory, ResultSetConsumer resultConsumer) throws SQLException {
         Connection conn = connection();
-        try (Statement statement = conn.createStatement();) {
+        try (Statement statement = statementFactory.createStatement(conn);) {
             if (LOGGER.isTraceEnabled()) {
                 LOGGER.trace("running '{}'", query);
             }
@@ -287,6 +303,21 @@ public class JdbcConnection implements AutoCloseable {
             }
         }
         return this;
+    }
+    
+    /**
+     * A function to create a statement from a connection.
+     * @author Randall Hauch
+     */
+    @FunctionalInterface
+    public interface StatementFactory {
+        /**
+         * Use the given connection to create a statement.
+         * @param connection the JDBC connection; never null
+         * @return the statement
+         * @throws SQLException if there are problems creating a statement
+         */
+        Statement createStatement(Connection connection) throws SQLException;
     }
 
     /**
@@ -521,7 +552,7 @@ public class JdbcConnection implements AutoCloseable {
     }
 
     /**
-     * Returns a JDBC connection string using the current configuration and url. 
+     * Returns a JDBC connection string using the current configuration and url.
      * 
      * @param urlPattern a {@code String} representing a JDBC connection with variables that will be replaced
      * @return a {@code String} where the variables in {@code urlPattern} are replaced with values from the configuration
@@ -529,16 +560,16 @@ public class JdbcConnection implements AutoCloseable {
     public String connectionString(String urlPattern) {
         Properties props = config.asProperties();
         return findAndReplace(urlPattern, props, JdbcConfiguration.DATABASE, JdbcConfiguration.HOSTNAME, JdbcConfiguration.PORT,
-                              JdbcConfiguration.USER, JdbcConfiguration.PASSWORD);   
+                              JdbcConfiguration.USER, JdbcConfiguration.PASSWORD);
     }
 
     /**
-     * Returns the username for this connection 
+     * Returns the username for this connection
      * 
      * @return a {@code String}, never {@code null}
      */
     public String username()  {
-        return config.getString(JdbcConfiguration.USER);    
+        return config.getString(JdbcConfiguration.USER);
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/util/Strings.java
+++ b/debezium-core/src/main/java/io/debezium/util/Strings.java
@@ -265,6 +265,26 @@ public final class Strings {
     }
 
     /**
+     * Pad the string with the specific character to ensure the string is at least the specified length.
+     * 
+     * @param original the string to be padded; may not be null
+     * @param length the minimum desired length; must be positive
+     * @param padChar the character to use for padding, if the supplied string is not long enough
+     * @return the padded string of the desired length
+     * @see #justifyLeft(String, int, char)
+     */
+    public static String pad(String original,
+                                   int length,
+                                   char padChar) {
+        if ( original.length() >= length ) return original;
+        StringBuilder sb = new StringBuilder(original);
+        while ( sb.length() < length ) {
+            sb.append(padChar);
+        }
+        return sb.toString();
+    }
+
+    /**
      * Set the length of the string, padding with the supplied character if the supplied string is shorter than desired, or
      * truncating the string if it is longer than desired. Unlike {@link #justifyLeft(String, int, char)}, this method does not
      * remove leading and trailing whitespace.

--- a/debezium-core/src/test/java/io/debezium/function/BufferedBlockingConsumerTest.java
+++ b/debezium-core/src/test/java/io/debezium/function/BufferedBlockingConsumerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.function;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Randall Hauch
+ */
+public class BufferedBlockingConsumerTest {
+
+    private List<Integer> history;
+    private BlockingConsumer<Integer> consumer;
+    
+
+    @Before
+    public void beforeEach() {
+        history = new LinkedList<>();
+        consumer = history::add;
+    }
+    
+    @Test
+    public void shouldMaintainSameOrder() throws InterruptedException {
+        BufferedBlockingConsumer<Integer> buffered = BufferedBlockingConsumer.bufferLast(consumer);
+        
+        // Add several values ...
+        buffered.accept(1);
+        buffered.accept(2);
+        buffered.accept(3);
+        buffered.accept(4);
+        buffered.accept(5);
+
+        // And verify the history contains all but the last value ...
+        assertThat(history).containsExactly(1,2,3,4);
+        
+        // Flush the last value...
+        buffered.flush();
+        
+        // And verify the history contains the same values ...
+        assertThat(history).containsExactly(1,2,3,4,5);
+    }
+
+}


### PR DESCRIPTION
By default the MySQL JDBC driver will put the entire result set into memory, which obviously doesn't work for tables of even moderate sizes. This change adds support for streaming rows in result sets when the tables have more than a configurable number of rows (defaults to 1,000).

This posed a problem for how we were previously finding the last row in the last table; the MySQL driver does not support `ResultSet.isLast()` on result sets that are streamed. Instead, this commit wraps the consumer to which the snapshot reader writes all source records, with a consumer that buffers the last record. When the snapshot completes, the offset is updated (denoting the end of the snapshot) and set on the last buffered record before that record is flushed to the normal consumer. This should add minimal overhead while simplifying the logic to ensure the last source record has the updated offset.

This also improves the log output of the snapshot process.