### PR TITLE
DRAFT: DBZ-190 Proposed changes to explicitly set a null default on optional field schemas

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/RecordMakers.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/RecordMakers.java
@@ -24,6 +24,7 @@ import io.debezium.annotation.ThreadSafe;
 import io.debezium.data.Envelope.FieldName;
 import io.debezium.data.Envelope.Operation;
 import io.debezium.data.Json;
+import io.debezium.data.OptionalSchema;
 import io.debezium.function.BlockingConsumer;
 import io.debezium.util.AvroValidator;
 
@@ -105,11 +106,11 @@ public class RecordMakers {
                                           .build();
             this.valueSchema = SchemaBuilder.struct()
                                             .name(validator.validate(topicName + ".Envelope"))
-                                            .field(FieldName.AFTER, Json.builder().optional().build())
-                                            .field("patch", Json.builder().optional().build())
+                                            .field(FieldName.AFTER, Json.builder().optional().defaultValue(null).build())
+                                            .field("patch", Json.builder().optional().defaultValue(null).build())
                                             .field(FieldName.SOURCE, source.schema())
-                                            .field(FieldName.OPERATION, Schema.OPTIONAL_STRING_SCHEMA)
-                                            .field(FieldName.TIMESTAMP, Schema.OPTIONAL_INT64_SCHEMA)
+                                            .field(FieldName.OPERATION, OptionalSchema.OPTIONAL_STRING_SCHEMA)
+                                            .field(FieldName.TIMESTAMP, OptionalSchema.OPTIONAL_INT64_SCHEMA)
                                             .build();
             JsonWriterSettings writerSettings = new JsonWriterSettings(JsonMode.STRICT, "", ""); // most compact JSON
             this.valueTransformer = (doc) -> doc.toJson(writerSettings);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/SourceInfo.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/SourceInfo.java
@@ -21,6 +21,7 @@ import org.bson.types.BSONTimestamp;
 
 import io.debezium.annotation.Immutable;
 import io.debezium.annotation.NotThreadSafe;
+import io.debezium.data.OptionalSchema;
 import io.debezium.util.AvroValidator;
 import io.debezium.util.Collect;
 
@@ -91,8 +92,8 @@ public final class SourceInfo {
                                                       .field(NAMESPACE, Schema.STRING_SCHEMA)
                                                       .field(TIMESTAMP, Schema.INT32_SCHEMA)
                                                       .field(ORDER, Schema.INT32_SCHEMA)
-                                                      .field(OPERATION_ID, Schema.OPTIONAL_INT64_SCHEMA)
-                                                      .field(INITIAL_SYNC, Schema.OPTIONAL_BOOLEAN_SCHEMA)
+                                                      .field(OPERATION_ID, OptionalSchema.OPTIONAL_INT64_SCHEMA)
+                                                      .field(INITIAL_SYNC, OptionalSchema.OPTIONAL_BOOLEAN_SCHEMA)
                                                       .build();
 
     private final ConcurrentMap<String, Map<String, String>> sourcePartitionsByReplicaSetName = new ConcurrentHashMap<>();

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
@@ -16,6 +16,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 
 import io.debezium.annotation.NotThreadSafe;
 import io.debezium.data.Envelope;
+import io.debezium.data.OptionalSchema;
 import io.debezium.document.Document;
 import io.debezium.relational.TableId;
 import io.debezium.util.Collect;
@@ -118,14 +119,14 @@ final class SourceInfo {
                                                      .field(SERVER_NAME_KEY, Schema.STRING_SCHEMA)
                                                      .field(SERVER_ID_KEY, Schema.INT64_SCHEMA)
                                                      .field(TIMESTAMP_KEY, Schema.INT64_SCHEMA)
-                                                     .field(GTID_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                                                     .field(GTID_KEY, OptionalSchema.OPTIONAL_STRING_SCHEMA)
                                                      .field(BINLOG_FILENAME_OFFSET_KEY, Schema.STRING_SCHEMA)
                                                      .field(BINLOG_POSITION_OFFSET_KEY, Schema.INT64_SCHEMA)
                                                      .field(BINLOG_ROW_IN_EVENT_OFFSET_KEY, Schema.INT32_SCHEMA)
-                                                     .field(SNAPSHOT_KEY, Schema.OPTIONAL_BOOLEAN_SCHEMA)
-                                                     .field(THREAD_KEY, Schema.OPTIONAL_INT64_SCHEMA)
-                                                     .field(DB_NAME_KEY, Schema.OPTIONAL_STRING_SCHEMA)
-                                                     .field(TABLE_NAME_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                                                     .field(SNAPSHOT_KEY, OptionalSchema.OPTIONAL_BOOLEAN_SCHEMA)
+                                                     .field(THREAD_KEY, OptionalSchema.OPTIONAL_INT64_SCHEMA)
+                                                     .field(DB_NAME_KEY, OptionalSchema.OPTIONAL_STRING_SCHEMA)
+                                                     .field(TABLE_NAME_KEY, OptionalSchema.OPTIONAL_STRING_SCHEMA)
                                                      .build();
 
     private String currentGtidSet;

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -30,16 +30,17 @@ import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Assert;
 
 import io.debezium.data.Bits;
 import io.debezium.data.Json;
+import io.debezium.data.OptionalSchema;
 import io.debezium.data.Uuid;
 import io.debezium.data.Xml;
 import io.debezium.data.geometry.Point;
@@ -52,7 +53,7 @@ import io.debezium.time.ZonedTimestamp;
 import io.debezium.util.VariableLatch;
 
 /**
- * Base class for the integration tests for the different {@link RecordsProducer} instances 
+ * Base class for the integration tests for the different {@link RecordsProducer} instances
  * 
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
@@ -80,43 +81,43 @@ public abstract class AbstractRecordsProducerTest {
                                                                  INSERT_CASH_TYPES_STMT, INSERT_STRING_TYPES_STMT));
     
     protected List<SchemaAndValueField> schemasAndValuesForNumericType() {
-        return Arrays.asList(new SchemaAndValueField("si", SchemaBuilder.OPTIONAL_INT16_SCHEMA, (short) 1),
-                             new SchemaAndValueField("i", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 123456),
-                             new SchemaAndValueField("bi", SchemaBuilder.OPTIONAL_INT64_SCHEMA, 1234567890123L),
+        return Arrays.asList(new SchemaAndValueField("si", OptionalSchema.OPTIONAL_INT16_SCHEMA, (short) 1),
+                             new SchemaAndValueField("i", OptionalSchema.OPTIONAL_INT32_SCHEMA, 123456),
+                             new SchemaAndValueField("bi", OptionalSchema.OPTIONAL_INT64_SCHEMA, 1234567890123L),
                              new SchemaAndValueField("d", Decimal.builder(1).optional().build(), BigDecimal.valueOf(1.1d)),
                              new SchemaAndValueField("n", Decimal.builder(2).optional().build(), BigDecimal.valueOf(22.22d)),
-                             new SchemaAndValueField("r", Schema.OPTIONAL_FLOAT32_SCHEMA, 3.3f),
-                             new SchemaAndValueField("db", Schema.OPTIONAL_FLOAT64_SCHEMA, 4.44d),
+                             new SchemaAndValueField("r", OptionalSchema.OPTIONAL_FLOAT32_SCHEMA, 3.3f),
+                             new SchemaAndValueField("db", OptionalSchema.OPTIONAL_FLOAT64_SCHEMA, 4.44d),
                              new SchemaAndValueField("ss", Schema.INT16_SCHEMA, (short) 1),
                              new SchemaAndValueField("bs", Schema.INT64_SCHEMA, 123L),
-                             new SchemaAndValueField("b", Schema.OPTIONAL_BOOLEAN_SCHEMA, Boolean.TRUE));
+                             new SchemaAndValueField("b", OptionalSchema.OPTIONAL_BOOLEAN_SCHEMA, Boolean.TRUE));
     }
     
     protected List<SchemaAndValueField> schemasAndValuesForStringTypes() {
-       return Arrays.asList(new SchemaAndValueField("vc", Schema.OPTIONAL_STRING_SCHEMA, "aa"),
-                            new SchemaAndValueField("vcv", Schema.OPTIONAL_STRING_SCHEMA, "bb"),
-                            new SchemaAndValueField("ch", Schema.OPTIONAL_STRING_SCHEMA, "cdef"),
-                            new SchemaAndValueField("c", Schema.OPTIONAL_STRING_SCHEMA, "abc"),
-                            new SchemaAndValueField("t", Schema.OPTIONAL_STRING_SCHEMA, "some text"));
+       return Arrays.asList(new SchemaAndValueField("vc", OptionalSchema.OPTIONAL_STRING_SCHEMA, "aa"),
+                            new SchemaAndValueField("vcv", OptionalSchema.OPTIONAL_STRING_SCHEMA, "bb"),
+                            new SchemaAndValueField("ch", OptionalSchema.OPTIONAL_STRING_SCHEMA, "cdef"),
+                            new SchemaAndValueField("c", OptionalSchema.OPTIONAL_STRING_SCHEMA, "abc"),
+                            new SchemaAndValueField("t", OptionalSchema.OPTIONAL_STRING_SCHEMA, "some text"));
     }
    
     protected List<SchemaAndValueField> schemasAndValuesForTextTypes() {
-        return Arrays.asList(new SchemaAndValueField("j", Json.builder().optional().build(), "{\"bar\": \"baz\"}"),
-                             new SchemaAndValueField("jb", Json.builder().optional().build(), "{\"bar\": \"baz\"}"),
-                             new SchemaAndValueField("x", Xml.builder().optional().build(), "<foo>bar</foo><foo>bar</foo>"),
-                             new SchemaAndValueField("u", Uuid.builder().optional().build(), "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"));
+        return Arrays.asList(new SchemaAndValueField("j", Json.builder().optional().defaultValue(null).build(), "{\"bar\": \"baz\"}"),
+                             new SchemaAndValueField("jb", Json.builder().optional().defaultValue(null).build(), "{\"bar\": \"baz\"}"),
+                             new SchemaAndValueField("x", Xml.builder().optional().defaultValue(null).build(), "<foo>bar</foo><foo>bar</foo>"),
+                             new SchemaAndValueField("u", Uuid.builder().optional().defaultValue(null).build(), "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"));
     }
     
     protected List<SchemaAndValueField> schemaAndValuesForGeomTypes() {
-        Schema pointSchema = Point.builder().optional().build();
+        Schema pointSchema = Point.builder().optional().defaultValue(null).build();
         return Collections.singletonList(new SchemaAndValueField("p", pointSchema, Point.createValue(pointSchema, 1, 1)));
     }
     
     protected List<SchemaAndValueField> schemaAndValuesForBinTypes() {
        return Arrays.asList(new SchemaAndValueField("ba", Schema.OPTIONAL_BYTES_SCHEMA, ByteBuffer.wrap(new byte[]{ 1, 2, 3})),
                             new SchemaAndValueField("bol", Schema.OPTIONAL_BOOLEAN_SCHEMA, false),
-                            new SchemaAndValueField("bs", Bits.builder(2).optional().build(), new byte[] { 3, 0 }),  // bitsets get converted from two's complement
-                            new SchemaAndValueField("bv", Bits.builder(2).optional().build(), new byte[] { 0, 0 }));
+                            new SchemaAndValueField("bs", Bits.builder(2).optional().defaultValue(null).build(), new byte[] { 3, 0 }),  // bitsets get converted from two's complement
+                            new SchemaAndValueField("bv", Bits.builder(2).optional().defaultValue(null).build(), new byte[] { 0, 0 }));
     }
     
     protected List<SchemaAndValueField> schemaAndValuesForDateTimeTypes() {
@@ -127,27 +128,27 @@ public abstract class AbstractRecordsProducerTest {
         String expectedTtz = "11:51:30Z";  //time is stored with TZ, should be read back at GMT
         double interval = MicroDuration.durationMicros(1, 2, 3, 4, 5, 0, PostgresValueConverter.DAYS_PER_MONTH_AVG);
     
-        return Arrays.asList(new SchemaAndValueField("ts", NanoTimestamp.builder().optional().build(), expectedTs),
-                             new SchemaAndValueField("tz", ZonedTimestamp.builder().optional().build(), expectedTz),
-                             new SchemaAndValueField("date", Date.builder().optional().build(), expectedDate),
-                             new SchemaAndValueField("ti", NanoTime.builder().optional().build(), expectedTi),
-                             new SchemaAndValueField("ttz", ZonedTime.builder().optional().build(), expectedTtz),
-                             new SchemaAndValueField("it", MicroDuration.builder().optional().build(), interval));
+        return Arrays.asList(new SchemaAndValueField("ts", NanoTimestamp.builder().optional().defaultValue(null).build(), expectedTs),
+                             new SchemaAndValueField("tz", ZonedTimestamp.builder().optional().defaultValue(null).build(), expectedTz),
+                             new SchemaAndValueField("date", Date.builder().optional().defaultValue(null).build(), expectedDate),
+                             new SchemaAndValueField("ti", NanoTime.builder().optional().defaultValue(null).build(), expectedTi),
+                             new SchemaAndValueField("ttz", ZonedTime.builder().optional().defaultValue(null).build(), expectedTtz),
+                             new SchemaAndValueField("it", MicroDuration.builder().optional().defaultValue(null).build(), interval));
     }
     
     protected List<SchemaAndValueField> schemaAndValuesForMoneyTypes() {
-        return Collections.singletonList(new SchemaAndValueField("csh", Decimal.builder(0).optional().build(), 
+        return Collections.singletonList(new SchemaAndValueField("csh", Decimal.builder(0).optional().defaultValue(null).build(),
                                                                  BigDecimal.valueOf(1234.11d)));
     }
     
     protected Map<String, List<SchemaAndValueField>> schemaAndValuesByTableName() {
         return ALL_STMTS.stream().collect(Collectors.toMap(AbstractRecordsProducerTest::tableNameFromInsertStmt,
-                                                           this::schemasAndValuesForTable));    
+                                                           this::schemasAndValuesForTable));
     }
     
     protected List<SchemaAndValueField> schemasAndValuesForTable(String insertTableStatement) {
         switch (insertTableStatement) {
-            case INSERT_NUMERIC_TYPES_STMT: 
+            case INSERT_NUMERIC_TYPES_STMT:
                 return schemasAndValuesForNumericType();
             case INSERT_BIN_TYPES_STMT:
                 return schemaAndValuesForBinTypes();
@@ -159,7 +160,7 @@ public abstract class AbstractRecordsProducerTest {
                 return schemaAndValuesForGeomTypes();
             case INSERT_STRING_TYPES_STMT:
                 return schemasAndValuesForStringTypes();
-            case INSERT_TEXT_TYPES_STMT: 
+            case INSERT_TEXT_TYPES_STMT:
                 return schemasAndValuesForTextTypes();
             default:
                 throw new IllegalArgumentException("unknown statement:" + insertTableStatement);
@@ -239,7 +240,7 @@ public abstract class AbstractRecordsProducerTest {
     }
     
     protected TestConsumer testConsumer(int expectedRecordsCount) {
-         return new TestConsumer(expectedRecordsCount);        
+         return new TestConsumer(expectedRecordsCount);
     }
     
     protected static class TestConsumer implements Consumer<SourceRecord> {
@@ -254,9 +255,9 @@ public abstract class AbstractRecordsProducerTest {
         @Override
         public void accept(SourceRecord record) {
             if (latch.getCount() == 0) {
-                fail("received more events than expected");                
+                fail("received more events than expected");
             }
-            records.add(record);  
+            records.add(record);
             latch.countDown();
         }
         
@@ -283,8 +284,8 @@ public abstract class AbstractRecordsProducerTest {
    
         protected void await(long timeout, TimeUnit unit) throws InterruptedException {
             if (!latch.await(timeout, unit)) {
-                fail("Consumer expected " + latch.getCount() + " records, but received " + records.size());                
-            } 
+                fail("Consumer expected " + latch.getCount() + " records, but received " + records.size());
+            }
         }
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
@@ -7,7 +7,6 @@
 package io.debezium.connector.postgresql;
 
 import static io.debezium.connector.postgresql.PostgresConnectorConfig.SCHEMA_BLACKLIST;
-import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -15,15 +14,19 @@ import static org.junit.Assert.assertNull;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.stream.IntStream;
+
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.data.Bits;
 import io.debezium.data.Json;
+import io.debezium.data.OptionalSchema;
 import io.debezium.data.Uuid;
 import io.debezium.data.Xml;
 import io.debezium.data.geometry.Point;
@@ -52,7 +55,7 @@ public class PostgresSchemaIT {
     
     @Before
     public void before() throws SQLException {
-        TestHelper.dropAllSchemas();        
+        TestHelper.dropAllSchemas();
     }
     
     @Test
@@ -65,23 +68,30 @@ public class PostgresSchemaIT {
             Arrays.stream(TEST_TABLES).forEach(tableId -> assertKeySchema(tableId, "pk", Schema.INT32_SCHEMA));
             assertTableSchema("public.numeric_table", "si, i, bi, d, n, r, db, ss, bs, b",
                               Schema.OPTIONAL_INT16_SCHEMA, Schema.OPTIONAL_INT32_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA,
-                              Decimal.builder(1).optional().build(), Decimal.builder(2).optional().build(), Schema.OPTIONAL_FLOAT32_SCHEMA,
+                              Decimal.builder(1).optional().defaultValue(null).build(),
+                              Decimal.builder(2).optional().defaultValue(null).build(), Schema.OPTIONAL_FLOAT32_SCHEMA,
                               Schema.OPTIONAL_FLOAT64_SCHEMA, Schema.INT16_SCHEMA, Schema.INT64_SCHEMA, Schema.OPTIONAL_BOOLEAN_SCHEMA);
             assertTableSchema("public.string_table", "vc, vcv, ch, c, t",
                               Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA,
                               Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
-            assertTableSchema("public.cash_table", "csh", Decimal.builder(0).optional().build());
+            assertTableSchema("public.cash_table", "csh", Decimal.builder(0).optional().defaultValue(null).build());
             assertTableSchema("public.bitbin_table", "ba, bol, bs, bv",
-                              Schema.OPTIONAL_BYTES_SCHEMA, Schema.OPTIONAL_BOOLEAN_SCHEMA, Bits.builder(2).optional().build(),
-                              Bits.builder(2).optional().build());
+                              Schema.OPTIONAL_BYTES_SCHEMA, Schema.OPTIONAL_BOOLEAN_SCHEMA,
+                              Bits.builder(2).optional().defaultValue(null).build(),
+                              Bits.builder(2).optional().defaultValue(null).build());
             assertTableSchema("public.time_table", "ts, tz, date, ti, ttz, it",
-                              NanoTimestamp.builder().optional().build(), ZonedTimestamp.builder().optional().build(),
-                              Date.builder().optional().build(), NanoTime.builder().optional().build(), ZonedTime.builder().optional().build(),
-                              MicroDuration.builder().optional().build());
+                              NanoTimestamp.builder().optional().defaultValue(null).build(),
+                              ZonedTimestamp.builder().optional().defaultValue(null).build(),
+                              Date.builder().optional().defaultValue(null).build(),
+                              NanoTime.builder().optional().defaultValue(null).build(),
+                              ZonedTime.builder().optional().defaultValue(null).build(),
+                              MicroDuration.builder().optional().defaultValue(null).build());
             assertTableSchema("public.text_table", "j, jb, x, u",
-                              Json.builder().optional().build(), Json.builder().optional().build(), Xml.builder().optional().build(),
-                              Uuid.builder().optional().build());
-            assertTableSchema("public.geom_table", "p", Point.builder().optional().build());
+                              Json.builder().optional().defaultValue(null).build(),
+                              Json.builder().optional().defaultValue(null).build(),
+                              Xml.builder().optional().defaultValue(null).build(),
+                              Uuid.builder().optional().defaultValue(null).build());
+            assertTableSchema("public.geom_table", "p", Point.builder().optional().defaultValue(null).build());
         }
     }
     
@@ -160,7 +170,7 @@ public class PostgresSchemaIT {
             schema.refresh(connection, false);
             assertTablesIncluded(tableId);
             assertTablesExcluded("public.table1");
-            assertTableSchema(tableId, "strcol", Schema.OPTIONAL_STRING_SCHEMA);
+            assertTableSchema(tableId, "strcol", OptionalSchema.OPTIONAL_STRING_SCHEMA);
         }
         
         statements = "ALTER TABLE table2 ADD COLUMN vc VARCHAR(2);" +
@@ -173,7 +183,7 @@ public class PostgresSchemaIT {
             assertTablesIncluded(tableId);
             assertTablesExcluded("public.table1");
             assertTableSchema(tableId, "vc, si",
-                              Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_INT16_SCHEMA);
+                              OptionalSchema.OPTIONAL_STRING_SCHEMA, OptionalSchema.OPTIONAL_INT16_SCHEMA);
             assertColumnsExcluded(tableId + ".strcol");
         }
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.After;
@@ -22,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.debezium.data.Envelope;
+import io.debezium.data.OptionalSchema;
 import io.debezium.data.VerifyRecord;
 
 /**
@@ -38,7 +40,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     @Before
     public void before() throws Exception {
         TestHelper.dropAllSchemas();
-        String statements = "CREATE SCHEMA public;" + 
+        String statements = "CREATE SCHEMA public;" +
                             "DROP TABLE IF EXISTS test_table;" +
                             "CREATE TABLE test_table (pk SERIAL, text TEXT, PRIMARY KEY(pk));" +
                             "INSERT INTO test_table(text) VALUES ('insert');";
@@ -126,7 +128,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         
         // default replica identity only fires previous values for PK changes
         List<SchemaAndValueField> expectedAfter = Collections.singletonList(
-                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "update"));
+                new SchemaAndValueField("text", OptionalSchema.OPTIONAL_STRING_SCHEMA, "update"));
         assertRecordSchemaAndValues(expectedAfter, updatedRecord, Envelope.FieldName.AFTER);
 
         // alter the table and set its replica identity to full the issue another update
@@ -139,11 +141,11 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         VerifyRecord.isValidUpdate(updatedRecord, PK_FIELD, 1);
         
         // now we should get both old and new values
-        List<SchemaAndValueField> expectedBefore = Collections.singletonList(new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA,
+        List<SchemaAndValueField> expectedBefore = Collections.singletonList(new SchemaAndValueField("text", OptionalSchema.OPTIONAL_STRING_SCHEMA,
                                                                                                "update"));
         assertRecordSchemaAndValues(expectedBefore, updatedRecord, Envelope.FieldName.BEFORE);
     
-        expectedAfter = Collections.singletonList(new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "update2"));
+        expectedAfter = Collections.singletonList(new SchemaAndValueField("text", OptionalSchema.OPTIONAL_STRING_SCHEMA, "update2"));
         assertRecordSchemaAndValues(expectedAfter, updatedRecord, Envelope.FieldName.AFTER);
     }
     
@@ -168,7 +170,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         List<SchemaAndValueField> expectedBefore = Collections.singletonList(new SchemaAndValueField("uvc", null, null));
         assertRecordSchemaAndValues(expectedBefore, updatedRecord, Envelope.FieldName.BEFORE);
     
-        List<SchemaAndValueField> expectedAfter = Collections.singletonList(new SchemaAndValueField("uvc", SchemaBuilder.OPTIONAL_STRING_SCHEMA, 
+        List<SchemaAndValueField> expectedAfter = Collections.singletonList(new SchemaAndValueField("uvc", OptionalSchema.OPTIONAL_STRING_SCHEMA,
                                                                                            "aa"));
         assertRecordSchemaAndValues(expectedAfter, updatedRecord, Envelope.FieldName.AFTER);
     
@@ -220,7 +222,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         // and finally insert of the new value
         SourceRecord insertRecord = consumer.remove();
         assertEquals(topicName, insertRecord.topic());
-        VerifyRecord.isValidInsert(insertRecord, PK_FIELD, 2);    
+        VerifyRecord.isValidInsert(insertRecord, PK_FIELD, 2);
     }
     
     @Test
@@ -236,8 +238,8 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         assertEquals(topicName("public.test_table"), insertRecord.topic());
         VerifyRecord.isValidInsert(insertRecord, PK_FIELD, 2);
         List<SchemaAndValueField> expectedSchemaAndValues = Arrays.asList(
-                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, "update"),
-                new SchemaAndValueField("default_column", SchemaBuilder.OPTIONAL_STRING_SCHEMA ,"default"));
+                new SchemaAndValueField("text", OptionalSchema.OPTIONAL_STRING_SCHEMA, "update"),
+                new SchemaAndValueField("default_column", OptionalSchema.OPTIONAL_STRING_SCHEMA ,"default"));
         assertRecordSchemaAndValues(expectedSchemaAndValues, insertRecord, Envelope.FieldName.AFTER);
     }
     

--- a/debezium-core/src/main/java/io/debezium/data/Envelope.java
+++ b/debezium-core/src/main/java/io/debezium/data/Envelope.java
@@ -203,8 +203,8 @@ public final class Envelope {
 
             @Override
             public Envelope build() {
-                builder.field(FieldName.OPERATION, OPERATION_REQUIRED ? Schema.STRING_SCHEMA : Schema.OPTIONAL_STRING_SCHEMA);
-                builder.field(FieldName.TIMESTAMP, Schema.OPTIONAL_INT64_SCHEMA);
+                builder.field(FieldName.OPERATION, OPERATION_REQUIRED ? Schema.STRING_SCHEMA : OptionalSchema.OPTIONAL_STRING_SCHEMA);
+                builder.field(FieldName.TIMESTAMP, OptionalSchema.OPTIONAL_INT64_SCHEMA);
                 builder.version(VERSION);
                 checkFieldIsDefined(FieldName.OPERATION, OPERATION_REQUIRED);
                 checkFieldIsDefined(FieldName.BEFORE, false);

--- a/debezium-core/src/main/java/io/debezium/data/OptionalSchema.java
+++ b/debezium-core/src/main/java/io/debezium/data/OptionalSchema.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.data;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+/**
+ * Utility class with customized {@link Schema} instances for the built-in primitives, except that these all have defaults
+ * set to null in addition to being optional.
+ * 
+ * @author Randall Hauch
+ */
+public interface OptionalSchema {
+
+    Schema OPTIONAL_INT8_SCHEMA = SchemaBuilder.int8().optional().defaultValue(null).build();
+    Schema OPTIONAL_INT16_SCHEMA = SchemaBuilder.int16().optional().defaultValue(null).build();
+    Schema OPTIONAL_INT32_SCHEMA = SchemaBuilder.int32().optional().defaultValue(null).build();
+    Schema OPTIONAL_INT64_SCHEMA = SchemaBuilder.int64().optional().defaultValue(null).build();
+    Schema OPTIONAL_FLOAT32_SCHEMA = SchemaBuilder.float32().optional().defaultValue(null).build();
+    Schema OPTIONAL_FLOAT64_SCHEMA = SchemaBuilder.float64().optional().defaultValue(null).build();
+    Schema OPTIONAL_BOOLEAN_SCHEMA = SchemaBuilder.bool().optional().defaultValue(null).build();
+    Schema OPTIONAL_STRING_SCHEMA = SchemaBuilder.string().optional().defaultValue(null).build();
+    Schema OPTIONAL_BYTES_SCHEMA = SchemaBuilder.bytes().optional().defaultValue(null).build();
+
+}

--- a/debezium-core/src/main/java/io/debezium/relational/TableSchemaBuilder.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableSchemaBuilder.java
@@ -147,7 +147,7 @@ public class TableSchemaBuilder {
                 addField(valSchemaBuilder, column, mapper);
             }
         });
-        Schema valSchema = valSchemaBuilder.optional().build();
+        Schema valSchema = valSchemaBuilder.optional().defaultValue(null).build();
         Schema keySchema = hasPrimaryKey.get() ? keySchemaBuilder.build() : null;
 
         if (LOGGER.isDebugEnabled()) {
@@ -317,7 +317,11 @@ public class TableSchemaBuilder {
                 // Let the mapper add properties to the schema ...
                 mapper.alterFieldSchema(column, fieldBuilder);
             }
-            if (column.isOptional()) fieldBuilder.optional();
+            if (column.isOptional()) {
+                // Need both optional and a null default value for Avro schema evolution rules
+                fieldBuilder.optional();
+                fieldBuilder.defaultValue(null);
+            }
             builder.field(column.name(), fieldBuilder.build());
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("- field '{}' ({}{}) from column {}", column.name(), builder.isOptional() ? "OPTIONAL " : "",

--- a/debezium-core/src/test/java/io/debezium/relational/TableSchemaBuilderTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/TableSchemaBuilderTest.java
@@ -103,13 +103,13 @@ public class TableSchemaBuilderTest {
         assertThat(values.field("C1").schema()).isEqualTo(SchemaBuilder.string().build());
         assertThat(values.field("C2").name()).isEqualTo("C2");
         assertThat(values.field("C2").index()).isEqualTo(1);
-        assertThat(values.field("C2").schema()).isEqualTo(Decimal.builder(3).optional().build()); // scale of 3
+        assertThat(values.field("C2").schema()).isEqualTo(Decimal.builder(3).optional().defaultValue(null).build()); // scale of 3
         assertThat(values.field("C3").name()).isEqualTo("C3");
         assertThat(values.field("C3").index()).isEqualTo(2);
-        assertThat(values.field("C3").schema()).isEqualTo(Date.builder().optional().build()); // optional date
+        assertThat(values.field("C3").schema()).isEqualTo(Date.builder().optional().defaultValue(null).build()); // optional date
         assertThat(values.field("C4").name()).isEqualTo("C4");
         assertThat(values.field("C4").index()).isEqualTo(3);
-        assertThat(values.field("C4").schema()).isEqualTo(SchemaBuilder.int32().optional().build()); // JDBC INTEGER = 32 bits
+        assertThat(values.field("C4").schema()).isEqualTo(SchemaBuilder.int32().optional().defaultValue(null).build()); // JDBC INTEGER = 32 bits
         Struct value = schema.valueFromColumnData(data);
         assertThat(value).isNotNull();
     }

--- a/debezium-embedded/src/main/java/io/debezium/connector/simple/SimpleSourceConnector.java
+++ b/debezium-embedded/src/main/java/io/debezium/connector/simple/SimpleSourceConnector.java
@@ -23,6 +23,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 
 import io.debezium.config.Configuration;
+import io.debezium.data.OptionalSchema;
 import io.debezium.util.Collect;
 
 /**
@@ -132,7 +133,7 @@ public class SimpleSourceConnector extends SourceConnector {
                                                   .name("simple.value")
                                                   .field("batch", Schema.INT32_SCHEMA)
                                                   .field("record", Schema.INT32_SCHEMA)
-                                                  .field("timestamp", Schema.OPTIONAL_INT64_SCHEMA)
+                                                  .field("timestamp", OptionalSchema.OPTIONAL_INT64_SCHEMA)
                                                   .build();
 
                 // Read the offset ...


### PR DESCRIPTION
**At this time, this should not be merged!**

Having to explicitly call `SchemaBuilder`'s `defaultValue(null)` everywhere we have an optional schema is really painful, but this PR contains all of the places where this would have to be done. But per my comment on [DBZ-190|https://issues.jboss.org/browse/DBZ-190], this still won't have any affect on the Avro schema generated by the {{AvroConverter}}.
