### PR TITLE
Cluster and server properties should be added into config, not set as default ones

### DIFF
--- a/debezium-core/src/test/java/io/debezium/kafka/KafkaCluster.java
+++ b/debezium-core/src/test/java/io/debezium/kafka/KafkaCluster.java
@@ -161,7 +161,8 @@ public class KafkaCluster {
     public KafkaCluster withKafkaConfiguration(Properties properties) {
         if (running) throw new IllegalStateException("Unable to add a broker when the cluster is already running");
         if (properties != null && !properties.isEmpty()) {
-            kafkaConfig = new Properties(properties);
+            kafkaConfig = new Properties();
+            kafkaConfig.putAll(properties);
             kafkaServers.values().forEach(kafka -> kafka.setProperties(kafkaConfig));
         }
         return this;

--- a/debezium-core/src/test/java/io/debezium/kafka/KafkaServer.java
+++ b/debezium-core/src/test/java/io/debezium/kafka/KafkaServer.java
@@ -151,7 +151,8 @@ public class KafkaServer {
      * @return the properties for the currently-running server; may be empty if not running
      */
     public Properties config() {
-        Properties runningConfig = new Properties(config);
+        Properties runningConfig = new Properties();
+        runningConfig.putAll(config);
         runningConfig.setProperty(KafkaConfig.ZkConnectProp(), zookeeperConnection());
         runningConfig.setProperty(KafkaConfig.BrokerIdProp(), Integer.toString(brokerId));
         runningConfig.setProperty(KafkaConfig.HostNameProp(), "localhost");


### PR DESCRIPTION
Hi,

Right now if you use `new KafkaCluster().withKafkaConfiguration(Properties)` operation, its invocation will be basically ignored.

The issues is that you use `new Properties(Properties defaults)` constructor [1] and set passed `Properties` as default values instead adding them into Properties object.

The solution to the issue is to use the following code...

    Properties config = new Properties();
    config.putAll(additionalProperties);

...instead of...

    Properties config = new Properties(additionalProperties);

[1] https://docs.oracle.com/javase/7/docs/api/java/util/Properties.html#Properties(java.util.Properties)