### PR TITLE
DBZ-196 Handle SAVEPOINT statements appearing in a MySQL replication stream

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
@@ -130,7 +130,7 @@ public class MySqlDdlParser extends DdlParser {
 
     @Override
     protected void initializeStatementStarts(TokenSet statementStartTokens) {
-        statementStartTokens.add("CREATE", "ALTER", "DROP", "INSERT", "GRANT", "REVOKE", "FLUSH", "TRUNCATE", "COMMIT", "USE");
+        statementStartTokens.add("CREATE", "ALTER", "DROP", "INSERT", "GRANT", "REVOKE", "FLUSH", "TRUNCATE", "COMMIT", "USE", "SAVEPOINT");
     }
 
     @Override


### PR DESCRIPTION
Hi Randall,

Here's the code that I've been using in testing to allow debezium to parse `SAVEPOINT`. As near as I can tell, there isn't any special logic required for mysql; the connector just needs to be able to parse and discard the statement.