### PR TITLE
DBZ-153 MySQL connector supports enum and set values with parentheses

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -640,7 +640,8 @@ public class MySqlDdlParserTest {
 
     @Test
     public void shouldParseEnumOptions() {
-        assertParseEnumAndSetOptions("ENUM('a','b','c')", "a,b,c");
+        assertParseEnumAndSetOptions("ENUM('a','b','c')","a,b,c");
+        assertParseEnumAndSetOptions("ENUM('a','multi','multi with () paren', 'other')", "a,multi,multi with () paren,other");
         assertParseEnumAndSetOptions("ENUM('a')", "a");
         assertParseEnumAndSetOptions("ENUM()", "");
         assertParseEnumAndSetOptions("ENUM ('a','b','c') CHARACTER SET", "a,b,c");
@@ -651,6 +652,7 @@ public class MySqlDdlParserTest {
     @Test
     public void shouldParseSetOptions() {
         assertParseEnumAndSetOptions("SET('a','b','c')", "a,b,c");
+        assertParseEnumAndSetOptions("SET('a','multi','multi with () paren', 'other')", "a,multi,multi with () paren,other");
         assertParseEnumAndSetOptions("SET('a')", "a");
         assertParseEnumAndSetOptions("SET()", "");
         assertParseEnumAndSetOptions("SET ('a','b','c') CHARACTER SET", "a,b,c");

--- a/debezium-core/src/test/java/io/debezium/relational/ddl/DataTypeParserTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/ddl/DataTypeParserTest.java
@@ -110,6 +110,8 @@ public class DataTypeParserTest {
     @Test
     public void shouldDetermineTypeWithWildcard() {
         assertType("ENUM('a','b','c')","ENUM",Types.CHAR);
+        assertEnumType("ENUM('a','multi','multi with () paren', 'other') followed by",
+                       "ENUM('a','multi','multi with () paren', 'other')");
     }
     
     protected void assertType( String content, String typeName, int jdbcType ) {
@@ -132,6 +134,15 @@ public class DataTypeParserTest {
         assertThat(type.length()).isEqualTo(length);
         assertThat(type.scale()).isEqualTo(scale);
         assertThat(type.arrayDimensions()).isEqualTo(arrayDims);
+    }
+    
+    protected void assertEnumType( String content, String expression ) {
+        DataType type = parser.parse(text(content), null);
+        assertThat(type).isNotNull();
+        assertThat(type.jdbcType()).isEqualTo(Types.CHAR);
+        assertThat(type.name()).isEqualTo("ENUM");
+        assertThat(type.length()).isEqualTo(-1);
+        assertThat(type.expression()).isEqualTo(expression);
     }
     
     protected void assertNoType( String content ) {


### PR DESCRIPTION
Changed the MySQL connector to support ENUM and SET literals with parentheses.