### PR TITLE
DBZ-217 Handling exceptions ocurring during binlog event deserialization

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/EventDataDeserializationExceptionData.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/EventDataDeserializationExceptionData.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import com.github.shyiko.mysql.binlog.event.EventData;
+import com.github.shyiko.mysql.binlog.event.EventType;
+import com.github.shyiko.mysql.binlog.event.deserialization.EventDataDeserializationException;
+
+/**
+ * Event data for an event of type {@link EventType#INCIDENT} representing a failure to deserialize a binlog event.
+ *
+ * @author Gunnar Morling
+ */
+public class EventDataDeserializationExceptionData implements EventData {
+
+    private static final long serialVersionUID = 1L;
+
+    private final EventDataDeserializationException cause;
+
+    public EventDataDeserializationExceptionData(EventDataDeserializationException cause) {
+        this.cause = cause;
+    }
+
+    public EventDataDeserializationException getCause() {
+        return cause;
+    }
+
+    @Override
+    public String toString() {
+        return "EventDataDeserializationExceptionData [cause=" + cause + "]";
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -19,8 +19,8 @@ import io.debezium.config.Configuration;
 import io.debezium.config.EnumeratedValue;
 import io.debezium.config.Field;
 import io.debezium.config.Field.ValidationOutput;
-import io.debezium.jdbc.JdbcValueConverters.DecimalMode;
 import io.debezium.jdbc.JdbcValueConverters.BigIntUnsignedMode;
+import io.debezium.jdbc.JdbcValueConverters.DecimalMode;
 import io.debezium.relational.history.DatabaseHistory;
 import io.debezium.relational.history.KafkaDatabaseHistory;
 
@@ -356,6 +356,21 @@ public class MySqlConnectorConfig {
             SecureConnectionMode mode = parse(value);
             if (mode == null && defaultValue != null) mode = parse(defaultValue);
             return mode;
+        }
+
+        public static enum EventDeserializationFailureHandlingMode implements EnumeratedValue {
+
+            IGNORE,
+            WARN,
+            FAIL;
+
+            @Override
+            public String getValue() {
+                return null;
+            }
+
+
+
         }
     }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -397,7 +397,10 @@ public class MySqlConnectorConfig {
          * @return the matching option, or null if no match is found
          */
         public static EventDeserializationFailureHandlingMode parse(String value) {
-            if (value == null) return null;
+            if (value == null) {
+                return null;
+            }
+
             value = value.trim();
 
             for (EventDeserializationFailureHandlingMode option : EventDeserializationFailureHandlingMode.values()) {
@@ -777,7 +780,7 @@ public class MySqlConnectorConfig {
                                                                             + "'long' represents values using Java's 'long', which may not offer the precision but will be far easier to use in consumers.");
 
     public static final Field EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE = Field.create("event.deserialization.failure.handling.mode")
-            .withDisplayName("Event deserialization failure Handling")
+            .withDisplayName("Event deserialization failure handling")
             .withEnum(EventDeserializationFailureHandlingMode.class, EventDeserializationFailureHandlingMode.FAIL)
             .withWidth(Width.SHORT)
             .withImportance(Importance.MEDIUM)

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
+import io.debezium.connector.mysql.MySqlConnectorConfig.EventDeserializationFailureHandlingMode;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.jdbc.JdbcConnection.ConnectionFactory;
@@ -28,7 +29,7 @@ import io.debezium.util.Strings;
 
 /**
  * A context for a JDBC connection to MySQL.
- * 
+ *
  * @author Randall Hauch
  */
 public class MySqlJdbcContext implements AutoCloseable {
@@ -95,6 +96,11 @@ public class MySqlJdbcContext implements AutoCloseable {
         return sslMode() != SecureConnectionMode.DISABLED;
     }
 
+    public EventDeserializationFailureHandlingMode eventDeserializationFailureHandlingMode() {
+        String mode = config.getString(MySqlConnectorConfig.EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE);
+        return EventDeserializationFailureHandlingMode.parse(mode);
+    }
+
     public void start() {
         if (sslModeEnabled()) {
             originalSystemProperties.clear();
@@ -152,7 +158,7 @@ public class MySqlJdbcContext implements AutoCloseable {
     /**
      * Determine if the current user has the named privilege. Note that if the user has the "ALL" privilege this method
      * returns {@code true}.
-     * 
+     *
      * @param grantName the name of the MySQL privilege; may not be null
      * @return {@code true} if the user has the named privilege, or {@code false} otherwise
      */
@@ -182,7 +188,7 @@ public class MySqlJdbcContext implements AutoCloseable {
 
     /**
      * Read the MySQL charset-related system variables.
-     * 
+     *
      * @param sql the reference that should be set to the SQL statement; may be null if not needed
      * @return the system variables that are related to server character sets; never null
      */
@@ -213,7 +219,7 @@ public class MySqlJdbcContext implements AutoCloseable {
 
     /**
      * Read the MySQL system variables.
-     * 
+     *
      * @param sql the reference that should be set to the SQL statement; may be null if not needed
      * @return the system variables that are related to server character sets; never null
      */


### PR DESCRIPTION
* Catching the exception and wrapping it into a pseudo INCIDENT event
* Logging the exception and the current SourceInfo state

https://issues.jboss.org/browse/DBZ-217

@rhauch I'm not yet familiar with the binlog format, but I hope the source info provides the state required for spotting the flawed event? It'll log output like so:

    2017-05-31 16:16:28,909 ERROR  MySQL|myServer1|binlog  Exception during event data deserialization (source info: binlog file 'mysql-bin.000002', pos=879, skipping 12758 events plus 0 rows, partion: {server=myServer1})   [io.debezium.connector.mysql.BinlogReader]
    com.github.shyiko.mysql.binlog.event.deserialization.EventDataDeserializationException: Failed to deserialize data of EventHeaderV4{timestamp=1496225416000, eventType=EXT_WRITE_ROWS, serverId=112233, headerLength=19, dataLength=40, nextPosition=2662649, flags=0}
        at com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer.deserializeEventData(EventDeserializer.java:212)
        at com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer.nextEvent(EventDeserializer.java:180)
        at io.debezium.connector.mysql.BinlogReader$1.nextEvent(BinlogReader.java:120)
        at com.github.shyiko.mysql.binlog.BinaryLogClient.listenForEventPackets(BinaryLogClient.java:741)
        at com.github.shyiko.mysql.binlog.BinaryLogClient.connect(BinaryLogClient.java:472)
        at com.github.shyiko.mysql.binlog.BinaryLogClient$5.run(BinaryLogClient.java:657)
        at java.lang.Thread.run(Thread.java:745)
    Caused by: java.io.EOFException
        at com.github.shyiko.mysql.binlog.io.ByteArrayInputStream.read(ByteArrayInputStream.java:190)
        at java.io.InputStream.read(InputStream.java:170)
        at com.github.shyiko.mysql.binlog.io.ByteArrayInputStream.fill(ByteArrayInputStream.java:96)
        at com.github.shyiko.mysql.binlog.io.ByteArrayInputStream.read(ByteArrayInputStream.java:89)
        at io.debezium.connector.mysql.RowDeserializers.deserializeString(RowDeserializers.java:246)
        at io.debezium.connector.mysql.RowDeserializers$WriteRowsDeserializer.deserializeString(RowDeserializers.java:185)
        at io.debezium.connector.mysql.BinlogReader$MyWriteRowsDeserializer.deserializeString(BinlogReader.java:174)
        at com.github.shyiko.mysql.binlog.event.deserialization.AbstractRowsEventDataDeserializer.deserializeCell(AbstractRowsEventDataDeserializer.java:176)
        at com.github.shyiko.mysql.binlog.event.deserialization.AbstractRowsEventDataDeserializer.deserializeRow(AbstractRowsEventDataDeserializer.java:132)
        at com.github.shyiko.mysql.binlog.event.deserialization.WriteRowsEventDataDeserializer.deserializeRows(WriteRowsEventDataDeserializer.java:64)
        at com.github.shyiko.mysql.binlog.event.deserialization.WriteRowsEventDataDeserializer.deserialize(WriteRowsEventDataDeserializer.java:56)
        at com.github.shyiko.mysql.binlog.event.deserialization.WriteRowsEventDataDeserializer.deserialize(WriteRowsEventDataDeserializer.java:32)
        at com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer.deserializeEventData(EventDeserializer.java:206)
        ... 6 more

Automating a test for this is very hard but I tested it manually by plugging in a custom deserializer which would provoke an EOF exception and I got the output above. Note the exception is just logged, not re-thrown, i.e. it will continue to read events after that (in the case of EOF there may not be more to read of course).