### PR TITLE
DBZ-176 Corrected MySQL DDL parser to support creating triggers with definers

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
@@ -269,7 +269,7 @@ public class MySqlDdlParser extends DdlParser {
         } else if (tokens.matchesAnyOf("DATABASE", "SCHEMA")) {
             parseCreateDatabase(marker);
         } else if (tokens.matchesAnyOf("EVENT")) {
-            parseCreateUnknown(marker);
+            parseCreateEvent(marker);
         } else if (tokens.matchesAnyOf("FUNCTION", "PROCEDURE")) {
             parseCreateProcedure(marker);
         } else if (tokens.matchesAnyOf("UNIQUE", "FULLTEXT", "SPATIAL", "INDEX")) {
@@ -279,11 +279,13 @@ public class MySqlDdlParser extends DdlParser {
         } else if (tokens.matchesAnyOf("TABLESPACE")) {
             parseCreateUnknown(marker);
         } else if (tokens.matchesAnyOf("TRIGGER")) {
-            parseCreateUnknown(marker);
+            parseCreateTrigger(marker);
         } else {
             // It could be several possible things (including more elaborate forms of those matches tried above),
             sequentially(this::parseCreateView,
                          this::parseCreateProcedure,
+                         this::parseCreateTrigger,
+                         this::parseCreateEvent,
                          this::parseCreateUnknown);
         }
     }
@@ -998,6 +1000,20 @@ public class MySqlDdlParser extends DdlParser {
     protected void parseCreateProcedure(Marker start) {
         parseDefiner(tokens.mark());
         tokens.consume("FUNCTION");
+        tokens.consume(); // name
+        consumeRemainingStatement(start);
+    }
+
+    protected void parseCreateTrigger(Marker start) {
+        parseDefiner(tokens.mark());
+        tokens.consume("TRIGGER");
+        tokens.consume(); // name
+        consumeRemainingStatement(start);
+    }
+
+    protected void parseCreateEvent(Marker start) {
+        parseDefiner(tokens.mark());
+        tokens.consume("EVENT");
         tokens.consume(); // name
         consumeRemainingStatement(start);
     }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -468,7 +468,7 @@ public class MySqlDdlParserTest {
 
     @Test
     public void shouldParseDefiner() {
-        String function = "FUNCTION fnA`( a int, b int ) RETURNS tinyint(1) begin anything end;";
+        String function = "FUNCTION fnA( a int, b int ) RETURNS tinyint(1) begin anything end;";
         String ddl = "CREATE DEFINER='mysqluser'@'%' " + function;
         parser.parse(ddl, tables);
         assertThat(tables.size()).isEqualTo(0); // no tables
@@ -761,6 +761,16 @@ public class MySqlDdlParserTest {
         assertThat(t.columnNames()).containsExactly("collection_id");
         assertThat(t.primaryKeyColumnNames()).containsExactly("collection_id");
         assertColumn(t, "collection_id", "INT UNSIGNED", Types.INTEGER, 11, -1, false, true, true);
+    }
+    
+    @FixFor("DBZ-176")
+    @Test
+    public void shouldParseButIgnoreCreateTriggerWithDefiner() {
+        parser.parse(readFile("ddl/mysql-dbz-176.ddl"), tables);
+        Testing.print(tables);
+        assertThat(tables.size()).isEqualTo(0); // 0 table
+        assertThat(listener.total()).isEqualTo(0);
+        listener.forEach(this::printEvent);
     }
     
     @Test

--- a/debezium-connector-mysql/src/test/resources/ddl/mysql-dbz-176.ddl
+++ b/debezium-connector-mysql/src/test/resources/ddl/mysql-dbz-176.ddl
@@ -1,0 +1,26 @@
+CREATE DEFINER=`trunk2`@`%` TRIGGER PipelineHistory_insert AFTER INSERT ON Pipeline
+ FOR EACH ROW BEGIN
+ INSERT INTO PipelineHistory (
+ PipelineId
+ , InterfaceId
+ , SourceHost
+ , SourceDir
+ , SourcePattern
+ , SinkHost
+ , SinkDir
+ , SinkCommand
+ , Active
+ , Retries
+ ) VALUES (
+ NEW.PipelineId
+ , NEW.InterfaceId
+ , NEW.SourceHost
+ , NEW.SourceDir
+ , NEW.SourcePattern
+ , NEW.SinkHost
+ , NEW.SinkDir
+ , NEW.SinkCommand
+ , NEW.Active
+ , NEW.Retries
+ );
+END

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/DdlTokenizer.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/DdlTokenizer.java
@@ -310,8 +310,8 @@ public class DdlTokenizer implements Tokenizer {
                 default:
                     startIndex = input.index();
                     Position startPosition = input.position(startIndex);
-                    // Read until another whitespace/symbol/decimal/slash is found
-                    while (input.hasNext() && !(input.isNextWhitespace() || input.isNextAnyOf("/.-(){}*,;+%?[]!<>|=:'\"\u2019"))) {
+                    // Read until another whitespace/symbol/decimal/slash/quote is found
+                    while (input.hasNext() && !(input.isNextWhitespace() || input.isNextAnyOf("/.-(){}*,;+%?[]!<>|=:'`\u2018\u2019\"\u2019"))) {
                         c = input.next();
                     }
                     endIndex = input.index() + 1; // beyond last character that was included


### PR DESCRIPTION
The MySQL DDL parser was not correclty handling `DEFINER` clauses within `CREATE TRIGGER` or `CREATE EVENT` statements. Support for `DEFINER` clauses was previously added for the various forms of `CREATE PROCEDURE`, `CREATE FUNCTION` and `CREATE VIEW` statements. These are the only kinds of statements that have the definer attribute, per the [MySQL documentation](https://dev.mysql.com/doc/refman/5.7/en/stored-programs-security.html).