### PR TITLE
DBZ-582 Introduced new configuration parameter 'kafka.force.compact.delete' t…

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -92,15 +92,14 @@ public class MongoDbConnectorConfig {
             .withValidation(Field::isBoolean)
             .withDescription("Whether invalid host names are allowed when using SSL. If true the connection will not prevent man-in-the-middle attacks");
 
-    public static final Field COMAPCT_DELETE_OPERATIONS = Field.create("kafka.force.compact.delete")
+    public static final Field COMPACT_DELETE_OPERATIONS = Field.create("tombstones.on.delete")
             .withDisplayName("Change the behaviour of Debezium with regards to delete operations")
             .withType(Type.BOOLEAN)
             .withWidth(Width.SHORT)
             .withImportance(Importance.MEDIUM)
             .withDefault(true)
             .withValidation(Field::isBoolean)
-            .withDescription("By default debezium will always produce two messages for each oplog delete operation, this is to allow kafka to compact " +
-                    "the topic. Change to false to produce only one message and maintain the full history of operations");
+            .withDescription("Whether delete operations should be represented by a delete event and a subsquent tombstone event (true) or only by a delete event (false). Emitting the tombstone event (the default behavior) allows Kafka to completely delete all events pertaining to the given key once the source record got deleted.");
 
     public static final Field MAX_COPY_THREADS = Field.create("initial.sync.max.threads")
                                                       .withDisplayName("Maximum number of threads for initial sync")
@@ -247,7 +246,7 @@ public class MongoDbConnectorConfig {
                                                      AUTO_DISCOVER_MEMBERS,
                                                      DATABASE_WHITELIST,
                                                      DATABASE_BLACKLIST,
-                                                     COMAPCT_DELETE_OPERATIONS);
+            COMPACT_DELETE_OPERATIONS);
 
     protected static Field.Set EXPOSED_FIELDS = ALL_FIELDS;
 
@@ -256,7 +255,7 @@ public class MongoDbConnectorConfig {
         Field.group(config, "MongoDB", HOSTS, USER, PASSWORD, LOGICAL_NAME, CONNECT_BACKOFF_INITIAL_DELAY_MS,
                     CONNECT_BACKOFF_MAX_DELAY_MS, MAX_FAILED_CONNECTIONS, AUTO_DISCOVER_MEMBERS,
                     SSL_ENABLED, SSL_ALLOW_INVALID_HOSTNAMES);
-        Field.group(config, "Events", DATABASE_WHITELIST, DATABASE_BLACKLIST, COLLECTION_WHITELIST, COLLECTION_BLACKLIST, COMAPCT_DELETE_OPERATIONS);
+        Field.group(config, "Events", DATABASE_WHITELIST, DATABASE_BLACKLIST, COLLECTION_WHITELIST, COLLECTION_BLACKLIST, COMPACT_DELETE_OPERATIONS);
         Field.group(config, "Connector", MAX_COPY_THREADS, MAX_QUEUE_SIZE, MAX_BATCH_SIZE, POLL_INTERVAL_MS);
         return config;
     }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -92,6 +92,16 @@ public class MongoDbConnectorConfig {
             .withValidation(Field::isBoolean)
             .withDescription("Whether invalid host names are allowed when using SSL. If true the connection will not prevent man-in-the-middle attacks");
 
+    public static final Field COMAPCT_DELETE_OPERATIONS = Field.create("kafka.force.compact.delete")
+            .withDisplayName("Change the behaviour of Debezium with regards to delete operations")
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.MEDIUM)
+            .withDefault(true)
+            .withValidation(Field::isBoolean)
+            .withDescription("By default debezium will always produce two messages for each oplog delete operation, this is to allow kafka to compact " +
+                    "the topic. Change to false to produce only one message and maintain the full history of operations");
+
     public static final Field MAX_COPY_THREADS = Field.create("initial.sync.max.threads")
                                                       .withDisplayName("Maximum number of threads for initial sync")
                                                       .withType(Type.INT)
@@ -236,7 +246,8 @@ public class MongoDbConnectorConfig {
                                                      COLLECTION_BLACKLIST,
                                                      AUTO_DISCOVER_MEMBERS,
                                                      DATABASE_WHITELIST,
-                                                     DATABASE_BLACKLIST);
+                                                     DATABASE_BLACKLIST,
+                                                     COMAPCT_DELETE_OPERATIONS);
 
     protected static Field.Set EXPOSED_FIELDS = ALL_FIELDS;
 
@@ -245,7 +256,7 @@ public class MongoDbConnectorConfig {
         Field.group(config, "MongoDB", HOSTS, USER, PASSWORD, LOGICAL_NAME, CONNECT_BACKOFF_INITIAL_DELAY_MS,
                     CONNECT_BACKOFF_MAX_DELAY_MS, MAX_FAILED_CONNECTIONS, AUTO_DISCOVER_MEMBERS,
                     SSL_ENABLED, SSL_ALLOW_INVALID_HOSTNAMES);
-        Field.group(config, "Events", DATABASE_WHITELIST, DATABASE_BLACKLIST, COLLECTION_WHITELIST, COLLECTION_BLACKLIST);
+        Field.group(config, "Events", DATABASE_WHITELIST, DATABASE_BLACKLIST, COLLECTION_WHITELIST, COLLECTION_BLACKLIST, COMAPCT_DELETE_OPERATIONS);
         Field.group(config, "Connector", MAX_COPY_THREADS, MAX_QUEUE_SIZE, MAX_BATCH_SIZE, POLL_INTERVAL_MS);
         return config;
     }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/RecordMakers.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/RecordMakers.java
@@ -13,6 +13,7 @@ import com.mongodb.DBCollection;
 import com.mongodb.MongoClient;
 import com.mongodb.util.JSONSerializers;
 import com.mongodb.util.ObjectSerializer;
+import io.debezium.config.Configuration;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -53,6 +54,7 @@ public class RecordMakers {
     private final Map<CollectionId, RecordsForCollection> recordMakerByCollectionId = new HashMap<>();
     private final Function<Document, String> valueTransformer;
     private final BlockingConsumer<SourceRecord> recorder;
+    protected final Configuration config;
 
     /**
      * Create the record makers using the supplied components.
@@ -61,12 +63,13 @@ public class RecordMakers {
      * @param topicSelector the selector for topic names; may not be null
      * @param recorder the potentially blocking consumer function to be called for each generated record; may not be null
      */
-    public RecordMakers(SourceInfo source, TopicSelector topicSelector, BlockingConsumer<SourceRecord> recorder) {
+    public RecordMakers(SourceInfo source, TopicSelector topicSelector, BlockingConsumer<SourceRecord> recorder, Configuration config) {
         this.source = source;
         this.topicSelector = topicSelector;
         JsonWriterSettings writerSettings = new JsonWriterSettings(JsonMode.STRICT, "", ""); // most compact JSON
         this.valueTransformer = (doc) -> doc.toJson(writerSettings);
         this.recorder = recorder;
+        this.config = config;
     }
 
     /**
@@ -78,7 +81,7 @@ public class RecordMakers {
     public RecordsForCollection forCollection(CollectionId collectionId) {
         return recordMakerByCollectionId.computeIfAbsent(collectionId, id -> {
             String topicName = topicSelector.getTopic(collectionId);
-            return new RecordsForCollection(collectionId, source, topicName, schemaNameValidator, valueTransformer, recorder);
+            return new RecordsForCollection(collectionId, source, topicName, schemaNameValidator, valueTransformer, recorder, config);
         });
     }
 
@@ -95,9 +98,10 @@ public class RecordMakers {
         private final Schema valueSchema;
         private final Function<Document, String> valueTransformer;
         private final BlockingConsumer<SourceRecord> recorder;
+        private final Configuration config;
 
         protected RecordsForCollection(CollectionId collectionId, SourceInfo source, String topicName, AvroValidator validator,
-                Function<Document, String> valueTransformer, BlockingConsumer<SourceRecord> recorder) {
+                Function<Document, String> valueTransformer, BlockingConsumer<SourceRecord> recorder, Configuration config) {
             this.sourcePartition = source.partition(collectionId.replicaSetName());
             this.collectionId = collectionId;
             this.replicaSetName = this.collectionId.replicaSetName();
@@ -118,6 +122,7 @@ public class RecordMakers {
             JsonWriterSettings writerSettings = new JsonWriterSettings(JsonMode.STRICT, "", ""); // most compact JSON
             this.valueTransformer = (doc) -> doc.toJson(writerSettings, MongoClient.getDefaultCodecRegistry().get(Document.class));
             this.recorder = recorder;
+            this.config = config;
         }
 
         /**
@@ -146,7 +151,6 @@ public class RecordMakers {
             assert objId != null;
             return createRecords(sourceValue, offset, Operation.READ, objId, object, timestamp);
         }
-
         /**
          * Generate and record one or more source records to describe the given event.
          * 
@@ -197,7 +201,7 @@ public class RecordMakers {
             SourceRecord record = new SourceRecord(sourcePartition, offset, topicName, partition, keySchema, key, valueSchema, value);
             recorder.accept(record);
 
-            if (operation == Operation.DELETE) {
+            if (operation == Operation.DELETE && config.getBoolean(MongoDbConnectorConfig.COMAPCT_DELETE_OPERATIONS)) {
                 // Also generate a tombstone event ...
                 record = new SourceRecord(sourcePartition, offset, topicName, partition, keySchema, key, null, null);
                 recorder.accept(record);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/RecordMakers.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/RecordMakers.java
@@ -53,7 +53,7 @@ public class RecordMakers {
     private final Map<CollectionId, RecordsForCollection> recordMakerByCollectionId = new HashMap<>();
     private final Function<Document, String> valueTransformer;
     private final BlockingConsumer<SourceRecord> recorder;
-    private final boolean compactOnDelete;
+    private final boolean emitTombstonesOnDelete;
 
     /**
      * Create the record makers using the supplied components.
@@ -62,13 +62,13 @@ public class RecordMakers {
      * @param topicSelector the selector for topic names; may not be null
      * @param recorder the potentially blocking consumer function to be called for each generated record; may not be null
      */
-    public RecordMakers(SourceInfo source, TopicSelector topicSelector, BlockingConsumer<SourceRecord> recorder, boolean compactOnDelete) {
+    public RecordMakers(SourceInfo source, TopicSelector topicSelector, BlockingConsumer<SourceRecord> recorder, boolean emitTombstonesOnDelete) {
         this.source = source;
         this.topicSelector = topicSelector;
         JsonWriterSettings writerSettings = new JsonWriterSettings(JsonMode.STRICT, "", ""); // most compact JSON
         this.valueTransformer = (doc) -> doc.toJson(writerSettings);
         this.recorder = recorder;
-        this.compactOnDelete = compactOnDelete;
+        this.emitTombstonesOnDelete = emitTombstonesOnDelete;
     }
 
     /**
@@ -80,7 +80,7 @@ public class RecordMakers {
     public RecordsForCollection forCollection(CollectionId collectionId) {
         return recordMakerByCollectionId.computeIfAbsent(collectionId, id -> {
             String topicName = topicSelector.getTopic(collectionId);
-            return new RecordsForCollection(collectionId, source, topicName, schemaNameValidator, valueTransformer, recorder, compactOnDelete);
+            return new RecordsForCollection(collectionId, source, topicName, schemaNameValidator, valueTransformer, recorder, emitTombstonesOnDelete);
         });
     }
 
@@ -97,10 +97,10 @@ public class RecordMakers {
         private final Schema valueSchema;
         private final Function<Document, String> valueTransformer;
         private final BlockingConsumer<SourceRecord> recorder;
-        private final boolean compactOnDelete;
+        private final boolean emitTombstonesOnDelete;
 
         protected RecordsForCollection(CollectionId collectionId, SourceInfo source, String topicName, AvroValidator validator,
-                Function<Document, String> valueTransformer, BlockingConsumer<SourceRecord> recorder, boolean compactOnDelete) {
+                Function<Document, String> valueTransformer, BlockingConsumer<SourceRecord> recorder, boolean emitTombstonesOnDelete) {
             this.sourcePartition = source.partition(collectionId.replicaSetName());
             this.collectionId = collectionId;
             this.replicaSetName = this.collectionId.replicaSetName();
@@ -121,7 +121,7 @@ public class RecordMakers {
             JsonWriterSettings writerSettings = new JsonWriterSettings(JsonMode.STRICT, "", ""); // most compact JSON
             this.valueTransformer = (doc) -> doc.toJson(writerSettings, MongoClient.getDefaultCodecRegistry().get(Document.class));
             this.recorder = recorder;
-            this.compactOnDelete = compactOnDelete;
+            this.emitTombstonesOnDelete = emitTombstonesOnDelete;
         }
 
         /**
@@ -200,7 +200,7 @@ public class RecordMakers {
             SourceRecord record = new SourceRecord(sourcePartition, offset, topicName, partition, keySchema, key, valueSchema, value);
             recorder.accept(record);
 
-            if (operation == Operation.DELETE && compactOnDelete) {
+            if (operation == Operation.DELETE && emitTombstonesOnDelete) {
                 // Also generate a tombstone event ...
                 record = new SourceRecord(sourcePartition, offset, topicName, partition, keySchema, key, null, null);
                 recorder.accept(record);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
@@ -115,7 +115,7 @@ public class Replicator {
         this.rsName = replicaSet.replicaSetName();
         this.copyThreads = Executors.newFixedThreadPool(context.maxNumberOfCopyThreads());
         this.bufferedRecorder = new BufferableRecorder(recorder);
-        this.recordMakers = new RecordMakers(this.source, context.topicSelector(), this.bufferedRecorder);
+        this.recordMakers = new RecordMakers(this.source, context.topicSelector(), this.bufferedRecorder, context.config);
         this.collectionFilter = this.context.collectionFilter();
         this.databaseFilter = this.context.databaseFilter();
         this.clock = this.context.clock();

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
@@ -115,7 +115,7 @@ public class Replicator {
         this.rsName = replicaSet.replicaSetName();
         this.copyThreads = Executors.newFixedThreadPool(context.maxNumberOfCopyThreads());
         this.bufferedRecorder = new BufferableRecorder(recorder);
-        this.recordMakers = new RecordMakers(this.source, context.topicSelector(), this.bufferedRecorder, context.config);
+        this.recordMakers = new RecordMakers(this.source, context.topicSelector(), this.bufferedRecorder, context.config.getBoolean(MongoDbConnectorConfig.COMPACT_DELETE_OPERATIONS));
         this.collectionFilter = this.context.collectionFilter();
         this.databaseFilter = this.context.databaseFilter();
         this.clock = this.context.clock();

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -108,6 +108,7 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.MAX_FAILED_CONNECTIONS);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.SSL_ENABLED);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.SSL_ALLOW_INVALID_HOSTNAMES);
+        assertNoConfigurationErrors(result, MongoDbConnectorConfig.COMAPCT_DELETE_OPERATIONS);
     }
 
     @Test
@@ -140,6 +141,7 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.MAX_FAILED_CONNECTIONS);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.SSL_ENABLED);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.SSL_ALLOW_INVALID_HOSTNAMES);
+        assertNoConfigurationErrors(result, MongoDbConnectorConfig.COMAPCT_DELETE_OPERATIONS);
     }
 
     @Test

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -108,7 +108,7 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.MAX_FAILED_CONNECTIONS);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.SSL_ENABLED);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.SSL_ALLOW_INVALID_HOSTNAMES);
-        assertNoConfigurationErrors(result, MongoDbConnectorConfig.COMAPCT_DELETE_OPERATIONS);
+        assertNoConfigurationErrors(result, MongoDbConnectorConfig.COMPACT_DELETE_OPERATIONS);
     }
 
     @Test
@@ -141,7 +141,7 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.MAX_FAILED_CONNECTIONS);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.SSL_ENABLED);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.SSL_ALLOW_INVALID_HOSTNAMES);
-        assertNoConfigurationErrors(result, MongoDbConnectorConfig.COMAPCT_DELETE_OPERATIONS);
+        assertNoConfigurationErrors(result, MongoDbConnectorConfig.COMPACT_DELETE_OPERATIONS);
     }
 
     @Test

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/RecordMakersTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/RecordMakersTest.java
@@ -46,7 +46,7 @@ public class RecordMakersTest {
     private RecordMakers recordMakers;
     private TopicSelector topicSelector;
     private List<SourceRecord> produced;
-    private boolean compactOnDelete;
+    private boolean emitTombstonesOnDelete;
 
 
     @Before
@@ -54,8 +54,8 @@ public class RecordMakersTest {
         source = new SourceInfo(SERVER_NAME);
         topicSelector = TopicSelector.defaultSelector(PREFIX);
         produced = new ArrayList<>();
-        compactOnDelete = true;
-        recordMakers = new RecordMakers(source, topicSelector, produced::add, compactOnDelete);
+        emitTombstonesOnDelete = true;
+        recordMakers = new RecordMakers(source, topicSelector, produced::add, emitTombstonesOnDelete);
     }
 
     @Test

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/RecordMakersTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/RecordMakersTest.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 
-import io.debezium.config.Configuration;
+import io.debezium.doc.FixFor;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.bson.BsonTimestamp;
@@ -46,7 +46,7 @@ public class RecordMakersTest {
     private RecordMakers recordMakers;
     private TopicSelector topicSelector;
     private List<SourceRecord> produced;
-    private Configuration configuration = Configuration.create().build();
+    private boolean compactOnDelete;
 
 
     @Before
@@ -54,7 +54,8 @@ public class RecordMakersTest {
         source = new SourceInfo(SERVER_NAME);
         topicSelector = TopicSelector.defaultSelector(PREFIX);
         produced = new ArrayList<>();
-        recordMakers = new RecordMakers(source, topicSelector, produced::add, configuration);
+        compactOnDelete = true;
+        recordMakers = new RecordMakers(source, topicSelector, produced::add, compactOnDelete);
     }
 
     @Test
@@ -165,9 +166,9 @@ public class RecordMakersTest {
     }
 
     @Test
+    @FixFor("DBZ-582")
     public void shouldGenerateRecordForDeleteEventWithoutTombstone() throws InterruptedException {
-        Configuration configurationTemp = Configuration.create().with(MongoDbConnectorConfig.COMAPCT_DELETE_OPERATIONS, "false").build();
-        RecordMakers recordMakersTemp = recordMakers = new RecordMakers(source, topicSelector, produced::add, configurationTemp);
+        RecordMakers recordMakersTemp = recordMakers = new RecordMakers(source, topicSelector, produced::add, false);
 
         BsonTimestamp ts = new BsonTimestamp(1000, 1);
         CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTest.java
@@ -44,7 +44,7 @@ public class UnwrapFromMongoDbEnvelopeTest {
     private RecordMakers recordMakers;
     private TopicSelector topicSelector;
     private List<SourceRecord> produced;
-    private boolean compactOnDelete;
+    private boolean emitTombstonesOnDelete;
 
     private UnwrapFromMongoDbEnvelope<SourceRecord> transformation;
 


### PR DESCRIPTION
…o allow user to decide whether he wants to have a null message produced alongside the delete operation message

## Problem synopsis 
Debezium aims to work with Kafka log compaction, however in certain scenarios this proves to be very problematic. It is definitely worth keeping that feature, but users should be given the option to decide if they really want it. In our case, real time, really fast ETL process with multiple transformations it simply prevented our application to work because of the unexpected null value on the topic.

### Detailed description of the problems which might be encountered by the users
The default behaviour is demonstrated here, screenshot from CLI with kafka-console-consumer running:
![1-1](https://user-images.githubusercontent.com/26857299/35485669-d0d2ffbe-045a-11e8-85cf-85ee9fd6a181.png)
As you can see for every delete operation, there is a delete message produced (1st row) and null message (2nd row)
This functionality is defined here, in debezium mongo connector code: 
```
                case DELETE:
                    // The delete event has nothing of any use, other than the _id which we already have in our key.
                    // So put nothing in the 'after' or 'patch' fields ...
                    break;
            }
            value.put(FieldName.SOURCE, source);
            value.put(FieldName.OPERATION, operation.code());
            value.put(FieldName.TIMESTAMP, timestamp);
            SourceRecord record = new SourceRecord(sourcePartition, offset, topicName, partition, keySchema, key, valueSchema, value);
            recorder.accept(record);
            if (operation == Operation.DELETE) {
                // Also generate a tombstone event ...
                record = new SourceRecord(sourcePartition, offset, topicName, partition, keySchema, key, null, null);
                recorder.accept(record);
                return 2;
            }
```
For log compaction it is fine, however this causes quite a serious problem for applications streaming from the oplog, using kafka streams API. In this case performance is everything so compaction is not the priority.

Consider the following code from Spring's `org.springframework.cloud.stream.binder.kstream`:
![2](https://user-images.githubusercontent.com/26857299/35485670-d0eb5686-045a-11e8-8421-d088b1419d8f.png)
The binder, binds to an inbound topic (Debezium) and reads from it automagically and tries to tackle the message, either cast it to an appropriate class or serve it to the client application as Message object, or String, or byte[] and so on. The problem is, if the message is `null` it will crash with `NullPointerException`. As you can see above on the breakpoint, `o2.getClass()` will of course generate the NullPointerException.

### Solution 
Added a new configuration flag (the default will keep the existing behaviour) `kafka.force.compact.delete` which is passed to `RecordMarkers` and changes the behaviour `createRecords()` method.
Please consider the following screenshot:
![3](https://user-images.githubusercontent.com/26857299/35485671-d102a43a-045a-11e8-95ad-7068ee584cdb.png)

The messages were picked by `kafka-console-consumer` again, the first message was produced with `kafka.force.compact.delete` config value set to `false`. As you can see, there's no `null` record following the delete operation record.
The second and third message were produced by debezium mongo connector running with `kafka.force.compact.delete` set to `true` - which is still a default behaviour for backwards compatibility.

### Unit Tests
Unit tests have been updated to cover this scenario
