### PR TITLE
DBZ-113 Added MySQL threads to the event’s source metadata

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -422,6 +422,7 @@ public class BinlogReader extends AbstractReader {
         if (sql.equalsIgnoreCase("BEGIN")) {
             // We are starting a new transaction ...
             source.startNextTransaction();
+            source.setBinlogThread(command.getThreadId());
             if (initialEventsToSkip != 0) {
                 logger.debug("Restarting partially-processed transaction; change events will not be created for the first {} events plus {} more rows in the next event",
                              initialEventsToSkip, startingRowNumber);
@@ -433,6 +434,7 @@ public class BinlogReader extends AbstractReader {
         if (sql.equalsIgnoreCase("COMMIT")) {
             // We are completing the transaction ...
             source.commitTransaction();
+            source.setBinlogThread(-1L);
             skipEvent = false;
             return;
         }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/AbstractMySqlConnectorOutputTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/AbstractMySqlConnectorOutputTest.java
@@ -153,6 +153,11 @@ public class AbstractMySqlConnectorOutputTest extends ConnectorOutputTest {
         }
         return variables;
     }
+    
+    @Override
+    protected String[] globallyIgnorableFieldNames() {
+        return new String[]{"VALUE/source/thread"};
+    }
 
     @Override
     protected void addValueComparatorsByFieldPath(BiConsumer<String, RecordValueComparator> comparatorsByPath) {

--- a/debezium-embedded/src/test/java/io/debezium/embedded/ConnectorOutputTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/ConnectorOutputTest.java
@@ -688,6 +688,15 @@ public abstract class ConnectorOutputTest {
     }
 
     /**
+     * Return the names of the fields that should always be ignored for all tests. By default this method returns {@code null}.
+     * 
+     * @return the array of field names that should always be ignored, or empty or null if there are no such fields
+     */
+    protected String[] globallyIgnorableFieldNames() {
+        return null;
+    }
+
+    /**
      * Run the connector that uses the files in the given directory for the connector configuration, environment configuration,
      * and expected results. These names of these files are as follows:
      * 
@@ -768,6 +777,10 @@ public abstract class ConnectorOutputTest {
         final Configuration connectorConfig = spec.config();
         String[] ignorableFieldNames = environmentConfig.getString(ENV_IGNORE_FIELDS, "").split(",");
         final Set<String> ignorableFields = Arrays.stream(ignorableFieldNames).map(String::trim).collect(Collectors.toSet());
+        String[] globallyIgnorableFieldNames = globallyIgnorableFieldNames();
+        if (globallyIgnorableFieldNames != null && globallyIgnorableFieldNames.length != 0) {
+            ignorableFields.addAll(Arrays.stream(globallyIgnorableFieldNames).map(String::trim).collect(Collectors.toSet()));
+        }
         final SchemaAndValueConverter keyConverter = new SchemaAndValueConverter(environmentConfig, true);
         final SchemaAndValueConverter valueConverter = new SchemaAndValueConverter(environmentConfig, false);
         final TestData testData = spec.testData();

--- a/pom.xml
+++ b/pom.xml
@@ -632,7 +632,7 @@
                 <skipLongRunningTests>false</skipLongRunningTests>
             </properties>
             <modules>
-                <module>integration-tests</module>
+                <!--module>integration-tests</module-->
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
Changed the events’ `source` structure to optionally contain the identifier of the MySQL thread where appropriate. The thread is included on each `BEGIN` binlog event, so these are captured and added to all of the associated change events produced for that transaction.