### PR TITLE
Fix Postgres SSL "require" mode bug

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.ConfigValue;
 
 import io.debezium.config.Configuration;
+import io.debezium.config.Configuration.EnumeratedValue;
 import io.debezium.config.Field;
 import io.debezium.config.Field.Recommender;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
@@ -156,7 +157,7 @@ public class PostgresConnectorConfig {
     /**
      * The set of predefined SecureConnectionMode options or aliases.
      */
-    public enum SecureConnectionMode {
+    public enum SecureConnectionMode implements EnumeratedValue {
         /**
          * Establish an unencrypted connection
          *
@@ -170,7 +171,7 @@ public class PostgresConnectorConfig {
          * 
          * see the {@code sslmode} Postgres JDBC driver option
          */
-        REQUIRED("require"),
+        REQUIRE("require"),
         
         /**
          * Like REQUIRED, but additionally verify the server TLS certificate against the configured Certificate Authority

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -151,7 +151,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         // the default docker image we're testing against doesn't use SSL, so check that the connector fails to start when
         // SSL is enabled
         Configuration config = TestHelper.defaultConfig().with(PostgresConnectorConfig.SSL_MODE,  
-                                                               PostgresConnectorConfig.SecureConnectionMode.REQUIRED).build();
+                                                               PostgresConnectorConfig.SecureConnectionMode.REQUIRE).build();
         start(PostgresConnector.class, config, (success, msg, error) -> {
             // we expect the task to fail at startup when we're printing the server info
             assertThat(success).isFalse();

--- a/debezium-core/src/main/java/io/debezium/config/Configuration.java
+++ b/debezium-core/src/main/java/io/debezium/config/Configuration.java
@@ -94,6 +94,17 @@ public interface Configuration {
          * @param value the value
          * @return this builder object so methods can be chained together; never null
          */
+        default B with(String key, EnumeratedValue value) {
+            return with(key, value != null ? value.getValue() : null);
+        }
+
+        /**
+         * Associate the given value with the specified key.
+         * 
+         * @param key the key
+         * @param value the value
+         * @return this builder object so methods can be chained together; never null
+         */
         default B with(String key, int value) {
             return with(key, Integer.toString(value));
         }
@@ -171,6 +182,17 @@ public interface Configuration {
          */
         default B withDefault(String key, Object value) {
             return withDefault(key, value != null ? value.toString() : null);
+        }
+
+        /**
+         * If there is no field with the specified key, then associate the given value with the specified key.
+         * 
+         * @param key the key
+         * @param value the value
+         * @return this builder object so methods can be chained together; never null
+         */
+        default B withDefault(String key, EnumeratedValue value) {
+            return withDefault(key, value != null ? value.getValue() : null);
         }
 
         /**
@@ -2007,4 +2029,7 @@ public interface Configuration {
         this.asMap().forEach(function);
     }
 
+    public interface EnumeratedValue {
+        abstract String getValue();
+    }
 }


### PR DESCRIPTION
* Was using invalid "required" parameter for sslmode when trying to connect to Postgres
* When the correct parameter, "require", was passed then the configuration validation would fail