### PR TITLE
Proposed fix for DBZ-250

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -38,7 +38,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     private final String pluginName;
     private final boolean dropSlotOnClose;
     private final Configuration originalConfig;
-    private final Integer statusUpdateIntervalSeconds;
+    private final int statusUpdateIntervalSeconds;
     
     private long defaultStartingPos;
     
@@ -56,7 +56,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                                          String slotName,
                                          String pluginName,
                                          boolean dropSlotOnClose,
-                                         Integer statusUpdateIntervalSeconds) {
+                                         int statusUpdateIntervalSeconds) {
         super(config, PostgresConnection.FACTORY, null ,PostgresReplicationConnection::defaultSettings);
         
         this.originalConfig = config;
@@ -154,7 +154,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                 .logical()
                 .withSlotName(slotName)
                 .withStartPosition(lsn);
-        if (statusUpdateIntervalSeconds != null) {
+        if (statusUpdateIntervalSeconds > 0) {
             streamBuilder.withStatusInterval(statusUpdateIntervalSeconds, TimeUnit.SECONDS);
         }
         PGReplicationStream stream = streamBuilder.start();
@@ -275,7 +275,6 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         }
     
         public ReplicationConnectionBuilder statusUpdateIntervalSeconds(final int statusUpdateIntervalSeconds) {
-            assert statusUpdateIntervalSeconds >= 0;
             this.statusUpdateIntervalSeconds = statusUpdateIntervalSeconds;
             return this;
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
@@ -122,7 +122,7 @@ public interface ReplicationConnection extends AutoCloseable {
         /**
          * The number of seconds the replication connection should periodically send updates to the server.
          * 
-         * @param statusUpdateIntervalSeconds a number of seconds; must be positive
+         * @param statusUpdateIntervalSeconds a number of seconds; zero or negative disables
          * @return this instance
          * @see #DEFAULT_STATUS_UPDATE_SECONDS
          */


### PR DESCRIPTION
Fix confusion between int with special value 0 and Integer with special value null, which resulted in high CPU usage due to ceaselessly polling postgres (createReplicationConnection uses zero with the intent of disabling polling).