### PR TITLE
DBZ-298 - fix for when names in PostgreSQL are quoted

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
@@ -6,6 +6,23 @@
 
 package io.debezium.connector.postgresql;
 
+import io.debezium.annotation.ThreadSafe;
+import io.debezium.connector.postgresql.connection.ReplicationConnection;
+import io.debezium.connector.postgresql.connection.ReplicationStream;
+import io.debezium.connector.postgresql.proto.PgProto;
+import io.debezium.data.Envelope;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.TableSchema;
+import io.debezium.util.LoggingContext;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.postgresql.geometric.PGpoint;
+
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.charset.Charset;
@@ -18,24 +35,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-
-import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.source.SourceRecord;
-import org.postgresql.geometric.PGpoint;
-
-import io.debezium.annotation.ThreadSafe;
-import io.debezium.connector.postgresql.connection.ReplicationConnection;
-import io.debezium.connector.postgresql.connection.ReplicationStream;
-import io.debezium.connector.postgresql.proto.PgProto;
-import io.debezium.data.Envelope;
-import io.debezium.relational.Column;
-import io.debezium.relational.Table;
-import io.debezium.relational.TableId;
-import io.debezium.relational.TableSchema;
-import io.debezium.util.LoggingContext;
 
 /**
  * A {@link RecordsProducer} which creates {@link org.apache.kafka.connect.source.SourceRecord records} from a Postgres
@@ -352,7 +351,8 @@ public class RecordsStreamProducer extends RecordsProducer {
         List<String> columnNames = table.columnNames();
         Object[] values = new Object[messageList.size()];
         messageList.forEach(message -> {
-            int position = columnNames.indexOf(message.getColumnName());
+            final String columnName = message.getColumnName().startsWith("\"") ? message.getColumnName().substring(1, message.getColumnName().length()-1) : message.getColumnName();
+            int position = columnNames.indexOf(columnName);
             assert position >= 0;
             values[position] = extractValueFromMessage(message);
         });
@@ -372,6 +372,7 @@ public class RecordsStreamProducer extends RecordsProducer {
         // on what we have in the table metadata....
         return messageList.stream().filter(message -> {
             String columnName = message.getColumnName();
+            if ( columnName.startsWith("\"") && columnName.endsWith("\"")) columnName = columnName.substring(1, columnName.length()-1);
             Column column = table.columnWithName(columnName);
             if (column == null) {
                 logger.debug("found new column '{}' present in the server message which is not part of the table metadata; refreshing table schema", columnName);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
@@ -6,22 +6,6 @@
 
 package io.debezium.connector.postgresql;
 
-import static io.debezium.connector.postgresql.PostgresConnectorConfig.SCHEMA_BLACKLIST;
-import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.stream.IntStream;
-
-import org.apache.kafka.connect.data.Decimal;
-import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.data.Schema;
-import org.junit.Before;
-import org.junit.Test;
-
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.data.Bits;
 import io.debezium.data.Json;
@@ -30,13 +14,21 @@ import io.debezium.data.Xml;
 import io.debezium.data.geometry.Point;
 import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchema;
-import io.debezium.time.Date;
-import io.debezium.time.MicroDuration;
-import io.debezium.time.NanoTime;
-import io.debezium.time.NanoTimestamp;
-import io.debezium.time.ZonedTime;
-import io.debezium.time.ZonedTimestamp;
+import io.debezium.time.*;
 import io.debezium.util.AvroValidator;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+import static io.debezium.connector.postgresql.PostgresConnectorConfig.SCHEMA_BLACKLIST;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.*;
 
 /**
  * Unit test for {@link PostgresSchema}
@@ -47,7 +39,7 @@ public class PostgresSchemaIT {
 
     private static final String[] TEST_TABLES = new String[] { "public.numeric_table", "public.string_table", "public.cash_table",
                                                                "public.bitbin_table",
-                                                               "public.time_table", "public.text_table", "public.geom_table", "public.tstzrange_table" };
+                                                               "public.time_table", "public.text_table", "public.geom_table", "public.tstzrange_table", "public.Quoted_Table" };
 
     private PostgresSchema schema;
 
@@ -85,6 +77,8 @@ public class PostgresSchemaIT {
             assertTableSchema("public.geom_table", "p", Point.builder().optional().build());
             assertTableSchema("public.tstzrange_table", "unbounded_exclusive_range, bounded_inclusive_range",
                               Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
+            assertTableSchema("public.Quoted_Table", "Quoted_Text_Column",
+                              Schema.OPTIONAL_STRING_SCHEMA);
         }
     }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -6,23 +6,23 @@
 
 package io.debezium.connector.postgresql;
 
-import static io.debezium.connector.postgresql.TestHelper.PK_FIELD;
-import static io.debezium.connector.postgresql.TestHelper.topicName;
-import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertFalse;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
+import io.debezium.data.Envelope;
+import io.debezium.data.VerifyRecord;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.debezium.data.Envelope;
-import io.debezium.data.VerifyRecord;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static io.debezium.connector.postgresql.TestHelper.PK_FIELD;
+import static io.debezium.connector.postgresql.TestHelper.topicName;
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Integration test for the {@link RecordsStreamProducer} class. This also tests indirectly the PG plugin functionality for
@@ -92,8 +92,20 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         // timezone range types
         consumer.expects(1);
         assertInsert(INSERT_TSTZRANGE_TYPES_STMT, schemaAndValuesForTstzRangeTypes());
+
     }
-    
+
+    @Test
+    public void shouldReceiveChangesForInsertsWithQuotedNames() throws Exception {
+        TestHelper.executeDDL("postgres_create_tables.ddl");
+
+        consumer = testConsumer(1);
+        recordsProducer.start(consumer);
+
+        // Quoted column name
+        assertInsert(INSERT_QUOTED_TYPES_STMT, schemasAndValuesForQuotedTypes());
+    }
+
     @Test
     public void shouldReceiveChangesForNewTable() throws Exception {
         String statement = "CREATE SCHEMA s1;" +

--- a/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
+++ b/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
@@ -1,3 +1,5 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
 -- Generate a number of tables to cover as many of the PG types as possible
 DROP SCHEMA IF EXISTS public CASCADE;
 CREATE SCHEMA public;
@@ -9,3 +11,4 @@ CREATE TABLE time_table (pk SERIAL, ts TIMESTAMP, tz TIMESTAMPTZ, date DATE, ti 
 CREATE TABLE text_table (pk SERIAL, j JSON, jb JSONB, x XML, u Uuid, PRIMARY KEY(pk));
 CREATE TABLE geom_table (pk SERIAL, p POINT, PRIMARY KEY(pk));
 CREATE TABLE tstzrange_table (pk serial, unbounded_exclusive_range tstzrange, bounded_inclusive_range tstzrange, PRIMARY KEY(pk));
+CREATE TABLE "Quoted_Table" (pk SERIAL, "Quoted_Text_Column" TEXT, PRIMARY KEY(pk));

--- a/debezium-core/src/main/java/io/debezium/relational/TableId.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableId.java
@@ -37,6 +37,12 @@ public final class TableId implements Comparable<TableId> {
     public static TableId parse(String str, boolean useCatalogBeforeSchema) {
         String[] parts = str.split("[\\" + '.' + "]");
         if ( parts.length < 0 ) return null;
+        for (int i = 0; i < parts.length; i++) {
+            String part = parts[i];
+            if ( part.startsWith("\"") && part.endsWith("\"") ) {
+                parts[i] = part.substring(1, part.length()-1);
+            }
+        }
         return TableId.parse(parts, parts.length, useCatalogBeforeSchema);
     }
 


### PR DESCRIPTION
Changes include a new test that creates a case-sensitive table and case-sensitive column within it (both quoted).