### PR TITLE
DBZ-326, DBZ-327

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -14,6 +14,7 @@ Gunnar Morling
 Horia Chiorean
 Jiri Pechanec
 Jure Kajzer
+Mario Mueller
 Matteo Capitanio
 Omar Al-Safi
 Prannoy Mittal

--- a/debezium-core/src/test/java/io/debezium/transforms/ByLogicalTableRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ByLogicalTableRouterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Mario Mueller
+ */
+public class ByLogicalTableRouterTest {
+
+    @Test(expected = ConnectException.class)
+    public void testBrokenKeyReplacementConfigurationNullValue() {
+        final ByLogicalTableRouter<SourceRecord> subject = new ByLogicalTableRouter<>();
+        final Map<String, String> props = new HashMap<>();
+
+        props.put("topic.regex", "someValidRegex(.*)");
+        props.put("topic.replacement", "$1");
+        props.put("key.field.regex", "If this is set, key.field.replacement must be non-empty");
+        subject.configure(props);
+    }
+
+    @Test(expected = ConnectException.class)
+    public void testBrokenKeyReplacementConfigurationEmptyValue() {
+        final ByLogicalTableRouter<SourceRecord> subject = new ByLogicalTableRouter<>();
+        final Map<String, String> props = new HashMap<>();
+
+        props.put("topic.regex", "someValidRegex(.*)");
+        props.put("topic.replacement", "$1");
+        props.put("key.field.regex", "If this is set, key.field.replacement must be non-empty");
+        props.put("key.field.replacement", "");
+        subject.configure(props);
+    }
+
+    @Test
+    public void testKeyReplacementWorkingConfiguration() {
+        final ByLogicalTableRouter<SourceRecord> subject = new ByLogicalTableRouter<>();
+        final Map<String, String> props = new HashMap<>();
+
+        props.put("topic.regex", "someValidRegex(.*)");
+        props.put("topic.replacement", "$1");
+        props.put("key.field.regex", "anotherValidRegex(.*)");
+        props.put("key.field.replacement", "$1");
+        subject.configure(props);
+        assertTrue(true);
+    }
+
+    @Test(expected = ConnectException.class)
+    public void testBrokenTopicReplacementConfigurationNullValue() {
+        final ByLogicalTableRouter<SourceRecord> subject = new ByLogicalTableRouter<>();
+        final Map<String, String> props = new HashMap<>();
+
+        // topic.replacement is not set, therefore null. Must crash.
+        props.put("topic.regex", "someValidRegex(.*)");
+        subject.configure(props);
+    }
+
+    @Test(expected = ConnectException.class)
+    public void testBrokenTopicReplacementConfigurationEmptyValue() {
+        final ByLogicalTableRouter<SourceRecord> subject = new ByLogicalTableRouter<>();
+        final Map<String, String> props = new HashMap<>();
+
+        // topic.replacement is set to empty string. Must crash.
+        props.put("topic.regex", "someValidRegex(.*)");
+        props.put("topic.replacement", "");
+        subject.configure(props);
+    }
+
+    // FIXME: This SMT can use more tests for more detailed coverage.
+    // The creation of a DBZ-ish SourceRecord is required for each test
+}


### PR DESCRIPTION
The two tickets unintentionally resulted in a higher modification as expected.
@gunnarmorling Sorry, there were a few conflicting changes (could be sorted to the one or the other ticket). I decided not to put effort in keeping them separated, but in producing working software.

- Move cache initialisation to the class members. The cache is per instance of the class and SMTs are bound to the connector in which they are configured. Clearing the cache on stop() seems therefore unnecessary, as we want to reuse the cache for the same connector instance on (re-)start.
- Remove the identity equality checks in favour of Objects.equals(), which are left-hand null-safe. Null-checks are still needed for semantical purposes.
- Logger moved to static member.
- Add new "isNotNull" validation function to Field, in order to allow empty strings as values.
- Topic Replacement and Key Field Replacement now allow empty, but non-null values.
- Fields where commonly used directly with an implicit .toString() call (e.g. in config.getString()). These calls are now replaced with an explicit .name() call on the field to no rely on the implicit logic.
- Moved for-loops to lambda syntax for better readability
- Reorder members and methods. "Static to local" and within that "public to private"

**What is missing:**
- More tests that use a `SourceRecord` (How do I create one that is close or equal to one that DBZ produces?)
- Docs, docs, docs

Signed-off-by: Mario Mueller <mario@xenji.com>