### PR TITLE
DBZ-424 Can't support PostgreSQL 10

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -190,7 +190,8 @@ public class PostgresConnection extends JdbcConnection {
      */
     public long currentXLogLocation() throws SQLException {
         AtomicLong result = new AtomicLong(0);
-        query("select * from pg_current_xlog_location()", rs -> {
+        int majorVersion = connection().getMetaData().getDatabaseMajorVersion();
+        query(majorVersion >= 10 ? "select * from pg_current_wal_lsn()" : "select * from pg_current_xlog_location()", rs -> {
             if (!rs.next()) {
                 throw new IllegalStateException("there should always be a valid xlog position");
             }


### PR DESCRIPTION
We can validate PostgreSQL version first and then use select pg_current_wal_lsn() instead when we use PostgreSQL 10.

https://issues.jboss.org/browse/DBZ-424