### PR TITLE
Add KafkaCluster.zkPort()

### DIFF
--- a/debezium-core/src/test/java/io/debezium/kafka/KafkaCluster.java
+++ b/debezium-core/src/test/java/io/debezium/kafka/KafkaCluster.java
@@ -351,6 +351,15 @@ public class KafkaCluster {
         return joiner.toString();
     }
 
+    /**
+     * Get the Zookeeper port.
+     *
+     * @return the Zookeeper port
+     */
+    public int zkPort() {
+        return zkServer.getPort();
+    }
+
     private void shutdownReliably(KafkaServer server) {
         try {
             server.shutdown(deleteDataUponShutdown);


### PR DESCRIPTION
If you start a cluster (e.g. in a test) without specifying a port
you get a random port. Sometimes you might want to connect to the
embedded zookeeper instance (for instance, to make an assertion about
a znode). To do this you need to know the port number. So let's expose it.