### PR TITLE
fix daylight savings test issues

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
@@ -225,7 +225,8 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 assertThat(c4DateTime.getYear()).isEqualTo(1970);
                 assertThat(c4DateTime.getMonth()).isEqualTo(Month.JANUARY);
                 assertThat(c4DateTime.getDayOfMonth()).isEqualTo(1);
-                assertThat(c4DateTime.getHour()).isEqualTo(0);
+                // Difference depends upon whether the zone we're in is also using DST as it is on the date in question ...
+                assertThat(c4DateTime.getHour()).isIn(0, 1);
                 assertThat(c4DateTime.getMinute()).isEqualTo(0);
                 assertThat(c4DateTime.getSecond()).isEqualTo(0);
                 assertThat(c4DateTime.getNano()).isEqualTo(0);
@@ -433,7 +434,8 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 assertThat(c4DateTime.getYear()).isEqualTo(1970);
                 assertThat(c4DateTime.getMonth()).isEqualTo(Month.JANUARY);
                 assertThat(c4DateTime.getDayOfMonth()).isEqualTo(1);
-                assertThat(c4DateTime.getHour()).isEqualTo(0);
+                // Difference depends upon whether the zone we're in is also using DST as it is on the date in question ...
+                assertThat(c4DateTime.getHour()).isIn(0, 1);
                 assertThat(c4DateTime.getMinute()).isEqualTo(0);
                 assertThat(c4DateTime.getSecond()).isEqualTo(0);
                 assertThat(c4DateTime.getNano()).isEqualTo(0);


### PR DESCRIPTION
I was getting errors running my tests ever since DST: https://gist.github.com/dasl-/0d227303ec280644c7ead44e28629232

Looks like there is already precedent in the code for doing this sort of thing: https://github.com/dasl-/debezium/blob/031c4a15524c1de72510d60d64c87aa344435599/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java#L604-L604