### PR TITLE
DBZ-147 Added ability to treat MySQL DECIMAL as double

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
@@ -18,9 +18,11 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.annotation.NotThreadSafe;
 import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig.DecimalHandlingMode;
 import io.debezium.connector.mysql.MySqlConnectorConfig.TemporalPrecisionMode;
 import io.debezium.connector.mysql.MySqlSystemVariables.Scope;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.jdbc.JdbcValueConverters.DecimalMode;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchema;
@@ -87,7 +89,10 @@ public class MySqlSchema {
         String timePrecisionModeStr = config.getString(MySqlConnectorConfig.TIME_PRECISION_MODE);
         TemporalPrecisionMode timePrecisionMode = TemporalPrecisionMode.parse(timePrecisionModeStr);
         boolean adaptiveTimePrecision = TemporalPrecisionMode.ADAPTIVE.equals(timePrecisionMode);
-        MySqlValueConverters valueConverters = new MySqlValueConverters(adaptiveTimePrecision);
+        String decimalHandlingModeStr = config.getString(MySqlConnectorConfig.DECIMAL_HANDLING_MODE);
+        DecimalHandlingMode decimalHandlingMode = DecimalHandlingMode.parse(decimalHandlingModeStr);
+        DecimalMode decimalMode = decimalHandlingMode.asDecimalMode();
+        MySqlValueConverters valueConverters = new MySqlValueConverters(decimalMode, adaptiveTimePrecision);
         this.schemaBuilder = new TableSchemaBuilder(valueConverters, schemaNameValidator::validate);
 
         // Set up the server name and schema prefix ...

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
@@ -55,12 +55,14 @@ public class MySqlValueConverters extends JdbcValueConverters {
      * to values that require timezones.
      * <p>
      * 
+     * @param decimalMode how {@code DECIMAL} and {@code NUMERIC} values should be treated; may be null if
+     *            {@link io.debezium.jdbc.JdbcValueConverters.DecimalMode#PRECISE} is to be used
      * @param adaptiveTimePrecision {@code true} if the time, date, and timestamp values should be based upon the precision of the
      *            database columns using {@link io.debezium.time} semantic types, or {@code false} if they should be fixed to
      *            millisecond precision using Kafka Connect {@link org.apache.kafka.connect.data} logical types.
      */
-    public MySqlValueConverters(boolean adaptiveTimePrecision) {
-        this(adaptiveTimePrecision, ZoneOffset.UTC);
+    public MySqlValueConverters(DecimalMode decimalMode, boolean adaptiveTimePrecision) {
+        this(decimalMode, adaptiveTimePrecision, ZoneOffset.UTC);
     }
 
     /**
@@ -68,14 +70,16 @@ public class MySqlValueConverters extends JdbcValueConverters {
      * information to values that require timezones. This default offset should not be needed when values are highly-correlated
      * with the expected SQL/JDBC types.
      * 
+     * @param decimalMode how {@code DECIMAL} and {@code NUMERIC} values should be treated; may be null if
+     *            {@link io.debezium.jdbc.JdbcValueConverters.DecimalMode#PRECISE} is to be used
      * @param adaptiveTimePrecision {@code true} if the time, date, and timestamp values should be based upon the precision of the
      *            database columns using {@link io.debezium.time} semantic types, or {@code false} if they should be fixed to
      *            millisecond precision using Kafka Connect {@link org.apache.kafka.connect.data} logical types.
      * @param defaultOffset the zone offset that is to be used when converting non-timezone related values to values that do
      *            have timezones; may be null if UTC is to be used
      */
-    public MySqlValueConverters(boolean adaptiveTimePrecision, ZoneOffset defaultOffset) {
-        super(adaptiveTimePrecision, defaultOffset);
+    public MySqlValueConverters(DecimalMode decimalMode, boolean adaptiveTimePrecision, ZoneOffset defaultOffset) {
+        super(decimalMode, adaptiveTimePrecision, defaultOffset);
     }
 
     @Override
@@ -199,9 +203,9 @@ public class MySqlValueConverters extends JdbcValueConverters {
             // The BinlogReader sees these JSON values as binary encoded, so we use the binlog client library's utility
             // to parse MySQL's internal binary representation into a JSON string, using the standard formatter.
             try {
-                String json = JsonBinary.parseAsString((byte[])data);
+                String json = JsonBinary.parseAsString((byte[]) data);
                 return json;
-            } catch ( IOException e) {
+            } catch (IOException e) {
                 throw new ConnectException("Failed to parse and read a JSON value on " + column + ": " + e.getMessage(), e);
             }
         }

--- a/debezium-connector-mysql/src/test/docker/init/setup.sql
+++ b/debezium-connector-mysql/src/test/docker/init/setup.sql
@@ -274,6 +274,16 @@ INSERT INTO dbz_123_bitvaluetest VALUES (b'1',b'10',b'01000000',b'10110111000001
 CREATE TABLE dbz_104_customers LIKE connector_test.customers;
 INSERT INTO dbz_104_customers SELECT * FROM connector_test.customers;
 
+-- DBZ-147 handle decimal value
+CREATE TABLE dbz_147_decimalvalues (
+  pk_column int auto_increment NOT NULL,
+  decimal_value decimal(7,2) NOT NULL,
+  PRIMARY KEY(pk_column)
+);
+INSERT INTO dbz_147_decimalvalues (pk_column, decimal_value)
+VALUES(default, 12345.67);
+
+
 -- ----------------------------------------------------------------------------------------------------------------
 -- DATABASE:  json_test
 -- ----------------------------------------------------------------------------------------------------------------

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -115,6 +115,8 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         assertNoConfigurationErrors(result, MySqlConnectorConfig.SSL_KEYSTORE_PASSWORD);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.SSL_TRUSTSTORE);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.SSL_TRUSTSTORE_PASSWORD);
+        assertNoConfigurationErrors(result, MySqlConnectorConfig.DECIMAL_HANDLING_MODE);
+        assertNoConfigurationErrors(result, MySqlConnectorConfig.TIME_PRECISION_MODE);
         assertConfigurationErrors(result, KafkaDatabaseHistory.BOOTSTRAP_SERVERS);
         assertConfigurationErrors(result, KafkaDatabaseHistory.TOPIC);
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS);
@@ -170,6 +172,8 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         assertNoConfigurationErrors(result, MySqlConnectorConfig.SSL_KEYSTORE_PASSWORD);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.SSL_TRUSTSTORE);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.SSL_TRUSTSTORE_PASSWORD);
+        assertNoConfigurationErrors(result, MySqlConnectorConfig.DECIMAL_HANDLING_MODE);
+        assertNoConfigurationErrors(result, MySqlConnectorConfig.TIME_PRECISION_MODE);
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.BOOTSTRAP_SERVERS);
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.TOPIC);
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS);
@@ -219,6 +223,8 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         assertNoConfigurationErrors(result, MySqlConnectorConfig.SSL_KEYSTORE_PASSWORD);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.SSL_TRUSTSTORE);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.SSL_TRUSTSTORE_PASSWORD);
+        assertNoConfigurationErrors(result, MySqlConnectorConfig.DECIMAL_HANDLING_MODE);
+        assertNoConfigurationErrors(result, MySqlConnectorConfig.TIME_PRECISION_MODE);
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.BOOTSTRAP_SERVERS);
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.TOPIC);
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS);
@@ -254,6 +260,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
                                             "regression_test.dbz_114_zerovaluetest",
                                             "regression_test.dbz_123_bitvaluetest",
                                             "regression_test.dbz_104_customers",
+                                            "regression_test.dbz_147_decimalvalues",
                                             "json_test.dbz_126_jsontable");
 
         // Now set the whitelist to two databases ...


### PR DESCRIPTION
By default the MySQL connector handles `DECIMAL` and `NUMERIC` columns using `java.math.BigDecimal` values and describing them using the `org.apache.kafka.connect.data.Decimal` schema type, which serializes the values to a binary form.

This change adds a configuration option that will keep the default behavior, but will instead allow handling `DECIMAL` adn `NUMERIC` values as Java `double` and a schema type of `FLOAT64`.