### PR TITLE
DBZ-128 Improved checking of MySQL status and configuration

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -91,10 +91,27 @@ public class MySqlConnectorConfig {
      * The set of predefined SnapshotMode options or aliases.
      */
     public static enum SnapshotMode {
+
         /**
-         * Forwards each event as a structured Kafka Connect message.
+         * Perform a snapshot when it is needed.
          */
-        WHEN_NEEDED("when_needed"), INITIAL("initial"), NEVER("never");
+        WHEN_NEEDED("when_needed"),
+        
+        /**
+         * Perform a snapshot only upon initial startup of a connector.
+         */
+        INITIAL("initial"),
+
+        /**
+         * Never perform a snapshot and only read the binlog. This assumes the binlog contains all the history of those
+         * databases and tables that will be captured.
+         */
+        NEVER("never"),
+
+        /**
+         * Perform a snapshot and then stop before attempting to read the binlog.
+         */
+        INITIAL_ONLY("initial_only");
 
         private final String value;
 
@@ -474,7 +491,8 @@ public class MySqlConnectorConfig {
                                                    .withDescription("The criteria for running a snapshot upon startup of the connector. "
                                                            + "Options include: "
                                                            + "'when_needed' to specify that the connector run a snapshot upon startup whenever it deems it necessary; "
-                                                           + "'initial' (the default) to specify the connector can run a snapshot only when no offsets are available for the logical server name; and "
+                                                           + "'initial' (the default) to specify the connector can run a snapshot only when no offsets are available for the logical server name; "
+                                                           + "'initial_only' same as 'initial' except the connector should stop after completing the snapshot and before it would normally read the binlog; and"
                                                            + "'never' to specify the connector should never run a snapshot and that upon first startup the connector should read from the beginning of the binlog. "
                                                            + "The 'never' mode should be used with care, and only when the binlog is known to contain all history.");
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -150,6 +150,10 @@ public final class MySqlTaskContext extends MySqlJdbcContext {
         return snapshotMode() == SnapshotMode.NEVER;
     }
 
+    public boolean isInitialSnapshotOnly() {
+        return snapshotMode() == SnapshotMode.INITIAL_ONLY;
+    }
+
     protected SnapshotMode snapshotMode() {
         String value = config.getString(MySqlConnectorConfig.SNAPSHOT_MODE);
         return SnapshotMode.parse(value, MySqlConnectorConfig.SNAPSHOT_MODE.defaultValueAsString());

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 
 import io.debezium.connector.mysql.RecordMakers.RecordsForTable;
@@ -130,8 +131,10 @@ public class SnapshotReader extends AbstractReader {
         try {
             // Call the completion function to say that we've successfully completed
             if (onSuccessfulCompletion != null) onSuccessfulCompletion.run();
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Throwable e) {
-            logger.error("Error calling completion function after completing snapshot", e);
+            throw new ConnectException("Error calling completion function after completing snapshot", e);
         }
     }
 


### PR DESCRIPTION
Added logic to verify that MySQL's row-level binlog is enabled, and whether it is likely that when snapshots are not performed that the binlog is likely to have been purged. Some situations will result in an error, while others are logged as warnings.