### PR TITLE
DBZ-168 MySQL connector ignores XA binlog events

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -425,6 +425,10 @@ public class BinlogReader extends AbstractReader {
             skipEvent = false;
             return;
         }
+        if (sql.toUpperCase().startsWith("XA ")) {
+            // This is an XA transaction, and we currently ignore these and do nothing ...
+            return;
+        }
         context.dbSchema().applyDdl(context.source(), command.getDatabase(), command.getSql(), (dbName, statements) -> {
             if (recordSchemaChangesInSourceRecords && recordMakers.schemaChanges(dbName, statements, super::enqueueRecord) > 0) {
                 logger.debug("Recorded DDL statements for database '{}': {}", dbName, statements);


### PR DESCRIPTION
MySQL 5.7.7 introduced new behavior for handling XA events in the binlog. See the [MySQL documentation](http://dev.mysql.com/doc/refman/5.7/en/xa-restrictions.html) for details. This PR changes the binlog reader so that `XA …` statements appearing in the binlog are ignored altogether.