### PR TITLE
WIP: DBZ-379 Postgres connector minimizes use of JDBC metadata

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PgOid.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PgOid.java
@@ -58,8 +58,13 @@ public final class PgOid extends Oid {
     }
 
     protected static int jdbcColumnToOid(Column column) {
-        String typeName = column.typeName();
+        if (column.jdbcType() == Types.ARRAY) {
+            return column.componentType();
+        }
+        return typeNameToOid(column.typeName());
+    }
 
+    public static int typeNameToOid(String typeName) {
         if (typeName.toUpperCase().equals("TSTZRANGE")) {
             return TSTZRANGE_OID;
         } else if (typeName.toUpperCase().equals("SMALLSERIAL")) {
@@ -70,8 +75,6 @@ public final class PgOid extends Oid {
             return PgOid.INT8;
         } else if (typeName.toUpperCase().equals("JSONB")) {
             return PgOid.JSONB_OID;
-        } else if (column.jdbcType() == Types.ARRAY) {
-            return column.componentType();
         }
         try {
             return Oid.valueOf(typeName);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PgOid.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PgOid.java
@@ -7,11 +7,15 @@
 package io.debezium.connector.postgresql;
 
 import java.sql.Types;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.postgresql.core.Oid;
 import org.postgresql.util.PSQLException;
 
+import io.debezium.connector.postgresql.connection.ReplicationMessage;
 import io.debezium.relational.Column;
+import io.debezium.relational.ColumnEditor;
 
 /**
  * Extension to the {@link org.postgresql.core.Oid} class which contains Postgres specific datatypes not found currently in the
@@ -33,11 +37,29 @@ public final class PgOid extends Oid {
 
     public static final int TSTZRANGE_OID = 3910;
 
+    private static final Map<String, String> longTypeNames = new HashMap<>();
+    static {
+        longTypeNames.put("bigint", "int8");
+        longTypeNames.put("bit varying", "varbit");
+        longTypeNames.put("boolean", "bool");
+        longTypeNames.put("character", "bpchar");
+        longTypeNames.put("character varying", "varchar");
+        longTypeNames.put("double precision", "float8");
+        longTypeNames.put("integer", "int4");
+        longTypeNames.put("real", "float4");
+        longTypeNames.put("smallint", "int2");
+        longTypeNames.put("timestamp without time zone", "timestamp");
+        longTypeNames.put("timestamp with time zone", "timestamptz");
+        longTypeNames.put("time without time zone", "time");
+        longTypeNames.put("time with time zone", "timetz");
+    }
+
     private PgOid() {
     }
 
     protected static int jdbcColumnToOid(Column column) {
         String typeName = column.typeName();
+
         if (typeName.toUpperCase().equals("TSTZRANGE")) {
             return TSTZRANGE_OID;
         } else if (typeName.toUpperCase().equals("SMALLSERIAL")) {
@@ -58,4 +80,29 @@ public final class PgOid extends Oid {
             return Oid.UNSPECIFIED;
         }
     }
+
+    public static String normalizeTypeName(String typeName) {
+        return longTypeNames.getOrDefault(typeName, typeName);
+    }
+
+    public static void reconcileJdbcOidTypeConstraints(final ReplicationMessage.Column column,
+            final ColumnEditor columnEditor) {
+        switch (column.getTypeName()) {
+            case "money":
+                // JDBC returns scale 0 but decoder plugin returns -1 (unscaled)
+                columnEditor.scale(0);
+                break;
+            case "timestamp":
+                // JDBC returns length/scale 29/6 but decoder plugin returns -1 (unlimited)
+                columnEditor.length(29);
+                columnEditor.scale(6);
+                break;
+            case "time":
+                // JDBC returns length/scale 15/6 but decoder plugin returns -1 (unlimited)
+                columnEditor.length(15);
+                columnEditor.scale(6);
+                break;
+        }
+    }
+
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PgOid.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PgOid.java
@@ -37,21 +37,21 @@ public final class PgOid extends Oid {
 
     public static final int TSTZRANGE_OID = 3910;
 
-    private static final Map<String, String> longTypeNames = new HashMap<>();
+    private static final Map<String, String> LONG_TYPE_NAMES = new HashMap<>();
     static {
-        longTypeNames.put("bigint", "int8");
-        longTypeNames.put("bit varying", "varbit");
-        longTypeNames.put("boolean", "bool");
-        longTypeNames.put("character", "bpchar");
-        longTypeNames.put("character varying", "varchar");
-        longTypeNames.put("double precision", "float8");
-        longTypeNames.put("integer", "int4");
-        longTypeNames.put("real", "float4");
-        longTypeNames.put("smallint", "int2");
-        longTypeNames.put("timestamp without time zone", "timestamp");
-        longTypeNames.put("timestamp with time zone", "timestamptz");
-        longTypeNames.put("time without time zone", "time");
-        longTypeNames.put("time with time zone", "timetz");
+        LONG_TYPE_NAMES.put("bigint", "int8");
+        LONG_TYPE_NAMES.put("bit varying", "varbit");
+        LONG_TYPE_NAMES.put("boolean", "bool");
+        LONG_TYPE_NAMES.put("character", "bpchar");
+        LONG_TYPE_NAMES.put("character varying", "varchar");
+        LONG_TYPE_NAMES.put("double precision", "float8");
+        LONG_TYPE_NAMES.put("integer", "int4");
+        LONG_TYPE_NAMES.put("real", "float4");
+        LONG_TYPE_NAMES.put("smallint", "int2");
+        LONG_TYPE_NAMES.put("timestamp without time zone", "timestamp");
+        LONG_TYPE_NAMES.put("timestamp with time zone", "timestamptz");
+        LONG_TYPE_NAMES.put("time without time zone", "time");
+        LONG_TYPE_NAMES.put("time with time zone", "timetz");
     }
 
     private PgOid() {
@@ -81,10 +81,24 @@ public final class PgOid extends Oid {
         }
     }
 
+    /**
+     * Converts a type name in long (readable) format like <code>boolean</code> to s standard
+     * data type name like <code>bool</code>.
+     * 
+     * @param typeName - a type name in long format 
+     * @return - the type name in standardized format
+     */
     public static String normalizeTypeName(String typeName) {
-        return longTypeNames.getOrDefault(typeName, typeName);
+        return LONG_TYPE_NAMES.getOrDefault(typeName, typeName);
     }
 
+    /**
+     * JDBC metadata are different for some of the unbounded types from those coming via decoder.
+     * This method sets the type constraints to the values provided by JDBC metadata. 
+     * 
+     * @param column - a column coming from decoder
+     * @param columnEditor - the JDBC counterpart of the column
+     */
     public static void reconcileJdbcOidTypeConstraints(final ReplicationMessage.Column column,
             final ColumnEditor columnEditor) {
         switch (column.getTypeName()) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
@@ -174,11 +174,11 @@ public class PostgresSchema {
         return !filters.tableFilter().test(id);
     }
 
-    protected boolean isJDBCType(String localTypeName, int jdbcType) {
-        return typeInfo != null && Integer.compare(jdbcType, columnTypeNameToJDBCTypeId(localTypeName)) == 0;
+    protected boolean isJdbcType(String localTypeName, int jdbcType) {
+        return typeInfo != null && columnTypeNameToJdbcTypeId(localTypeName) == jdbcType;
     }
 
-    protected int columnTypeNameToJDBCTypeId(String localTypeName) {
+    protected int columnTypeNameToJdbcTypeId(String localTypeName) {
         return typeInfo.get(localTypeName);
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
@@ -130,6 +130,18 @@ public class PostgresSchema {
     }
 
     /**
+     * Refreshes the schema content with a table constructed externally
+     * 
+     * @param table constructed externally - typically from decoder metadata
+     */
+    protected void refresh(Table table) {
+        // overwrite (add or update) or views of the tables
+        tables.overwriteTable(table);
+        // and refresh the schema
+        refreshSchema(table.id());
+    }
+
+    /**
      * Get the {@link Filters database and table filters} defined by the configuration.
      *
      * @return the filters; never null
@@ -162,11 +174,11 @@ public class PostgresSchema {
         return !filters.tableFilter().test(id);
     }
 
-    protected boolean isType(String localTypeName, int jdbcType) {
-        return typeInfo != null && Integer.compare(jdbcType, columnTypeNameToPgOid(localTypeName)) == 0;
+    protected boolean isJDBCType(String localTypeName, int jdbcType) {
+        return typeInfo != null && Integer.compare(jdbcType, columnTypeNameToJDBCTypeId(localTypeName)) == 0;
     }
 
-    protected int columnTypeNameToPgOid(String localTypeName) {
+    protected int columnTypeNameToJDBCTypeId(String localTypeName) {
         return typeInfo.get(localTypeName);
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -434,6 +434,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
     }
 
     private boolean isVariableScaleDecimal(final Column column) {
-        return column.scale() == 0 && column.length() == VARIABLE_SCALE_DECIMAL_LENGTH;
+        return (column.scale() == 0 && column.length() == VARIABLE_SCALE_DECIMAL_LENGTH)
+                || (column.scale() == -1 && column.length() == -1);
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
@@ -8,6 +8,7 @@ package io.debezium.connector.postgresql;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -15,6 +16,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -29,6 +31,7 @@ import io.debezium.connector.postgresql.connection.ReplicationMessage;
 import io.debezium.connector.postgresql.connection.ReplicationStream;
 import io.debezium.data.Envelope;
 import io.debezium.relational.Column;
+import io.debezium.relational.ColumnEditor;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchema;
@@ -93,6 +96,7 @@ public class RecordsStreamProducer extends RecordsProducer {
 
             // refresh the schema so we have a latest view of the DB tables
             taskContext.refreshSchema(true);
+
             // the new thread will inherit it's parent MDC
             executorService.submit(() -> streamChanges(recordConsumer));
         } catch (Throwable t) {
@@ -119,7 +123,7 @@ public class RecordsStreamProducer extends RecordsProducer {
                 }
                 taskContext.failTask(e);
                 throw new ConnectException(e);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 logger.error("unexpected exception while streaming logical changes", e);
                 taskContext.failTask(e);
                 throw new ConnectException(e);
@@ -228,18 +232,18 @@ public class RecordsStreamProducer extends RecordsProducer {
         ReplicationMessage.Operation operation = message.getOperation();
         switch (operation) {
             case INSERT: {
-                Object[] row = columnValues(message.getNewTupleList(), tableId, true);
+                Object[] row = columnValues(message.getNewTupleList(), tableId, true, message.hasMetadata());
                 generateCreateRecord(tableId, row, consumer);
                 break;
             }
             case UPDATE: {
-                Object[] newRow = columnValues(message.getNewTupleList(), tableId, true);
-                Object[] oldRow = columnValues(message.getOldTupleList(), tableId, true);
+                Object[] newRow = columnValues(message.getNewTupleList(), tableId, true, message.hasMetadata());
+                Object[] oldRow = columnValues(message.getOldTupleList(), tableId, false, message.hasMetadata());
                 generateUpdateRecord(tableId, oldRow, newRow, consumer);
                 break;
             }
             case DELETE: {
-                Object[] row = columnValues(message.getOldTupleList(), tableId, false);
+                Object[] row = columnValues(message.getOldTupleList(), tableId, false, message.hasMetadata());
                 generateDeleteRecord(tableId, row, consumer);
                 break;
             }
@@ -372,7 +376,7 @@ public class RecordsStreamProducer extends RecordsProducer {
         recordConsumer.accept(record);
     }
 
-    private Object[] columnValues(List<ReplicationMessage.Column> messageList, TableId tableId, boolean refreshSchemaIfChanged)
+    private Object[] columnValues(List<ReplicationMessage.Column> messageList, TableId tableId, boolean refreshSchemaIfChanged, boolean metadataInMessage)
             throws SQLException {
         if (messageList == null || messageList.isEmpty()) {
             return null;
@@ -381,11 +385,16 @@ public class RecordsStreamProducer extends RecordsProducer {
         assert table != null;
 
         // check if we need to refresh our local schema due to DB schema changes for this table
-        if (refreshSchemaIfChanged && schemaChanged(messageList, table)) {
+        if (refreshSchemaIfChanged && schemaChanged(messageList, table, metadataInMessage)) {
             try (final PostgresConnection connection = taskContext.createConnection()) {
+                // Refresh the schema so we get information about primary keys
                 schema().refresh(connection, tableId);
+                // Update the schema with metadata coming from decoder message
+                if (metadataInMessage) {
+                    schema().refresh(tableFromFromMessage(messageList, schema().tableFor(tableId)));
+                }
+                table = schema().tableFor(tableId);
             }
-            table = schema().tableFor(tableId);
         }
 
         // based on the schema columns, create the values on the same position as the columns
@@ -402,7 +411,7 @@ public class RecordsStreamProducer extends RecordsProducer {
         return values;
     }
 
-    private boolean schemaChanged(List<ReplicationMessage.Column> messageList, Table table) {
+    private boolean schemaChanged(List<ReplicationMessage.Column> messageList, Table table, boolean metadataInMessage) {
         List<String> columnNames = table.columnNames();
         int messagesCount = messageList.size();
         if (columnNames.size() != messagesCount) {
@@ -419,10 +428,14 @@ public class RecordsStreamProducer extends RecordsProducer {
             if (column == null) {
                 logger.debug("found new column '{}' present in the server message which is not part of the table metadata; refreshing table schema", columnName);
                 return true;
-            } else if (!schema().isType(column.typeName(), column.jdbcType())) {
-                logger.debug("detected new type for column '{}', old type was '{}', new type is '{}'; refreshing table schema", columnName, column.jdbcType(),
-                            message.getType());
-                return true;
+            } else {
+                final int localType = column.jdbcType();
+                final int incomingType = metadataInMessage ? typeNameToJDBCType(message) : message.getType();
+                if (localType != incomingType) {
+                    logger.debug("detected new type for column '{}', old type was '{}', new type is '{}'; refreshing table schema", columnName, column.jdbcType(),
+                                message.getType());
+                    return true;
+                }
             }
             return false;
         }).findFirst().isPresent();
@@ -458,5 +471,35 @@ public class RecordsStreamProducer extends RecordsProducer {
             typeResolverConnection = (PgConnection)taskContext.createConnection().connection();
         }
         return typeResolverConnection;
+    }
+
+    private Table tableFromFromMessage(List<ReplicationMessage.Column> messageList, Table table) {
+        return table.edit()
+            .setColumns(messageList.stream()
+                .map(column -> {
+                    final ColumnEditor columnEditor = Column.editor()
+                            .name(column.getName())
+                            .jdbcType(column.getType() == Types.ARRAY ? Types.ARRAY : typeNameToJDBCType(column))
+                            .type(column.getTypeName())
+                            .optional(column.isOptional());
+                    PgOid.reconcileJdbcOidTypeConstraints(column, columnEditor);
+                    if (column.getType() == Types.ARRAY) {
+                        columnEditor.componentType(column.getArrayElementOidType());
+                    }
+                    if (column.getTypeModifiers().length > 0) {
+                        columnEditor.length(column.getTypeModifiers()[0]);
+                    }
+                    if (column.getTypeModifiers().length > 1) {
+                        columnEditor.scale(column.getTypeModifiers()[1]);
+                    }
+                    return columnEditor.create();
+                })
+                .collect(Collectors.toList())
+            )
+            .setPrimaryKeyNames(table.filterColumnNames(c -> table.isPrimaryKeyColumn(c.name()))).create();
+    }
+
+    private int typeNameToJDBCType(final ReplicationMessage.Column column) {
+        return taskContext.schema().columnTypeNameToJDBCTypeId(column.getTypeName());
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractReplicationMessageColumn.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractReplicationMessageColumn.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.connection;
+
+import java.sql.Types;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.connector.postgresql.PgOid;
+
+/**
+ * Extracts type information from replication messages and associates them with each column.
+ * The metadata are parsed lazily.
+ * 
+ * @author Jiri Pechanec
+ *
+ */
+public abstract class AbstractReplicationMessageColumn implements ReplicationMessage.Column {
+
+    public static class TypeMetadata {
+        private static final Logger LOGGER = LoggerFactory.getLogger(TypeMetadata.class);
+
+        private static final int[] EMPTY_TYPE_MODIFIERS = {};
+        private static final Pattern TYPE_PATTERN = Pattern.compile("^(?<full>(?<base>[^(\\[]+)(?:\\((?<mod>.+)\\))?(?<suffix>.*?))(?<array>\\[\\])?$");
+        private static final Pattern TYPEMOD_PATTERN = Pattern.compile("\\s*,\\s*");
+            // "text"; "character varying(255)"; "numeric(12,3)"; "geometry(MultiPolygon,4326)"; "timestamp (12) with time zone"; "int[]"
+
+        private String baseType;
+        private String fullType;
+        private int[] typeModifiers;
+        private boolean isArray;
+        private String normalizedTypeName;
+        private boolean optional;
+
+        public TypeMetadata(String columnName, String typeWithModifiers, boolean optional) {
+            this.optional = optional;
+            Matcher m = TYPE_PATTERN.matcher(typeWithModifiers);
+            if (!m.matches()) {
+                LOGGER.error("Failed to parse columnType for {} '{}'", columnName, typeWithModifiers);
+                throw new ConnectException(String.format("Failed to parse columnType '%s' for column %s", typeWithModifiers, columnName));
+            }
+            fullType = m.group("full");
+            baseType = m.group("base").trim();
+            if (!Objects.toString(m.group("suffix"), "").isEmpty()) {
+                baseType = String.join(" ", baseType, m.group("suffix").trim());
+            }
+            typeModifiers = EMPTY_TYPE_MODIFIERS;
+            if (m.group("mod") != null) {
+                final String[] typeModifiersStr = TYPEMOD_PATTERN.split(m.group("mod"));
+                typeModifiers = new int[typeModifiersStr.length];
+                for (int i = 0; i < typeModifiersStr.length; i++) {
+                    try {
+                    typeModifiers[i] = Integer.parseInt(typeModifiersStr[i]);
+                    } catch (NumberFormatException e) {
+                        LOGGER.error("Failed to parse type modifier for {} '{}'", columnName, typeModifiersStr[i]);
+                        throw new ConnectException(String.format("Failed to parse type modifier '%s' for column %s", typeModifiersStr[i], columnName));
+                    }
+                }
+            }
+            isArray = (m.group("array") != null);
+
+            if (baseType.startsWith("_")) {
+                // old-style type specifiers use an _ prefix for arrays
+                // e.g. int4[] would be "_int4"
+                baseType = baseType.substring(1);
+                fullType = fullType.substring(1);
+                isArray = true;
+            }
+            normalizedTypeName = PgOid.normalizeTypeName(baseType);
+
+            if (isArray) {
+                normalizedTypeName = "_" + normalizedTypeName;
+            }
+        }
+
+        public String getBaseType() {
+            return baseType;
+        }
+
+        public String getFullType() {
+            return fullType;
+        }
+
+        public int[] getTypeModifiers() {
+            return typeModifiers;
+        }
+
+        public boolean isArray() {
+            return isArray;
+        }
+
+        public String getNormalizedTypeName() {
+            return normalizedTypeName;
+        }
+
+        public boolean isOptional() {
+            return optional;
+        }
+    }
+
+
+    private String columnName;
+    private String typeWithModifiers;
+    private boolean optional;
+    private TypeMetadata typeMetadata;
+    private boolean hasMetadata;
+
+    public AbstractReplicationMessageColumn(String columnName, String typeWithModifiers, boolean optional, ReplicationMessage message) {
+        super();
+        this.columnName = columnName;
+        this.typeWithModifiers = typeWithModifiers;
+        this.optional = optional;
+        this.hasMetadata = message.hasMetadata();
+    }
+
+    private void initMetadata() {
+        assert hasMetadata : "Metadata not available";
+        typeMetadata = new TypeMetadata(columnName, typeWithModifiers, optional);
+    }
+
+    /**
+     * @return OID value of the type
+     */
+    @Override
+    public int getType() {
+        if (hasMetadata) {
+            initMetadata();
+            return typeMetadata.isArray() ? Types.ARRAY : getOidType();
+        }
+        return getOidType();
+    }
+
+    /**
+     * @return OID type of elements for arrays
+     */
+    @Override
+    public int getArrayElementOidType() {
+        initMetadata();
+        assert typeMetadata.isArray();
+        return getOidType();
+    }
+
+    /**
+     * @return the type of the field in format as used in JDBC driver
+     */
+    @Override
+    public String getTypeName() {
+        initMetadata();
+        return typeMetadata.getNormalizedTypeName();
+    }
+
+    @Override
+    public String getName() {
+        return columnName;
+    }
+
+    /**
+     * @return the type modifiers associated with type
+     */
+    @Override
+    public int[] getTypeModifiers() {
+        initMetadata();
+        return typeMetadata.getTypeModifiers();
+    }
+
+    /**
+     * @return true if the column is optional
+     */
+    @Override
+    public boolean isOptional() {
+        assert hasMetadata : "Metadata not available";
+        return optional;
+    }
+
+    protected abstract int getOidType();
+
+    protected TypeMetadata getTypeMetadata() {
+        initMetadata();
+        return typeMetadata;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractReplicationMessageColumn.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractReplicationMessageColumn.java
@@ -140,12 +140,12 @@ public abstract class AbstractReplicationMessageColumn implements ReplicationMes
     private TypeMetadata typeMetadata;
     private final boolean hasMetadata;
 
-    public AbstractReplicationMessageColumn(String columnName, String typeWithModifiers, boolean optional, ReplicationMessage message) {
+    public AbstractReplicationMessageColumn(String columnName, String typeWithModifiers, boolean optional, boolean hasMetadata) {
         super();
         this.columnName = columnName;
         this.typeWithModifiers = typeWithModifiers;
         this.optional = optional;
-        this.hasMetadata = message.hasMetadata();
+        this.hasMetadata = hasMetadata;
     }
 
     private void initMetadata() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractReplicationMessageColumn.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractReplicationMessageColumn.java
@@ -81,13 +81,13 @@ public abstract class AbstractReplicationMessageColumn implements ReplicationMes
                 typeModifiers = new int[typeModifiersStr.length];
                 for (int i = 0; i < typeModifiersStr.length; i++) {
                     try {
-                    typeModifiers[i] = Integer.parseInt(typeModifiersStr[i]);
+                        typeModifiers[i] = Integer.parseInt(typeModifiersStr[i]);
                     } catch (NumberFormatException e) {
                         throw new ConnectException(String.format("Failed to parse type modifier '%s' for column %s", typeModifiersStr[i], columnName));
                     }
                 }
             }
-            boolean isArray = (m.group("array") != null);
+            boolean isArray = m.group("array") != null;
 
             if (baseType.startsWith("_")) {
                 // old-style type specifiers use an _ prefix for arrays
@@ -202,7 +202,6 @@ public abstract class AbstractReplicationMessageColumn implements ReplicationMes
      */
     @Override
     public boolean isOptional() {
-        assert hasMetadata : "Metadata not available";
         return optional;
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractReplicationMessageColumn.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractReplicationMessageColumn.java
@@ -83,7 +83,6 @@ public abstract class AbstractReplicationMessageColumn implements ReplicationMes
                     try {
                     typeModifiers[i] = Integer.parseInt(typeModifiersStr[i]);
                     } catch (NumberFormatException e) {
-                        LOGGER.error("Failed to parse type modifier for {} '{}'", columnName, typeModifiersStr[i]);
                         throw new ConnectException(String.format("Failed to parse type modifier '%s' for column %s", typeModifiersStr[i], columnName));
                     }
                 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoder.java
@@ -32,10 +32,30 @@ public interface MessageDecoder {
 
     /**
      * Allows MessageDecoder to configure options with which the replication stream is started.
+     * The messages CAN contain type metadata.
      * See PostgreSQL command START_REPLICATION SLOT for more details.
      *
      * @param builder
      * @return the builder instance
      */
-    ChainedLogicalStreamBuilder options(final ChainedLogicalStreamBuilder builder);
+    ChainedLogicalStreamBuilder optionsWithMetadata(final ChainedLogicalStreamBuilder builder);
+
+    /**
+     * Allows MessageDecoder to configure options with which the replication stream is started.
+     * The messages MUST NOT contain type metadata.
+     * See PostgreSQL command START_REPLICATION SLOT for more details.
+     *
+     * @param builder
+     * @return the builder instance
+     */
+    ChainedLogicalStreamBuilder optionsWithoutMetadata(final ChainedLogicalStreamBuilder builder);
+
+    /**
+     * Signals to MessageDecoder that the plug-in may or must not contain type metadata.
+     * 
+     * @param flag - <code>true</code> if messages CAN contain type metadata,
+     * <code>false</code> if messages must not contain type metadata 
+     */
+    default void canHaveMetadata(boolean flag) {
+    }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoder.java
@@ -56,6 +56,6 @@ public interface MessageDecoder {
      * @param flag - <code>true</code> if messages CAN contain type metadata,
      * <code>false</code> if messages must not contain type metadata 
      */
-    default void canHaveMetadata(boolean flag) {
+    default void setMayContainMetadata(boolean flag) {
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -154,13 +154,13 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         PGReplicationStream s;
         try {
             s = startPgReplicationStream(lsn, messageDecoder::optionsWithMetadata);
-            messageDecoder.canHaveMetadata(true);
+            messageDecoder.setMayContainMetadata(true);
         } catch (PSQLException e) {
             if (e.getMessage().matches("(?s)ERROR: option .* is unknown.*")) {
                 // It is possible we are connecting to an old wal2json plug-in
                 LOGGER.warn("Could not register for streaming with metadata in messages, falling back to messages without metadata");
                 s = startPgReplicationStream(lsn, messageDecoder::optionsWithoutMetadata);
-                messageDecoder.canHaveMetadata(false);
+                messageDecoder.setMayContainMetadata(false);
             } else {
                 throw e;
             }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
@@ -35,8 +35,12 @@ public interface ReplicationMessage {
      */
     public interface Column {
         String getName();
-        Object getType();
+        int getType();
+        int getArrayElementOidType();
+        String getTypeName();
         Object getValue(final PgConnectionSupplier connection);
+        int[] getTypeModifiers();
+        boolean isOptional();
     }
 
     /**
@@ -68,4 +72,9 @@ public interface ReplicationMessage {
      * @return Set of new values of table columns, null for DELETE
      */
     public List<Column> getNewTupleList();
+
+    /**
+     * @return true if type metadata are passed as a part of message
+     */
+    boolean hasMetadata();
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoMessageDecoder.java
@@ -47,10 +47,6 @@ public class PgProtoMessageDecoder implements MessageDecoder {
             final byte[] content = Arrays.copyOfRange(source, buffer.arrayOffset(), source.length);
             final RowMessage message = PgProto.RowMessage.parseFrom(content);
             if (!message.getNewTypeinfoList().isEmpty() && message.getNewTupleCount() != message.getNewTypeinfoCount()) {
-                LOGGER.error("Message from transaction {} has {} data columns but only {} of type info",
-                        message.getTransactionId(),
-                        message.getNewTupleCount(),
-                        message.getNewTypeinfoCount());
                 throw new ConnectException(String.format("Message from transaction {} has {} data columns but only {} of type info",
                         message.getTransactionId(),
                         message.getNewTupleCount(),

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoMessageDecoder.java
@@ -10,12 +10,15 @@ import java.sql.SQLException;
 import java.util.Arrays;
 
 import org.postgresql.replication.fluent.logical.ChainedLogicalStreamBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import io.debezium.connector.postgresql.connection.MessageDecoder;
 import io.debezium.connector.postgresql.connection.ReplicationStream.ReplicationMessageProcessor;
 import io.debezium.connector.postgresql.proto.PgProto;
+import io.debezium.connector.postgresql.proto.PgProto.RowMessage;
 
 /**
  * ProtoBuf deserialization of message sent by <a href="https://github.com/debezium/postgres-decoderbufs">Postgres Decoderbufs</>.
@@ -25,6 +28,8 @@ import io.debezium.connector.postgresql.proto.PgProto;
  *
  */
 public class PgProtoMessageDecoder implements MessageDecoder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PgProtoMessageDecoder.class);
 
     public PgProtoMessageDecoder() {
         super();
@@ -37,9 +42,17 @@ public class PgProtoMessageDecoder implements MessageDecoder {
                 throw new IllegalStateException(
                         "Invalid buffer received from PG server during streaming replication");
             }
-            byte[] source = buffer.array();
-            byte[] content = Arrays.copyOfRange(source, buffer.arrayOffset(), source.length);
-            processor.process(new PgProtoReplicationMessage(PgProto.RowMessage.parseFrom(content)));
+            final byte[] source = buffer.array();
+            final byte[] content = Arrays.copyOfRange(source, buffer.arrayOffset(), source.length);
+            final RowMessage message = PgProto.RowMessage.parseFrom(content);
+            if (!message.getNewTypeinfoList().isEmpty() && message.getNewTupleCount() != message.getNewTypeinfoCount()) {
+                LOGGER.warn("Message from transaction {} has {} data columns but only {} of type info",
+                        message.getTransactionId(),
+                        message.getNewTupleCount(),
+                        message.getNewTypeinfoCount());
+                return;
+            }
+            processor.process(new PgProtoReplicationMessage(message));
         } catch (InvalidProtocolBufferException e) {
             throw new RuntimeException(e);
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoMessageDecoder.java
@@ -63,7 +63,12 @@ public class PgProtoMessageDecoder implements MessageDecoder {
     }
 
     @Override
-    public ChainedLogicalStreamBuilder options(ChainedLogicalStreamBuilder builder) {
+    public ChainedLogicalStreamBuilder optionsWithMetadata(ChainedLogicalStreamBuilder builder) {
+        return builder;
+    }
+
+    @Override
+    public ChainedLogicalStreamBuilder optionsWithoutMetadata(ChainedLogicalStreamBuilder builder) {
         return builder;
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
@@ -11,8 +11,10 @@ import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.apache.kafka.connect.data.Field;
 import org.postgresql.geometric.PGpoint;
@@ -23,8 +25,10 @@ import org.slf4j.LoggerFactory;
 import io.debezium.connector.postgresql.PgOid;
 import io.debezium.connector.postgresql.PostgresValueConverter;
 import io.debezium.connector.postgresql.RecordsStreamProducer.PgConnectionSupplier;
+import io.debezium.connector.postgresql.connection.AbstractReplicationMessageColumn;
 import io.debezium.connector.postgresql.connection.ReplicationMessage;
 import io.debezium.connector.postgresql.proto.PgProto;
+import io.debezium.util.Strings;
 
 /**
  * Replication message representing message sent by <a href="https://github.com/debezium/postgres-decoderbufs">Postgres Decoderbufs</>
@@ -72,33 +76,38 @@ class PgProtoReplicationMessage implements ReplicationMessage {
 
     @Override
     public List<ReplicationMessage.Column> getOldTupleList() {
-        return transform(rawMessage.getOldTupleList());
+        return transform(rawMessage.getOldTupleList(), null);
     }
 
     @Override
     public List<ReplicationMessage.Column> getNewTupleList() {
-        return transform(rawMessage.getNewTupleList());
+        return transform(rawMessage.getNewTupleList(), rawMessage.getNewTypeinfoList());
     }
 
-    private List<ReplicationMessage.Column> transform(List<PgProto.DatumMessage> messageList) {
-        return messageList.stream()
-                .map(datum -> new ReplicationMessage.Column() {
+    @Override
+    public boolean hasMetadata() {
+        return !(rawMessage.getNewTypeinfoList() == null || rawMessage.getNewTypeinfoList().isEmpty());
+    }
 
-                    @Override
-                    public Object getValue(PgConnectionSupplier connection) {
-                        return PgProtoReplicationMessage.this.getValue(datum, connection);
-                    }
+    private List<ReplicationMessage.Column> transform(List<PgProto.DatumMessage> messageList, List<PgProto.TypeInfo> typeInfoList) {
+        return IntStream.range(0, messageList.size())
+                .mapToObj(index -> { 
+                    final PgProto.DatumMessage datum = messageList.get(index);
+                    final Optional<PgProto.TypeInfo> typeInfo = Optional.ofNullable(hasMetadata() && typeInfoList != null ? typeInfoList.get(index) : null);
+                    final String columnName = Strings.unquoteIdentifierPart(datum.getColumnName());
+                    return new AbstractReplicationMessageColumn(columnName, typeInfo.map(PgProto.TypeInfo::getModifier).orElse(null), typeInfo.map(PgProto.TypeInfo::getValueOptional).orElse(Boolean.FALSE), PgProtoReplicationMessage.this) {
 
-                    @Override
-                    public Object getType() {
-                        return datum.getColumnType();
-                    }
+                        @Override
+                        public Object getValue(PgConnectionSupplier connection) {
+                            return PgProtoReplicationMessage.this.getValue(datum, connection);
+                        }
 
-                    @Override
-                    public String getName() {
-                        return datum.getColumnName();
-                    }
-                })
+                        @Override
+                        protected int getOidType() {
+                            return (int)datum.getColumnType();
+                        };
+                    };
+                   })
                 .collect(Collectors.toList());
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
@@ -95,7 +95,7 @@ class PgProtoReplicationMessage implements ReplicationMessage {
                     final PgProto.DatumMessage datum = messageList.get(index);
                     final Optional<PgProto.TypeInfo> typeInfo = Optional.ofNullable(hasMetadata() && typeInfoList != null ? typeInfoList.get(index) : null);
                     final String columnName = Strings.unquoteIdentifierPart(datum.getColumnName());
-                    return new AbstractReplicationMessageColumn(columnName, typeInfo.map(PgProto.TypeInfo::getModifier).orElse(null), typeInfo.map(PgProto.TypeInfo::getValueOptional).orElse(Boolean.FALSE), PgProtoReplicationMessage.this) {
+                    return new AbstractReplicationMessageColumn(columnName, typeInfo.map(PgProto.TypeInfo::getModifier).orElse(null), typeInfo.map(PgProto.TypeInfo::getValueOptional).orElse(Boolean.FALSE), hasMetadata()) {
 
                         @Override
                         public Object getValue(PgConnectionSupplier connection) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonMessageDecoder.java
@@ -74,7 +74,7 @@ public class Wal2JsonMessageDecoder implements MessageDecoder {
     }
 
     @Override
-    public void canHaveMetadata(boolean flag) {
+    public void setMayContainMetadata(boolean flag) {
         canHaveMetadata = flag;
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonMessageDecoder.java
@@ -63,6 +63,7 @@ public class Wal2JsonMessageDecoder implements MessageDecoder {
             .withSlotOption("pretty-print", 1)
             .withSlotOption("write-in-chunks", 0)
             .withSlotOption("include-xids", 1)
-            .withSlotOption("include-timestamp", 1);
+            .withSlotOption("include-timestamp", 1)
+            .withSlotOption("include-not-null", "true");
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
@@ -10,9 +10,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -31,6 +28,8 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.postgresql.PostgresValueConverter;
 import io.debezium.connector.postgresql.RecordsStreamProducer.PgConnectionSupplier;
+import io.debezium.connector.postgresql.connection.AbstractReplicationMessageColumn;
+import io.debezium.connector.postgresql.connection.AbstractReplicationMessageColumn.TypeMetadata;
 import io.debezium.connector.postgresql.connection.ReplicationMessage;
 import io.debezium.document.Array;
 import io.debezium.document.Document;
@@ -45,7 +44,6 @@ import io.debezium.util.Strings;
 class Wal2JsonReplicationMessage implements ReplicationMessage {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Wal2JsonReplicationMessage.class);
-    private static final Pattern TYPE_PATTERN = Pattern.compile("^(?<full>(?<base>[^(\\[]+)(?:\\((?<mod>.+)\\))?(?<suffix>.*?))(?<array>\\[\\])?$");
 
     private final int txId;
     private final long commitTime;
@@ -90,18 +88,24 @@ class Wal2JsonReplicationMessage implements ReplicationMessage {
     @Override
     public List<ReplicationMessage.Column> getOldTupleList() {
         final Document oldkeys = rawMessage.getDocument("oldkeys");
-        return oldkeys != null ? transform(oldkeys, "keynames", "keytypes", "keyvalues") : null;
+        return oldkeys != null ? transform(oldkeys, "keynames", "keytypes", "keyvalues", "columnoptionals") : null;
     }
 
     @Override
     public List<ReplicationMessage.Column> getNewTupleList() {
-        return transform(rawMessage, "columnnames", "columntypes", "columnvalues");
+        return transform(rawMessage, "columnnames", "columntypes", "columnvalues", "columnoptionals");
     }
 
-    private List<ReplicationMessage.Column> transform(final Document data, final String nameField, final String typeField, final String valueField) {
+    @Override
+    public boolean hasMetadata() {
+        return true;
+    }
+
+    private List<ReplicationMessage.Column> transform(final Document data, final String nameField, final String typeField, final String valueField, final String optionalsField) {
         final Array columnNames = data.getArray(nameField);
         final Array columnTypes = data.getArray(typeField);
         final Array columnValues = data.getArray(valueField);
+        final Array columnOptionals = data.getArray(optionalsField);
 
         if (columnNames.size() != columnTypes.size() || columnNames.size() != columnValues.size()) {
             throw new ConnectException("Column related arrays do not have the same size");
@@ -112,23 +116,19 @@ class Wal2JsonReplicationMessage implements ReplicationMessage {
         for (int i = 0; i < columnNames.size(); i++) {
             String columnName = columnNames.get(i).asString();
             String columnType = columnTypes.get(i).asString();
+            boolean columnOptional = columnOptionals != null ? columnOptionals.get(i).asBoolean() : false;
             Value rawValue = columnValues.get(i);
 
-            columns.add(new ReplicationMessage.Column() {
+            columns.add(new AbstractReplicationMessageColumn(columnName, columnType, columnOptional, Wal2JsonReplicationMessage.this) {
 
                 @Override
                 public Object getValue(PgConnectionSupplier connection) {
-                    return Wal2JsonReplicationMessage.this.getValue(columnName, columnType, rawValue, connection);
+                    return Wal2JsonReplicationMessage.this.getValue(columnName, getTypeMetadata(), rawValue, connection);
                 }
 
                 @Override
-                public String getType() {
-                    return columnType;
-                }
-
-                @Override
-                public String getName() {
-                    return columnName;
+                protected int getOidType() {
+                    return 0;
                 }
             });
         }
@@ -147,53 +147,27 @@ class Wal2JsonReplicationMessage implements ReplicationMessage {
      *
      * @return the value; may be null
      */
-    public Object getValue(String columnName, String columnType, Value rawValue, final PgConnectionSupplier connection) {
+    public Object getValue(String columnName, TypeMetadata typeMetadata, Value rawValue, final PgConnectionSupplier connection) {
         if (rawValue.isNull()) {
             // nulls are null
             return null;
         }
 
-        // we support wal2json both before & after commit 0255f2ac, which means we may get old-style type names
-        // (eg. int2, timetz, varchar, numeric, _int4)
-        // or new-style/verbose ones
-        // (eg. smallint; time with time zone; character varying (255); decimal (10,3), integer[])
-
-        Matcher m = TYPE_PATTERN.matcher(columnType);
-        if (!m.matches()) {
-            LOGGER.error("Failed to parse columnType for {} '{}'", columnName, columnType);
-            throw new ConnectException(String.format("Failed to parse columnType '%s' for column %s", columnType, columnName));
-        }
-        String fullType = m.group("full");
-        String baseType = m.group("base").trim();
-        if (!Objects.toString(m.group("suffix"), "").isEmpty()) {
-            baseType = String.join(" ", baseType, m.group("suffix").trim());
-        }
-
-        boolean isArray = (m.group("array") != null);
-
-        if (baseType.startsWith("_")) {
-            // old-style type specifiers use an _ prefix for arrays
-            // e.g. int4[] would be "_int4"
-            baseType = baseType.substring(1);
-            fullType = fullType.substring(1);
-            isArray = true;
-        }
-
-        if (isArray) {
+        if (typeMetadata.isArray()) {
             try {
                 final String dataString = rawValue.asString();
-                PgArray arrayData = new PgArray(connection.get(), connection.get().getTypeInfo().getPGArrayType(fullType), dataString);
+                PgArray arrayData = new PgArray(connection.get(), connection.get().getTypeInfo().getPGArrayType(typeMetadata.getFullType()), dataString);
                 Object deserializedArray = arrayData.getArray();
                 // TODO: what types are these? Shouldn't they pass through this function again?
                 return Arrays.asList((Object[])deserializedArray);
             }
             catch (SQLException e) {
-                LOGGER.warn("Unexpected exception trying to process PgArray ({}) column '{}', {}", columnType, columnName, e);
+                LOGGER.warn("Unexpected exception trying to process PgArray ({}) column '{}', {}", typeMetadata.getFullType(), columnName, e);
             }
             return null;
         }
 
-        switch (baseType) {
+        switch (typeMetadata.getBaseType()) {
             // include all types from https://www.postgresql.org/docs/current/static/datatype.html#DATATYPE-TABLE
             // plus aliases from the shorter names produced by older wal2json
             case "boolean":

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
@@ -48,11 +48,13 @@ class Wal2JsonReplicationMessage implements ReplicationMessage {
     private final int txId;
     private final long commitTime;
     private final Document rawMessage;
+    private final boolean hasMetadata;
 
-    public Wal2JsonReplicationMessage(final int txId, final long commitTime, final Document rawMessage) {
+    public Wal2JsonReplicationMessage(final int txId, final long commitTime, final Document rawMessage, final boolean hasMetadata) {
         this.txId = txId;
         this.commitTime = commitTime;
         this.rawMessage = rawMessage;
+        this.hasMetadata = hasMetadata;
     }
 
     @Override
@@ -98,7 +100,7 @@ class Wal2JsonReplicationMessage implements ReplicationMessage {
 
     @Override
     public boolean hasMetadata() {
-        return true;
+        return hasMetadata;
     }
 
     private List<ReplicationMessage.Column> transform(final Document data, final String nameField, final String typeField, final String valueField, final String optionalsField) {
@@ -119,7 +121,7 @@ class Wal2JsonReplicationMessage implements ReplicationMessage {
             boolean columnOptional = columnOptionals != null ? columnOptionals.get(i).asBoolean() : false;
             Value rawValue = columnValues.get(i);
 
-            columns.add(new AbstractReplicationMessageColumn(columnName, columnType, columnOptional, Wal2JsonReplicationMessage.this) {
+            columns.add(new AbstractReplicationMessageColumn(columnName, columnType, columnOptional, true) {
 
                 @Override
                 public Object getValue(PgConnectionSupplier connection) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
@@ -26,6 +26,7 @@ import org.postgresql.util.PGmoney;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.connector.postgresql.PgOid;
 import io.debezium.connector.postgresql.PostgresValueConverter;
 import io.debezium.connector.postgresql.RecordsStreamProducer.PgConnectionSupplier;
 import io.debezium.connector.postgresql.connection.AbstractReplicationMessageColumn;
@@ -130,7 +131,9 @@ class Wal2JsonReplicationMessage implements ReplicationMessage {
 
                 @Override
                 protected int getOidType() {
-                    return 0;
+                    return getTypeMetadata().isArray() ?
+                            PgOid.typeNameToOid(getTypeMetadata().getNormalizedTypeName().substring(1)) :
+                            PgOid.typeNameToOid(getTypeMetadata().getNormalizedTypeName());
                 }
             });
         }

--- a/debezium-connector-postgres/src/main/proto/pg_logicaldec.proto
+++ b/debezium-connector-postgres/src/main/proto/pg_logicaldec.proto
@@ -30,6 +30,11 @@ message DatumMessage {
     }
 }
 
+message TypeInfo {
+    required string modifier = 1;
+    required bool value_optional = 2;
+}
+
 message RowMessage {
     optional uint32 transaction_id = 1;
     optional uint64 commit_time = 2;
@@ -37,4 +42,5 @@ message RowMessage {
     optional Op op = 4;
     repeated DatumMessage new_tuple = 5;
     repeated DatumMessage old_tuple = 6;
+    repeated TypeInfo new_typeinfo = 7;
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -403,7 +403,7 @@ public abstract class AbstractRecordsProducerTest {
             Schema schema = content.schema();
             Field field = schema.field(fieldName);
             assertNotNull(fieldName + " not found in schema " + schema, field);
-            assertEquals("Schema for " + field + " does not match the actual value", this.schema, field.schema());
+            assertEquals("Schema for " + field.name() + " does not match the actual value", this.schema, field.schema());
         }
     }
 

--- a/debezium-core/src/main/java/io/debezium/relational/ColumnImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnImpl.java
@@ -153,7 +153,7 @@ final class ColumnImpl implements Column, Comparable<Column> {
     }
 
     @Override
-    public ColumnEditor edit()  {
+    public ColumnEditor edit() {
         final ColumnEditor editor = Column.editor()
                 .name(name())
                 .type(typeName(), typeExpression())

--- a/debezium-core/src/main/java/io/debezium/relational/ColumnImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnImpl.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.relational;
 
+import java.sql.Types;
+
 import io.debezium.util.Strings;
 
 final class ColumnImpl implements Column, Comparable<Column> {
@@ -149,10 +151,10 @@ final class ColumnImpl implements Column, Comparable<Column> {
         if (generated) sb.append(" GENERATED");
         return sb.toString();
     }
-    
+
     @Override
     public ColumnEditor edit()  {
-        return Column.editor()
+        final ColumnEditor editor = Column.editor()
                 .name(name())
                 .type(typeName(), typeExpression())
                 .jdbcType(jdbcType())
@@ -163,6 +165,9 @@ final class ColumnImpl implements Column, Comparable<Column> {
                 .optional(isOptional())
                 .autoIncremented(isAutoIncremented())
                 .generated(isGenerated());
-}
-
+        if (jdbcType() == Types.ARRAY) {
+            editor.componentType(componentType());
+        }
+        return editor;
+    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-379

This is a request for preliminary preview
requires
* https://github.com/debezium/postgres-decoderbufs/pull/10
* https://github.com/debezium/postgres-decoderbufs/pull/11

and it is expected to be modified after https://github.com/debezium/debezium/pull/347 is merged

Two things need to be modified yet
 * `PgOid` handling is incosistent and can trigger wals schema refresh (albeit with the correct result)
 * `tableFromFromMessage` - a `switch` statement that reconciles differences between decoder types and JDBC types will be extracetd elsewhere
 


