### PR TITLE
Fixed MySQL integration test expected results

### DIFF
--- a/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/master/no-snapshot/filter-db/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/master/no-snapshot/filter-db/env.properties
@@ -10,4 +10,4 @@ connector.timeout.in.seconds=3
 # We ignore the time-related fields in the record value, since these depend upon when the server is started,
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/master/no-snapshot/filter-table/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/master/no-snapshot/filter-table/env.properties
@@ -10,4 +10,4 @@ connector.timeout.in.seconds=3
 # We ignore the time-related fields in the record value, since these depend upon when the server is started,
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/master/no-snapshot/no-filter/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/master/no-snapshot/no-filter/env.properties
@@ -10,4 +10,4 @@ connector.timeout.in.seconds=3
 # We ignore the time-related fields in the record value, since these depend upon when the server is started,
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/master/snapshot/filter-db/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/master/snapshot/filter-db/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=3
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/master/snapshot/filter-table/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/master/snapshot/filter-table/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=3
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/master/snapshot/no-filter/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/master/snapshot/no-filter/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=3
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/replica/no-snapshot/filter-db/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/replica/no-snapshot/filter-db/env.properties
@@ -10,4 +10,4 @@ connector.timeout.in.seconds=3
 # We ignore the time-related fields in the record value, since these depend upon when the server is started,
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/replica/no-snapshot/filter-table/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/replica/no-snapshot/filter-table/env.properties
@@ -10,4 +10,4 @@ connector.timeout.in.seconds=3
 # We ignore the time-related fields in the record value, since these depend upon when the server is started,
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/replica/no-snapshot/no-filter/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/replica/no-snapshot/no-filter/env.properties
@@ -10,4 +10,4 @@ connector.timeout.in.seconds=3
 # We ignore the time-related fields in the record value, since these depend upon when the server is started,
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/replica/snapshot/filter-db/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/replica/snapshot/filter-db/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=3
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/replica/snapshot/filter-table/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/replica/snapshot/filter-table/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=3
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/replica/snapshot/no-filter/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/expected/replica/snapshot/no-filter/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=3
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/no-snapshot/filter-db/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/no-snapshot/filter-db/env.properties
@@ -10,4 +10,4 @@ connector.timeout.in.seconds=3
 # We ignore the time-related fields in the record value, since these depend upon when the server is started,
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/no-snapshot/filter-table/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/no-snapshot/filter-table/env.properties
@@ -10,4 +10,4 @@ connector.timeout.in.seconds=3
 # We ignore the time-related fields in the record value, since these depend upon when the server is started,
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/no-snapshot/no-filter/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/no-snapshot/no-filter/env.properties
@@ -10,4 +10,4 @@ connector.timeout.in.seconds=3
 # We ignore the time-related fields in the record value, since these depend upon when the server is started,
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/snapshot/filter-db/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/snapshot/filter-db/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=3
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/snapshot/filter-db/expected-records.json
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/snapshot/filter-db/expected-records.json
@@ -176,7 +176,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz84_integer_types_table"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz84_integer_types_table`"
   }
 }, {
   "sourcePartition" : {
@@ -266,7 +266,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_123_bitvaluetest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_123_bitvaluetest`"
   }
 }, {
   "sourcePartition" : {
@@ -356,7 +356,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_104_customers"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_104_customers`"
   }
 }, {
   "sourcePartition" : {
@@ -446,7 +446,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_100_enumsettest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_100_enumsettest`"
   }
 }, {
   "sourcePartition" : {
@@ -536,7 +536,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_114_zerovaluetest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_114_zerovaluetest`"
   }
 }, {
   "sourcePartition" : {
@@ -626,7 +626,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_147_decimalvalues"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_147_decimalvalues`"
   }
 }, {
   "sourcePartition" : {
@@ -716,7 +716,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.t1464075356413_testtable6"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`t1464075356413_testtable6`"
   }
 }, {
   "sourcePartition" : {
@@ -806,7 +806,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_85_fractest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_85_fractest`"
   }
 }, {
   "sourcePartition" : {
@@ -896,7 +896,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_102_charsettest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_102_charsettest`"
   }
 }, {
   "sourcePartition" : {
@@ -986,7 +986,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP DATABASE IF EXISTS regression_test"
+    "ddl" : "DROP DATABASE IF EXISTS `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -1076,7 +1076,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "CREATE DATABASE regression_test"
+    "ddl" : "CREATE DATABASE `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -1166,7 +1166,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "USE regression_test"
+    "ddl" : "USE `regression_test`"
   }
 }, {
   "sourcePartition" : {

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/snapshot/filter-table/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/snapshot/filter-table/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=3
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/snapshot/filter-table/expected-records.json
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/snapshot/filter-table/expected-records.json
@@ -176,7 +176,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.products_on_hand"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`products_on_hand`"
   }
 }, {
   "sourcePartition" : {
@@ -266,7 +266,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.customers"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`customers`"
   }
 }, {
   "sourcePartition" : {
@@ -356,7 +356,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.products"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`products`"
   }
 }, {
   "sourcePartition" : {
@@ -446,7 +446,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP DATABASE IF EXISTS connector_test_ro"
+    "ddl" : "DROP DATABASE IF EXISTS `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -536,7 +536,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "CREATE DATABASE connector_test_ro"
+    "ddl" : "CREATE DATABASE `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -626,7 +626,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "USE connector_test_ro"
+    "ddl" : "USE `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/snapshot/no-filter/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/snapshot/no-filter/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=3
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/snapshot/no-filter/expected-records.json
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/expected/snapshot/no-filter/expected-records.json
@@ -176,7 +176,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP TABLE IF EXISTS connector_test.customers"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test`.`customers`"
   }
 }, {
   "sourcePartition" : {
@@ -266,7 +266,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz84_integer_types_table"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz84_integer_types_table`"
   }
 }, {
   "sourcePartition" : {
@@ -356,7 +356,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_123_bitvaluetest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_123_bitvaluetest`"
   }
 }, {
   "sourcePartition" : {
@@ -446,7 +446,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_104_customers"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_104_customers`"
   }
 }, {
   "sourcePartition" : {
@@ -536,7 +536,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_100_enumsettest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_100_enumsettest`"
   }
 }, {
   "sourcePartition" : {
@@ -626,7 +626,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_147_decimalvalues"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_147_decimalvalues`"
   }
 }, {
   "sourcePartition" : {
@@ -716,7 +716,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.t1464075356413_testtable6"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`t1464075356413_testtable6`"
   }
 }, {
   "sourcePartition" : {
@@ -806,7 +806,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP TABLE IF EXISTS connector_test.products_on_hand"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test`.`products_on_hand`"
   }
 }, {
   "sourcePartition" : {
@@ -896,7 +896,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.products"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`products`"
   }
 }, {
   "sourcePartition" : {
@@ -986,7 +986,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP TABLE IF EXISTS connector_test.orders"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test`.`orders`"
   }
 }, {
   "sourcePartition" : {
@@ -1076,7 +1076,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_102_charsettest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_102_charsettest`"
   }
 }, {
   "sourcePartition" : {
@@ -1166,7 +1166,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP TABLE IF EXISTS connector_test.products"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test`.`products`"
   }
 }, {
   "sourcePartition" : {
@@ -1256,7 +1256,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.products_on_hand"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`products_on_hand`"
   }
 }, {
   "sourcePartition" : {
@@ -1346,7 +1346,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_114_zerovaluetest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_114_zerovaluetest`"
   }
 }, {
   "sourcePartition" : {
@@ -1436,7 +1436,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_85_fractest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_85_fractest`"
   }
 }, {
   "sourcePartition" : {
@@ -1526,7 +1526,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.customers"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`customers`"
   }
 }, {
   "sourcePartition" : {
@@ -1616,7 +1616,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.orders"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`orders`"
   }
 }, {
   "sourcePartition" : {
@@ -1706,7 +1706,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP DATABASE IF EXISTS connector_test"
+    "ddl" : "DROP DATABASE IF EXISTS `connector_test`"
   }
 }, {
   "sourcePartition" : {
@@ -1796,7 +1796,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "CREATE DATABASE connector_test"
+    "ddl" : "CREATE DATABASE `connector_test`"
   }
 }, {
   "sourcePartition" : {
@@ -1886,7 +1886,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "USE connector_test"
+    "ddl" : "USE `connector_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2336,7 +2336,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP DATABASE IF EXISTS regression_test"
+    "ddl" : "DROP DATABASE IF EXISTS `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2426,7 +2426,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "CREATE DATABASE regression_test"
+    "ddl" : "CREATE DATABASE `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2516,7 +2516,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "USE regression_test"
+    "ddl" : "USE `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -3416,7 +3416,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP DATABASE IF EXISTS connector_test_ro"
+    "ddl" : "DROP DATABASE IF EXISTS `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -3506,7 +3506,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "CREATE DATABASE connector_test_ro"
+    "ddl" : "CREATE DATABASE `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -3596,7 +3596,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "USE connector_test_ro"
+    "ddl" : "USE `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/no-snapshot/filter-db/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/no-snapshot/filter-db/env.properties
@@ -7,7 +7,7 @@ connector.timeout.in.seconds=3
 # The comma-separated relative paths of the record fields to be ignored during comparison.
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
-# We ignore the time-related fields in the record value, since these depend upon when the server is started,
+# We ignore the time-related fields in the record value, since these depend upon when the server is started.
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/no-snapshot/filter-table/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/no-snapshot/filter-table/env.properties
@@ -7,7 +7,7 @@ connector.timeout.in.seconds=3
 # The comma-separated relative paths of the record fields to be ignored during comparison.
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
-# We ignore the time-related fields in the record value, since these depend upon when the server is started,
+# We ignore the time-related fields in the record value, since these depend upon when the server is started.
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/no-snapshot/no-filter/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/no-snapshot/no-filter/env.properties
@@ -7,7 +7,7 @@ connector.timeout.in.seconds=3
 # The comma-separated relative paths of the record fields to be ignored during comparison.
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
-# We ignore the time-related fields in the record value, since these depend upon when the server is started,
+# We ignore the time-related fields in the record value, since these depend upon when the server is started.
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/snapshot/filter-db/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/snapshot/filter-db/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=3
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/snapshot/filter-db/expected-records.json
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/snapshot/filter-db/expected-records.json
@@ -178,7 +178,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz84_integer_types_table"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz84_integer_types_table`"
   }
 }, {
   "sourcePartition" : {
@@ -269,7 +269,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_123_bitvaluetest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_123_bitvaluetest`"
   }
 }, {
   "sourcePartition" : {
@@ -360,7 +360,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "DROP TABLE IF EXISTS json_test.dbz_126_jsontable"
+    "ddl" : "DROP TABLE IF EXISTS `json_test`.`dbz_126_jsontable`"
   }
 }, {
   "sourcePartition" : {
@@ -451,7 +451,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_104_customers"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_104_customers`"
   }
 }, {
   "sourcePartition" : {
@@ -542,7 +542,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_100_enumsettest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_100_enumsettest`"
   }
 }, {
   "sourcePartition" : {
@@ -633,7 +633,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_114_zerovaluetest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_114_zerovaluetest`"
   }
 }, {
   "sourcePartition" : {
@@ -724,7 +724,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_147_decimalvalues"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_147_decimalvalues`"
   }
 }, {
   "sourcePartition" : {
@@ -815,7 +815,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.t1464075356413_testtable6"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`t1464075356413_testtable6`"
   }
 }, {
   "sourcePartition" : {
@@ -906,7 +906,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_85_fractest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_85_fractest`"
   }
 }, {
   "sourcePartition" : {
@@ -997,7 +997,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_102_charsettest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_102_charsettest`"
   }
 }, {
   "sourcePartition" : {
@@ -1088,7 +1088,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP DATABASE IF EXISTS regression_test"
+    "ddl" : "DROP DATABASE IF EXISTS `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -1179,7 +1179,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "CREATE DATABASE regression_test"
+    "ddl" : "CREATE DATABASE `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -1270,7 +1270,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "USE regression_test"
+    "ddl" : "USE `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2180,7 +2180,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "DROP DATABASE IF EXISTS json_test"
+    "ddl" : "DROP DATABASE IF EXISTS `json_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2271,7 +2271,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "CREATE DATABASE json_test"
+    "ddl" : "CREATE DATABASE `json_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2362,7 +2362,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "USE json_test"
+    "ddl" : "USE `json_test`"
   }
 }, {
   "sourcePartition" : {

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/snapshot/filter-table/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/snapshot/filter-table/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=3
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/snapshot/filter-table/expected-records.json
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/snapshot/filter-table/expected-records.json
@@ -178,7 +178,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.products_on_hand"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`products_on_hand`"
   }
 }, {
   "sourcePartition" : {
@@ -269,7 +269,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.customers"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`customers`"
   }
 }, {
   "sourcePartition" : {
@@ -360,7 +360,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.products"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`products`"
   }
 }, {
   "sourcePartition" : {
@@ -451,7 +451,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP DATABASE IF EXISTS connector_test_ro"
+    "ddl" : "DROP DATABASE IF EXISTS `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -542,7 +542,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "CREATE DATABASE connector_test_ro"
+    "ddl" : "CREATE DATABASE `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -633,7 +633,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "USE connector_test_ro"
+    "ddl" : "USE `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/snapshot/no-filter/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/snapshot/no-filter/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=3
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/snapshot/no-filter/expected-records.json
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/master/snapshot/no-filter/expected-records.json
@@ -178,7 +178,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP TABLE IF EXISTS connector_test.customers"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test`.`customers`"
   }
 }, {
   "sourcePartition" : {
@@ -269,7 +269,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz84_integer_types_table"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz84_integer_types_table`"
   }
 }, {
   "sourcePartition" : {
@@ -360,7 +360,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_123_bitvaluetest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_123_bitvaluetest`"
   }
 }, {
   "sourcePartition" : {
@@ -451,7 +451,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "DROP TABLE IF EXISTS json_test.dbz_126_jsontable"
+    "ddl" : "DROP TABLE IF EXISTS `json_test`.`dbz_126_jsontable`"
   }
 }, {
   "sourcePartition" : {
@@ -542,7 +542,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_104_customers"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_104_customers`"
   }
 }, {
   "sourcePartition" : {
@@ -633,7 +633,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_100_enumsettest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_100_enumsettest`"
   }
 }, {
   "sourcePartition" : {
@@ -724,7 +724,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_147_decimalvalues"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_147_decimalvalues`"
   }
 }, {
   "sourcePartition" : {
@@ -815,7 +815,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.t1464075356413_testtable6"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`t1464075356413_testtable6`"
   }
 }, {
   "sourcePartition" : {
@@ -906,7 +906,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP TABLE IF EXISTS connector_test.products_on_hand"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test`.`products_on_hand`"
   }
 }, {
   "sourcePartition" : {
@@ -997,7 +997,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.products"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`products`"
   }
 }, {
   "sourcePartition" : {
@@ -1088,7 +1088,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP TABLE IF EXISTS connector_test.orders"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test`.`orders`"
   }
 }, {
   "sourcePartition" : {
@@ -1179,7 +1179,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_102_charsettest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_102_charsettest`"
   }
 }, {
   "sourcePartition" : {
@@ -1270,7 +1270,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP TABLE IF EXISTS connector_test.products"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test`.`products`"
   }
 }, {
   "sourcePartition" : {
@@ -1361,7 +1361,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.products_on_hand"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`products_on_hand`"
   }
 }, {
   "sourcePartition" : {
@@ -1452,7 +1452,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_114_zerovaluetest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_114_zerovaluetest`"
   }
 }, {
   "sourcePartition" : {
@@ -1543,7 +1543,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_85_fractest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_85_fractest`"
   }
 }, {
   "sourcePartition" : {
@@ -1634,7 +1634,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.customers"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`customers`"
   }
 }, {
   "sourcePartition" : {
@@ -1725,7 +1725,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.orders"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`orders`"
   }
 }, {
   "sourcePartition" : {
@@ -1816,7 +1816,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP DATABASE IF EXISTS connector_test"
+    "ddl" : "DROP DATABASE IF EXISTS `connector_test`"
   }
 }, {
   "sourcePartition" : {
@@ -1907,7 +1907,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "CREATE DATABASE connector_test"
+    "ddl" : "CREATE DATABASE `connector_test`"
   }
 }, {
   "sourcePartition" : {
@@ -1998,7 +1998,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "USE connector_test"
+    "ddl" : "USE `connector_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2453,7 +2453,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP DATABASE IF EXISTS regression_test"
+    "ddl" : "DROP DATABASE IF EXISTS `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2544,7 +2544,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "CREATE DATABASE regression_test"
+    "ddl" : "CREATE DATABASE `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2635,7 +2635,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "USE regression_test"
+    "ddl" : "USE `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -3545,7 +3545,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP DATABASE IF EXISTS connector_test_ro"
+    "ddl" : "DROP DATABASE IF EXISTS `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -3636,7 +3636,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "CREATE DATABASE connector_test_ro"
+    "ddl" : "CREATE DATABASE `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -3727,7 +3727,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "USE connector_test_ro"
+    "ddl" : "USE `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -4182,7 +4182,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "DROP DATABASE IF EXISTS json_test"
+    "ddl" : "DROP DATABASE IF EXISTS `json_test`"
   }
 }, {
   "sourcePartition" : {
@@ -4273,7 +4273,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "CREATE DATABASE json_test"
+    "ddl" : "CREATE DATABASE `json_test`"
   }
 }, {
   "sourcePartition" : {
@@ -4364,7 +4364,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "USE json_test"
+    "ddl" : "USE `json_test`"
   }
 }, {
   "sourcePartition" : {

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/no-snapshot/filter-db/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/no-snapshot/filter-db/env.properties
@@ -7,7 +7,7 @@ connector.timeout.in.seconds=3
 # The comma-separated relative paths of the record fields to be ignored during comparison.
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
-# We ignore the time-related fields in the record value, since these depend upon when the server is started,
+# We ignore the time-related fields in the record value, since these depend upon when the server is started.
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/no-snapshot/filter-table/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/no-snapshot/filter-table/env.properties
@@ -7,7 +7,7 @@ connector.timeout.in.seconds=3
 # The comma-separated relative paths of the record fields to be ignored during comparison.
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
-# We ignore the time-related fields in the record value, since these depend upon when the server is started,
+# We ignore the time-related fields in the record value, since these depend upon when the server is started.
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/no-snapshot/no-filter/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/no-snapshot/no-filter/env.properties
@@ -7,7 +7,7 @@ connector.timeout.in.seconds=3
 # The comma-separated relative paths of the record fields to be ignored during comparison.
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
-# We ignore the time-related fields in the record value, since these depend upon when the server is started,
+# We ignore the time-related fields in the record value, since these depend upon when the server is started.
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/snapshot/filter-db/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/snapshot/filter-db/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=3
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/snapshot/filter-db/expected-records.json
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/snapshot/filter-db/expected-records.json
@@ -178,7 +178,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz84_integer_types_table"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz84_integer_types_table`"
   }
 }, {
   "sourcePartition" : {
@@ -269,7 +269,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_123_bitvaluetest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_123_bitvaluetest`"
   }
 }, {
   "sourcePartition" : {
@@ -360,7 +360,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "DROP TABLE IF EXISTS json_test.dbz_126_jsontable"
+    "ddl" : "DROP TABLE IF EXISTS `json_test`.`dbz_126_jsontable`"
   }
 }, {
   "sourcePartition" : {
@@ -451,7 +451,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_104_customers"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_104_customers`"
   }
 }, {
   "sourcePartition" : {
@@ -542,7 +542,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_100_enumsettest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_100_enumsettest`"
   }
 }, {
   "sourcePartition" : {
@@ -633,7 +633,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_114_zerovaluetest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_114_zerovaluetest`"
   }
 }, {
   "sourcePartition" : {
@@ -724,7 +724,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_147_decimalvalues"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_147_decimalvalues`"
   }
 }, {
   "sourcePartition" : {
@@ -815,7 +815,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.t1464075356413_testtable6"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`t1464075356413_testtable6`"
   }
 }, {
   "sourcePartition" : {
@@ -906,7 +906,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_85_fractest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_85_fractest`"
   }
 }, {
   "sourcePartition" : {
@@ -997,7 +997,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_102_charsettest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_102_charsettest`"
   }
 }, {
   "sourcePartition" : {
@@ -1088,7 +1088,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP DATABASE IF EXISTS regression_test"
+    "ddl" : "DROP DATABASE IF EXISTS `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -1179,7 +1179,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "CREATE DATABASE regression_test"
+    "ddl" : "CREATE DATABASE `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -1270,7 +1270,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "USE regression_test"
+    "ddl" : "USE `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2180,7 +2180,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "DROP DATABASE IF EXISTS json_test"
+    "ddl" : "DROP DATABASE IF EXISTS `json_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2271,7 +2271,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "CREATE DATABASE json_test"
+    "ddl" : "CREATE DATABASE `json_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2362,7 +2362,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "USE json_test"
+    "ddl" : "USE `json_test`"
   }
 }, {
   "sourcePartition" : {

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/snapshot/filter-table/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/snapshot/filter-table/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=3
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/snapshot/filter-table/expected-records.json
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/snapshot/filter-table/expected-records.json
@@ -178,7 +178,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.products_on_hand"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`products_on_hand`"
   }
 }, {
   "sourcePartition" : {
@@ -269,7 +269,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.customers"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`customers`"
   }
 }, {
   "sourcePartition" : {
@@ -360,7 +360,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.products"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`products`"
   }
 }, {
   "sourcePartition" : {
@@ -451,7 +451,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP DATABASE IF EXISTS connector_test_ro"
+    "ddl" : "DROP DATABASE IF EXISTS `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -542,7 +542,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "CREATE DATABASE connector_test_ro"
+    "ddl" : "CREATE DATABASE `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -633,7 +633,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "USE connector_test_ro"
+    "ddl" : "USE `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/snapshot/no-filter/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/snapshot/no-filter/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=3
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/snapshot/no-filter/expected-records.json
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/expected/replica/snapshot/no-filter/expected-records.json
@@ -178,7 +178,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP TABLE IF EXISTS connector_test.customers"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test`.`customers`"
   }
 }, {
   "sourcePartition" : {
@@ -269,7 +269,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz84_integer_types_table"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz84_integer_types_table`"
   }
 }, {
   "sourcePartition" : {
@@ -360,7 +360,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_123_bitvaluetest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_123_bitvaluetest`"
   }
 }, {
   "sourcePartition" : {
@@ -451,7 +451,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "DROP TABLE IF EXISTS json_test.dbz_126_jsontable"
+    "ddl" : "DROP TABLE IF EXISTS `json_test`.`dbz_126_jsontable`"
   }
 }, {
   "sourcePartition" : {
@@ -542,7 +542,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_104_customers"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_104_customers`"
   }
 }, {
   "sourcePartition" : {
@@ -633,7 +633,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_100_enumsettest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_100_enumsettest`"
   }
 }, {
   "sourcePartition" : {
@@ -724,7 +724,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_147_decimalvalues"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_147_decimalvalues`"
   }
 }, {
   "sourcePartition" : {
@@ -815,7 +815,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.t1464075356413_testtable6"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`t1464075356413_testtable6`"
   }
 }, {
   "sourcePartition" : {
@@ -906,7 +906,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP TABLE IF EXISTS connector_test.products_on_hand"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test`.`products_on_hand`"
   }
 }, {
   "sourcePartition" : {
@@ -997,7 +997,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.products"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`products`"
   }
 }, {
   "sourcePartition" : {
@@ -1088,7 +1088,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP TABLE IF EXISTS connector_test.orders"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test`.`orders`"
   }
 }, {
   "sourcePartition" : {
@@ -1179,7 +1179,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_102_charsettest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_102_charsettest`"
   }
 }, {
   "sourcePartition" : {
@@ -1270,7 +1270,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP TABLE IF EXISTS connector_test.products"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test`.`products`"
   }
 }, {
   "sourcePartition" : {
@@ -1361,7 +1361,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.products_on_hand"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`products_on_hand`"
   }
 }, {
   "sourcePartition" : {
@@ -1452,7 +1452,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_114_zerovaluetest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_114_zerovaluetest`"
   }
 }, {
   "sourcePartition" : {
@@ -1543,7 +1543,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_85_fractest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_85_fractest`"
   }
 }, {
   "sourcePartition" : {
@@ -1634,7 +1634,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.customers"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`customers`"
   }
 }, {
   "sourcePartition" : {
@@ -1725,7 +1725,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.orders"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`orders`"
   }
 }, {
   "sourcePartition" : {
@@ -1816,7 +1816,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP DATABASE IF EXISTS connector_test"
+    "ddl" : "DROP DATABASE IF EXISTS `connector_test`"
   }
 }, {
   "sourcePartition" : {
@@ -1907,7 +1907,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "CREATE DATABASE connector_test"
+    "ddl" : "CREATE DATABASE `connector_test`"
   }
 }, {
   "sourcePartition" : {
@@ -1998,7 +1998,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "USE connector_test"
+    "ddl" : "USE `connector_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2453,7 +2453,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP DATABASE IF EXISTS regression_test"
+    "ddl" : "DROP DATABASE IF EXISTS `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2544,7 +2544,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "CREATE DATABASE regression_test"
+    "ddl" : "CREATE DATABASE `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2635,7 +2635,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "USE regression_test"
+    "ddl" : "USE `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -3545,7 +3545,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP DATABASE IF EXISTS connector_test_ro"
+    "ddl" : "DROP DATABASE IF EXISTS `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -3636,7 +3636,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "CREATE DATABASE connector_test_ro"
+    "ddl" : "CREATE DATABASE `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -3727,7 +3727,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "USE connector_test_ro"
+    "ddl" : "USE `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -4182,7 +4182,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "DROP DATABASE IF EXISTS json_test"
+    "ddl" : "DROP DATABASE IF EXISTS `json_test`"
   }
 }, {
   "sourcePartition" : {
@@ -4273,7 +4273,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "CREATE DATABASE json_test"
+    "ddl" : "CREATE DATABASE `json_test`"
   }
 }, {
   "sourcePartition" : {
@@ -4364,7 +4364,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "USE json_test"
+    "ddl" : "USE `json_test`"
   }
 }, {
   "sourcePartition" : {

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/no-snapshot/filter-db/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/no-snapshot/filter-db/env.properties
@@ -10,4 +10,4 @@ connector.timeout.in.seconds=10
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/no-snapshot/filter-table/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/no-snapshot/filter-table/env.properties
@@ -10,4 +10,4 @@ connector.timeout.in.seconds=10
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/no-snapshot/no-filter/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/no-snapshot/no-filter/env.properties
@@ -10,4 +10,4 @@ connector.timeout.in.seconds=10
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
 # and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/snapshot/filter-db/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/snapshot/filter-db/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=10
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/snapshot/filter-db/expected-records.json
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/snapshot/filter-db/expected-records.json
@@ -176,7 +176,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz84_integer_types_table"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz84_integer_types_table`"
   }
 }, {
   "sourcePartition" : {
@@ -266,7 +266,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_123_bitvaluetest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_123_bitvaluetest`"
   }
 }, {
   "sourcePartition" : {
@@ -356,7 +356,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "DROP TABLE IF EXISTS json_test.dbz_126_jsontable"
+    "ddl" : "DROP TABLE IF EXISTS `json_test`.`dbz_126_jsontable`"
   }
 }, {
   "sourcePartition" : {
@@ -446,7 +446,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_104_customers"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_104_customers`"
   }
 }, {
   "sourcePartition" : {
@@ -536,7 +536,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_100_enumsettest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_100_enumsettest`"
   }
 }, {
   "sourcePartition" : {
@@ -626,7 +626,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_114_zerovaluetest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_114_zerovaluetest`"
   }
 }, {
   "sourcePartition" : {
@@ -716,7 +716,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_147_decimalvalues"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_147_decimalvalues`"
   }
 }, {
   "sourcePartition" : {
@@ -806,7 +806,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.t1464075356413_testtable6"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`t1464075356413_testtable6`"
   }
 }, {
   "sourcePartition" : {
@@ -896,7 +896,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_85_fractest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_85_fractest`"
   }
 }, {
   "sourcePartition" : {
@@ -986,7 +986,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_102_charsettest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_102_charsettest`"
   }
 }, {
   "sourcePartition" : {
@@ -1076,7 +1076,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP DATABASE IF EXISTS regression_test"
+    "ddl" : "DROP DATABASE IF EXISTS `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -1166,7 +1166,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "CREATE DATABASE regression_test"
+    "ddl" : "CREATE DATABASE `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -1256,7 +1256,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "USE regression_test"
+    "ddl" : "USE `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2156,7 +2156,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "DROP DATABASE IF EXISTS json_test"
+    "ddl" : "DROP DATABASE IF EXISTS `json_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2246,7 +2246,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "CREATE DATABASE json_test"
+    "ddl" : "CREATE DATABASE `json_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2336,7 +2336,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "USE json_test"
+    "ddl" : "USE `json_test`"
   }
 }, {
   "sourcePartition" : {

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/snapshot/filter-table/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/snapshot/filter-table/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=10
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/snapshot/filter-table/expected-records.json
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/snapshot/filter-table/expected-records.json
@@ -176,7 +176,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.products_on_hand"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`products_on_hand`"
   }
 }, {
   "sourcePartition" : {
@@ -266,7 +266,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.customers"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`customers`"
   }
 }, {
   "sourcePartition" : {
@@ -356,7 +356,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.products"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`products`"
   }
 }, {
   "sourcePartition" : {
@@ -446,7 +446,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP DATABASE IF EXISTS connector_test_ro"
+    "ddl" : "DROP DATABASE IF EXISTS `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -536,7 +536,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "CREATE DATABASE connector_test_ro"
+    "ddl" : "CREATE DATABASE `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -626,7 +626,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "USE connector_test_ro"
+    "ddl" : "USE `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/snapshot/no-filter/env.properties
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/snapshot/no-filter/env.properties
@@ -8,5 +8,6 @@ connector.timeout.in.seconds=10
 # Precede with "KEY/" for fields in the key, and "VALUE/" for fields in the record values.
 #
 # We ignore the time-related fields in the record value, since these depend upon when the server is started.
+# and the 'event' number since that varies each time the server starts up
 # 
-ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, SOURCEOFFSET/ts_sec
+ignore.fields=VALUE/source/ts_sec, VALUE/ts_ms, VALUE/source/pos, SOURCEOFFSET/ts_sec, SOURCEOFFSET/event, SOURCEOFFSET/pos

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/snapshot/no-filter/expected-records.json
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/expected/snapshot/no-filter/expected-records.json
@@ -176,7 +176,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP TABLE IF EXISTS connector_test.customers"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test`.`customers`"
   }
 }, {
   "sourcePartition" : {
@@ -266,7 +266,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz84_integer_types_table"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz84_integer_types_table`"
   }
 }, {
   "sourcePartition" : {
@@ -356,7 +356,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_123_bitvaluetest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_123_bitvaluetest`"
   }
 }, {
   "sourcePartition" : {
@@ -446,7 +446,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "DROP TABLE IF EXISTS json_test.dbz_126_jsontable"
+    "ddl" : "DROP TABLE IF EXISTS `json_test`.`dbz_126_jsontable`"
   }
 }, {
   "sourcePartition" : {
@@ -536,7 +536,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_104_customers"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_104_customers`"
   }
 }, {
   "sourcePartition" : {
@@ -626,7 +626,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_100_enumsettest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_100_enumsettest`"
   }
 }, {
   "sourcePartition" : {
@@ -716,7 +716,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_147_decimalvalues"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_147_decimalvalues`"
   }
 }, {
   "sourcePartition" : {
@@ -806,7 +806,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.t1464075356413_testtable6"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`t1464075356413_testtable6`"
   }
 }, {
   "sourcePartition" : {
@@ -896,7 +896,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP TABLE IF EXISTS connector_test.products_on_hand"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test`.`products_on_hand`"
   }
 }, {
   "sourcePartition" : {
@@ -986,7 +986,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.products"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`products`"
   }
 }, {
   "sourcePartition" : {
@@ -1076,7 +1076,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP TABLE IF EXISTS connector_test.orders"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test`.`orders`"
   }
 }, {
   "sourcePartition" : {
@@ -1166,7 +1166,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_102_charsettest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_102_charsettest`"
   }
 }, {
   "sourcePartition" : {
@@ -1256,7 +1256,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP TABLE IF EXISTS connector_test.products"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test`.`products`"
   }
 }, {
   "sourcePartition" : {
@@ -1346,7 +1346,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.products_on_hand"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`products_on_hand`"
   }
 }, {
   "sourcePartition" : {
@@ -1436,7 +1436,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_114_zerovaluetest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_114_zerovaluetest`"
   }
 }, {
   "sourcePartition" : {
@@ -1526,7 +1526,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP TABLE IF EXISTS regression_test.dbz_85_fractest"
+    "ddl" : "DROP TABLE IF EXISTS `regression_test`.`dbz_85_fractest`"
   }
 }, {
   "sourcePartition" : {
@@ -1616,7 +1616,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.customers"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`customers`"
   }
 }, {
   "sourcePartition" : {
@@ -1706,7 +1706,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP TABLE IF EXISTS connector_test_ro.orders"
+    "ddl" : "DROP TABLE IF EXISTS `connector_test_ro`.`orders`"
   }
 }, {
   "sourcePartition" : {
@@ -1796,7 +1796,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "DROP DATABASE IF EXISTS connector_test"
+    "ddl" : "DROP DATABASE IF EXISTS `connector_test`"
   }
 }, {
   "sourcePartition" : {
@@ -1886,7 +1886,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "CREATE DATABASE connector_test"
+    "ddl" : "CREATE DATABASE `connector_test`"
   }
 }, {
   "sourcePartition" : {
@@ -1976,7 +1976,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test",
-    "ddl" : "USE connector_test"
+    "ddl" : "USE `connector_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2426,7 +2426,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "DROP DATABASE IF EXISTS regression_test"
+    "ddl" : "DROP DATABASE IF EXISTS `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2516,7 +2516,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "CREATE DATABASE regression_test"
+    "ddl" : "CREATE DATABASE `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -2606,7 +2606,7 @@
       "snapshot" : true
     },
     "databaseName" : "regression_test",
-    "ddl" : "USE regression_test"
+    "ddl" : "USE `regression_test`"
   }
 }, {
   "sourcePartition" : {
@@ -3506,7 +3506,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "DROP DATABASE IF EXISTS connector_test_ro"
+    "ddl" : "DROP DATABASE IF EXISTS `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -3596,7 +3596,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "CREATE DATABASE connector_test_ro"
+    "ddl" : "CREATE DATABASE `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -3686,7 +3686,7 @@
       "snapshot" : true
     },
     "databaseName" : "connector_test_ro",
-    "ddl" : "USE connector_test_ro"
+    "ddl" : "USE `connector_test_ro`"
   }
 }, {
   "sourcePartition" : {
@@ -4136,7 +4136,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "DROP DATABASE IF EXISTS json_test"
+    "ddl" : "DROP DATABASE IF EXISTS `json_test`"
   }
 }, {
   "sourcePartition" : {
@@ -4226,7 +4226,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "CREATE DATABASE json_test"
+    "ddl" : "CREATE DATABASE `json_test`"
   }
 }, {
   "sourcePartition" : {
@@ -4316,7 +4316,7 @@
       "snapshot" : true
     },
     "databaseName" : "json_test",
-    "ddl" : "USE json_test"
+    "ddl" : "USE `json_test`"
   }
 }, {
   "sourcePartition" : {


### PR DESCRIPTION
A recent change to MySQL added quoted identifiers from DDL statements (e.g., resulting from `SHOW CREATE TABLE <quotedIdentifier>`), so the expected results were changed to reflect this. Also, the `pos` field is quite brittle and changes with many MySQL version upgrades in the Docker images, so those fields are now ignored during the integration tests.