### PR TITLE
Add postgres tstzrange support to connector

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PgOid.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PgOid.java
@@ -28,12 +28,17 @@ public final class PgOid extends Oid {
      * Internal PG types as returned by the plugin
      */
     protected static final int JSONB_OID = 3802;
+
+    protected static final int TSTZRANGE_OID = 3910;
     
     private PgOid() {
     }
     
     protected static int jdbcColumnToOid(Column column) {
         String typeName = column.typeName();
+        if (typeName.toUpperCase().equals("TSTZRANGE")) {
+            return TSTZRANGE_OID;
+        }
         try {
             return valueOf(typeName);
         } catch (PSQLException e) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -78,6 +78,8 @@ public class PostgresValueConverter extends JdbcValueConverters {
             case PgOid.JSONB_JDBC_OID:
             case PgOid.JSON:
                 return Json.builder();
+            case PgOid.TSTZRANGE_OID:
+                return SchemaBuilder.string();
             case PgOid.UUID:
                 return Uuid.builder();
             case PgOid.POINT:
@@ -106,6 +108,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
                 return data -> convertBigInt(column, fieldDefn, data);
             case PgOid.JSONB_JDBC_OID:
             case PgOid.UUID:
+            case PgOid.TSTZRANGE_OID:
             case PgOid.JSON:
                 return data -> super.convertString(column, fieldDefn, data);
             case PgOid.POINT:

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
@@ -8,6 +8,7 @@ package io.debezium.connector.postgresql;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
@@ -472,6 +473,8 @@ public class RecordsStreamProducer extends RecordsProducer {
                 PgProto.Point datumPoint = datumMessage.getDatumPoint();
                 return new PGpoint(datumPoint.getX(), datumPoint.getY());
             }
+            case PgOid.TSTZRANGE_OID:
+                return datumMessage.hasDatumBytes() ? new String(datumMessage.getDatumBytes().toByteArray(), Charset.forName("UTF-8")) : null;
             default: {
                 logger.warn("processing column '{}' with unknown data type '{}' as byte array", datumMessage.getColumnName(),
                             datumMessage.getColumnType());

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
@@ -46,7 +46,7 @@ public class PostgresSchemaIT {
     
     private static final String[] TEST_TABLES = new String[] { "public.numeric_table", "public.string_table", "public.cash_table",
                                                                "public.bitbin_table",
-                                                               "public.time_table", "public.text_table", "public.geom_table" };
+                                                               "public.time_table", "public.text_table", "public.geom_table", "public.tstzrange_table" };
     
     private PostgresSchema schema;
     
@@ -82,6 +82,7 @@ public class PostgresSchemaIT {
                               Json.builder().optional().build(), Json.builder().optional().build(), Xml.builder().optional().build(),
                               Uuid.builder().optional().build());
             assertTableSchema("public.geom_table", "p", Point.builder().optional().build());
+            assertTableSchema("public.tstzrange_table", "t", Schema.OPTIONAL_STRING_SCHEMA);
         }
     }
     

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -88,6 +88,10 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         // geom types
         consumer.expects(1);
         assertInsert(INSERT_GEOM_TYPES_STMT, schemaAndValuesForGeomTypes());
+
+        // timezone range types
+        consumer.expects(1);
+        assertInsert(INSERT_TSTZRANGE_TYPES_STMT, schemaAndValuesForTstzRangeTypes());
     }
     
     @Test

--- a/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
+++ b/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
@@ -8,3 +8,4 @@ CREATE TABLE bitbin_table (pk SERIAL, ba BYTEA, bol BIT(1), bs BIT(2), bv BIT VA
 CREATE TABLE time_table (pk SERIAL, ts TIMESTAMP, tz TIMESTAMPTZ, date DATE, ti TIME, ttz TIME WITH TIME ZONE, it INTERVAL, PRIMARY KEY(pk));
 CREATE TABLE text_table (pk SERIAL, j JSON, jb JSONB, x XML, u Uuid, PRIMARY KEY(pk));
 CREATE TABLE geom_table (pk SERIAL, p POINT, PRIMARY KEY(pk));
+CREATE TABLE tstzrange_table (pk serial, t tstzrange, PRIMARY KEY(pk));


### PR DESCRIPTION
Hi Debezium team,

My team was hoping to take advantage of the postgres connector, but we ran into a slight snag as the current implementation does not handle the tstzrange type well. It gets declared a json type in the schema and the fallback code, when pushing, call it a binary array datum, which consequently gets sent onward by the connector as a "toString" byte array (ex: [B@6e33589e ).

I have not checked what happens with other range types, but notice they also fall out of the covered types.

Let me know what I can do to help this along. 
arosenber