### PR TITLE
DBZ-213 Corrected MongoDB connector build

### DIFF
--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -115,7 +115,7 @@
                         <color>yellow</color>
                       </log>
                       <wait>
-                        <log>waiting for connections on port 27017</log> <!-- internal port -->
+                        <log>(?s)waiting for connections on port 27017.*waiting for connections on port 27017</log> <!-- internal port, multiline matching -->
                         <time>30000</time> <!-- 30 seconds max -->
                       </wait>
                     </run>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <version.war.plugin>2.5</version.war.plugin>
         <version.codehaus.helper.plugin>1.8</version.codehaus.helper.plugin>
         <version.google.formatter.plugin>0.3.1</version.google.formatter.plugin>
-        <version.docker.maven.plugin>0.19.0</version.docker.maven.plugin>
+        <version.docker.maven.plugin>0.20.1</version.docker.maven.plugin>
         <version.staging.plugin>1.6.3</version.staging.plugin>
         <version.protoc.maven.plugin>3.0.0.1</version.protoc.maven.plugin>
 


### PR DESCRIPTION
Changed how the mongo-init process waits to begin by now looking for the second MongoDB server log message saying it is ready, since the MongoDB image now has different startup behavior.