### PR TITLE
DBZ-198 Improved MySQL DDL parser to better handle blocks

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -800,6 +800,17 @@ public class MySqlDdlParserTest {
         assertThat(t.columnWithName("scope_action_ids").position()).isEqualTo(6);
     }
 
+    @FixFor("DBZ-198")
+    @Test
+    public void shouldParseButIgnoreCreateFunctionWithDefiner() {
+        parser.parse(readFile("ddl/mysql-dbz-198.ddl"), tables);
+        Testing.print(tables);
+        assertThat(tables.size()).isEqualTo(0); // 0 table
+        assertThat(listener.total()).isEqualTo(0);
+        listener.forEach(this::printEvent);
+    }
+
+    @FixFor("DBZ-200")
     @Test
     public void shouldParseStatementForDbz200() {
         parser.parse(readFile("ddl/mysql-dbz-200.ddl"), tables);

--- a/debezium-connector-mysql/src/test/resources/ddl/mysql-dbz-198.ddl
+++ b/debezium-connector-mysql/src/test/resources/ddl/mysql-dbz-198.ddl
@@ -1,0 +1,46 @@
+CREATE DEFINER=`parasshah`@`%` PROCEDURE `find_par`(seed INT)
+BEGIN
+  DECLARE i int default 0;
+   DROP TABLE IF EXISTS _result;
+   CREATE TEMPORARY TABLE _result (node int primary key,id int,type varchar(20));
+   INSERT INTO _result(node,id,type) VALUES(seed,i,'exam');
+   DROP TABLE IF EXISTS _tmp;
+  CREATE TEMPORARY TABLE _tmp (parent_node int,child_node int);
+  REPEAT
+    TRUNCATE TABLE _tmp;
+    INSERT INTO _tmp SELECT EM.PARENT_EXAM_ID as parent_node, _result.node as child_node
+           FROM _result JOIN EXAM_MAPPING EM ON EM.CHILD_EXAM_ID = _result.node;  
+    INSERT IGNORE INTO _result(node,id,type) values ((SELECT parent_node FROM _tmp),i+1,'exam' );
+    UNTIL ROW_COUNT() = 0
+  END REPEAT;
+  select max(id) from _result into i;
+  labelXYZ: REPEAT
+    TRUNCATE TABLE _tmp;
+    INSERT INTO _tmp SELECT EM.EXAM_STRUCTURE_ID as parent_node, _result.node as child_node
+           FROM _result JOIN EXAM_STRUCTURE_EXAM_MAPPING EM ON EM.EXAM_ID = _result.node and _result.id = i;  
+    INSERT IGNORE INTO _result(node,id,type) values ((SELECT parent_node FROM _tmp),i+1,'exam_structure');
+    UNTIL ROW_COUNT() = 0
+  END REPEAT labelXYZ;
+  select max(id) from _result into i;
+  labelABC: REPEAT
+    TRUNCATE TABLE _tmp;
+    INSERT INTO _tmp SELECT EM.PARENT_EXAM_STRUCTURE_ID as parent_node, _result.node as child_node
+           FROM _result JOIN EXAM_STRUCTURE_MAPPING EM ON EM.CHILD_EXAM_STRUCTURE_ID = _result.node and _result.id = i;  
+    if ((SELECT EM.PARENT_EXAM_STRUCTURE_ID as parent_node, _result.node as child_node
+         FROM _result JOIN EXAM_STRUCTURE_MAPPING EM ON EM.CHILD_EXAM_STRUCTURE_ID = _result.node and _result.id = i)!= NULL)
+    then
+      INSERT IGNORE INTO _result(node,id,type) values ((SELECT parent_node FROM _tmp),i+1,'exam_structure');
+    end if;
+    UNTIL ROW_COUNT() = 0
+  END REPEAT;
+  TRUNCATE TABLE _tmp;
+  SELECT * FROM _result;
+  DROP TABLE _tmp;
+  
+  nestedBegin: BEGIN
+    DECLARE i int default 0;
+    doubleNestedBegin: BEGIN
+        DECLARE i int default 0;
+    END doubleNestedBegin
+  END
+END

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/DdlParser.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/DdlParser.java
@@ -581,12 +581,8 @@ public class DdlParser {
             if (tokens.matches(DdlTokenizer.STATEMENT_KEY)) {
                 break;
             }
-            if (tokens.canConsume("BEGIN")) {
-                tokens.consumeThrough("END");
-                while (tokens.canConsume("IF")) {
-                    // We just read through an 'END IF', but need to read until the next 'END'
-                    tokens.consumeThrough("END");
-                }
+            if (tokens.matches("BEGIN")) {
+                consumeBeginStatement(tokens.mark());
             } else if (tokens.matches(DdlTokenizer.STATEMENT_TERMINATOR)) {
                 tokens.consume();
                 break;
@@ -596,6 +592,21 @@ public class DdlParser {
         }
     }
 
+    /**
+     * Consume the entire {@code BEGIN...END} block that appears next in the token stream. This method may need to be
+     * specialized for a specific DDL grammar.
+     * 
+     * @param start the marker at which the statement was begun
+     */
+    protected void consumeBeginStatement(Marker start) {
+        tokens.consume("BEGIN");
+        tokens.consumeThrough("END");
+        while (tokens.canConsume("IF")) {
+            // We just read through an 'END IF', but need to read until the next 'END'
+            tokens.consumeThrough("END");
+        }
+    }
+    
     /**
      * Consume the next token that is a single-quoted string.
      * 

--- a/debezium-core/src/main/java/io/debezium/text/TokenStream.java
+++ b/debezium-core/src/main/java/io/debezium/text/TokenStream.java
@@ -536,7 +536,19 @@ public class TokenStream {
      * @throws NoSuchElementException if there is no previous token
      */
     public Position previousPosition() {
-        return previousToken().position();
+        return previousPosition(1);
+    }
+    
+    /**
+     * Get the position of a token earlier in the stream from the current position.
+     * 
+     * @param count the number of tokens before the current position (e.g., 1 for the previous position)
+     * @return the previous token's position; never null
+     * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
+     * @throws NoSuchElementException if there is no previous token
+     */
+    public Position previousPosition(int count) {
+        return previousToken(1).position();
     }
 
     /**
@@ -977,7 +989,7 @@ public class TokenStream {
      * @throws ParsingException if the specified token cannot be found
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
      */
-    public TokenStream consumeUntil(String expected, String skipMatchingTokens) throws ParsingException, IllegalStateException {
+    public TokenStream consumeUntil(String expected, String... skipMatchingTokens) throws ParsingException, IllegalStateException {
         if (ANY_VALUE == expected) {
             consume();
             return this;
@@ -985,7 +997,7 @@ public class TokenStream {
         Marker start = mark();
         int remaining = 0;
         while (hasNext()) {
-            if (skipMatchingTokens != null && matches(skipMatchingTokens)) ++remaining;
+            if (skipMatchingTokens != null && matchesAnyOf(skipMatchingTokens)) ++remaining;
             if (matches(expected)) {
                 if (remaining == 0) {
                     break;
@@ -1723,11 +1735,15 @@ public class TokenStream {
     /**
      * Get the previous token. This does not modify the state.
      * 
+     * @param count the number of tokens back from the current position that this method should return
      * @return the previous token; never null
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
      * @throws NoSuchElementException if there is no previous token
      */
-    final Token previousToken() throws IllegalStateException, NoSuchElementException {
+    public final Token previousToken(int count) throws IllegalStateException, NoSuchElementException {
+        if (count < 1) {
+            throw new IllegalArgumentException("The count must be positive");
+        }
         if (currentToken == null) {
             if (completed) {
                 if (tokens.isEmpty()) {
@@ -1737,10 +1753,11 @@ public class TokenStream {
             }
             throw new IllegalStateException("start() method must be called before consuming or matching");
         }
-        if (tokenIterator.previousIndex() == 0) {
+        int index = tokenIterator.previousIndex() - count;
+        if (index < 0) {
             throw new NoSuchElementException("No more content");
         }
-        return tokens.get(tokenIterator.previousIndex() - 1);
+        return tokens.get(tokenIterator.previousIndex() - count);
     }
 
     String generateFragment() {

--- a/debezium-core/src/test/java/io/debezium/text/TokenStreamTest.java
+++ b/debezium-core/src/test/java/io/debezium/text/TokenStreamTest.java
@@ -482,4 +482,49 @@ public class TokenStreamTest {
         assertThat(tokens.nextPosition().column()).isEqualTo(7);
 
     }
+    
+    @Test
+    public void shouldConsumeUntilWithoutRepeats() {
+        makeCaseInsensitive();
+        String content = "FOO BEGIN A1 A2 A3 END BAR";
+        tokens = new TokenStream(content, tokenizer, true);
+        tokens.start();
+
+        tokens.consume(); // FOO
+        tokens.consume("BEGIN");
+        tokens.consumeUntil("END");
+        tokens.consume("END");
+        tokens.consume("BAR");
+        assertThat(tokens.hasNext()).isFalse();
+    }
+    
+    @Test
+    public void shouldConsumeUntilWithRepeats() {
+        makeCaseInsensitive();
+        String content = "FOO BEGIN A1 A2 A3 BEGIN B1 B2 END A4 BEGIN C1 C2 END A5 END BAR";
+        tokens = new TokenStream(content, tokenizer, true);
+        tokens.start();
+
+        tokens.consume(); // FOO
+        tokens.consume("BEGIN");
+        tokens.consumeUntil("END", "BEGIN");
+        tokens.consume("END");
+        tokens.consume("BAR");
+        assertThat(tokens.hasNext()).isFalse();
+    }
+    
+    @Test
+    public void shouldConsumeUntilWithRepeatsAndMultipleSkipTokens() {
+        makeCaseInsensitive();
+        String content = "FOO BEGIN A1 A2 A3 IF B1 B2 END A4 REPEAT C1 C2 END A5 END BAR";
+        tokens = new TokenStream(content, tokenizer, true);
+        tokens.start();
+
+        tokens.consume(); // FOO
+        tokens.consume("BEGIN");
+        tokens.consumeUntil("END", "BEGIN", "IF", "REPEAT");
+        tokens.consume("END");
+        tokens.consume("BAR");
+        assertThat(tokens.hasNext()).isFalse();
+    }
 }


### PR DESCRIPTION
The MySQL parser now properly handles control blocks such as `BEGIN…END`, `IF…END IF`, `REPEAT…END REPEAT`, and `LOOP…END LOOP`, even in cases where the block is preceded by and terminated by a label.