### PR TITLE
DBZ-170 Changed the MongoDB connector’s connection logic

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
@@ -107,6 +107,10 @@ public final class MongoDbConnectorTask extends SourceTask {
             // Read from the configuration the information about the replica sets we are to watch ...
             final String hosts = config.getString(MongoDbConnectorConfig.HOSTS);
             final ReplicaSets replicaSets = ReplicaSets.parse(hosts);
+            if ( replicaSets.validReplicaSetCount() == 0) {
+                logger.info("Unable to start MongoDB connector task since no replica sets were found at {}", hosts);
+                return;
+            }
 
             // Set up the task record queue ...
             this.queue = new TaskRecordQueue(config, replicaSets.replicaSetCount(), running::get, recordSummarizer);
@@ -115,8 +119,10 @@ public final class MongoDbConnectorTask extends SourceTask {
             SourceInfo source = replicationContext.source();
             Collection<Map<String, String>> partitions = new ArrayList<>();
             replicaSets.onEachReplicaSet(replicaSet -> {
-                String replicaSetName = replicaSet.replicaSetName();
-                partitions.add(source.partition(replicaSetName));
+                String replicaSetName = replicaSet.replicaSetName(); // may be null for standalone servers
+                if (replicaSetName != null) {
+                    partitions.add(source.partition(replicaSetName));
+                }
             });
             context.offsetStorageReader().offsets(partitions).forEach(source::setOffsetFor);
 
@@ -124,8 +130,9 @@ public final class MongoDbConnectorTask extends SourceTask {
             final int numThreads = replicaSets.replicaSetCount();
             final ExecutorService executor = Executors.newFixedThreadPool(numThreads);
             AtomicInteger stillRunning = new AtomicInteger(numThreads);
+            logger.info("Ignoring unnamed replica sets: {}", replicaSets.unnamedReplicaSets());
             logger.info("Starting {} thread(s) to replicate replica sets: {}", numThreads, replicaSets);
-            replicaSets.all().forEach(replicaSet -> {
+            replicaSets.validReplicaSets().forEach(replicaSet -> {
                 // Create a replicator for this replica set ...
                 Replicator replicator = new Replicator(replicationContext, replicaSet, queue::enqueue);
                 replicators.add(replicator);
@@ -196,7 +203,7 @@ public final class MongoDbConnectorTask extends SourceTask {
         private final Consumer<List<SourceRecord>> batchConsumer;
 
         protected TaskRecordQueue(Configuration config, int numThreads, BooleanSupplier isRunning,
-                Consumer<List<SourceRecord>> batchConsumer) {
+                                  Consumer<List<SourceRecord>> batchConsumer) {
             final int maxQueueSize = config.getInteger(MongoDbConnectorConfig.MAX_QUEUE_SIZE);
             final long pollIntervalMs = config.getLong(MongoDbConnectorConfig.POLL_INTERVAL_MS);
             maxBatchSize = config.getInteger(MongoDbConnectorConfig.MAX_BATCH_SIZE);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSets.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSets.java
@@ -94,6 +94,15 @@ public class ReplicaSets {
     }
 
     /**
+     * Get the number of replica sets with names.
+     * 
+     * @return the valid replica set count
+     */
+    public int validReplicaSetCount() {
+        return replicaSetsByName.size();
+    }
+    
+    /**
      * Perform the supplied function on each of the replica sets
      * 
      * @param function the consumer function; may not be null
@@ -129,6 +138,28 @@ public class ReplicaSets {
     public List<ReplicaSet> all() {
         List<ReplicaSet> replicaSets = new ArrayList<>();
         replicaSets.addAll(replicaSetsByName.values());
+        replicaSets.addAll(nonReplicaSets);
+        return replicaSets;
+    }
+
+    /**
+     * Get a copy of all of the valid {@link ReplicaSet} objects that have names.
+     * 
+     * @return the valid replica set objects; never null but possibly empty
+     */
+    public List<ReplicaSet> validReplicaSets() {
+        List<ReplicaSet> replicaSets = new ArrayList<>();
+        replicaSets.addAll(replicaSetsByName.values());
+        return replicaSets;
+    }
+
+    /**
+     * Get a copy of all of the {@link ReplicaSet} objects that have no names.
+     * 
+     * @return the unnamed replica set objects; never null but possibly empty
+     */
+    public List<ReplicaSet> unnamedReplicaSets() {
+        List<ReplicaSet> replicaSets = new ArrayList<>();
         replicaSets.addAll(nonReplicaSets);
         return replicaSets;
     }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/SourceInfo.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/SourceInfo.java
@@ -168,6 +168,7 @@ public final class SourceInfo {
      * @return the source partition information; never null
      */
     public Map<String, String> partition(String replicaSetName) {
+        if (replicaSetName == null) throw new IllegalArgumentException("Replica set name may not be null");
         return sourcePartitionsByReplicaSetName.computeIfAbsent(replicaSetName, rsName -> {
             return Collect.hashMapOf(SERVER_ID_KEY, serverName, REPLICA_SET_NAME, rsName);
         });


### PR DESCRIPTION
This change alters the way the MongoDB connects to the various servers in a cluster. Previously, the ConnectionContext constructor currently set up the MongoDB client with credentials for the `admin` and `config` databases, and apparently the client eagerly performs authentication against all databases passed in, rather than doing this lazily as DBs are use.

Instead, the code no longer sets up the credentials for the `config` database and instead only sets up credentials for the `admin` database for authentication and authorization. This works as long as the user specified in the connector configuration can read the `config` database.

Several other changes were made to improve the error handling and reporting when the replica set information cannot be read from the `config` database.