### PR TITLE
DBZ-116 Improved logging when MySQL connector is reading binlog

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
@@ -174,13 +174,22 @@ public abstract class AbstractReader {
         }
         
         if (batch.isEmpty() && success.get() && records.isEmpty()) {
-            // We found no records but the snapshot completed successfully, so we're done
+            // We found no records but the operation completed successfully, so we're done
             this.running.set(false);
             doCleanup();
             return null;
         }
+        pollComplete(batch);
         logger.trace("Completed batch of {} records", batch.size());
         return batch;
+    }
+    
+    /**
+     * Method called when {@link #poll()} completes sending a non-zero-sized batch of records.
+     * @param batch the batch of records being recorded
+     */
+    protected void pollComplete( List<SourceRecord> batch ) {
+        // do nothing
     }
 
     /**

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.source.SourceRecord;
 
 import com.github.shyiko.mysql.binlog.BinaryLogClient;
 import com.github.shyiko.mysql.binlog.BinaryLogClient.LifecycleListener;
@@ -177,6 +178,14 @@ public class BinlogReader extends AbstractReader {
 
     @Override
     protected void doCleanup() {
+    }
+
+    @Override
+    protected void pollComplete(List<SourceRecord> batch) {
+        if (!batch.isEmpty()) {
+            SourceRecord lastRecord = batch.get(batch.size() - 1);
+            logger.info("{} records sent, last offset: {}", batch.size(), lastRecord.sourceOffset());
+        }
     }
 
     protected void logEvent(Event event) {


### PR DESCRIPTION
The MySQL connector now outputs an INFO log message whenever its task's `poll()` method returns a non-empty list of `SourceRecord` objects, where the message includes the number of records and the offset of the last record.