### PR TITLE
DBZ-102 MySQL connector support for column charsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ August XX, 2016 - [Detailed release notes](https://issues.jboss.org/browse/DBZ/f
 
 ### Backwards-incompatible changes since 0.3.0
 
-None
+* MySQL connector now properly decodes string values from the binlog based upon the column's character set encoding as read by the DDL statement. Upon upgrade and restart, the connector will re-read the recorded database history and now associate the columns with their the character sets, and any newly processed events will use properly encoded strings values. As expected, previously generated events are never altered. Force a snapshot to regenerate events for the servers. [DBZ-102](https://issues.jboss.org/projects/DBZ/issues/DBZ-102)
 
 ### Fixes since 0.3.0
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -114,11 +114,13 @@ public final class MySqlConnectorTask extends SourceTask {
                     // full history of the database.
                     logger.info("Found no existing offset and snapshots disallowed, so starting at beginning of binlog");
                     source.setBinlogStartPoint("", 0L);// start from the beginning of the binlog
+                    taskContext.initializeHistory();
                 } else {
                     // We are allowed to use snapshots, and that is the best way to start ...
                     startWithSnapshot = true;
                     // The snapshot will determine if GTIDs are set
                     logger.info("Found no existing offset, so preparing to perform a snapshot");
+                    // The snapshot will also initialize history ...
                 }
             }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.mysql;
 
-import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,7 +31,7 @@ import io.debezium.util.Strings;
  */
 public class MySqlJdbcContext implements AutoCloseable {
 
-    protected static final String MYSQL_CONNECTION_URL = "jdbc:mysql://${hostname}:${port}/?useInformationSchema=true&nullCatalogMeansCurrent=false&useSSL=${useSSL}";
+    protected static final String MYSQL_CONNECTION_URL = "jdbc:mysql://${hostname}:${port}/?useInformationSchema=true&nullCatalogMeansCurrent=false&useSSL=${useSSL}&useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8";
     protected static ConnectionFactory FACTORY = JdbcConnection.patternBasedFactory(MYSQL_CONNECTION_URL);
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
@@ -49,10 +48,7 @@ public class MySqlJdbcContext implements AutoCloseable {
         boolean useSSL = sslModeEnabled();
         Configuration jdbcConfig = config.subset("database.", true)
                                          .edit()
-                                         .with("useInformationSchema", "true")
-                                         .with("nullCatalogMeansCurrent", "false")
                                          .with("useSSL", Boolean.toString(useSSL))
-                                         .with("characterEncoding", StandardCharsets.UTF_8.name())
                                          .build();
         this.jdbc = new JdbcConnection(jdbcConfig, FACTORY);
     }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -5,9 +5,14 @@
  */
 package io.debezium.connector.mysql;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
@@ -18,6 +23,7 @@ import io.debezium.config.Field;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.jdbc.JdbcConnection.ConnectionFactory;
+import io.debezium.util.Strings;
 
 /**
  * A context for a JDBC connection to MySQL.
@@ -32,19 +38,21 @@ public class MySqlJdbcContext implements AutoCloseable {
     protected final Logger logger = LoggerFactory.getLogger(getClass());
     protected final Configuration config;
     protected final JdbcConnection jdbc;
-    private final Map<String,String> originalSystemProperties = new HashMap<>();
+    private final Map<String, String> originalSystemProperties = new HashMap<>();
 
     public MySqlJdbcContext(Configuration config) {
         this.config = config; // must be set before most methods are used
 
         // Set up the JDBC connection without actually connecting, with extra MySQL-specific properties
-        // to give us better JDBC database metadata behavior ...
+        // to give us better JDBC database metadata behavior, including using UTF-8 for the client-side character encoding
+        // per https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-charsets.html
         boolean useSSL = sslModeEnabled();
         Configuration jdbcConfig = config.subset("database.", true)
                                          .edit()
                                          .with("useInformationSchema", "true")
                                          .with("nullCatalogMeansCurrent", "false")
                                          .with("useSSL", Boolean.toString(useSSL))
+                                         .with("characterEncoding", StandardCharsets.UTF_8.name())
                                          .build();
         this.jdbc = new JdbcConnection(jdbcConfig, FACTORY);
     }
@@ -81,11 +89,11 @@ public class MySqlJdbcContext implements AutoCloseable {
         String mode = config.getString(MySqlConnectorConfig.SSL_MODE);
         return SecureConnectionMode.parse(mode);
     }
-    
+
     public boolean sslModeEnabled() {
         return sslMode() != SecureConnectionMode.DISABLED;
     }
-    
+
     public void start() {
         if (sslModeEnabled()) {
             originalSystemProperties.clear();
@@ -104,9 +112,9 @@ public class MySqlJdbcContext implements AutoCloseable {
             logger.error("Unexpected error shutting down the database connection", e);
         } finally {
             // Reset the system properties to their original value ...
-            originalSystemProperties.forEach((name,value)->{
-                if ( value != null ) {
-                    System.setProperty(name,value);
+            originalSystemProperties.forEach((name, value) -> {
+                if (value != null) {
+                    System.setProperty(name, value);
                 } else {
                     System.clearProperty(name);
                 }
@@ -121,6 +129,59 @@ public class MySqlJdbcContext implements AutoCloseable {
 
     protected String connectionString() {
         return jdbc.connectionString(MYSQL_CONNECTION_URL);
+    }
+
+    /**
+     * Read the MySQL charset-related system variables.
+     * 
+     * @param sql the reference that should be set to the SQL statement; may be null if not needed
+     * @return the system variables that are related to server character sets; never null
+     */
+    protected Map<String, String> readMySqlCharsetSystemVariables(AtomicReference<String> sql) {
+        // Read the system variables from the MySQL instance and get the current database name ...
+        Map<String, String> variables = new HashMap<>();
+        try (JdbcConnection mysql = jdbc.connect()) {
+            logger.debug("Reading MySQL charset-related system variables before parsing DDL history.");
+            String statement = "SHOW VARIABLES WHERE Variable_name IN ('character_set_server','collation_server')";
+            if (sql != null) sql.set(statement);
+            mysql.query(statement, rs -> {
+                while (rs.next()) {
+                    String varName = rs.getString(1);
+                    String value = rs.getString(2);
+                    if (varName != null && value != null) {
+                        variables.put(varName, value);
+                        logger.debug("\t{} = {}",
+                                     Strings.pad(varName, 45, ' '),
+                                     Strings.pad(value, 45, ' '));
+                    }
+                }
+            });
+        } catch (SQLException e) {
+            throw new ConnectException("Error reading MySQL variables: " + e.getMessage(), e);
+        }
+        return variables;
+    }
+
+    protected String setStatementFor(Map<String, String> variables) {
+        StringBuilder sb = new StringBuilder("SET ");
+        boolean first = true;
+        List<String> varNames = new ArrayList<>(variables.keySet());
+        Collections.sort(varNames);
+        for (String varName : varNames) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(", ");
+            }
+            sb.append(varName).append("=");
+            String value = variables.get(varName);
+            if (value == null) value = "";
+            if (value.contains(",") || value.contains(";")) {
+                value = "'" + value + "'";
+            }
+            sb.append(value);
+        }
+        return sb.append(";").toString();
     }
 
     protected void setSystemProperty(String property, Field field, boolean showValueInError) {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
@@ -24,6 +24,7 @@ import com.github.shyiko.mysql.binlog.event.deserialization.AbstractRowsEventDat
 import io.debezium.annotation.NotThreadSafe;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnectorConfig.TemporalPrecisionMode;
+import io.debezium.connector.mysql.MySqlSystemVariables.Scope;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.jdbc.TimeZoneAdapter;
 import io.debezium.relational.Table;
@@ -106,7 +107,7 @@ public class MySqlSchema {
         boolean adaptiveTimePrecision = TemporalPrecisionMode.ADAPTIVE.equals(timePrecisionMode);
         MySqlValueConverters valueConverters = new MySqlValueConverters(adaptiveTimePrecision);
         this.schemaBuilder = new TableSchemaBuilder(valueConverters, schemaNameValidator::validate);
-        
+
         // Set up the server name and schema prefix ...
         if (serverName != null) serverName = serverName.trim();
         this.serverName = serverName;
@@ -197,6 +198,26 @@ public class MySqlSchema {
         return dbHistory.toString();
     }
 
+    /**
+     * Set the system variables on the DDL parser.
+     * 
+     * @param variables the system variables; may not be null but may be empty
+     */
+    public void setSystemVariables(Map<String, String> variables) {
+        variables.forEach((varName, value) -> {
+            ddlParser.systemVariables().setVariable(Scope.SESSION, varName, value);
+        });
+    }
+    
+    /**
+     * Get the system variables as known by the DDL parser.
+     * 
+     * @return the system variables; never null
+     */
+    public MySqlSystemVariables systemVariables() {
+        return ddlParser.systemVariables();
+    }
+    
     /**
      * Load the schema for the databases using JDBC database metadata. If there are changes relative to any
      * table definitions that existed when this method is called, those changes are recorded in the database history
@@ -335,12 +356,12 @@ public class MySqlSchema {
                     // the same order they were read for each _affected_ database, grouped together if multiple apply
                     // to the same _affected_ database...
                     ddlChanges.groupStatementStringsByDatabase((dbName, ddl) -> {
-                        if (filters.databaseFilter().test(dbName)) {
+                        if (filters.databaseFilter().test(dbName) || dbName == null || "".equals(dbName)) {
                             if (dbName == null) dbName = "";
                             statementConsumer.consume(dbName, ddlStatements);
                         }
                     });
-                } else if (filters.databaseFilter().test(databaseName)) {
+                } else if (filters.databaseFilter().test(databaseName) || databaseName == null || "".equals(databaseName)) {
                     if (databaseName == null) databaseName = "";
                     statementConsumer.consume(databaseName, ddlStatements);
                 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSystemVariables.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSystemVariables.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Encapsulates a set of the MySQL system variables.
+ * 
+ * @author Randall Hauch
+ */
+public class MySqlSystemVariables {
+
+    public static enum Scope {
+        GLOBAL, SESSION, LOCAL;
+    }
+    
+    /**
+     * The system variable name for the name of the character set that the server uses by default.
+     * See http://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_character-set-server
+     */
+    public static final String CHARSET_NAME_SERVER = "character_set_server";
+
+    private final ConcurrentMap<String, String> global = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, String> session = new ConcurrentHashMap<>();
+
+    /**
+     * Create an instance.
+     */
+    public MySqlSystemVariables() {
+    }
+
+    /**
+     * Set the variable with the specified scope.
+     * 
+     * @param scope the variable scope; may be null if the session scope is to be used
+     * @param name the name of the variable; may not be null
+     * @param value the variable value; may be null if the value for the named variable is to be removed
+     * @return this object for method chaining purposes; never null
+     */
+    public MySqlSystemVariables setVariable(Scope scope, String name, String value) {
+        name = variableName(name);
+        if (value != null) {
+            forScope(scope).put(name, value);
+        } else {
+            forScope(scope).remove(name);
+        }
+        return this;
+    }
+
+    /**
+     * Get the variable with the specified name and scope.
+     * 
+     * @param name the name of the variable; may not be null
+     * @param scope the variable scope; may not be null
+     * @return the variable value; may be null if the variable is not currently set
+     */
+    public String getVariable(String name, Scope scope) {
+        name = variableName(name);
+        return forScope(scope).get(name);
+    }
+
+    /**
+     * Get the variable with the specified name, first checking the {@link Scope#SESSION session} (or {@link Scope#LOCAL local})
+     * variables and then the {@link Scope#GLOBAL global} variables.
+     * 
+     * @param name the name of the variable; may not be null
+     * @return the variable value; may be null if the variable is not currently set
+     */
+    public String getVariable(String name) {
+        name = variableName(name);
+        String value = session.get(name);
+        if (value == null) {
+            value = global.get(name);
+        }
+        return value;
+    }
+
+    private String variableName(String name) {
+        return name.toLowerCase();
+    }
+
+    private ConcurrentMap<String, String> forScope(Scope scope) {
+        if (scope != null) {
+            switch (scope) {
+                case GLOBAL:
+                    return global;
+                case SESSION:
+                case LOCAL:
+                    return session;
+            }
+        }
+        return session;
+    }
+
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
@@ -122,6 +122,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
             case Types.SQLXML:
                 Charset charset = charsetFor(column);
                 if (charset != null) {
+                    logger.debug("Using {} charset by default for column: {}", charset, column);
                     return (data) -> convertString(column, fieldDefn, charset, data);
                 }
                 logger.warn("Using UTF-8 charset by default for column without charset: {}", column);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
@@ -5,14 +5,20 @@
  */
 package io.debezium.connector.mysql;
 
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
 import java.sql.Types;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
 import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.source.SourceRecord;
 
 import com.github.shyiko.mysql.binlog.event.deserialization.AbstractRowsEventDataDeserializer;
+import com.mysql.jdbc.CharsetMapping;
 
 import io.debezium.annotation.Immutable;
 import io.debezium.jdbc.JdbcValueConverters;
@@ -73,11 +79,11 @@ public class MySqlValueConverters extends JdbcValueConverters {
             return Year.builder();
         }
         if (matches(typeName, "ENUM")) {
-            String commaSeparatedOptions = extractEnumAndSetOptions(column,true);
+            String commaSeparatedOptions = extractEnumAndSetOptions(column, true);
             return io.debezium.data.Enum.builder(commaSeparatedOptions);
         }
         if (matches(typeName, "SET")) {
-            String commaSeparatedOptions = extractEnumAndSetOptions(column,true);
+            String commaSeparatedOptions = extractEnumAndSetOptions(column, true);
             return io.debezium.data.EnumSet.builder(commaSeparatedOptions);
         }
         // Otherwise, let the base class handle it ...
@@ -93,16 +99,85 @@ public class MySqlValueConverters extends JdbcValueConverters {
         }
         if (matches(typeName, "ENUM")) {
             // Build up the character array based upon the column's type ...
-            String options = extractEnumAndSetOptions(column,false);
+            String options = extractEnumAndSetOptions(column, false);
             return (data) -> convertEnumToString(options, column, fieldDefn, data);
         }
         if (matches(typeName, "SET")) {
             // Build up the character array based upon the column's type ...
-            String options = extractEnumAndSetOptions(column,false);
+            String options = extractEnumAndSetOptions(column, false);
             return (data) -> convertSetToString(options, column, fieldDefn, data);
         }
+        
+        // We have to convert bytes encoded in the column's character set ...
+        switch (column.jdbcType()) {
+            case Types.CHAR: // variable-length
+            case Types.VARCHAR: // variable-length
+            case Types.LONGVARCHAR: // variable-length
+            case Types.CLOB: // variable-length
+            case Types.NCHAR: // fixed-length
+            case Types.NVARCHAR: // fixed-length
+            case Types.LONGNVARCHAR: // fixed-length
+            case Types.NCLOB: // fixed-length
+            case Types.DATALINK:
+            case Types.SQLXML:
+                Charset charset = charsetFor(column);
+                if (charset != null) {
+                    return (data) -> convertString(column, fieldDefn, charset, data);
+                }
+                logger.warn("Using UTF-8 charset by default for column without charset: {}", column);
+                return (data) -> convertString(column, fieldDefn, StandardCharsets.UTF_8, data);
+            default:
+                break;
+        }
+
         // Otherwise, let the base class handle it ...
         return super.converter(column, fieldDefn);
+    }
+
+    /**
+     * Return the {@link Charset} instance with the MySQL-specific character set name used by the given column.
+     * 
+     * @param column the column in which the character set is used; never null
+     * @return the Java {@link Charset}, or null if there is no mapping
+     */
+    protected Charset charsetFor(Column column) {
+        String mySqlCharsetName = column.charsetName();
+        if (mySqlCharsetName == null) {
+            logger.warn("Column is missing a character set: {}", column);
+            return null;
+        }
+        String encoding = CharsetMapping.getJavaEncodingForMysqlCharset(mySqlCharsetName);
+        if (encoding == null) {
+            logger.warn("Column uses MySQL character set '{}', which has no mapping to a Java character set", mySqlCharsetName);
+        } else {
+            try {
+                return Charset.forName(encoding);
+            } catch (IllegalCharsetNameException e) {
+                logger.error("Unable to load Java charset '{}' for column with MySQL character set '{}'", encoding, mySqlCharsetName);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Convert the {@link String} or {@code byte[]} value to a string value used in a {@link SourceRecord}.
+     * 
+     * @param column the column in which the value appears
+     * @param fieldDefn the field definition for the {@link SourceRecord}'s {@link Schema}; never null
+     * @param columnCharset the Java character set in which column byte[] values are encoded; may not be null
+     * @param data the data; may be null
+     * @return the string value; may be null if the value is null or is an unknown input type
+     */
+    protected Object convertString(Column column, Field fieldDefn, Charset columnCharset, Object data) {
+        if (data == null) return null;
+        if (data instanceof byte[]) {
+            // Decode the binary representation using the given character encoding ...
+            return new String((byte[]) data, columnCharset);
+        }
+        if (data instanceof String) {
+            return data;
+        }
+        return handleUnknownData(column, fieldDefn, data);
     }
 
     /**
@@ -151,7 +226,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
         }
         if (data instanceof Integer) {
             // The binlog will contain an int with the 1-based index of the option in the enum value ...
-            int index = ((Integer) data).intValue() - 1;    // 'options' is 0-based
+            int index = ((Integer) data).intValue() - 1; // 'options' is 0-based
             if (index < options.length()) {
                 return options.substring(index, index + 1);
             }
@@ -180,7 +255,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
         if (data instanceof Long) {
             // The binlog will contain a long with the indexes of the options in the set value ...
             long indexes = ((Long) data).longValue();
-            return convertSetValue(indexes,options);
+            return convertSetValue(indexes, options);
         }
         return handleUnknownData(column, fieldDefn, data);
     }
@@ -200,25 +275,29 @@ public class MySqlValueConverters extends JdbcValueConverters {
 
     protected String extractEnumAndSetOptions(Column column, boolean commaSeparated) {
         String options = MySqlDdlParser.parseSetAndEnumOptions(column.typeExpression());
-        if ( !commaSeparated ) return options;
+        if (!commaSeparated) return options;
         StringBuilder sb = new StringBuilder();
         boolean first = true;
-        for ( int i=0; i!=options.length(); ++i ) {
-            if ( first ) first = false;
-            else sb.append(',');
+        for (int i = 0; i != options.length(); ++i) {
+            if (first)
+                first = false;
+            else
+                sb.append(',');
             sb.append(options.charAt(i));
         }
         return sb.toString();
     }
-    
-    protected String convertSetValue( long indexes, String options ) {
+
+    protected String convertSetValue(long indexes, String options) {
         StringBuilder sb = new StringBuilder();
         int index = 0;
         boolean first = true;
         while (indexes != 0L) {
             if (indexes % 2L != 0) {
-                if ( first ) first = false;
-                else sb.append(',');
+                if (first)
+                    first = false;
+                else
+                    sb.append(',');
                 sb.append(options.substring(index, index + 1));
             }
             ++index;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RowDeserializers.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RowDeserializers.java
@@ -56,6 +56,16 @@ class RowDeserializers {
         public DeleteRowsDeserializer(Map<Long, TableMapEventData> tableMapEventByTableId) {
             super(tableMapEventByTableId);
         }
+        
+        @Override
+        protected Serializable deserializeString(int length, ByteArrayInputStream inputStream) throws IOException {
+            return RowDeserializers.deserializeString(length, inputStream);
+        }
+        
+        @Override
+        protected Serializable deserializeVarString(int meta, ByteArrayInputStream inputStream) throws IOException {
+            return RowDeserializers.deserializeVarString(meta, inputStream);
+        }
 
         @Override
         protected Serializable deserializeDate(ByteArrayInputStream inputStream) throws IOException {
@@ -102,6 +112,16 @@ class RowDeserializers {
 
         public UpdateRowsDeserializer(Map<Long, TableMapEventData> tableMapEventByTableId) {
             super(tableMapEventByTableId);
+        }
+
+        @Override
+        protected Serializable deserializeString(int length, ByteArrayInputStream inputStream) throws IOException {
+            return RowDeserializers.deserializeString(length, inputStream);
+        }
+        
+        @Override
+        protected Serializable deserializeVarString(int meta, ByteArrayInputStream inputStream) throws IOException {
+            return RowDeserializers.deserializeVarString(meta, inputStream);
         }
 
         @Override
@@ -152,6 +172,16 @@ class RowDeserializers {
         }
 
         @Override
+        protected Serializable deserializeString(int length, ByteArrayInputStream inputStream) throws IOException {
+            return RowDeserializers.deserializeString(length, inputStream);
+        }
+        
+        @Override
+        protected Serializable deserializeVarString(int meta, ByteArrayInputStream inputStream) throws IOException {
+            return RowDeserializers.deserializeVarString(meta, inputStream);
+        }
+
+        @Override
         protected Serializable deserializeDate(ByteArrayInputStream inputStream) throws IOException {
             return RowDeserializers.deserializeDate(inputStream);
         }
@@ -190,6 +220,34 @@ class RowDeserializers {
         protected Serializable deserializeYear(ByteArrayInputStream inputStream) throws IOException {
             return RowDeserializers.deserializeYear(inputStream);
         }
+    }
+
+    /**
+     * Converts a MySQL string to a {@code byte[]}.
+     * 
+     * @param length the number of bytes used to store the length of the string
+     * @param inputStream the binary stream containing the raw binlog event data for the value
+     * @return the {@code byte[]} object
+     * @throws IOException if there is an error reading from the binlog event data
+     */
+    protected static Serializable deserializeString(int length, ByteArrayInputStream inputStream) throws IOException {
+        // charset is not present in the binary log (meaning there is no way to distinguish between CHAR / BINARY)
+        // as a result - return byte[] instead of an actual String
+        int stringLength = length < 256 ? inputStream.readInteger(1) : inputStream.readInteger(2);
+        return inputStream.read(stringLength);
+    }
+
+    /**
+     * Converts a MySQL string to a {@code byte[]}.
+     * 
+     * @param meta the {@code meta} value containing the number of bytes in the length field
+     * @param inputStream the binary stream containing the raw binlog event data for the value
+     * @return the {@code byte[]} object
+     * @throws IOException if there is an error reading from the binlog event data
+     */
+    protected static Serializable deserializeVarString(int meta, ByteArrayInputStream inputStream) throws IOException {
+        int varcharLength = meta < 256 ? inputStream.readInteger(1) : inputStream.readInteger(2);
+        return inputStream.read(varcharLength);
     }
 
     /**

--- a/debezium-connector-mysql/src/test/docker/init/setup.sql
+++ b/debezium-connector-mysql/src/test/docker/init/setup.sql
@@ -238,3 +238,15 @@ CREATE TABLE dbz_100_enumsettest (
 INSERT INTO dbz_100_enumsettest VALUES ('a', 'a,b,c');
 INSERT INTO dbz_100_enumsettest VALUES ('b', 'b,a');
 INSERT INTO dbz_100_enumsettest VALUES ('c', 'a');
+
+-- DBZ-102 handle character sets
+-- Use session variables to dictate the character sets used by the client running these commands so
+-- the literal value is interpretted correctly...
+set character_set_client=utf8;
+set character_set_connection=utf8;
+CREATE TABLE dbz_102_charsettest (
+  id INT(11) NOT NULL AUTO_INCREMENT,
+  text VARCHAR(255) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=2001 DEFAULT CHARSET=utf8;
+INSERT INTO dbz_102_charsettest VALUES (default, "产品");

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/BinlogReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/BinlogReaderIT.java
@@ -116,6 +116,7 @@ public class BinlogReaderIT {
         context = new MySqlTaskContext(config);
         context.start();
         context.source().setBinlogStartPoint("",0L); // start from beginning
+        context.initializeHistory();
         reader = new BinlogReader(context);
 
         // Start reading the binlog ...
@@ -175,6 +176,7 @@ public class BinlogReaderIT {
         context = new MySqlTaskContext(config);
         context.start();
         context.source().setBinlogStartPoint("",0L); // start from beginning
+        context.initializeHistory();
         reader = new BinlogReader(context);
 
         // Start reading the binlog ...

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -286,16 +286,17 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         // ---------------------------------------------------------------------------------------------------------------
         // Consume all of the events due to startup and initialization of the database
         // ---------------------------------------------------------------------------------------------------------------
-        SourceRecords records = consumeRecordsByTopic(5 + 9 + 9 + 4 + 11); // 11 schema change records
-        assertThat(records.recordsForTopic("myServer").size()).isEqualTo(11);
+        SourceRecords records = consumeRecordsByTopic(5 + 9 + 9 + 4 + 11 + 1); // 11 schema change records + 1 SET statement
+        assertThat(records.recordsForTopic("myServer").size()).isEqualTo(12);
         assertThat(records.recordsForTopic("myServer.connector_test.products").size()).isEqualTo(9);
         assertThat(records.recordsForTopic("myServer.connector_test.products_on_hand").size()).isEqualTo(9);
         assertThat(records.recordsForTopic("myServer.connector_test.customers").size()).isEqualTo(4);
         assertThat(records.recordsForTopic("myServer.connector_test.orders").size()).isEqualTo(5);
         assertThat(records.topics().size()).isEqualTo(5);
-        assertThat(records.databaseNames().size()).isEqualTo(1);
+        assertThat(records.databaseNames().size()).isEqualTo(2);
         assertThat(records.ddlRecordsForDatabase("connector_test").size()).isEqualTo(11);
         assertThat(records.ddlRecordsForDatabase("readbinlog_test")).isNull();
+        assertThat(records.ddlRecordsForDatabase("").size()).isEqualTo(1);
         records.ddlRecordsForDatabase("connector_test").forEach(this::print);
 
         // Check that all records are valid, can be serialized and deserialized ...

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
@@ -86,17 +86,18 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
         // Consume all of the events due to startup and initialization of the database
         // ---------------------------------------------------------------------------------------------------------------
         // Testing.Debug.enable();
-        SourceRecords records = consumeRecordsByTopic(5 + 6); // 5 schema change record, 6 inserts
+        SourceRecords records = consumeRecordsByTopic(6 + 7); // 5 schema change record, 7 inserts
         stopConnector();
         assertThat(records).isNotNull();
-        assertThat(records.recordsForTopic("regression").size()).isEqualTo(5);
+        assertThat(records.recordsForTopic("regression").size()).isEqualTo(6);
         assertThat(records.recordsForTopic("regression.regression_test.t1464075356413_testtable6").size()).isEqualTo(1);
         assertThat(records.recordsForTopic("regression.regression_test.dbz84_integer_types_table").size()).isEqualTo(1);
         assertThat(records.recordsForTopic("regression.regression_test.dbz_85_fractest").size()).isEqualTo(1);
         assertThat(records.recordsForTopic("regression.regression_test.dbz_100_enumsettest").size()).isEqualTo(3);
-        assertThat(records.topics().size()).isEqualTo(5);
+        assertThat(records.recordsForTopic("regression.regression_test.dbz_102_charsettest").size()).isEqualTo(1);
+        assertThat(records.topics().size()).isEqualTo(6);
         assertThat(records.databaseNames().size()).isEqualTo(1);
-        assertThat(records.ddlRecordsForDatabase("regression_test").size()).isEqualTo(5);
+        assertThat(records.ddlRecordsForDatabase("regression_test").size()).isEqualTo(6);
         assertThat(records.ddlRecordsForDatabase("connector_test")).isNull();
         assertThat(records.ddlRecordsForDatabase("readbinlog_test")).isNull();
         records.ddlRecordsForDatabase("regression_test").forEach(this::print);
@@ -118,6 +119,10 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 } else {
                     fail("c1 didn't match expected value");
                 }
+            } else if (record.topic().endsWith("dbz_102_charsettest")) {
+                Struct after = value.getStruct(Envelope.FieldName.AFTER);
+                String text = after.getString("text");
+                assertThat(text).isEqualTo("产品");
             } else if (record.topic().endsWith("dbz_85_fractest")) {
                 // The microseconds of all three should be exactly 780
                 Struct after = value.getStruct(Envelope.FieldName.AFTER);
@@ -207,17 +212,18 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
         // Consume all of the events due to startup and initialization of the database
         // ---------------------------------------------------------------------------------------------------------------
         // Testing.Debug.enable();
-        SourceRecords records = consumeRecordsByTopic(5 + 6); // 5 schema change record, 6 inserts
+        SourceRecords records = consumeRecordsByTopic(6 + 7); // 6 schema change record, 7 inserts
         stopConnector();
         assertThat(records).isNotNull();
-        assertThat(records.recordsForTopic("regression").size()).isEqualTo(5);
+        assertThat(records.recordsForTopic("regression").size()).isEqualTo(6);
         assertThat(records.recordsForTopic("regression.regression_test.t1464075356413_testtable6").size()).isEqualTo(1);
         assertThat(records.recordsForTopic("regression.regression_test.dbz84_integer_types_table").size()).isEqualTo(1);
         assertThat(records.recordsForTopic("regression.regression_test.dbz_85_fractest").size()).isEqualTo(1);
         assertThat(records.recordsForTopic("regression.regression_test.dbz_100_enumsettest").size()).isEqualTo(3);
-        assertThat(records.topics().size()).isEqualTo(5);
+        assertThat(records.recordsForTopic("regression.regression_test.dbz_102_charsettest").size()).isEqualTo(1);
+        assertThat(records.topics().size()).isEqualTo(6);
         assertThat(records.databaseNames().size()).isEqualTo(1);
-        assertThat(records.ddlRecordsForDatabase("regression_test").size()).isEqualTo(5);
+        assertThat(records.ddlRecordsForDatabase("regression_test").size()).isEqualTo(6);
         assertThat(records.ddlRecordsForDatabase("connector_test")).isNull();
         assertThat(records.ddlRecordsForDatabase("readbinlog_test")).isNull();
         records.ddlRecordsForDatabase("regression_test").forEach(this::print);
@@ -239,6 +245,10 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 } else {
                     fail("c1 didn't match expected value");
                 }
+            } else if (record.topic().endsWith("dbz_102_charsettest")) {
+                Struct after = value.getStruct(Envelope.FieldName.AFTER);
+                String text = after.getString("text");
+                assertThat(text).isEqualTo("产品");
             } else if (record.topic().endsWith("dbz_85_fractest")) {
                 // The microseconds of all three should be exactly 780
                 Struct after = value.getStruct(Envelope.FieldName.AFTER);
@@ -324,21 +334,27 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
         // ---------------------------------------------------------------------------------------------------------------
         // Consume all of the events due to startup and initialization of the database
         // ---------------------------------------------------------------------------------------------------------------
-        // Testing.Debug.enable();
-        // 12 schema change records = 1 set variables, 5 drop tables, 1 drop database, 1 create database, 1 use database, 5 create
-        // tables
-        SourceRecords records = consumeRecordsByTopic(12 + 6); // plus 6 data records ...
+        Testing.Debug.enable();
+        // We expect a total of 14 schema change records:
+        // 1 set variables
+        // 6 drop tables
+        // 1 drop database
+        // 1 create database
+        // 1 use database
+        // 6 create tables
+        SourceRecords records = consumeRecordsByTopic(14 + 7); // plus 7 data records ...
         stopConnector();
         assertThat(records).isNotNull();
-        assertThat(records.recordsForTopic("regression").size()).isEqualTo(12);
+        assertThat(records.recordsForTopic("regression").size()).isEqualTo(14);
         assertThat(records.recordsForTopic("regression.regression_test.t1464075356413_testtable6").size()).isEqualTo(1);
         assertThat(records.recordsForTopic("regression.regression_test.dbz84_integer_types_table").size()).isEqualTo(1);
         assertThat(records.recordsForTopic("regression.regression_test.dbz_85_fractest").size()).isEqualTo(1);
         assertThat(records.recordsForTopic("regression.regression_test.dbz_100_enumsettest").size()).isEqualTo(3);
-        assertThat(records.topics().size()).isEqualTo(5);
+        assertThat(records.recordsForTopic("regression.regression_test.dbz_102_charsettest").size()).isEqualTo(1);
+        assertThat(records.topics().size()).isEqualTo(6);
         assertThat(records.databaseNames().size()).isEqualTo(2);
         assertThat(records.databaseNames()).containsOnly("regression_test","");
-        assertThat(records.ddlRecordsForDatabase("regression_test").size()).isEqualTo(11);
+        assertThat(records.ddlRecordsForDatabase("regression_test").size()).isEqualTo(13);
         assertThat(records.ddlRecordsForDatabase("connector_test")).isNull();
         assertThat(records.ddlRecordsForDatabase("readbinlog_test")).isNull();
         assertThat(records.ddlRecordsForDatabase("").size()).isEqualTo(1); // SET statement
@@ -361,6 +377,10 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 } else {
                     fail("c1 didn't match expected value");
                 }
+            } else if (record.topic().endsWith("dbz_102_charsettest")) {
+                Struct after = value.getStruct(Envelope.FieldName.AFTER);
+                String text = after.getString("text");
+                assertThat(text).isEqualTo("产品");
             } else if (record.topic().endsWith("dbz_85_fractest")) {
                 // The microseconds of all three should be exactly 780
                 Struct after = value.getStruct(Envelope.FieldName.AFTER);

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
@@ -109,11 +109,11 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 Struct after = value.getStruct(Envelope.FieldName.AFTER);
                 String c1 = after.getString("c1");
                 String c2 = after.getString("c2");
-                if ( c1.equals("a") ) {
+                if (c1.equals("a")) {
                     assertThat(c2).isEqualTo("a,b,c");
-                } else if ( c1.equals("b") ) {
+                } else if (c1.equals("b")) {
                     assertThat(c2).isEqualTo("a,b");
-                } else if ( c1.equals("c") ) {
+                } else if (c1.equals("c")) {
                     assertThat(c2).isEqualTo("a");
                 } else {
                     fail("c1 didn't match expected value");
@@ -230,11 +230,11 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 Struct after = value.getStruct(Envelope.FieldName.AFTER);
                 String c1 = after.getString("c1");
                 String c2 = after.getString("c2");
-                if ( c1.equals("a") ) {
+                if (c1.equals("a")) {
                     assertThat(c2).isEqualTo("a,b,c");
-                } else if ( c1.equals("b") ) {
+                } else if (c1.equals("b")) {
                     assertThat(c2).isEqualTo("a,b");
-                } else if ( c1.equals("c") ) {
+                } else if (c1.equals("c")) {
                     assertThat(c2).isEqualTo("a");
                 } else {
                     fail("c1 didn't match expected value");
@@ -325,20 +325,23 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
         // Consume all of the events due to startup and initialization of the database
         // ---------------------------------------------------------------------------------------------------------------
         // Testing.Debug.enable();
-        // 11 schema change records = 5 drop tables, 1 drop database, 1 create database, 1 use database, 5 create tables
-        SourceRecords records = consumeRecordsByTopic(11 + 6); // plus 6 data records ...
+        // 12 schema change records = 1 set variables, 5 drop tables, 1 drop database, 1 create database, 1 use database, 5 create
+        // tables
+        SourceRecords records = consumeRecordsByTopic(12 + 6); // plus 6 data records ...
         stopConnector();
         assertThat(records).isNotNull();
-        assertThat(records.recordsForTopic("regression").size()).isEqualTo(11);
+        assertThat(records.recordsForTopic("regression").size()).isEqualTo(12);
         assertThat(records.recordsForTopic("regression.regression_test.t1464075356413_testtable6").size()).isEqualTo(1);
         assertThat(records.recordsForTopic("regression.regression_test.dbz84_integer_types_table").size()).isEqualTo(1);
         assertThat(records.recordsForTopic("regression.regression_test.dbz_85_fractest").size()).isEqualTo(1);
         assertThat(records.recordsForTopic("regression.regression_test.dbz_100_enumsettest").size()).isEqualTo(3);
         assertThat(records.topics().size()).isEqualTo(5);
-        assertThat(records.databaseNames().size()).isEqualTo(1);
+        assertThat(records.databaseNames().size()).isEqualTo(2);
+        assertThat(records.databaseNames()).containsOnly("regression_test","");
         assertThat(records.ddlRecordsForDatabase("regression_test").size()).isEqualTo(11);
         assertThat(records.ddlRecordsForDatabase("connector_test")).isNull();
         assertThat(records.ddlRecordsForDatabase("readbinlog_test")).isNull();
+        assertThat(records.ddlRecordsForDatabase("").size()).isEqualTo(1); // SET statement
         records.ddlRecordsForDatabase("regression_test").forEach(this::print);
 
         // Check that all records are valid, can be serialized and deserialized ...
@@ -349,11 +352,11 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 Struct after = value.getStruct(Envelope.FieldName.AFTER);
                 String c1 = after.getString("c1");
                 String c2 = after.getString("c2");
-                if ( c1.equals("a") ) {
+                if (c1.equals("a")) {
                     assertThat(c2).isEqualTo("a,b,c");
-                } else if ( c1.equals("b") ) {
+                } else if (c1.equals("b")) {
                     assertThat(c2).isEqualTo("a,b");
-                } else if ( c1.equals("c") ) {
+                } else if (c1.equals("c")) {
                     assertThat(c2).isEqualTo("a");
                 } else {
                     fail("c1 didn't match expected value");

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -21,7 +21,6 @@ import io.debezium.relational.Column;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
-import io.debezium.relational.ddl.DdlParser;
 import io.debezium.relational.ddl.DdlParserListener.Event;
 import io.debezium.relational.ddl.SimpleDdlParserListener;
 import io.debezium.util.IoUtil;
@@ -29,7 +28,7 @@ import io.debezium.util.Testing;
 
 public class MySqlDdlParserTest {
 
-    private DdlParser parser;
+    private MySqlDdlParser parser;
     private Tables tables;
     private SimpleDdlParserListener listener;
 
@@ -212,7 +211,7 @@ public class MySqlDdlParserTest {
         assertThat(t).isNotNull();
         assertThat(t.columnNames()).containsExactly("col1");
         assertThat(t.primaryKeyColumnNames()).isEmpty();
-        assertColumn(t, "col1", "VARCHAR CHARACTER SET greek", Types.VARCHAR, 25, -1, true, false, false);
+        assertColumn(t, "col1", "VARCHAR", Types.VARCHAR, 25, -1, true, false, false);
     }
 
     @Test
@@ -224,7 +223,7 @@ public class MySqlDdlParserTest {
         assertThat(t).isNotNull();
         assertThat(t.columnNames()).containsExactly("col1");
         assertThat(t.primaryKeyColumnNames()).isEmpty();
-        assertColumn(t, "col1", "VARCHAR", Types.VARCHAR, 25, -1, true, false, false);
+        assertColumn(t, "col1", "VARCHAR", Types.VARCHAR, 25, null, true);
 
         ddl = "ALTER TABLE t MODIFY col1 VARCHAR(50) CHARACTER SET greek;";
         parser.parse(ddl, tables);
@@ -232,7 +231,7 @@ public class MySqlDdlParserTest {
         assertThat(t2).isNotNull();
         assertThat(t2.columnNames()).containsExactly("col1");
         assertThat(t2.primaryKeyColumnNames()).isEmpty();
-        assertColumn(t2, "col1", "VARCHAR CHARACTER SET greek", Types.VARCHAR, 50, -1, true, false, false);
+        assertColumn(t2, "col1", "VARCHAR", Types.VARCHAR, 50, "greek", true);
 
         ddl = "ALTER TABLE t MODIFY col1 VARCHAR(75) CHARSET utf8;";
         parser.parse(ddl, tables);
@@ -240,7 +239,176 @@ public class MySqlDdlParserTest {
         assertThat(t3).isNotNull();
         assertThat(t3.columnNames()).containsExactly("col1");
         assertThat(t3.primaryKeyColumnNames()).isEmpty();
-        assertColumn(t3, "col1", "VARCHAR CHARSET utf8", Types.VARCHAR, 75, -1, true, false, false);
+        assertColumn(t3, "col1", "VARCHAR", Types.VARCHAR, 75, "utf8", true);
+    }
+
+    @Test
+    public void shouldParseCreateDatabaseAndTableThatUsesDefaultCharacterSets() {
+        String ddl = "SET character_set_server=utf8;" + System.lineSeparator()
+                + "CREATE DATABASE db1 CHARACTER SET utf8mb4;" + System.lineSeparator()
+                + "USE db1;" + System.lineSeparator()
+                + "CREATE TABLE t1 (" + System.lineSeparator()
+                + " id int(11) not null auto_increment," + System.lineSeparator()
+                + " c1 varchar(255) default null," + System.lineSeparator()
+                + " c2 varchar(255) charset default not null," + System.lineSeparator()
+                + " c3 varchar(255) charset latin2 not null," + System.lineSeparator()
+                + " primary key ('id')" + System.lineSeparator()
+                + ") engine=InnoDB auto_increment=1006 default charset=latin1;" + System.lineSeparator();
+        parser.parse(ddl, tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_database", "utf8mb4"); // changes when we use a different database
+        assertThat(tables.size()).isEqualTo(1);
+        Table t = tables.forTable(new TableId("db1", null, "t1"));
+        assertThat(t).isNotNull();
+        assertThat(t.columnNames()).containsExactly("id", "c1", "c2", "c3");
+        assertThat(t.primaryKeyColumnNames()).containsExactly("id");
+        assertColumn(t, "id", "INT", Types.INTEGER, 11, -1, false, true, true);
+        assertColumn(t, "c1", "VARCHAR", Types.VARCHAR, 255, "latin1", true);
+        assertColumn(t, "c2", "VARCHAR", Types.VARCHAR, 255, "latin1", false);
+        assertColumn(t, "c3", "VARCHAR", Types.VARCHAR, 255, "latin2", false);
+
+        // Create a similar table but without a default charset for the table ...
+        ddl = "CREATE TABLE t2 (" + System.lineSeparator()
+                + " id int(11) not null auto_increment," + System.lineSeparator()
+                + " c1 varchar(255) default null," + System.lineSeparator()
+                + " c2 varchar(255) charset default not null," + System.lineSeparator()
+                + " c3 varchar(255) charset latin2 not null," + System.lineSeparator()
+                + " primary key ('id')" + System.lineSeparator()
+                + ") engine=InnoDB auto_increment=1006;" + System.lineSeparator();
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(2);
+        Table t2 = tables.forTable(new TableId("db1", null, "t2"));
+        assertThat(t2).isNotNull();
+        assertThat(t2.columnNames()).containsExactly("id", "c1", "c2", "c3");
+        assertThat(t2.primaryKeyColumnNames()).containsExactly("id");
+        assertColumn(t2, "id", "INT", Types.INTEGER, 11, -1, false, true, true);
+        assertColumn(t2, "c1", "VARCHAR", Types.VARCHAR, 255, "utf8mb4", true);
+        assertColumn(t2, "c2", "VARCHAR", Types.VARCHAR, 255, "utf8mb4", false);
+        assertColumn(t2, "c3", "VARCHAR", Types.VARCHAR, 255, "latin2", false);
+    }
+
+    @Test
+    public void shouldParseCreateDatabaseAndUseDatabaseStatementsAndHaveCharacterEncodingVariablesUpdated() {
+        parser.parse("SET character_set_server=utf8;", tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_database", null);
+
+        parser.parse("CREATE DATABASE db1 CHARACTER SET utf8mb4;", tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_database", null); // changes when we USE a different database
+
+        parser.parse("USE db1;", tables);// changes the "character_set_database" system variable ...
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_database", "utf8mb4");
+
+        parser.parse("CREATE DATABASE db2 CHARACTER SET latin1;", tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_database", "utf8mb4");
+
+        parser.parse("USE db2;", tables);// changes the "character_set_database" system variable ...
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_database", "latin1");
+
+        parser.parse("USE db1;", tables);// changes the "character_set_database" system variable ...
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_database", "utf8mb4");
+    }
+
+    @Test
+    public void shouldParseSetCharacterSetStatement() {
+        parser.parse("SET character_set_server=utf8;", tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_connection", null);
+        assertVariable("character_set_database", null);
+
+        parser.parse("SET CHARACTER SET utf8mb4;", tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_client", "utf8mb4");
+        assertVariable("character_set_results", "utf8mb4");
+        assertVariable("character_set_connection", null);
+        assertVariable("character_set_database", null);
+
+        // Set the character set to the default for the current database, or since there is none then that of the server ...
+        parser.parse("SET CHARACTER SET default;", tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_client", "utf8");
+        assertVariable("character_set_results", "utf8");
+        assertVariable("character_set_connection", null);
+        assertVariable("character_set_database", null);
+
+        parser.parse("SET CHARSET utf16;", tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_client", "utf16");
+        assertVariable("character_set_results", "utf16");
+        assertVariable("character_set_connection", null);
+        assertVariable("character_set_database", null);
+
+        parser.parse("SET CHARSET default;", tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_client", "utf8");
+        assertVariable("character_set_results", "utf8");
+        assertVariable("character_set_connection", null);
+        assertVariable("character_set_database", null);
+
+        parser.parse("CREATE DATABASE db1 CHARACTER SET cs1;", tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_database", null); // changes when we USE a different database
+
+        parser.parse("USE db1;", tables);// changes the "character_set_database" system variable ...
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_database", "cs1");
+
+        parser.parse("SET CHARSET default;", tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_client", "cs1");
+        assertVariable("character_set_results", "cs1");
+        assertVariable("character_set_connection", null);
+        assertVariable("character_set_database", "cs1");
+    }
+
+    @Test
+    public void shouldParseSetNamesStatement() {
+        parser.parse("SET character_set_server=utf8;", tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_connection", null);
+        assertVariable("character_set_database", null);
+
+        parser.parse("SET NAMES utf8mb4 COLLATE junk;", tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_client", "utf8mb4");
+        assertVariable("character_set_results", "utf8mb4");
+        assertVariable("character_set_connection", "utf8mb4");
+        assertVariable("character_set_database", null);
+
+        // Set the character set to the default for the current database, or since there is none then that of the server ...
+        parser.parse("SET NAMES default;", tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_client", "utf8");
+        assertVariable("character_set_results", "utf8");
+        assertVariable("character_set_connection", "utf8");
+        assertVariable("character_set_database", null);
+
+        parser.parse("SET NAMES utf16;", tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_client", "utf16");
+        assertVariable("character_set_results", "utf16");
+        assertVariable("character_set_connection", "utf16");
+        assertVariable("character_set_database", null);
+
+        parser.parse("CREATE DATABASE db1 CHARACTER SET cs1;", tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_database", null); // changes when we USE a different database
+
+        parser.parse("USE db1;", tables);// changes the "character_set_database" system variable ...
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_database", "cs1");
+
+        parser.parse("SET NAMES default;", tables);
+        assertVariable("character_set_server", "utf8");
+        assertVariable("character_set_client", "cs1");
+        assertVariable("character_set_results", "cs1");
+        assertVariable("character_set_connection", "cs1");
+        assertVariable("character_set_database", "cs1");
     }
 
     @Test
@@ -259,7 +427,7 @@ public class MySqlDdlParserTest {
         parser.parse(ddl, tables);
         Table t2 = tables.forTable(new TableId(null, null, "t"));
         assertThat(t2).isNotNull();
-        assertThat(t2.columnNames()).containsExactly("col1","col2");
+        assertThat(t2.columnNames()).containsExactly("col1", "col2");
         assertThat(t2.primaryKeyColumnNames()).isEmpty();
         assertColumn(t2, "col1", "VARCHAR", Types.VARCHAR, 25, -1, true, false, false);
         assertColumn(t2, "col2", "VARCHAR", Types.VARCHAR, 50, -1, false, false, false);
@@ -270,7 +438,7 @@ public class MySqlDdlParserTest {
         parser.parse(ddl, tables);
         Table t3 = tables.forTable(new TableId(null, null, "t"));
         assertThat(t3).isNotNull();
-        assertThat(t3.columnNames()).containsExactly("col1","col3", "col2");
+        assertThat(t3.columnNames()).containsExactly("col1", "col3", "col2");
         assertThat(t3.primaryKeyColumnNames()).isEmpty();
         assertColumn(t3, "col1", "VARCHAR", Types.VARCHAR, 25, -1, true, false, false);
         assertColumn(t3, "col3", "FLOAT", Types.FLOAT, -1, -1, false, false, false);
@@ -304,15 +472,96 @@ public class MySqlDdlParserTest {
     }
 
     @Test
+    public void shouldParseSetOfOneVariableStatementWithoutTerminator() {
+        String ddl = "set character_set_client=utf8";
+        parser.parse(ddl, tables);
+        assertVariable("character_set_client", "utf8");
+    }
+
+    @Test
+    public void shouldParseSetOfOneVariableStatementWithTerminator() {
+        String ddl = "set character_set_client = utf8;";
+        parser.parse(ddl, tables);
+        assertVariable("character_set_client", "utf8");
+    }
+
+    @Test
+    public void shouldParseSetOfSameVariableWithDifferentScope() {
+        String ddl = "SET GLOBAL sort_buffer_size=1000000, SESSION sort_buffer_size=1000000";
+        parser.parse(ddl, tables);
+        assertGlobalVariable("sort_buffer_size", "1000000");
+        assertSessionVariable("sort_buffer_size", "1000000");
+    }
+
+    @Test
+    public void shouldParseSetOfMultipleVariablesWithInferredScope() {
+        String ddl = "SET GLOBAL v1=1, v2=2";
+        parser.parse(ddl, tables);
+        assertGlobalVariable("v1", "1");
+        assertGlobalVariable("v2", "2");
+        assertSessionVariable("v2", null);
+    }
+
+    @Test
+    public void shouldParseSetOfGlobalVariable() {
+        String ddl = "SET GLOBAL v1=1; SET @@global.v2=2";
+        parser.parse(ddl, tables);
+        assertGlobalVariable("v1", "1");
+        assertGlobalVariable("v2", "2");
+        assertSessionVariable("v1", null);
+        assertSessionVariable("v2", null);
+    }
+
+    @Test
+    public void shouldParseSetOfLocalVariable() {
+        String ddl = "SET LOCAL v1=1; SET @@local.v2=2";
+        parser.parse(ddl, tables);
+        assertLocalVariable("v1", "1");
+        assertLocalVariable("v2", "2");
+        assertSessionVariable("v1", "1");
+        assertSessionVariable("v2", "2");
+        assertGlobalVariable("v1", null);
+        assertGlobalVariable("v2", null);
+    }
+
+    @Test
+    public void shouldParseSetOfSessionVariable() {
+        String ddl = "SET SESSION v1=1; SET @@session.v2=2";
+        parser.parse(ddl, tables);
+        assertLocalVariable("v1", "1");
+        assertLocalVariable("v2", "2");
+        assertSessionVariable("v1", "1");
+        assertSessionVariable("v2", "2");
+        assertGlobalVariable("v1", null);
+        assertGlobalVariable("v2", null);
+    }
+
+    @Test
+    public void shouldParseButNotSetUserVariableWithHyphenDelimiter() {
+        String ddl = "SET @a-b-c-d:=1";
+        parser.parse(ddl, tables);
+        assertLocalVariable("a-b-c-d", null);
+        assertSessionVariable("a-b-c-d", null);
+        assertGlobalVariable("a-b-c-d", null);
+    }
+
+    @Test
+    public void shouldParseVariableWithHyphenDelimiter() {
+        String ddl = "SET a-b-c-d=1";
+        parser.parse(ddl, tables);
+        assertSessionVariable("a-b-c-d", "1");
+    }
+
+    @Test
     public void shouldParseStatementsWithQuotedIdentifiers() {
         parser.parse(readFile("ddl/mysql-quoted.ddl"), tables);
         Testing.print(tables);
         assertThat(tables.size()).isEqualTo(4);
         assertThat(listener.total()).isEqualTo(10);
-        assertThat(tables.forTable("connector_test_ro",null,"products")).isNotNull();
-        assertThat(tables.forTable("connector_test_ro",null,"products_on_hand")).isNotNull();
-        assertThat(tables.forTable("connector_test_ro",null,"customers")).isNotNull();
-        assertThat(tables.forTable("connector_test_ro",null,"orders")).isNotNull();
+        assertThat(tables.forTable("connector_test_ro", null, "products")).isNotNull();
+        assertThat(tables.forTable("connector_test_ro", null, "products_on_hand")).isNotNull();
+        assertThat(tables.forTable("connector_test_ro", null, "customers")).isNotNull();
+        assertThat(tables.forTable("connector_test_ro", null, "orders")).isNotNull();
     }
 
     @Test
@@ -345,7 +594,7 @@ public class MySqlDdlParserTest {
         Testing.print(tables);
         assertThat(tables.size()).isEqualTo(6);
         assertThat(listener.total()).isEqualTo(62);
-        // listener.forEach(this::printEvent);
+        listener.forEach(this::printEvent);
     }
 
     @Test
@@ -378,32 +627,62 @@ public class MySqlDdlParserTest {
         assertThat(listener.total()).isEqualTo(16);
         listener.forEach(this::printEvent);
     }
-    
+
     @Test
     public void shouldParseEnumOptions() {
-        assertParseEnumAndSetOptions("ENUM('a','b','c')","abc");
-        assertParseEnumAndSetOptions("ENUM('a')","a");
-        assertParseEnumAndSetOptions("ENUM()","");
-        assertParseEnumAndSetOptions("ENUM ('a','b','c') CHARACTER SET","abc");
-        assertParseEnumAndSetOptions("ENUM ('a') CHARACTER SET","a");
-        assertParseEnumAndSetOptions("ENUM () CHARACTER SET","");
-    }
-    
-    @Test
-    public void shouldParseSetOptions() {
-        assertParseEnumAndSetOptions("SET('a','b','c')","abc");
-        assertParseEnumAndSetOptions("SET('a')","a");
-        assertParseEnumAndSetOptions("SET()","");
-        assertParseEnumAndSetOptions("SET ('a','b','c') CHARACTER SET","abc");
-        assertParseEnumAndSetOptions("SET ('a') CHARACTER SET","a");
-        assertParseEnumAndSetOptions("SET () CHARACTER SET","");
+        assertParseEnumAndSetOptions("ENUM('a','b','c')", "abc");
+        assertParseEnumAndSetOptions("ENUM('a')", "a");
+        assertParseEnumAndSetOptions("ENUM()", "");
+        assertParseEnumAndSetOptions("ENUM ('a','b','c') CHARACTER SET", "abc");
+        assertParseEnumAndSetOptions("ENUM ('a') CHARACTER SET", "a");
+        assertParseEnumAndSetOptions("ENUM () CHARACTER SET", "");
     }
 
-    protected void assertParseEnumAndSetOptions( String typeExpression, String optionString ) {
+    @Test
+    public void shouldParseSetOptions() {
+        assertParseEnumAndSetOptions("SET('a','b','c')", "abc");
+        assertParseEnumAndSetOptions("SET('a')", "a");
+        assertParseEnumAndSetOptions("SET()", "");
+        assertParseEnumAndSetOptions("SET ('a','b','c') CHARACTER SET", "abc");
+        assertParseEnumAndSetOptions("SET ('a') CHARACTER SET", "a");
+        assertParseEnumAndSetOptions("SET () CHARACTER SET", "");
+    }
+
+    protected void assertParseEnumAndSetOptions(String typeExpression, String optionString) {
         String options = MySqlDdlParser.parseSetAndEnumOptions(typeExpression);
         assertThat(options).isEqualTo(optionString);
     }
-    
+
+    protected void assertVariable(String name, String expectedValue) {
+        String actualValue = parser.systemVariables().getVariable(name);
+        if (expectedValue == null) {
+            assertThat(actualValue).isNull();
+        } else {
+            assertThat(actualValue).isEqualToIgnoringCase(expectedValue);
+        }
+    }
+
+    protected void assertVariable(MySqlSystemVariables.Scope scope, String name, String expectedValue) {
+        String actualValue = parser.systemVariables().getVariable(name, scope);
+        if (expectedValue == null) {
+            assertThat(actualValue).isNull();
+        } else {
+            assertThat(actualValue).isEqualToIgnoringCase(expectedValue);
+        }
+    }
+
+    protected void assertGlobalVariable(String name, String expectedValue) {
+        assertVariable(MySqlSystemVariables.Scope.GLOBAL, name, expectedValue);
+    }
+
+    protected void assertSessionVariable(String name, String expectedValue) {
+        assertVariable(MySqlSystemVariables.Scope.SESSION, name, expectedValue);
+    }
+
+    protected void assertLocalVariable(String name, String expectedValue) {
+        assertVariable(MySqlSystemVariables.Scope.LOCAL, name, expectedValue);
+    }
+
     protected void printEvent(Event event) {
         Testing.print(event);
     }
@@ -442,6 +721,20 @@ public class MySqlDdlParserTest {
         }
         assert false : "should never get here";
         return null;
+    }
+
+    protected void assertColumn(Table table, String name, String typeName, int jdbcType, int length,
+                                String charsetName, boolean optional) {
+        Column column = table.columnWithName(name);
+        assertThat(column.name()).isEqualTo(name);
+        assertThat(column.typeName()).isEqualTo(typeName);
+        assertThat(column.jdbcType()).isEqualTo(jdbcType);
+        assertThat(column.length()).isEqualTo(length);
+        assertThat(column.charsetName()).isEqualTo(charsetName);
+        assertThat(column.scale()).isEqualTo(-1);
+        assertThat(column.isOptional()).isEqualTo(optional);
+        assertThat(column.isGenerated()).isFalse();
+        assertThat(column.isAutoIncremented()).isFalse();
     }
 
     protected void assertColumn(Table table, String name, String typeName, int jdbcType, int length, int scale,

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSchemaTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSchemaTest.java
@@ -61,7 +61,10 @@ public class MySqlSchemaTest {
         mysql.start();
 
         // Testing.Print.enable();
+
+        // Set up the server ...
         source.setBinlogStartPoint("binlog-001",400);
+        mysql.applyDdl(source, "db1", "SET " + MySqlSystemVariables.CHARSET_NAME_SERVER + "=utf8mb4", this::printStatements);
         mysql.applyDdl(source, "db1", readFile("ddl/mysql-products.ddl"), this::printStatements);
 
         // Check that we have tables ...
@@ -82,6 +85,7 @@ public class MySqlSchemaTest {
         mysql.start();
 
         source.setBinlogStartPoint("binlog-001",400);
+        mysql.applyDdl(source, "mysql", "SET " + MySqlSystemVariables.CHARSET_NAME_SERVER + "=utf8mb4", this::printStatements);
         mysql.applyDdl(source, "mysql", readFile("ddl/mysql-test-init-5.7.ddl"), this::printStatements);
 
         source.setBinlogStartPoint("binlog-001",1000);
@@ -107,6 +111,7 @@ public class MySqlSchemaTest {
         mysql.start();
 
         source.setBinlogStartPoint("binlog-001",400);
+        mysql.applyDdl(source, "mysql", "SET " + MySqlSystemVariables.CHARSET_NAME_SERVER + "=utf8mb4", this::printStatements);
         mysql.applyDdl(source, "mysql", readFile("ddl/mysql-test-init-5.7.ddl"), this::printStatements);
 
         source.setBinlogStartPoint("binlog-001",1000);

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotReaderIT.java
@@ -268,10 +268,10 @@ public class SnapshotReaderIT {
         // The last poll should always return null ...
         assertThat(records).isNull();
         
-        // There should be 11 schema changes ...
-        assertThat(schemaChanges.recordCount()).isEqualTo(11);
-        assertThat(schemaChanges.databaseCount()).isEqualTo(1);
-        assertThat(schemaChanges.databases()).containsOnly(DB_NAME);
+        // There should be 11 schema changes plus 1 SET statement ...
+        assertThat(schemaChanges.recordCount()).isEqualTo(12);
+        assertThat(schemaChanges.databaseCount()).isEqualTo(2);
+        assertThat(schemaChanges.databases()).containsOnly(DB_NAME,"");
         
         // Check the records via the store ...
         assertThat(store.collectionCount()).isEqualTo(4);

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -646,7 +646,8 @@ public class JdbcConnection implements AutoCloseable {
             // Then define the table ...
             List<Column> columns = columnsByTable.get(id);
             Collections.sort(columns);
-            tables.overwriteTable(id, columns, pkColumnNames);
+            String defaultCharsetName = null; // JDBC does not expose character sets
+            tables.overwriteTable(id, columns, pkColumnNames, defaultCharsetName);
         }
 
         if (removeTablesNotFoundInJdbc) {

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
@@ -61,7 +61,7 @@ public class JdbcValueConverters implements ValueConverterProvider {
     private static final Double DOUBLE_TRUE = new Double(1.0d);
     private static final Double DOUBLE_FALSE = new Double(0.0d);
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
     private final ZoneOffset defaultOffset;
     private final boolean adaptiveTimePrecision;
 

--- a/debezium-core/src/main/java/io/debezium/relational/Column.java
+++ b/debezium-core/src/main/java/io/debezium/relational/Column.java
@@ -20,6 +20,7 @@ public interface Column extends Comparable<Column> {
 
     /**
      * Obtain an column definition editor that can be used to define a column.
+     * 
      * @return the editor; never null
      */
     public static ColumnEditor editor() {
@@ -63,6 +64,14 @@ public interface Column extends Comparable<Column> {
     String typeExpression();
 
     /**
+     * Get the database-specific name of the character set used by this column.
+     * 
+     * @return the database-specific character set name, or null if the column's data type doesn't {@link #typeUsesCharset() use
+     *         character sets} or no character set is specified
+     */
+    String charsetName();
+
+    /**
      * Get the maximum length of this column's values. For numeric columns, this represents the precision.
      * 
      * @return the length of the column
@@ -83,7 +92,7 @@ public interface Column extends Comparable<Column> {
      * @see #isRequired()
      */
     boolean isOptional();
-    
+
     /**
      * Determine whether this column is required. This is equivalent to calling {@code !isOptional()}.
      * 
@@ -119,16 +128,28 @@ public interface Column extends Comparable<Column> {
      * 
      * @return the editor; never null
      */
-    default ColumnEditor edit() {
-        return Column.editor()
-                               .name(name())
-                               .type(typeName(),typeExpression())
-                               .jdbcType(jdbcType())
-                               .length(length())
-                               .scale(scale())
-                               .position(position())
-                               .optional(isOptional())
-                               .autoIncremented(isAutoIncremented())
-                               .generated(isGenerated());
+    ColumnEditor edit();
+
+    /**
+     * Determine whether this column has a {@link #typeName()} or {@link #jdbcType()} to which a character set applies.
+     * 
+     * @return {@code true} if a character set applies the column's type, or {@code false} otherwise
+     */
+    default boolean typeUsesCharset() {
+        switch (jdbcType()) {
+            case Types.CHAR:
+            case Types.VARCHAR:
+            case Types.LONGVARCHAR:
+            case Types.CLOB:
+            case Types.NCHAR:
+            case Types.NVARCHAR:
+            case Types.LONGNVARCHAR:
+            case Types.NCLOB:
+            case Types.DATALINK:
+            case Types.SQLXML:
+                return true;
+            default:
+                return false;
+        }
     }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/ColumnEditor.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnEditor.java
@@ -54,6 +54,22 @@ public interface ColumnEditor extends Comparable<Column> {
     String typeExpression();
 
     /**
+     * Get the database-specific name of the character set used by this column.
+     * 
+     * @return the database-specific character set name, or null if the column's data type doesn't use character sets or no
+     * character set is specified
+     */
+    String charsetName();
+
+    /**
+     * Get the database-specific name of the character set defined by this column's table, which is used if a character set is
+     * not explicitly set on this column.
+     * 
+     * @return the database-specific character set name defined for this column's table, or null if not defined
+     */
+    String charsetNameOfTable();
+
+    /**
      * Get the maximum length of this column's values. For numeric columns, this represents the precision.
      * 
      * @return the length of the column
@@ -122,6 +138,22 @@ public interface ColumnEditor extends Comparable<Column> {
      * @return this editor so callers can chain methods together
      */
     ColumnEditor jdbcType(int jdbcType);
+
+    /**
+     * Set the database-specific name of the character set used by this column.
+     * 
+     * @param charsetName the database-specific character set name; may be null
+     * @return this editor so callers can chain methods together
+     */
+    ColumnEditor charsetName(String charsetName);
+
+    /**
+     * Set the database-specific name of the character set defined by this column's table.
+     * 
+     * @param charsetName the database-specific character set name; may be null
+     * @return this editor so callers can chain methods together
+     */
+    ColumnEditor charsetNameOfTable(String charsetName);
 
     /**
      * Set the maximum length of this column's values. For numeric columns, this represents the precision.

--- a/debezium-core/src/main/java/io/debezium/relational/ColumnEditorImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnEditorImpl.java
@@ -13,6 +13,8 @@ final class ColumnEditorImpl implements ColumnEditor {
     private int jdbcType = Types.INTEGER;
     private String typeName;
     private String typeExpression;
+    private String charsetName;
+    private String tableCharsetName;
     private int length = -1;
     private int scale = -1;
     private int position = 1;
@@ -42,7 +44,17 @@ final class ColumnEditorImpl implements ColumnEditor {
     public int jdbcType() {
         return jdbcType;
     }
-
+    
+    @Override
+    public String charsetName() {
+        return charsetName;
+    }
+    
+    @Override
+    public String charsetNameOfTable() {
+        return tableCharsetName;
+    }
+    
     @Override
     public int length() {
         return length;
@@ -100,6 +112,18 @@ final class ColumnEditorImpl implements ColumnEditor {
     }
 
     @Override
+    public ColumnEditor charsetName(String charsetName) {
+        this.charsetName = charsetName;
+        return this;
+    }
+    
+    @Override
+    public ColumnEditor charsetNameOfTable(String charsetName) {
+        this.tableCharsetName = charsetName;
+        return this;
+    }
+
+    @Override
     public ColumnEditorImpl length(int length) {
         assert length >= -1;
         this.length = length;
@@ -139,7 +163,7 @@ final class ColumnEditorImpl implements ColumnEditor {
 
     @Override
     public Column create() {
-        return new ColumnImpl(name, position, jdbcType, typeName, typeExpression, length, scale, optional, autoIncremented, generated);
+        return new ColumnImpl(name, position, jdbcType, typeName, typeExpression, charsetName, tableCharsetName, length, scale, optional, autoIncremented, generated);
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/relational/ColumnImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnImpl.java
@@ -5,25 +5,35 @@
  */
 package io.debezium.relational;
 
+import io.debezium.util.Strings;
+
 final class ColumnImpl implements Column, Comparable<Column> {
     private final String name;
     private final int position;
     private final int jdbcType;
     private final String typeName;
     private final String typeExpression;
+    private final String charsetName;
     private final int length;
     private final int scale;
     private final boolean optional;
     private final boolean autoIncremented;
     private final boolean generated;
 
-    protected ColumnImpl(String columnName, int position, int jdbcType, String typeName, String typeExpression, int columnLength,
-            int columnScale, boolean optional, boolean autoIncremented, boolean generated) {
+    protected ColumnImpl(String columnName, int position, int jdbcType, String typeName, String typeExpression,
+                         String charsetName, String defaultCharsetName, int columnLength, int columnScale,
+                         boolean optional, boolean autoIncremented, boolean generated) {
         this.name = columnName;
         this.position = position;
         this.jdbcType = jdbcType;
         this.typeName = typeName;
         this.typeExpression = typeExpression;
+        // We want to always capture the charset name for the column (if the column needs one) ...
+        if ( typeUsesCharset() && (charsetName == null || "DEFAULT".equalsIgnoreCase(charsetName)) ) {
+            // Use the default charset name ...
+            charsetName = defaultCharsetName;
+        }
+        this.charsetName = charsetName;
         this.length = columnLength;
         this.scale = columnScale;
         this.optional = optional;
@@ -58,6 +68,11 @@ final class ColumnImpl implements Column, Comparable<Column> {
         return typeExpression;
     }
 
+    @Override
+    public String charsetName() {
+        return charsetName;
+    }
+    
     @Override
     public int length() {
         return length;
@@ -97,6 +112,7 @@ final class ColumnImpl implements Column, Comparable<Column> {
                     this.typeExpression().equalsIgnoreCase(that.typeExpression()) &&
                     this.typeName().equalsIgnoreCase(that.typeName()) &&
                     this.jdbcType() == that.jdbcType() &&
+                    Strings.equalsIgnoreCase(this.charsetName(),that.charsetName()) &&
                     this.position() == that.position() &&
                     this.length() == that.length() &&
                     this.scale() == that.scale() &&
@@ -118,10 +134,28 @@ final class ColumnImpl implements Column, Comparable<Column> {
             }
             sb.append(')');
         }
+        if (charsetName != null && !charsetName.isEmpty()) {
+            sb.append(" CHARSET ").append(charsetName);
+        }
         if (!optional) sb.append(" NOT NULL");
         if (autoIncremented) sb.append(" AUTO_INCREMENTED");
         if (generated) sb.append(" GENERATED");
         return sb.toString();
     }
+    
+    @Override
+    public ColumnEditor edit()  {
+        return Column.editor()
+                .name(name())
+                .type(typeName(), typeExpression())
+                .jdbcType(jdbcType())
+                .charsetName(charsetName)
+                .length(length())
+                .scale(scale())
+                .position(position())
+                .optional(isOptional())
+                .autoIncremented(isAutoIncremented())
+                .generated(isGenerated());
+}
 
 }

--- a/debezium-core/src/main/java/io/debezium/relational/Table.java
+++ b/debezium-core/src/main/java/io/debezium/relational/Table.java
@@ -95,6 +95,14 @@ public interface Table {
     Column columnWithName(String name);
 
     /**
+     * Get the database-specific name of the default character set used by columns in this table.
+     * 
+     * @return the database-specific character set name used by default in columns of this table, or {@code null} if there is no
+     * such default character set name defined on the table
+     */
+    String defaultCharsetName();
+
+    /**
      * Determine if the named column is part of the primary key.
      * 
      * @param columnName the name of the column

--- a/debezium-core/src/main/java/io/debezium/relational/TableEditor.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableEditor.java
@@ -187,6 +187,20 @@ public interface TableEditor {
     TableEditor setUniqueValues();
     
     /**
+     * Set the name of the character set that should be used by default in the columns that require a character set but have
+     * not defined one.
+     * @param charsetName the name of the character set that should be used by default
+     * @return this editor so callers can chain methods together
+     */
+    TableEditor setDefaultCharsetName(String charsetName);
+
+    /**
+     * Determine if a {@link #setDefaultCharsetName(String) default character set} has been set on this table.
+     * @return {@code true} if this has a default character set, or {@code false} if one has not yet been set
+     */
+    boolean hasDefaultCharsetName();
+    
+    /**
      * Determine whether this table's primary key contains all columns (via {@link #setUniqueValues()}) such that all rows
      * within the table are unique.
      * @return {@code true} if {@link #setUniqueValues()} was last called on this table, or {@code false} otherwise

--- a/debezium-core/src/main/java/io/debezium/relational/TableEditorImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableEditorImpl.java
@@ -18,6 +18,7 @@ final class TableEditorImpl implements TableEditor {
     private LinkedHashMap<String, Column> sortedColumns = new LinkedHashMap<>();
     private final List<String> pkColumnNames = new ArrayList<>();
     private boolean uniqueValues = false;
+    private String defaultCharsetName;
 
     protected TableEditorImpl() {
     }
@@ -142,6 +143,17 @@ final class TableEditorImpl implements TableEditor {
     public boolean hasUniqueValues() {
         return uniqueValues;
     }
+    
+    @Override
+    public TableEditor setDefaultCharsetName(String charsetName) {
+        this.defaultCharsetName = charsetName;
+        return this;
+    }
+    
+    @Override
+    public boolean hasDefaultCharsetName() {
+        return this.defaultCharsetName != null && !this.defaultCharsetName.trim().isEmpty();
+    }
 
     @Override
     public TableEditor removeColumn(String columnName) {
@@ -231,6 +243,11 @@ final class TableEditorImpl implements TableEditor {
     @Override
     public Table create() {
         if (id == null) throw new IllegalStateException("Unable to create a table from an editor that has no table ID");
-        return new TableImpl(id, new ArrayList<>(sortedColumns.values()), primaryKeyColumnNames());
+        List<Column> columns = new ArrayList<>();
+        sortedColumns.values().forEach(column->{
+            column = column.edit().charsetNameOfTable(defaultCharsetName).create();
+            columns.add(column);
+        });
+        return new TableImpl(id, columns, primaryKeyColumnNames(), defaultCharsetName);
     }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/TableImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableImpl.java
@@ -11,6 +11,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.debezium.util.Strings;
+
 final class TableImpl implements Table {
 
     private final TableId id;
@@ -18,12 +20,13 @@ final class TableImpl implements Table {
     private final List<String> pkColumnNames;
     private final List<String> columnNames;
     private final Map<String, Column> columnsByLowercaseName;
+    private final String defaultCharsetName;
 
     protected TableImpl(Table table) {
-        this(table.id(), table.columns(), table.primaryKeyColumnNames());
+        this(table.id(), table.columns(), table.primaryKeyColumnNames(), table.defaultCharsetName());
     }
 
-    protected TableImpl(TableId id, List<Column> sortedColumns, List<String> pkColumnNames) {
+    protected TableImpl(TableId id, List<Column> sortedColumns, List<String> pkColumnNames, String defaultCharsetName) {
         this.id = id;
         this.columnDefs = Collections.unmodifiableList(sortedColumns);
         this.pkColumnNames = pkColumnNames == null ? Collections.emptyList() : Collections.unmodifiableList(pkColumnNames);
@@ -35,8 +38,9 @@ final class TableImpl implements Table {
         }
         this.columnsByLowercaseName = Collections.unmodifiableMap(defsByLowercaseName);
         this.columnNames = Collections.unmodifiableList(columnNames);
+        this.defaultCharsetName = defaultCharsetName;
     }
-    
+
     @Override
     public TableId id() {
         return id;
@@ -61,20 +65,26 @@ final class TableImpl implements Table {
     public Column columnWithName(String name) {
         return columnsByLowercaseName.get(name.toLowerCase());
     }
-    
+
+    @Override
+    public String defaultCharsetName() {
+        return defaultCharsetName;
+    }
+
     @Override
     public int hashCode() {
         return id.hashCode();
     }
-    
+
     @Override
     public boolean equals(Object obj) {
-        if ( obj== this) return true;
-        if ( obj instanceof Table ) {
-            Table that = (Table)obj;
-            return  this.id().equals(that.id())
+        if (obj == this) return true;
+        if (obj instanceof Table) {
+            Table that = (Table) obj;
+            return this.id().equals(that.id())
                     && this.columns().equals(that.columns())
-                    && this.primaryKeyColumnNames().equals(that.primaryKeyColumnNames());
+                    && this.primaryKeyColumnNames().equals(that.primaryKeyColumnNames())
+                    && Strings.equalsIgnoreCase(this.defaultCharsetName(), that.defaultCharsetName());
         }
         return false;
     }
@@ -85,7 +95,7 @@ final class TableImpl implements Table {
         toString(sb, "");
         return sb.toString();
     }
-    
+
     protected void toString(StringBuilder sb, String prefix) {
         if (prefix == null) prefix = "";
         sb.append(prefix).append("columns: {").append(System.lineSeparator());
@@ -94,10 +104,14 @@ final class TableImpl implements Table {
         }
         sb.append(prefix).append("}").append(System.lineSeparator());
         sb.append(prefix).append("primary key: ").append(primaryKeyColumnNames()).append(System.lineSeparator());
+        sb.append(prefix).append("default charset: ").append(defaultCharsetName()).append(System.lineSeparator());
     }
 
     @Override
     public TableEditor edit() {
-        return new TableEditorImpl().tableId(id).setColumns(columnDefs).setPrimaryKeyNames(pkColumnNames);
+        return new TableEditorImpl().tableId(id)
+                                    .setColumns(columnDefs)
+                                    .setPrimaryKeyNames(pkColumnNames)
+                                    .setDefaultCharsetName(defaultCharsetName);
     }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/DdlChanges.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/DdlChanges.java
@@ -128,6 +128,8 @@ public class DdlChanges implements DdlParserListener {
             case DROP_DATABASE:
                 DatabaseEvent dbEvent = (DatabaseEvent) event;
                 return dbEvent.databaseName();
+            case SET_VARIABLE:
+                return "";
         }
         assert false : "Should never happen";
         return null;

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/DdlParser.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/DdlParser.java
@@ -577,7 +577,9 @@ public class DdlParser {
      */
     protected void consumeRemainingStatement(Marker start) {
         while (tokens.hasNext()) {
-            if (tokens.matches(DdlTokenizer.STATEMENT_KEY)) break;
+            if (tokens.matches(DdlTokenizer.STATEMENT_KEY)) {
+                break;
+            }
             if (tokens.canConsume("BEGIN")) {
                 tokens.consumeThrough("END");
             } else if (tokens.matches(DdlTokenizer.STATEMENT_TERMINATOR)) {

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/DdlParserListener.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/DdlParserListener.java
@@ -34,6 +34,7 @@ public interface DdlParserListener {
         CREATE_TABLE, ALTER_TABLE, DROP_TABLE,
         CREATE_INDEX, DROP_INDEX,
         CREATE_DATABASE, ALTER_DATABASE, DROP_DATABASE,
+        SET_VARIABLE,
     }
 
     /**
@@ -283,4 +284,40 @@ public interface DdlParserListener {
         }
     }
 
+    /**
+     * An event describing the setting of a variable.
+     */
+    @Immutable
+    public static class SetVariableEvent extends Event {
+        
+        private final String variableName;
+        private final String value;
+
+        public SetVariableEvent(String variableName, String value, String ddlStatement) {
+            super(EventType.SET_VARIABLE, ddlStatement);
+            this.variableName = variableName;
+            this.value = value;
+        }
+
+        /**
+         * Get the name of the variable that was set.
+         * @return the variable name; never null
+         */
+        public String variableName() {
+            return variableName;
+        }
+        
+        /**
+         * Get the value of the variable that was set.
+         * @return the variable value; may be null
+         */
+        public String variableValue() {
+            return value;
+        }
+        
+        @Override
+        public String toString() {
+            return statement();
+        }
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/text/TokenStream.java
+++ b/debezium-core/src/main/java/io/debezium/text/TokenStream.java
@@ -213,7 +213,8 @@ import io.debezium.util.Strings;
  * <pre>
  * public class BasicTokenizer implements Tokenizer {
  *     public void tokenize(CharacterStream input,
- *                          Tokens tokens) throws ParsingException {
+ *                          Tokens tokens)
+ *             throws ParsingException {
  *         while (input.hasNext()) {
  *             char c = input.next();
  *             switch (c) {
@@ -481,7 +482,7 @@ public class TokenStream {
      * @throws NoSuchElementException if there are no more tokens
      */
     public Marker mark() {
-        if ( completed ) {
+        if (completed) {
             return new Marker(null, tokenIterator.previousIndex());
         }
         Token currentToken = currentToken();
@@ -741,7 +742,8 @@ public class TokenStream {
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
      */
     public TokenStream consume(String expected,
-                               String... expectedForNextTokens) throws ParsingException, IllegalStateException {
+                               String... expectedForNextTokens)
+            throws ParsingException, IllegalStateException {
         consume(expected);
         for (String nextExpected : expectedForNextTokens) {
             consume(nextExpected);
@@ -850,7 +852,7 @@ public class TokenStream {
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
      */
     public TokenStream consumeThrough(char expected) throws ParsingException, IllegalStateException {
-        return consumeThrough(String.valueOf(expected),null);
+        return consumeThrough(String.valueOf(expected), null);
     }
 
     /**
@@ -862,13 +864,13 @@ public class TokenStream {
      * 
      * @param expected the token that is to be found
      * @param skipMatchingTokens the token that, if found, should result in skipping {@code expected} once for each occurrence
-     * of {@code skipMatchingTokens}; may be null
+     *            of {@code skipMatchingTokens}; may be null
      * @return this token stream instance so callers can chain together methods; never null
      * @throws ParsingException if the specified token cannot be found
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
      */
     public TokenStream consumeThrough(char expected, char skipMatchingTokens) throws ParsingException, IllegalStateException {
-        return consumeThrough(String.valueOf(expected),String.valueOf(skipMatchingTokens));
+        return consumeThrough(String.valueOf(expected), String.valueOf(skipMatchingTokens));
     }
 
     /**
@@ -884,8 +886,9 @@ public class TokenStream {
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
      */
     public TokenStream consumeThrough(String expected) throws ParsingException, IllegalStateException {
-        return consumeThrough(expected,null);
+        return consumeThrough(expected, null);
     }
+
     /**
      * Attempt to consume all tokens until the specified token is consumed, and then stop. If it is not found, then the token
      * stream is left untouched and a ParsingException is thrown.
@@ -895,7 +898,7 @@ public class TokenStream {
      * 
      * @param expected the token that is to be found
      * @param skipMatchingTokens the token that, if found, should result in skipping {@code expected} once for each occurrence
-     * of {@code skipMatchingTokens}; may be null
+     *            of {@code skipMatchingTokens}; may be null
      * @return this token stream instance so callers can chain together methods; never null
      * @throws ParsingException if the specified token cannot be found
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
@@ -905,7 +908,7 @@ public class TokenStream {
             consume();
             return this;
         }
-        consumeUntil(expected,skipMatchingTokens);
+        consumeUntil(expected, skipMatchingTokens);
         consume(expected);
         return this;
     }
@@ -935,7 +938,7 @@ public class TokenStream {
      * 
      * @param expected the token that is to be found
      * @param skipMatchingTokens the token that, if found, should result in skipping {@code expected} once for each occurrence
-     * of {@code skipMatchingTokens}
+     *            of {@code skipMatchingTokens}
      * @return this token stream instance so callers can chain together methods; never null
      * @throws ParsingException if the specified token cannot be found
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
@@ -957,7 +960,7 @@ public class TokenStream {
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
      */
     public TokenStream consumeUntil(String expected) throws ParsingException, IllegalStateException {
-        return consumeUntil(expected,null);
+        return consumeUntil(expected, null);
     }
 
     /**
@@ -969,7 +972,7 @@ public class TokenStream {
      * 
      * @param expected the token that is to be found
      * @param skipMatchingTokens the token that, if found, should result in skipping {@code expected} once for each occurrence
-     * of {@code skipMatchingTokens}; may be null
+     *            of {@code skipMatchingTokens}; may be null
      * @return this token stream instance so callers can chain together methods; never null
      * @throws ParsingException if the specified token cannot be found
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
@@ -982,9 +985,9 @@ public class TokenStream {
         Marker start = mark();
         int remaining = 0;
         while (hasNext()) {
-            if ( skipMatchingTokens != null && matches(skipMatchingTokens)) ++remaining;
-            if ( matches(expected) ) {
-                if ( remaining == 0 ) {
+            if (skipMatchingTokens != null && matches(skipMatchingTokens)) ++remaining;
+            if (matches(expected)) {
+                if (remaining == 0) {
                     break;
                 }
                 --remaining;
@@ -995,6 +998,25 @@ public class TokenStream {
             rewind(start);
             throw new ParsingException(tokens.get(tokens.size() - 1).position(),
                     "No more content but was expecting to find " + expected);
+        }
+        return this;
+    }
+
+    /**
+     * Consume the token stream until one of the stop tokens or the end of the stream is found.
+     * 
+     * @param stopTokens the stop tokens; may not be null
+     * @return this token stream instance so callers can chain together methods; never null
+     * @throws ParsingException if none of the specified tokens can be found
+     * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
+     */
+    public TokenStream consumeUntilEndOrOneOf(String... stopTokens)
+            throws ParsingException, IllegalStateException {
+        while (hasNext()) {
+            if (matchesAnyOf(stopTokens)) {
+                break;
+            }
+            consume();
         }
         return this;
     }
@@ -1149,7 +1171,8 @@ public class TokenStream {
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
      */
     public boolean canConsume(String currentExpected,
-                              String... expectedForNextTokens) throws IllegalStateException {
+                              String... expectedForNextTokens)
+            throws IllegalStateException {
         if (completed) return false;
         ListIterator<Token> iter = tokens.listIterator(tokenIterator.previousIndex());
         if (!iter.hasNext()) return false;
@@ -1264,7 +1287,8 @@ public class TokenStream {
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
      */
     public boolean canConsumeAnyOf(String firstOption,
-                                   String... additionalOptions) throws IllegalStateException {
+                                   String... additionalOptions)
+            throws IllegalStateException {
         if (completed) return false;
         if (canConsume(firstOption)) return true;
         for (String nextOption : additionalOptions) {
@@ -1312,7 +1336,8 @@ public class TokenStream {
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
      */
     public boolean canConsumeAnyOf(int firstTypeOption,
-                                   int... additionalTypeOptions) throws IllegalStateException {
+                                   int... additionalTypeOptions)
+            throws IllegalStateException {
         if (completed) return false;
         if (canConsume(firstTypeOption)) return true;
         for (int nextTypeOption : additionalTypeOptions) {
@@ -1384,7 +1409,8 @@ public class TokenStream {
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
      */
     public boolean matches(String currentExpected,
-                           String... expectedForNextTokens) throws IllegalStateException {
+                           String... expectedForNextTokens)
+            throws IllegalStateException {
         if (completed) return false;
         ListIterator<Token> iter = tokens.listIterator(tokenIterator.previousIndex());
         if (!iter.hasNext()) return false;
@@ -1457,7 +1483,8 @@ public class TokenStream {
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
      */
     public boolean matches(int currentExpectedType,
-                           int... expectedTypeForNextTokens) throws IllegalStateException {
+                           int... expectedTypeForNextTokens)
+            throws IllegalStateException {
         if (completed) return false;
         ListIterator<Token> iter = tokens.listIterator(tokenIterator.previousIndex());
         if (!iter.hasNext()) return false;
@@ -1504,7 +1531,8 @@ public class TokenStream {
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
      */
     public boolean matchesAnyOf(String firstOption,
-                                String... additionalOptions) throws IllegalStateException {
+                                String... additionalOptions)
+            throws IllegalStateException {
         if (completed) return false;
         Token current = currentToken();
         if (current.matches(firstOption)) return true;
@@ -1555,7 +1583,8 @@ public class TokenStream {
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
      */
     public boolean matchesAnyOf(int firstTypeOption,
-                                int... additionalTypeOptions) throws IllegalStateException {
+                                int... additionalTypeOptions)
+            throws IllegalStateException {
         if (completed) return false;
         Token current = currentToken();
         if (current.matches(firstTypeOption)) return true;
@@ -1762,7 +1791,8 @@ public class TokenStream {
          * @throws ParsingException if there is an error while processing the character stream (e.g., a quote is not closed, etc.)
          */
         void tokenize(CharacterStream input,
-                      Tokens tokens) throws ParsingException;
+                      Tokens tokens)
+                throws ParsingException;
     }
 
     /**
@@ -2363,7 +2393,8 @@ public class TokenStream {
 
         @Override
         public void tokenize(CharacterStream input,
-                             Tokens tokens) throws ParsingException {
+                             Tokens tokens)
+                throws ParsingException {
             while (input.hasNext()) {
                 char c = input.next();
                 switch (c) {

--- a/debezium-core/src/main/java/io/debezium/util/Strings.java
+++ b/debezium-core/src/main/java/io/debezium/util/Strings.java
@@ -143,6 +143,20 @@ public final class Strings {
     }
 
     /**
+     * Check whether the two {@link String} instances are equal ignoring case.
+     * 
+     * @param str1 the first character sequence; may be null
+     * @param str2 the second character sequence; may be null
+     * @return {@code true} if both are null or if the two strings are equal to each other ignoring case, or {@code false}
+     *         otherwise
+     */
+    public static boolean equalsIgnoreCase(String str1, String str2) {
+        if (str1 == str2) return true;
+        if (str1 == null) return str2 == null;
+        return str1.equalsIgnoreCase(str2);
+    }
+
+    /**
      * Returns a new String composed of the supplied integer values joined together
      * with a copy of the specified {@code delimiter}.
      *
@@ -274,11 +288,11 @@ public final class Strings {
      * @see #justifyLeft(String, int, char)
      */
     public static String pad(String original,
-                                   int length,
-                                   char padChar) {
-        if ( original.length() >= length ) return original;
+                             int length,
+                             char padChar) {
+        if (original.length() >= length) return original;
         StringBuilder sb = new StringBuilder(original);
-        while ( sb.length() < length ) {
+        while (sb.length() < length) {
             sb.append(padChar);
         }
         return sb.toString();
@@ -482,7 +496,7 @@ public final class Strings {
      * @return the number, or {@code null} if the value is not a number
      */
     public static Number asNumber(String value) {
-        return asNumber(value,null);
+        return asNumber(value, null);
     }
 
     /**


### PR DESCRIPTION
The MySQL binlog events contain the binary representation of string-like values as encoded per the column's character set. Properly decoding these into Java strings requires capturing the column, table, and database character set when parsing the DDL statements. Also, the binlog client must be used to properly deserialize the binary values as read from the binlog events, using the columns character set.

Unfortunately, MySQL DDL allows columns (at the time the columns are created or modified) to inherit the default character set for the table, or if that is not defined the default character set for the database, or if that is not defined the character set for the server. So, in addition to modifying the MySQL DDL parser to support capturing the character set name for each column, it also had to be changed to know what these default character set names are.

The default character sets are all available via MySQL server/session/local variables. Although strictly speaking the character set variables cannot be set globally, MySQL DDL does allow session and local variables to be set with `SET` statements. Therefore, this commit enhances the MySQL DDL parser to parse `SET` statements and to track the various global, session, and local variables as seen by the DDL parser. Upon connector startup, a subset of server variables (related to character sets and collations) are read from the database via JDBC and used to initialize the DDL parser via `SET` methods.

In addition to initializing the DDL parser with the system variables related to character sets and collation, it is important to also capture the server and database default character sets in the database history so that the correct character sets are used for columns even when the default character sets have changed on the database and/or the server. Therefore, upon startup or snapshot the MySQL connector records in the database history a `SET` statement for the `character_set_server` and `collation_server` system variables so that, upon a later restart, the history's DDL statements can be re-parsed with the correct default server and database character sets. Also, when the MySQL connector reloads the database history (upon startup), the recorded default server character set is compared with the MySQL instance's current server character set, and if they are different the current character set is recorded with a new `SET` statement.

These extra steps ensure that the connector use the correct character set for each column, even when the connector restarts and reloads the database history captured by a previous version of the connector. IOW, the MySQL connector can be safely upgraded, and the new version will correctly start using the columns' character sets to decode the string-like values.

The MySQL connector performs a snapshot using JDBC rather than reading from the binlog, so the JDBC connection was altered so the MySQL driver always use UTF-8 to decode the values obtained from result sets (and all other operations). Since the JDBC driver does this conversion, the MySQL connector does not have to modify any of the String values obtained during the snapshot. (The connector's `MySqlValueConverters` class is responsible for this conversion, and it can easily distinguish since the JDBC driver always returns Java `String` objects and the binlog reader always returns `byte[]` for the strings in the binlog events.)

This pull request also adds a table and data to one of the MySQL databases used in the integration tests, and the tests were modified to verify that the UTF-8 data stored in the table is able to be handled properly when obtaining a snapshot and when reading the binlog.