### PR TITLE
DBZ-114 MySQL connector now handles "zero-value" dates and timestamps

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -31,7 +31,7 @@ import io.debezium.util.Strings;
  */
 public class MySqlJdbcContext implements AutoCloseable {
 
-    protected static final String MYSQL_CONNECTION_URL = "jdbc:mysql://${hostname}:${port}/?useInformationSchema=true&nullCatalogMeansCurrent=false&useSSL=${useSSL}&useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8";
+    protected static final String MYSQL_CONNECTION_URL = "jdbc:mysql://${hostname}:${port}/?useInformationSchema=true&nullCatalogMeansCurrent=false&useSSL=${useSSL}&useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8&zeroDateTimeBehavior=convertToNull";
     protected static ConnectionFactory FACTORY = JdbcConnection.patternBasedFactory(MYSQL_CONNECTION_URL);
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
@@ -167,10 +167,17 @@ public class MySqlValueConverters extends JdbcValueConverters {
      * @param fieldDefn the field definition for the {@link SourceRecord}'s {@link Schema}; never null
      * @param columnCharset the Java character set in which column byte[] values are encoded; may not be null
      * @param data the data; may be null
-     * @return the string value; may be null if the value is null or is an unknown input type
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertString(Column column, Field fieldDefn, Charset columnCharset, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return "";
+        }
         if (data instanceof byte[]) {
             // Decode the binary representation using the given character encoding ...
             return new String((byte[]) data, columnCharset);
@@ -188,11 +195,18 @@ public class MySqlValueConverters extends JdbcValueConverters {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a year literal integer value; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     @SuppressWarnings("deprecation")
     protected Object convertYearToInt(Column column, Field fieldDefn, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return 0;
+        }
         if (data instanceof java.time.Year) {
             // The MySQL binlog always returns a Year object ...
             return ((java.time.Year) data).getValue();
@@ -216,11 +230,18 @@ public class MySqlValueConverters extends JdbcValueConverters {
      * @param options the characters that appear in the same order as defined in the column; may not be null
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
-     * @param data the data object to be converted into an {@code ENUM} literal String value; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @param data the data object to be converted into an {@code ENUM} literal String value
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertEnumToString(String options, Column column, Field fieldDefn, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return "";
+        }
         if (data instanceof String) {
             // JDBC should return strings ...
             return data;
@@ -245,10 +266,17 @@ public class MySqlValueConverters extends JdbcValueConverters {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into an {@code SET} literal String value; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertSetToString(String options, Column column, Field fieldDefn, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return "";
+        }
         if (data instanceof String) {
             // JDBC should return strings ...
             return data;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RowDeserializers.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RowDeserializers.java
@@ -56,12 +56,12 @@ class RowDeserializers {
         public DeleteRowsDeserializer(Map<Long, TableMapEventData> tableMapEventByTableId) {
             super(tableMapEventByTableId);
         }
-        
+
         @Override
         protected Serializable deserializeString(int length, ByteArrayInputStream inputStream) throws IOException {
             return RowDeserializers.deserializeString(length, inputStream);
         }
-        
+
         @Override
         protected Serializable deserializeVarString(int meta, ByteArrayInputStream inputStream) throws IOException {
             return RowDeserializers.deserializeVarString(meta, inputStream);
@@ -118,7 +118,7 @@ class RowDeserializers {
         protected Serializable deserializeString(int length, ByteArrayInputStream inputStream) throws IOException {
             return RowDeserializers.deserializeString(length, inputStream);
         }
-        
+
         @Override
         protected Serializable deserializeVarString(int meta, ByteArrayInputStream inputStream) throws IOException {
             return RowDeserializers.deserializeVarString(meta, inputStream);
@@ -175,7 +175,7 @@ class RowDeserializers {
         protected Serializable deserializeString(int length, ByteArrayInputStream inputStream) throws IOException {
             return RowDeserializers.deserializeString(length, inputStream);
         }
-        
+
         @Override
         protected Serializable deserializeVarString(int meta, ByteArrayInputStream inputStream) throws IOException {
             return RowDeserializers.deserializeVarString(meta, inputStream);
@@ -215,7 +215,7 @@ class RowDeserializers {
         protected Serializable deserializeTimestampV2(int meta, ByteArrayInputStream inputStream) throws IOException {
             return RowDeserializers.deserializeTimestampV2(meta, inputStream);
         }
-        
+
         @Override
         protected Serializable deserializeYear(ByteArrayInputStream inputStream) throws IOException {
             return RowDeserializers.deserializeYear(inputStream);
@@ -252,6 +252,9 @@ class RowDeserializers {
 
     /**
      * Converts a MySQL {@code DATE} value to a {@link LocalDate}.
+     * <p>
+     * This method treats all <a href="http://dev.mysql.com/doc/refman/5.7/en/date-and-time-types.html">zero values</a>
+     * for {@code DATE} columns as NULL, since they cannot be accurately represented as valid {@link LocalDate} objects.
      * 
      * @param inputStream the binary stream containing the raw binlog event data for the value
      * @return the {@link LocalDate} object
@@ -319,6 +322,9 @@ class RowDeserializers {
 
     /**
      * Converts a MySQL {@code DATETIME} value <em>without fractional seconds</em> to a {@link LocalDateTime}.
+     * <p>
+     * This method treats all <a href="http://dev.mysql.com/doc/refman/5.7/en/date-and-time-types.html">zero values</a>
+     * for {@code DATETIME} columns as NULL, since they cannot be accurately represented as valid {@link LocalDateTime} objects.
      * 
      * @param inputStream the binary stream containing the raw binlog event data for the value
      * @return the {@link LocalDateTime} object
@@ -333,11 +339,17 @@ class RowDeserializers {
         int minutes = split[1];
         int seconds = split[0];
         int nanoOfSecond = 0; // This version does not support fractional seconds
+        if (year == 0 || month == 0 || day == 0) {
+            return null;
+        }
         return LocalDateTime.of(year, month, day, hours, minutes, seconds, nanoOfSecond);
     }
 
     /**
      * Converts a MySQL {@code DATETIME} value <em>with fractional seconds</em> to a {@link LocalDateTime}.
+     * <p>
+     * This method treats all <a href="http://dev.mysql.com/doc/refman/5.7/en/date-and-time-types.html">zero values</a>
+     * for {@code DATETIME} columns as NULL, since they cannot be accurately represented as valid {@link LocalDateTime} objects.
      * 
      * @param meta the {@code meta} value containing the fractional second precision, or {@code fsp}
      * @param inputStream the binary stream containing the raw binlog event data for the value
@@ -489,7 +501,7 @@ class RowDeserializers {
      * Note the original is licensed under the same Apache Software License 2.0 as Debezium.
      * 
      * @param fsp the fractional seconds precision describing the number of digits precision used to store the fractional seconds
-     * (e.g., 1 for storing tenths of a second, 2 for storing hundredths, 3 for storing milliseconds, etc.)
+     *            (e.g., 1 for storing tenths of a second, 2 for storing hundredths, 3 for storing milliseconds, etc.)
      * @param inputStream the binary data stream
      * @return the number of nanoseconds
      * @throws IOException if there is an error reading from the binlog event data

--- a/debezium-connector-mysql/src/test/docker/init/setup.sql
+++ b/debezium-connector-mysql/src/test/docker/init/setup.sql
@@ -250,3 +250,13 @@ CREATE TABLE dbz_102_charsettest (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=2001 DEFAULT CHARSET=utf8;
 INSERT INTO dbz_102_charsettest VALUES (default, "产品");
+
+-- DBZ-114 handle zero-value dates
+CREATE TABLE dbz_114_zerovaluetest (
+  c1 DATE,
+  c2 TIME(2),
+  c3 DATETIME(2),
+  c4 TIMESTAMP(2)
+);
+INSERT IGNORE INTO dbz_114_zerovaluetest VALUES ('0000-00-00', '00:00:00.000', '0000-00-00 00:00:00.000', '0000-00-00 00:00:00.000');
+INSERT IGNORE INTO dbz_114_zerovaluetest VALUES ('0001-00-00', '00:01:00.000', '0001-00-00 00:00:00.000', '0001-00-00 00:00:00.000');

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
@@ -8,6 +8,8 @@ package io.debezium.jdbc;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.Types;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
@@ -311,10 +313,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertTimestampWithZone(Column column, Field fieldDefn, Object data) {
-        if ( data == null ) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            data = OffsetDateTime.of(LocalDate.ofEpochDay(0),LocalTime.MIDNIGHT, defaultOffset); // return epoch
+        }
         try {
             return ZonedTimestamp.toIsoString(data, defaultOffset);
         } catch (IllegalArgumentException e) {
@@ -335,10 +344,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertTimeWithZone(Column column, Field fieldDefn, Object data) {
-        if ( data == null ) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            data = OffsetTime.of(LocalTime.MIDNIGHT, defaultOffset); // return epoch time
+        }
         try {
             return ZonedTime.toIsoString(data, defaultOffset);
         } catch (IllegalArgumentException e) {
@@ -357,10 +373,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertTimestampToEpochMillis(Column column, Field fieldDefn, Object data) {
-        if ( data == null ) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return 0L; // return epoch
+        }
         try {
             return Timestamp.toEpochMillis(data);
         } catch (IllegalArgumentException e) {
@@ -379,10 +402,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertTimestampToEpochMicros(Column column, Field fieldDefn, Object data) {
-        if ( data == null ) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return 0L; // return epoch
+        }
         try {
             return MicroTimestamp.toEpochMicros(data);
         } catch (IllegalArgumentException e) {
@@ -401,10 +431,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertTimestampToEpochNanos(Column column, Field fieldDefn, Object data) {
-        if ( data == null ) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return 0L; // return epoch
+        }
         try {
             return NanoTimestamp.toEpochNanos(data);
         } catch (IllegalArgumentException e) {
@@ -423,10 +460,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertTimestampToEpochMillisAsDate(Column column, Field fieldDefn, Object data) {
-        if ( data == null ) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return new java.util.Date(0L); // return epoch
+        }
         try {
             return new java.util.Date(Timestamp.toEpochMillis(data));
         } catch (IllegalArgumentException e) {
@@ -446,10 +490,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertTimeToMillisPastMidnight(Column column, Field fieldDefn, Object data) {
-        if ( data == null ) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return 0; // return epoch
+        }
         try {
             return Time.toMilliOfDay(data);
         } catch (IllegalArgumentException e) {
@@ -469,10 +520,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertTimeToMicrosPastMidnight(Column column, Field fieldDefn, Object data) {
-        if ( data == null ) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return 0L; // return epoch
+        }
         try {
             return MicroTime.toMicroOfDay(data);
         } catch (IllegalArgumentException e) {
@@ -492,10 +550,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertTimeToNanosPastMidnight(Column column, Field fieldDefn, Object data) {
-        if ( data == null ) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return 0L; // return epoch
+        }
         try {
             return NanoTime.toNanoOfDay(data);
         } catch (IllegalArgumentException e) {
@@ -515,10 +580,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertTimeToMillisPastMidnightAsDate(Column column, Field fieldDefn, Object data) {
-        if ( data == null ) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return 0L; // return epoch
+        }
         try {
             return new java.util.Date(Time.toMilliOfDay(data));
         } catch (IllegalArgumentException e) {
@@ -536,17 +608,24 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * 
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
-     * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @param data the data object to be converted into a {@link Date Kafka Connect date} type
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertDateToEpochDays(Column column, Field fieldDefn, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return 0; // return epoch
+        }
         try {
             return Date.toEpochDay(data);
         } catch (IllegalArgumentException e) {
             logger.warn("Unexpected JDBC DATE value for field {} with schema {}: class={}, value={}", fieldDefn.name(),
                         fieldDefn.schema(), data.getClass(), data);
-            return null;
+            return handleUnknownData(column, fieldDefn, data);
         }
     }
 
@@ -561,11 +640,18 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * 
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
-     * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @param data the data object to be converted into a {@link Date Kafka Connect date} type
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertDateToEpochDaysAsDate(Column column, Field fieldDefn, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return new java.util.Date(0L); // return epoch
+        }
         try {
             int epochDay = Date.toEpochDay(data);
             long epochMillis = TimeUnit.DAYS.toMillis(epochDay);
@@ -589,10 +675,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertBinary(Column column, Field fieldDefn, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            data = new byte[0];
+        }
         if (data instanceof char[]) {
             data = new String((char[]) data); // convert to string
         }
@@ -613,7 +706,8 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * 
      * @param value the binary value for which no conversion was found; never null
      * @param fieldDefn the field definition in the Kafka Connect schema; never null
-     * @return the converted value, or null
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      * @see #convertBinary(Column, Field, Object)
      */
     protected byte[] unexpectedBinary(Object value, Field fieldDefn) {
@@ -628,7 +722,8 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertTinyInt(Column column, Field fieldDefn, Object data) {
         return convertSmallInt(column, fieldDefn, data);
@@ -640,10 +735,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertSmallInt(Column column, Field fieldDefn, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return 0;
+        }
         if (data instanceof Short) return data;
         if (data instanceof Number) {
             Number value = (Number) data;
@@ -661,10 +763,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertInteger(Column column, Field fieldDefn, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return 0;
+        }
         if (data instanceof Integer) return data;
         if (data instanceof Number) {
             Number value = (Number) data;
@@ -682,10 +791,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertBigInt(Column column, Field fieldDefn, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return 0L;
+        }
         if (data instanceof Long) return data;
         if (data instanceof Number) {
             Number value = (Number) data;
@@ -703,7 +819,8 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertFloat(Column column, Field fieldDefn, Object data) {
         return convertDouble(column, fieldDefn, data);
@@ -715,10 +832,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertDouble(Column column, Field fieldDefn, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return 0.0d;
+        }
         if (data instanceof Double) return data;
         if (data instanceof Number) {
             Number value = (Number) data;
@@ -736,10 +860,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertReal(Column column, Field fieldDefn, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return 0.0f;
+        }
         if (data instanceof Float) return data;
         if (data instanceof Number) {
             Number value = (Number) data;
@@ -757,10 +888,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertNumeric(Column column, Field fieldDefn, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return new BigDecimal(0);
+        }
         BigDecimal decimal = null;
         if (data instanceof BigDecimal)
             decimal = (BigDecimal) data;
@@ -788,10 +926,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertDecimal(Column column, Field fieldDefn, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return new BigDecimal(0);
+        }
         BigDecimal decimal = null;
         if (data instanceof BigDecimal)
             decimal = (BigDecimal) data;
@@ -821,10 +966,18 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertString(Column column, Field fieldDefn, Object data) {
-        return data == null ? null : data.toString();
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return "";
+        }
+        return data.toString();
     }
 
     /**
@@ -833,10 +986,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertRowId(Column column, Field fieldDefn, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return ByteBuffer.wrap(new byte[0]);
+        }
         if (data instanceof java.sql.RowId) {
             java.sql.RowId row = (java.sql.RowId) data;
             return ByteBuffer.wrap(row.getBytes());
@@ -850,10 +1010,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertBit(Column column, Field fieldDefn, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return false;
+        }
         if (data instanceof Boolean) return data;
         if (data instanceof Short) return ((Short) data).intValue() == 0 ? Boolean.FALSE : Boolean.TRUE;
         if (data instanceof Integer) return ((Integer) data).intValue() == 0 ? Boolean.FALSE : Boolean.TRUE;
@@ -867,10 +1034,17 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object convertBoolean(Column column, Field fieldDefn, Object data) {
-        if (data == null) return null;
+        if (data == null) {
+            data = fieldDefn.schema().defaultValue();
+        }
+        if (data == null) {
+            if (column.isOptional()) return null;
+            return false;
+        }
         if (data instanceof Boolean) return data;
         if (data instanceof Short) return ((Short) data).intValue() == 0 ? Boolean.FALSE : Boolean.TRUE;
         if (data instanceof Integer) return ((Integer) data).intValue() == 0 ? Boolean.FALSE : Boolean.TRUE;
@@ -884,11 +1058,16 @@ public class JdbcValueConverters implements ValueConverterProvider {
      * @param column the column definition describing the {@code data} value; never null
      * @param fieldDefn the field definition; never null
      * @param data the data object to be converted into a {@link Date Kafka Connect date} type; never null
-     * @return the converted value, or null if the conversion could not be made
+     * @return the converted value, or null if the conversion could not be made and the column allows nulls
+     * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
     protected Object handleUnknownData(Column column, Field fieldDefn, Object data) {
-        logger.warn("Unexpected value for JDBC type {} and column {}: class={}, value={}", column.jdbcType(), column,
-                    data.getClass(), data);
-        return null;
+        if (column.isOptional() || fieldDefn.schema().isOptional()) {
+            logger.warn("Unexpected value for JDBC type {} and column {}: class={}", column.jdbcType(), column,
+                        data.getClass()); // don't include value in case its sensitive
+            return null;
+        }
+        throw new IllegalArgumentException("Unexpected value for JDBC type " + column.jdbcType() + " and column " + column +
+                                           ": class=" + data.getClass());  // don't include value in case its sensitive
     }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/TableSchemaBuilder.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableSchemaBuilder.java
@@ -226,11 +226,10 @@ public class TableSchemaBuilder {
                     Object value = row[recordIndexes[i]];
                     ValueConverter converter = converters[i];
                     if (converter != null) {
-                        if (value != null) value = converter.convert(value);
                         try {
+                            value = converter.convert(value);
                             result.put(fields[i], value);
-                        } catch (DataException e) {
-                            if (value != null) value = converter.convert(value);
+                        } catch (DataException|IllegalArgumentException e) {
                             Column col = columns.get(i);
                             LOGGER.error("Failed to properly convert data value for '" + tableId + "." + col.name() + "' of type "
                                     + col.typeName() + ":", e);
@@ -340,6 +339,6 @@ public class TableSchemaBuilder {
      * @return the value conversion function; may not be null
      */
     protected ValueConverter createValueConverterFor(Column column, Field fieldDefn) {
-        return valueConverterProvider.converter(column, fieldDefn).nullOr();
+        return valueConverterProvider.converter(column, fieldDefn);
     }
 }


### PR DESCRIPTION
MySQL supports "zero-value" dates and timestamps, but these cannot be represented as valid dates or timestamps using the Java types. For example, the zero-value `0000-00-00` for a date has what Java considers to be an invalid month and day-of-the-month.

This commit changes how the MySQL connector handles these values to not throw exceptions. When columns allow nulls, such values will be treated as nulls; when columns do not allow null values, these values will be converted to a "zero-value" for the corresponding Java representation (e.g., the epoch day or timestamp). A new test case verifies the behaviors.