### PR TITLE
DBZ-115 Add support to recognize older row_event formats

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -142,6 +142,9 @@ public class BinlogReader extends AbstractReader {
         eventHandlers.put(EventType.TABLE_MAP, this::handleUpdateTableMetadata);
         eventHandlers.put(EventType.QUERY, this::handleQueryEvent);
         eventHandlers.put(EventType.GTID, this::handleGtidEvent);
+        eventHandlers.put(EventType.WRITE_ROWS, this::handleInsert);
+        eventHandlers.put(EventType.UPDATE_ROWS, this::handleUpdate);
+        eventHandlers.put(EventType.DELETE_ROWS, this::handleDelete);
         eventHandlers.put(EventType.EXT_WRITE_ROWS, this::handleInsert);
         eventHandlers.put(EventType.EXT_UPDATE_ROWS, this::handleUpdate);
         eventHandlers.put(EventType.EXT_DELETE_ROWS, this::handleDelete);


### PR DESCRIPTION
Reason for this pull request is because of the following error:
```
2016-10-07 22:47:31,575 TRACE  MySQL|my_williedb|binlog  Ignoring event due to missing handler: Event{header=EventHeaderV4{timestamp=1475873147000, eventType=UPDATE_ROWS, serverId=1, headerLength=19, dataLength=117, nextPosition=1120, flags=0}, data=UpdateRowsEventData{tableId=748, includedColumnsBeforeUpdate={0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, includedColumns={0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, rows=[
    {before=[16192792, 12, 34227952, 10, 8, 0, 1109399502, 2016-06-25T17:55:33Z, 2016-10-07T20:23:48.472583Z, 0], after=[16192792, 12, 34227952, 10, 8, 0, 1109459289, 2016-06-25T17:55:33Z, 2016-10-07T20:45:47.985929Z, 0]}
]}}   [io.debezium.connector.mysql.BinlogReader]
```

The binlog reader does not recognize any `EventType` with prior row_event versions in the handler map, and is ignoring those entries as a result. Adding these row_event `EventType` to the `eventHandler` map should resolve the problem.