### PR TITLE
DBZ-408 Consuming COLUMN token only for ALTER TABLE statements, so to…

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
@@ -700,7 +700,7 @@ public class MySqlDdlParser extends DdlParser {
 
         try {
             // It's either quoted (meaning it's a column definition)
-            if (isAlterStatement) {
+            if (isAlterStatement && !quoted) {
                 tokens.canConsume("COLUMN"); // optional for ALTER TABLE
             }
 
@@ -1213,7 +1213,9 @@ public class MySqlDdlParser extends DdlParser {
             } else if (tokens.canConsume("PARTITION")) {
                 parsePartitionNames(start);
             } else {
-                tokens.canConsume("COLUMN");
+                if(!isNextTokenQuotedIdentifier()) {
+                    tokens.canConsume("COLUMN");
+                }
                 String columnName = parseColumnName();
                 table.removeColumn(columnName);
             }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.sql.Types;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -1108,6 +1109,7 @@ public class MySqlDdlParserTest {
     public void shouldParseCreateTableStatementWithColumnNamedColumn() {
         String ddl = "CREATE TABLE `mytable` ( " + System.lineSeparator()
                     + " `def` int(11) unsigned NOT NULL AUTO_INCREMENT, " + System.lineSeparator()
+                    + " `ghi` varchar(255) NOT NULL DEFAULT '', " + System.lineSeparator()
                     + " `column` varchar(255) NOT NULL DEFAULT '', " + System.lineSeparator()
                     + " PRIMARY KEY (`def`) " + System.lineSeparator()
                   + " ) ENGINE=InnoDB DEFAULT CHARSET=utf8;";
@@ -1117,6 +1119,87 @@ public class MySqlDdlParserTest {
         Table mytable = tables.forTable(new TableId(null, null, "mytable"));
         assertThat(mytable).isNotNull();
         assertColumn(mytable, "column", "VARCHAR", Types.VARCHAR, 255, -1, false, false, false);
+        assertColumn(mytable, "ghi", "VARCHAR", Types.VARCHAR, 255, -1, false, false, false);
+    }
+
+    @Test
+    @FixFor("DBZ-408")
+    public void shouldParseAlterTableStatementWithColumnNamedColumnWithoutColumnWord() {
+        String ddl = "CREATE TABLE `mytable` ( " + System.lineSeparator()
+                    + " `def` int(11) unsigned NOT NULL AUTO_INCREMENT, " + System.lineSeparator()
+                    + " PRIMARY KEY (`def`) " + System.lineSeparator()
+                  + " ) ENGINE=InnoDB DEFAULT CHARSET=utf8;";
+
+        parser.parse(ddl, tables);
+
+        ddl = "ALTER TABLE `mytable` "
+                + "ADD `column` varchar(255) NOT NULL DEFAULT '', "
+                + "ADD `ghi` varchar(255) NOT NULL DEFAULT '', "
+                + "ADD jkl varchar(255) NOT NULL DEFAULT '' ;";
+
+        parser.parse(ddl, tables);
+
+        assertThat(tables.size()).isEqualTo(1);
+
+        Table mytable = tables.forTable(new TableId(null, null, "mytable"));
+        assertThat(mytable).isNotNull();
+        assertColumn(mytable, "column", "VARCHAR", Types.VARCHAR, 255, -1, false, false, false);
+        assertColumn(mytable, "ghi", "VARCHAR", Types.VARCHAR, 255, -1, false, false, false);
+        assertColumn(mytable, "jkl", "VARCHAR", Types.VARCHAR, 255, -1, false, false, false);
+
+        ddl = "ALTER TABLE `mytable` "
+                + "DROP `column`, "
+                + "DROP `ghi`, "
+                + "DROP jkl";
+
+        parser.parse(ddl, tables);
+        mytable = tables.forTable(new TableId(null, null, "mytable"));
+        List<String> mytableColumnNames = mytable.columns()
+            .stream()
+            .map(Column::name)
+            .collect(Collectors.toList());
+
+        assertThat(mytableColumnNames).containsOnly("def");
+    }
+
+    @Test
+    @FixFor("DBZ-408")
+    public void shouldParseAlterTableStatementWithColumnNamedColumnWithColumnWord() {
+        String ddl = "CREATE TABLE `mytable` ( " + System.lineSeparator()
+                    + " `def` int(11) unsigned NOT NULL AUTO_INCREMENT, " + System.lineSeparator()
+                    + " PRIMARY KEY (`def`) " + System.lineSeparator()
+                  + " ) ENGINE=InnoDB DEFAULT CHARSET=utf8;";
+
+        parser.parse(ddl, tables);
+
+        ddl = "ALTER TABLE `mytable` "
+                + "ADD COLUMN `column` varchar(255) NOT NULL DEFAULT '', "
+                + "ADD COLUMN `ghi` varchar(255) NOT NULL DEFAULT '', "
+                + "ADD COLUMN jkl varchar(255) NOT NULL DEFAULT '' ;";
+
+        parser.parse(ddl, tables);
+
+        assertThat(tables.size()).isEqualTo(1);
+
+        Table mytable = tables.forTable(new TableId(null, null, "mytable"));
+        assertThat(mytable).isNotNull();
+        assertColumn(mytable, "column", "VARCHAR", Types.VARCHAR, 255, -1, false, false, false);
+        assertColumn(mytable, "ghi", "VARCHAR", Types.VARCHAR, 255, -1, false, false, false);
+        assertColumn(mytable, "jkl", "VARCHAR", Types.VARCHAR, 255, -1, false, false, false);
+
+        ddl = "ALTER TABLE `mytable` "
+                + "DROP COLUMN `column`, "
+                + "DROP COLUMN `ghi`, "
+                + "DROP COLUMN jkl";
+
+        parser.parse(ddl, tables);
+        mytable = tables.forTable(new TableId(null, null, "mytable"));
+        List<String> mytableColumnNames = mytable.columns()
+            .stream()
+            .map(Column::name)
+            .collect(Collectors.toList());
+
+        assertThat(mytableColumnNames).containsOnly("def");
     }
 
     @Test

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -1104,6 +1104,22 @@ public class MySqlDdlParserTest {
     }
 
     @Test
+    @FixFor("DBZ-408")
+    public void shouldParseCreateTableStatementWithColumnNamedColumn() {
+        String ddl = "CREATE TABLE `mytable` ( " + System.lineSeparator()
+                    + " `def` int(11) unsigned NOT NULL AUTO_INCREMENT, " + System.lineSeparator()
+                    + " `column` varchar(255) NOT NULL DEFAULT '', " + System.lineSeparator()
+                    + " PRIMARY KEY (`def`) " + System.lineSeparator()
+                  + " ) ENGINE=InnoDB DEFAULT CHARSET=utf8;";
+
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(1);
+        Table mytable = tables.forTable(new TableId(null, null, "mytable"));
+        assertThat(mytable).isNotNull();
+        assertColumn(mytable, "column", "VARCHAR", Types.VARCHAR, 255, -1, false, false, false);
+    }
+
+    @Test
     public void parseDdlForDecAndFixed() {
         String ddl = "CREATE TABLE t ( c1 DEC(2) NOT NULL, c2 FIXED(1,0) NOT NULL);";
         parser.parse(ddl, tables);


### PR DESCRIPTION
… support columns named "column" (escaped) in CREATE TABLE statements

https://issues.jboss.org/browse/DBZ-408

Needs backporting to the 0.6 branch, too.