### PR TITLE
DBZ-162 Corrected DDL parsing of MySQL functions

### DIFF
--- a/debezium-connector-mysql/src/test/docker/init/setup.sql
+++ b/debezium-connector-mysql/src/test/docker/init/setup.sql
@@ -283,6 +283,23 @@ CREATE TABLE dbz_147_decimalvalues (
 INSERT INTO dbz_147_decimalvalues (pk_column, decimal_value)
 VALUES(default, 12345.67);
 
+-- DBZ-162 handle function declarations with newline characters
+DELIMITER $$
+CREATE FUNCTION fnDbz162( p_creditLimit DOUBLE ) RETURNS VARCHAR(10)
+    DETERMINISTIC
+BEGIN
+ DECLARE lvl VARCHAR(10);
+ IF p_creditLimit > 50000 THEN
+   SET lvl = 'PLATINUM';
+ ELSEIF (p_creditLimit <= 50000 AND p_creditLimit >= 10000) THEN
+   SET lvl = 'GOLD';
+ ELSEIF p_creditLimit < 10000 THEN
+   SET lvl = 'SILVER';
+ END IF;
+ RETURN (lvl);
+END;
+$$
+DELIMITER ;
 
 -- ----------------------------------------------------------------------------------------------------------------
 -- DATABASE:  json_test

--- a/debezium-connector-mysql/src/test/resources/ddl/mysql-dbz-162.ddl
+++ b/debezium-connector-mysql/src/test/resources/ddl/mysql-dbz-162.ddl
@@ -1,0 +1,31 @@
+CREATE DEFINER=`trunk2`@`%` FUNCTION `fnContainsMeasure`(
+ physId int,
+ measureId int
+ ) RETURNS tinyint(1)
+    DETERMINISTIC
+begin
+ select
+ s.Result
+ from (
+ SELECT exists(
+ SELECT
+ ph.PhysicianId is not null as Result
+ FROM Physician ph
+ JOIN ReportingOptions ro ON ph.ReportingOptionsId = ro.Id and ph.PhysicianId = physId
+ JOIN ReportingOptionsIndividualMeasure roim ON ro.Id = roim.ReportingOptionsId
+ WHERE
+ roim.IndividualMeasureId = measureId
+ ) as Result
+ ) s
+ limit 1
+ into @result;
+ return @result;
+end;
+
+CREATE TABLE `test` (id INT(11) UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT);
+
+ALTER TABLE `test` CHANGE `id` `collection_id` INT(11)
+UNSIGNED
+NOT NULL
+AUTO_INCREMENT;
+

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/DdlParser.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/DdlParser.java
@@ -582,10 +582,15 @@ public class DdlParser {
             }
             if (tokens.canConsume("BEGIN")) {
                 tokens.consumeThrough("END");
+                while (tokens.canConsume("IF")) {
+                    // We just read through an 'END IF', but need to read until the next 'END'
+                    tokens.consumeThrough("END");
+                }
             } else if (tokens.matches(DdlTokenizer.STATEMENT_TERMINATOR)) {
                 tokens.consume();
                 break;
             }
+            if (!tokens.hasNext()) return;
             tokens.consume();
         }
     }

--- a/debezium-core/src/test/java/io/debezium/relational/history/AbstractDatabaseHistoryTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/history/AbstractDatabaseHistoryTest.java
@@ -80,8 +80,8 @@ public abstract class AbstractDatabaseHistoryTest {
     @Test
     public void shouldRecordChangesAndRecoverToVariousPoints() {
         record(01, 0, "CREATE TABLE foo ( first VARCHAR(22) NOT NULL );", all, t3, t2, t1, t0);
-        record(23, 1, "CREATE TABLE person ( name VARCHAR(22) NOT NULL );", all, t3, t2, t1);
-        record(30, 2, "CREATE TABLE address ( street VARCHAR(22) NOT NULL );", all, t3, t2);
+        record(23, 1, "CREATE TABLE\\nperson ( name VARCHAR(22) NOT NULL );", all, t3, t2, t1);
+        record(30, 2, "CREATE TABLE address\\n( street VARCHAR(22) NOT NULL );", all, t3, t2);
         record(32, 3, "ALTER TABLE address ADD city VARCHAR(22) NOT NULL;", all, t3);
 
         // Testing.Print.enable();


### PR DESCRIPTION
The MySQL DDL parser was not properly consuming function declarations. For functions, the parser consumes the entire statement without handline the various expressions within the function declaration, but the parser was not properly finding the end of the statement and instead was continuing to try to consume values beyond the end of the statement.

Specifically, when the parser consumes a `BEGIN`, it looks for a corresponding `END`. However, if it encountered an `END IF`, the `IF` plus any remaining tokens were left on the token stream and unprocessed. This confused the parser, which keep looking for statements and ultimately ended with a `No more content` error.

This case was replicated in integration tests, and the code fixed to properly find the end of the statements.