### PR TITLE
DBZ-40 Creates the scaffolding required for the sqlserver connector module

### DIFF
--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -1,0 +1,259 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-parent</artifactId>
+        <version>0.5.1-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>debezium-connector-sqlserver</artifactId>
+    <name>Debezium Connector for MS Sql Server</name>
+    <packaging>jar</packaging>
+    <properties>
+        <!-- 
+          Specify the properties that will be used for setting up the integration tests' Docker container.
+          Note that the `dockerhost.ip` property is computed from the IP address of DOCKER_HOST, which will
+          work on all platforms. We'll set some of these as system properties during integration testing.
+      -->
+        <sqlserver.port>1433</sqlserver.port>
+        <sqlserver.user>sa</sqlserver.user>
+        <sqlserver.password>Password!</sqlserver.password>
+        <sqlserver.dbname>master</sqlserver.dbname>
+        <docker.filter>microsoft/mssql-server-linux</docker.filter>
+        <docker.skip>false</docker.skip>
+        <docker.showLogs>true</docker.showLogs>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-embedded</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-embedded</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-avro-converter</artifactId>
+        </dependency>
+    </dependencies>
+   
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <watchInterval>500</watchInterval>
+                    <logDate>default</logDate>
+                    <verbose>true</verbose>
+                    <images>
+                        <image>
+                            <!-- A Docker image using the Postgres Server with the DBZ decoderbufs plugin -->
+                            <name>${docker.filter}</name>  
+                            <run>
+                                <namingStrategy>none</namingStrategy>
+                                <env>
+                                    <ACCEPT_EULA>Y</ACCEPT_EULA>
+                                    <SA_PASSWORD>${sqlserver.password}</SA_PASSWORD>
+                                </env>
+                                <ports>
+                                    <port>${sqlserver.port}:1433</port>
+                                </ports>
+                                <log>
+                                    <prefix>sqlserver</prefix>
+                                    <enabled>true</enabled>
+                                    <color>yellow</color>
+                                </log>
+                                <wait>
+                                    <time>30000</time> <!-- 30 seconds max -->
+                                    <log>SQL Server is now ready for client connections</log>
+                                </wait>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
+                <!--
+                Connect this plugin to the maven lifecycle around the integration-test phase:
+                start the container in pre-integration-test and stop it in post-integration-test.
+                -->
+                <executions>
+                    <execution>
+                        <id>start</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- 
+            Unlike surefire, the failsafe plugin ensures 'post-integration-test' phase always runs, even
+            when there are failed integration tests. We rely upon this to always shut down the Docker container
+            after the integration tests (defined as '*IT.java') are run.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>verify</id>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipTests>${skipITs}</skipTests>
+                    <enableAssertions>true</enableAssertions>
+                    <systemPropertyVariables>
+                        <!-- Make these available to the tests via system properties -->
+                        <database.hostname>${docker.host.address}</database.hostname>
+                        <database.port>${sqlserver.port}</database.port>
+                        <database.user>${sqlserver.user}</database.user>
+                        <database.password>${sqlserver.password}</database.password>
+                        <database.dbname>${sqlserver.dbname}</database.dbname>
+                        <skipLongRunningTests>${skipLongRunningTests}</skipLongRunningTests>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+        <resources>
+            <!-- Apply the properties set in the POM to the resource files -->
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>*</include>
+                    <include>**/*</include>
+                </includes>
+            </resource>
+        </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>*</include>
+                    <include>**/*</include>
+                </includes>
+            </testResource>
+        </testResources>
+    </build>
+    <!--
+    Define several useful profiles
+    -->
+    <profiles>
+        <profile>
+            <id>assembly</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>io.debezium</groupId>
+                                <artifactId>debezium-assembly-descriptors</artifactId>
+                                <version>${project.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <finalName>${project.artifactId}-${project.version}</finalName>
+                                    <attach>true</attach>  <!-- we want attach & deploy these to Maven -->
+                                    <descriptorRefs>
+                                        <descriptorRef>connector-distribution</descriptorRef>
+                                    </descriptorRefs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              Do not perform any Docker-related functionality
+              To use, specify "-DskipITs" on the Maven command line.
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+        <profile>
+            <id>skip-integration-tests</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>skipITs</name>
+                </property>
+            </activation>
+            <properties>
+                <docker.skip>true</docker.skip>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.sqlserver;
+
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.util.IoUtil;
+
+/**
+ * {@link JdbcConnection} extension to be used with Microsoft SQL Server
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class SqlServerConnection extends JdbcConnection {
+    
+    private static final String URL_PATTERN = "jdbc:sqlserver://${" + JdbcConfiguration.HOSTNAME + "}:${"
+                                              + JdbcConfiguration.PORT + "};databaseName=${" + JdbcConfiguration.DATABASE + "}";
+    protected static ConnectionFactory FACTORY = JdbcConnection.patternBasedFactory(URL_PATTERN,
+                                                                                    com.microsoft.sqlserver.jdbc.SQLServerDriver.class.getName(),
+                                                                                    SqlServerConnection.class.getClassLoader());
+    private static Logger LOGGER = LoggerFactory.getLogger(SqlServerConnection.class);
+    
+    private static final String STATEMENTS_PLACEHOLDER = "#";
+    private static final String ENABLE_DB_CDC;
+    private static final String ENABLE_TABLE_CDC;
+    private static final String CDC_WRAPPERS_DML;
+
+    static {
+        try {
+            Properties statements = new Properties();
+            ClassLoader classLoader = SqlServerConnection.class.getClassLoader();
+            statements.load(classLoader.getResourceAsStream("statements.properties"));
+            ENABLE_DB_CDC = statements.getProperty("enable_cdc_for_db");
+            ENABLE_TABLE_CDC = statements.getProperty("enable_cdc_for_table");
+            CDC_WRAPPERS_DML = IoUtil.read(classLoader.getResourceAsStream("generate_cdc_wrappers.sql"));
+        } catch (Exception e) {
+            throw new RuntimeException("Cannot load SQL Server statements", e);
+        }
+    }
+    
+    /**
+     * Creates a new connection using the supplied configuration.
+     *
+     * @param config {@link Configuration} instance, may not be null.
+     */
+    public SqlServerConnection(Configuration config) {
+        super(config, FACTORY);
+    }
+    
+    /**
+     * Returns a JDBC connection string for the current configuration.
+     *
+     * @return a {@code String} where the variables in {@code urlPattern} are replaced with values from the configuration
+     */
+    public String connectionString() {
+        return connectionString(URL_PATTERN);
+    }
+    
+    /**
+     * Enables CDC for a given database, if not already enabled.
+     * 
+     * @param name the name of the DB, may not be {@code null}
+     * @throws SQLException if anything unexpected fails
+     */
+    public void enableDBCDC( String name) throws SQLException {
+        Objects.requireNonNull(name);
+        execute(ENABLE_DB_CDC.replace(STATEMENTS_PLACEHOLDER, name));
+    }
+    
+    
+    /**
+     * Enables CDC for a table if not already enabled and generates the wrapper functions for that table. 
+     *
+     * @param name the name of the table, may not be {@code null}
+     * @throws SQLException if anything unexpected fails
+     */
+    public void enableTableCDC(String name) throws SQLException {
+        Objects.requireNonNull(name);
+        String enableCdcForTableStmt = ENABLE_TABLE_CDC.replace(STATEMENTS_PLACEHOLDER, name);
+        String generateWrapperFunctionsStmts = CDC_WRAPPERS_DML.replaceAll(STATEMENTS_PLACEHOLDER, name);
+        execute(enableCdcForTableStmt, generateWrapperFunctionsStmts);
+    }
+}

--- a/debezium-connector-sqlserver/src/main/resources/generate_cdc_wrappers.sql
+++ b/debezium-connector-sqlserver/src/main/resources/generate_cdc_wrappers.sql
@@ -1,0 +1,33 @@
+IF EXISTS(select 1 from sys.tables where name = '#' AND is_tracked_by_cdc=1)
+    BEGIN
+        RETURN
+    END
+ELSE
+    BEGIN
+        DECLARE @wrapper_functions TABLE(
+            function_name SYSNAME,
+            create_script NVARCHAR(MAX))
+
+        INSERT INTO @wrapper_functions
+        EXEC sys.sp_cdc_generate_wrapper_function
+
+        DECLARE @create_script NVARCHAR(MAX)
+
+        DECLARE #hfunctions CURSOR LOCAL FAST_FORWARD
+        FOR
+            SELECT create_script
+            FROM @wrapper_functions
+
+        OPEN #hfunctions
+        FETCH #hfunctions
+        INTO @create_script
+        WHILE (@@fetch_status <> -1)
+            BEGIN
+                EXEC sp_executesql @create_script
+                FETCH #hfunctions
+                INTO @create_script
+            END
+
+        CLOSE #hfunctions
+        DEALLOCATE #hfunctions
+    END    

--- a/debezium-connector-sqlserver/src/main/resources/statements.properties
+++ b/debezium-connector-sqlserver/src/main/resources/statements.properties
@@ -1,0 +1,4 @@
+enable_cdc_for_db=IF EXISTS(select 1 from sys.databases where name='#' AND is_cdc_enabled=0)\n\
+  EXEC sys.sp_cdc_enable_db
+enable_cdc_for_table=IF EXISTS(select 1 from sys.tables where name = '#' AND is_tracked_by_cdc=0)\n\
+  EXEC sys.sp_cdc_enable_table @source_schema = N'dbo', @source_name = N'#', @role_name = NULL, @supports_net_changes = 0

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.sqlserver;
+
+import java.sql.SQLException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Integration test for {@link SqlServerConnection}
+ * 
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class SqlServerConnectionIT {
+    
+    @BeforeClass
+    public static void beforeClass() throws SQLException {
+        //NOTE: you cannot enable CDC for the "master" db (the default one) so all tests must use a separate database...
+        try (SqlServerConnection connection = new SqlServerConnection(TestHelper.defaultJdbcConfig())) {
+            connection.connect();
+            String sql = "IF EXISTS(select 1 from sys.databases where name='testDB') DROP DATABASE testDB\n" +
+                         "CREATE DATABASE testDB\n";
+            connection.execute(sql);
+        }
+    }
+    
+    @Test
+    public void shouldEnableCDCForDatabase() throws Exception {
+        try (SqlServerConnection connection = new SqlServerConnection(TestHelper.defaultJdbcConfig())) {
+            connection.connect();
+            connection.execute("USE testDB");
+            // NOTE: you cannot enable CDC on master
+            connection.enableDBCDC("testDB");
+        }       
+    }
+    
+    @Test
+    public void shouldEnableCDCWithWrapperFunctionsForTable() throws Exception {
+        try (SqlServerConnection connection = new SqlServerConnection(TestHelper.defaultJdbcConfig())) {
+            connection.connect();
+            connection.execute("USE testDB");
+            // NOTE: you cannot enable CDC on master
+            connection.enableDBCDC("testDB");
+
+            // create table if exists
+            String sql = "IF EXISTS (select 1 from sys.objects where name = 'testTable' and type = 'u')\n" +
+                         "DROP TABLE testTable\n" + 
+                         "CREATE TABLE testTable (ID int not null identity(1, 1) primary key, NUMBER int, TEXT text)";
+            connection.execute(sql);
+            
+            // then enable CDC and wrapper functions
+            connection.enableTableCDC("testTable");
+            
+            // insert some data
+            
+            connection.execute("INSERT INTO testTable (NUMBER, TEXT) values (1, 'aaa')\n" +
+                               "INSERT INTO testTable (NUMBER, TEXT) values (2, 'bbb')");
+            // and issue a test call to a CDC wrapper function
+            /**
+             * The following fails if CDC is not supported on a particular SQL Server instance
+             * 
+            connection.call("cdc.fn_all_changes_dbo_testTable(?,?,?)", call -> {
+                call.setDate(1, null);
+                call.setDate(2, null);
+                call.setString(3, "all");
+            }, null);
+             */
+        }
+    
+    }
+    
+}

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TestHelper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.sqlserver;
+
+import io.debezium.config.Configuration;
+import io.debezium.jdbc.JdbcConfiguration;
+
+/**
+ * @author Horia Chiorean (hchiorea@redhat.com)
+ */
+public class TestHelper {
+    
+    protected static JdbcConfiguration defaultJdbcConfig() {
+        return JdbcConfiguration.copy(Configuration.fromSystemProperties("database."))
+                                .withDefault(JdbcConfiguration.DATABASE, "master")
+                                .withDefault(JdbcConfiguration.HOSTNAME, "192.168.99.100")
+                                .withDefault(JdbcConfiguration.PORT, 1433)
+                                .withDefault(JdbcConfiguration.USER, "sa")
+                                .withDefault(JdbcConfiguration.PASSWORD, "Password!")
+                                .build();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <version.mysql.binlog>0.9.0</version.mysql.binlog>
         <version.mongo.server>3.2.12</version.mongo.server>
         <version.mongo.driver>3.4.2</version.mongo.driver>
+        <version.sqlserver.driver>6.1.0.jre8</version.sqlserver.driver>
         
         <!-- Connectors -->
         <version.com.google.protobuf>2.6.1</version.com.google.protobuf>
@@ -109,6 +110,7 @@
         <module>debezium-connector-mysql</module>
         <module>debezium-connector-postgres</module>
         <module>debezium-connector-mongodb</module>
+        <!--<module>debezium-connector-sqlserver</module>-->
     </modules>
 
     <distributionManagement>
@@ -248,6 +250,13 @@
                 <groupId>org.mongodb</groupId>
                 <artifactId>mongodb-driver</artifactId>
                 <version>${version.mongo.driver}</version>
+            </dependency>
+            
+            <!--SQL Server -->
+            <dependency>
+                <groupId>com.microsoft.sqlserver</groupId>
+                <artifactId>mssql-jdbc</artifactId>
+                <version>${version.sqlserver.driver}</version>
             </dependency>
 
             <!-- Logging -->


### PR DESCRIPTION
This PR contains a fully functional Maven module for the `sqlserver-connector`. It also contains the initial work required into enabling CDC functionality for SQLServer, together with an integration test to validate this behavior.

However, since at this time the Linux Docker Image still does not contain the SQLServer Agent required for using the CDC functionality, the functionality in this PR is limited.

Note that the Maven module is commented out from the main DBZ build.