### PR TITLE
DBZ-349 Better support for large append-only tables by making the snapshotting process restartable for MySQL

### DIFF
--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -36,6 +36,11 @@
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
 
         <!-- Testing -->
         <dependency>

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -652,6 +652,15 @@ public class MySqlConnectorConfig {
                                                                    + "'precise' (the default) uses java.math.BigDecimal to represent values, which are encoded in the change events using a binary representation and Kafka Connect's 'org.apache.kafka.connect.data.Decimal' type; "
                                                                    + "'double' represents values using Java's 'double', which may not offer the precision but will be far easier to use in consumers.");
 
+    public static final Field SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE = Field.create("snapshot.select.statement.overrides")
+            .withDisplayName("Overrides for the default select statement used during snapshotting")
+            .withType(Type.STRING)
+            .withWidth(Width.LONG)
+            .withImportance(Importance.MEDIUM)
+            .withDescription("The value is a JSON-encoded map, where the key is the name of the table, the value is the select statement to use when retrieving data from the " +
+                    "specific table during snapshotting. A possible use case for large append-only tables is setting a specific point where to start snapshotting, in case " +
+                    "a previous snapshotting was interrupted.");
+
     /**
      * Method that generates a Field for specifying that string columns whose names match a set of regular expressions should
      * have their values truncated to be no longer than the specified number of characters.

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -5,12 +5,17 @@
  */
 package io.debezium.connector.mysql;
 
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
 import io.debezium.function.Predicates;
@@ -33,6 +38,8 @@ public final class MySqlTaskContext extends MySqlJdbcContext {
     private final RecordMakers recordProcessor;
     private final Predicate<String> gtidSourceFilter;
     private final Clock clock = Clock.system();
+    private final ObjectMapper jsonObjectMapper = new ObjectMapper();
+    private Map<String, String> snapshotSelectOverridesByTable;
 
     public MySqlTaskContext(Configuration config) {
         super(config);
@@ -187,6 +194,24 @@ public final class MySqlTaskContext extends MySqlJdbcContext {
 
     public boolean useMinimalSnapshotLocking() {
         return config.getBoolean(MySqlConnectorConfig.SNAPSHOT_MINIMAL_LOCKING);
+    }
+
+    public Optional<String> getSnapshotSelectOverride(String tableId) {
+        if (snapshotSelectOverridesByTable == null) {
+            snapshotSelectOverridesByTable = new HashMap<>();
+            String overridesInJson = config.getString(MySqlConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE, ()->null);
+            if (overridesInJson != null) {
+                TypeReference<HashMap<String, String>> typeRef = new TypeReference<HashMap<String, String>>() {};
+                try {
+                    snapshotSelectOverridesByTable = jsonObjectMapper.readValue(overridesInJson, typeRef);
+                } catch (IOException ioe) {
+                    logger.warn(String.format("Failed to parse value of %s as JSON. Value is: %s",
+                            MySqlConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
+                            overridesInJson));
+                }
+            }
+        }
+        return Optional.ofNullable(snapshotSelectOverridesByTable.get(tableId));
     }
 
     @Override

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -426,7 +426,10 @@ public class SnapshotReader extends AbstractReader {
                             // Scan the rows in the table ...
                             long start = clock.currentTimeInMillis();
                             logger.info("Step {}: - scanning table '{}' ({} of {} tables)", step, tableId, ++counter, tableIds.size());
-                            sql.set("SELECT * FROM " + quote(tableId));
+                            String selectStatement = context.getSnapshotSelectOverride(tableId.toString())
+                                    .orElse("SELECT * FROM " + quote(tableId));
+                            logger.info("For table '{}' using select statement: '{}'", tableId, selectStatement);
+                            sql.set(selectStatement);
                             try {
                                 int stepNum = step;
                                 mysql.query(sql.get(), statementFactory, rs -> {

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,12 @@
                 <artifactId>jackson-core</artifactId>
                 <version>${version.jackson}</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${version.jackson}</version>
+            </dependency>
+
 
             <!-- Kafka Connect -->
             <dependency>


### PR DESCRIPTION
This change allows one to override the default 'select * from ...' used during snapshotting a table with a custom select statement, which makes it possible to continue an interrupted snapshot process for append-only tables. 
This is useful for large tables that take a very long time to snapshot and thus are prone to be interrupted for some reason during snapshotting.