### PR TITLE
DBZ-197 Corrected MySQL connector to handle invalid enum values

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
@@ -306,8 +306,13 @@ public class MySqlValueConverters extends JdbcValueConverters {
 
             if (options != null) {
                 // The binlog will contain an int with the 1-based index of the option in the enum value ...
-                int index = ((Integer) data).intValue() - 1; // 'options' is 0-based
-                if (index < options.size()) {
+                int value = ((Integer)data).intValue();
+                if (value == 0) {
+                    // an invalid value was specified, which corresponds to the empty string '' and an index of 0
+                    return "";
+                }
+                int index = value - 1; // 'options' is 0-based
+                if (index < options.size() && index >= 0) {
                     return options.get(index);
                 }
             }


### PR DESCRIPTION
MySQL represents an invalid [enum literal](https://dev.mysql.com/doc/refman/5.7/en/enum.html) in the binlog events as an empty string or an value of `0`. Now, when the connector comes across such a value in the binlog, it will instead use an empty string for the enum literal.