### PR TITLE
DBZ-163 Stop Travis-CI’s MySQL and PostgreSQL instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,11 @@ jdk:
 services:
   - docker
 
-# Install Maven 3.3.9, since the Jolokia Maven plugin requires 3.2.1 or later but Travis current runs 3.1.x
+# First stop MySQL and PostgreSQL that run by default (see DBZ-163). Then check Docker status. Finally,
+# install Maven 3.3.9, since the Jolokia Maven plugin requires 3.2.1 or later but Travis current runs 3.1.x
 before_install:
+  - sudo service mysql-5.6 stop || sudo service mysql stop
+  - sudo /etc/init.d/postgresql stop
   - docker -v
   - docker ps -a
   - wget https://archive.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip


### PR DESCRIPTION
Recently, Travis-CI changed the sudo enabled Trusty images that we use in our builds to by-default install and run MySQL 5.6 and Postgres 9.6. This commit stops those services in the `before_install` step of our Travis-CI builds.