### PR TITLE
DBZ-144 Corrected MySQL connector restart logic

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -139,7 +139,7 @@ public final class MySqlConnectorTask extends SourceTask {
             if (!startWithSnapshot && source.gtidSet() == null && isGtidModeEnabled()) {
                 // The snapshot will properly determine the GTID set, but we're not starting with a snapshot and GTIDs were not
                 // previously used but the MySQL server has them enabled ...
-                source.setGtidSet("");
+                source.setCompletedGtidSet("");
             }
 
             // Check whether the row-level binlog is enabled ...

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -265,11 +265,11 @@ public final class MySqlTaskContext extends MySqlJdbcContext {
      *         none were filtered
      */
     public GtidSet filterGtidSet(GtidSet availableServerGtidSet) {
-        logger.info("Attempting to generate a filtered GTID set");
         String gtidStr = source.gtidSet();
         if (gtidStr == null) {
             return null;
         }
+        logger.info("Attempting to generate a filtered GTID set");
         logger.info("GTID set from previous recorded offset: {}", gtidStr);
         GtidSet filteredGtidSet = new GtidSet(gtidStr);
         Predicate<String> gtidSourceFilter = gtidSourceFilter();

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -222,7 +222,7 @@ public class SnapshotReader extends AbstractReader {
                     if (rs.getMetaData().getColumnCount() > 4) {
                         // This column exists only in MySQL 5.6.5 or later ...
                         String gtidSet = rs.getString(5);// GTID set, may be null, blank, or contain a GTID set
-                        source.setGtidSet(gtidSet);
+                        source.setCompletedGtidSet(gtidSet);
                         logger.info("\t using binlog '{}' at position '{}' and gtid '{}'", binlogFilename, binlogPosition,
                                     gtidSet);
                     } else {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTaskContextTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTaskContextTest.java
@@ -215,7 +215,7 @@ public class MySqlTaskContextTest {
                                .build();
         context = new MySqlTaskContext(config);
         context.start();
-        context.source().setGtidSet(gtidStr);
+        context.source().setCompletedGtidSet(gtidStr);
 
         GtidSet mergedGtidSet = context.filterGtidSet(new GtidSet(availableServerGtidStr));
         assertThat(mergedGtidSet).isNotNull();

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
@@ -31,20 +31,25 @@ public class SourceInfoTest {
     private static final String SERVER_NAME = "my-server"; // can technically be any string
 
     private SourceInfo source;
+    private boolean inTxn = false;
+    private long positionOfBeginEvent = 0L;
+    private int eventNumberInTxn = 0;
 
     @Before
     public void beforeEach() {
         source = new SourceInfo();
+        inTxn = false;
+        positionOfBeginEvent = 0L;
+        eventNumberInTxn = 0;
     }
 
     @Test
     public void shouldStartSourceInfoFromZeroBinlogCoordinates() {
         source.setBinlogStartPoint(FILENAME, 0);
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(0);
-        assertThat(source.lastBinlogPosition()).isEqualTo(0);
-        assertThat(source.nextEventRowNumber()).isEqualTo(0);
-        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.binlogPosition()).isEqualTo(0);
+        assertThat(source.eventsToSkipUponRestart()).isEqualTo(0);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isFalse();
     }
 
@@ -52,10 +57,8 @@ public class SourceInfoTest {
     public void shouldStartSourceInfoFromNonZeroBinlogCoordinates() {
         source.setBinlogStartPoint(FILENAME, 100);
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(100);
-        assertThat(source.lastBinlogPosition()).isEqualTo(100);
-        assertThat(source.nextEventRowNumber()).isEqualTo(0);
-        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.binlogPosition()).isEqualTo(100);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isFalse();
     }
 
@@ -68,10 +71,8 @@ public class SourceInfoTest {
         sourceWith(offset(0, 0));
         assertThat(source.gtidSet()).isNull();
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(0);
-        assertThat(source.lastBinlogPosition()).isEqualTo(0);
-        assertThat(source.nextEventRowNumber()).isEqualTo(0);
-        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.binlogPosition()).isEqualTo(0);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isFalse();
     }
 
@@ -80,10 +81,8 @@ public class SourceInfoTest {
         sourceWith(offset(100, 0));
         assertThat(source.gtidSet()).isNull();
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(100);
-        assertThat(source.lastBinlogPosition()).isEqualTo(100);
-        assertThat(source.nextEventRowNumber()).isEqualTo(0);
-        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.binlogPosition()).isEqualTo(100);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isFalse();
     }
 
@@ -92,10 +91,8 @@ public class SourceInfoTest {
         sourceWith(offset(0, 5));
         assertThat(source.gtidSet()).isNull();
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(0);
-        assertThat(source.lastBinlogPosition()).isEqualTo(0);
-        assertThat(source.nextEventRowNumber()).isEqualTo(5);
-        assertThat(source.lastEventRowNumber()).isEqualTo(5);
+        assertThat(source.binlogPosition()).isEqualTo(0);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isFalse();
     }
 
@@ -104,10 +101,8 @@ public class SourceInfoTest {
         sourceWith(offset(100, 5));
         assertThat(source.gtidSet()).isNull();
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(100);
-        assertThat(source.lastBinlogPosition()).isEqualTo(100);
-        assertThat(source.nextEventRowNumber()).isEqualTo(5);
-        assertThat(source.lastEventRowNumber()).isEqualTo(5);
+        assertThat(source.binlogPosition()).isEqualTo(100);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isFalse();
     }
 
@@ -116,10 +111,8 @@ public class SourceInfoTest {
         sourceWith(offset(0, 0, true));
         assertThat(source.gtidSet()).isNull();
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(0);
-        assertThat(source.lastBinlogPosition()).isEqualTo(0);
-        assertThat(source.nextEventRowNumber()).isEqualTo(0);
-        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.binlogPosition()).isEqualTo(0);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isTrue();
     }
 
@@ -128,10 +121,8 @@ public class SourceInfoTest {
         sourceWith(offset(100, 0, true));
         assertThat(source.gtidSet()).isNull();
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(100);
-        assertThat(source.lastBinlogPosition()).isEqualTo(100);
-        assertThat(source.nextEventRowNumber()).isEqualTo(0);
-        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.binlogPosition()).isEqualTo(100);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isTrue();
     }
 
@@ -140,10 +131,8 @@ public class SourceInfoTest {
         sourceWith(offset(0, 5, true));
         assertThat(source.gtidSet()).isNull();
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(0);
-        assertThat(source.lastBinlogPosition()).isEqualTo(0);
-        assertThat(source.nextEventRowNumber()).isEqualTo(5);
-        assertThat(source.lastEventRowNumber()).isEqualTo(5);
+        assertThat(source.binlogPosition()).isEqualTo(0);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isTrue();
     }
 
@@ -152,10 +141,8 @@ public class SourceInfoTest {
         sourceWith(offset(100, 5, true));
         assertThat(source.gtidSet()).isNull();
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(100);
-        assertThat(source.lastBinlogPosition()).isEqualTo(100);
-        assertThat(source.nextEventRowNumber()).isEqualTo(5);
-        assertThat(source.lastEventRowNumber()).isEqualTo(5);
+        assertThat(source.binlogPosition()).isEqualTo(100);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isTrue();
     }
 
@@ -164,10 +151,8 @@ public class SourceInfoTest {
         sourceWith(offset(GTID_SET, 0, 0, false));
         assertThat(source.gtidSet()).isEqualTo(GTID_SET);
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(0);
-        assertThat(source.lastBinlogPosition()).isEqualTo(0);
-        assertThat(source.nextEventRowNumber()).isEqualTo(0);
-        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.binlogPosition()).isEqualTo(0);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isFalse();
     }
 
@@ -176,10 +161,8 @@ public class SourceInfoTest {
         sourceWith(offset(GTID_SET, 0, 5, false));
         assertThat(source.gtidSet()).isEqualTo(GTID_SET);
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(0);
-        assertThat(source.lastBinlogPosition()).isEqualTo(0);
-        assertThat(source.nextEventRowNumber()).isEqualTo(5);
-        assertThat(source.lastEventRowNumber()).isEqualTo(5);
+        assertThat(source.binlogPosition()).isEqualTo(0);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isFalse();
     }
 
@@ -188,10 +171,8 @@ public class SourceInfoTest {
         sourceWith(offset(GTID_SET, 100, 0, false));
         assertThat(source.gtidSet()).isEqualTo(GTID_SET);
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(100);
-        assertThat(source.lastBinlogPosition()).isEqualTo(100);
-        assertThat(source.nextEventRowNumber()).isEqualTo(0);
-        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.binlogPosition()).isEqualTo(100);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isFalse();
     }
 
@@ -200,10 +181,8 @@ public class SourceInfoTest {
         sourceWith(offset(GTID_SET, 100, 5, false));
         assertThat(source.gtidSet()).isEqualTo(GTID_SET);
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(100);
-        assertThat(source.lastBinlogPosition()).isEqualTo(100);
-        assertThat(source.nextEventRowNumber()).isEqualTo(5);
-        assertThat(source.lastEventRowNumber()).isEqualTo(5);
+        assertThat(source.binlogPosition()).isEqualTo(100);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isFalse();
     }
 
@@ -212,10 +191,8 @@ public class SourceInfoTest {
         sourceWith(offset(GTID_SET, 0, 0, true));
         assertThat(source.gtidSet()).isEqualTo(GTID_SET);
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(0);
-        assertThat(source.lastBinlogPosition()).isEqualTo(0);
-        assertThat(source.nextEventRowNumber()).isEqualTo(0);
-        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.binlogPosition()).isEqualTo(0);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isTrue();
     }
 
@@ -224,10 +201,8 @@ public class SourceInfoTest {
         sourceWith(offset(GTID_SET, 0, 5, true));
         assertThat(source.gtidSet()).isEqualTo(GTID_SET);
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(0);
-        assertThat(source.lastBinlogPosition()).isEqualTo(0);
-        assertThat(source.nextEventRowNumber()).isEqualTo(5);
-        assertThat(source.lastEventRowNumber()).isEqualTo(5);
+        assertThat(source.binlogPosition()).isEqualTo(0);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isTrue();
     }
 
@@ -236,10 +211,8 @@ public class SourceInfoTest {
         sourceWith(offset(GTID_SET, 100, 0, true));
         assertThat(source.gtidSet()).isEqualTo(GTID_SET);
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(100);
-        assertThat(source.lastBinlogPosition()).isEqualTo(100);
-        assertThat(source.nextEventRowNumber()).isEqualTo(0);
-        assertThat(source.lastEventRowNumber()).isEqualTo(0);
+        assertThat(source.binlogPosition()).isEqualTo(100);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isTrue();
     }
 
@@ -248,10 +221,8 @@ public class SourceInfoTest {
         sourceWith(offset(GTID_SET, 100, 5, true));
         assertThat(source.gtidSet()).isEqualTo(GTID_SET);
         assertThat(source.binlogFilename()).isEqualTo(FILENAME);
-        assertThat(source.nextBinlogPosition()).isEqualTo(100);
-        assertThat(source.lastBinlogPosition()).isEqualTo(100);
-        assertThat(source.nextEventRowNumber()).isEqualTo(5);
-        assertThat(source.lastEventRowNumber()).isEqualTo(5);
+        assertThat(source.binlogPosition()).isEqualTo(100);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isTrue();
     }
 
@@ -262,19 +233,89 @@ public class SourceInfoTest {
     @Test
     public void shouldAdvanceSourceInfoFromNonZeroPositionAndRowZeroForEventsWithOneRow() {
         sourceWith(offset(100, 0));
+
+        // Try a transactions with just one event ...
+        handleTransactionBegin(150, 2);
         handleNextEvent(200, 10, withRowCount(1));
+        handleTransactionCommit(210, 2);
+
+        handleTransactionBegin(210, 2);
         handleNextEvent(220, 10, withRowCount(1));
+        handleTransactionCommit(230, 3);
+
+        handleTransactionBegin(240, 2);
         handleNextEvent(250, 50, withRowCount(1));
+        handleTransactionCommit(300, 4);
+
+        // Try a transactions with multiple events ...
+        handleTransactionBegin(340, 2);
+        handleNextEvent(350, 20, withRowCount(1));
+        handleNextEvent(370, 30, withRowCount(1));
+        handleNextEvent(400, 40, withRowCount(1));
+        handleTransactionCommit(440, 4);
+
+        handleTransactionBegin(500, 2);
+        handleNextEvent(510, 20, withRowCount(1));
+        handleNextEvent(540, 15, withRowCount(1));
+        handleNextEvent(560, 10, withRowCount(1));
+        handleTransactionCommit(580, 4);
+
+        // Try another single event transaction ...
+        handleTransactionBegin(600, 2);
+        handleNextEvent(610, 50, withRowCount(1));
+        handleTransactionCommit(660, 4);
+
+        // Try event outside of a transaction ...
+        handleNextEvent(670, 10, withRowCount(1));
+
+        // Try another single event transaction ...
+        handleTransactionBegin(700, 2);
+        handleNextEvent(710, 50, withRowCount(1));
+        handleTransactionCommit(760, 4);
     }
 
     @Test
     public void shouldAdvanceSourceInfoFromNonZeroPositionAndRowZeroForEventsWithMultipleRow() {
         sourceWith(offset(100, 0));
+
+        // Try a transactions with just one event ...
+        handleTransactionBegin(150, 2);
         handleNextEvent(200, 10, withRowCount(3));
+        handleTransactionCommit(210, 2);
+
+        handleTransactionBegin(210, 2);
         handleNextEvent(220, 10, withRowCount(4));
-        handleNextEvent(250, 50, withRowCount(6));
-        handleNextEvent(300, 20, withRowCount(1));
-        handleNextEvent(350, 20, withRowCount(3));
+        handleTransactionCommit(230, 3);
+
+        handleTransactionBegin(240, 2);
+        handleNextEvent(250, 50, withRowCount(5));
+        handleTransactionCommit(300, 4);
+
+        // Try a transactions with multiple events ...
+        handleTransactionBegin(340, 2);
+        handleNextEvent(350, 20, withRowCount(6));
+        handleNextEvent(370, 30, withRowCount(1));
+        handleNextEvent(400, 40, withRowCount(3));
+        handleTransactionCommit(440, 4);
+
+        handleTransactionBegin(500, 2);
+        handleNextEvent(510, 20, withRowCount(8));
+        handleNextEvent(540, 15, withRowCount(9));
+        handleNextEvent(560, 10, withRowCount(1));
+        handleTransactionCommit(580, 4);
+
+        // Try another single event transaction ...
+        handleTransactionBegin(600, 2);
+        handleNextEvent(610, 50, withRowCount(1));
+        handleTransactionCommit(660, 4);
+
+        // Try event outside of a transaction ...
+        handleNextEvent(670, 10, withRowCount(5));
+
+        // Try another single event transaction ...
+        handleTransactionBegin(700, 2);
+        handleNextEvent(710, 50, withRowCount(3));
+        handleTransactionCommit(760, 4);
     }
 
     // -------------------------------------------------------------------------------------
@@ -285,33 +326,78 @@ public class SourceInfoTest {
         return rowCount;
     }
 
-    protected void handleNextEvent(long positionOfEvent, long eventSize, int rowCount) {
+    protected void handleTransactionBegin(long positionOfEvent, int eventSize) {
         source.setEventPosition(positionOfEvent, eventSize);
-        for (int i = 0; i != rowCount; ++i) {
+        positionOfBeginEvent = positionOfEvent;
+        source.startNextTransaction();
+        inTxn = true;
+
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
+    }
+
+    protected void handleTransactionCommit(long positionOfEvent, int eventSize) {
+        source.setEventPosition(positionOfEvent, eventSize);
+        source.commitTransaction();
+        eventNumberInTxn = 0;
+        inTxn = false;
+
+        // Verify the offset ...
+        Map<String, ?> offset = source.offset();
+
+        // The offset position should be the position of the next event
+        long position = (Long) offset.get(SourceInfo.BINLOG_POSITION_OFFSET_KEY);
+        assertThat(position).isEqualTo(positionOfEvent + eventSize);
+        Long rowsToSkip = (Long) offset.get(SourceInfo.BINLOG_ROW_IN_EVENT_OFFSET_KEY);
+        if (rowsToSkip == null) rowsToSkip = 0L;
+        assertThat(rowsToSkip).isEqualTo(0);
+        assertThat(offset.get(SourceInfo.EVENTS_TO_SKIP_OFFSET_KEY)).isNull();
+        if (source.gtidSet() != null) {
+            assertThat(offset.get(SourceInfo.GTID_SET_KEY)).isEqualTo(source.gtidSet());
+        }
+    }
+
+    protected void handleNextEvent(long positionOfEvent, long eventSize, int rowCount) {
+        if (inTxn) ++eventNumberInTxn;
+        source.setEventPosition(positionOfEvent, eventSize);
+        for (int row = 0; row != rowCount; ++row) {
             // Get the offset for this row (always first!) ...
-            Map<String, ?> offset = source.offsetForRow(i, rowCount);
-            if ((i + 1) < rowCount) {
-                // This is not the last row, so the next binlog position should be for next row in this event ...
-                assertThat(offset.get(SourceInfo.BINLOG_POSITION_OFFSET_KEY)).isEqualTo(positionOfEvent);
-                assertThat(offset.get(SourceInfo.BINLOG_EVENT_ROW_NUMBER_OFFSET_KEY)).isEqualTo(i+1);
-            } else {
-                // This is the last row, so the next binlog position should be for first row in next event ...
-                assertThat(offset.get(SourceInfo.BINLOG_POSITION_OFFSET_KEY)).isEqualTo(positionOfEvent + eventSize);
-                assertThat(offset.get(SourceInfo.BINLOG_EVENT_ROW_NUMBER_OFFSET_KEY)).isEqualTo(0);
-            }
+            Map<String, ?> offset = source.offsetForRow(row, rowCount);
             assertThat(offset.get(SourceInfo.BINLOG_FILENAME_OFFSET_KEY)).isEqualTo(FILENAME);
-            if ( source.gtidSet() != null ) {
+            if (source.gtidSet() != null) {
                 assertThat(offset.get(SourceInfo.GTID_SET_KEY)).isEqualTo(source.gtidSet());
+            }
+            long position = (Long) offset.get(SourceInfo.BINLOG_POSITION_OFFSET_KEY);
+            if (inTxn) {
+                // regardless of the row count, the position is always the txn begin position ...
+                assertThat(position).isEqualTo(positionOfBeginEvent);
+                // and the number of the last completed event (the previous one) ...
+                Long eventsToSkip = (Long) offset.get(SourceInfo.EVENTS_TO_SKIP_OFFSET_KEY);
+                if (eventsToSkip == null) eventsToSkip = 0L;
+                assertThat(eventsToSkip).isEqualTo(eventNumberInTxn - 1);
+            } else {
+                // Matches the next event ...
+                assertThat(position).isEqualTo(positionOfEvent + eventSize);
+                assertThat(offset.get(SourceInfo.EVENTS_TO_SKIP_OFFSET_KEY)).isNull();
+            }
+            Long rowsToSkip = (Long) offset.get(SourceInfo.BINLOG_ROW_IN_EVENT_OFFSET_KEY);
+            if (rowsToSkip == null) rowsToSkip = 0L;
+            if( (row+1) == rowCount) {
+                // This is the last row, so the next binlog position should be the number of rows in the event ...
+                assertThat(rowsToSkip).isEqualTo(rowCount);
+            } else {
+                // This is not the last row, so the next binlog position should be the row number ...
+                assertThat(rowsToSkip).isEqualTo(row+1);
             }
             // Get the source struct for this row (always second), which should always reflect this row in this event ...
             Struct recordSource = source.struct();
             assertThat(recordSource.getInt64(SourceInfo.BINLOG_POSITION_OFFSET_KEY)).isEqualTo(positionOfEvent);
-            assertThat(recordSource.getInt32(SourceInfo.BINLOG_EVENT_ROW_NUMBER_OFFSET_KEY)).isEqualTo(i);
+            assertThat(recordSource.getInt32(SourceInfo.BINLOG_ROW_IN_EVENT_OFFSET_KEY)).isEqualTo(row);
             assertThat(recordSource.getString(SourceInfo.BINLOG_FILENAME_OFFSET_KEY)).isEqualTo(FILENAME);
-            if ( source.gtidSet() != null ) {
+            if (source.gtidSet() != null) {
                 assertThat(recordSource.getString(SourceInfo.GTID_SET_KEY)).isEqualTo(source.gtidSet());
             }
         }
+        source.completeEvent();
     }
 
     protected Map<String, String> offset(long position, int row) {
@@ -326,7 +412,7 @@ public class SourceInfoTest {
         Map<String, String> offset = new HashMap<>();
         offset.put(SourceInfo.BINLOG_FILENAME_OFFSET_KEY, FILENAME);
         offset.put(SourceInfo.BINLOG_POSITION_OFFSET_KEY, Long.toString(position));
-        offset.put(SourceInfo.BINLOG_EVENT_ROW_NUMBER_OFFSET_KEY, Integer.toString(row));
+        offset.put(SourceInfo.BINLOG_ROW_IN_EVENT_OFFSET_KEY, Integer.toString(row));
         if (gtidSet != null) offset.put(SourceInfo.GTID_SET_KEY, gtidSet);
         if (snapshot) offset.put(SourceInfo.SNAPSHOT_KEY, Boolean.TRUE.toString());
         return offset;
@@ -393,12 +479,40 @@ public class SourceInfoTest {
 
     @Test
     public void shouldOrderPositionWithoutGtidAsBeforePositionWithGtid() {
-        assertPositionWithoutGtids("filename.01", Integer.MAX_VALUE, 0).isBefore(positionWithGtids("IdA:1-5"));
+        assertPositionWithoutGtids("filename.01", Integer.MAX_VALUE, 0, 0).isBefore(positionWithGtids("IdA:1-5"));
     }
 
     @Test
     public void shouldOrderPositionWithGtidAsAfterPositionWithoutGtid() {
-        assertPositionWithGtids("IdA:1-5").isAfter(positionWithoutGtids("filename.01", 0, 0));
+        assertPositionWithGtids("IdA:1-5").isAfter(positionWithoutGtids("filename.01", 0, 0, 0));
+    }
+
+    @Test
+    public void shouldComparePositionsWithoutGtids() {
+        // Same position ...
+        assertPositionWithoutGtids("fn.01", 1, 0, 0).isAt(positionWithoutGtids("fn.01", 1, 0, 0));
+        assertPositionWithoutGtids("fn.01", 1, 0, 1).isAt(positionWithoutGtids("fn.01", 1, 0, 1));
+        assertPositionWithoutGtids("fn.03", 1, 0, 1).isAt(positionWithoutGtids("fn.03", 1, 0, 1));
+        assertPositionWithoutGtids("fn.01", 1, 1, 0).isAt(positionWithoutGtids("fn.01", 1, 1, 0));
+        assertPositionWithoutGtids("fn.01", 1, 1, 1).isAt(positionWithoutGtids("fn.01", 1, 1, 1));
+        assertPositionWithoutGtids("fn.03", 1, 1, 1).isAt(positionWithoutGtids("fn.03", 1, 1, 1));
+
+        // Before position ...
+        assertPositionWithoutGtids("fn.01", 1, 0, 0).isBefore(positionWithoutGtids("fn.01", 1, 0, 1));
+        assertPositionWithoutGtids("fn.01", 1, 0, 0).isBefore(positionWithoutGtids("fn.01", 2, 0, 0));
+        assertPositionWithoutGtids("fn.01", 1, 0, 1).isBefore(positionWithoutGtids("fn.01", 1, 0, 2));
+        assertPositionWithoutGtids("fn.01", 1, 0, 1).isBefore(positionWithoutGtids("fn.01", 2, 0, 0));
+        assertPositionWithoutGtids("fn.01", 1, 1, 0).isBefore(positionWithoutGtids("fn.01", 1, 1, 1));
+        assertPositionWithoutGtids("fn.01", 1, 1, 0).isBefore(positionWithoutGtids("fn.01", 1, 2, 0));
+        assertPositionWithoutGtids("fn.01", 1, 1, 1).isBefore(positionWithoutGtids("fn.01", 1, 2, 0));
+        assertPositionWithoutGtids("fn.01", 1, 1, 1).isBefore(positionWithoutGtids("fn.01", 2, 0, 0));
+
+        // After position ...
+        assertPositionWithoutGtids("fn.01", 1, 0, 1).isAfter(positionWithoutGtids("fn.01", 0, 0, 99));
+        assertPositionWithoutGtids("fn.01", 1, 0, 1).isAfter(positionWithoutGtids("fn.01", 1, 0, 0));
+        assertPositionWithoutGtids("fn.01", 1, 1, 1).isAfter(positionWithoutGtids("fn.01", 0, 0, 99));
+        assertPositionWithoutGtids("fn.01", 1, 1, 1).isAfter(positionWithoutGtids("fn.01", 1, 0, 0));
+        assertPositionWithoutGtids("fn.01", 1, 1, 1).isAfter(positionWithoutGtids("fn.01", 1, 1, 0));
     }
 
     @FixFor("DBZ-107")
@@ -410,21 +524,21 @@ public class SourceInfoTest {
         String gtidCleaned = "036d85a9-64e5-11e6-9b48-42010af0000c:1-2," +
                 "7145bf69-d1ca-11e5-a588-0242ac110004:1-3149," +
                 "7c1de3f2-3fd2-11e6-9cdc-42010af000bc:1-39";
-        source.setGtidSet(gtidExecuted);
+        source.setCompletedGtidSet(gtidExecuted);
         assertThat(source.gtidSet()).isEqualTo(gtidCleaned);
     }
 
     @FixFor("DBZ-107")
     @Test
     public void shouldNotSetBlankGtidSet() {
-        source.setGtidSet("");
+        source.setCompletedGtidSet("");
         assertThat(source.gtidSet()).isNull();
     }
 
     @FixFor("DBZ-107")
     @Test
     public void shouldNotSetNullGtidSet() {
-        source.setGtidSet(null);
+        source.setCompletedGtidSet(null);
         assertThat(source.gtidSet()).isNull();
     }
 
@@ -439,20 +553,22 @@ public class SourceInfoTest {
         return Document.create(SourceInfo.GTID_SET_KEY, gtids);
     }
 
-    protected Document positionWithoutGtids(String filename, int position, int row) {
-        return positionWithoutGtids(filename, position, row, false);
+    protected Document positionWithoutGtids(String filename, int position, int event, int row) {
+        return positionWithoutGtids(filename, position, event, row, false);
     }
 
-    protected Document positionWithoutGtids(String filename, int position, int row, boolean snapshot) {
+    protected Document positionWithoutGtids(String filename, int position, int event, int row, boolean snapshot) {
         if (snapshot) {
             return Document.create(SourceInfo.BINLOG_FILENAME_OFFSET_KEY, filename,
                                    SourceInfo.BINLOG_POSITION_OFFSET_KEY, position,
-                                   SourceInfo.BINLOG_EVENT_ROW_NUMBER_OFFSET_KEY, row,
+                                   SourceInfo.BINLOG_ROW_IN_EVENT_OFFSET_KEY, row,
+                                   SourceInfo.EVENTS_TO_SKIP_OFFSET_KEY, event,
                                    SourceInfo.SNAPSHOT_KEY, true);
         }
         return Document.create(SourceInfo.BINLOG_FILENAME_OFFSET_KEY, filename,
                                SourceInfo.BINLOG_POSITION_OFFSET_KEY, position,
-                               SourceInfo.BINLOG_EVENT_ROW_NUMBER_OFFSET_KEY, row);
+                               SourceInfo.BINLOG_ROW_IN_EVENT_OFFSET_KEY, row,
+                               SourceInfo.EVENTS_TO_SKIP_OFFSET_KEY, event);
     }
 
     protected PositionAssert assertThatDocument(Document position) {
@@ -467,12 +583,12 @@ public class SourceInfoTest {
         return assertThatDocument(positionWithGtids(gtids, snapshot));
     }
 
-    protected PositionAssert assertPositionWithoutGtids(String filename, int position, int row) {
-        return assertPositionWithoutGtids(filename, position, row, false);
+    protected PositionAssert assertPositionWithoutGtids(String filename, int position, int event, int row) {
+        return assertPositionWithoutGtids(filename, position, event, row, false);
     }
 
-    protected PositionAssert assertPositionWithoutGtids(String filename, int position, int row, boolean snapshot) {
-        return assertThatDocument(positionWithoutGtids(filename, position, row, snapshot));
+    protected PositionAssert assertPositionWithoutGtids(String filename, int position, int event, int row, boolean snapshot) {
+        return assertThatDocument(positionWithoutGtids(filename, position, event, row, snapshot));
     }
 
     protected static class PositionAssert extends GenericAssert<PositionAssert, Document> {

--- a/debezium-connector-mysql/src/test/resources/log4j.properties
+++ b/debezium-connector-mysql/src/test/resources/log4j.properties
@@ -12,3 +12,4 @@ log4j.logger.io.debezium=INFO
 log4j.logger.io.debezium.embedded.EmbeddedEngine$EmbeddedConfig=WARN
 #log4j.logger.io.debezium.connector.mysql.BinlogReader=DEBUG
 #log4j.logger.io.debezium.connector.mysql.SnapshotReader=DEBUG
+#log4j.logger.io.debezium.relational.history=DEBUG

--- a/debezium-core/src/main/java/io/debezium/document/Document.java
+++ b/debezium-core/src/main/java/io/debezium/document/Document.java
@@ -92,6 +92,19 @@ public interface Document extends Iterable<Document.Field>, Comparable<Document>
         return new BasicDocument().set(fieldName1, value1).set(fieldName2, value2).set(fieldName3, value3).set(fieldName4, value4);
     }
 
+    static Document create(CharSequence fieldName1, Object value1, CharSequence fieldName2, Object value2, CharSequence fieldName3,
+                           Object value3, CharSequence fieldName4, Object value4, CharSequence fieldName5, Object value5) {
+        return new BasicDocument().set(fieldName1, value1).set(fieldName2, value2).set(fieldName3, value3).set(fieldName4, value4)
+                                  .set(fieldName5, value5);
+    }
+
+    static Document create(CharSequence fieldName1, Object value1, CharSequence fieldName2, Object value2, CharSequence fieldName3,
+                           Object value3, CharSequence fieldName4, Object value4, CharSequence fieldName5, Object value5,
+                           CharSequence fieldName6, Object value6) {
+        return new BasicDocument().set(fieldName1, value1).set(fieldName2, value2).set(fieldName3, value3).set(fieldName4, value4)
+                                  .set(fieldName5, value5).set(fieldName6, value6);
+    }
+
     /**
      * Return the number of name-value fields in this object.
      * 
@@ -159,7 +172,7 @@ public interface Document extends Iterable<Document.Field>, Comparable<Document>
             parent = find(parentPath, (missingPath, missingIndex) -> {
                 invalid.accept(missingPath); // invoke the invalid handler
                 return Optional.empty();
-            } , invalid);
+            }, invalid);
         } else {
             // Create any missing intermediaries using the segment after the missing segment to determine which
             // type of intermediate value to add ...
@@ -170,7 +183,7 @@ public interface Document extends Iterable<Document.Field>, Comparable<Document>
                 } else {
                     return Optional.of(Value.create(Document.create()));
                 }
-            } , invalid);
+            }, invalid);
         }
         if (!parent.isPresent()) return Optional.empty();
         String lastSegment = path.lastSegment().get();
@@ -202,8 +215,7 @@ public interface Document extends Iterable<Document.Field>, Comparable<Document>
      *         valid
      */
     default Optional<Value> find(Path path) {
-        return find(path, (missingPath, missingIndex) -> Optional.empty(), (invalidPath) -> {
-        });
+        return find(path, (missingPath, missingIndex) -> Optional.empty(), (invalidPath) -> {});
     }
 
     /**
@@ -719,7 +731,7 @@ public interface Document extends Iterable<Document.Field>, Comparable<Document>
      * @return This document, to allow for chaining methods
      */
     Document removeAll();
-    
+
     /**
      * Sets on this object all name/value pairs from the supplied object. If the supplied object is null, this method does
      * nothing.

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
@@ -1169,8 +1169,9 @@ public class JdbcValueConverters implements ValueConverterProvider {
      */
     protected Object handleUnknownData(Column column, Field fieldDefn, Object data) {
         if (column.isOptional() || fieldDefn.schema().isOptional()) {
+            Class<?> dataClass = data.getClass();
             logger.warn("Unexpected value for JDBC type {} and column {}: class={}", column.jdbcType(), column,
-                        data.getClass()); // don't include value in case its sensitive
+                        dataClass.isArray() ? dataClass.getSimpleName() : dataClass.getName()); // don't include value in case its sensitive
             return null;
         }
         throw new IllegalArgumentException("Unexpected value for JDBC type " + column.jdbcType() + " and column " + column +

--- a/debezium-core/src/main/java/io/debezium/relational/history/AbstractDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/AbstractDatabaseHistory.java
@@ -46,6 +46,7 @@ public abstract class AbstractDatabaseHistory implements DatabaseHistory {
 
     @Override
     public final void recover(Map<String, ?> source, Map<String, ?> position, Tables schema, DdlParser ddlParser) {
+        logger.debug("Recovering DDL history for source partition {} and offset {}",source,position);
         HistoryRecord stopPoint = new HistoryRecord(source, position, null, null);
         recoverRecords(schema,ddlParser,recovered->{
             if (comparator.isAtOrBefore(recovered,stopPoint)) {
@@ -53,7 +54,10 @@ public abstract class AbstractDatabaseHistory implements DatabaseHistory {
                 if (ddl != null) {
                     ddlParser.setCurrentSchema(recovered.databaseName()); // may be null
                     ddlParser.parse(ddl, schema);
+                    logger.debug("Applying: {}", ddl);
                 }
+            } else {
+                logger.debug("Skipping: {}", recovered.ddl());
             }
         });
     }

--- a/debezium-core/src/test/java/io/debezium/data/VerifyRecord.java
+++ b/debezium-core/src/test/java/io/debezium/data/VerifyRecord.java
@@ -281,7 +281,7 @@ public class VerifyRecord {
      * @param record the record to validate; may not be null
      */
     public static void isValid(SourceRecord record) {
-        print(record);
+        //print(record);
 
         JsonNode keyJson = null;
         JsonNode valueJson = null;

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -7,8 +7,11 @@ package io.debezium.embedded;
 
 import static org.junit.Assert.fail;
 
+import java.math.BigDecimal;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -22,6 +25,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigValue;
@@ -29,11 +33,17 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.json.JsonDeserializer;
+import org.apache.kafka.connect.runtime.WorkerConfig;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.FileOffsetBackingStore;
+import org.apache.kafka.connect.storage.OffsetStorageReaderImpl;
+import org.fest.assertions.Delta;
 import org.junit.After;
 import org.junit.Before;
 import org.slf4j.Logger;
@@ -42,8 +52,10 @@ import org.slf4j.LoggerFactory;
 import static org.fest.assertions.Assertions.assertThat;
 
 import io.debezium.config.Configuration;
+import io.debezium.data.SchemaUtil;
 import io.debezium.data.VerifyRecord;
 import io.debezium.embedded.EmbeddedEngine.CompletionCallback;
+import io.debezium.embedded.EmbeddedEngine.EmbeddedConfig;
 import io.debezium.function.BooleanConsumer;
 import io.debezium.relational.history.HistoryRecord;
 import io.debezium.util.LoggingContext;
@@ -162,6 +174,22 @@ public abstract class AbstractConnectorTest implements Testing {
     }
 
     /**
+     * Create a {@link CompletionCallback} that logs when the engine fails to start the connector or when the connector
+     * stops running after completing successfully or due to an error
+     * 
+     * @return the logging {@link CompletionCallback}
+     */
+    protected CompletionCallback loggingCompletion() {
+        return (success, msg, error) -> {
+            if (success) {
+                logger.info(msg);
+            } else {
+                logger.error(msg, error);
+            }
+        };
+    }
+
+    /**
      * Start the connector using the supplied connector configuration, where upon completion the status of the connector is
      * logged.
      * 
@@ -169,13 +197,21 @@ public abstract class AbstractConnectorTest implements Testing {
      * @param connectorConfig the configuration for the connector; may not be null
      */
     protected void start(Class<? extends SourceConnector> connectorClass, Configuration connectorConfig) {
-        start(connectorClass, connectorConfig, (success, msg, error) -> {
-            if (success) {
-                logger.info(msg);
-            } else {
-                logger.error(msg, error);
-            }
-        });
+        start(connectorClass, connectorConfig, loggingCompletion(), null);
+    }
+
+    /**
+     * Start the connector using the supplied connector configuration, where upon completion the status of the connector is
+     * logged. The connector will stop immediately when the supplied predicate returns true.
+     * 
+     * @param connectorClass the connector class; may not be null
+     * @param connectorConfig the configuration for the connector; may not be null
+     * @param isStopRecord the function that will be called to determine if the connector should be stopped before processing
+     *            this record; may be null if not needed
+     */
+    protected void start(Class<? extends SourceConnector> connectorClass, Configuration connectorConfig,
+                         Predicate<SourceRecord> isStopRecord) {
+        start(connectorClass, connectorConfig, loggingCompletion(), isStopRecord);
     }
 
     /**
@@ -186,7 +222,23 @@ public abstract class AbstractConnectorTest implements Testing {
      * @param callback the function that will be called when the engine fails to start the connector or when the connector
      *            stops running after completing successfully or due to an error; may be null
      */
-    protected void start(Class<? extends SourceConnector> connectorClass, Configuration connectorConfig, CompletionCallback callback) {
+    protected void start(Class<? extends SourceConnector> connectorClass, Configuration connectorConfig,
+                         CompletionCallback callback) {
+        start(connectorClass, connectorConfig, callback, null);
+    }
+
+    /**
+     * Start the connector using the supplied connector configuration.
+     * 
+     * @param connectorClass the connector class; may not be null
+     * @param connectorConfig the configuration for the connector; may not be null
+     * @param isStopRecord the function that will be called to determine if the connector should be stopped before processing
+     *            this record; may be null if not needed
+     * @param callback the function that will be called when the engine fails to start the connector or when the connector
+     *            stops running after completing successfully or due to an error; may be null
+     */
+    protected void start(Class<? extends SourceConnector> connectorClass, Configuration connectorConfig,
+                         CompletionCallback callback, Predicate<SourceRecord> isStopRecord) {
         Configuration config = Configuration.copy(connectorConfig)
                                             .with(EmbeddedEngine.ENGINE_NAME, "testing-connector")
                                             .with(EmbeddedEngine.CONNECTOR_CLASS, connectorClass.getName())
@@ -202,11 +254,14 @@ public abstract class AbstractConnectorTest implements Testing {
             }
             Testing.debug("Stopped connector");
         };
-
         // Create the connector ...
         engine = EmbeddedEngine.create()
                                .using(config)
                                .notifying((record) -> {
+                                   if (isStopRecord != null && isStopRecord.test(record)) {
+                                       logger.error("Stopping connector after record as requested");
+                                       throw new ConnectException("Stopping connector after record as requested");
+                                   }
                                    try {
                                        consumedLines.put(record);
                                    } catch (InterruptedException e) {
@@ -306,7 +361,6 @@ public abstract class AbstractConnectorTest implements Testing {
         consumeRecords(numRecords, records::add);
         return records;
     }
-    
 
     protected class SourceRecords {
         private final List<SourceRecord> records = new ArrayList<>();
@@ -467,6 +521,55 @@ public abstract class AbstractConnectorTest implements Testing {
     protected void assertTombstone(SourceRecord record) {
         VerifyRecord.isValidTombstone(record);
     }
+    
+    protected void assertOffset(SourceRecord record, Map<String,?> expectedOffset) {
+        Map<String,?> offset = record.sourceOffset();
+        assertThat(offset).isEqualTo(expectedOffset);
+    }
+    
+    protected void assertOffset(SourceRecord record, String offsetField, Object expectedValue) {
+        Map<String,?> offset = record.sourceOffset();
+        Object value = offset.get(offsetField);
+        assertSameValue(value,expectedValue);
+    }
+    
+    protected void assertValueField(SourceRecord record, String fieldPath, Object expectedValue) {
+        Object value = record.value();
+        String[] fieldNames = fieldPath.split("/");
+        String pathSoFar = null;
+        for (int i=0; i!=fieldNames.length; ++i) {
+            String fieldName = fieldNames[i];
+            if (value instanceof Struct) {
+                value = ((Struct)value).get(fieldName);
+            } else {
+                // We expected the value to be a struct ...
+                String path = pathSoFar == null ? "record value" : ("'" + pathSoFar + "'");
+                String msg = "Expected the " + path + " to be a Struct but was " + value.getClass().getSimpleName() + " in record: " + SchemaUtil.asString(record);
+                fail(msg);
+            }
+            pathSoFar = pathSoFar == null ? fieldName : pathSoFar + "/" + fieldName;
+        }
+        assertSameValue(value,expectedValue);
+    }
+    
+    private void assertSameValue(Object actual, Object expected) {
+        if(expected instanceof Double || expected instanceof Float || expected instanceof BigDecimal) {
+            // Value should be within 1%
+            double expectedNumericValue = ((Number)expected).doubleValue();
+            double actualNumericValue = ((Number)actual).doubleValue();
+            assertThat(actualNumericValue).isEqualTo(expectedNumericValue, Delta.delta(0.01d*expectedNumericValue));
+        } else if (expected instanceof Integer || expected instanceof Long || expected instanceof Short) {
+            long expectedNumericValue = ((Number)expected).longValue();
+            long actualNumericValue = ((Number)actual).longValue();
+            assertThat(actualNumericValue).isEqualTo(expectedNumericValue);
+        } else if (expected instanceof Boolean) {
+            boolean expectedValue = ((Boolean)expected).booleanValue();
+            boolean actualValue = ((Boolean)expected).booleanValue();
+            assertThat(actualValue).isEqualTo(expectedValue);
+        } else {
+            assertThat(actual).isEqualTo(expected);
+        }
+    }
 
     /**
      * Assert that the supplied {@link Struct} is {@link Struct#validate() valid} and its {@link Struct#schema() schema}
@@ -512,7 +615,8 @@ public abstract class AbstractConnectorTest implements Testing {
         assertThat(value.errorMessages().size()).isEqualTo(numErrors);
     }
 
-    protected void assertConfigurationErrors(Config config, io.debezium.config.Field field, int minErrorsInclusive, int maxErrorsInclusive) {
+    protected void assertConfigurationErrors(Config config, io.debezium.config.Field field, int minErrorsInclusive,
+                                             int maxErrorsInclusive) {
         ConfigValue value = configValue(config, field.name());
         assertThat(value.errorMessages().size()).isGreaterThanOrEqualTo(minErrorsInclusive);
         assertThat(value.errorMessages().size()).isLessThanOrEqualTo(maxErrorsInclusive);
@@ -526,8 +630,8 @@ public abstract class AbstractConnectorTest implements Testing {
     protected void assertNoConfigurationErrors(Config config, io.debezium.config.Field... fields) {
         for (io.debezium.config.Field field : fields) {
             ConfigValue value = configValue(config, field.name());
-            if ( value != null ) {
-                if ( !value.errorMessages().isEmpty() ) {
+            if (value != null) {
+                if (!value.errorMessages().isEmpty()) {
                     fail("Error messages on field '" + field.name() + "': " + value.errorMessages());
                 }
             }
@@ -536,6 +640,61 @@ public abstract class AbstractConnectorTest implements Testing {
 
     protected ConfigValue configValue(Config config, String fieldName) {
         return config.configValues().stream().filter(value -> value.name().equals(fieldName)).findFirst().orElse(null);
+    }
+
+    /**
+     * Utility to read the last committed offset for the specified partition.
+     * 
+     * @param config the configuration of the engine used to persist the offsets
+     * @param partition the partition
+     * @return the map of partitions to offsets; never null but possibly empty
+     */
+    protected <T> Map<String, Object> readLastCommittedOffset(Configuration config, Map<String, T> partition) {
+        return readLastCommittedOffsets(config, Arrays.asList(partition)).get(partition);
+    }
+
+    /**
+     * Utility to read the last committed offsets for the specified partitions.
+     * 
+     * @param config the configuration of the engine used to persist the offsets
+     * @param partitions the partitions
+     * @return the map of partitions to offsets; never null but possibly empty
+     */
+    protected <T> Map<Map<String, T>, Map<String, Object>> readLastCommittedOffsets(Configuration config,
+                                                                                    Collection<Map<String, T>> partitions) {
+        config = config.edit().with(EmbeddedEngine.ENGINE_NAME, "testing-connector")
+                       .with(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG, OFFSET_STORE_PATH)
+                       .with(EmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS, 0)
+                       .build();
+
+        final String engineName = config.getString(EmbeddedEngine.ENGINE_NAME);
+        Converter keyConverter = config.getInstance(EmbeddedEngine.INTERNAL_KEY_CONVERTER_CLASS, Converter.class);
+        keyConverter.configure(config.subset(EmbeddedEngine.INTERNAL_KEY_CONVERTER_CLASS.name() + ".", true).asMap(), true);
+        Converter valueConverter = config.getInstance(EmbeddedEngine.INTERNAL_VALUE_CONVERTER_CLASS, Converter.class);
+        Configuration valueConverterConfig = config;
+        if (valueConverter instanceof JsonConverter) {
+            // Make sure that the JSON converter is configured to NOT enable schemas ...
+            valueConverterConfig = config.edit().with(EmbeddedEngine.INTERNAL_VALUE_CONVERTER_CLASS + ".schemas.enable", false).build();
+        }
+        valueConverter.configure(valueConverterConfig.subset(EmbeddedEngine.INTERNAL_VALUE_CONVERTER_CLASS.name() + ".", true).asMap(),
+                                 false);
+
+        // Create the worker config, adding extra fields that are required for validation of a worker config
+        // but that are not used within the embedded engine (since the source records are never serialized) ...
+        Map<String, String> embeddedConfig = config.asMap(EmbeddedEngine.ALL_FIELDS);
+        embeddedConfig.put(WorkerConfig.KEY_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+        embeddedConfig.put(WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, JsonConverter.class.getName());
+        WorkerConfig workerConfig = new EmbeddedConfig(embeddedConfig);
+
+        FileOffsetBackingStore offsetStore = new FileOffsetBackingStore();
+        offsetStore.configure(workerConfig);
+        offsetStore.start();
+        try {
+            OffsetStorageReaderImpl offsetReader = new OffsetStorageReaderImpl(offsetStore, engineName, keyConverter, valueConverter);
+            return offsetReader.offsets(partitions);
+        } finally {
+            offsetStore.stop();
+        }
     }
 
 }


### PR DESCRIPTION
Added tests to verify whether the connector is properly restarting in the binlog when previously the connector failed or stopped in the middle of a transaction. The tests showed that the connector is not able to properly start when using or not using GTIDs, since restarting from an arbitrary binlog event causes problems since the `TABLE_MAP` events for the affected tables are skipped.

The logic was changed significantly to record in the offsets the binlog coordinates of each transaction, which should work whether or not GTIDs are used. Upon restart, the connector may have to re-read the events that were previously processed, but now the offset also includes the number of events that were previously processed so that these can be skipped upon restart. When GTIDs are used, the offset also includes the GTID set from the last transaction known to have completed.

This has an unforunate side effect since the offsets capture a transaction was completed only when it generates a source record for the subsequent transaction. This is because the connector generates source records (with their offsets) for the binlog events in the transaction before the transaction's commit is seen. And, since no additional source records are produced for the transaction commit, the recorded offsets will show that the prior transaction is complete and that all of the events in the subsequent transaction are to be skipped. Thus, upon restart the connector has to re-read (but ignore) all of the binlog events associated with the completed transaction. This shouldn’t be a problem, and will only slow restarts for very large transactions.