### PR TITLE
DBZ-242 Corrected MySQL filters to handle built-in tables

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
@@ -88,8 +88,8 @@ public class Filters {
             this.tableFilter = tableFilter.and(isBuiltInTable.negate());
             this.dbFilter = dbFilter.and(isBuiltInDb.negate());
         } else {
-            this.tableFilter = tableFilter.or(isBuiltInTable);
-            this.dbFilter = dbFilter.or(isBuiltInDb);
+            this.tableFilter = tableFilter;
+            this.dbFilter = dbFilter;
         }
 
         // Define the filter that excludes blacklisted columns, truncated columns, and masked columns ...

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSchemaTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSchemaTest.java
@@ -105,7 +105,7 @@ public class MySqlSchemaTest {
     public void shouldLoadSystemAndNonSystemTablesAndConsumeAllDatabases() throws InterruptedException {
         mysql = build.storeDatabaseHistoryInFile(TEST_FILE_PATH)
                      .serverName(SERVER_NAME)
-                     .includeDatabases("connector_test")
+                     .includeDatabases("connector_test,mysql")
                      .includeBuiltInTables()
                      .createSchemas();
         mysql.start();


### PR DESCRIPTION
When the `table.ignore.built` is set to `false`, the MySQL connector included all of the ~250 system tables yet the database and table filters were never applied to these system tables and therefore all would be captured. With this change, the database filters and table filters now apply to the system tables should they not be ignored.

Note that this does change the behavior of the connector when `table.ignore.built` is set to `false`. However, it is unlikely that anyone is seriously capturing all of the system table changes, so correcting the behavior is the preferred solution.