### PR TITLE
DBZ-402 Stop binlog reader to unregister MXBean in snapshot only mode

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -154,6 +154,8 @@ public final class MySqlConnectorTask extends SourceTask {
                 if (taskContext.isInitialSnapshotOnly()) {
                     logger.warn("This connector will only perform a snapshot, and will stop after that completes.");
                     readers.uponCompletion("Connector configured to only perform snapshot, and snapshot completed successfully. Connector will terminate.");
+                    // Snapshot Only: stop binlogReader in order to gracefully unregister metrics, which were registered during BinlogReader construction above
+                    binlogReader.stop();
                 } else {
                     if (!rowBinlogEnabled) {
                         throw new ConnectException("The MySQL server is not configured to use a row-level binlog, which is "


### PR DESCRIPTION
This is a simple tweak that will gracefully unregister the MXBean, but it probably shouldn't be created in the first place in this snapshot mode.

Let me know if there's a more ideal solution and I can adjust.
