### PR TITLE
DBZ-123 Corrected MySQL Connector's support for BIT(n) columns

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.mysql;
 
+import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
@@ -69,6 +70,11 @@ public class MySqlValueConverters extends JdbcValueConverters {
      */
     public MySqlValueConverters(boolean adaptiveTimePrecision, ZoneOffset defaultOffset) {
         super(adaptiveTimePrecision, defaultOffset);
+    }
+    
+    @Override
+    protected ByteOrder byteOrderOfBitType() {
+        return ByteOrder.BIG_ENDIAN;
     }
 
     @Override

--- a/debezium-connector-mysql/src/test/docker/init/setup.sql
+++ b/debezium-connector-mysql/src/test/docker/init/setup.sql
@@ -260,3 +260,14 @@ CREATE TABLE dbz_114_zerovaluetest (
 );
 INSERT IGNORE INTO dbz_114_zerovaluetest VALUES ('0000-00-00', '00:00:00.000', '0000-00-00 00:00:00.000', '0000-00-00 00:00:00.000');
 INSERT IGNORE INTO dbz_114_zerovaluetest VALUES ('0001-00-00', '00:01:00.000', '0001-00-00 00:00:00.000', '0001-00-00 00:00:00.000');
+
+
+-- DBZ-123 handle bit values, including bit field literals
+CREATE TABLE dbz_123_bitvaluetest (
+  c1 BIT,
+  c2 BIT(2),
+  c3 BIT(8) NOT NULL,
+  c4 BIT(64)
+);
+INSERT INTO dbz_123_bitvaluetest VALUES (1,2,64,23989979);
+INSERT INTO dbz_123_bitvaluetest VALUES (b'1',b'10',b'01000000',b'1011011100000111011011011');

--- a/debezium-core/src/main/java/io/debezium/data/Bits.java
+++ b/debezium-core/src/main/java/io/debezium/data/Bits.java
@@ -52,11 +52,11 @@ public class Bits {
      * @param value the logical value
      * @return the encoded value
      */
-    public static byte[] fromLogical(Schema schema, BitSet value) {
+    public static byte[] fromBitSet(Schema schema, BitSet value) {
         return value.toByteArray();
     }
 
-    public static BitSet toLogical(Schema schema, byte[] value) {
+    public static BitSet toBitSet(Schema schema, byte[] value) {
         return BitSet.valueOf(value);
     }
 }


### PR DESCRIPTION
Corrected how the MySQL connector is treating columns of type `BIT(n)`, where _n_ is the number of bits in the value. When  `n=1`, the resulting values are booleans; when `n>1`, the resulting values are little endian `byte[]` that have the minimum number of bytes to hold the `n` bits.