### PR TITLE
DBZ-253 Avoiding exception when receiving DDL events with table maint…

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
@@ -39,7 +39,7 @@ import io.debezium.text.TokenStream.Marker;
  * <p>
  * See the <a href="http://dev.mysql.com/doc/refman/5.7/en/sql-syntax-data-definition.html">MySQL SQL Syntax documentation</a> for
  * the grammar supported by this parser.
- * 
+ *
  * @author Randall Hauch
  */
 @NotThreadSafe
@@ -63,7 +63,7 @@ public class MySqlDdlParser extends DdlParser {
 
     /**
      * Create a new DDL parser for MySQL.
-     * 
+     *
      * @param includeViews {@code true} if view definitions should be included, or {@code false} if they should be skipped
      */
     public MySqlDdlParser(boolean includeViews) {
@@ -134,7 +134,10 @@ public class MySqlDdlParser extends DdlParser {
 
     @Override
     protected void initializeStatementStarts(TokenSet statementStartTokens) {
-        statementStartTokens.add("CREATE", "ALTER", "DROP", "INSERT", "GRANT", "REVOKE", "FLUSH", "TRUNCATE", "COMMIT", "USE", "SAVEPOINT");
+        statementStartTokens.add("CREATE", "ALTER", "DROP", "INSERT", "GRANT", "REVOKE", "FLUSH", "TRUNCATE", "COMMIT", "USE", "SAVEPOINT",
+                // table maintenance statements: https://dev.mysql.com/doc/refman/5.7/en/table-maintenance-sql.html
+                "ANALYZE", "OPTIMIZE", "REPAIR"
+        );
     }
 
     @Override
@@ -734,7 +737,7 @@ public class MySqlDdlParser extends DdlParser {
     /**
      * Parse the {@code ENUM} or {@code SET} data type expression to extract the character options, where the index(es) appearing
      * in the {@code ENUM} or {@code SET} values can be used to identify the acceptable characters.
-     * 
+     *
      * @param typeExpression the data type expression
      * @return the string containing the character options allowed by the {@code ENUM} or {@code SET}; never null
      */
@@ -1391,7 +1394,7 @@ public class MySqlDdlParser extends DdlParser {
 
     /**
      * Get the name of the character set for the current database, via the "character_set_database" system property.
-     * 
+     *
      * @return the name of the character set for the current database, or null if not known ...
      */
     protected String currentDatabaseCharset() {
@@ -1445,7 +1448,7 @@ public class MySqlDdlParser extends DdlParser {
 
     /**
      * Consume an expression surrounded by parentheses.
-     * 
+     *
      * @param start the start of the statement
      */
     protected void consumeExpression(Marker start) {
@@ -1458,7 +1461,7 @@ public class MySqlDdlParser extends DdlParser {
      * <a href="https://dev.mysql.com/doc/refman/5.7/en/begin-end.html"><code>BEGIN...END</code> blocks</a>,
      * <a href="https://dev.mysql.com/doc/refman/5.7/en/statement-labels.html">labeled statements</a>,
      * and control blocks.
-     * 
+     *
      * @param start the marker at which the statement was begun
      */
     @Override
@@ -1531,7 +1534,7 @@ public class MySqlDdlParser extends DdlParser {
      * Get the label that appears with a colon character just prior to the current position. Some MySQL DDL statements can be
      * <a href="https://dev.mysql.com/doc/refman/5.7/en/statement-labels.html">labeled</a>, and this label can then appear at the
      * end of a block.
-     * 
+     *
      * @return the label for the block starting at the current position; null if there is no such label
      * @throws NoSuchElementException if there is no previous token
      */
@@ -1545,7 +1548,7 @@ public class MySqlDdlParser extends DdlParser {
 
     /**
      * Try calling the supplied functions in sequence, stopping as soon as one of them succeeds.
-     * 
+     *
      * @param functions the functions
      */
     @SuppressWarnings("unchecked")
@@ -1569,7 +1572,7 @@ public class MySqlDdlParser extends DdlParser {
      * Parse and consume the {@code DEFAULT} clause. Currently, this method does not capture the default in any way,
      * since that will likely require parsing the default clause into a useful value (e.g., dealing with hexadecimals,
      * bit-set literals, date-time literals, etc.).
-     * 
+     *
      * @param start the marker at the beginning of the clause
      */
     protected void parseDefaultClause(Marker start) {

--- a/debezium-connector-mysql/src/test/docker/init/setup.sql
+++ b/debezium-connector-mysql/src/test/docker/init/setup.sql
@@ -498,3 +498,23 @@ CREATE TABLE dbz_222_point (
 INSERT INTO dbz_222_point VALUES (default,GeomFromText('POINT(1 1)'), 1.0, 1.0);
 INSERT INTO dbz_222_point VALUES (default,GeomFromText('POINT(8.25554554 3.22124447)'), 8.25554554, 3.22124447);
 INSERT INTO dbz_222_point VALUES (default,GeomFromText('POINT(0 0)'), 0.0, 0.0);
+
+-- ----------------------------------------------------------------------------------------------------------------
+-- DATABASE:  table_maintenance_test
+-- ----------------------------------------------------------------------------------------------------------------
+-- The integration test for this database expects to scan all of the binlog events associated with this database
+-- without error or problems. The integration test does not modify any records in this database, so this script
+-- must contain all operations to these tables.
+--
+CREATE DATABASE table_maintenance_test;
+USE table_maintenance_test;
+
+CREATE TABLE dbz_253_table_maintenance_test (
+      id INT AUTO_INCREMENT NOT NULL,
+      other int,
+      PRIMARY KEY (id)
+) DEFAULT CHARSET=utf8;
+
+ANALYZE TABLE dbz_253_table_maintenance_test;
+OPTIMIZE TABLE dbz_253_table_maintenance_test;
+REPAIR TABLE dbz_253_table_maintenance_test;

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTableMaintenanceStatementsIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTableMaintenanceStatementsIT.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.sql.SQLException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.relational.history.FileDatabaseHistory;
+import io.debezium.util.Testing;
+
+/**
+ * @author Gunnar Morling
+ */
+public class MySqlTableMaintenanceStatementsIT extends AbstractConnectorTest {
+
+    private static final Path DB_HISTORY_PATH = Testing.Files.createTestingPath("file-db-history-table-maintenance.txt")
+                                                             .toAbsolutePath();
+
+    private Configuration config;
+
+    @Before
+    public void beforeEach() {
+        stopConnector();
+        initializeConnectorTestFramework();
+        Testing.Files.delete(DB_HISTORY_PATH);
+    }
+
+    @After
+    public void afterEach() {
+        try {
+            stopConnector();
+        } finally {
+            Testing.Files.delete(DB_HISTORY_PATH);
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-253")
+    public void shouldConsumeAllEventsFromDatabaseUsingBinlogAndNoSnapshot() throws SQLException, InterruptedException {
+        // Use the DB configuration to define the connector's configuration ...
+        config = Configuration.create()
+                .with(MySqlConnectorConfig.HOSTNAME, System.getProperty("database.hostname"))
+                .with(MySqlConnectorConfig.PORT, System.getProperty("database.port"))
+                .with(MySqlConnectorConfig.USER, "snapper")
+                .with(MySqlConnectorConfig.PASSWORD, "snapperpass")
+                .with(
+                        MySqlConnectorConfig.SSL_MODE,
+                        MySqlConnectorConfig.SecureConnectionMode.DISABLED.name().toLowerCase()
+                )
+                .with(MySqlConnectorConfig.SERVER_ID, 18765)
+                .with(MySqlConnectorConfig.SERVER_NAME, "tablemaintenanceit")
+                .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
+                .with(MySqlConnectorConfig.DATABASE_WHITELIST, "table_maintenance_test")
+                .with(MySqlConnectorConfig.DATABASE_HISTORY, FileDatabaseHistory.class)
+                .with(
+                        MySqlConnectorConfig.SNAPSHOT_MODE,
+                        MySqlConnectorConfig.SnapshotMode.NEVER.toString()
+                )
+                .with(FileDatabaseHistory.FILE_PATH, DB_HISTORY_PATH)
+                .build();
+
+        // Start the connector ...
+        start(MySqlConnector.class, config);
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Consume all of the events due to startup and initialization of the database
+        // ---------------------------------------------------------------------------------------------------------------
+        //Testing.Debug.enable();
+        int numCreateDatabase = 1;
+        int numCreateTables = 1;
+        int numTableMaintenanceStatements = 3;
+        SourceRecords records = consumeRecordsByTopic(numCreateDatabase + numCreateTables + numTableMaintenanceStatements);
+        stopConnector();
+        assertThat(records).isNotNull();
+        assertThat(records.recordsForTopic("tablemaintenanceit").size()).isEqualTo(numCreateDatabase + numCreateTables + numTableMaintenanceStatements);
+        assertThat(records.databaseNames()).containsOnly("table_maintenance_test");
+        assertThat(records.ddlRecordsForDatabase("table_maintenance_test").size()).isEqualTo(
+            numCreateDatabase + numCreateTables + numTableMaintenanceStatements);
+
+        // Check that all records are valid, can be serialized and deserialized ...
+        records.forEach(this::validate);
+    }
+}


### PR DESCRIPTION
…enance statements

@rhauch this should fix [DBZ-253](https://issues.jboss.org/browse/DBZ-253) by letting the DDL parser gracefully handle table maintenance statements such as `ANALYZE`.

There's no specific handling of these (I don't think anything is needed?). the only thing I was wondering is whether those statements should show up in the schema change topic (currently they do). They don't actually change the schema, but then I reckon reporting events for them doesn't do harm. WDYT?