### PR TITLE
DBZ-123 Corrected the MySQL DDL parser to properly handle bit-set literals

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
@@ -1322,6 +1322,13 @@ public class MySqlDdlParser extends DdlParser {
         parsingFailed(marker.position(), errors, "Unable to parse statement");
     }
 
+    /**
+     * Parse and consume the {@code DEFAULT} clause. Currently, this method does not capture the default in any way,
+     * since that will likely require parsing the default clause into a useful value (e.g., dealing with hexadecimals,
+     * bit-set literals, date-time literals, etc.).
+
+     * @param start the marker at the beginning of the clause
+     */
     protected void parseDefaultClause(Marker start) {
         tokens.consume("DEFAULT");
         if (isNextTokenQuotedIdentifier()) {
@@ -1342,7 +1349,6 @@ public class MySqlDdlParser extends DdlParser {
                 // do nothing ...
             } else {
                 parseLiteral(start);
-                // do nothing ...
             }
         }
     }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -589,6 +589,14 @@ public class MySqlDdlParserTest {
     }
 
     @Test
+    public void shouldParseStatementForDbz123() {
+        parser.parse(readFile("ddl/mysql-dbz-123.ddl"), tables);
+        Testing.print(tables);
+        assertThat(tables.size()).isEqualTo(1);
+        assertThat(listener.total()).isEqualTo(1);
+    }
+
+    @Test
     public void shouldParseTestStatements() {
         parser.parse(readFile("ddl/mysql-test-statements.ddl"), tables);
         Testing.print(tables);

--- a/debezium-connector-mysql/src/test/resources/ddl/mysql-dbz-123.ddl
+++ b/debezium-connector-mysql/src/test/resources/ddl/mysql-dbz-123.ddl
@@ -1,0 +1,11 @@
+CREATE TABLE `DBZ123` (
+  `Id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `Provider_ID` bigint(20) NOT NULL,
+  `External_ID` varchar(255) NOT NULL,
+  `Name` varchar(255) NOT NULL,
+  `Is_Enabled` bit(1) NOT NULL DEFAULT b'1',
+  `binaryRepresentation` BLOB NOT NULL DEFAULT x'cafe',
+  `BonusFactor` decimal(19,8) NOT NULL,
+  PRIMARY KEY (`Id`),
+  UNIQUE KEY `game_unq` (`Provider_ID`,`External_ID`)
+) ENGINE=InnoDB AUTO_INCREMENT=2374 DEFAULT CHARSET=utf8

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/DdlParser.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/DdlParser.java
@@ -664,14 +664,17 @@ public class DdlParser {
             parseCharacterSetName(start);
             return parseCharacterLiteral(start);
         }
-        if (tokens.canConsume('N')) {
+        if (tokens.canConsume("N")) {
             return parseCharacterLiteral(start);
         }
         if (tokens.canConsume("U", "&")) {
             return parseCharacterLiteral(start);
         }
-        if (tokens.canConsume('X')) {
+        if (tokens.canConsume("X")) {
             return parseCharacterLiteral(start);
+        }
+        if (tokens.canConsume("B")) {
+            return parseBitFieldLiteral(start);
         }
         if (tokens.matchesAnyOf(DdlTokenizer.DOUBLE_QUOTED_STRING, DdlTokenizer.SINGLE_QUOTED_STRING)) {
             return tokens.consume();
@@ -749,6 +752,10 @@ public class DdlParser {
             return name + "." + id;
         }
         return name;
+    }
+
+    protected String parseBitFieldLiteral(Marker start) {
+        return consumeQuotedString();
     }
 
     protected String parseDateLiteral(Marker start) {


### PR DESCRIPTION
The DDL parser now properly handles bit-set literals, and several minor case-sensitivity bugs dealing with other escaped literals.