### PR TITLE
DBZ-187 Upgrade MongoDB server and Java driver versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
         <version.mysql.server>5.7</version.mysql.server>
         <version.mysql.driver>5.1.40</version.mysql.driver>
         <version.mysql.binlog>0.9.0</version.mysql.binlog>
-        <version.mongo.server>3.2.6</version.mongo.server>
-        <version.mongo.driver>3.2.2</version.mongo.driver>
+        <version.mongo.server>3.2.12</version.mongo.server>
+        <version.mongo.driver>3.4.2</version.mongo.driver>
         
         <!-- Connectors -->
         <version.com.google.protobuf>2.6.1</version.com.google.protobuf>


### PR DESCRIPTION
Upgraded the MongoDB server to 3.2.12 and the Java driver to 3.4.2.