### PR TITLE
DBZ-118 Change database.server.id to support Long instead of Int

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -256,11 +256,11 @@ public class MySqlConnectorConfig {
 
     public static final Field SERVER_ID = Field.create("database.server.id")
                                                .withDisplayName("Cluster ID")
-                                               .withType(Type.INT)
-                                               .withWidth(Width.SHORT)
+                                               .withType(Type.LONG)
+                                               .withWidth(Width.LONG)
                                                .withImportance(Importance.HIGH)
                                                .withDefault(MySqlConnectorConfig::randomServerId)
-                                               .withValidation(Field::isRequired, Field::isPositiveInteger)
+                                               .withValidation(Field::isRequired, Field::isPositiveLong)
                                                .withDescription("A numeric ID of this database client, which must be unique across all "
                                                        + "currently-running database processes in the cluster. This connector joins the "
                                                        + "MySQL database cluster as another server (with this unique ID) so it can read "


### PR DESCRIPTION
This is to support Long data types for server.id instead of int. 