### PR TITLE
[DBZ-342] fix broken MySQL data type "TIME"

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -21,6 +21,7 @@ import io.debezium.config.Field;
 import io.debezium.config.Field.ValidationOutput;
 import io.debezium.jdbc.JdbcValueConverters.BigIntUnsignedMode;
 import io.debezium.jdbc.JdbcValueConverters.DecimalMode;
+import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.history.DatabaseHistory;
 import io.debezium.relational.history.KafkaDatabaseHistory;
 
@@ -30,65 +31,9 @@ import io.debezium.relational.history.KafkaDatabaseHistory;
 public class MySqlConnectorConfig {
 
     /**
-     * The set of predefined TemporalPrecisionMode options or aliases.
-     */
-    public static enum TemporalPrecisionMode implements EnumeratedValue {
-        /**
-         * Represent time and date values based upon the resolution in the database, using {@link io.debezium.time} semantic
-         * types.
-         */
-        ADAPTIVE("adaptive"),
-
-        /**
-         * Represent time and date values using Kafka Connect {@link org.apache.kafka.connect.data} logical types, which always
-         * have millisecond precision.
-         */
-        CONNECT("connect");
-
-        private final String value;
-
-        private TemporalPrecisionMode(String value) {
-            this.value = value;
-        }
-
-        @Override
-        public String getValue() {
-            return value;
-        }
-
-        /**
-         * Determine if the supplied value is one of the predefined options.
-         *
-         * @param value the configuration property value; may not be null
-         * @return the matching option, or null if no match is found
-         */
-        public static TemporalPrecisionMode parse(String value) {
-            if (value == null) return null;
-            value = value.trim();
-            for (TemporalPrecisionMode option : TemporalPrecisionMode.values()) {
-                if (option.getValue().equalsIgnoreCase(value)) return option;
-            }
-            return null;
-        }
-
-        /**
-         * Determine if the supplied value is one of the predefined options.
-         *
-         * @param value the configuration property value; may not be null
-         * @param defaultValue the default value; may be null
-         * @return the matching option, or null if no match is found and the non-null default is invalid
-         */
-        public static TemporalPrecisionMode parse(String value, String defaultValue) {
-            TemporalPrecisionMode mode = parse(value);
-            if (mode == null && defaultValue != null) mode = parse(defaultValue);
-            return mode;
-        }
-    }
-
-    /**
      * The set of predefined DecimalHandlingMode options or aliases.
      */
-    public static enum DecimalHandlingMode implements EnumeratedValue {
+    public enum DecimalHandlingMode implements EnumeratedValue {
         /**
          * Represent {@code DECIMAL} and {@code NUMERIC} values as precise {@link BigDecimal} values, which are
          * represented in change events in a binary form. This is precise but difficult to use.
@@ -753,13 +698,14 @@ public class MySqlConnectorConfig {
 
     public static final Field TIME_PRECISION_MODE = Field.create("time.precision.mode")
                                                          .withDisplayName("Time Precision")
-                                                         .withEnum(TemporalPrecisionMode.class, TemporalPrecisionMode.ADAPTIVE)
+                                                         .withEnum(TemporalPrecisionMode.class, TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS)
                                                          .withWidth(Width.SHORT)
                                                          .withImportance(Importance.MEDIUM)
                                                          .withDescription("Time, date, and timestamps can be represented with different kinds of precisions, including:"
-                                                                 + "'adaptive' (the default) bases the precision of time, date, and timestamp values on the database column's precision; "
+                                                                 + "'adaptive_time_microseconds' (the default) like 'adaptive' mode, but TIME fields always use microseconds precision;"
+                                                                 + "'adaptive' (deprecated) bases the precision of time, date, and timestamp values on the database column's precision; "
                                                                  + "'connect' always represents time, date, and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, "
-                                                                 + "which uses millisecond precision regardless of the database columns' precision .");
+                                                                 + "which uses millisecond precision regardless of the database columns' precision.");
 
     public static final Field DECIMAL_HANDLING_MODE = Field.create("decimal.handling.mode")
                                                            .withDisplayName("Decimal Handling")

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
@@ -19,11 +19,11 @@ import io.debezium.annotation.NotThreadSafe;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnectorConfig.BigIntUnsignedHandlingMode;
 import io.debezium.connector.mysql.MySqlConnectorConfig.DecimalHandlingMode;
-import io.debezium.connector.mysql.MySqlConnectorConfig.TemporalPrecisionMode;
 import io.debezium.connector.mysql.MySqlSystemVariables.Scope;
 import io.debezium.document.Document;
 import io.debezium.jdbc.JdbcValueConverters.BigIntUnsignedMode;
 import io.debezium.jdbc.JdbcValueConverters.DecimalMode;
+import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchema;
@@ -92,14 +92,13 @@ public class MySqlSchema {
         // Use MySQL-specific converters and schemas for values ...
         String timePrecisionModeStr = config.getString(MySqlConnectorConfig.TIME_PRECISION_MODE);
         TemporalPrecisionMode timePrecisionMode = TemporalPrecisionMode.parse(timePrecisionModeStr);
-        boolean adaptiveTimePrecision = TemporalPrecisionMode.ADAPTIVE.equals(timePrecisionMode);
         String decimalHandlingModeStr = config.getString(MySqlConnectorConfig.DECIMAL_HANDLING_MODE);
         DecimalHandlingMode decimalHandlingMode = DecimalHandlingMode.parse(decimalHandlingModeStr);
         DecimalMode decimalMode = decimalHandlingMode.asDecimalMode();
         String bigIntUnsignedHandlingModeStr = config.getString(MySqlConnectorConfig.BIGINT_UNSIGNED_HANDLING_MODE);
         BigIntUnsignedHandlingMode bigIntUnsignedHandlingMode = BigIntUnsignedHandlingMode.parse(bigIntUnsignedHandlingModeStr);
         BigIntUnsignedMode bigIntUnsignedMode = bigIntUnsignedHandlingMode.asBigIntUnsignedMode();
-        MySqlValueConverters valueConverters = new MySqlValueConverters(decimalMode, adaptiveTimePrecision, bigIntUnsignedMode);
+        MySqlValueConverters valueConverters = new MySqlValueConverters(decimalMode, timePrecisionMode, bigIntUnsignedMode);
         this.schemaBuilder = new TableSchemaBuilder(valueConverters, schemaNameValidator::validate);
 
         // Set up the server name and schema prefix ...

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -264,7 +264,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         // ---------------------------------------------------------------------------------------------------------------
         // Consume all of the events due to startup and initialization of the database
         // ---------------------------------------------------------------------------------------------------------------
-        SourceRecords records = consumeRecordsByTopic(5 + 9 + 9 + 4 + 11 + 1); // 11 schema change records + 1 SET statement
+        SourceRecords records = consumeRecordsByTopic(5 + 9 + 9 + 4 + 11 + 1 + 2); // 11 schema change records + 1 SET statement
         assertThat(records.recordsForTopic(DATABASE.getServerName()).size()).isEqualTo(12);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("products")).size()).isEqualTo(9);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("products_on_hand")).size()).isEqualTo(9);
@@ -696,12 +696,12 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
 
         // Consume the first records due to startup and initialization of the database ...
         // Testing.Print.enable();
-        SourceRecords records = consumeRecordsByTopic(9 + 9 + 4 + 5);
+        SourceRecords records = consumeRecordsByTopic(9 + 9 + 4 + 5 + 1);
         assertThat(records.recordsForTopic(RO_DATABASE.topicForTable("products")).size()).isEqualTo(9);
         assertThat(records.recordsForTopic(RO_DATABASE.topicForTable("products_on_hand")).size()).isEqualTo(9);
         assertThat(records.recordsForTopic(RO_DATABASE.topicForTable("customers")).size()).isEqualTo(4);
         assertThat(records.recordsForTopic(RO_DATABASE.topicForTable("orders")).size()).isEqualTo(5);
-        assertThat(records.topics().size()).isEqualTo(4);
+        assertThat(records.topics().size()).isEqualTo(5);
 
         // Check that all records are valid, can be serialized and deserialized ...
         records.forEach(this::validate);

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
@@ -6,6 +6,8 @@
 package io.debezium.connector.mysql;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
@@ -20,6 +22,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAdjuster;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.connect.data.Struct;
@@ -31,10 +34,10 @@ import org.junit.Test;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnectorConfig.DecimalHandlingMode;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
-import io.debezium.connector.mysql.MySqlConnectorConfig.TemporalPrecisionMode;
 import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.time.ZonedTimestamp;
 import io.debezium.util.Testing;
 
@@ -84,12 +87,15 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
         // ---------------------------------------------------------------------------------------------------------------
         // Testing.Debug.enable();
         int numCreateDatabase = 1;
-        int numCreateTables = 9;
-        int numDataRecords = 16;
-        SourceRecords records = consumeRecordsByTopic(numCreateDatabase + numCreateTables + numDataRecords);
+        int numCreateTables = 11;
+        int numDataRecords = 20;
+        int numCreateDefiner = 1;
+        SourceRecords records =
+            consumeRecordsByTopic(numCreateDatabase + numCreateTables + numDataRecords + numCreateDefiner);
         stopConnector();
         assertThat(records).isNotNull();
-        assertThat(records.recordsForTopic(DATABASE.getServerName()).size()).isEqualTo(numCreateDatabase + numCreateTables);
+        assertThat(records.recordsForTopic(DATABASE.getServerName()).size())
+            .isEqualTo(numCreateDatabase + numCreateTables + numCreateDefiner);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("t1464075356413_testtable6")).size()).isEqualTo(1);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz84_integer_types_table")).size()).isEqualTo(1);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_85_fractest")).size()).isEqualTo(1);
@@ -99,9 +105,11 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_123_bitvaluetest")).size()).isEqualTo(2);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_104_customers")).size()).isEqualTo(4);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_147_decimalvalues")).size()).isEqualTo(1);
-        assertThat(records.topics().size()).isEqualTo(1 + numCreateTables);
+        assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_342_timetest")).size()).isEqualTo(1);
+        assertThat(records.topics().size()).isEqualTo(numCreateTables + 1);
         assertThat(records.databaseNames().size()).isEqualTo(1);
-        assertThat(records.ddlRecordsForDatabase(DATABASE.getDatabaseName()).size()).isEqualTo(numCreateDatabase + numCreateTables);
+        assertThat(records.ddlRecordsForDatabase(DATABASE.getDatabaseName()).size())
+            .isEqualTo(numCreateDatabase + numCreateTables + numCreateDefiner);
         assertThat(records.ddlRecordsForDatabase("connector_test")).isNull();
         assertThat(records.ddlRecordsForDatabase("readbinlog_test")).isNull();
         records.ddlRecordsForDatabase(DATABASE.getDatabaseName()).forEach(this::print);
@@ -135,7 +143,7 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 // c3 DATETIME(2),
                 // c4 TIMESTAMP(2)
                 //
-                // {"c1" : "16321", "c2" : "64264780", "c3" : "1410198664780", "c4" : "2014-09-08T17:51:04.78-05:00"}
+                // {"c1" : "16321", "c2" : "17:51:04.777", "c3" : "1410198664780", "c4" : "2014-09-08T17:51:04.78-05:00"}
 
                 // '2014-09-08'
                 Integer c1 = after.getInt32("c1"); // epoch days
@@ -146,13 +154,14 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 assertThat(io.debezium.time.Date.toEpochDay(c1Date, ADJUSTER)).isEqualTo(c1);
 
                 // '17:51:04.777'
-                Integer c2 = after.getInt32("c2"); // milliseconds past midnight
-                LocalTime c2Time = LocalTime.ofNanoOfDay(TimeUnit.MILLISECONDS.toNanos(c2));
-                assertThat(c2Time.getHour()).isEqualTo(17);
-                assertThat(c2Time.getMinute()).isEqualTo(51);
-                assertThat(c2Time.getSecond()).isEqualTo(4);
-                assertThat(c2Time.getNano()).isEqualTo((int) TimeUnit.MILLISECONDS.toNanos(780));
-                assertThat(io.debezium.time.Time.toMilliOfDay(c2Time, ADJUSTER)).isEqualTo(c2);
+                Long c2 = after.getInt64("c2");
+                Duration c2Time = Duration.ofNanos(c2 * 1_000);
+                assertThat(c2Time.toHours()).isEqualTo(17);
+                assertThat(c2Time.toMinutes()).isEqualTo(1071);
+                assertThat(c2Time.getSeconds()).isEqualTo(64264);
+                assertThat(c2Time.getNano()).isEqualTo(780000000);
+                assertThat(c2Time.toNanos()).isEqualTo(64264780000000L);
+                assertThat(c2Time).isEqualTo(Duration.ofHours(17).plusMinutes(51).plusSeconds(4).plusMillis(780));
 
                 // '2014-09-08 17:51:04.777'
                 Long c3 = after.getInt64("c3"); // epoch millis
@@ -199,13 +208,14 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 assertThat(after.getInt32("c1")).isNull(); // epoch days
 
                 // '00:00:00.000'
-                Integer c2 = after.getInt32("c2"); // milliseconds past midnight
-                LocalTime c2Time = LocalTime.ofNanoOfDay(TimeUnit.MILLISECONDS.toNanos(c2));
-                assertThat(c2Time.getHour()).isEqualTo(0);
-                assertThat(c2Time.getMinute() == 0 || c2Time.getMinute() == 1).isTrue();
-                assertThat(c2Time.getSecond()).isEqualTo(0);
+                Long c2 = after.getInt64("c2");
+                Duration c2Time = Duration.ofNanos(c2 * 1_000);
+                assertThat(c2Time.toHours()).isEqualTo(0);
+                assertThat(c2Time.toMinutes() == 1 || c2Time.toMinutes() == 0).isTrue();
+                assertThat(c2Time.getSeconds() == 0 || c2Time.getSeconds() == 60).isTrue();
                 assertThat(c2Time.getNano()).isEqualTo(0);
-                assertThat(io.debezium.time.Time.toMilliOfDay(c2Time, ADJUSTER)).isEqualTo(c2);
+                assertThat(c2Time.toNanos() == 0 || c2Time.toNanos() == 60000000000L).isTrue();
+                assertThat(c2Time.equals(Duration.ofSeconds(0)) || c2Time.equals(Duration.ofMinutes(1))).isTrue();
 
                 assertThat(after.getInt64("c3")).isNull(); // epoch millis
 
@@ -262,6 +272,57 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 assertThat(decimalValue).isInstanceOf(BigDecimal.class);
                 BigDecimal bigValue = (BigDecimal) decimalValue;
                 assertThat(bigValue.doubleValue()).isEqualTo(12345.67, Delta.delta(0.01));
+            } else if (record.topic().endsWith("dbz_342_timetest")) {
+                Struct after = value.getStruct(Envelope.FieldName.AFTER);
+
+                // '517:51:04.777'
+                long c1 = after.getInt64("c1");
+                Duration c1Time = Duration.ofNanos(c1 * 1_000);
+                Duration c1ExpectedTime = toDuration("PT517H51M4.78S");
+                assertEquals(c1ExpectedTime, c1Time);
+                assertEquals(c1ExpectedTime.toNanos(), c1Time.toNanos());
+                assertThat(c1Time.toNanos()).isEqualTo(1864264780000000L);
+                assertThat(c1Time).isEqualTo(Duration.ofHours(517).plusMinutes(51).plusSeconds(4).plusMillis(780));
+
+                // '-13:14:50'
+                long c2 = after.getInt64("c2");
+                Duration c2Time = Duration.ofNanos(c2 * 1_000);
+                Duration c2ExpectedTime = toDuration("-PT13H14M50S");
+                assertEquals(c2ExpectedTime, c2Time);
+                assertEquals(c2ExpectedTime.toNanos(), c2Time.toNanos());
+                assertThat(c2Time.toNanos()).isEqualTo(-47690000000000L);
+                assertTrue(c2Time.isNegative());
+                assertThat(c2Time).isEqualTo(Duration.ofHours(-13).minusMinutes(14).minusSeconds(50));
+
+                // '-733:00:00.0011'
+                long c3 = after.getInt64("c3");
+                Duration c3Time = Duration.ofNanos(c3 * 1_000);
+                Duration c3ExpectedTime = toDuration("-PT733H0M0.001S");
+                assertEquals(c3ExpectedTime, c3Time);
+                assertEquals(c3ExpectedTime.toNanos(), c3Time.toNanos());
+                assertThat(c3Time.toNanos()).isEqualTo(-2638800001000000L);
+                assertTrue(c3Time.isNegative());
+                assertThat(c3Time).isEqualTo(Duration.ofHours(-733).minusMillis(1));
+
+                // '-1:59:59.0011'
+                long c4 = after.getInt64("c4");
+                Duration c4Time = Duration.ofNanos(c4 * 1_000);
+                Duration c4ExpectedTime = toDuration("-PT1H59M59.001S");
+                assertEquals(c4ExpectedTime, c4Time);
+                assertEquals(c4ExpectedTime.toNanos(), c4Time.toNanos());
+                assertThat(c4Time.toNanos()).isEqualTo(-7199001000000L);
+                assertTrue(c4Time.isNegative());
+                assertThat(c4Time).isEqualTo(Duration.ofHours(-1).minusMinutes(59).minusSeconds(59).minusMillis(1));
+
+                // '-838:59:58.999999'
+                long c5 = after.getInt64("c5");
+                Duration c5Time = Duration.ofNanos(c5 * 1_000);
+                Duration c5ExpectedTime = toDuration("-PT838H59M58.999999S");
+                assertEquals(c5ExpectedTime, c5Time);
+                assertEquals(c5ExpectedTime.toNanos(), c5Time.toNanos());
+                assertThat(c5Time.toNanos()).isEqualTo(-3020398999999000L);
+                assertTrue(c5Time.isNegative());
+                assertThat(c5Time).isEqualTo(Duration.ofHours(-838).minusMinutes(59).minusSeconds(58).minusNanos(999999000));
             }
         });
     }
@@ -284,12 +345,15 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
         // ---------------------------------------------------------------------------------------------------------------
         // Testing.Debug.enable();
         int numCreateDatabase = 1;
-        int numCreateTables = 9;
-        int numDataRecords = 16;
-        SourceRecords records = consumeRecordsByTopic(numCreateDatabase + numCreateTables + numDataRecords);
+        int numCreateTables = 11;
+        int numDataRecords = 20;
+        int numCreateDefiner = 1;
+        SourceRecords records =
+                consumeRecordsByTopic(numCreateDatabase + numCreateTables + numDataRecords + numCreateDefiner);
         stopConnector();
         assertThat(records).isNotNull();
-        assertThat(records.recordsForTopic(DATABASE.getServerName()).size()).isEqualTo(numCreateDatabase + numCreateTables);
+        assertThat(records.recordsForTopic(DATABASE.getServerName()).size())
+            .isEqualTo(numCreateDatabase + numCreateTables + numCreateDefiner);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("t1464075356413_testtable6")).size()).isEqualTo(1);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz84_integer_types_table")).size()).isEqualTo(1);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_85_fractest")).size()).isEqualTo(1);
@@ -301,7 +365,8 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_147_decimalvalues")).size()).isEqualTo(1);
         assertThat(records.topics().size()).isEqualTo(1 + numCreateTables);
         assertThat(records.databaseNames().size()).isEqualTo(1);
-        assertThat(records.ddlRecordsForDatabase(DATABASE.getDatabaseName()).size()).isEqualTo(numCreateDatabase + numCreateTables);
+        assertThat(records.ddlRecordsForDatabase(DATABASE.getDatabaseName()).size())
+            .isEqualTo(numCreateDatabase + numCreateTables + numCreateDefiner);
         assertThat(records.ddlRecordsForDatabase("connector_test")).isNull();
         assertThat(records.ddlRecordsForDatabase("readbinlog_test")).isNull();
         records.ddlRecordsForDatabase(DATABASE.getDatabaseName()).forEach(this::print);
@@ -478,14 +543,18 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
         // Consume all of the events due to startup and initialization of the database
         // ---------------------------------------------------------------------------------------------------------------
         // Testing.Debug.enable();
-        int numTables = 10;
-        int numDataRecords = 19;
+        int numCreateDatabase = 1;
+        int numTables = 11;
+        int numDataRecords = 20;
         int numDdlRecords = numTables * 2 + 3; // for each table (1 drop + 1 create) + for each db (1 create + 1 drop + 1 use)
+        int numCreateDefiner = 1;
         int numSetVariables = 1;
-        SourceRecords records = consumeRecordsByTopic(numDdlRecords + numSetVariables + numDataRecords);
+        SourceRecords records =
+            consumeRecordsByTopic(numDdlRecords + numSetVariables + numDataRecords + numCreateDefiner + numCreateDatabase);
         stopConnector();
         assertThat(records).isNotNull();
-        assertThat(records.recordsForTopic(DATABASE.getServerName()).size()).isEqualTo(numDdlRecords + numSetVariables);
+        assertThat(records.recordsForTopic(DATABASE.getServerName()).size())
+            .isEqualTo(numDdlRecords + numSetVariables);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("t1464075356413_testtable6")).size()).isEqualTo(1);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz84_integer_types_table")).size()).isEqualTo(1);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_85_fractest")).size()).isEqualTo(1);
@@ -496,6 +565,7 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_104_customers")).size()).isEqualTo(4);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_147_decimalvalues")).size()).isEqualTo(1);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_195_numvalues")).size()).isEqualTo(3);
+        assertThat(records.recordsForTopic(DATABASE.topicForTable("dbz_342_timetest")).size()).isEqualTo(1);
         assertThat(records.topics().size()).isEqualTo(numTables + 1);
         assertThat(records.databaseNames().size()).isEqualTo(2);
         assertThat(records.databaseNames()).containsOnly(DATABASE.getDatabaseName(), "");
@@ -534,7 +604,7 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 // c3 DATETIME(2),
                 // c4 TIMESTAMP(2)
                 //
-                // {"c1" : "16321", "c2" : "64264780", "c3" : "1410198664780", "c4" : "2014-09-08T17:51:04.78-05:00"}
+                // {"c1" : "16321", "c2" : "17:51:04.777", "c3" : "1410198664780", "c4" : "2014-09-08T17:51:04.78-05:00"}
 
                 // '2014-09-08'
                 Integer c1 = after.getInt32("c1"); // epoch days
@@ -545,14 +615,14 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 assertThat(io.debezium.time.Date.toEpochDay(c1Date, ADJUSTER)).isEqualTo(c1);
 
                 // '17:51:04.777'
-                Integer c2 = after.getInt32("c2"); // milliseconds past midnight
-                LocalTime c2Time = LocalTime.ofNanoOfDay(TimeUnit.MILLISECONDS.toNanos(c2));
-                assertThat(c2Time.getHour()).isEqualTo(17);
-                assertThat(c2Time.getMinute()).isEqualTo(51);
-                assertThat(c2Time.getSecond()).isEqualTo(4);
-                assertThat(c2Time.getNano()).isEqualTo(0); // What!?!? The MySQL Connect/J driver indeed returns 0 for fractional
-                                                           // part
-                assertThat(io.debezium.time.Time.toMilliOfDay(c2Time, ADJUSTER)).isEqualTo(c2);
+                Long c2 = after.getInt64("c2");
+                Duration c2Time = Duration.ofNanos(c2 * 1_000);
+                assertThat(c2Time.toHours()).isEqualTo(17);
+                assertThat(c2Time.toMinutes()).isEqualTo(1071);
+                assertThat(c2Time.getSeconds()).isEqualTo(64264);
+                assertThat(c2Time.getNano()).isEqualTo(780000000);
+                assertThat(c2Time.toNanos()).isEqualTo(64264780000000L);
+                assertThat(c2Time).isEqualTo(Duration.ofHours(17).plusMinutes(51).plusSeconds(4).plusMillis(780));
 
                 // '2014-09-08 17:51:04.777'
                 Long c3 = after.getInt64("c3"); // epoch millis
@@ -633,6 +703,57 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 } else {
                     assertThat(intValue.intValue()).isEqualTo(0);
                 }
+            }  else if (record.topic().endsWith("dbz_342_timetest")) {
+                Struct after = value.getStruct(Envelope.FieldName.AFTER);
+
+                // '517:51:04.777'
+                long c1 = after.getInt64("c1");
+                Duration c1Time = Duration.ofNanos(c1 * 1_000);
+                Duration c1ExpectedTime = toDuration("PT517H51M4.78S");
+                assertEquals(c1ExpectedTime, c1Time);
+                assertEquals(c1ExpectedTime.toNanos(), c1Time.toNanos());
+                assertThat(c1Time.toNanos()).isEqualTo(1864264780000000L);
+                assertThat(c1Time).isEqualTo(Duration.ofHours(517).plusMinutes(51).plusSeconds(4).plusMillis(780));
+
+                // '-13:14:50'
+                long c2 = after.getInt64("c2");
+                Duration c2Time = Duration.ofNanos(c2 * 1_000);
+                Duration c2ExpectedTime = toDuration("-PT13H14M50S");
+                assertEquals(c2ExpectedTime, c2Time);
+                assertEquals(c2ExpectedTime.toNanos(), c2Time.toNanos());
+                assertThat(c2Time.toNanos()).isEqualTo(-47690000000000L);
+                assertTrue(c2Time.isNegative());
+                assertThat(c2Time).isEqualTo(Duration.ofHours(-13).minusMinutes(14).minusSeconds(50));
+
+                // '-733:00:00.0011'
+                long c3 = after.getInt64("c3");
+                Duration c3Time = Duration.ofNanos(c3 * 1_000);
+                Duration c3ExpectedTime = toDuration("-PT733H0M0.001S");
+                assertEquals(c3ExpectedTime, c3Time);
+                assertEquals(c3ExpectedTime.toNanos(), c3Time.toNanos());
+                assertThat(c3Time.toNanos()).isEqualTo(-2638800001000000L);
+                assertTrue(c3Time.isNegative());
+                assertThat(c3Time).isEqualTo(Duration.ofHours(-733).minusMillis(1));
+
+                // '-1:59:59.0011'
+                long c4 = after.getInt64("c4");
+                Duration c4Time = Duration.ofNanos(c4 * 1_000);
+                Duration c4ExpectedTime = toDuration("-PT1H59M59.001S");
+                assertEquals(c4ExpectedTime, c4Time);
+                assertEquals(c4ExpectedTime.toNanos(), c4Time.toNanos());
+                assertThat(c4Time.toNanos()).isEqualTo(-7199001000000L);
+                assertTrue(c4Time.isNegative());
+                assertThat(c4Time).isEqualTo(Duration.ofHours(-1).minusMinutes(59).minusSeconds(59).minusMillis(1));
+
+                // '-838:59:58.999999'
+                long c5 = after.getInt64("c5");
+                Duration c5Time = Duration.ofNanos(c5 * 1_000);
+                Duration c5ExpectedTime = toDuration("-PT838H59M58.999999S");
+                assertEquals(c5ExpectedTime, c5Time);
+                assertEquals(c5ExpectedTime.toNanos(), c5Time.toNanos());
+                assertThat(c5Time.toNanos()).isEqualTo(-3020398999999000L);
+                assertTrue(c5Time.isNegative());
+                assertThat(c5Time).isEqualTo(Duration.ofHours(-838).minusMinutes(59).minusSeconds(58).minusNanos(999999000));
             }
         });
     }
@@ -698,5 +819,9 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
         LocalDateTime expectedLocalDateTime = LocalDateTime.parse("2014-09-08T17:51:04.780");
         ZoneOffset expectedOffset = defaultZoneId.getRules().getOffset(expectedLocalDateTime);
         assertThat(c4DateTime.getOffset()).isEqualTo(expectedOffset);
+    }
+
+    private Duration toDuration(String duration) {
+        return Duration.parse(duration);
     }
 }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotReaderIT.java
@@ -9,10 +9,13 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.After;
 import org.junit.Before;
@@ -106,7 +109,7 @@ public class SnapshotReaderIT {
         assertThat(schemaChanges.recordCount()).isEqualTo(0);
 
         // Check the records via the store ...
-        assertThat(store.collectionCount()).isEqualTo(4);
+        assertThat(store.collectionCount()).isEqualTo(5);
         Collection products = store.collection(DATABASE.getDatabaseName(), "products");
         assertThat(products.numberOfCreates()).isEqualTo(9);
         assertThat(products.numberOfUpdates()).isEqualTo(0);
@@ -142,6 +145,25 @@ public class SnapshotReaderIT {
         assertThat(orders.numberOfTombstones()).isEqualTo(0);
         assertThat(orders.numberOfKeySchemaChanges()).isEqualTo(1);
         assertThat(orders.numberOfValueSchemaChanges()).isEqualTo(1);
+
+        Collection timetest = store.collection(DATABASE.getDatabaseName(), "dbz_342_timetest");
+        assertThat(timetest.numberOfCreates()).isEqualTo(1);
+        assertThat(timetest.numberOfUpdates()).isEqualTo(0);
+        assertThat(timetest.numberOfDeletes()).isEqualTo(0);
+        assertThat(timetest.numberOfReads()).isEqualTo(0);
+        assertThat(timetest.numberOfTombstones()).isEqualTo(0);
+        assertThat(timetest.numberOfKeySchemaChanges()).isEqualTo(1);
+        assertThat(timetest.numberOfValueSchemaChanges()).isEqualTo(1);
+        final List<Struct> timerecords = new ArrayList<>();
+        timetest.forEach(val -> {
+            timerecords.add(((Struct) val.value()).getStruct("after"));
+        });
+        Struct after = timerecords.get(0);
+        assertThat(after.get("c1")).isEqualTo(toMicroSeconds("PT517H51M04.78S"));
+        assertThat(after.get("c2")).isEqualTo(toMicroSeconds("-PT13H14M50S"));
+        assertThat(after.get("c3")).isEqualTo(toMicroSeconds("-PT733H0M0.001S"));
+        assertThat(after.get("c4")).isEqualTo(toMicroSeconds("-PT1H59M59.001S"));
+        assertThat(after.get("c5")).isEqualTo(toMicroSeconds("-PT838H59M58.999999S"));
 
         // Make sure the snapshot completed ...
         if (completed.await(10, TimeUnit.SECONDS)) {
@@ -185,7 +207,7 @@ public class SnapshotReaderIT {
 
         // Check the records via the store ...
         assertThat(store.databases()).containsOnly(DATABASE.getDatabaseName(), OTHER_DATABASE.getDatabaseName()); // 2 databases
-        assertThat(store.collectionCount()).isEqualTo(8); // 2 databases
+        assertThat(store.collectionCount()).isEqualTo(9); // 2 databases
 
         Collection products = store.collection(DATABASE.getDatabaseName(), "products");
         assertThat(products.numberOfCreates()).isEqualTo(0);
@@ -222,6 +244,25 @@ public class SnapshotReaderIT {
         assertThat(orders.numberOfTombstones()).isEqualTo(0);
         assertThat(orders.numberOfKeySchemaChanges()).isEqualTo(1);
         assertThat(orders.numberOfValueSchemaChanges()).isEqualTo(1);
+
+        Collection timetest = store.collection(DATABASE.getDatabaseName(), "dbz_342_timetest");
+        assertThat(timetest.numberOfCreates()).isEqualTo(0);
+        assertThat(timetest.numberOfUpdates()).isEqualTo(0);
+        assertThat(timetest.numberOfDeletes()).isEqualTo(0);
+        assertThat(timetest.numberOfReads()).isEqualTo(1);
+        assertThat(timetest.numberOfTombstones()).isEqualTo(0);
+        assertThat(timetest.numberOfKeySchemaChanges()).isEqualTo(1);
+        assertThat(timetest.numberOfValueSchemaChanges()).isEqualTo(1);
+        final List<Struct> timerecords = new ArrayList<>();
+        timetest.forEach(val -> {
+            timerecords.add(((Struct) val.value()).getStruct("after"));
+        });
+        Struct after = timerecords.get(0);
+        assertThat(after.get("c1")).isEqualTo(toMicroSeconds("PT517H51M04.78S"));
+        assertThat(after.get("c2")).isEqualTo(toMicroSeconds("-PT13H14M50S"));
+        assertThat(after.get("c3")).isEqualTo(toMicroSeconds("-PT733H0M0.001S"));
+        assertThat(after.get("c4")).isEqualTo(toMicroSeconds("-PT1H59M59.001S"));
+        assertThat(after.get("c5")).isEqualTo(toMicroSeconds("-PT838H59M58.999999S"));
 
         // Make sure the snapshot completed ...
         if (completed.await(10, TimeUnit.SECONDS)) {
@@ -261,12 +302,12 @@ public class SnapshotReaderIT {
         assertThat(records).isNull();
 
         // There should be 11 schema changes plus 1 SET statement ...
-        assertThat(schemaChanges.recordCount()).isEqualTo(12);
+        assertThat(schemaChanges.recordCount()).isEqualTo(14);
         assertThat(schemaChanges.databaseCount()).isEqualTo(2);
         assertThat(schemaChanges.databases()).containsOnly(DATABASE.getDatabaseName(), "");
 
         // Check the records via the store ...
-        assertThat(store.collectionCount()).isEqualTo(4);
+        assertThat(store.collectionCount()).isEqualTo(5);
         Collection products = store.collection(DATABASE.getDatabaseName(), "products");
         assertThat(products.numberOfCreates()).isEqualTo(9);
         assertThat(products.numberOfUpdates()).isEqualTo(0);
@@ -302,6 +343,25 @@ public class SnapshotReaderIT {
         assertThat(orders.numberOfTombstones()).isEqualTo(0);
         assertThat(orders.numberOfKeySchemaChanges()).isEqualTo(1);
         assertThat(orders.numberOfValueSchemaChanges()).isEqualTo(1);
+
+        Collection timetest = store.collection(DATABASE.getDatabaseName(), "dbz_342_timetest");
+        assertThat(timetest.numberOfCreates()).isEqualTo(1);
+        assertThat(timetest.numberOfUpdates()).isEqualTo(0);
+        assertThat(timetest.numberOfDeletes()).isEqualTo(0);
+        assertThat(timetest.numberOfReads()).isEqualTo(0);
+        assertThat(timetest.numberOfTombstones()).isEqualTo(0);
+        assertThat(timetest.numberOfKeySchemaChanges()).isEqualTo(1);
+        assertThat(timetest.numberOfValueSchemaChanges()).isEqualTo(1);
+        final List<Struct> timerecords = new ArrayList<>();
+        timetest.forEach(val -> {
+            timerecords.add(((Struct) val.value()).getStruct("after"));
+        });
+        Struct after = timerecords.get(0);
+        assertThat(after.get("c1")).isEqualTo(toMicroSeconds("PT517H51M04.78S"));
+        assertThat(after.get("c2")).isEqualTo(toMicroSeconds("-PT13H14M50S"));
+        assertThat(after.get("c3")).isEqualTo(toMicroSeconds("-PT733H0M0.001S"));
+        assertThat(after.get("c4")).isEqualTo(toMicroSeconds("-PT1H59M59.001S"));
+        assertThat(after.get("c5")).isEqualTo(toMicroSeconds("-PT838H59M58.999999S"));
 
         // Make sure the snapshot completed ...
         if (completed.await(10, TimeUnit.SECONDS)) {
@@ -353,5 +413,9 @@ public class SnapshotReaderIT {
         } else {
             fail("failed to complete the snapshot within 10 seconds");
         }
+    }
+
+    private long toMicroSeconds(String duration) {
+        return Duration.parse(duration).toNanos() / 1_000;
     }
 }

--- a/debezium-connector-mysql/src/test/resources/ddl/connector_test_ro.sql
+++ b/debezium-connector-mysql/src/test/resources/ddl/connector_test_ro.sql
@@ -79,3 +79,13 @@ INSERT INTO ids VALUES(1);
 INSERT INTO ids2 VALUES(1);
 DROP TEMPORARY TABLE ids;
 DROP TEMPORARY TABLE ids2;
+
+-- DBZ-342 handle TIME values that exceed the value range of java.sql.Time
+CREATE TABLE dbz_342_timetest (
+  c1 TIME(2) PRIMARY KEY,
+  c2 TIME(0),
+  c3 TIME(3),
+  c4 TIME(3),
+  c5 TIME(6)
+);
+INSERT INTO dbz_342_timetest VALUES ('517:51:04.777', '-13:14:50', '-733:00:00.0011', '-1:59:59.0011', '-838:59:58.999999');

--- a/debezium-connector-mysql/src/test/resources/ddl/regression_test.sql
+++ b/debezium-connector-mysql/src/test/resources/ddl/regression_test.sql
@@ -145,3 +145,13 @@ CREATE TABLE dbz_195_numvalues (
 INSERT INTO dbz_195_numvalues VALUES (default,0);
 INSERT INTO dbz_195_numvalues VALUES (default,-2147483648);
 INSERT INTO dbz_195_numvalues VALUES (default,2147483647);
+
+-- DBZ-342 handle TIME values that exceed the value range of java.sql.Time
+CREATE TABLE dbz_342_timetest (
+  c1 TIME(2),
+  c2 TIME(0),
+  c3 TIME(3),
+  c4 TIME(3),
+  c5 TIME(6)
+);
+INSERT INTO dbz_342_timetest VALUES ('517:51:04.777', '-13:14:50', '-733:00:00.0011', '-1:59:59.0011', '-838:59:58.999999');

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
@@ -61,7 +61,7 @@ public class PostgresSchema {
         this.filters = new Filters(config);
         this.tables = new Tables();
 
-        PostgresValueConverter valueConverter = new PostgresValueConverter(config.decimalHandlingMode(), config.adaptiveTimePrecision(),
+        PostgresValueConverter valueConverter = new PostgresValueConverter(config.decimalHandlingMode(), config.temporalPrecisionMode(),
                 ZoneOffset.UTC, null);
         this.schemaNameValidator = AvroValidator.create(LOGGER)::validate;
         this.schemaBuilder = new TableSchemaBuilder(valueConverter, this.schemaNameValidator);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -35,6 +35,7 @@ import io.debezium.data.Uuid;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.data.geometry.Point;
 import io.debezium.jdbc.JdbcValueConverters;
+import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.Column;
 import io.debezium.relational.ValueConverter;
 import io.debezium.time.MicroDuration;
@@ -64,8 +65,8 @@ public class PostgresValueConverter extends JdbcValueConverters {
      */
     private static final int VARIABLE_SCALE_DECIMAL_LENGTH = 131089;
 
-    protected PostgresValueConverter(DecimalMode decimalMode, boolean adaptiveTimePrecision, ZoneOffset defaultOffset, BigIntUnsignedMode bigIntUnsignedMode) {
-        super(decimalMode, adaptiveTimePrecision, defaultOffset, null, bigIntUnsignedMode);
+    protected PostgresValueConverter(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode, ZoneOffset defaultOffset, BigIntUnsignedMode bigIntUnsignedMode) {
+        super(decimalMode, temporalPrecisionMode, defaultOffset, null, bigIntUnsignedMode);
     }
 
     @Override
@@ -117,7 +118,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
             case PgOid.BOOL_ARRAY:
                 return SchemaBuilder.array(SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA);
             case PgOid.DATE_ARRAY:
-                if (adaptiveTimePrecision) {
+                if (adaptiveTimePrecisionMode || adaptiveTimeMicrosecondsPrecisionMode) {
                     return SchemaBuilder.array(io.debezium.time.Date.builder().optional().build());
                 }
                 return SchemaBuilder.array(org.apache.kafka.connect.data.Date.builder().optional().build());

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -52,6 +52,7 @@ import io.debezium.data.geometry.Point;
 import io.debezium.relational.TableId;
 import io.debezium.time.Date;
 import io.debezium.time.MicroDuration;
+import io.debezium.time.MicroTime;
 import io.debezium.time.NanoTime;
 import io.debezium.time.NanoTimestamp;
 import io.debezium.time.ZonedTime;
@@ -202,6 +203,22 @@ public abstract class AbstractRecordsProducerTest {
                              new SchemaAndValueField("it", MicroDuration.builder().optional().build(), interval));
     }
 
+    protected List<SchemaAndValueField> schemaAndValuesForDateTimeTypesAdaptiveTimeMicroseconds() {
+        long expectedTs = NanoTimestamp.toEpochNanos(LocalDateTime.parse("2016-11-04T13:51:30"), null);
+        String expectedTz = "2016-11-04T11:51:30Z"; //timestamp is stored with TZ, should be read back with UTC
+        int expectedDate = Date.toEpochDay(LocalDate.parse("2016-11-04"), null);
+        long expectedTi = LocalTime.parse("13:51:30").toNanoOfDay() / 1_000;
+        String expectedTtz = "11:51:30Z";  //time is stored with TZ, should be read back at GMT
+        double interval = MicroDuration.durationMicros(1, 2, 3, 4, 5, 0, PostgresValueConverter.DAYS_PER_MONTH_AVG);
+
+        return Arrays.asList(new SchemaAndValueField("ts", NanoTimestamp.builder().optional().build(), expectedTs),
+                new SchemaAndValueField("tz", ZonedTimestamp.builder().optional().build(), expectedTz),
+                new SchemaAndValueField("date", Date.builder().optional().build(), expectedDate),
+                new SchemaAndValueField("ti", MicroTime.builder().optional().build(), expectedTi),
+                new SchemaAndValueField("ttz", ZonedTime.builder().optional().build(), expectedTtz),
+                new SchemaAndValueField("it", MicroDuration.builder().optional().build(), interval));
+    }
+
     protected List<SchemaAndValueField> schemaAndValuesForMoneyTypes() {
         return Collections.singletonList(new SchemaAndValueField("csh", Decimal.builder(0).optional().build(),
                                                                  BigDecimal.valueOf(1234.11d)));
@@ -232,6 +249,18 @@ public abstract class AbstractRecordsProducerTest {
     protected Map<String, List<SchemaAndValueField>> schemaAndValuesByTableName() {
         return ALL_STMTS.stream().collect(Collectors.toMap(AbstractRecordsProducerTest::tableNameFromInsertStmt,
                                                            this::schemasAndValuesForTable));
+    }
+
+    protected Map<String, List<SchemaAndValueField>> schemaAndValuesByTableNameAdaptiveTimeMicroseconds() {
+        return ALL_STMTS.stream().collect(Collectors.toMap(AbstractRecordsProducerTest::tableNameFromInsertStmt,
+                this::schemasAndValuesForTableAdaptiveTimeMicroseconds));
+    }
+
+    protected List<SchemaAndValueField> schemasAndValuesForTableAdaptiveTimeMicroseconds(String insertTableStatement) {
+        if (insertTableStatement.equals(INSERT_DATE_TIME_TYPES_STMT)) {
+            return schemaAndValuesForDateTimeTypesAdaptiveTimeMicroseconds();
+        }
+        return schemasAndValuesForTable(insertTableStatement);
     }
 
     protected List<SchemaAndValueField> schemasAndValuesForTable(String insertTableStatement) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -46,6 +46,7 @@ import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
 import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.embedded.EmbeddedEngine;
+import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.util.Strings;
 
 /**
@@ -145,7 +146,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         validateField(validatedConfig, PostgresConnectorConfig.COLUMN_BLACKLIST, null);
         validateField(validatedConfig, PostgresConnectorConfig.SNAPSHOT_MODE, INITIAL);
         validateField(validatedConfig, PostgresConnectorConfig.SNAPSHOT_LOCK_TIMEOUT_MS, PostgresConnectorConfig.DEFAULT_SNAPSHOT_LOCK_TIMEOUT_MILLIS);
-        validateField(validatedConfig, PostgresConnectorConfig.TIME_PRECISION_MODE, PostgresConnectorConfig.TemporalPrecisionMode.ADAPTIVE);
+        validateField(validatedConfig, PostgresConnectorConfig.TIME_PRECISION_MODE, TemporalPrecisionMode.ADAPTIVE);
         validateField(validatedConfig, PostgresConnectorConfig.DECIMAL_HANDLING_MODE, PostgresConnectorConfig.DecimalHandlingMode.PRECISE);
         validateField(validatedConfig, PostgresConnectorConfig.SSL_SOCKET_FACTORY, null);
         validateField(validatedConfig, PostgresConnectorConfig.TCP_KEEPALIVE, null);

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -341,7 +341,7 @@ public class JdbcConnection implements AutoCloseable {
      * @see #execute(Operations)
      */
     public JdbcConnection query(String query, ResultSetConsumer resultConsumer) throws SQLException {
-        return query(query,conn->conn.createStatement(),resultConsumer);
+        return query(query, Connection::createStatement, resultConsumer);
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/jdbc/TemporalPrecisionMode.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/TemporalPrecisionMode.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.jdbc;
+
+import io.debezium.config.EnumeratedValue;
+
+/**
+ * The set of predefined TemporalPrecisionMode options.
+ */
+public enum TemporalPrecisionMode implements EnumeratedValue {
+    /**
+     * Represent time and date values based upon the resolution in the database, using {@link io.debezium.time} semantic
+     * types.
+     */
+    ADAPTIVE("adaptive"),
+
+    /**
+     * Represent timestamp, datetime and date values based upon the resolution in the database, using
+     * {@link io.debezium.time} semantic types. TIME fields will always be represented as microseconds
+     * in INT64 / {@link java.lang.Long} using {@link io.debezium.time.MicroTime}
+     */
+    ADAPTIVE_TIME_MICROSECONDS("adaptive_time_microseconds"),
+
+    /**
+     * Represent time and date values using Kafka Connect {@link org.apache.kafka.connect.data} logical types, which always
+     * have millisecond precision.
+     */
+    CONNECT("connect");
+
+    private final String value;
+
+    TemporalPrecisionMode(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @return the matching option, or null if no match is found
+     */
+    public static TemporalPrecisionMode parse(String value) {
+        if (value == null) return null;
+        value = value.trim();
+        for (TemporalPrecisionMode option : TemporalPrecisionMode.values()) {
+            if (option.getValue().equalsIgnoreCase(value)) return option;
+        }
+        return null;
+    }
+
+    /**
+     * Determine if the supplied value is one of the predefined options.
+     *
+     * @param value the configuration property value; may not be null
+     * @param defaultValue the default value; may be null
+     * @return the matching option, or null if no match is found and the non-null default is invalid
+     */
+    public static TemporalPrecisionMode parse(String value, String defaultValue) {
+        TemporalPrecisionMode mode = parse(value);
+        if (mode == null && defaultValue != null) mode = parse(defaultValue);
+        return mode;
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/time/Conversions.java
+++ b/debezium-core/src/main/java/io/debezium/time/Conversions.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.time;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -91,6 +92,14 @@ final class Conversions {
                                 date.getMinutes(),
                                 date.getSeconds(),
                                 nanosOfSecond);
+        }
+        if (obj instanceof Duration) {
+            Long value = ((Duration) obj).toNanos();
+            if (value >= 0 && value <= NANOSECONDS_PER_DAY) {
+                return LocalTime.ofNanoOfDay(value);
+            } else {
+                throw new IllegalArgumentException("Time values must use number of milliseconds greater than 0 and less than 86400000000000");
+            }
         }
         if ( obj instanceof Long) {
             // Assume the value is the epoch day number

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/docker/init/setup.sql
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-gtid-integration-tests/src/test/docker/init/setup.sql
@@ -282,3 +282,13 @@ CREATE TABLE dbz_147_decimalvalues (
 );
 INSERT INTO dbz_147_decimalvalues (pk_column, decimal_value)
 VALUES(default, 12345.67);
+
+-- DBZ-342 handle TIME values that exceed the value range of java.sql.Time
+CREATE TABLE dbz_342_timetest (
+  c1 TIME(2),
+  c2 TIME(0),
+  c3 TIME(3),
+  c4 TIME(3),
+  c5 TIME(6)
+);
+INSERT INTO dbz_342_timetest VALUES ('517:51:04.777', '-13:14:50', '-733:00:00.0011', '-1:59:59.0011', '-838:59:58.999999');

--- a/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/docker/init/setup.sql
+++ b/integration-tests/mysql/debezium-connector-mysql-5.6-integration-tests/src/test/docker/init/setup.sql
@@ -282,3 +282,13 @@ CREATE TABLE dbz_147_decimalvalues (
 );
 INSERT INTO dbz_147_decimalvalues (pk_column, decimal_value)
 VALUES(default, 12345.67);
+
+-- DBZ-342 handle TIME values that exceed the value range of java.sql.Time
+CREATE TABLE dbz_342_timetest (
+  c1 TIME(2),
+  c2 TIME(0),
+  c3 TIME(3),
+  c4 TIME(3),
+  c5 TIME(6)
+);
+INSERT INTO dbz_342_timetest VALUES ('517:51:04.777', '-13:14:50', '-733:00:00.0011', '-1:59:59.0011', '-838:59:58.999999');

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/docker/init/setup.sql
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-gtid-integration-tests/src/test/docker/init/setup.sql
@@ -426,3 +426,13 @@ INSERT INTO dbz_126_jsontable VALUES (default,CAST(x'cafe' AS JSON), -- BLOB as 
 INSERT INTO dbz_126_jsontable VALUES (default,CAST(x'cafebabe' AS JSON), -- BLOB as Base64
                                               '"yv66vg=="',
                                               '"yv66vg=="');
+
+-- DBZ-342 handle TIME values that exceed the value range of java.sql.Time
+CREATE TABLE dbz_342_timetest (
+  c1 TIME(2),
+  c2 TIME(0),
+  c3 TIME(3),
+  c4 TIME(3),
+  c5 TIME(6)
+);
+INSERT INTO dbz_342_timetest VALUES ('517:51:04.777', '-13:14:50', '-733:00:00.0011', '-1:59:59.0011', '-838:59:58.999999');

--- a/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/docker/init/setup.sql
+++ b/integration-tests/mysql/debezium-connector-mysql-5.7-integration-tests/src/test/docker/init/setup.sql
@@ -426,3 +426,13 @@ INSERT INTO dbz_126_jsontable VALUES (default,CAST(x'cafe' AS JSON), -- BLOB as 
 INSERT INTO dbz_126_jsontable VALUES (default,CAST(x'cafebabe' AS JSON), -- BLOB as Base64
                                               '"yv66vg=="',
                                               '"yv66vg=="');
+
+-- DBZ-342 handle TIME values that exceed the value range of java.sql.Time
+CREATE TABLE dbz_342_timetest (
+  c1 TIME(2),
+  c2 TIME(0),
+  c3 TIME(3),
+  c4 TIME(3),
+  c5 TIME(6)
+);
+INSERT INTO dbz_342_timetest VALUES ('517:51:04.777', '-13:14:50', '-733:00:00.0011', '-1:59:59.0011', '-838:59:58.999999');


### PR DESCRIPTION
DBZ-342: fix broken handling of MySQL data type "TIME" for negative values and positive values >= 24:00:00 hours 
@see https://issues.jboss.org/browse/DBZ-342