### PR TITLE
Correct the text describing the default values to match the actual defaults

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -368,7 +368,7 @@ public class PostgresConnectorConfig {
                                                     .withType(Type.INT)
                                                     .withWidth(Width.SHORT)
                                                     .withImportance(Importance.MEDIUM)
-                                                    .withDescription("Maximum size of the queue for change events read from the database log but not yet recorded or forwarded. Defaults to 2048, and should always be larger than the maximum batch size.")
+                                                    .withDescription("Maximum size of the queue for change events read from the database log but not yet recorded or forwarded. Defaults to 20480, and should always be larger than the maximum batch size.")
                                                     .withDefault(DEFAULT_MAX_QUEUE_SIZE)
                                                     .withValidation(PostgresConnectorConfig::validateMaxQueueSize);
 
@@ -377,7 +377,7 @@ public class PostgresConnectorConfig {
                                                     .withType(Type.INT)
                                                     .withWidth(Width.SHORT)
                                                     .withImportance(Importance.MEDIUM)
-                                                    .withDescription("Maximum size of each batch of source records. Defaults to 10024.")
+                                                    .withDescription("Maximum size of each batch of source records. Defaults to 10240.")
                                                     .withDefault(DEFAULT_MAX_BATCH_SIZE)
                                                     .withValidation(Field::isPositiveInteger);
 
@@ -395,7 +395,7 @@ public class PostgresConnectorConfig {
                                                       .withType(Type.LONG)
                                                       .withWidth(Width.SHORT)
                                                       .withImportance(Importance.MEDIUM)
-                                                      .withDescription("Frequency in milliseconds to wait for new change events to appear after receiving no events. Defaults to 1 second (1000 ms).")
+                                                      .withDescription("Frequency in milliseconds to wait for new change events to appear after receiving no events. Defaults to 0.5 second (500 ms).")
                                                       .withDefault(DEFAULT_POLL_INTERVAL_MILLIS)
                                                       .withValidation(Field::isPositiveInteger);
 


### PR DESCRIPTION
Several configuration descriptions have text like this:
  Maximum size of each batch of source records. Defaults to 10024.
In every case except for one the described default did not match the actual default (for example here the actual is 10240).  This patch fixes up the descriptions.

However this issue is just going to reappear again the next time someone tweaks a default, as they'll likely forget to update the description.  The nicest fix would be to automatically get it right by computing the text from DEFAULT_MAX_BATCH_SIZE, probably something like this (I didn't try it):
  .withDescription("Maximum size of the queue for change events read from the database log but not yet recorded or forwarded. Defaults to " + String(DEFAULT_MAX_BATCH_SIZE) + ", and should always be larger than the maximum batch size.")
I was surprised it wasn't done like this already (I checked some other connectors and they also just hardware the text), is there some reason for that?

Another possibility is of course to not attempt to give the default value in the description at all.