### PR TITLE
DBZ-99 Added support for MySQL connector to connect securely to MySQL

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -6,9 +6,16 @@
 package io.debezium.connector.mysql;
 
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import io.debezium.config.Configuration;
+import io.debezium.config.Field;
+import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.jdbc.JdbcConnection.ConnectionFactory;
 
@@ -19,22 +26,25 @@ import io.debezium.jdbc.JdbcConnection.ConnectionFactory;
  */
 public class MySqlJdbcContext implements AutoCloseable {
 
-    protected static final String MYSQL_CONNECTION_URL = "jdbc:mysql://${hostname}:${port}/?useInformationSchema=true&nullCatalogMeansCurrent=false";
+    protected static final String MYSQL_CONNECTION_URL = "jdbc:mysql://${hostname}:${port}/?useInformationSchema=true&nullCatalogMeansCurrent=false&useSSL=${useSSL}";
     protected static ConnectionFactory FACTORY = JdbcConnection.patternBasedFactory(MYSQL_CONNECTION_URL);
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
     protected final Configuration config;
     protected final JdbcConnection jdbc;
+    private final Map<String,String> originalSystemProperties = new HashMap<>();
 
     public MySqlJdbcContext(Configuration config) {
         this.config = config; // must be set before most methods are used
 
         // Set up the JDBC connection without actually connecting, with extra MySQL-specific properties
         // to give us better JDBC database metadata behavior ...
+        boolean useSSL = sslModeEnabled();
         Configuration jdbcConfig = config.subset("database.", true)
                                          .edit()
                                          .with("useInformationSchema", "true")
                                          .with("nullCatalogMeansCurrent", "false")
+                                         .with("useSSL", Boolean.toString(useSSL))
                                          .build();
         this.jdbc = new JdbcConnection(jdbcConfig, FACTORY);
     }
@@ -67,7 +77,24 @@ public class MySqlJdbcContext implements AutoCloseable {
         return config.getInteger(MySqlConnectorConfig.PORT);
     }
 
+    public SecureConnectionMode sslMode() {
+        String mode = config.getString(MySqlConnectorConfig.SSL_MODE);
+        return SecureConnectionMode.parse(mode);
+    }
+    
+    public boolean sslModeEnabled() {
+        return sslMode() != SecureConnectionMode.DISABLED;
+    }
+    
     public void start() {
+        if (sslModeEnabled()) {
+            originalSystemProperties.clear();
+            // Set the System properties for SSL for the MySQL driver ...
+            setSystemProperty("javax.net.ssl.keyStore", MySqlConnectorConfig.SSL_KEYSTORE, true);
+            setSystemProperty("javax.net.ssl.keyStorePassword", MySqlConnectorConfig.SSL_KEYSTORE_PASSWORD, false);
+            setSystemProperty("javax.net.ssl.trustStore", MySqlConnectorConfig.SSL_TRUSTSTORE, true);
+            setSystemProperty("javax.net.ssl.trustStorePassword", MySqlConnectorConfig.SSL_KEYSTORE_PASSWORD, false);
+        }
     }
 
     public void shutdown() {
@@ -75,6 +102,15 @@ public class MySqlJdbcContext implements AutoCloseable {
             jdbc.close();
         } catch (SQLException e) {
             logger.error("Unexpected error shutting down the database connection", e);
+        } finally {
+            // Reset the system properties to their original value ...
+            originalSystemProperties.forEach((name,value)->{
+                if ( value != null ) {
+                    System.setProperty(name,value);
+                } else {
+                    System.clearProperty(name);
+                }
+            });
         }
     }
 
@@ -82,8 +118,27 @@ public class MySqlJdbcContext implements AutoCloseable {
     public void close() {
         shutdown();
     }
-    
+
     protected String connectionString() {
         return jdbc.connectionString(MYSQL_CONNECTION_URL);
+    }
+
+    protected void setSystemProperty(String property, Field field, boolean showValueInError) {
+        String value = config.getString(field);
+        if (value != null) {
+            String existingValue = System.getProperty(property);
+            if (existingValue != null && existingValue.equalsIgnoreCase(value)) {
+                String msg = "System or JVM property '" + property + "' is already defined, but the configuration property '" + field.name()
+                        + "' defines a different value";
+                if (showValueInError) {
+                    msg = "System or JVM property '" + property + "' is already defined as " + existingValue
+                            + ", but the configuration property '" + field.name() + "' defines a different value '" + value + "'";
+                }
+                throw new ConnectException(msg);
+            } else {
+                String existing = System.setProperty(property, value);
+                originalSystemProperties.put(property, existing); // the existing value may be null
+            }
+        }
     }
 }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/BinlogReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/BinlogReaderIT.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import static org.fest.assertions.Assertions.assertThat;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
 import io.debezium.data.KeyValueStore;
 import io.debezium.data.KeyValueStore.Collection;
 import io.debezium.data.SchemaChangeHistory;
@@ -99,14 +100,14 @@ public class BinlogReaderIT {
                             .with(MySqlConnectorConfig.PORT, port)
                             .with(MySqlConnectorConfig.USER, "replicator")
                             .with(MySqlConnectorConfig.PASSWORD, "replpass")
+                            .with(MySqlConnectorConfig.SSL_MODE, SecureConnectionMode.DISABLED.name().toLowerCase())
                             .with(MySqlConnectorConfig.SERVER_ID, 18911)
                             .with(MySqlConnectorConfig.SERVER_NAME, LOGICAL_NAME)
                             .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
                             .with(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
                             .with(MySqlConnectorConfig.DATABASE_WHITELIST, DB_NAME)
                             .with(MySqlConnectorConfig.DATABASE_HISTORY, FileDatabaseHistory.class)
-                            .with(FileDatabaseHistory.FILE_PATH, DB_HISTORY_PATH)
-                            .with("database.useSSL", false); // eliminates MySQL driver warning about SSL connections
+                            .with(FileDatabaseHistory.FILE_PATH, DB_HISTORY_PATH);
     }
 
     @Test

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySQLConnection.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySQLConnection.java
@@ -26,6 +26,7 @@ public class MySQLConnection extends JdbcConnection {
     public static MySQLConnection forTestDatabase(String databaseName) {
         return new MySQLConnection(JdbcConfiguration.copy(Configuration.fromSystemProperties("database."))
                                                     .withDatabase(databaseName)
+                                                    .with("useSSL", false)
                                                     .build());
     }
 
@@ -42,6 +43,7 @@ public class MySQLConnection extends JdbcConnection {
                                                     .withDatabase(databaseName)
                                                     .withUser(username)
                                                     .withPassword(password)
+                                                    .with("useSSL", false)
                                                     .build());
     }
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import static org.fest.assertions.Assertions.assertThat;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
 import io.debezium.connector.mysql.MySqlConnectorConfig.TemporalPrecisionMode;
 import io.debezium.data.Envelope;
@@ -68,6 +69,7 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                               .with(MySqlConnectorConfig.PORT, System.getProperty("database.port"))
                               .with(MySqlConnectorConfig.USER, "snapper")
                               .with(MySqlConnectorConfig.PASSWORD, "snapperpass")
+                              .with(MySqlConnectorConfig.SSL_MODE, SecureConnectionMode.DISABLED.name().toLowerCase())
                               .with(MySqlConnectorConfig.SERVER_ID, 18765)
                               .with(MySqlConnectorConfig.SERVER_NAME, "regression")
                               .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
@@ -76,7 +78,6 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                               .with(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
                               .with(MySqlConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.toString())
                               .with(FileDatabaseHistory.FILE_PATH, DB_HISTORY_PATH)
-                              .with("database.useSSL", false) // eliminates MySQL driver warning about SSL connections
                               .build();
         // Start the connector ...
         start(MySqlConnector.class, config);
@@ -188,6 +189,7 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                               .with(MySqlConnectorConfig.PORT, System.getProperty("database.port"))
                               .with(MySqlConnectorConfig.USER, "snapper")
                               .with(MySqlConnectorConfig.PASSWORD, "snapperpass")
+                              .with(MySqlConnectorConfig.SSL_MODE, SecureConnectionMode.DISABLED.name().toLowerCase())
                               .with(MySqlConnectorConfig.SERVER_ID, 18765)
                               .with(MySqlConnectorConfig.SERVER_NAME, "regression")
                               .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
@@ -197,7 +199,6 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                               .with(MySqlConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.toString())
                               .with(MySqlConnectorConfig.TIME_PRECISION_MODE, TemporalPrecisionMode.CONNECT.toString())
                               .with(FileDatabaseHistory.FILE_PATH, DB_HISTORY_PATH)
-                              .with("database.useSSL", false) // eliminates MySQL driver warning about SSL connections
                               .build();
         // Start the connector ...
         start(MySqlConnector.class, config);
@@ -307,6 +308,7 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                               .with(MySqlConnectorConfig.PORT, System.getProperty("database.port"))
                               .with(MySqlConnectorConfig.USER, "snapper")
                               .with(MySqlConnectorConfig.PASSWORD, "snapperpass")
+                              .with(MySqlConnectorConfig.SSL_MODE, SecureConnectionMode.DISABLED.name().toLowerCase())
                               .with(MySqlConnectorConfig.SERVER_ID, 18765)
                               .with(MySqlConnectorConfig.SERVER_NAME, "regression")
                               .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
@@ -315,7 +317,6 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                               .with(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
                               .with(MySqlConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL.toString())
                               .with(FileDatabaseHistory.FILE_PATH, DB_HISTORY_PATH)
-                              .with("database.useSSL", false) // eliminates MySQL driver warning about SSL connections
                               .build();
         // Start the connector ...
         start(MySqlConnector.class, config);

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTaskContextIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTaskContextIT.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import static org.fest.assertions.Assertions.assertThat;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
 import io.debezium.relational.history.FileDatabaseHistory;
 import io.debezium.util.Testing;
@@ -69,12 +70,12 @@ public class MySqlTaskContextIT {
                             .with(MySqlConnectorConfig.PORT, port)
                             .with(MySqlConnectorConfig.USER, username)
                             .with(MySqlConnectorConfig.PASSWORD, password)
+                            .with(MySqlConnectorConfig.SSL_MODE, SecureConnectionMode.DISABLED.name().toLowerCase())
                             .with(MySqlConnectorConfig.SERVER_ID, serverId)
                             .with(MySqlConnectorConfig.SERVER_NAME, serverName)
                             .with(MySqlConnectorConfig.DATABASE_WHITELIST, databaseName)
                             .with(MySqlConnectorConfig.DATABASE_HISTORY, FileDatabaseHistory.class)
-                            .with(FileDatabaseHistory.FILE_PATH, DB_HISTORY_PATH)
-                            .with("database.useSSL",false); // eliminates MySQL driver warning about SSL connections
+                            .with(FileDatabaseHistory.FILE_PATH, DB_HISTORY_PATH);
     }
 
     @Test

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/ReadBinLogIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/ReadBinLogIT.java
@@ -44,6 +44,7 @@ import com.github.shyiko.mysql.binlog.event.UpdateRowsEventData;
 import com.github.shyiko.mysql.binlog.event.WriteRowsEventData;
 import com.github.shyiko.mysql.binlog.event.XidEventData;
 import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
+import com.github.shyiko.mysql.binlog.network.SSLMode;
 import com.github.shyiko.mysql.binlog.network.ServerException;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -105,6 +106,7 @@ public class ReadBinLogIT implements Testing {
         client = new BinaryLogClient(config.getHostname(), config.getPort(), "replicator", "replpass");
         client.setServerId(client.getServerId() - 1); // avoid clashes between BinaryLogClient instances
         client.setKeepAlive(false);
+        client.setSSLMode(SSLMode.DISABLED);
         client.registerEventListener(counters);
         client.registerEventListener(this::recordEvent);
         client.registerLifecycleListener(new TraceLifecycleListener());

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotReaderIT.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import static org.fest.assertions.Assertions.assertThat;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
 import io.debezium.data.KeyValueStore;
 import io.debezium.data.KeyValueStore.Collection;
 import io.debezium.data.SchemaChangeHistory;
@@ -70,14 +71,14 @@ public class SnapshotReaderIT {
                             .with(MySqlConnectorConfig.PORT, port)
                             .with(MySqlConnectorConfig.USER, "snapper")
                             .with(MySqlConnectorConfig.PASSWORD, "snapperpass")
+                            .with(MySqlConnectorConfig.SSL_MODE, SecureConnectionMode.DISABLED.toString().toLowerCase())
                             .with(MySqlConnectorConfig.SERVER_ID, 18911)
                             .with(MySqlConnectorConfig.SERVER_NAME, LOGICAL_NAME)
                             .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
                             .with(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
                             .with(MySqlConnectorConfig.DATABASE_WHITELIST, DB_NAME)
                             .with(MySqlConnectorConfig.DATABASE_HISTORY, FileDatabaseHistory.class)
-                            .with(FileDatabaseHistory.FILE_PATH, DB_HISTORY_PATH)
-                            .with("database.useSSL",false); // eliminates MySQL driver warning about SSL connections
+                            .with(FileDatabaseHistory.FILE_PATH, DB_HISTORY_PATH);
     }
 
     @Test

--- a/debezium-core/src/main/java/io/debezium/config/Field.java
+++ b/debezium-core/src/main/java/io/debezium/config/Field.java
@@ -639,8 +639,26 @@ public final class Field {
      * @return the new field; never null
      */
     public <T extends Enum<T>> Field withEnum(Class<T> enumType) {
+        return withEnum(enumType,null);
+    }
+
+    /**
+     * Create and return a new Field instance that is a copy of this field but has a {@link #withType(Type) type} of
+     * {@link org.apache.kafka.connect.data.Schema.Type#STRING}, a {@link #withRecommender(Recommender) recommender}
+     * that returns a list of {@link Enum#name() Enum names} as valid values, and a validator that verifies values are valid
+     * enumeration names.
+     * 
+     * @param enumType the enumeration type for the field
+     * @param defaultOption the default enumeration value; may be null
+     * @return the new field; never null
+     */
+    public <T extends Enum<T>> Field withEnum(Class<T> enumType, T defaultOption) {
         EnumRecommender<T> recommendator = new EnumRecommender<>(enumType);
-        return withType(Type.STRING).withRecommender(recommendator).withValidation(recommendator);
+        Field result = withType(Type.STRING).withRecommender(recommendator).withValidation(recommendator);
+        if ( defaultOption != null ) {
+            result = result.withDefault(defaultOption.name().toLowerCase());
+        }
+        return result;
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -134,15 +134,22 @@ public class JdbcConnection implements AutoCloseable {
 
     private static String findAndReplace(String url, Properties props, Field... variables) {
         for (Field field : variables) {
-            String variable = field.name();
-            if (variable != null && url.contains("${" + variable + "}")) {
-                // Otherwise, we have to remove it from the properties ...
-                String value = props.getProperty(variable);
-                if (value != null) {
-                    props.remove(variable);
-                    // And replace the variable ...
-                    url = url.replaceAll("\\$\\{" + variable + "\\}", value);
-                }
+            if ( field != null ) url = findAndReplace(url, field.name(), props);
+        }
+        for (Object key : new HashSet<>(props.keySet())) {
+            if (key != null ) url = findAndReplace(url, key.toString(), props);
+        }
+        return url;
+    }
+    
+    private static String findAndReplace(String url, String name, Properties props) {
+        if (name != null && url.contains("${" + name + "}")) {
+            // Otherwise, we have to remove it from the properties ...
+            String value = props.getProperty(name);
+            if (value != null) {
+                props.remove(name);
+                // And replace the variable ...
+                url = url.replaceAll("\\$\\{" + name + "\\}", value);
             }
         }
         return url;

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.embedded;
 
+import static org.junit.Assert.fail;
+
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -510,6 +512,12 @@ public abstract class AbstractConnectorTest implements Testing {
         assertThat(value.errorMessages().size()).isEqualTo(numErrors);
     }
 
+    protected void assertConfigurationErrors(Config config, io.debezium.config.Field field, int minErrorsInclusive, int maxErrorsInclusive) {
+        ConfigValue value = configValue(config, field.name());
+        assertThat(value.errorMessages().size()).isGreaterThanOrEqualTo(minErrorsInclusive);
+        assertThat(value.errorMessages().size()).isLessThanOrEqualTo(maxErrorsInclusive);
+    }
+
     protected void assertConfigurationErrors(Config config, io.debezium.config.Field field) {
         ConfigValue value = configValue(config, field.name());
         assertThat(value.errorMessages().size()).isGreaterThan(0);
@@ -518,7 +526,11 @@ public abstract class AbstractConnectorTest implements Testing {
     protected void assertNoConfigurationErrors(Config config, io.debezium.config.Field... fields) {
         for (io.debezium.config.Field field : fields) {
             ConfigValue value = configValue(config, field.name());
-            assertThat(value.errorMessages().size()).isEqualTo(0);
+            if ( value != null ) {
+                if ( !value.errorMessages().isEmpty() ) {
+                    fail("Error messages on field '" + field.name() + "': " + value.errorMessages());
+                }
+            }
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <version.postgresql.server>9.4</version.postgresql.server>
         <version.mysql.server>5.7</version.mysql.server>
         <version.mysql.driver>5.1.39</version.mysql.driver>
-        <version.mysql.binlog>0.3.3</version.mysql.binlog>
+        <version.mysql.binlog>0.4.0</version.mysql.binlog>
         <version.mongo.server>3.2.6</version.mongo.server>
         <version.mongo.driver>3.2.2</version.mongo.driver>
 


### PR DESCRIPTION
Changed the MySQL connector to have several new configuration properties for setting up the SSL key store and trust store, which can be used in place of System or JDK properties. Two additional configuration properties separately enable secure connections to MySQL and to enable secure connections for the database history's Kafka producer and consumer.

Modified several integration tests to ensure all MySQL connections are made with `useSSL=false`.