### PR TITLE
DBZ-188 More efficient GTID source filters for MySQL Connector

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -47,8 +47,8 @@ public final class MySqlTaskContext extends MySqlJdbcContext {
         // Set up the GTID filter ...
         String gtidSetIncludes = config.getString(MySqlConnectorConfig.GTID_SOURCE_INCLUDES);
         String gtidSetExcludes = config.getString(MySqlConnectorConfig.GTID_SOURCE_EXCLUDES);
-        this.gtidSourceFilter = gtidSetIncludes != null ? Predicates.includes(gtidSetIncludes)
-                : (gtidSetExcludes != null ? Predicates.excludes(gtidSetExcludes) : null);
+        this.gtidSourceFilter = gtidSetIncludes != null ? Predicates.includesUuids(gtidSetIncludes)
+                : (gtidSetExcludes != null ? Predicates.excludesUuids(gtidSetExcludes) : null);
 
         // Set up the MySQL schema ...
         this.dbSchema = new MySqlSchema(config, serverName(), this.gtidSourceFilter);

--- a/debezium-core/src/main/java/io/debezium/util/Strings.java
+++ b/debezium-core/src/main/java/io/debezium/util/Strings.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -780,6 +781,21 @@ public final class Strings {
             l.add(tokens.nextToken());
         }
         return l;
+    }
+
+    /**
+     * Determine if the supplied string is a valid {@link UUID}.
+     * @param str the string to evaluate
+     * @return {@code true} if the string is a valid representation of a UUID, or {@code false} otherwise
+     */
+    public static boolean isUuid(String str) {
+        if (str == null) return false;
+        try {
+            UUID.fromString(str);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     private Strings() {

--- a/debezium-core/src/test/java/io/debezium/function/PredicatesTest.java
+++ b/debezium-core/src/test/java/io/debezium/function/PredicatesTest.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.function;
 
+import java.util.UUID;
 import java.util.function.Predicate;
 
 import org.junit.Test;
@@ -53,6 +54,39 @@ public class PredicatesTest {
         assertThat(p.test(0)).isTrue();
         assertThat(p.test(6)).isTrue();
         assertThat(p.test(-1)).isTrue();
+    }
+
+    @Test
+    public void shouldMatchCommaSeparatedUuidLiterals() {
+        String uuid1 = UUID.randomUUID().toString();
+        String uuid2 = UUID.randomUUID().toString();
+        String uuid3 = UUID.randomUUID().toString();
+        String uuid4 = UUID.randomUUID().toString();
+        String uuid4Prefix = uuid4.substring(0,10) + ".*";
+        Predicate<String> p = Predicates.includesUuids(uuid1 + "," + uuid2);
+        assertThat(p.test(uuid1)).isTrue();
+        assertThat(p.test(uuid2)).isTrue();
+        assertThat(p.test(uuid3)).isFalse();
+        assertThat(p.test(uuid4)).isFalse();
+        
+        p = Predicates.excludesUuids(uuid1 + "," + uuid2);
+        assertThat(p.test(uuid1)).isFalse();
+        assertThat(p.test(uuid2)).isFalse();
+        assertThat(p.test(uuid3)).isTrue();
+        assertThat(p.test(uuid4)).isTrue();
+        
+        p = Predicates.includesUuids(uuid1 + "," + uuid2 + "," + uuid4Prefix);
+        assertThat(p.test(uuid1)).isTrue();
+        assertThat(p.test(uuid2)).isTrue();
+        assertThat(p.test(uuid3)).isFalse();
+        assertThat(p.test(uuid4)).isTrue();
+        
+        p = Predicates.excludesUuids(uuid1 + "," + uuid2 + "," + uuid4Prefix);
+        assertThat(p.test(uuid1)).isFalse();
+        assertThat(p.test(uuid2)).isFalse();
+        assertThat(p.test(uuid3)).isTrue();
+        assertThat(p.test(uuid4)).isFalse();
+        
     }
 
 }


### PR DESCRIPTION
Changed the GTID source filters in the MySQL connector to be far more efficient when the filters specify literal UUIDs rather than regex patterns. In these cases, the predicate just checks whether a supplied value is in a hash set, and no regular expression patterns are used.

The GTID source filters can still be a combination of UUID literals and regular expressions, and the predicate will use the best implementation for each. For example, if the filters include all UUID literals, then regular expressions will never be used.