### PR TITLE
DBZ-139 Corrected binlog timestamp handling

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -272,7 +272,7 @@ public class BinlogReader extends AbstractReader {
         // Update the source offset info. Note that the client returns the value in *milliseconds*, even though the binlog
         // contains only *seconds* precision ...
         EventHeader eventHeader = event.getHeader();
-        source.setBinlogTimestampSeconds(eventHeader.getTimestamp() / 1000L); // client returns milliseconds, we record seconds
+        source.setBinlogTimestampSeconds(eventHeader.getTimestamp() / 1000L); // client returns milliseconds, but only second precision
         source.setBinlogServerId(eventHeader.getServerId());
         EventType eventType = eventHeader.getEventType();
         if (eventType == EventType.ROTATE) {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
@@ -307,11 +307,14 @@ final class SourceInfo {
 
     /**
      * Set the number of <em>seconds</em> since Unix epoch (January 1, 1970) as found within the MySQL binary log file.
+     * Note that the value in the binlog events is in seconds, but the library we use returns the value in milliseconds
+     * (with only second precision and therefore all fractions of a second are zero). We capture this as seconds
+     * since that is the precision that MySQL uses.
      * 
      * @param timestampInSeconds the timestamp in <em>seconds</em> found within the binary log file
      */
     public void setBinlogTimestampSeconds(long timestampInSeconds) {
-        this.binlogTimestampSeconds = timestampInSeconds / 1000;
+        this.binlogTimestampSeconds = timestampInSeconds;
     }
 
     /**


### PR DESCRIPTION
MySQL records the timestamp with second precision in binlog events, but the library we use multiplies by 1000 to return the padded value in milliseconds (even though the value still has second precision). The BinlogReader converts this back to seconds, so the SourceInfo should not also be dividing by 1000.