### PR TITLE
DBZ-149 Corrected type of BINARY column

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
@@ -108,9 +108,9 @@ public class MySqlDdlParser extends DdlParser {
         dataTypes.register(Types.INTEGER, "YEAR[(2|4)]");
         dataTypes.register(Types.BLOB, "CHAR[(L)] BINARY");
         dataTypes.register(Types.BLOB, "VARCHAR(L) BINARY");
-        dataTypes.register(Types.CHAR, "CHAR[(L)]");
+        dataTypes.register(Types.BLOB, "BINARY[(L)]");
         dataTypes.register(Types.VARCHAR, "VARCHAR(L)");
-        dataTypes.register(Types.CHAR, "BINARY[(L)]");
+        dataTypes.register(Types.CHAR, "CHAR[(L)]");
         dataTypes.register(Types.VARBINARY, "VARBINARY(L)");
         dataTypes.register(Types.BLOB, "TINYBLOB");
         dataTypes.register(Types.BLOB, "BLOB");


### PR DESCRIPTION
The MySQL connector (or rather the DDL parser used in the connector) improperly assumed a `CHAR` JDBC type (and Avro schema `STRING` type) for MySQL columns of type `BINARY`. This corrects the error.