### PR TITLE
DBZ-133 Support 'schema' snapshot mode for MySQL connector

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -103,6 +103,12 @@ public class MySqlConnectorConfig {
         INITIAL("initial"),
 
         /**
+         * Perform a snapshot of database schema(not include initial data in databases) only upon initial startup of a
+         * connector.
+         */
+        SCHEMA_ONLY("schema_only"),
+
+        /**
          * Never perform a snapshot and only read the binlog. This assumes the binlog contains all the history of those
          * databases and tables that will be captured.
          */

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -103,8 +103,9 @@ public class MySqlConnectorConfig {
         INITIAL("initial"),
 
         /**
-         * Perform a snapshot of database schema(not include initial data in databases) only upon initial startup of a
-         * connector.
+         * Perform a snapshot of only the database schemas (without data) and then begin reading the binlog.
+         * This should be used with care, but it is very useful when the change event consumers need only the changes
+         * from the point in time the snapshot is made (and doesn't care about any state or changes prior to this point).
          */
         SCHEMA_ONLY("schema_only"),
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -150,15 +150,13 @@ public final class MySqlConnectorTask extends SourceTask {
                 if (taskContext.isInitialSnapshotOnly()) {
                     logger.warn("This connector will only perform a snapshot, and will stop after that completes.");
                     this.snapshotReader.onSuccessfulCompletion(this::skipReadBinlog);
-                } else if (rowBinlogEnabled) {
-                    // This is the normal mode ...
-                    this.snapshotReader.onSuccessfulCompletion(this::transitionToReadBinlog);
                 } else {
-                    assert !rowBinlogEnabled;
-                    assert !taskContext.isInitialSnapshotOnly();
-                    throw new ConnectException("The MySQL server is not configured to use a row-level binlog, which is "
-                            + "required for this connector to work properly. Change the MySQL configuration to use a "
-                            + "row-level binlog and restart the connector.");
+                    this.snapshotReader.onSuccessfulCompletion(this::transitionToReadBinlog);
+                    if (!rowBinlogEnabled) {
+                        throw new ConnectException("The MySQL server is not configured to use a row-level binlog, which is "
+                                + "required for this connector to work properly. Change the MySQL configuration to use a "
+                                + "row-level binlog and restart the connector.");
+                    }
                 }
                 this.snapshotReader.useMinimalBlocking(taskContext.useMinimalSnapshotLocking());
                 if (snapshotEventsAreInserts) this.snapshotReader.generateInsertEvents();

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -179,6 +179,10 @@ public final class MySqlTaskContext extends MySqlJdbcContext {
         return snapshotMode() == SnapshotMode.INITIAL_ONLY;
     }
 
+    public boolean isSchemaOnlySnapshot() {
+        return snapshotMode() == SnapshotMode.SCHEMA_ONLY;
+    }
+
     protected SnapshotMode snapshotMode() {
         String value = config.getString(MySqlConnectorConfig.SNAPSHOT_MODE);
         return SnapshotMode.parse(value, MySqlConnectorConfig.SNAPSHOT_MODE.defaultValueAsString());


### PR DESCRIPTION
Enables schema-only snapshot mode that does capture the database table schemas but does *not* copy the data. When this snapshot completes, the connector will continue by reading the binlog from the point in time the snapshot was made.

This option should be used with care because it does not provide a consistent copy of the database. However, it still is very useful when the change event consumers need only the changes from the point in time the snapshot is made. For example, consider an application that merely wants to know about the database changes that were made _since the application has started running_.

This supersedes #125, which had an extra merge in the history, but does retain all of the changes made by @pranmitt to implement this feature and add tests to verify initial data is not copied when this snapshot mode is used.