### PR TITLE
DBZ-243 Don't mention default value for "database.server.name"

### DIFF
--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -344,7 +344,7 @@
         <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
               This assembly profile is used during official builds. In addition to 
               compiling, and running the unit and integration tests like the non-assembly
-              profiles, this provfile creates additional (like the connector plugin archives),
+              profiles, this profile creates additional (like the connector plugin archives),
               starts up all three Docker containers (normal MySQL, MySQL+GTIDs, and alt-MySQL)
               and runs the integration tests against each of them.
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -62,7 +62,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         * 
+         *
          * @param value the configuration property value; may not be null
          * @return the matching option, or null if no match is found
          */
@@ -77,7 +77,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         * 
+         *
          * @param value the configuration property value; may not be null
          * @param defaultValue the default value; may be null
          * @return the matching option, or null if no match is found and the non-null default is invalid
@@ -127,7 +127,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         * 
+         *
          * @param value the configuration property value; may not be null
          * @return the matching option, or null if no match is found
          */
@@ -142,7 +142,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         * 
+         *
          * @param value the configuration property value; may not be null
          * @param defaultValue the default value; may be null
          * @return the matching option, or null if no match is found and the non-null default is invalid
@@ -199,7 +199,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         * 
+         *
          * @param value the configuration property value; may not be null
          * @return the matching option, or null if no match is found
          */
@@ -214,7 +214,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         * 
+         *
          * @param value the configuration property value; may not be null
          * @param defaultValue the default value; may be null
          * @return the matching option, or null if no match is found and the non-null default is invalid
@@ -268,7 +268,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         * 
+         *
          * @param value the configuration property value; may not be null
          * @return the matching option, or null if no match is found
          */
@@ -283,7 +283,7 @@ public class MySqlConnectorConfig {
 
         /**
          * Determine if the supplied value is one of the predefined options.
-         * 
+         *
          * @param value the configuration property value; may not be null
          * @param defaultValue the default value; may be null
          * @return the matching option, or null if no match is found and the non-null default is invalid
@@ -343,7 +343,7 @@ public class MySqlConnectorConfig {
                                                  .withDescription("Unique name that identifies the database server and all recorded offsets, and"
                                                          + "that is used as a prefix for all schemas and topics. "
                                                          + "Each distinct MySQL installation should have a separate namespace and monitored by "
-                                                         + "at most one Debezium connector. Defaults to 'host:port'");
+                                                         + "at most one Debezium connector.");
 
     public static final Field SERVER_ID = Field.create("database.server.id")
                                                .withDisplayName("Cluster ID")
@@ -662,7 +662,7 @@ public class MySqlConnectorConfig {
     /**
      * Method that generates a Field for specifying that string columns whose names match a set of regular expressions should
      * have their values truncated to be no longer than the specified number of characters.
-     * 
+     *
      * @param length the maximum length of the column's string values written in source records; must be positive
      * @return the field; never null
      */
@@ -677,7 +677,7 @@ public class MySqlConnectorConfig {
     /**
      * Method that generates a Field for specifying that string columns whose names match a set of regular expressions should
      * have their values masked by the specified number of asterisk ('*') characters.
-     * 
+     *
      * @param length the number of asterisks that should appear in place of the column's string values written in source records;
      *            must be positive
      * @return the field; never null


### PR DESCRIPTION
Hey @rhauch, I'm not 100% sure: it is optional for Postgres, so perhaps the isRequired validation is actually a glitch in the MySQL connector?

Also I was wondering whether we should try and consolidate the settings shared acrossed connectors within core. This would avoid this sort of inconsistency. WDYT?