### PR TITLE
DBZ-152 Enabled MySQL connector to skip table count checks during snapshot

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -553,13 +553,15 @@ public class MySqlConnectorConfig {
                                                       .withValidation(Field::isPositiveInteger);
 
     public static final Field ROW_COUNT_FOR_STREAMING_RESULT_SETS = Field.create("min.row.count.to.stream.results")
-                                                                         .withDisplayName("Stream result set larger than")
+                                                                         .withDisplayName("Stream result set of size")
                                                                          .withType(Type.LONG)
                                                                          .withWidth(Width.MEDIUM)
                                                                          .withImportance(Importance.LOW)
-                                                                         .withDescription("The number of rows a table must contain to stream results rather than pull all into memory during snapshots. Defaults to 1,000.")
+                                                                         .withDescription("The number of rows a table must contain to stream results rather than pull "
+                                                                                 + "all into memory during snapshots. Defaults to 1,000. Use 0 to stream all results "
+                                                                                 + "and completely avoid checking the size of each table.")
                                                                          .withDefault(1_000)
-                                                                         .withValidation(Field::isPositiveInteger);
+                                                                         .withValidation(Field::isNonNegativeLong);
 
     /**
      * The database history class is hidden in the {@link #configDef()} since that is designed to work with a user interface,


### PR DESCRIPTION
Determining the number of rows in large InnoDB tables using `SELECT COUNT(*) FROM ...` queries could be expensive and time consuming. Rather than always doing these checks, this change expands the MySQL connector’s `min.row.count.to.stream.results` configuration property to accept a value of 0 (rather than just positive numbers). The connector uses a zero value to signify that streaming should be used for all tables and to completely avoid running `SELECT COUNT(*) FROM tableA` queries.