### PR TITLE
DBZ-341 Ignore malformed messages coming from database history

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/history/HistoryRecord.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/HistoryRecord.java
@@ -74,4 +74,13 @@ public class HistoryRecord {
     public String toString() {
         return doc.toString();
     }
+
+    /**
+     * Verifies that the record contains mandatory fields - source and position
+     *
+     * @return false if mandatory fields are missing
+     */
+    public boolean isValid() {
+        return source() != null && position() != null;
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
@@ -200,17 +200,17 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
                         if (lastOffset == null || lastOffset.longValue() < record.offset()) {
                             if (record.value() == null) {
                                 logger.warn("Skipping null database history record. " +
-                                        "This is often not an issue, but if it happens repeatedly please check the '{}' topic.");
+                                        "This is often not an issue, but if it happens repeatedly please check the '{}' topic.", topicName);
                             } else {
                                 HistoryRecord recordObj = new HistoryRecord(reader.read(record.value()));
-                                logger.trace("Recovering database history: {}" + recordObj);
+                                logger.trace("Recovering database history: {}", recordObj);
                                 if (recordObj == null || !recordObj.isValid()) {
                                     logger.warn("Skipping invalid database history record '{}'. " +
                                             "This is often not an issue, but if it happens repeatedly please check the '{}' topic.",
                                             recordObj, topicName);
                                 } else {
                                     records.accept(recordObj);
-                                    logger.trace("Recovered database history: {}" + recordObj);
+                                    logger.trace("Recovered database history: {}", recordObj);
                                 }
                             }
                             offsetsByPartition.put(partition, new Long(record.offset()));

--- a/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
@@ -201,17 +201,14 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
                             if (record.value() == null) {
                                 logger.warn("Skipping null database history record. " +
                                         "This is often not an issue, but if it happens repeatedly please check the '{}' topic.");
-                            }
-                            else {
+                            } else {
                                 HistoryRecord recordObj = new HistoryRecord(reader.read(record.value()));
                                 logger.trace("Recovering database history: {}" + recordObj);
                                 if (recordObj == null || !recordObj.isValid()) {
                                     logger.warn("Skipping invalid database history record '{}'. " +
                                             "This is often not an issue, but if it happens repeatedly please check the '{}' topic.",
-                                            recordObj,
-                                            topicName);
-                                }
-                                else {
+                                            recordObj, topicName);
+                                } else {
                                     records.accept(recordObj);
                                     logger.trace("Recovered database history: {}" + recordObj);
                                 }
@@ -221,8 +218,7 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
                         }
                     } catch (IOException e) {
                         logger.error("Error while deserializing history record '{}'", record, e);
-                    }
-                    catch (final Exception e) {
+                    } catch (final Exception e) {
                         logger.error("Unexpected exception while processing record '{}'", record, e);
                         throw e;
                     }


### PR DESCRIPTION
This is just first step - to log history message before an exception is thrown to enable easier diagnostics