### PR TITLE
[DBZ-244] Allow unvalidated SSL connections

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -440,6 +440,12 @@ public class PostgresConnectorConfig {
                                                    .withImportance(Importance.MEDIUM)
                                                    .withDescription("File containing the root certificate(s) against which the server is validated. See the Postgres JDBC SSL docs for further information");
     
+    public static final Field SSL_SOCKET_FACTORY = Field.create(DATABASE_CONFIG_PREFIX + "sslfactory")
+                                                        .withDisplayName("SSL Root Certificate")
+                                                        .withType(Type.STRING)
+                                                        .withWidth(Width.LONG)
+                                                        .withImportance(Importance.MEDIUM)
+                                                        .withDescription("A name of class to that creates SSL Sockets. Use org.postgresql.ssl.NonValidatingFactory to disable SSL validation in development environments");
     
     /**
      * A comma-separated list of regular expressions that match schema names to be monitored.
@@ -560,7 +566,7 @@ public class PostgresConnectorConfig {
                                                      COLUMN_BLACKLIST, SNAPSHOT_MODE, 
                                                      TIME_PRECISION_MODE,
                                                      SSL_MODE, SSL_CLIENT_CERT, SSL_CLIENT_KEY_PASSWORD,
-                                                     SSL_ROOT_CERT, SSL_CLIENT_KEY, SNAPSHOT_LOCK_TIMEOUT_MS, ROWS_FETCH_SIZE);
+                                                     SSL_ROOT_CERT, SSL_CLIENT_KEY, SNAPSHOT_LOCK_TIMEOUT_MS, ROWS_FETCH_SIZE, SSL_SOCKET_FACTORY);
     
     private final Configuration config;
     private final String serverName;
@@ -685,7 +691,7 @@ public class PostgresConnectorConfig {
         ConfigDef config = new ConfigDef();
         Field.group(config, "Postgres", SLOT_NAME, PLUGIN_NAME, SERVER_NAME, DATABASE_NAME, HOSTNAME, PORT,
                     USER, PASSWORD, SSL_MODE, SSL_CLIENT_CERT, SSL_CLIENT_KEY_PASSWORD, SSL_ROOT_CERT, SSL_CLIENT_KEY,
-                    DROP_SLOT_ON_STOP);
+                    DROP_SLOT_ON_STOP, SSL_SOCKET_FACTORY);
         Field.group(config, "Events", SCHEMA_WHITELIST, SCHEMA_BLACKLIST, TABLE_WHITELIST, TABLE_BLACKLIST, 
                     COLUMN_BLACKLIST);
         Field.group(config, "Connector", TOPIC_SELECTION_STRATEGY, POLL_INTERVAL_MS, MAX_BATCH_SIZE, MAX_QUEUE_SIZE, 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -144,7 +144,8 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
                       PostgresConnectorConfig.DEFAULT_SNAPSHOT_LOCK_TIMEOUT_MILLIS);
         validateField(validatedConfig, PostgresConnectorConfig.TIME_PRECISION_MODE, 
                       PostgresConnectorConfig.TemporalPrecisionMode.ADAPTIVE.name().toLowerCase());
-    }
+        validateField(validatedConfig, PostgresConnectorConfig.SSL_SOCKET_FACTORY, null);
+   }
     
     @Test
     public void shouldSupportSSLParameters() throws Exception {


### PR DESCRIPTION
If a user wants to simplify a dev environment and skip certificate validation he needs to provide a custom socket factory.