### PR TITLE
DBZ-194 Improved MySQL connector’s built-in table filtering

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
@@ -29,17 +29,6 @@ import io.debezium.util.Collect;
 @Immutable
 public class Filters {
 
-    protected static final Set<String> BUILT_IN_TABLE_NAMES = Collect.unmodifiableSet("db", "user", "func", "plugin", "tables_priv",
-                                                                                      "columns_priv", "help_topic", "help_category",
-                                                                                      "help_relation", "help_keyword",
-                                                                                      "time_zone_name", "time_zone", "time_zone_transition",
-                                                                                      "time_zone_transition_type", "time_zone_leap_second",
-                                                                                      "proc", "procs_priv", "general_log", "event",
-                                                                                      "ndb_binlog_index",
-                                                                                      "innodb_table_stats", "innodb_index_stats",
-                                                                                      "slave_relay_log_info", "slave_master_info",
-                                                                                      "slave_worker_info", "gtid_executed",
-                                                                                      "server_cost", "engine_cost");
     protected static final Set<String> BUILT_IN_DB_NAMES = Collect.unmodifiableSet("mysql", "performance_schema","sys", "information_schema");
 
     protected static boolean isBuiltInDatabase(String databaseName) {
@@ -47,7 +36,7 @@ public class Filters {
     }
 
     protected static boolean isBuiltInTable(TableId id ) {
-        return isBuiltInDatabase(id.catalog()) || BUILT_IN_TABLE_NAMES.contains(id.table().toLowerCase());
+        return isBuiltInDatabase(id.catalog());
     }
 
     protected static boolean isNotBuiltInDatabase(String databaseName) {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -259,7 +260,8 @@ public class SnapshotReader extends AbstractReader {
                         logger.warn("\t skipping database '{}' due to error reading tables: {}", dbName, e.getMessage());
                     }
                 }
-                logger.info("\t snapshot continuing with databases: {}", readableDatabaseNames);
+                final Set<String> includedDatabaseNames = readableDatabaseNames.stream().filter(filters.databaseFilter()).collect(Collectors.toSet());
+                logger.info("\tsnapshot continuing with database(s): {}", includedDatabaseNames);
 
                 if (!isLocked) {
                     // ------------------------------------

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/FiltersTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/FiltersTest.java
@@ -278,18 +278,14 @@ public class FiltersTest {
     }
 
     protected void assertSystemTablesExcluded() {
-        Filters.BUILT_IN_TABLE_NAMES.forEach(tableName->{
-            Filters.BUILT_IN_DB_NAMES.forEach(dbName->{
-                assertTableExcluded(dbName + "." + tableName);
-            });
+        Filters.BUILT_IN_DB_NAMES.forEach(dbName -> {
+            assertTableExcluded(dbName + ".foo");
         });
     }
 
     protected void assertSystemTablesIncluded() {
-        Filters.BUILT_IN_TABLE_NAMES.forEach(tableName->{
-            Filters.BUILT_IN_DB_NAMES.forEach(dbName->{
-                assertTableIncluded(dbName + "." + tableName);
-            });
+        Filters.BUILT_IN_DB_NAMES.forEach(dbName -> {
+            assertTableIncluded(dbName + ".foo");
         });
     }
 


### PR DESCRIPTION
The MySQL connector’s built-in table filter now just filters out all tables within the known built-in databases, and does not check the names of the tables. Thus, the connector should no longer filter out tables in other databases that happen to have the same names as the tables in the built-in databases.