### PR TITLE
DBZ-3 Changed the PostgreSQL connector’s use of Docker containers

### DIFF
--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -138,16 +138,7 @@
                                 </log>
                                 <wait>
                                     <time>30000</time> <!-- 30 seconds max -->
-                                    <!--
-                                        The current debezium/postgres docker image restarts the server once when it initializes 
-                                        permissions, so we can't really wait for a log. Instead, we'll wait for the PG port
-                                        to become available
-                                    -->
-                                    <tcp>
-                                        <ports>
-                                            <port>5432</port>
-                                        </ports>
-                                    </tcp>
+                                    <log>PostgreSQL init process complete</log>
                                 </wait>
                             </run>
                         </image>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <version.war.plugin>2.5</version.war.plugin>
         <version.codehaus.helper.plugin>1.8</version.codehaus.helper.plugin>
         <version.google.formatter.plugin>0.3.1</version.google.formatter.plugin>
-        <version.docker.maven.plugin>0.18.1</version.docker.maven.plugin>
+        <version.docker.maven.plugin>0.19.0</version.docker.maven.plugin>
         <version.staging.plugin>1.6.3</version.staging.plugin>
         <version.protoc.maven.plugin>3.0.0.1</version.protoc.maven.plugin>
 


### PR DESCRIPTION
The PostgreSQL connetor was not able to build locally, since the Maven build would wait forever trying to talk to the TCP port for PostgreSQL before starting the integration tests. Even when I corrected the `wait` specification to use the localhost (rather than the direct container address), the build successfully connected to Postgres when it started the first time but before it shutdown to adjust the configuration, and thus the tests failed as the server was shutdown. The build now looks for a specific log message which is unique and output by the container after the second startup, and this seems to work great (at least locally).