### PR TITLE
DBZ-306 add support for different mongodb _id types in key struct

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/RecordMakers.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/RecordMakers.java
@@ -9,6 +9,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+import com.mongodb.DBCollection;
+import com.mongodb.util.JSONSerializers;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -16,7 +18,6 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.bson.Document;
 import org.bson.json.JsonMode;
 import org.bson.json.JsonWriterSettings;
-import org.bson.types.ObjectId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,7 +102,7 @@ public class RecordMakers {
             this.topicName = topicName;
             this.keySchema = SchemaBuilder.struct()
                                           .name(validator.validate(topicName + ".Key"))
-                                          .field("_id", Schema.STRING_SCHEMA)
+                                          .field("id", Schema.STRING_SCHEMA)
                                           .build();
             this.valueSchema = SchemaBuilder.struct()
                                             .name(validator.validate(topicName + ".Envelope"))
@@ -138,7 +139,8 @@ public class RecordMakers {
         public int recordObject(CollectionId id, Document object, long timestamp) throws InterruptedException {
             final Struct sourceValue = source.lastOffsetStruct(replicaSetName, id);
             final Map<String, ?> offset = source.lastOffset(replicaSetName);
-            String objId = objectIdLiteralFrom(object);
+            String objId = idObjToJson(object);
+            assert objId != null;
             return createRecords(sourceValue, offset, Operation.READ, objId, object, timestamp);
         }
 
@@ -157,7 +159,7 @@ public class RecordMakers {
             Document patchObj = oplogEvent.get("o", Document.class);
             // Updates have an 'o2' field, since the updated object in 'o' might not have the ObjectID ...
             Object o2 = oplogEvent.get("o2");
-            String objId = o2 != null ? objectIdLiteral(o2) : objectIdLiteralFrom(patchObj);
+            String objId = o2 != null ? idObjToJson(o2) : idObjToJson(patchObj);
             assert objId != null;
             Operation operation = operationLiterals.get(oplogEvent.getString("op"));
             return createRecords(sourceValue, offset, operation, objId, patchObj, timestamp);
@@ -201,37 +203,20 @@ public class RecordMakers {
             return 1;
         }
 
-        protected String objectIdLiteralFrom(Document obj) {
-            if (obj == null) {
+        protected String idObjToJson(Object idObj) {
+            if(idObj == null) {
                 return null;
             }
-            Object id = obj.get("_id");
-            return objectIdLiteral(id);
-        }
-
-        protected String objectIdLiteral(Object id) {
-            if (id == null) {
-                return null;
+            if(!(idObj instanceof Document)) {
+                return JSONSerializers.getStrict().serialize(idObj);
             }
-            if (id instanceof ObjectId) {
-                return ((ObjectId) id).toHexString();
-            }
-            if (id instanceof String) {
-                return (String) id;
-            }
-            if (id instanceof Document) {
-                Document doc = (Document)id;
-                if (doc.containsKey("_id") && doc.size() == 1) {
-                    // This is an embedded ObjectId ...
-                    return objectIdLiteral(doc.get("_id"));
-                }
-                return valueTransformer.apply((Document) id);
-            }
-            return id.toString();
+            return JSONSerializers.getStrict().serialize(
+                    ((Document)idObj).get(DBCollection.ID_FIELD_NAME)
+            );
         }
 
         protected Struct keyFor(String objId) {
-            return new Struct(keySchema).put("_id", objId);
+            return new Struct(keySchema).put("id", objId);
         }
     }
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/RecordMakers.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/RecordMakers.java
@@ -11,6 +11,7 @@ import java.util.function.Function;
 
 import com.mongodb.DBCollection;
 import com.mongodb.util.JSONSerializers;
+import com.mongodb.util.ObjectSerializer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -36,6 +37,7 @@ import io.debezium.util.AvroValidator;
 @ThreadSafe
 public class RecordMakers {
 
+    private static final ObjectSerializer jsonSerializer = JSONSerializers.getStrict();
     private static final Map<String, Operation> operationLiterals = new HashMap<>();
     static {
         operationLiterals.put("i", Operation.CREATE);
@@ -204,13 +206,13 @@ public class RecordMakers {
         }
 
         protected String idObjToJson(Object idObj) {
-            if(idObj == null) {
+            if (idObj == null) {
                 return null;
             }
-            if(!(idObj instanceof Document)) {
-                return JSONSerializers.getStrict().serialize(idObj);
+            if (!(idObj instanceof Document)) {
+                return jsonSerializer.serialize(idObj);
             }
-            return JSONSerializers.getStrict().serialize(
+            return jsonSerializer.serialize(
                     ((Document)idObj).get(DBCollection.ID_FIELD_NAME)
             );
         }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
+import com.mongodb.util.JSON;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -293,10 +294,10 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
         Testing.debug("Update event: " + updateRecord);
         Struct insertKey = (Struct)insertRecord.key();
         Struct updateKey = (Struct)updateRecord.key();
-        String insertId = insertKey.getString("_id");
-        String updatetId = updateKey.getString("_id");
+        String insertId = JSON.parse(insertKey.getString("id")).toString();
+        String updateId = JSON.parse(updateKey.getString("id")).toString();
         assertThat(insertId).isEqualTo(id.get());
-        assertThat(updatetId).isEqualTo(id.get());
+        assertThat(updateId).isEqualTo(id.get());
     }
 
     protected void verifyFromInitialSync(SourceRecord record, AtomicBoolean foundLast) {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/RecordMakersTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/RecordMakersTest.java
@@ -8,6 +8,7 @@ package io.debezium.connector.mongodb;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.mongodb.util.JSONSerializers;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.bson.BsonTimestamp;
@@ -76,7 +77,7 @@ public class RecordMakersTest {
         Struct key = (Struct) record.key();
         Struct value = (Struct) record.value();
         assertThat(key.schema()).isSameAs(record.keySchema());
-        assertThat(key.get("_id")).isEqualTo(objId.toString());
+        assertThat(key.get("id")).isEqualTo(JSONSerializers.getStrict().serialize(objId));
         assertThat(value.schema()).isSameAs(record.valueSchema());
         // assertThat(value.getString(FieldName.BEFORE)).isNull();
         assertThat(value.getString(FieldName.AFTER)).isEqualTo(obj.toJson(WRITER_SETTINGS));
@@ -106,7 +107,7 @@ public class RecordMakersTest {
         Struct key = (Struct) record.key();
         Struct value = (Struct) record.value();
         assertThat(key.schema()).isSameAs(record.keySchema());
-        assertThat(key.get("_id")).isEqualTo(objId.toString());
+        assertThat(key.get("id")).isEqualTo(JSONSerializers.getStrict().serialize(objId));
         assertThat(value.schema()).isSameAs(record.valueSchema());
         // assertThat(value.getString(FieldName.BEFORE)).isNull();
         assertThat(value.getString(FieldName.AFTER)).isNull();
@@ -137,7 +138,7 @@ public class RecordMakersTest {
         Struct key = (Struct) record.key();
         Struct value = (Struct) record.value();
         assertThat(key.schema()).isSameAs(record.keySchema());
-        assertThat(key.get("_id")).isEqualTo(objId.toString());
+        assertThat(key.get("id")).isEqualTo(JSONSerializers.getStrict().serialize(objId));
         assertThat(value.schema()).isSameAs(record.valueSchema());
         assertThat(value.getString(FieldName.AFTER)).isNull();
         assertThat(value.getString("patch")).isNull();
@@ -150,7 +151,7 @@ public class RecordMakersTest {
         SourceRecord tombstone = produced.get(1);
         Struct key2 = (Struct) tombstone.key();
         assertThat(key2.schema()).isSameAs(tombstone.keySchema());
-        assertThat(key2.get("_id")).isEqualTo(objId.toString());
+        assertThat(key2.get("id")).isEqualTo(JSONSerializers.getStrict().serialize(objId));
         assertThat(tombstone.value()).isNull();
         assertThat(tombstone.valueSchema()).isNull();
     }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ReplicatorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ReplicatorIT.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.mongodb.util.JSON;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.bson.Document;
@@ -208,7 +209,7 @@ public class ReplicatorIT extends AbstractMongoIT {
         records.forEach(record -> {
             VerifyRecord.isValid(record);
             Struct key = (Struct) record.key();
-            ObjectId id = new ObjectId(key.getString("_id"));
+            ObjectId id = (ObjectId)(JSON.parse(key.getString("id")));
             foundIds.add(id);
             if (record.value() != null) {
                 Struct value = (Struct) record.value();


### PR DESCRIPTION
This addresses a potential bug / design flaw with regard to the handling of the _id field of MongoDB CDC events in the key struct of SourceRecords. Currently, the problem is that _id fields are always
represented as flat strings.

Rationale:

At the moment, one cannot even distinguish simple cases e.g. a numeric _id field holding the integer 1234 vs. a string _id field holding "1234". While for CREATE/READ events consumers can re-create the correct (original) _id type based on the "after" field found in the value struct, it is not possible to use this workaround for idempotent change or delete events respectively. For these we need to rely on a correct _id type in order to be able to refer to the corresponding data records and apply the changes or deletetions at the consuming sink.

I recently discussed this with @rhauch (in confluent slack community) and the conclusion was that it might make most sense to address this issue by allowing the SourceRecords to reflect the different types that _id fields might exhibit. Looking at the current implementation I decided to remove the rigid / pre-defined keySchema and corresponding _id handling approach. Instead, I'm introducing a simple inner class IdStructConverter with static conversion methods (type-specific ones) inside RecordMakers class. In addition to that, there is now a new method idStructFor(...) - it delegates to the IdStructConverter to create a proper Struct for the _id field - which is used by the existing createRecords(...) method.

Implications:

Because of this change 3 affected unit test methods had to be adapted accordingly  since the _id fields of type ObjectId are not just strings any longer after that change.

Clearly, the suggested PR is a breaking change in the sense that any downstream consumers which "accidentally" rely on the _id field to be always a flat string need to be modified as well.
