### PR TITLE
Respect any existing auto.create.topics.enable when creating a server

### DIFF
--- a/debezium-core/src/test/java/io/debezium/kafka/KafkaServer.java
+++ b/debezium-core/src/test/java/io/debezium/kafka/KafkaServer.java
@@ -155,7 +155,7 @@ public class KafkaServer {
         runningConfig.setProperty(KafkaConfig.ZkConnectProp(), zookeeperConnection());
         runningConfig.setProperty(KafkaConfig.BrokerIdProp(), Integer.toString(brokerId));
         runningConfig.setProperty(KafkaConfig.HostNameProp(), "localhost");
-        runningConfig.setProperty(KafkaConfig.AutoCreateTopicsEnableProp(), String.valueOf(Boolean.TRUE));
+        runningConfig.setProperty(KafkaConfig.AutoCreateTopicsEnableProp(), String.valueOf(config.getOrDefault(KafkaConfig.AutoCreateTopicsEnableProp(), Boolean.TRUE)));
         // 1 partition for the __consumer_offsets_ topic should be enough
         runningConfig.setProperty(KafkaConfig.OffsetsTopicPartitionsProp(), Integer.toString(1));
         return runningConfig;


### PR DESCRIPTION
https://github.com/EnMasseProject/amqp-kafka-bridge/ is using your `KafkaCluster` for testing and when testing an error scenario I noticed that it's impossible to create a cluster with `auto.create.topics.enable=false`, because it's always overwritten in `KafkaServer`.