### PR TITLE
Fix inaccurate comment on MySQLSchema.tables method

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
@@ -163,7 +163,7 @@ public class MySqlSchema {
 
     /**
      * Get all of the table definitions for all database tables as defined by
-     * {@link #applyDdl(SourceInfo, String, String, DatabaseStatementStringConsumer) applied DDL statements}, including those
+     * {@link #applyDdl(SourceInfo, String, String, DatabaseStatementStringConsumer) applied DDL statements}, excluding those
      * that have been excluded by the {@link #filters() filters}.
      * 
      * @return the table definitions; never null


### PR DESCRIPTION
As far as I can tell this comment is inaccurate.  

The method appears to be filtering the tables, even though the comment claims it will include those tables excluded by the filter.