### PR TITLE
DBZ-188: Allow a debezium mysql connector to filter production of DML…

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -416,7 +416,7 @@ public class BinlogReader extends AbstractReader {
         source.startGtid(gtid, gtidSet.toString()); // rather than use the client's GTID set
         ignoreDmlEventByGtidSource = false;
         if (gtidDmlSourceFilter != null && gtid != null) {
-            String uuid = gtid.substring(0, gtid.indexOf(":"));
+            String uuid = gtid.trim().substring(0, gtid.indexOf(":"));
             if (!gtidDmlSourceFilter.test(uuid)) {
                 ignoreDmlEventByGtidSource = true;
             }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -51,7 +51,7 @@ import io.debezium.util.Strings;
 
 /**
  * A component that reads the binlog of a MySQL server, and records any schema changes in {@link MySqlSchema}.
- *
+ * 
  * @author Randall Hauch
  *
  */
@@ -81,7 +81,7 @@ public class BinlogReader extends AbstractReader {
 
     /**
      * Create a binlog reader.
-     *
+     * 
      * @param name the name of this reader; may not be null
      * @param context the task context in which this reader is running; may not be null
      */
@@ -170,7 +170,7 @@ public class BinlogReader extends AbstractReader {
         if (availableServerGtidStr != null && !availableServerGtidStr.trim().isEmpty()) {
             // The server is using GTIDs, so enable the handler ...
             eventHandlers.put(EventType.GTID, this::handleGtidEvent);
-
+            
             // Now look at the GTID set from the server and what we've previously seen ...
             GtidSet availableServerGtidSet = new GtidSet(availableServerGtidStr);
             GtidSet filteredGtidSet = context.filterGtidSet(availableServerGtidSet);
@@ -354,7 +354,7 @@ public class BinlogReader extends AbstractReader {
 
     /**
      * Handle the supplied event that signals that mysqld has stopped.
-     *
+     * 
      * @param event the server stopped event to be processed; may not be null
      */
     protected void handleServerStop(Event event) {
@@ -364,7 +364,7 @@ public class BinlogReader extends AbstractReader {
     /**
      * Handle the supplied event that is sent by a master to a slave to let the slave know that the master is still alive. Not
      * written to a binary log.
-     *
+     * 
      * @param event the server stopped event to be processed; may not be null
      */
     protected void handleServerHeartbeat(Event event) {
@@ -374,7 +374,7 @@ public class BinlogReader extends AbstractReader {
     /**
      * Handle the supplied event that signals that an out of the ordinary event that occurred on the master. It notifies the slave
      * that something happened on the master that might cause data to be in an inconsistent state.
-     *
+     * 
      * @param event the server stopped event to be processed; may not be null
      */
     protected void handleServerIncident(Event event) {
@@ -385,7 +385,7 @@ public class BinlogReader extends AbstractReader {
      * Handle the supplied event with a {@link RotateEventData} that signals the logs are being rotated. This means that either
      * the server was restarted, or the binlog has transitioned to a new file. In either case, subsequent table numbers will be
      * different than those seen to this point, so we need to {@link RecordMakers#clear() discard the cache of record makers}.
-     *
+     * 
      * @param event the database change data event to be processed; may not be null
      */
     protected void handleRotateLogsEvent(Event event) {
@@ -405,7 +405,7 @@ public class BinlogReader extends AbstractReader {
      * we actually want to capture all GTID set values found in the binlog, whether or not we process them.
      * However, only when we connect do we actually want to pass to MySQL only those GTID ranges that are applicable
      * per the configuration.
-     *
+     * 
      * @param event the GTID event to be processed; may not be null
      */
     protected void handleGtidEvent(Event event) {
@@ -426,7 +426,7 @@ public class BinlogReader extends AbstractReader {
     /**
      * Handle the supplied event with an {@link QueryEventData} by possibly recording the DDL statements as changes in the
      * MySQL schemas.
-     *
+     * 
      * @param event the database change data event to be processed; may not be null
      * @throws InterruptedException if this thread is interrupted while recording the DDL statements
      */
@@ -476,7 +476,7 @@ public class BinlogReader extends AbstractReader {
      * <li>the table structure is modified (e.g., via an {@code ALTER TABLE ...} command); or</li>
      * <li>MySQL rotates to a new binary log file, even if the table structure does not change.</li>
      * </ol>
-     *
+     * 
      * @param event the update event; never null
      */
     protected void handleUpdateTableMetadata(Event event) {
@@ -494,7 +494,7 @@ public class BinlogReader extends AbstractReader {
 
     /**
      * Generate source records for the supplied event with an {@link WriteRowsEventData}.
-     *
+     * 
      * @param event the database change data event to be processed; may not be null
      * @throws InterruptedException if this thread is interrupted while blocking
      */
@@ -541,7 +541,7 @@ public class BinlogReader extends AbstractReader {
 
     /**
      * Generate source records for the supplied event with an {@link UpdateRowsEventData}.
-     *
+     * 
      * @param event the database change data event to be processed; may not be null
      * @throws InterruptedException if this thread is interrupted while blocking
      */
@@ -592,7 +592,7 @@ public class BinlogReader extends AbstractReader {
 
     /**
      * Generate source records for the supplied event with an {@link DeleteRowsEventData}.
-     *
+     * 
      * @param event the database change data event to be processed; may not be null
      * @throws InterruptedException if this thread is interrupted while blocking
      */
@@ -639,7 +639,7 @@ public class BinlogReader extends AbstractReader {
 
     /**
      * Handle a {@link EventType#VIEW_CHANGE} event.
-     *
+     * 
      * @param event the database change data event to be processed; may not be null
      * @throws InterruptedException if this thread is interrupted while blocking
      */
@@ -647,10 +647,10 @@ public class BinlogReader extends AbstractReader {
         logger.debug("View Change event: {}", event);
         // do nothing
     }
-
+    
     /**
      * Handle a {@link EventType#XA_PREPARE} event.
-     *
+     * 
      * @param event the database change data event to be processed; may not be null
      * @throws InterruptedException if this thread is interrupted while blocking
      */
@@ -658,7 +658,7 @@ public class BinlogReader extends AbstractReader {
         logger.debug("XA Prepare event: {}", event);
         // do nothing
     }
-
+    
     protected SSLMode sslModeFor(SecureConnectionMode mode) {
         switch (mode) {
             case DISABLED:

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -451,6 +451,7 @@ public class BinlogReader extends AbstractReader {
             source.commitTransaction();
             source.setBinlogThread(-1L);
             skipEvent = false;
+            ignoreDmlEventByGtidSource = false;
             return;
         }
         if (sql.toUpperCase().startsWith("XA ")) {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -105,8 +105,8 @@ public class BinlogReader extends AbstractReader {
         client.registerLifecycleListener(new ReaderThreadLifecycleListener());
         if (logger.isDebugEnabled()) client.registerEventListener(this::logEvent);
 
-        String gtidDmlSourceIncludes = context.config().getString(MySqlConnectorConfig.GTID_DML_SOURCE_INCLUDES);
-        gtidDmlSourceFilter = gtidDmlSourceIncludes != null ? Predicates.includes(gtidDmlSourceIncludes) : null;
+        Boolean filterDmlEventsByGtidSource = context.config().getBoolean(MySqlConnectorConfig.GTID_SOURCE_FILTER_DML_EVENTS);
+        gtidDmlSourceFilter = filterDmlEventsByGtidSource ? context.gtidSourceFilter() : null;
 
         // Set up the event deserializer with additional type(s) ...
         final Map<Long, TableMapEventData> tableMapEventByTableId = new HashMap<Long, TableMapEventData>();
@@ -505,6 +505,7 @@ public class BinlogReader extends AbstractReader {
             return;
         }
         if (ignoreDmlEventByGtidSource) {
+            logger.debug("Skipping DML event because this GTID source is filtered: {}", event);
             return;
         }
         WriteRowsEventData write = unwrapData(event);
@@ -551,6 +552,7 @@ public class BinlogReader extends AbstractReader {
             return;
         }
         if (ignoreDmlEventByGtidSource) {
+            logger.debug("Skipping DML event because this GTID source is filtered: {}", event);
             return;
         }
         UpdateRowsEventData update = unwrapData(event);
@@ -601,6 +603,7 @@ public class BinlogReader extends AbstractReader {
             return;
         }
         if (ignoreDmlEventByGtidSource) {
+            logger.debug("Skipping DML event because this GTID source is filtered: {}", event);
             return;
         }
         DeleteRowsEventData deleted = unwrapData(event);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 
-import io.debezium.function.Predicates;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -499,6 +499,7 @@ public class MySqlConnectorConfig {
                                                           .withRecommender(DATABASE_LIST_RECOMMENDER)
                                                           .withDependents(TABLE_WHITELIST_NAME)
                                                           .withDescription("The source UUIDs used to include GTID ranges when determine the starting position in the MySQL server's binlog.");
+
     /**
      * A comma-separated list of regular expressions that match source UUIDs in the GTID set used to find the binlog
      * position in the MySQL server. Only the GTID ranges that have sources matching none of these exclude patterns will
@@ -517,9 +518,9 @@ public class MySqlConnectorConfig {
     /**
      * If set to true, we will only produce DML events into Kafka for transactions that were written on mysql servers
      * with UUIDs matching the filters defined by the {@link GTID_SOURCE_INCLUDES} or {@link GTID_SOURCE_EXCLUDES}
-     * configuration options.
+     * configuration options, if they are specified.
      *
-     * Defaults to false.
+     * Defaults to true.
      *
      * When true, either {@link GTID_SOURCE_INCLUDES} or {@link GTID_SOURCE_EXCLUDES} must be set.
      */
@@ -528,9 +529,8 @@ public class MySqlConnectorConfig {
                                                           .withType(Type.BOOLEAN)
                                                           .withWidth(Width.SHORT)
                                                           .withImportance(Importance.MEDIUM)
-                                                          .withDefault(false)
-                                                          .withValidation(MySqlConnectorConfig::validateGtidSourceFilterDmlEvents)
-                                                          .withDescription("If set to true, we will only produce DML events into Kafka for transactions that were written on mysql servers with UUIDs matching the filters defined by the gtid.source.includes or gtid.source.excludes configuration options.");
+                                                          .withDefault(true)
+                                                          .withDescription("If set to true, we will only produce DML events into Kafka for transactions that were written on mysql servers with UUIDs matching the filters defined by the gtid.source.includes or gtid.source.excludes configuration options, if they are specified.");
 
     public static final Field CONNECTION_TIMEOUT_MS = Field.create("connect.timeout.ms")
                                                            .withDisplayName("Connection Timeout (ms)")
@@ -830,17 +830,6 @@ public class MySqlConnectorConfig {
         String excludes = config.getString(GTID_SOURCE_EXCLUDES);
         if (includes != null && excludes != null) {
             problems.accept(GTID_SOURCE_EXCLUDES, excludes, "Included GTID source UUIDs are already specified");
-            return 1;
-        }
-        return 0;
-    }
-
-    private static int validateGtidSourceFilterDmlEvents(Configuration config, Field field, ValidationOutput problems) {
-        String includes = config.getString(GTID_SOURCE_INCLUDES);
-        String excludes = config.getString(GTID_SOURCE_EXCLUDES);
-        Boolean filterDmlEvents = config.getBoolean(GTID_SOURCE_FILTER_DML_EVENTS);
-        if (filterDmlEvents && includes == null && excludes == null) {
-            problems.accept(GTID_SOURCE_FILTER_DML_EVENTS, filterDmlEvents , "Either gtid.source.includes or gtid.source.excludes must be specified.");
             return 1;
         }
         return 0;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -62,7 +62,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         *
+         * 
          * @param value the configuration property value; may not be null
          * @return the matching option, or null if no match is found
          */
@@ -77,7 +77,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         *
+         * 
          * @param value the configuration property value; may not be null
          * @param defaultValue the default value; may be null
          * @return the matching option, or null if no match is found and the non-null default is invalid
@@ -127,7 +127,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         *
+         * 
          * @param value the configuration property value; may not be null
          * @return the matching option, or null if no match is found
          */
@@ -142,7 +142,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         *
+         * 
          * @param value the configuration property value; may not be null
          * @param defaultValue the default value; may be null
          * @return the matching option, or null if no match is found and the non-null default is invalid
@@ -199,7 +199,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         *
+         * 
          * @param value the configuration property value; may not be null
          * @return the matching option, or null if no match is found
          */
@@ -214,7 +214,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         *
+         * 
          * @param value the configuration property value; may not be null
          * @param defaultValue the default value; may be null
          * @return the matching option, or null if no match is found and the non-null default is invalid
@@ -268,7 +268,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         *
+         * 
          * @param value the configuration property value; may not be null
          * @return the matching option, or null if no match is found
          */
@@ -283,7 +283,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         *
+         * 
          * @param value the configuration property value; may not be null
          * @param defaultValue the default value; may be null
          * @return the matching option, or null if no match is found and the non-null default is invalid
@@ -662,7 +662,7 @@ public class MySqlConnectorConfig {
     /**
      * Method that generates a Field for specifying that string columns whose names match a set of regular expressions should
      * have their values truncated to be no longer than the specified number of characters.
-     *
+     * 
      * @param length the maximum length of the column's string values written in source records; must be positive
      * @return the field; never null
      */
@@ -677,7 +677,7 @@ public class MySqlConnectorConfig {
     /**
      * Method that generates a Field for specifying that string columns whose names match a set of regular expressions should
      * have their values masked by the specified number of asterisk ('*') characters.
-     *
+     * 
      * @param length the number of asterisks that should appear in place of the column's string values written in source records;
      *            must be positive
      * @return the field; never null

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -14,6 +14,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import io.debezium.function.BooleanConsumer;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
@@ -486,18 +487,6 @@ public class MySqlConnectorConfig {
                                                       .withDescription("");
 
     /**
-     * A comma-separated list of regular expressions that match source UUIDs of transactions for which we will produce
-     * DML events into Kafka. When DML events having UUIDs that do not match any of these regular expressions are
-     * processed, they will be ignored and not produced into Kafka.
-     */
-    public static final Field GTID_DML_SOURCE_INCLUDES = Field.create("gtid.dml_source.includes")
-                                                          .withDisplayName("Include GTID sources for DML production into Kafka")
-                                                          .withType(Type.LIST)
-                                                          .withWidth(Width.LONG)
-                                                          .withImportance(Importance.HIGH)
-                                                          .withDescription("We will only produce DML events into Kafka for transactions that were written on mysql servers with UUIDs included in this list.");
-
-    /**
      * A comma-separated list of regular expressions that match source UUIDs in the GTID set used to find the binlog
      * position in the MySQL server. Only the GTID ranges that have sources matching one of these include patterns will
      * be used.
@@ -525,6 +514,24 @@ public class MySqlConnectorConfig {
                                                           .withValidation(MySqlConnectorConfig::validateGtidSetExcludes)
                                                           .withInvisibleRecommender()
                                                           .withDescription("The source UUIDs used to exclude GTID ranges when determine the starting position in the MySQL server's binlog.");
+
+    /**
+     * If set to true, we will only produce DML events into Kafka for transactions that were written on mysql servers
+     * with UUIDs matching the filters defined by the {@link GTID_SOURCE_INCLUDES} or {@link GTID_SOURCE_EXCLUDES}
+     * configuration options.
+     *
+     * Defaults to false.
+     *
+     * Must be used with either {@link GTID_SOURCE_INCLUDES} or {@link GTID_SOURCE_EXCLUDES}.
+     */
+    public static final Field GTID_SOURCE_FILTER_DML_EVENTS = Field.create("gtid.source.filter.dml_events")
+                                                          .withDisplayName("Filter DML events")
+                                                          .withType(Type.BOOLEAN)
+                                                          .withWidth(Width.SHORT)
+                                                          .withImportance(Importance.MEDIUM)
+                                                          .withDefault(false)
+                                                          .withValidation(MySqlConnectorConfig::validateGtidSourceFilterDmlEvents)
+                                                          .withDescription("If set to true, we will only produce DML events into Kafka for transactions that were written on mysql servers with UUIDs matching the filters defined by the gtid.source.includes or gtid.source.excludes configuration options.");
 
     public static final Field CONNECTION_TIMEOUT_MS = Field.create("connect.timeout.ms")
                                                            .withDisplayName("Connection Timeout (ms)")
@@ -695,8 +702,8 @@ public class MySqlConnectorConfig {
                                                      TABLE_WHITELIST, TABLE_BLACKLIST, TABLES_IGNORE_BUILTIN,
                                                      DATABASE_WHITELIST, DATABASE_BLACKLIST,
                                                      COLUMN_BLACKLIST, SNAPSHOT_MODE, SNAPSHOT_MINIMAL_LOCKING,
-                                                     GTID_DML_SOURCE_INCLUDES,
                                                      GTID_SOURCE_INCLUDES, GTID_SOURCE_EXCLUDES,
+                                                     GTID_SOURCE_FILTER_DML_EVENTS,
                                                      TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE,
                                                      SSL_MODE, SSL_KEYSTORE, SSL_KEYSTORE_PASSWORD,
                                                      SSL_TRUSTSTORE, SSL_TRUSTSTORE_PASSWORD, JDBC_DRIVER);
@@ -720,8 +727,8 @@ public class MySqlConnectorConfig {
                     KafkaDatabaseHistory.TOPIC, KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS,
                     KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS, DATABASE_HISTORY);
         Field.group(config, "Events", INCLUDE_SCHEMA_CHANGES, TABLES_IGNORE_BUILTIN, DATABASE_WHITELIST, TABLE_WHITELIST,
-                    COLUMN_BLACKLIST, TABLE_BLACKLIST, DATABASE_BLACKLIST, GTID_DML_SOURCE_INCLUDES,
-                    GTID_SOURCE_INCLUDES, GTID_SOURCE_EXCLUDES);
+                    COLUMN_BLACKLIST, TABLE_BLACKLIST, DATABASE_BLACKLIST,
+                    GTID_SOURCE_INCLUDES, GTID_SOURCE_EXCLUDES, GTID_SOURCE_FILTER_DML_EVENTS);
         Field.group(config, "Connector", CONNECTION_TIMEOUT_MS, KEEP_ALIVE, MAX_QUEUE_SIZE, MAX_BATCH_SIZE, POLL_INTERVAL_MS,
                     SNAPSHOT_MODE, SNAPSHOT_MINIMAL_LOCKING, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE);
         return config;
@@ -824,6 +831,17 @@ public class MySqlConnectorConfig {
         String excludes = config.getString(GTID_SOURCE_EXCLUDES);
         if (includes != null && excludes != null) {
             problems.accept(GTID_SOURCE_EXCLUDES, excludes, "Included GTID source UUIDs are already specified");
+            return 1;
+        }
+        return 0;
+    }
+
+    private static int validateGtidSourceFilterDmlEvents(Configuration config, Field field, ValidationOutput problems) {
+        String includes = config.getString(GTID_SOURCE_INCLUDES);
+        String excludes = config.getString(GTID_SOURCE_EXCLUDES);
+        Boolean filterDmlEvents = config.getBoolean(GTID_SOURCE_FILTER_DML_EVENTS);
+        if (includes == null && excludes == null) {
+            problems.accept(GTID_SOURCE_FILTER_DML_EVENTS, filterDmlEvents , "Either gtid.source.includes or gtid.source.excludes must be specified.");
             return 1;
         }
         return 0;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -14,7 +14,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import io.debezium.function.BooleanConsumer;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -62,7 +62,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         * 
+         *
          * @param value the configuration property value; may not be null
          * @return the matching option, or null if no match is found
          */
@@ -77,7 +77,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         * 
+         *
          * @param value the configuration property value; may not be null
          * @param defaultValue the default value; may be null
          * @return the matching option, or null if no match is found and the non-null default is invalid
@@ -127,7 +127,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         * 
+         *
          * @param value the configuration property value; may not be null
          * @return the matching option, or null if no match is found
          */
@@ -142,7 +142,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         * 
+         *
          * @param value the configuration property value; may not be null
          * @param defaultValue the default value; may be null
          * @return the matching option, or null if no match is found and the non-null default is invalid
@@ -199,7 +199,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         * 
+         *
          * @param value the configuration property value; may not be null
          * @return the matching option, or null if no match is found
          */
@@ -214,7 +214,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         * 
+         *
          * @param value the configuration property value; may not be null
          * @param defaultValue the default value; may be null
          * @return the matching option, or null if no match is found and the non-null default is invalid
@@ -268,7 +268,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         * 
+         *
          * @param value the configuration property value; may not be null
          * @return the matching option, or null if no match is found
          */
@@ -283,7 +283,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         * 
+         *
          * @param value the configuration property value; may not be null
          * @param defaultValue the default value; may be null
          * @return the matching option, or null if no match is found and the non-null default is invalid
@@ -486,6 +486,18 @@ public class MySqlConnectorConfig {
                                                       .withDescription("");
 
     /**
+     * A comma-separated list of regular expressions that match source UUIDs of transactions for which we will produce
+     * DML events into Kafka. When DML events having UUIDs that do not match any of these regular expressions are
+     * processed, they will be ignored and not produced into Kafka.
+     */
+    public static final Field GTID_DML_SOURCE_INCLUDES = Field.create("gtid.dml_source.includes")
+                                                          .withDisplayName("Include GTID sources for DML production into Kafka")
+                                                          .withType(Type.LIST)
+                                                          .withWidth(Width.LONG)
+                                                          .withImportance(Importance.HIGH)
+                                                          .withDescription("We will only produce DML events into Kafka for transactions that were written on mysql servers with UUIDs included in this list.");
+
+    /**
      * A comma-separated list of regular expressions that match source UUIDs in the GTID set used to find the binlog
      * position in the MySQL server. Only the GTID ranges that have sources matching one of these include patterns will
      * be used.
@@ -499,7 +511,6 @@ public class MySqlConnectorConfig {
                                                           .withRecommender(DATABASE_LIST_RECOMMENDER)
                                                           .withDependents(TABLE_WHITELIST_NAME)
                                                           .withDescription("The source UUIDs used to include GTID ranges when determine the starting position in the MySQL server's binlog.");
-
     /**
      * A comma-separated list of regular expressions that match source UUIDs in the GTID set used to find the binlog
      * position in the MySQL server. Only the GTID ranges that have sources matching none of these exclude patterns will
@@ -645,7 +656,7 @@ public class MySqlConnectorConfig {
     /**
      * Method that generates a Field for specifying that string columns whose names match a set of regular expressions should
      * have their values truncated to be no longer than the specified number of characters.
-     * 
+     *
      * @param length the maximum length of the column's string values written in source records; must be positive
      * @return the field; never null
      */
@@ -660,7 +671,7 @@ public class MySqlConnectorConfig {
     /**
      * Method that generates a Field for specifying that string columns whose names match a set of regular expressions should
      * have their values masked by the specified number of asterisk ('*') characters.
-     * 
+     *
      * @param length the number of asterisks that should appear in place of the column's string values written in source records;
      *            must be positive
      * @return the field; never null
@@ -684,6 +695,7 @@ public class MySqlConnectorConfig {
                                                      TABLE_WHITELIST, TABLE_BLACKLIST, TABLES_IGNORE_BUILTIN,
                                                      DATABASE_WHITELIST, DATABASE_BLACKLIST,
                                                      COLUMN_BLACKLIST, SNAPSHOT_MODE, SNAPSHOT_MINIMAL_LOCKING,
+                                                     GTID_DML_SOURCE_INCLUDES,
                                                      GTID_SOURCE_INCLUDES, GTID_SOURCE_EXCLUDES,
                                                      TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE,
                                                      SSL_MODE, SSL_KEYSTORE, SSL_KEYSTORE_PASSWORD,
@@ -708,7 +720,7 @@ public class MySqlConnectorConfig {
                     KafkaDatabaseHistory.TOPIC, KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS,
                     KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS, DATABASE_HISTORY);
         Field.group(config, "Events", INCLUDE_SCHEMA_CHANGES, TABLES_IGNORE_BUILTIN, DATABASE_WHITELIST, TABLE_WHITELIST,
-                    COLUMN_BLACKLIST, TABLE_BLACKLIST, DATABASE_BLACKLIST,
+                    COLUMN_BLACKLIST, TABLE_BLACKLIST, DATABASE_BLACKLIST, GTID_DML_SOURCE_INCLUDES,
                     GTID_SOURCE_INCLUDES, GTID_SOURCE_EXCLUDES);
         Field.group(config, "Connector", CONNECTION_TIMEOUT_MS, KEEP_ALIVE, MAX_QUEUE_SIZE, MAX_BATCH_SIZE, POLL_INTERVAL_MS,
                     SNAPSHOT_MODE, SNAPSHOT_MINIMAL_LOCKING, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -521,7 +521,7 @@ public class MySqlConnectorConfig {
      *
      * Defaults to false.
      *
-     * Must be used with either {@link GTID_SOURCE_INCLUDES} or {@link GTID_SOURCE_EXCLUDES}.
+     * When true, either {@link GTID_SOURCE_INCLUDES} or {@link GTID_SOURCE_EXCLUDES} must be set.
      */
     public static final Field GTID_SOURCE_FILTER_DML_EVENTS = Field.create("gtid.source.filter.dml_events")
                                                           .withDisplayName("Filter DML events")
@@ -839,7 +839,7 @@ public class MySqlConnectorConfig {
         String includes = config.getString(GTID_SOURCE_INCLUDES);
         String excludes = config.getString(GTID_SOURCE_EXCLUDES);
         Boolean filterDmlEvents = config.getBoolean(GTID_SOURCE_FILTER_DML_EVENTS);
-        if (includes == null && excludes == null) {
+        if (filterDmlEvents && includes == null && excludes == null) {
             problems.accept(GTID_SOURCE_FILTER_DML_EVENTS, filterDmlEvents , "Either gtid.source.includes or gtid.source.excludes must be specified.");
             return 1;
         }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -73,7 +73,6 @@ public final class MySqlTaskContext extends MySqlJdbcContext {
             if (gtidSetIncludes != null) {
                 gtidSourceFilter = filterIncludesRegex ? Predicates.includes(gtidSetIncludes) :
                         Predicates.includesNonRegex(gtidSetIncludes);
-
             } else if (gtidSetExcludes != null) {
                 gtidSourceFilter = filterIncludesRegex ? Predicates.excludes(gtidSetExcludes) :
                         Predicates.excludesNonRegex(gtidSetExcludes);

--- a/debezium-core/src/main/java/io/debezium/function/Predicates.java
+++ b/debezium-core/src/main/java/io/debezium/function/Predicates.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.function;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -79,6 +81,62 @@ public class Predicates {
      */
     public static <T> Predicate<T> excludes(String regexPatterns, Function<T, String> conversion) {
         return includes(regexPatterns, conversion).negate();
+    }
+
+    /**
+     * Generate a predicate function that for any supplied parameter returns {@code true} if <i>any</i> of the strings
+     * in the supplied comma-separated list matches the predicate parameter in a case-insensitive manner.
+     *
+     * @param nonRegexPatterns the comma-separated regular expression pattern (or literal) strings; may not be null
+     * @return the predicate function that performs the matching
+     */
+    public static Predicate<String> includesNonRegex(String nonRegexPatterns) {
+        return includesNonRegex(nonRegexPatterns, (str) -> str);
+    }
+
+    /**
+     * Generate a predicate function that for any supplied string returns {@code true} if <i>none</i> of the string
+     * in the supplied comma-separated list matches the predicate parameter in a case-insensitive manner.
+     *
+     * @param nonRegexPatterns the comma-separated regular expression pattern (or literal) strings; may not be null
+     * @return the predicate function that performs the matching
+     */
+    public static Predicate<String> excludesNonRegex(String nonRegexPatterns) {
+        return includesNonRegex(nonRegexPatterns).negate();
+    }
+
+    /**
+     * Generate a predicate function that for any supplied parameter returns {@code true} if <i>any</i> of the strings
+     * in the supplied comma-separated list matches the predicate parameter in a case-insensitive manner.
+     *
+     * @param nonRegexPatterns the comma-separated  literal strings; may not be null
+     * @param conversion the function that converts each predicate-supplied value to a string that can be matched against the
+     *            literal strings; may not be null
+     * @return the predicate function that performs the matching
+     */
+    public static <T> Predicate<T> includesNonRegex(String nonRegexPatterns, Function<T, String> conversion) {
+        String[] patterns = nonRegexPatterns.toLowerCase().split(",");
+        Set<String> patternSet = new HashSet<>(Arrays.asList(patterns));
+        return (t) -> {
+            String str = conversion.apply(t).toLowerCase();
+            if (patternSet.contains(str)) {
+                return true;
+            }
+            return false;
+        };
+    }
+
+    /**
+     * Generate a predicate function that for any supplied parameter returns {@code true} if <i>none</i> of the strings
+     * in the supplied comma-separated list matches the predicate parameter in a case-insensitive manner.
+     *
+     * @param nonRegexPatterns the comma-separated literal strings; may not be null
+     * @param conversion the function that converts each predicate-supplied value to a string that can be matched against the
+     *            strings; may not be null
+     * @return the predicate function that performs the matching
+     */
+    public static <T> Predicate<T> excludesNonRegex(String nonRegexPatterns, Function<T, String> conversion) {
+        return includesNonRegex(nonRegexPatterns, conversion).negate();
     }
 
     /**


### PR DESCRIPTION
… events into kafka by the mysql UUID of the event

With GTIDs enabled, each transaction in the binlog contains a GTID event, which gives us access to the GTID of the transaction. The GTID has the following format: source_id:transaction_id, where source_id is the UUID of the mysql server the transaction was written to.

I propose to allow a debezium instance to be configured with a UUID pattern to check against before producing DML events into Kafka. Debezium would produce a DML event into kafka if and only if the UUID in the event's GTID matches the pattern with which debezium was configured.