### PR TITLE
DBZ-146 Improved error handling of MySQL Connector

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
@@ -117,14 +117,14 @@ public class MySqlSchema {
     /**
      * Start by acquiring resources needed to persist the database history
      */
-    public void start() {
+    public synchronized void start() {
         this.dbHistory.start();
     }
 
     /**
      * Stop recording history and release any resources acquired since {@link #start()}.
      */
-    public void shutdown() {
+    public synchronized void shutdown() {
         this.dbHistory.stop();
     }
 

--- a/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
@@ -96,7 +96,7 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
     private String topicName;
     private Configuration consumerConfig;
     private Configuration producerConfig;
-    private KafkaProducer<String, String> producer;
+    private volatile KafkaProducer<String, String> producer;
     private int recoveryAttempts = -1;
     private int pollIntervalMs = -1;
 
@@ -151,6 +151,9 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
 
     @Override
     protected void storeRecord(HistoryRecord record) {
+        if (this.producer == null) {
+            throw new IllegalStateException("No producer is available. Ensure that 'start()' is called before storing database history records.");
+        }
         logger.trace("Storing record into database history: {}", record);
         try {
             ProducerRecord<String, String> produced = new ProducerRecord<>(topicName, partition, null, record.toString());


### PR DESCRIPTION
Improved the error handling of the MySQL connector to ensure that we’re always stopping the connector when we have a problem handling a binlog event or if we have problems starting.