### PR TITLE
DBZ-173 Upgraded Confluent Platform libraries used in test cases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <version.org.slf4j>1.7.21</version.org.slf4j>
         <version.log4j>1.2.17</version.log4j>
         <!-- check new release version at https://github.com/confluentinc/schema-registry/releases -->
-        <version.confluent.platform>3.0.0</version.confluent.platform>
+        <version.confluent.platform>3.1.2</version.confluent.platform>
 
         <!-- Databases -->
         <version.postgresql.driver>42.0.0-SNAPSHOT</version.postgresql.driver>


### PR DESCRIPTION
Some of our test cases verify (de)serialization using the Avro Converter, which is included in the Confluent Platform. This commit upgrades the Confluent Platform to version 3.1.2, which matches Kafka 0.10.1.1.