### PR TITLE
DBZ-201 Corrected handling of ObjectID within non-insert events

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/RecordMakers.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/RecordMakers.java
@@ -220,6 +220,11 @@ public class RecordMakers {
                 return (String) id;
             }
             if (id instanceof Document) {
+                Document doc = (Document)id;
+                if (doc.containsKey("_id") && doc.size() == 1) {
+                    // This is an embedded ObjectId ...
+                    return objectIdLiteral(doc.get("_id"));
+                }
                 return valueTransformer.apply((Document) id);
             }
             return id.toString();


### PR DESCRIPTION
Corrected how the MongoDB extracts the event key from the update event’s ObjectID, and verified the behavior with an integration test.