### PR TITLE
DBZ-143 Support multi-channel MySQL failover

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/GtidSet.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/GtidSet.java
@@ -8,6 +8,7 @@ package io.debezium.connector.mysql;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -98,6 +99,19 @@ public final class GtidSet {
             if (!uuidSet.isContainedWithin(thatSet)) return false;
         }
         return true;
+    }
+
+    /**
+     * Obtain a copy of this {@link GtidSet} except overwritten with all of the GTID ranges in the supplied {@link GtidSet}.
+     * @param other the other {@link GtidSet} with ranges to add/overwrite on top of those in this set;
+     * @return the new GtidSet, or this object if {@code other} is null or empty; never null
+     */
+    public GtidSet with(GtidSet other) {
+        if (other == null || other.uuidSetsByServerId.isEmpty()) return this;
+        Map<String, UUIDSet> newSet = new HashMap<>();
+        newSet.putAll(this.uuidSetsByServerId);
+        newSet.putAll(other.uuidSetsByServerId);
+        return new GtidSet(newSet);
     }
 
     @Override

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -123,6 +123,26 @@ public class MySqlJdbcContext implements AutoCloseable {
         shutdown();
     }
 
+    /**
+     * Determine the available GTID set for MySQL.
+     *
+     * @return the string representation of MySQL's GTID sets.
+     */
+    public String knownGtidSet() {
+        AtomicReference<String> gtidSetStr = new AtomicReference<String>();
+        try {
+            jdbc.query("SHOW MASTER STATUS", rs -> {
+                if (rs.next()) {
+                    gtidSetStr.set(rs.getString(5));// GTID set, may be null, blank, or contain a GTID set
+                }
+            });
+        } catch (SQLException e) {
+            throw new ConnectException("Unexpected error while connecting to MySQL and looking at GTID mode: ", e);
+        }
+
+        return gtidSetStr.get();
+    }
+
     protected String connectionString() {
         return jdbc.connectionString(MYSQL_CONNECTION_URL);
     }


### PR DESCRIPTION
Make Debezium merge its GTID set with the GTID set on the server that it's connecting to. This allows Debezium to consume from a MySQL server that might have a different set of channels (upstream masters), provided that the server has the data that Debezium needs.