### PR TITLE
DBZ-389: More flexibility in Snapshot and Binlog Readers

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -354,7 +354,7 @@ public class BinlogReader extends AbstractReader {
     public Document getLastOffsetDocument() {
         return SourceInfo.createDocumentFromOffset(lastOffset);
     }
-    
+
     @Override
     protected void doStop() {
         try {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 
 import io.debezium.annotation.Immutable;
-import io.debezium.document.Document;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 
@@ -86,7 +85,7 @@ public class BinlogReader extends AbstractReader {
     private com.github.shyiko.mysql.binlog.GtidSet gtidSet;
 
     // This reader will attempt to halt once this predicate returns true when given the current offset.
-    private final Predicate<Document> offsetHaltPredicate;
+    private final Predicate<Map<String, ?>> offsetHaltPredicate;
 
     public static class BinlogPosition {
         final String filename;
@@ -144,7 +143,7 @@ public class BinlogReader extends AbstractReader {
      * @param context the task context in which this reader is running; may not be null
      * @param offsetHaltPredicate predicate for halting this reader once a particular offset has been reached; may be null.
      */
-    public BinlogReader(String name, MySqlTaskContext context, Predicate<Document> offsetHaltPredicate) {
+    public BinlogReader(String name, MySqlTaskContext context, Predicate<Map<String, ?>> offsetHaltPredicate) {
         super(name, context);
         this.offsetHaltPredicate = offsetHaltPredicate == null ? new NeverHaltPredicate() : offsetHaltPredicate;
 
@@ -340,19 +339,19 @@ public class BinlogReader extends AbstractReader {
      * Halting predicate that always returns false.
      */
     @Immutable
-    private static class NeverHaltPredicate implements Predicate<Document> {
+    private static class NeverHaltPredicate implements Predicate<Map<String, ?>> {
 
         @Override
-        public boolean test(Document fields) {
+        public boolean test(Map<String, ?> offset) {
             return false;
         }
     }
 
     /**
-     * @return a Document representing the last offset.
+     * @return a copy of the last offset of this reader.
      */
-    public Document getLastOffsetDocument() {
-        return SourceInfo.createDocumentFromOffset(lastOffset);
+    public Map<String, ?> getLastOffset() {
+        return new HashMap<>(lastOffset);
     }
 
     @Override
@@ -399,8 +398,7 @@ public class BinlogReader extends AbstractReader {
                     previousOutputMillis += millisSinceLastOutput;
                 }
             }
-            Document lastOffsetDocument = getLastOffsetDocument();
-            if (offsetHaltPredicate.test(lastOffsetDocument)) {
+            if (offsetHaltPredicate.test(lastOffset)) {
                 this.stop();
             }
         }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
@@ -62,6 +62,12 @@ public class Filters {
     private final Predicate<ColumnId> columnFilter;
     private final ColumnMappers columnMappers;
 
+    // store this information for easy extraction later.
+    private final String dbWhitelist;
+    private final String dbBlacklist;
+    private final String tableWhitelist;
+    private final String tableBlacklist;
+
     /**
      * @param config the configuration; may not be null
      */
@@ -69,18 +75,23 @@ public class Filters {
         this.isBuiltInDb = Filters::isBuiltInDatabase;
         this.isBuiltInTable = Filters::isBuiltInTable;
 
+        this.dbWhitelist = config.getString(MySqlConnectorConfig.DATABASE_WHITELIST);
+        this.dbBlacklist = config.getString(MySqlConnectorConfig.DATABASE_BLACKLIST);
+        this.tableWhitelist = config.getString(MySqlConnectorConfig.TABLE_WHITELIST);
+        this.tableBlacklist = config.getString(MySqlConnectorConfig.TABLE_BLACKLIST);
+
         // Define the filter used for database names ...
         Predicate<String> dbFilter = Selectors.databaseSelector()
-                                              .includeDatabases(config.getString(MySqlConnectorConfig.DATABASE_WHITELIST))
-                                              .excludeDatabases(config.getString(MySqlConnectorConfig.DATABASE_BLACKLIST))
+                                              .includeDatabases(dbWhitelist)
+                                              .excludeDatabases(dbBlacklist)
                                               .build();
 
         // Define the filter using the whitelists and blacklists for tables and database names ...
         Predicate<TableId> tableFilter = Selectors.tableSelector()
-                                                  .includeDatabases(config.getString(MySqlConnectorConfig.DATABASE_WHITELIST))
-                                                  .excludeDatabases(config.getString(MySqlConnectorConfig.DATABASE_BLACKLIST))
-                                                  .includeTables(config.getString(MySqlConnectorConfig.TABLE_WHITELIST))
-                                                  .excludeTables(config.getString(MySqlConnectorConfig.TABLE_BLACKLIST))
+                                                  .includeDatabases(dbWhitelist)
+                                                  .excludeDatabases(dbBlacklist)
+                                                  .includeTables(tableWhitelist)
+                                                  .excludeTables(tableBlacklist)
                                                   .build();
 
         // Ignore built-in databases and tables ...
@@ -136,4 +147,19 @@ public class Filters {
         return columnMappers;
     }
 
+    public String getDatabaseWhitelist() {
+        return this.dbWhitelist;
+    }
+
+    public String getDatabaseBlacklist() {
+        return this.dbBlacklist;
+    }
+
+    public String getTableWhitelist() {
+        return this.tableWhitelist;
+    }
+
+    public String getTableBlacklist() {
+        return this.tableBlacklist;
+    }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
@@ -7,6 +7,7 @@ package io.debezium.connector.mysql;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -62,49 +63,17 @@ public class Filters {
     private final Predicate<ColumnId> columnFilter;
     private final ColumnMappers columnMappers;
 
-    // store this information for easy extraction later.
-    private final String dbWhitelist;
-    private final String dbBlacklist;
-    private final String tableWhitelist;
-    private final String tableBlacklist;
-
-    /**
-     * @param config the configuration; may not be null
-     */
-    public Filters(Configuration config) {
-        this.isBuiltInDb = Filters::isBuiltInDatabase;
-        this.isBuiltInTable = Filters::isBuiltInTable;
-
-        this.dbWhitelist = config.getString(MySqlConnectorConfig.DATABASE_WHITELIST);
-        this.dbBlacklist = config.getString(MySqlConnectorConfig.DATABASE_BLACKLIST);
-        this.tableWhitelist = config.getString(MySqlConnectorConfig.TABLE_WHITELIST);
-        this.tableBlacklist = config.getString(MySqlConnectorConfig.TABLE_BLACKLIST);
-
-        // Define the filter used for database names ...
-        Predicate<String> dbFilter = Selectors.databaseSelector()
-                                              .includeDatabases(dbWhitelist)
-                                              .excludeDatabases(dbBlacklist)
-                                              .build();
-
-        // Define the filter using the whitelists and blacklists for tables and database names ...
-        Predicate<TableId> tableFilter = Selectors.tableSelector()
-                                                  .includeDatabases(dbWhitelist)
-                                                  .excludeDatabases(dbBlacklist)
-                                                  .includeTables(tableWhitelist)
-                                                  .excludeTables(tableBlacklist)
-                                                  .build();
-
-        // Ignore built-in databases and tables ...
-        if (config.getBoolean(MySqlConnectorConfig.TABLES_IGNORE_BUILTIN)) {
-            this.tableFilter = tableFilter.and(isBuiltInTable.negate());
-            this.dbFilter = dbFilter.and(isBuiltInDb.negate());
-        } else {
-            this.tableFilter = tableFilter;
-            this.dbFilter = dbFilter;
-        }
-
-        // Define the filter that excludes blacklisted columns, truncated columns, and masked columns ...
-        this.columnFilter = Selectors.excludeColumns(config.getString(MySqlConnectorConfig.COLUMN_BLACKLIST));
+    private Filters(Predicate<String> dbFilter,
+                    Predicate<TableId> tableFilter,
+                    Predicate<String> isBuiltInDb,
+                    Predicate<TableId> isBuiltInTable,
+                    Predicate<ColumnId> columnFilter,
+                    Configuration config) {
+        this.dbFilter = dbFilter;
+        this.tableFilter = tableFilter;
+        this.isBuiltInDb = isBuiltInDb;
+        this.isBuiltInTable = isBuiltInTable;
+        this.columnFilter = columnFilter;
 
         // Define the truncated, masked, and mapped columns ...
         ColumnMappers.Builder columnMapperBuilder = ColumnMappers.create();
@@ -147,19 +116,148 @@ public class Filters {
         return columnMappers;
     }
 
-    public String getDatabaseWhitelist() {
-        return this.dbWhitelist;
-    }
+    public static class Builder {
 
-    public String getDatabaseBlacklist() {
-        return this.dbBlacklist;
-    }
+        private Predicate<String> dbFilter;
+        private Predicate<TableId> tableFilter;
+        private Predicate<String> isBuiltInDb = Filters::isBuiltInDatabase;
+        private Predicate<TableId> isBuiltInTable = Filters::isBuiltInTable;
+        private Predicate<ColumnId> columnFilter;
+        private final Configuration config;
 
-    public String getTableWhitelist() {
-        return this.tableWhitelist;
-    }
+        /**
+         * Create a Builder for a filter.
+         * Set the initial filter data to match the filter data in the given configuration.
+         * @param config the configuration of the connector.
+         */
+        public Builder(Configuration config) {
+            this.config = config;
+            setFiltersFromStrings(config.getString(MySqlConnectorConfig.DATABASE_WHITELIST),
+                                  config.getString(MySqlConnectorConfig.DATABASE_BLACKLIST),
+                                  config.getString(MySqlConnectorConfig.TABLE_WHITELIST),
+                                  config.getString(MySqlConnectorConfig.TABLE_BLACKLIST));
+        }
 
-    public String getTableBlacklist() {
-        return this.tableBlacklist;
+        /**
+         * Completely reset the filter to match the filter info in the given offsets.
+         * This will completely reset the filters to those passed in.
+         * @param offsets The offsets to set the filter info to.
+         * @return this
+         */
+        public Builder setFiltersFromOffsets(Map<String, ?> offsets) {
+            setFiltersFromStrings((String)offsets.get(SourceInfo.DATABASE_WHITELIST_KEY),
+                                  (String)offsets.get(SourceInfo.DATABASE_BLACKLIST_KEY),
+                                  (String)offsets.get(SourceInfo.TABLE_WHITELIST_KEY),
+                                  (String)offsets.get(SourceInfo.TABLE_BLACKLIST_KEY));
+            return this;
+        }
+
+        private void setFiltersFromStrings(String dbWhitelist,
+                                           String dbBlacklist,
+                                           String tableWhitelist,
+                                           String tableBlacklist) {
+            Predicate<String> dbFilter = Selectors.databaseSelector()
+                .includeDatabases(dbWhitelist)
+                .excludeDatabases(dbBlacklist)
+                .build();
+
+            // Define the filter using the whitelists and blacklists for tables and database names ...
+            Predicate<TableId> tableFilter = Selectors.tableSelector()
+                .includeDatabases(dbWhitelist)
+                .excludeDatabases(dbBlacklist)
+                .includeTables(tableWhitelist)
+                .excludeTables(tableBlacklist)
+                .build();
+
+            // Ignore built-in databases and tables ...
+            if (config.getBoolean(MySqlConnectorConfig.TABLES_IGNORE_BUILTIN)) {
+                this.tableFilter = tableFilter.and(isBuiltInTable.negate());
+                this.dbFilter = dbFilter.and(isBuiltInDb.negate());
+            } else {
+                this.tableFilter = tableFilter;
+                this.dbFilter = dbFilter;
+            }
+        }
+
+        /**
+         * Set the filter to match the given other filter.
+         * This will completely reset the filters to those passed in.
+         * @param filters The other filter
+         * @return this
+         */
+        public Builder setFiltersFromFilters(Filters filters) {
+            this.dbFilter = filters.dbFilter;
+            this.tableFilter = filters.tableFilter;
+            this.isBuiltInDb = filters.isBuiltInDb;
+            this.isBuiltInTable = filters.isBuiltInTable;
+            this.columnFilter = filters.columnFilter;
+            return this;
+        }
+
+        /**
+         * Exclude all those tables included by the given filter.
+         * @param otherFilter the filter
+         * @return this
+         */
+        public Builder excludeAllTables(Filters otherFilter) {
+            excludeDatabases(otherFilter.dbFilter);
+            excludeTables(otherFilter.tableFilter);
+            return this;
+        }
+
+        /**
+         * Exclude all the databases that the given predicate tests as true for.
+         * @param databases the databases to excluded
+         * @return
+         */
+        public Builder excludeDatabases(Predicate<String> databases) {
+            this.dbFilter = this.dbFilter.and(databases.negate());
+            return this;
+        }
+
+        /**
+         * Include all the databases that the given predicate tests as true for.
+         * All databases previously included will still be included.
+         * @param databases the databases to be included
+         * @return
+         */
+        public Builder includeDatabases(Predicate<String> databases) {
+            this.dbFilter = this.dbFilter.or(databases);
+            return this;
+        }
+
+        /**
+         * Exclude all the tables that the given predicate tests as true for.
+         * @param tables the tables to be excluded.
+         * @return this
+         */
+        public Builder excludeTables(Predicate<TableId> tables) {
+            this.tableFilter = this.tableFilter.and(tables.negate());
+            return this;
+        }
+
+        /**
+         * Include the tables that the given predicate tests as true for.
+         * Tables previously included will still be included.
+         * @param tables the tables to be included.
+         * @return this
+         */
+        public Builder includeTables(Predicate<TableId> tables) {
+            this.tableFilter = this.tableFilter.or(tables);
+            return this;
+        }
+
+        /**
+         * Build the filters.
+         * @return the {@link Filters}
+         */
+        public Filters build() {
+            return new Filters(this.dbFilter,
+                               this.tableFilter,
+                               this.isBuiltInDb,
+                               this.isBuiltInTable,
+                               this.columnFilter,
+                               this.config);
+        }
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -357,7 +357,9 @@ public class MySqlConnectorConfig {
     }
 
     private static final String DATABASE_WHITELIST_NAME = "database.whitelist";
+    private static final String DATABASE_BLACKLIST_NAME = "database.blacklist";
     private static final String TABLE_WHITELIST_NAME = "table.whitelist";
+    private static final String TABLE_BLACKLIST_NAME = "table.blacklist";
     private static final String TABLE_IGNORE_BUILTIN_NAME = "table.ignore.builtin";
 
     /**
@@ -501,7 +503,7 @@ public class MySqlConnectorConfig {
      * A comma-separated list of regular expressions that match database names to be excluded from monitoring.
      * May not be used with {@link #DATABASE_WHITELIST}.
      */
-    public static final Field DATABASE_BLACKLIST = Field.create("database.blacklist")
+    public static final Field DATABASE_BLACKLIST = Field.create(DATABASE_BLACKLIST_NAME)
                                                         .withDisplayName("Exclude Databases")
                                                         .withType(Type.STRING)
                                                         .withWidth(Width.LONG)
@@ -529,7 +531,7 @@ public class MySqlConnectorConfig {
      * monitoring. Fully-qualified names for tables are of the form {@code <databaseName>.<tableName>} or
      * {@code <databaseName>.<schemaName>.<tableName>}. May not be used with {@link #TABLE_WHITELIST}.
      */
-    public static final Field TABLE_BLACKLIST = Field.create("table.blacklist")
+    public static final Field TABLE_BLACKLIST = Field.create(TABLE_BLACKLIST_NAME)
                                                      .withDisplayName("Exclude Tables")
                                                      .withType(Type.STRING)
                                                      .withWidth(Width.LONG)

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -164,6 +164,14 @@ public final class MySqlConnectorTask extends SourceTask {
                     readers.add(binlogReader);
                 }
             } else {
+                if (!source.hasFilterInfo()) {
+                    // if we don't have filter info, either
+                    // 1. the snapshot was taken in a version of debezium before the filter info was stored in the offsets, or
+                    // 2. this connector previously had no filter information.
+                    // either way, we have to assume that the filter information currently in the config accurately reflects
+                    // the current state of the connector.
+                    source.setFilterData(new Filters(config));
+                }
                 if (!rowBinlogEnabled) {
                     throw new ConnectException(
                             "The MySQL server does not appear to be using a row-level binlog, which is required for this connector to work properly. Enable this mode and restart the connector.");

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
@@ -82,8 +82,11 @@ public class MySqlSchema {
      *          returns {@code true} if a GTID source is to be included, or {@code false} if a GTID source is to be excluded;
      *          may be null if not needed
      */
-    public MySqlSchema(Configuration config, String serverName, Predicate<String> gtidFilter) {
-        this.filters = new Filters(config);
+    public MySqlSchema(Configuration config,
+                       String serverName,
+                       Filters tableFilters,
+                       Predicate<String> gtidFilter) {
+        this.filters = tableFilters;
         this.ddlParser = new MySqlDdlParser(false);
         this.tables = new Tables();
         this.ddlChanges = new DdlChanges(this.ddlParser.terminator());

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -36,7 +36,7 @@ public final class MySqlTaskContext extends MySqlJdbcContext {
     private final Predicate<String> ddlFilter;
     private final Clock clock = Clock.system();
 
-    public MySqlTaskContext(Configuration config) {
+    public MySqlTaskContext(Configuration config, Filters filters) {
         super(config);
 
         // Set up the topic selector ...
@@ -53,7 +53,7 @@ public final class MySqlTaskContext extends MySqlJdbcContext {
                 : (gtidSetExcludes != null ? Predicates.excludesUuids(gtidSetExcludes) : null);
 
         // Set up the MySQL schema ...
-        this.dbSchema = new MySqlSchema(config, serverName(), this.gtidSourceFilter);
+        this.dbSchema = new MySqlSchema(config, serverName(), filters, this.gtidSourceFilter);
 
         // Set up the record processor ...
         this.recordProcessor = new RecordMakers(dbSchema, source, topicSelector);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -655,7 +655,7 @@ public class SnapshotReader extends AbstractReader {
                     // are not denoted as a snapshot ...
                     source.completeSnapshot();
                     // set the filter in the offset
-                    source.setFilterData(filters);
+                    source.setFilterDataFromConfig(context.config);
                 } finally {
                     // Set the completion flag ...
                     completeSuccessfully();

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -654,6 +654,8 @@ public class SnapshotReader extends AbstractReader {
                     // Mark the source as having completed the snapshot. This will ensure the `source` field on records
                     // are not denoted as a snapshot ...
                     source.completeSnapshot();
+                    // set the filter in the offset
+                    source.setFilterData(filters);
                 } finally {
                     // Set the completion flag ...
                     completeSuccessfully();

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import io.debezium.config.Configuration;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -477,14 +478,14 @@ final class SourceInfo {
     }
 
     /**
-     * Set the filter data for the offset from the given {@link Filters}
-     * @param filters the filters
+     * Set the filter data for the offset from the given {@link Configuration}
+     * @param config the configuration
      */
-    public void setFilterData(Filters filters) {
-        this.databaseWhitelist = filters.getDatabaseWhitelist();
-        this.databaseBlacklist = filters.getDatabaseBlacklist();
-        this.tableWhitelist = filters.getTableWhitelist();
-        this.tableBlacklist = filters.getTableBlacklist();
+    public void setFilterDataFromConfig(Configuration config) {
+        this.databaseWhitelist = config.getString(MySqlConnectorConfig.DATABASE_WHITELIST);
+        this.databaseBlacklist = config.getString(MySqlConnectorConfig.DATABASE_BLACKLIST);
+        this.tableWhitelist = config.getString(MySqlConnectorConfig.TABLE_WHITELIST);
+        this.tableBlacklist = config.getString(MySqlConnectorConfig.TABLE_BLACKLIST);
     }
 
     /**
@@ -542,6 +543,14 @@ final class SourceInfo {
             this.tableWhitelist = (String) sourceOffset.get(TABLE_WHITELIST_KEY);
             this.tableBlacklist = (String) sourceOffset.get(TABLE_BLACKLIST_KEY);
         }
+    }
+
+    public static boolean offsetsHaveFilterInfo(Map<String, ?> sourceOffset) {
+        return sourceOffset != null &&
+            sourceOffset.containsKey(DATABASE_BLACKLIST_KEY) ||
+            sourceOffset.containsKey(DATABASE_WHITELIST_KEY) ||
+            sourceOffset.containsKey(TABLE_BLACKLIST_KEY) ||
+            sourceOffset.containsKey(TABLE_WHITELIST_KEY);
     }
 
     private long longOffsetValue(Map<String, ?> values, String key) {
@@ -644,6 +653,24 @@ final class SourceInfo {
             }
         }
         return sb.toString();
+    }
+    
+    /**
+     * Create a {@link Document} from the given offset.
+     *
+     * @param offset the offset to create the document from.
+     * @return a {@link Document} with the offset data.
+     */
+    public static Document createDocumentFromOffset(Map<String, ?> offset) {
+        Document offsetDocument = Document.create();
+        // all of the offset keys represent int, long, or string types, so we  don't need to worry about references
+        // and information changing underneath us.
+
+        for (Map.Entry<String, ?> entry : offset.entrySet()) {
+            offsetDocument.set(entry.getKey(), entry.getValue());
+        }
+
+        return offsetDocument;
     }
 
     /**

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/BinlogReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/BinlogReaderIT.java
@@ -109,11 +109,12 @@ public class BinlogReaderIT {
     @Test
     public void shouldCreateSnapshotOfSingleDatabase() throws Exception {
         config = simpleConfig().build();
-        context = new MySqlTaskContext(config);
+        Filters filters = new Filters.Builder(config).build();
+        context = new MySqlTaskContext(config, filters);
         context.start();
         context.source().setBinlogStartPoint("",0L); // start from beginning
         context.initializeHistory();
-        reader = new BinlogReader("binlog", context);
+        reader = new BinlogReader("binlog", context, null);
 
         // Start reading the binlog ...
         reader.start();
@@ -169,11 +170,12 @@ public class BinlogReaderIT {
     @Test
     public void shouldCreateSnapshotOfSingleDatabaseWithSchemaChanges() throws Exception {
         config = simpleConfig().with(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES, true).build();
-        context = new MySqlTaskContext(config);
+        Filters filters = new Filters.Builder(config).build();
+        context = new MySqlTaskContext(config, filters);
         context.start();
         context.source().setBinlogStartPoint("",0L); // start from beginning
         context.initializeHistory();
-        reader = new BinlogReader("binlog", context);
+        reader = new BinlogReader("binlog", context, null);
 
         // Start reading the binlog ...
         reader.start();
@@ -240,11 +242,12 @@ public class BinlogReaderIT {
                                .with(MySqlConnectorConfig.DATABASE_WHITELIST, REGRESSION_DATABASE.getDatabaseName())
                                .with(MySqlConnectorConfig.TABLE_WHITELIST, REGRESSION_DATABASE.qualifiedTableName(tableName))
                                .build();
-        context = new MySqlTaskContext(config);
+        Filters filters = new Filters.Builder(config).build();
+        context = new MySqlTaskContext(config, filters);
         context.start();
         context.source().setBinlogStartPoint("",0L); // start from beginning
         context.initializeHistory();
-        reader = new BinlogReader("binlog", context);
+        reader = new BinlogReader("binlog", context, null);
 
         // Start reading the binlog ...
         reader.start();

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/BinlogReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/BinlogReaderIT.java
@@ -283,11 +283,12 @@ public class BinlogReaderIT {
                                .with(MySqlConnectorConfig.DATABASE_WHITELIST, REGRESSION_DATABASE.getDatabaseName())
                                .with(MySqlConnectorConfig.TABLE_WHITELIST, REGRESSION_DATABASE.qualifiedTableName(tableName))
                                .build();
-        context = new MySqlTaskContext(config);
+        Filters filters = new Filters.Builder(config).build();
+        context = new MySqlTaskContext(config, filters);
         context.start();
         context.source().setBinlogStartPoint("",0L); // start from beginning
         context.initializeHistory();
-        reader = new BinlogReader("binlog", context);
+        reader = new BinlogReader("binlog", context, null);
 
         // Start reading the binlog ...
         reader.start();

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/Configurator.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/Configurator.java
@@ -16,73 +16,84 @@ import io.debezium.relational.history.FileDatabaseHistory;
  * 
  * @author Randall Hauch
  */
-public class Configurator {
+/*package local*/ class Configurator {
 
     private Configuration.Builder configBuilder = Configuration.create();
 
-    public Configurator with(Field field, String value) {
+    /*package local*/ Configurator with(Field field, String value) {
         configBuilder.with(field, value);
         return this;
     }
 
-    public Configurator with(Field field, boolean value) {
+    /*package local*/ Configurator with(Field field, boolean value) {
         configBuilder.with(field, value);
         return this;
     }
 
-    public Configurator serverName(String serverName) {
+    /*package local*/ Configurator serverName(String serverName) {
         return with(MySqlConnectorConfig.SERVER_NAME, serverName);
     }
 
-    public Configurator includeDatabases(String regexList) {
+    /*package local*/ Configurator includeDatabases(String regexList) {
         return with(MySqlConnectorConfig.DATABASE_WHITELIST, regexList);
     }
 
-    public Configurator excludeDatabases(String regexList) {
+    /*package local*/ Configurator excludeDatabases(String regexList) {
         return with(MySqlConnectorConfig.DATABASE_BLACKLIST, regexList);
     }
 
-    public Configurator includeTables(String regexList) {
+    /*package local*/ Configurator includeTables(String regexList) {
         return with(MySqlConnectorConfig.TABLE_WHITELIST, regexList);
     }
 
-    public Configurator excludeTables(String regexList) {
+    /*package local*/ Configurator excludeTables(String regexList) {
         return with(MySqlConnectorConfig.TABLE_BLACKLIST, regexList);
     }
 
-    public Configurator excludeColumns(String regexList) {
+    /*package local*/ Configurator excludeColumns(String regexList) {
         return with(MySqlConnectorConfig.COLUMN_BLACKLIST, regexList);
     }
 
-    public Configurator truncateColumns(int length, String fullyQualifiedTableNames) {
+    /*package local*/ Configurator truncateColumns(int length, String fullyQualifiedTableNames) {
         return with(MySqlConnectorConfig.TRUNCATE_COLUMN(length), fullyQualifiedTableNames);
     }
 
-    public Configurator maskColumns(int length, String fullyQualifiedTableNames) {
+   /*package local*/ Configurator maskColumns(int length, String fullyQualifiedTableNames) {
         return with(MySqlConnectorConfig.MASK_COLUMN(length), fullyQualifiedTableNames);
     }
 
-    public Configurator excludeBuiltInTables() {
+    /*package local*/ Configurator excludeBuiltInTables() {
         return with(MySqlConnectorConfig.TABLES_IGNORE_BUILTIN, true);
     }
 
-    public Configurator includeBuiltInTables() {
+    /*package local*/ Configurator includeBuiltInTables() {
         return with(MySqlConnectorConfig.TABLES_IGNORE_BUILTIN, false);
     }
 
-    public Configurator storeDatabaseHistoryInFile(Path path) {
+    /*package local*/ Configurator storeDatabaseHistoryInFile(Path path) {
         with(MySqlConnectorConfig.DATABASE_HISTORY, FileDatabaseHistory.class.getName());
         with(FileDatabaseHistory.FILE_PATH,path.toAbsolutePath().toString());
         return this;
     }
 
-    public Filters createFilters() {
-        return new Filters(configBuilder.build());
+    /*package local*/ Filters createFilters() {
+        return new Filters.Builder(configBuilder.build()).build();
     }
 
-    public MySqlSchema createSchemas() {
+    /*package local*/ MySqlSchema createSchemas() {
         Configuration config = configBuilder.build();
-        return new MySqlSchema(config,config.getString(MySqlConnectorConfig.SERVER_NAME), null);
+        return new MySqlSchema(config,
+                               config.getString(MySqlConnectorConfig.SERVER_NAME),
+                               createFilters(),
+                               null);
+    }
+
+    /*package local*/ MySqlSchema createSchemasWithFilter(Filters filters) {
+        Configuration config = configBuilder.build();
+        return new MySqlSchema(config,
+                               config.getString(MySqlConnectorConfig.SERVER_NAME),
+                               filters,
+                               null);
     }
 
 }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTaskContextIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTaskContextIT.java
@@ -21,7 +21,7 @@ public class MySqlTaskContextIT extends MySqlTaskContextTest {
     @Test
     public void shouldCreateTaskFromConfiguration() throws Exception {
         config = simpleConfig().build();
-        context = new MySqlTaskContext(config);
+        context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
         assertThat(context.config()).isSameAs(config);
 
@@ -56,7 +56,7 @@ public class MySqlTaskContextIT extends MySqlTaskContextTest {
     @Test
     public void shouldCloseJdbcConnectionOnShutdown() throws Exception {
         config = simpleConfig().build();
-        context = new MySqlTaskContext(config);
+        context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
 
         assertNotConnectedToJdbc();

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTaskContextTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTaskContextTest.java
@@ -92,7 +92,7 @@ public class MySqlTaskContextTest {
     public void shouldCreateTaskFromConfigurationWithNeverSnapshotMode() throws Exception {
         config = simpleConfig().with(MySqlConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
                                .build();
-        context = new MySqlTaskContext(config);
+        context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
 
         assertThat("" + context.snapshotMode().getValue()).isEqualTo(SnapshotMode.NEVER.getValue());
@@ -104,7 +104,7 @@ public class MySqlTaskContextTest {
     public void shouldCreateTaskFromConfigurationWithWhenNeededSnapshotMode() throws Exception {
         config = simpleConfig().with(MySqlConnectorConfig.SNAPSHOT_MODE, SnapshotMode.WHEN_NEEDED)
                                .build();
-        context = new MySqlTaskContext(config);
+        context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
 
         assertThat("" + context.snapshotMode().getValue()).isEqualTo(SnapshotMode.WHEN_NEEDED.getValue());
@@ -116,7 +116,7 @@ public class MySqlTaskContextTest {
     public void shouldUseGtidSetIncludes() throws Exception {
         config = simpleConfig().with(MySqlConnectorConfig.GTID_SOURCE_INCLUDES, "a,b,c,d.*")
                                .build();
-        context = new MySqlTaskContext(config);
+        context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
 
         Predicate<String> filter = context.gtidSourceFilter();
@@ -143,7 +143,7 @@ public class MySqlTaskContextTest {
         config = simpleConfig().with(MySqlConnectorConfig.GTID_SOURCE_INCLUDES,
                                      "036d85a9-64e5-11e6-9b48-42010af0000c,7145bf69-d1ca-11e5-a588-0242ac110004")
                                .build();
-        context = new MySqlTaskContext(config);
+        context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
 
         Predicate<String> filter = context.gtidSourceFilter();
@@ -173,7 +173,7 @@ public class MySqlTaskContextTest {
         config = simpleConfig().with(MySqlConnectorConfig.GTID_SOURCE_EXCLUDES,
                                      "7c1de3f2-3fd2-11e6-9cdc-42010af000bc")
                                .build();
-        context = new MySqlTaskContext(config);
+        context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
 
         Predicate<String> filter = context.gtidSourceFilter();
@@ -202,7 +202,7 @@ public class MySqlTaskContextTest {
                                .with(MySqlConnectorConfig.GTID_SOURCE_EXCLUDES,
                                      "7c1de3f2-3fd2-11e6-9cdc-42010af000bc:1-41")
                                .build();
-        context = new MySqlTaskContext(config);
+        context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         boolean valid = config.validateAndRecord(MySqlConnectorConfig.ALL_FIELDS, msg -> {});
         assertThat(valid).isFalse();
     }
@@ -217,7 +217,7 @@ public class MySqlTaskContextTest {
         config = simpleConfig().with(MySqlConnectorConfig.GTID_SOURCE_INCLUDES,
                                      "036d85a9-64e5-11e6-9b48-42010af0000c")
                                .build();
-        context = new MySqlTaskContext(config);
+        context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
         context.source().setCompletedGtidSet(gtidStr);
 
@@ -245,7 +245,7 @@ public class MySqlTaskContextTest {
                 + "d079cbb3-750f-11e6-954e-42010af00c28:1-11544291:11544293-11885648";
         config = simpleConfig().with(MySqlConnectorConfig.GTID_SOURCE_EXCLUDES, "96c2072e-e428-11e6-9590-42010a28002d")
                                .build();
-        context = new MySqlTaskContext(config);
+        context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
         context.source().setCompletedGtidSet(lastGtidStr);
         HistoryRecordComparator comparator = context.dbSchema().historyComparator();
@@ -272,7 +272,7 @@ public class MySqlTaskContextTest {
     public void shouldIgnoreDatabaseHistoryProperties() throws Exception {
         config = simpleConfig().with(KafkaDatabaseHistory.TOPIC, "dummytopic")
                                .build();
-        context = new MySqlTaskContext(config);
+        context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
 
         context.jdbc().config().forEach((k, v) -> {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotReaderIT.java
@@ -80,7 +80,7 @@ public class SnapshotReaderIT {
     public void shouldCreateSnapshotOfSingleDatabase() throws Exception {
         config = simpleConfig()
                 .build();
-        context = new MySqlTaskContext(config);
+        context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
         reader = new SnapshotReader("snapshot", context);
         reader.uponCompletion(completed::countDown);
@@ -177,7 +177,7 @@ public class SnapshotReaderIT {
     @Test
     public void shouldCreateSnapshotOfSingleDatabaseUsingReadEvents() throws Exception {
         config = simpleConfig().with(MySqlConnectorConfig.DATABASE_WHITELIST, "connector_(.*)_" + DATABASE.getIdentifier()).build();
-        context = new MySqlTaskContext(config);
+        context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
         reader = new SnapshotReader("snapshot", context);
         reader.uponCompletion(completed::countDown);
@@ -276,7 +276,7 @@ public class SnapshotReaderIT {
     @Test
     public void shouldCreateSnapshotOfSingleDatabaseWithSchemaChanges() throws Exception {
         config = simpleConfig().with(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES, true).build();
-        context = new MySqlTaskContext(config);
+        context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
         reader = new SnapshotReader("snapshot", context);
         reader.uponCompletion(completed::countDown);
@@ -375,7 +375,7 @@ public class SnapshotReaderIT {
     @Test
     public void shouldCreateSnapshotSchemaOnly() throws Exception {
         config = simpleConfig().with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.SCHEMA_ONLY).build();
-        context = new MySqlTaskContext(config);
+        context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
         reader = new SnapshotReader("snapshot", context);
         reader.uponCompletion(completed::countDown);

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
@@ -181,8 +181,7 @@ public class SourceInfoTest {
                                                          .with(MySqlConnectorConfig.DATABASE_BLACKLIST, databaseBlacklist)
                                                          .with(MySqlConnectorConfig.TABLE_BLACKLIST, tableBlacklist)
                                                          .build();
-        final Filters filters = new Filters(configuration);
-        source.setFilterData(filters);
+        source.setFilterDataFromConfig(configuration);
 
         assertThat(source.hasFilterInfo()).isTrue();
         assertEquals(databaseBlacklist, source.getDatabaseBlacklist());

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.mysql;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
@@ -13,6 +14,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import io.debezium.config.Configuration;
 import org.apache.avro.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.fest.assertions.GenericAssert;
@@ -147,6 +149,44 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(100);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isTrue();
+    }
+
+    @Test
+    public void shouldRecoverSourceInfoFromOffsetWithFilterData() {
+        final String databaseWhitelist = "a,b";
+        final String tableWhitelist = "c.foo,d.bar,d.baz";
+        Map<String, String> offset = offset(10, 10);
+        offset.put(SourceInfo.DATABASE_WHITELIST_KEY, databaseWhitelist);
+        offset.put(SourceInfo.TABLE_WHITELIST_KEY, tableWhitelist);
+
+        sourceWith(offset);
+        assertThat(source.hasFilterInfo()).isTrue();
+        assertEquals(databaseWhitelist, source.getDatabaseWhitelist());
+        assertEquals(tableWhitelist, source.getTableWhitelist());
+        // confirm other filter info is null
+        assertThat(source.getDatabaseBlacklist()).isNull();
+        assertThat(source.getTableBlacklist()).isNull();
+    }
+
+    @Test
+    public void setOffsetFilterFromFilter() {
+        final String databaseBlacklist = "a,b";
+        final String tableBlacklist = "c.foo, d.bar, d.baz";
+        Map<String, String> offset = offset(10, 10);
+
+        sourceWith(offset);
+        assertThat(!source.hasFilterInfo());
+
+        final Configuration configuration = Configuration.create()
+                                                         .with(MySqlConnectorConfig.DATABASE_BLACKLIST, databaseBlacklist)
+                                                         .with(MySqlConnectorConfig.TABLE_BLACKLIST, tableBlacklist)
+                                                         .build();
+        final Filters filters = new Filters(configuration);
+        source.setFilterData(filters);
+
+        assertThat(source.hasFilterInfo()).isTrue();
+        assertEquals(databaseBlacklist, source.getDatabaseBlacklist());
+        assertEquals(tableBlacklist, source.getTableBlacklist());
     }
 
     @Test


### PR DESCRIPTION
Have readers use filters directly rather than inferring a filter from the configuration directly.
Create methods to allow BinlogReaders to halt once a certain offset has been reached.
Create methods to determine if the configured whitelist/blacklist has been modified, and create methods to create
filters for the new and old configurations.
Rejigger some previously changed logic in Filters; filters no longer keep track of their string representation.