### PR TITLE
DBZ-124 Eliminated the JMX "already registered" warning in the MySQL connector

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
@@ -106,7 +106,11 @@ public class MySqlSchema {
                     config.getString(MySqlConnectorConfig.DATABASE_HISTORY));
         }
         // Do not remove the prefix from the subset of config properties ...
-        Configuration dbHistoryConfig = config.subset(DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING, false);
+        String connectorName = config.getString("name", serverName);
+        Configuration dbHistoryConfig = config.subset(DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING, false)
+                                              .edit()
+                                              .withDefault(DatabaseHistory.NAME, connectorName + "-dbhistory")
+                                              .build();
         this.dbHistory.configure(dbHistoryConfig, HISTORY_COMPARATOR); // validates
     }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -40,7 +40,6 @@ public final class MySqlTaskContext extends MySqlJdbcContext {
 
         // Set up the MySQL schema ...
         this.dbSchema = new MySqlSchema(config, serverName());
-        this.dbSchema.start();
 
         // Set up the record processor ...
         this.recordProcessor = new RecordMakers(dbSchema, source, topicSelector);

--- a/debezium-core/src/main/java/io/debezium/config/Configuration.java
+++ b/debezium-core/src/main/java/io/debezium/config/Configuration.java
@@ -974,7 +974,10 @@ public interface Configuration {
      *         such key-value pair in the configuration
      */
     default String getString(Field field, String defaultValue) {
-        return getString(field.name(), () -> field.defaultValueAsString());
+        return getString(field.name(), () -> {
+            String value = field.defaultValueAsString();
+            return value != null ? value : defaultValue;
+        });
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
@@ -7,7 +7,12 @@ package io.debezium.relational.history;
 
 import java.util.Map;
 
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigDef.Width;
+
 import io.debezium.config.Configuration;
+import io.debezium.config.Field;
 import io.debezium.relational.Tables;
 import io.debezium.relational.ddl.DdlParser;
 
@@ -21,6 +26,14 @@ import io.debezium.relational.ddl.DdlParser;
 public interface DatabaseHistory {
 
     public static final String CONFIGURATION_FIELD_PREFIX_STRING = "database.history.";
+
+    public static final Field NAME = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "name")
+                                          .withDisplayName("Logical name for the database history")
+                                          .withType(Type.STRING)
+                                          .withWidth(Width.MEDIUM)
+                                          .withImportance(Importance.LOW)
+                                          .withDescription("The name used for the database history, perhaps differently by each implementation.")
+                                          .withValidation(Field::isOptional);
 
     /**
      * Configure this instance.

--- a/debezium-core/src/test/java/io/debezium/relational/history/KafkaDatabaseHistoryTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/history/KafkaDatabaseHistoryTest.java
@@ -75,8 +75,12 @@ public class KafkaDatabaseHistoryTest {
         config = Configuration.create()
                               .with(KafkaDatabaseHistory.BOOTSTRAP_SERVERS, kafka.brokerList())
                               .with(KafkaDatabaseHistory.TOPIC, topicName)
+                              .with(DatabaseHistory.NAME, "my-db-history")
                               .build();
         history.configure(config,null);
+        history.start();
+        
+        // Should be able to call start more than once ...
         history.start();
 
         DdlParser recoveryParser = new DdlParserSql2003();

--- a/debezium-core/src/test/resources/log4j.properties
+++ b/debezium-core/src/test/resources/log4j.properties
@@ -41,6 +41,8 @@ log4j.additivity.io.debezium=false
 # Kafka is pretty verbose at INFO level, so for brevity use ERROR everywhere except INFO at kafka.server.KafkaServer
 log4j.logger.org.apache.kafka=ERROR, kafka
 log4j.additivity.org.apache.kafka=false
+log4j.logger.org.apache.kafka.common.utils=WARN, kafka
+log4j.additivity.org.apache.kafka=false
 log4j.logger.kafka=ERROR, kafka
 log4j.additivity.kafka=false
 log4j.logger.kafka.server.KafkaServer=ERROR, kafka


### PR DESCRIPTION
The `KafkaDatabaseHistory` was always creating a new producer whenever its `start()` method was called, even if it were called more than once. And, the `MySqlSchema` was calling `start()` twice, resulting in multiple producers being created and registered with JMX. Both issues were fixed.

Also, UUIDs were being used as the name of the JMX MBean for the producer, unless the `database.history.consumer.client.id` and `database.history.producer.client.id` properties were being explicitly set. Now, the MySQL connector will by default set the `client.id` property on both the database history's Kafka consumer and producer to `{connectorName}-dbhistory`. Of course, the `database.history.consumer.client.id` and `database.history.producer.client.id` properties can still be set to define the name of the producer and consumer.