### PR TITLE
DBZ-453 support for newer PG wal2json with verbose type specifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,18 +75,18 @@ Using Docker has several advantages:
 
 1. You don't have to install, configure, and run specific versions of each external services on your local machine, or have access to them on your local network. Even if you do, Debezium's build won't use them.
 1. We can test multiple versions of an external service. Each module can start whatever containers it needs, so different modules can easily use different versions of the services.
-1. Everyone can run complete builds locally. You don't have to rely upon a remote continuous integration server running the build in an environment set up with all the required services. 
+1. Everyone can run complete builds locally. You don't have to rely upon a remote continuous integration server running the build in an environment set up with all the required services.
 1. All builds are consistent. When multiple developers each build the same codebase, they should see exactly the same results -- as long as they're using the same or equivalent JDK, Maven, and Docker versions. That's because the containers will be running the same versions of the services on the same operating systems. Plus, all of the tests are designed to connect to the systems running in the containers, so nobody has to fiddle with connection properties or custom configurations specific to their local environments.
 1. No need to clean up the services, even if those services modify and store data locally. Docker *images* are cached, so building them reusing them to start containers is fast and consistent. However, Docker *containers* are never reused: they always start in their pristine initial state, and are discarded when they are shutdown. Integration tests rely upon containers, and so cleanup is handled automatically.
 
-### Configure your docker environment
+### Configure your Docker environment
 
 The Docker Maven Plugin will resolve the docker host by checking the following environment variables:
 
     export DOCKER_HOST=tcp://10.1.2.2:2376
     export DOCKER_CERT_PATH=/path/to/cdk/.vagrant/machines/default/virtualbox/.docker
     export DOCKER_TLS_VERIFY=1
-    
+
 These can be set automatically if using Docker Machine or something similar.
 
 ### Building the code
@@ -102,13 +102,22 @@ Then build the code using Maven:
 
 The build starts and uses several Docker containers for different DBMSes. Note that if Docker is not running or configured, you'll likely get an arcane error -- if this is the case, always verify that Docker is running, perhaps by using `docker ps` to list the running containers.
 
-### Don't have docker running locally for builds?
+### Don't have Docker running locally for builds?
 
 You can skip the integration tests and docker-builds with the following command:
 
     $ mvn clean install -DskipITs
 
+### Running tests of the Postgres connector using the wal2json logical decoding plug-in
+
+The Postgres connector supports two logical decoding plug-ins for streaming changes from the DB server to the connector: decoderbufs (the default) and wal2json.
+To run the integration tests of the PG connector using wal2json, enable the "wal2json-decoder" build profile:
+
+    $ mvn clean install -pl :debezium-connector-postgres -Pwal2json-decoder
+
+A few tests currently don't pass when using the wal2json plug-in.
+Look for references to the types defined in `io.debezium.connector.postgresql.DecoderDifferences` to find these tests.
+
 ## Contributing
 
 The Debezium community welcomes anyone that wants to help out in any way, whether that includes reporting problems, helping with documentation, or contributing code changes to fix bugs, add tests, or implement new features. See [this document](CONTRIBUTE.md) for details.
-

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PgOid.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PgOid.java
@@ -40,15 +40,22 @@ public final class PgOid extends Oid {
         String typeName = column.typeName();
         if (typeName.toUpperCase().equals("TSTZRANGE")) {
             return TSTZRANGE_OID;
-        }
-        else if (column.jdbcType() == Types.ARRAY) {
+        } else if (typeName.toUpperCase().equals("SMALLSERIAL")) {
+            return PgOid.INT2;
+        } else if (typeName.toUpperCase().equals("SERIAL")) {
+            return PgOid.INT4;
+        } else if (typeName.toUpperCase().equals("BIGSERIAL")) {
+            return PgOid.INT8;
+        } else if (typeName.toUpperCase().equals("JSONB")) {
+            return PgOid.JSONB_OID;
+        } else if (column.jdbcType() == Types.ARRAY) {
             return column.componentType();
         }
         try {
             return Oid.valueOf(typeName);
         } catch (PSQLException e) {
             // not known by the driver PG driver
-            return column.jdbcType();
+            return Oid.UNSPECIFIED;
         }
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -385,7 +385,9 @@ public class PostgresConnectorConfig {
                                               .withEnum(LogicalDecoder.class, LogicalDecoder.DECODERBUFS)
                                               .withWidth(Width.MEDIUM)
                                               .withImportance(Importance.MEDIUM)
-                                              .withDescription("The name of the Postgres logical decoding plugin installed on the server. Defaults to '"+ LogicalDecoder.DECODERBUFS.getValue() + "'");
+                                              .withDescription("The name of the Postgres logical decoding plugin installed on the server. " +
+                                                      "Supported values are '"+ LogicalDecoder.DECODERBUFS.getValue() + "' and '"+ LogicalDecoder.WAL2JSON.getValue() + "'. " +
+                                                      "Defaults to '"+ LogicalDecoder.DECODERBUFS.getValue() + "'.");
 
     public static final Field SLOT_NAME = Field.create("slot.name")
                                               .withDisplayName("Slot")

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -87,6 +87,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
             case PgOid.OID:
                 return SchemaBuilder.int64();
             case PgOid.JSONB_JDBC_OID:
+            case PgOid.JSONB_OID:
             case PgOid.JSON:
                 return Json.builder();
             case PgOid.TSTZRANGE_OID:
@@ -142,6 +143,9 @@ public class PostgresValueConverter extends JdbcValueConverters {
                 // These array types still need to be implemented.  The superclass won't handle them so
                 // we return null here until we can code schema implementations for them.
                 return null;
+            case PgOid.UNSPECIFIED:
+                return SchemaBuilder.bytes();
+
             default:
                 return super.schemaBuilder(column);
         }
@@ -174,6 +178,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
             case PgOid.OID:
                 return data -> convertBigInt(column, fieldDefn, data);
             case PgOid.JSONB_JDBC_OID:
+            case PgOid.JSONB_OID:
             case PgOid.UUID:
             case PgOid.TSTZRANGE_OID:
             case PgOid.JSON:
@@ -222,6 +227,10 @@ public class PostgresValueConverter extends JdbcValueConverters {
             case PgOid.JSON_ARRAY:
             case PgOid.REF_CURSOR_ARRAY:
                 return super.converter(column, fieldDefn);
+
+            case PgOid.UNSPECIFIED:
+                return data -> convertBinary(column, fieldDefn, data);
+
             default:
                 return super.converter(column, fieldDefn);
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -143,9 +143,6 @@ public class PostgresValueConverter extends JdbcValueConverters {
                 // These array types still need to be implemented.  The superclass won't handle them so
                 // we return null here until we can code schema implementations for them.
                 return null;
-            case PgOid.UNSPECIFIED:
-                return SchemaBuilder.bytes();
-
             default:
                 return super.schemaBuilder(column);
         }
@@ -227,10 +224,6 @@ public class PostgresValueConverter extends JdbcValueConverters {
             case PgOid.JSON_ARRAY:
             case PgOid.REF_CURSOR_ARRAY:
                 return super.converter(column, fieldDefn);
-
-            case PgOid.UNSPECIFIED:
-                return data -> convertBinary(column, fieldDefn, data);
-
             default:
                 return super.converter(column, fieldDefn);
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
@@ -220,9 +220,7 @@ class PgProtoReplicationMessage implements ReplicationMessage {
                 }
                 return null;
             default: {
-                LOGGER.warn("processing column '{}' with unknown data type '{}' as byte array", datumMessage.getColumnName(),
-                            datumMessage.getColumnType());
-                return datumMessage.hasDatumBytes()? datumMessage.getDatumBytes().toByteArray() : null;
+                return null;
             }
         }
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
@@ -332,32 +332,30 @@ class Wal2JsonReplicationMessage implements ReplicationMessage {
                     throw new ConnectException(e);
                 }
 
-            // catch-all for other known/builtin PG types
-            // TODO: improve with more specific/useful classes here?
             case "bit":
             case "bit varying":
             case "varbit":
-            case "cidr":
-            case "inet":
             case "json":
             case "jsonb":
+            case "xml":
+            case "uuid":
+            case "tstzrange":
+                return rawValue.asString();
+            // catch-all for other known/builtin PG types
+            // TODO: improve with more specific/useful classes here?
+            case "cidr":
+            case "inet":
             case "macaddr":
             case "macaddr8":
             case "pg_lsn":
             case "tsquery":
-            case "tstzrange":
             case "tsvector":
             case "txid_snapshot":
-            case "uuid":
-            case "xml":
             // catch-all for unknown (extension module/custom) types
             default:
                 break;
         }
-        // this includes things like PostGIS geometries or other custom types.
-        // leave up to the downstream message recipient to deal with.
-        LOGGER.warn("processing column '{}' with unknown data type '{}' as byte array", columnName,
-                columnType);
-        return rawValue.asString();
+
+        return null;
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -94,9 +94,6 @@ public abstract class AbstractRecordsProducerTest {
     protected static final String INSERT_ARRAY_TYPES_WITH_NULL_VALUES_STMT = "INSERT INTO array_table_with_nulls (int_array, bigint_array, text_array) " +
             "VALUES (null, null, null)";
 
-    protected static final String INSERT_CUSTOM_TYPES_STMT = "INSERT INTO custom_table (lt, i, n) " +
-            "VALUES ('Top.Collections.Pictures.Astronomy.Galaxies', '978-0-393-04002-9', NULL)";
-
     protected static final String INSERT_QUOTED_TYPES_STMT = "INSERT INTO \"Quoted_\"\" . Schema\".\"Quoted_\"\" . Table\" (\"Quoted_\"\" . Text_Column\") " +
                                                              "VALUES ('some text')";
 
@@ -228,12 +225,6 @@ public abstract class AbstractRecordsProducerTest {
         );
     }
 
-    protected List<SchemaAndValueField> schemasAndValuesForCustomTypes() {
-        return Arrays.asList(new SchemaAndValueField("lt", Schema.OPTIONAL_BYTES_SCHEMA, ByteBuffer.wrap("Top.Collections.Pictures.Astronomy.Galaxies".getBytes())),
-                             new SchemaAndValueField("i", Schema.OPTIONAL_BYTES_SCHEMA, ByteBuffer.wrap("0-393-04002-X".getBytes())),
-                             new SchemaAndValueField("n", Schema.OPTIONAL_STRING_SCHEMA, null));
-    }
-
     protected List<SchemaAndValueField> schemasAndValuesForQuotedTypes() {
        return Arrays.asList(new SchemaAndValueField("Quoted_\" . Text_Column", Schema.OPTIONAL_STRING_SCHEMA, "some text"));
     }
@@ -265,8 +256,6 @@ public abstract class AbstractRecordsProducerTest {
                 return schemasAndValuesForArrayTypes();
             case INSERT_ARRAY_TYPES_WITH_NULL_VALUES_STMT:
                 return schemasAndValuesForArrayTypesWithNullValues();
-            case INSERT_CUSTOM_TYPES_STMT:
-                return schemasAndValuesForCustomTypes();
             case INSERT_QUOTED_TYPES_STMT:
                 return schemasAndValuesForQuotedTypes();
             default:

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -94,6 +94,9 @@ public abstract class AbstractRecordsProducerTest {
     protected static final String INSERT_ARRAY_TYPES_WITH_NULL_VALUES_STMT = "INSERT INTO array_table_with_nulls (int_array, bigint_array, text_array) " +
             "VALUES (null, null, null)";
 
+    protected static final String INSERT_CUSTOM_TYPES_STMT = "INSERT INTO custom_table (lt, i) " +
+            "VALUES ('Top.Collections.Pictures.Astronomy.Galaxies', '978-0-393-04002-9')";
+
     protected static final String INSERT_QUOTED_TYPES_STMT = "INSERT INTO \"Quoted_\"\" . Schema\".\"Quoted_\"\" . Table\" (\"Quoted_\"\" . Text_Column\") " +
                                                              "VALUES ('some text')";
 
@@ -155,6 +158,7 @@ public abstract class AbstractRecordsProducerTest {
                              new SchemaAndValueField("u", Uuid.builder().optional().build(), "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"));
     }
 
+
     protected List<SchemaAndValueField> schemaAndValuesForGeomTypes() {
         Schema pointSchema = Point.builder().optional().build();
         return Collections.singletonList(new SchemaAndValueField("p", pointSchema, Point.createValue(pointSchema, 1, 1)));
@@ -183,6 +187,13 @@ public abstract class AbstractRecordsProducerTest {
                             new SchemaAndValueField("bol", Schema.OPTIONAL_BOOLEAN_SCHEMA, false),
                             new SchemaAndValueField("bs", Bits.builder(2).optional().build(), new byte[] { 3, 0 }),  // bitsets get converted from two's complement
                             new SchemaAndValueField("bv", Bits.builder(2).optional().build(), new byte[] { 0, 0 }));
+    }
+
+    protected List<SchemaAndValueField> schemaAndValuesForBinTypesNull() {
+        return Arrays.asList(new SchemaAndValueField("ba", Schema.OPTIONAL_BYTES_SCHEMA, null),
+                             new SchemaAndValueField("bol", Schema.OPTIONAL_BOOLEAN_SCHEMA, null),
+                             new SchemaAndValueField("bs", Bits.builder(2).optional().build(), null),
+                             new SchemaAndValueField("bv", Bits.builder(2).optional().build(), null));
     }
 
     protected List<SchemaAndValueField> schemaAndValuesForDateTimeTypes() {
@@ -224,6 +235,11 @@ public abstract class AbstractRecordsProducerTest {
         );
     }
 
+    protected List<SchemaAndValueField> schemasAndValuesForCustomTypes() {
+        return Arrays.asList(new SchemaAndValueField("lt", Schema.OPTIONAL_STRING_SCHEMA, "Top.Collections.Pictures.Astronomy.Galaxies"),
+                             new SchemaAndValueField("i", Schema.OPTIONAL_STRING_SCHEMA, "978-0-393-04002-9"));
+    }
+
     protected List<SchemaAndValueField> schemasAndValuesForQuotedTypes() {
        return Arrays.asList(new SchemaAndValueField("Quoted_\" . Text_Column", Schema.OPTIONAL_STRING_SCHEMA, "some text"));
     }
@@ -255,6 +271,8 @@ public abstract class AbstractRecordsProducerTest {
                 return schemasAndValuesForArrayTypes();
             case INSERT_ARRAY_TYPES_WITH_NULL_VALUES_STMT:
                 return schemasAndValuesForArrayTypesWithNullValues();
+            case INSERT_CUSTOM_TYPES_STMT:
+                return schemasAndValuesForCustomTypes();
             case INSERT_QUOTED_TYPES_STMT:
                 return schemasAndValuesForQuotedTypes();
             default:

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -94,8 +94,8 @@ public abstract class AbstractRecordsProducerTest {
     protected static final String INSERT_ARRAY_TYPES_WITH_NULL_VALUES_STMT = "INSERT INTO array_table_with_nulls (int_array, bigint_array, text_array) " +
             "VALUES (null, null, null)";
 
-    protected static final String INSERT_CUSTOM_TYPES_STMT = "INSERT INTO custom_table (lt, i) " +
-            "VALUES ('Top.Collections.Pictures.Astronomy.Galaxies', '978-0-393-04002-9')";
+    protected static final String INSERT_CUSTOM_TYPES_STMT = "INSERT INTO custom_table (lt, i, n) " +
+            "VALUES ('Top.Collections.Pictures.Astronomy.Galaxies', '978-0-393-04002-9', NULL)";
 
     protected static final String INSERT_QUOTED_TYPES_STMT = "INSERT INTO \"Quoted_\"\" . Schema\".\"Quoted_\"\" . Table\" (\"Quoted_\"\" . Text_Column\") " +
                                                              "VALUES ('some text')";
@@ -189,13 +189,6 @@ public abstract class AbstractRecordsProducerTest {
                             new SchemaAndValueField("bv", Bits.builder(2).optional().build(), new byte[] { 0, 0 }));
     }
 
-    protected List<SchemaAndValueField> schemaAndValuesForBinTypesNull() {
-        return Arrays.asList(new SchemaAndValueField("ba", Schema.OPTIONAL_BYTES_SCHEMA, null),
-                             new SchemaAndValueField("bol", Schema.OPTIONAL_BOOLEAN_SCHEMA, null),
-                             new SchemaAndValueField("bs", Bits.builder(2).optional().build(), null),
-                             new SchemaAndValueField("bv", Bits.builder(2).optional().build(), null));
-    }
-
     protected List<SchemaAndValueField> schemaAndValuesForDateTimeTypes() {
         long expectedTs = NanoTimestamp.toEpochNanos(LocalDateTime.parse("2016-11-04T13:51:30"), null);
         String expectedTz = "2016-11-04T11:51:30Z"; //timestamp is stored with TZ, should be read back with UTC
@@ -236,8 +229,9 @@ public abstract class AbstractRecordsProducerTest {
     }
 
     protected List<SchemaAndValueField> schemasAndValuesForCustomTypes() {
-        return Arrays.asList(new SchemaAndValueField("lt", Schema.OPTIONAL_STRING_SCHEMA, "Top.Collections.Pictures.Astronomy.Galaxies"),
-                             new SchemaAndValueField("i", Schema.OPTIONAL_STRING_SCHEMA, "978-0-393-04002-9"));
+        return Arrays.asList(new SchemaAndValueField("lt", Schema.OPTIONAL_BYTES_SCHEMA, ByteBuffer.wrap("Top.Collections.Pictures.Astronomy.Galaxies".getBytes())),
+                             new SchemaAndValueField("i", Schema.OPTIONAL_BYTES_SCHEMA, ByteBuffer.wrap("0-393-04002-X".getBytes())),
+                             new SchemaAndValueField("n", Schema.OPTIONAL_STRING_SCHEMA, null));
     }
 
     protected List<SchemaAndValueField> schemasAndValuesForQuotedTypes() {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
@@ -99,7 +99,7 @@ public class PostgresSchemaIT {
             assertTableSchema("public.tstzrange_table", "unbounded_exclusive_range, bounded_inclusive_range",
                               Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
             assertTableSchema("public.custom_table", "lt, i",
-                              Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
+                              Schema.OPTIONAL_BYTES_SCHEMA, Schema.OPTIONAL_BYTES_SCHEMA);
             assertTableSchema("public.array_table", "int_array, bigint_array, text_array",
                               SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).optional().build(), SchemaBuilder.array(Schema.OPTIONAL_INT64_SCHEMA).optional().build(),
                               SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build());

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
@@ -98,8 +98,6 @@ public class PostgresSchemaIT {
             assertTableSchema("public.geom_table", "p", Point.builder().optional().build());
             assertTableSchema("public.tstzrange_table", "unbounded_exclusive_range, bounded_inclusive_range",
                               Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
-            assertTableSchema("public.custom_table", "lt, i",
-                              Schema.OPTIONAL_BYTES_SCHEMA, Schema.OPTIONAL_BYTES_SCHEMA);
             assertTableSchema("public.array_table", "int_array, bigint_array, text_array",
                               SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).optional().build(), SchemaBuilder.array(Schema.OPTIONAL_INT64_SCHEMA).optional().build(),
                               SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build());

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
@@ -98,6 +98,8 @@ public class PostgresSchemaIT {
             assertTableSchema("public.geom_table", "p", Point.builder().optional().build());
             assertTableSchema("public.tstzrange_table", "unbounded_exclusive_range, bounded_inclusive_range",
                               Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
+            assertTableSchema("public.custom_table", "lt, i",
+                              Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA);
             assertTableSchema("public.array_table", "int_array, bigint_array, text_array",
                               SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).optional().build(), SchemaBuilder.array(Schema.OPTIONAL_INT64_SCHEMA).optional().build(),
                               SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build());

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -112,6 +112,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
     @Test
     @ShouldFailWhen(DecoderDifferences.AreQuotedIdentifiersUnsupported.class)
+    // TODO DBZ-493
     public void shouldReceiveChangesForInsertsWithQuotedNames() throws Exception {
         TestHelper.executeDDL("postgres_create_tables.ddl");
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -108,10 +108,6 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         // timezone range types
         consumer.expects(1);
         assertInsert(INSERT_TSTZRANGE_TYPES_STMT, schemaAndValuesForTstzRangeTypes());
-
-        // custom types + null value
-        consumer.expects(1);
-        assertInsert(INSERT_CUSTOM_TYPES_STMT, schemasAndValuesForCustomTypes());
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -109,13 +109,9 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         consumer.expects(1);
         assertInsert(INSERT_TSTZRANGE_TYPES_STMT, schemaAndValuesForTstzRangeTypes());
 
-        // custom types
+        // custom types + null value
         consumer.expects(1);
         assertInsert(INSERT_CUSTOM_TYPES_STMT, schemasAndValuesForCustomTypes());
-
-        // null data
-        consumer.expects(1);
-        assertInsert(INSERT_BIN_TYPES_STMT, schemaAndValuesForBinTypesNull());
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -109,6 +109,13 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         consumer.expects(1);
         assertInsert(INSERT_TSTZRANGE_TYPES_STMT, schemaAndValuesForTstzRangeTypes());
 
+        // custom types
+        consumer.expects(1);
+        assertInsert(INSERT_CUSTOM_TYPES_STMT, schemasAndValuesForCustomTypes());
+
+        // null data
+        consumer.expects(1);
+        assertInsert(INSERT_BIN_TYPES_STMT, schemaAndValuesForBinTypesNull());
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
+++ b/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
@@ -3,18 +3,22 @@
 -- Generate a number of tables to cover as many of the PG types as possible
 DROP SCHEMA IF EXISTS public CASCADE;
 CREATE SCHEMA public;
+CREATE EXTENSION IF NOT EXISTS ltree SCHEMA public;
+CREATE EXTENSION IF NOT EXISTS isn SCHEMA public;
+
 CREATE TABLE numeric_table (pk SERIAL, si SMALLINT, i INTEGER, bi BIGINT, r REAL, db DOUBLE PRECISION, ss SMALLSERIAL, bs BIGSERIAL, b BOOLEAN, PRIMARY KEY(pk));
 -- no suffix -fixed scale, zs - zero scale, vs - variable scale
 CREATE TABLE numeric_decimal_table (pk SERIAL, d DECIMAL(3,2), dzs DECIMAL(4), dvs DECIMAL, n NUMERIC(6,4), nzs NUMERIC(4), nvs NUMERIC, PRIMARY KEY(pk));
 CREATE TABLE string_table (pk SERIAL, vc VARCHAR(2), vcv CHARACTER VARYING(2), ch CHARACTER(4), c CHAR(3), t TEXT, PRIMARY KEY(pk));
 CREATE TABLE cash_table (pk SERIAL, csh MONEY, PRIMARY KEY(pk));
 CREATE TABLE bitbin_table (pk SERIAL, ba BYTEA, bol BIT(1), bs BIT(2), bv BIT VARYING(2) , PRIMARY KEY(pk));
-CREATE TABLE time_table (pk SERIAL, ts TIMESTAMP, tz TIMESTAMPTZ, date DATE, ti TIME, ttz TIME WITH TIME ZONE, it INTERVAL, PRIMARY KEY(pk));
+CREATE TABLE time_table (pk SERIAL, ts TIMESTAMP, tz TIMESTAMPTZ, date DATE, ti TIME, ttz TIME WITH TIME ZONE, it INTERVAL, tsp TIMESTAMP (0) WITH TIME ZONE, PRIMARY KEY(pk));
 CREATE TABLE text_table (pk SERIAL, j JSON, jb JSONB, x XML, u Uuid, PRIMARY KEY(pk));
 CREATE TABLE geom_table (pk SERIAL, p POINT, PRIMARY KEY(pk));
 CREATE TABLE tstzrange_table (pk serial, unbounded_exclusive_range tstzrange, bounded_inclusive_range tstzrange, PRIMARY KEY(pk));
 CREATE TABLE array_table (pk SERIAL, int_array INT[], bigint_array BIGINT[], text_array TEXT[], PRIMARY KEY(pk));
 CREATE TABLE array_table_with_nulls (pk SERIAL, int_array INT[], bigint_array BIGINT[], text_array TEXT[], PRIMARY KEY(pk));
+CREATE TABLE custom_table (pk serial, lt ltree, i isbn, PRIMARY KEY(pk));
 
 DROP SCHEMA IF EXISTS "Quoted_"" . Schema" CASCADE;
 CREATE SCHEMA "Quoted_"" . Schema";

--- a/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
+++ b/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
@@ -3,6 +3,7 @@
 -- Generate a number of tables to cover as many of the PG types as possible
 DROP SCHEMA IF EXISTS public CASCADE;
 CREATE SCHEMA public;
+-- load contrib extensions for testing non-builtin types
 CREATE EXTENSION IF NOT EXISTS ltree SCHEMA public;
 CREATE EXTENSION IF NOT EXISTS isn SCHEMA public;
 
@@ -18,7 +19,7 @@ CREATE TABLE geom_table (pk SERIAL, p POINT, PRIMARY KEY(pk));
 CREATE TABLE tstzrange_table (pk serial, unbounded_exclusive_range tstzrange, bounded_inclusive_range tstzrange, PRIMARY KEY(pk));
 CREATE TABLE array_table (pk SERIAL, int_array INT[], bigint_array BIGINT[], text_array TEXT[], PRIMARY KEY(pk));
 CREATE TABLE array_table_with_nulls (pk SERIAL, int_array INT[], bigint_array BIGINT[], text_array TEXT[], PRIMARY KEY(pk));
-CREATE TABLE custom_table (pk serial, lt ltree, i isbn, PRIMARY KEY(pk));
+CREATE TABLE custom_table (pk serial, lt ltree, i isbn, n TEXT, PRIMARY KEY(pk));
 
 DROP SCHEMA IF EXISTS "Quoted_"" . Schema" CASCADE;
 CREATE SCHEMA "Quoted_"" . Schema";

--- a/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
+++ b/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
@@ -3,9 +3,6 @@
 -- Generate a number of tables to cover as many of the PG types as possible
 DROP SCHEMA IF EXISTS public CASCADE;
 CREATE SCHEMA public;
--- load contrib extensions for testing non-builtin types
-CREATE EXTENSION IF NOT EXISTS ltree SCHEMA public;
-CREATE EXTENSION IF NOT EXISTS isn SCHEMA public;
 
 CREATE TABLE numeric_table (pk SERIAL, si SMALLINT, i INTEGER, bi BIGINT, r REAL, db DOUBLE PRECISION, ss SMALLSERIAL, bs BIGSERIAL, b BOOLEAN, PRIMARY KEY(pk));
 -- no suffix -fixed scale, zs - zero scale, vs - variable scale
@@ -19,7 +16,6 @@ CREATE TABLE geom_table (pk SERIAL, p POINT, PRIMARY KEY(pk));
 CREATE TABLE tstzrange_table (pk serial, unbounded_exclusive_range tstzrange, bounded_inclusive_range tstzrange, PRIMARY KEY(pk));
 CREATE TABLE array_table (pk SERIAL, int_array INT[], bigint_array BIGINT[], text_array TEXT[], PRIMARY KEY(pk));
 CREATE TABLE array_table_with_nulls (pk SERIAL, int_array INT[], bigint_array BIGINT[], text_array TEXT[], PRIMARY KEY(pk));
-CREATE TABLE custom_table (pk serial, lt ltree, i isbn, n TEXT, PRIMARY KEY(pk));
 
 DROP SCHEMA IF EXISTS "Quoted_"" . Schema" CASCADE;
 CREATE SCHEMA "Quoted_"" . Schema";


### PR DESCRIPTION
Passes all unit tests with `mvn install -Pwal2json-decoder` both with PG built against the old https://github.com/eulerto/wal2json/tree/645ab69a & current https://github.com/eulerto/wal2json/tree/5352cc41 wal2json commits.