### PR TITLE
DBZ-232 Removed the database and table name recommenders

### DIFF
--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -31,7 +31,6 @@ import com.mongodb.client.model.InsertOneOptions;
 import static org.fest.assertions.Assertions.assertThat;
 
 import io.debezium.config.Configuration;
-import io.debezium.config.Field.Recommender;
 import io.debezium.connector.mongodb.ConnectionContext.MongoPrimary;
 import io.debezium.data.Envelope;
 import io.debezium.data.Envelope.Operation;
@@ -137,27 +136,6 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.CONNECT_BACKOFF_INITIAL_DELAY_MS);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.CONNECT_BACKOFF_MAX_DELAY_MS);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.MAX_FAILED_CONNECTIONS);
-
-        // Testing.Debug.enable();
-
-        Recommender dbNameRecommender = MongoDbConnectorConfig.DATABASE_LIST.recommender();
-        List<Object> dbNames = dbNameRecommender.validValues(MongoDbConnectorConfig.DATABASE_LIST, config);
-        Testing.debug("List of dbNames: " + dbNames);
-        assertThat(dbNames).contains("dbval", "dbval2");    // may have more depending upon order
-
-        Recommender collectionNameRecommender = MongoDbConnectorConfig.COLLECTION_WHITELIST.recommender();
-        List<Object> collectionNames = collectionNameRecommender.validValues(MongoDbConnectorConfig.COLLECTION_WHITELIST, config);
-        Testing.debug("List of collection names: " + collectionNames);
-        assertThat(collectionNames).isEmpty();
-
-        // Now set the whitelist to two databases ...
-        Configuration config2 = config.edit()
-                                      .with(MongoDbConnectorConfig.DATABASE_LIST, "dbval")
-                                      .build();
-
-        List<Object> collectionNames2 = collectionNameRecommender.validValues(MongoDbConnectorConfig.COLLECTION_WHITELIST, config2);
-        assertThat(collectionNames2).containsOnly("dbval.validationColl1");
-        Testing.debug("List of collection names: " + collectionNames2);
     }
 
     @Test

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import static org.fest.assertions.Assertions.assertThat;
 
 import io.debezium.config.Configuration;
-import io.debezium.config.Field.Recommender;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
 import io.debezium.data.Envelope;
@@ -229,57 +228,6 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.TOPIC);
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS);
         assertNoConfigurationErrors(result, KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS);
-
-        // Testing.Debug.enable();
-
-        Recommender dbNameRecommender = MySqlConnectorConfig.DATABASE_WHITELIST.recommender();
-        List<Object> dbNames = dbNameRecommender.validValues(MySqlConnectorConfig.DATABASE_WHITELIST, config);
-        Testing.debug("List of dbNames: " + dbNames);
-        assertThat(dbNames).containsOnly("connector_test", "readbinlog_test", "regression_test", "json_test",
-                                         "connector_test_ro", "emptydb", "geometry_test");
-
-        Recommender tableNameRecommender = MySqlConnectorConfig.TABLE_WHITELIST.recommender();
-        List<Object> tableNames = tableNameRecommender.validValues(MySqlConnectorConfig.TABLE_WHITELIST, config);
-        Testing.debug("List of tableNames: " + tableNames);
-        assertThat(tableNames).containsOnly("readbinlog_test.product",
-                                            "readbinlog_test.purchased",
-                                            "readbinlog_test.person",
-                                            "connector_test.customers",
-                                            "connector_test.orders",
-                                            "connector_test.products",
-                                            "connector_test.products_on_hand",
-                                            "connector_test_ro.customers",
-                                            "connector_test_ro.orders",
-                                            "connector_test_ro.products",
-                                            "connector_test_ro.products_on_hand",
-                                            "regression_test.t1464075356413_testtable6",
-                                            "regression_test.dbz_85_fractest",
-                                            "regression_test.dbz84_integer_types_table",
-                                            "regression_test.dbz_100_enumsettest",
-                                            "regression_test.dbz_102_charsettest",
-                                            "regression_test.dbz_114_zerovaluetest",
-                                            "regression_test.dbz_123_bitvaluetest",
-                                            "regression_test.dbz_104_customers",
-                                            "regression_test.dbz_147_decimalvalues",
-                                            "regression_test.dbz_195_numvalues",
-                                            "json_test.dbz_126_jsontable",
-                                            "geometry_test.dbz_222_point");
-
-        // Now set the whitelist to two databases ...
-        Configuration config2 = config.edit()
-                                      .with(MySqlConnectorConfig.DATABASE_WHITELIST, "connector_test,connector_test_ro")
-                                      .build();
-
-        List<Object> tableNames2 = tableNameRecommender.validValues(MySqlConnectorConfig.TABLE_WHITELIST, config2);
-        assertThat(tableNames2).containsOnly("connector_test.customers",
-                                             "connector_test.orders",
-                                             "connector_test.products",
-                                             "connector_test.products_on_hand",
-                                             "connector_test_ro.customers",
-                                             "connector_test_ro.orders",
-                                             "connector_test_ro.products",
-                                             "connector_test_ro.products_on_hand");
-        Testing.debug("List of tableNames: " + tableNames2);
     }
 
     @Test


### PR DESCRIPTION
It’s not clear how valuable these recommenders actually are. First, it’s not clear about the expected semantics: can the user use values that don’t appear in the recommended values? Second, the recommenders that return large numbers of values can be slow and can result in very large REST API responses.

Debezium was using recommenders to return the database and table/collection names, but these lists can be very large for large databases. Rather than cap the number of recommended values and have the recommender return a subset of all potential values, we will instead remove the recommenders altogether.