### PR TITLE
DBZ-131 Improved logging while reading binlog

### DIFF
--- a/debezium-core/src/main/java/io/debezium/util/DelayStrategy.java
+++ b/debezium-core/src/main/java/io/debezium/util/DelayStrategy.java
@@ -43,7 +43,7 @@ public interface DelayStrategy {
     }
 
     /**
-     * Create a delay strategy that applies an linearly-increasing delay as long as the criteria is met. As soon as
+     * Create a delay strategy that applies a constant delay as long as the criteria is met. As soon as
      * the criteria is not met, the delay resets to zero.
      * 
      * @param delayInMilliseconds the initial delay; must be positive

--- a/debezium-core/src/main/java/io/debezium/util/ElapsedTimeStrategy.java
+++ b/debezium-core/src/main/java/io/debezium/util/ElapsedTimeStrategy.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * Encapsulates the logic of determining a delay when some criteria is met.
+ * 
+ * @author Randall Hauch
+ */
+@FunctionalInterface
+public interface ElapsedTimeStrategy {
+
+    /**
+     * Determine if the time period has elapsed since this method was last called.
+     * 
+     * @return {@code true} if this invocation caused the thread to sleep, or {@code false} if this method did not sleep
+     */
+    boolean hasElapsed();
+
+    /**
+     * Create an elapsed time strategy that always is elapsed.
+     * 
+     * @return the strategy; never null
+     */
+    public static ElapsedTimeStrategy none() {
+        return () -> true;
+    }
+
+    /**
+     * Create a strategy whose time periods are constant.
+     * 
+     * @param clock the clock used to determine if sufficient time has elapsed; may not be null
+     * @param delayInMilliseconds the time period; must be positive
+     * @return the strategy; never null
+     */
+    public static ElapsedTimeStrategy constant(Clock clock, long delayInMilliseconds) {
+        if (delayInMilliseconds <= 0) throw new IllegalArgumentException("Initial delay must be positive");
+        return new ElapsedTimeStrategy() {
+            private long nextTimestamp = 0L;
+
+            @Override
+            public boolean hasElapsed() {
+                if (nextTimestamp == 0L) {
+                    // Initialize ...
+                    nextTimestamp = clock.currentTimeInMillis() + delayInMilliseconds;
+                    return true;
+                }
+                long current = clock.currentTimeInMillis();
+                if (current >= nextTimestamp) {
+                    do {
+                        long multiple = 1 + (current - nextTimestamp) / delayInMilliseconds;
+                        nextTimestamp += multiple * delayInMilliseconds;
+                    } while (current > nextTimestamp);
+                    return true;
+                }
+                return false;
+            }
+        };
+    }
+
+    /**
+     * Create a strategy whose time periods start out at one length but then change to another length after another
+     * period has elapsed.
+     * 
+     * @param clock the clock used to determine if sufficient time has elapsed; may not be null
+     * @param preStepDelayInMilliseconds the time period before the step has occurred; must be positive
+     * @param stepFunction the function that determines if the step time has elapsed; may not be null
+     * @param postStepDelayInMilliseconds the time period before the step has occurred; must be positive
+     * @return the strategy; never null
+     */
+    public static ElapsedTimeStrategy step(Clock clock,
+                                           long preStepDelayInMilliseconds,
+                                           BooleanSupplier stepFunction,
+                                           long postStepDelayInMilliseconds) {
+        if (preStepDelayInMilliseconds <= 0) throw new IllegalArgumentException("Pre-step delay must be positive");
+        if (postStepDelayInMilliseconds <= 0) throw new IllegalArgumentException("Post-step delay must be positive");
+        return new ElapsedTimeStrategy() {
+            private long nextTimestamp = 0L;
+            private boolean elapsed = false;
+            private long delta = 0L;
+
+            @Override
+            public boolean hasElapsed() {
+                if (nextTimestamp == 0L) {
+                    // Initialize ...
+                    elapsed = stepFunction.getAsBoolean();
+                    delta = elapsed ? postStepDelayInMilliseconds : preStepDelayInMilliseconds;
+                    nextTimestamp = clock.currentTimeInMillis() + delta;
+                    return true;
+                }
+                if (!elapsed) {
+                    elapsed = stepFunction.getAsBoolean();
+                    if (elapsed) delta = postStepDelayInMilliseconds;
+                }
+                long current = clock.currentTimeInMillis();
+                if (current >= nextTimestamp) {
+                    do {
+                        assert delta > 0;
+                        long multiple = 1 + (current - nextTimestamp) / delta;
+                        nextTimestamp += multiple * delta;
+                    } while (nextTimestamp <= current);
+                    return true;
+                }
+                return false;
+            }
+        };
+    }
+
+    /**
+     * Create a strategy whose time periods linearly increase in length.
+     * 
+     * @param clock the clock used to determine if sufficient time has elapsed; may not be null
+     * @param delayInMilliseconds the initial delay; must be positive
+     * @return the strategy; never null
+     */
+    public static ElapsedTimeStrategy linear(Clock clock, long delayInMilliseconds) {
+        if (delayInMilliseconds <= 0) throw new IllegalArgumentException("Initial delay must be positive");
+        return new ElapsedTimeStrategy() {
+            private long nextTimestamp = 0L;
+            private long counter = 1L;
+
+            @Override
+            public boolean hasElapsed() {
+                if (nextTimestamp == 0L) {
+                    // Initialize ...
+                    nextTimestamp = clock.currentTimeInMillis() + delayInMilliseconds;
+                    counter = 1L;
+                    return true;
+                }
+                long current = clock.currentTimeInMillis();
+                if (current >= nextTimestamp) {
+                    do {
+                        if (counter < Long.MAX_VALUE) ++counter;
+                        nextTimestamp += (delayInMilliseconds * counter);
+                    } while (nextTimestamp <= current);
+                    return true;
+                }
+                return false;
+            }
+        };
+    }
+
+    /**
+     * Create a strategy whose time periods increase exponentially.
+     * 
+     * @param clock the clock used to determine if sufficient time has elapsed; may not be null
+     * @param initialDelayInMilliseconds the initial delay; must be positive
+     * @param maxDelayInMilliseconds the maximum delay; must be greater than the initial delay
+     * @return the strategy; never null
+     */
+    public static ElapsedTimeStrategy exponential(Clock clock,
+                                                  long initialDelayInMilliseconds,
+                                                  long maxDelayInMilliseconds) {
+        return exponential(clock, initialDelayInMilliseconds, maxDelayInMilliseconds, 2.0);
+    }
+
+    /**
+     * Create a strategy whose time periods increase exponentially.
+     * 
+     * @param clock the clock used to determine if sufficient time has elapsed; may not be null
+     * @param initialDelayInMilliseconds the initial delay; must be positive
+     * @param maxDelayInMilliseconds the maximum delay; must be greater than the initial delay
+     * @param multiplier the factor by which the delay increases each pass
+     * @return the strategy
+     */
+    public static ElapsedTimeStrategy exponential(Clock clock,
+                                                  long initialDelayInMilliseconds,
+                                                  long maxDelayInMilliseconds,
+                                                  double multiplier) {
+        if (multiplier <= 1.0) throw new IllegalArgumentException("Multiplier must be greater than 1");
+        if (initialDelayInMilliseconds <= 0) throw new IllegalArgumentException("Initial delay must be positive");
+        if (initialDelayInMilliseconds >= maxDelayInMilliseconds)
+            throw new IllegalArgumentException("Maximum delay must be greater than initial delay");
+
+        return new ElapsedTimeStrategy() {
+            private long nextTimestamp = 0L;
+            private long previousDelay = 0L;
+
+            @Override
+            public boolean hasElapsed() {
+                if (nextTimestamp == 0L) {
+                    // Initialize ...
+                    nextTimestamp = clock.currentTimeInMillis() + initialDelayInMilliseconds;
+                    previousDelay = initialDelayInMilliseconds;
+                    return true;
+                }
+                long current = clock.currentTimeInMillis();
+                if (current >= nextTimestamp) {
+                    do {
+                        // Compute how long to delay ...
+                        long nextDelay = (long) (previousDelay * multiplier);
+                        if ( nextDelay >= maxDelayInMilliseconds ) {
+                            previousDelay = maxDelayInMilliseconds;
+                            // If we're not there yet, then we know the increment is linear from here ...
+                            if (nextTimestamp < current) {
+                                long multiple = 1 + (current - nextTimestamp) / maxDelayInMilliseconds;
+                                nextTimestamp += multiple * maxDelayInMilliseconds;
+                            }
+                        } else {
+                            previousDelay = nextDelay;
+                        }
+                        nextTimestamp += previousDelay;
+                    } while (nextTimestamp <= current);
+                    return true;
+                }
+                return false;
+            }
+        };
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/util/ElapsedTimeStrategyTest.java
+++ b/debezium-core/src/test/java/io/debezium/util/ElapsedTimeStrategyTest.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Randall Hauch
+ *
+ */
+public class ElapsedTimeStrategyTest {
+
+    private ElapsedTimeStrategy delay;
+    private MockClock clock;
+
+    @Before
+    public void beforeEach() {
+        clock = new MockClock();
+    }
+    
+    @Test
+    public void testConstantDelay() {
+        clock.advanceTo(100);
+        delay = ElapsedTimeStrategy.constant(clock, 10);
+        // Initial call should always be true ...
+        assertElapsed();
+        // next stop at 100+10=110
+
+        assertNotElapsed();
+        clock.advanceTo(109);
+        assertNotElapsed();
+        clock.advanceTo(110);
+        assertElapsed();
+        // next stop at 110+10=120
+
+        clock.advanceTo(119);
+        assertNotElapsed();
+        clock.advanceTo(128);
+        assertElapsed();
+        // next stop at 120+10=130
+
+        clock.advanceTo(130);
+        assertElapsed();
+        // next stop at 130+10=140
+
+        clock.advanceTo(139);
+        assertNotElapsed();
+        clock.advanceTo(140);
+        assertElapsed();
+
+        // Advance many multiples should be instantaneous...
+        clock.advanceTo(100000000000000L);
+        assertElapsed();
+    }
+    
+    @Test
+    public void testLinearDelay() {
+        clock.advanceTo(100);
+        delay = ElapsedTimeStrategy.linear(clock, 100);
+        // Initial call should always be true ...
+        assertElapsed();
+        // next stop at 100+(100*1)=200
+        assertNotElapsed();
+        clock.advanceTo(199);
+        assertNotElapsed();
+        clock.advanceTo(200);
+        assertElapsed();
+        // next stop at 200+(100*2)=400
+        
+        clock.advanceTo(201);
+        assertNotElapsed();
+        clock.advanceTo(301);
+        assertNotElapsed();
+        clock.advanceTo(400);
+        assertElapsed();
+        // next stop at 400+(100*3)=700
+
+        clock.advanceTo(401);
+        assertNotElapsed();
+        clock.advanceTo(699);
+        assertNotElapsed();
+        clock.advanceTo(701);
+        assertElapsed();
+        // next stop at 700+(100*4)=1100
+
+        clock.advanceTo(1099);
+        assertNotElapsed();
+        clock.advanceTo(1101);
+        assertElapsed();
+
+        // Advance many multiples should be instantaneous...
+        clock.advanceTo(100000000000000L);
+        assertElapsed();
+    }
+    
+    @Test
+    public void testStepDelayStartingBeforeStep() {
+        clock.advanceTo(100);
+        // start out before the step ...
+        AtomicBoolean step = new AtomicBoolean(false);
+        delay = ElapsedTimeStrategy.step(clock, 10, step::get, 100);
+
+        // Initial call should always be true ...
+        assertElapsed();
+        // next stop at 100+(10)=110
+        assertNotElapsed();
+        clock.advanceTo(109);
+        assertNotElapsed();
+        clock.advanceTo(110);
+        assertElapsed();
+        // next stop at 110+(10)=120
+        
+        clock.advanceTo(119);
+        assertNotElapsed();
+        clock.advanceTo(120);
+        assertElapsed();
+        // next stop at 120+(10)=130
+
+        clock.advanceTo(129);
+        assertNotElapsed();
+
+        // trigger the step ...
+        step.set(true);
+        assertNotElapsed();
+
+        clock.advanceTo(130);
+        assertElapsed();
+        // next stop at 130+(100)=230
+
+        clock.advanceTo(229);
+        assertNotElapsed();
+        clock.advanceTo(230);
+        assertElapsed();
+        // next stop at 230+(100)=330
+
+        clock.advanceTo(329);
+        assertNotElapsed();
+        // un-trigger the step, but the strategy shouldn't care about this at all
+        step.set(false);
+
+        clock.advanceTo(330);
+        assertElapsed();
+        // next stop at 330+(100)=430
+
+        clock.advanceTo(331);
+        assertNotElapsed();
+        clock.advanceTo(341);
+        assertNotElapsed();
+        clock.advanceTo(429);
+        assertNotElapsed();
+        clock.advanceTo(430);
+        assertElapsed();
+
+        // Advance many multiples should be instantaneous...
+        clock.advanceTo(100000000000000L);
+        assertElapsed();
+    }
+    
+    
+    @Test
+    public void testStepDelayStartingAfterStep() {
+        clock.advanceTo(100);
+        // start out before the step ...
+        AtomicBoolean step = new AtomicBoolean(true);
+        delay = ElapsedTimeStrategy.step(clock, 10, step::get, 100);
+
+        // Initial call should always be true ...
+        assertElapsed();
+        // next stop at 100+(100)=200
+        assertNotElapsed();
+        clock.advanceTo(109);
+        assertNotElapsed();
+        clock.advanceTo(110);
+        assertNotElapsed();
+        clock.advanceTo(199);
+        assertNotElapsed();
+        clock.advanceTo(200);
+        assertElapsed();
+        // next stop at 200+(100)=300
+        
+        clock.advanceTo(209);
+        assertNotElapsed();
+        clock.advanceTo(300);
+        assertElapsed();
+        // next stop at 300+(100)=400
+
+        // un-trigger the step, but the strategy shouldn't care about this at all
+        step.set(false);
+        assertNotElapsed();
+
+        clock.advanceTo(399);
+        assertNotElapsed();
+        clock.advanceTo(400);
+        assertElapsed();
+        // next stop at 400+(100)=500
+
+        clock.advanceTo(409);
+        assertNotElapsed();
+        clock.advanceTo(410);
+        assertNotElapsed();
+        clock.advanceTo(499);
+        assertNotElapsed();
+        clock.advanceTo(500);
+        assertElapsed();
+
+        // trigger the step, but the strategy shouldn't care about this at all
+        step.set(true);
+        clock.advanceTo(501);
+        assertNotElapsed();
+        clock.advanceTo(510);
+        assertNotElapsed();
+        clock.advanceTo(599);
+        assertNotElapsed();
+        clock.advanceTo(600);
+        assertElapsed();
+
+        // Advance many multiples should be instantaneous...
+        clock.advanceTo(100000000000000L);
+        assertElapsed();
+    }
+    
+    @Test
+    public void testExponentialDelay() {
+        clock.advanceTo(100);
+        delay = ElapsedTimeStrategy.exponential(clock, 100, 4000);
+        // Initial call should always be true ...
+        assertElapsed();
+        // next stop at 100+(100)=200
+        
+        assertNotElapsed();
+        clock.advanceTo(199);
+        assertNotElapsed();
+        clock.advanceTo(200);
+        assertElapsed();
+        // next stop at 200+(100*2)=400
+        
+        clock.advanceTo(201);
+        assertNotElapsed();
+        clock.advanceTo(301);
+        assertNotElapsed();
+        clock.advanceTo(400);
+        assertElapsed();
+        // next stop at 400+(200*2)=800
+
+        clock.advanceTo(401);
+        assertNotElapsed();
+        clock.advanceTo(799);
+        assertNotElapsed();
+        clock.advanceTo(800);
+        assertElapsed();
+        // next stop at 800+(400*2)=1600
+
+        clock.advanceTo(801);
+        assertNotElapsed();
+        clock.advanceTo(1599);
+        assertNotElapsed();
+        clock.advanceTo(1600);
+        assertElapsed();
+        // next stop at 1600+(800*2)=3200
+
+        clock.advanceTo(1601);
+        assertNotElapsed();
+        clock.advanceTo(3199);
+        assertNotElapsed();
+        clock.advanceTo(3200);
+        assertElapsed();
+        // next stop at 3200+(1600*2)=6400
+
+        clock.advanceTo(3201);
+        assertNotElapsed();
+        clock.advanceTo(6399);
+        assertNotElapsed();
+        clock.advanceTo(6400);
+        assertElapsed();
+        // next stop at 6400+(3200*2)=12800, but max delta is 4000, so
+        // next stop at 6400+(4000)=10400
+
+        clock.advanceTo(6401);
+        assertNotElapsed();
+        clock.advanceTo(10399);
+        assertNotElapsed();
+        clock.advanceTo(10400);
+        assertElapsed();
+
+        // Advance many multiples should be instantaneous...
+        clock.advanceTo(100000000000000L);
+        assertElapsed();
+        clock.advanceTo(100000000000001L);
+        assertNotElapsed();
+        clock.advanceTo(100000000006400L);
+        assertElapsed();
+    }
+    
+    protected void assertElapsed() {
+        assertThat(delay.hasElapsed()).isTrue();
+        assertNotElapsed();
+    }
+    
+    protected void assertNotElapsed() {
+        for (int i=0; i!=5; ++i) {
+            assertThat(delay.hasElapsed()).isFalse();
+        }
+    }
+
+}

--- a/debezium-core/src/test/java/io/debezium/util/MockClock.java
+++ b/debezium-core/src/test/java/io/debezium/util/MockClock.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Debezium Authors.
+ * 
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+/**
+ * @author Randall Hauch
+ *
+ */
+public class MockClock implements Clock {
+
+    private long currentTimeInMillis;
+    
+    public MockClock() {
+    }
+    
+    public MockClock(long timeInMillis) {
+        assert timeInMillis >= 0;
+        currentTimeInMillis = timeInMillis;
+    }
+    
+    public MockClock advanceTo(long timeInMillis) {
+        assert timeInMillis >= 0;
+        currentTimeInMillis = timeInMillis;
+        return this;
+    }
+
+    public MockClock increment(long timeInMillis) {
+        assert timeInMillis >= 0;
+        currentTimeInMillis += timeInMillis;
+        return this;
+    }
+
+    @Override
+    public long currentTimeInMillis() {
+        return currentTimeInMillis;
+    }
+    
+    @Override
+    public String toString() {
+        return Strings.duration(currentTimeInMillis);
+    }
+}


### PR DESCRIPTION
When the MySQL connector is reading the binlog, it outputs INFO log messages reporting status at an exponentially-increasing rate, starting at every 5 seconds and doubling until a max period of 1 hour. This output is useful when the connector starts to know that it is working, but thereafter the usefulness decreases. Once an hour is probably acceptable output.

This is not intended to replace the capturing of metrics, but is merely an aid to easily tell via the logs whether the connector continues to work.

Also improved the log message when the binlog reader stops to capture the total number of events recorded by Kafka Connect and the last recorded offset.