### PR TITLE
DBZ-216 MySQL connector should ignore `DELETE FROM` statements

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
@@ -134,10 +134,12 @@ public class MySqlDdlParser extends DdlParser {
 
     @Override
     protected void initializeStatementStarts(TokenSet statementStartTokens) {
-        statementStartTokens.add("CREATE", "ALTER", "DROP", "INSERT", "GRANT", "REVOKE", "FLUSH", "TRUNCATE", "COMMIT", "USE", "SAVEPOINT",
+        statementStartTokens.add("CREATE", "ALTER", "DROP", "GRANT", "REVOKE", "FLUSH", "TRUNCATE", "COMMIT", "USE", "SAVEPOINT",
                 // table maintenance statements: https://dev.mysql.com/doc/refman/5.7/en/table-maintenance-sql.html
-                "ANALYZE", "OPTIMIZE", "REPAIR"
-        );
+                "ANALYZE", "OPTIMIZE", "REPAIR",
+                // DML-related statements
+                "DELETE", "INSERT"
+                );
     }
 
     @Override
@@ -156,6 +158,10 @@ public class MySqlDdlParser extends DdlParser {
             parseUse(marker);
         } else if (tokens.matches("SET")) {
             parseSet(marker);
+        } else if (tokens.matches("INSERT")) {
+            consumeStatement();
+        } else if (tokens.matches("DELETE")) {
+            consumeStatement();
         } else {
             parseUnknownStatement(marker);
         }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -655,6 +655,22 @@ public class MySqlDdlParserTest {
     }
 
     @Test
+    public void shouldParseAndIgnoreDeleteStatements() {
+        String ddl = "DELETE FROM blah blah";
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(0);
+        assertThat(listener.total()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldParseAndIgnoreInsertStatements() {
+        String ddl = "INSERT INTO blah blah";
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(0);
+        assertThat(listener.total()).isEqualTo(0);
+    }
+
+    @Test
     public void shouldParseStatementsWithQuotedIdentifiers() {
         parser.parse(readFile("ddl/mysql-quoted.ddl"), tables);
         Testing.print(tables);


### PR DESCRIPTION
Parse and ignore any `DELETE` statements that might be seen in the binlog.

Theoretically, the binlog of a properly-configured MySQL server with row-level binlog enabled should never see these statements. However, users on Amazon RDS run into this quite frequently, and we should just handle and ignore them.