### PR TITLE
DBZ-285 Updating Confluent platform version to 3.3.0; it doesn't exac…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <version.org.slf4j>1.7.25</version.org.slf4j>
         <version.log4j>1.2.17</version.log4j>
         <!-- check new release version at https://github.com/confluentinc/schema-registry/releases -->
-        <version.confluent.platform>3.2.2</version.confluent.platform>
+        <version.confluent.platform>3.3.0</version.confluent.platform>
 
         <!-- Databases -->
         <version.postgresql.driver>42.0.0-SNAPSHOT</version.postgresql.driver>


### PR DESCRIPTION
…tly match Kafka 1.0.0, but its only used for a test dependency so that's alright

Noticed this small inconcistency (3.2.2. still was for 0.10.x). This should be backported to 0.6, where versions will align nicely.