### PR TITLE
DBZ-519 NullPointerException happened for PAUSED task

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -151,7 +151,9 @@ public class PostgresConnectorTask extends SourceTask {
     
     @Override
     public void commit() throws InterruptedException {
-        producer.commit();
+        if (running.get()) {
+            producer.commit();
+        }
     }
     
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorTaskIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorTaskIT.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.postgresql;
+
+import io.debezium.doc.FixFor;
+import org.junit.Test;
+
+/**
+ * Integration test for {@link PostgresConnectorTask} class.
+ */
+public class PostgresConnectorTaskIT {
+
+    @Test
+    @FixFor("DBZ-519")
+    public void shouldNotThrowNullPointerExceptionDuringCommit() throws Exception {
+        PostgresConnectorTask postgresConnectorTask = new PostgresConnectorTask();
+        postgresConnectorTask.commit();
+    }
+}


### PR DESCRIPTION
PostgresConnectorTask throws java.lang.NullPointerException during commit for PAUSED connector after the restart of Kafka Connect application.

https://issues.jboss.org/browse/DBZ-519