### PR TITLE
Add support for dec and fixed for mysql ddl parser.

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
@@ -89,6 +89,8 @@ public class MySqlDdlParser extends DdlParser {
         dataTypes.register(Types.DOUBLE, "DOUBLE[(M[,D])] [UNSIGNED|SIGNED] [ZEROFILL]");
         dataTypes.register(Types.FLOAT, "FLOAT[(M[,D])] [UNSIGNED|SIGNED] [ZEROFILL]");
         dataTypes.register(Types.DECIMAL, "DECIMAL[(M[,D])] [UNSIGNED|SIGNED] [ZEROFILL]");
+        dataTypes.register(Types.DECIMAL, "FIXED[(M[,D])] [UNSIGNED|SIGNED] [ZEROFILL]");
+        dataTypes.register(Types.DECIMAL, "DEC[(M[,D])] [UNSIGNED|SIGNED] [ZEROFILL]");
         dataTypes.register(Types.NUMERIC, "NUMERIC[(M[,D])] [UNSIGNED|SIGNED] [ZEROFILL]");
         dataTypes.register(Types.BOOLEAN, "BOOLEAN");
         dataTypes.register(Types.BOOLEAN, "BOOL");

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -1103,6 +1103,19 @@ public class MySqlDdlParserTest {
         assertColumn(t2, "c2", "NCHAR", Types.NCHAR, 10, "utf8", true);
     }
 
+    @Test
+    public void parseDdlForDecAndFixed() {
+        String ddl = "CREATE TABLE t ( c1 DEC(2) NOT NULL, c2 FIXED(1,0) NOT NULL);";
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(1);
+        Table t = tables.forTable(new TableId(null, null, "t"));
+        assertThat(t).isNotNull();
+        assertThat(t.columnNames()).containsExactly("c1", "c2");
+        assertThat(t.primaryKeyColumnNames()).isEmpty();
+        assertColumn(t, "c1", "DEC", Types.DECIMAL, 2, -1, false, false, false);
+        assertColumn(t, "c2", "FIXED", Types.DECIMAL, 1, 0, false, false, false);
+    }
+
     protected void assertParseEnumAndSetOptions(String typeExpression, String optionString) {
         List<String> options = MySqlDdlParser.parseSetAndEnumOptions(typeExpression);
         String commaSeperatedOptions = Strings.join(",", options);


### PR DESCRIPTION
According to Mysql document, https://dev.mysql.com/doc/refman/5.7/en/numeric-types.html
keywords DEC and FIXED are synonyms for DECIMAL.

https://issues.jboss.org/browse/DBZ-359