### PR TITLE
DBZ-251 Prepopulate readbinlog_test database

### DIFF
--- a/debezium-connector-mysql/src/test/docker/init/setup.sql
+++ b/debezium-connector-mysql/src/test/docker/init/setup.sql
@@ -17,8 +17,28 @@ CREATE DATABASE emptydb;
 
 -- ----------------------------------------------------------------------------------------------------------------
 -- DATABASE:  readbinlog_test
+-- Database needs to be populated to break dependency between MetadataIT and MySqlConnectorIT.shouldValidateAcceptableConfiguration run order
 -- ----------------------------------------------------------------------------------------------------------------
 CREATE DATABASE readbinlog_test;
+USE readbinlog_test;
+CREATE TABLE person (
+  name VARCHAR(255) primary key,
+  birthdate DATE NULL,
+  age INTEGER NULL DEFAULT 10,
+  salary DECIMAL(5,2), bitStr BIT(18)
+);
+CREATE TABLE product (
+  id INT NOT NULL AUTO_INCREMENT,
+  createdByDate DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  modifiedDate DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY(id)
+);
+CREATE TABLE purchased (
+  purchaser VARCHAR(255) NOT NULL,
+  productId INT NOT NULL,
+  purchaseDate DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY(productId,purchaser)
+);
 
 -- ----------------------------------------------------------------------------------------------------------------
 -- DATABASE:  connector_test


### PR DESCRIPTION
Test execution is depending on test order - if MySqlConnectorIT is executed before MetadataIT then readbinlog_test is empty and method shouldValidateAcceptableConfiguration() fails onvalidation of list of tables