### PR TITLE
DBZ-193 MySQL DDL parser handling FULLTEXT index

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -516,13 +516,13 @@ public class MySqlConnectorConfig {
                                                           .withDescription("The source UUIDs used to exclude GTID ranges when determine the starting position in the MySQL server's binlog.");
 
     /**
-     * If set to true, we will only produce DML events into Kafka for transactions that were written on mysql servers
-     * with UUIDs matching the filters defined by the {@link GTID_SOURCE_INCLUDES} or {@link GTID_SOURCE_EXCLUDES}
+     * If set to true, we will only produce DML events into Kafka for transactions that were written on MySQL servers
+     * with UUIDs matching the filters defined by the {@link #GTID_SOURCE_INCLUDES} or {@link #GTID_SOURCE_EXCLUDES}
      * configuration options, if they are specified.
      *
      * Defaults to true.
      *
-     * When true, either {@link GTID_SOURCE_INCLUDES} or {@link GTID_SOURCE_EXCLUDES} must be set.
+     * When true, either {@link #GTID_SOURCE_INCLUDES} or {@link #GTID_SOURCE_EXCLUDES} must be set.
      */
     public static final Field GTID_SOURCE_FILTER_DML_EVENTS = Field.create("gtid.source.filter.dml.events")
                                                           .withDisplayName("Filter DML events")

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
@@ -606,7 +606,7 @@ public class MySqlDdlParser extends DdlParser {
             }
             parseIndexColumnNames(start);
             parseIndexOptions(start);
-        } else if (!quoted && tokens.canConsume("FULLTEXT", "SPATIAL")) {
+        } else if (!quoted && tokens.canConsumeAnyOf("FULLTEXT", "SPATIAL")) {
             tokens.canConsumeAnyOf("INDEX", "KEY");
             if (!tokens.matches('(')) {
                 tokens.consume(); // name of unique index ...

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -773,6 +773,33 @@ public class MySqlDdlParserTest {
         listener.forEach(this::printEvent);
     }
     
+    @FixFor("DBZ-193")
+    @Test
+    public void shouldParseFulltextKeyInCreateTable() {
+        parser.parse(readFile("ddl/mysql-dbz-193.ddl"), tables);
+        Testing.print(tables);
+        assertThat(tables.size()).isEqualTo(1); // 1 table
+        assertThat(listener.total()).isEqualTo(1);
+        listener.forEach(this::printEvent);
+
+        Table t = tables.forTable(new TableId(null, null, "roles"));
+        assertThat(t).isNotNull();
+        assertThat(t.columnNames()).containsExactly("id", "name", "context", "organization_id", "client_id", "scope_action_ids");
+        assertThat(t.primaryKeyColumnNames()).containsExactly("id");
+        assertColumn(t, "id", "VARCHAR", Types.VARCHAR, 32, -1, false, false, false);
+        assertColumn(t, "name", "VARCHAR", Types.VARCHAR, 100, -1, false, false, false);
+        assertColumn(t, "context", "VARCHAR", Types.VARCHAR, 20, -1, false, false, false);
+        assertColumn(t, "organization_id", "INT", Types.INTEGER, 11, -1, true, false, false);
+        assertColumn(t, "client_id", "VARCHAR", Types.VARCHAR, 32, -1, false, false, false);
+        assertColumn(t, "scope_action_ids", "TEXT", Types.VARCHAR, -1, -1, false, false, false);
+        assertThat(t.columnWithName("id").position()).isEqualTo(1);
+        assertThat(t.columnWithName("name").position()).isEqualTo(2);
+        assertThat(t.columnWithName("context").position()).isEqualTo(3);
+        assertThat(t.columnWithName("organization_id").position()).isEqualTo(4);
+        assertThat(t.columnWithName("client_id").position()).isEqualTo(5);
+        assertThat(t.columnWithName("scope_action_ids").position()).isEqualTo(6);
+    }
+    
     @Test
     public void shouldParseTicketMonsterLiquibaseStatements() {
         parser.parse(readLines(1, "ddl/mysql-ticketmonster-liquibase.ddl"), tables);

--- a/debezium-connector-mysql/src/test/resources/ddl/mysql-dbz-193.ddl
+++ b/debezium-connector-mysql/src/test/resources/ddl/mysql-dbz-193.ddl
@@ -1,0 +1,10 @@
+CREATE TABLE `roles` (
+`id` varchar(32) NOT NULL,
+`name` varchar(100) NOT NULL,
+`context` varchar(20) NOT NULL,
+`organization_id` int(11) DEFAULT NULL,
+`client_id` varchar(32) NOT NULL,
+`scope_action_ids` text NOT NULL,
+PRIMARY KEY (`id`),
+FULLTEXT KEY `scope_action_ids_idx` (`scope_action_ids`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Corrected the MySQL DDL parser to correctly handle `FULLTEXT` indexes within a `CREATE TABLE` statement. The parser was incorrectly using `canConsume(...)` with a list of options instead of `canConsumeAnyOf(...)`.