### PR TITLE
DBZ-580 Establishing ChangeEventQueue type to be used as queue across all the connectors

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -8,12 +8,8 @@ package io.debezium.connector.postgresql;
 
 import java.sql.SQLException;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -24,14 +20,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.config.Configuration;
-import io.debezium.config.ConfigurationDefaults;
+import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
-import io.debezium.time.Temporals;
-import io.debezium.util.Clock;
 import io.debezium.util.LoggingContext;
-import io.debezium.util.Metronome;
-import io.debezium.util.Threads;
-import io.debezium.util.Threads.Timer;
 
 /**
  * Kafka connect source task which uses Postgres logical decoding over a streaming replication connection to process DB changes.
@@ -45,12 +36,14 @@ public class PostgresConnectorTask extends SourceTask {
     private final AtomicBoolean running = new AtomicBoolean(false);
 
     private PostgresTaskContext taskContext;
-    private BlockingQueue<ChangeEvent> queue;
-    private int maxBatchSize;
     private RecordsProducer producer;
-    private Metronome metronome;
-    private Duration pollInterval;
     private volatile long lastProcessedLsn;
+
+    /**
+     * A queue with change events filled by the snapshot and streaming producers, consumed
+     * by Kafka Connect via this task.
+     */
+    private ChangeEventQueue<ChangeEvent> changeEventQueue;
 
     @Override
     public void start(Map<String, String> props) {
@@ -72,10 +65,6 @@ public class PostgresConnectorTask extends SourceTask {
         // create the task context and schema...
         PostgresSchema schema = new PostgresSchema(config);
         this.taskContext = new PostgresTaskContext(config, schema);
-
-        // create the queue in which records will be produced
-        this.queue = new LinkedBlockingDeque<>(config.maxQueueSize());
-        this.maxBatchSize = config.maxBatchSize();
 
         SourceInfo sourceInfo = new SourceInfo(config.serverName());
         Map<String, Object> existingOffset = context.offsetStorageReader().offset(sourceInfo.partition());
@@ -118,28 +107,17 @@ public class PostgresConnectorTask extends SourceTask {
                 }
             }
 
-            metronome = Metronome.sleeper(config.pollIntervalMs(), TimeUnit.MILLISECONDS, Clock.SYSTEM);
-            pollInterval = Duration.ofMillis(config.pollIntervalMs());
-            producer.start(this::enqueueRecord);
+            changeEventQueue = new ChangeEventQueue.Builder<ChangeEvent>()
+                .pollInterval(Duration.ofMillis(config.pollIntervalMs()))
+                .maxBatchSize(config.maxBatchSize())
+                .maxQueueSize(config.maxQueueSize())
+                .loggingContextSupplier(this::getLoggingContext)
+                .build();
+
+            producer.start(changeEventQueue::enqueue, changeEventQueue::producerFailure);
             running.compareAndSet(false, true);
         }  catch (SQLException e) {
             throw new ConnectException(e);
-        } finally {
-            previousContext.restore();
-        }
-    }
-
-    private void enqueueRecord(ChangeEvent record) {
-        LoggingContext.PreviousContext previousContext = taskContext.configureLoggingContext(CONTEXT_NAME);
-        try {
-            queue.put(record);
-            if (logger.isDebugEnabled()) {
-                logger.debug("Placed source record '{}' into queue", record);
-            }
-        } catch (InterruptedException e) {
-            logger.debug("received interrupt request");
-            // clear the interrupted status
-            Thread.interrupted();
         } finally {
             previousContext.restore();
         }
@@ -164,43 +142,19 @@ public class PostgresConnectorTask extends SourceTask {
 
     @Override
     public List<SourceRecord> poll() throws InterruptedException {
-        LoggingContext.PreviousContext previousContext = taskContext.configureLoggingContext(CONTEXT_NAME);
-        try {
-            logger.debug("polling records...");
-            List<ChangeEvent> events = new ArrayList<>();
-            final Timer timeout = Threads.timer(Clock.SYSTEM, Temporals.max(pollInterval, ConfigurationDefaults.RETURN_CONTROL_INTERVAL));
-            while (running.get() && queue.drainTo(events, maxBatchSize) == 0) {
-                if (taskContext.getTaskFailure() != null) {
-                    throw new ConnectException(taskContext.getTaskFailure());
-                }
-                try {
-                    logger.debug("no records available yet, sleeping a bit...");
-                    // no records yet, so wait a bit
-                    metronome.pause();
-                    if (timeout.expired()) {
-                        break;
-                    }
-                    logger.debug("checking for more records...");
-                } catch (InterruptedException e) {
-                    // we've been requested to stop polling
-                    Thread.interrupted();
+        List<ChangeEvent> events = changeEventQueue.poll();
+
+        if (events.size() > 0) {
+            for (int i = events.size() - 1; i >= 0; i--) {
+                SourceRecord r = events.get(i).getRecord();
+                if (events.get(i).isLastOfLsn()) {
+                    Map<String, ?> offset = r.sourceOffset();
+                    lastProcessedLsn = (Long)offset.get(SourceInfo.LSN_KEY);
                     break;
                 }
             }
-            if (events.size() > 0) {
-                for (int i = events.size() - 1; i >= 0; i--) {
-                    SourceRecord r = events.get(i).getRecord();
-                    if (events.get(i).isLastOfLsn()) {
-                        Map<String, ?> offset = r.sourceOffset();
-                        lastProcessedLsn = (Long)offset.get(SourceInfo.LSN_KEY);
-                        break;
-                    }
-                }
-            }
-            return events.stream().map(ChangeEvent::getRecord).collect(Collectors.toList());
-        } finally {
-            previousContext.restore();
         }
+        return events.stream().map(ChangeEvent::getRecord).collect(Collectors.toList());
     }
 
     @Override
@@ -213,5 +167,9 @@ public class PostgresConnectorTask extends SourceTask {
     @Override
     public String version() {
         return Module.version();
+    }
+
+    private LoggingContext.PreviousContext getLoggingContext() {
+        return  taskContext.configureLoggingContext(CONTEXT_NAME);
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
@@ -10,9 +10,9 @@ import java.sql.SQLException;
 import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
@@ -183,8 +183,8 @@ public class PostgresSchema {
         return typeInfo.get(localTypeName);
     }
 
-    protected Stream<TableId> tables() {
-        return tables.tableIds().stream();
+    protected Set<TableId> tables() {
+        return tables.tableIds();
     }
 
     /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTaskContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTaskContext.java
@@ -27,7 +27,6 @@ public class PostgresTaskContext {
     private final Clock clock;
     private final TopicSelector topicSelector;
     private final PostgresSchema schema;
-    private volatile Throwable taskFailure;
 
     protected PostgresTaskContext(PostgresConnectorConfig config, PostgresSchema schema) {
         this.config = config;
@@ -93,14 +92,6 @@ public class PostgresTaskContext {
      */
     protected LoggingContext.PreviousContext configureLoggingContext(String contextName) {
         return LoggingContext.forConnector("Postgres", config.serverName(), contextName);
-    }
-
-    Throwable getTaskFailure() {
-        return taskFailure;
-    }
-
-    void failTask(final Throwable taskFailure) {
-        this.taskFailure = taskFailure;
     }
 
     PostgresConnectorConfig getConfig() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsProducer.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.data.Envelope;
+import io.debezium.function.BlockingConsumer;
 import io.debezium.relational.TableSchema;
 import io.debezium.util.Clock;
 
@@ -40,7 +41,7 @@ public abstract class RecordsProducer {
      *
      * @param recordsConsumer a consumer of {@link ChangeEvent} instances, may not be null
      */
-    protected abstract void start(Consumer<ChangeEvent> recordsConsumer, Consumer<Throwable> failureConsumer);
+    protected abstract void start(BlockingConsumer<ChangeEvent> recordsConsumer, Consumer<Throwable> failureConsumer);
 
     /**
      * Notification that offsets have been committed to Kafka up to the given LSN.

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsProducer.java
@@ -40,7 +40,7 @@ public abstract class RecordsProducer {
      *
      * @param recordsConsumer a consumer of {@link ChangeEvent} instances, may not be null
      */
-    protected abstract void start(Consumer<ChangeEvent> recordsConsumer);
+    protected abstract void start(Consumer<ChangeEvent> recordsConsumer, Consumer<Throwable> failureConsumer);
 
     /**
      * Notification that offsets have been committed to Kafka up to the given LSN.

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoder.java
@@ -28,7 +28,7 @@ public interface MessageDecoder {
      * @param buffer - binary representation of replication message
      * @param processor - message processing on arrival
      */
-    void processMessage(final ByteBuffer buffer, ReplicationMessageProcessor processor) throws SQLException;
+    void processMessage(final ByteBuffer buffer, ReplicationMessageProcessor processor) throws SQLException, InterruptedException;
 
     /**
      * Allows MessageDecoder to configure options with which the replication stream is started.

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -180,7 +180,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             private volatile LogSequenceNumber lastReceivedLSN;
 
             @Override
-            public void read(ReplicationMessageProcessor processor) throws SQLException {
+            public void read(ReplicationMessageProcessor processor) throws SQLException, InterruptedException {
                 ByteBuffer read = stream.read();
                 // the lsn we started from is inclusive, so we need to avoid sending back the same message twice
                 if (lsnLong >= stream.getLastReceiveLSN().asLong()) {
@@ -190,7 +190,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             }
 
             @Override
-            public void readPending(ReplicationMessageProcessor processor) throws SQLException {
+            public void readPending(ReplicationMessageProcessor processor) throws SQLException, InterruptedException {
                 ByteBuffer read = stream.readPending();
                 // the lsn we started from is inclusive, so we need to avoid sending back the same message twice
                 if (read == null ||  lsnLong >= stream.getLastReceiveLSN().asLong()) {
@@ -199,7 +199,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                 deserializeMessages(read, processor);
             }
 
-            private void deserializeMessages(ByteBuffer buffer, ReplicationMessageProcessor processor) throws SQLException {
+            private void deserializeMessages(ByteBuffer buffer, ReplicationMessageProcessor processor) throws SQLException, InterruptedException {
                 lastReceivedLSN = stream.getLastReceiveLSN();
                 messageDecoder.processMessage(buffer, processor);
             }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationStream.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationStream.java
@@ -18,7 +18,7 @@ import org.postgresql.replication.PGReplicationStream;
 public interface ReplicationStream extends AutoCloseable {
     @FunctionalInterface
     public interface ReplicationMessageProcessor {
-        void process(ReplicationMessage message) throws SQLException;
+        void process(ReplicationMessage message) throws SQLException, InterruptedException;
     }
 
     /**
@@ -29,7 +29,7 @@ public interface ReplicationStream extends AutoCloseable {
      * @throws SQLException if anything unexpected fails
      * @see PGReplicationStream#read()
      */
-    void read(ReplicationMessageProcessor processor) throws SQLException;
+    void read(ReplicationMessageProcessor processor) throws SQLException, InterruptedException;
 
     /**
      * Attempts to read a replication message from a replication connection, returning that message if it's available or returning
@@ -40,7 +40,7 @@ public interface ReplicationStream extends AutoCloseable {
      * @throws SQLException if anything unexpected fails
      * @see PGReplicationStream#readPending()
      */
-    void readPending(ReplicationMessageProcessor processor) throws SQLException;
+    void readPending(ReplicationMessageProcessor processor) throws SQLException, InterruptedException;
 
     /**
      * Sends a message to the server informing it about that latest position in the WAL that this stream has read via

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoMessageDecoder.java
@@ -29,7 +29,7 @@ import io.debezium.connector.postgresql.proto.PgProto.RowMessage;
 public class PgProtoMessageDecoder implements MessageDecoder {
 
     @Override
-    public void processMessage(final ByteBuffer buffer, ReplicationMessageProcessor processor) throws SQLException {
+    public void processMessage(final ByteBuffer buffer, ReplicationMessageProcessor processor) throws SQLException, InterruptedException {
         try {
             if (!buffer.hasArray()) {
                 throw new IllegalStateException(

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonMessageDecoder.java
@@ -40,7 +40,7 @@ public class Wal2JsonMessageDecoder implements MessageDecoder {
     private boolean containsMetadata = false;
 
     @Override
-    public void processMessage(ByteBuffer buffer, ReplicationMessageProcessor processor) throws SQLException {
+    public void processMessage(ByteBuffer buffer, ReplicationMessageProcessor processor) throws SQLException, InterruptedException {
         try {
             if (!buffer.hasArray()) {
                 throw new IllegalStateException("Invalid buffer received from PG server during streaming replication");

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -55,6 +55,7 @@ import io.debezium.data.Xml;
 import io.debezium.data.geometry.Geography;
 import io.debezium.data.geometry.Geometry;
 import io.debezium.data.geometry.Point;
+import io.debezium.function.BlockingConsumer;
 import io.debezium.relational.TableId;
 import io.debezium.time.Date;
 import io.debezium.time.MicroDuration;
@@ -522,7 +523,7 @@ public abstract class AbstractRecordsProducerTest {
          return new TestConsumer(expectedRecordsCount, topicPrefixes);
     }
 
-    protected static class TestConsumer implements Consumer<ChangeEvent> {
+    protected static class TestConsumer implements BlockingConsumer<ChangeEvent> {
         private final ConcurrentLinkedQueue<SourceRecord> records;
         private final VariableLatch latch;
         private final List<String> topicPrefixes;

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -66,7 +66,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         TestHelper.execute(statementsBuilder);
 
         //then start the producer and validate all records are there
-        snapshotProducer.start(consumer);
+        snapshotProducer.start(consumer, e -> {});
         consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
 
         Map<String, List<SchemaAndValueField>> expectedValuesByTableName = super.schemaAndValuesByTableName();
@@ -93,7 +93,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
 
         snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER), true);
         TestConsumer consumer = testConsumer(2, "s1", "s2");
-        snapshotProducer.start(consumer);
+        snapshotProducer.start(consumer, e -> {});
 
         // first make sure we get the initial records from both schemas...
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
@@ -122,7 +122,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         int expectedRecordsCount = 6;
         consumer = testConsumer(expectedRecordsCount, "s1", "s2");
         snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER), true);
-        snapshotProducer.start(consumer);
+        snapshotProducer.start(consumer, e -> {});
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
 
         AtomicInteger counter = new AtomicInteger(0);
@@ -176,7 +176,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         TestHelper.execute(statementsBuilder);
 
         //then start the producer and validate all records are there
-        snapshotProducer.start(consumer);
+        snapshotProducer.start(consumer, e -> {});
         consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
 
         Map<String, List<SchemaAndValueField>> expectedValuesByTableName = super.schemaAndValuesByTableNameAdaptiveTimeMicroseconds();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -46,7 +47,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
     private RecordsStreamProducer recordsProducer;
     private TestConsumer consumer;
-
+    private final Consumer<Throwable> blackHole = t -> {};
     @Rule
     public TestRule conditionalFail = new ConditionalFail();
 
@@ -77,7 +78,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         TestHelper.executeDDL("postgres_create_tables.ddl");
 
         consumer = testConsumer(1);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
 
         //numerical types
         assertInsert(INSERT_NUMERIC_TYPES_STMT, schemasAndValuesForNumericType());
@@ -124,7 +125,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         TestHelper.executeDDL("postgis_create_tables.ddl");
         consumer = testConsumer(1, "public"); // spatial_ref_sys produces a tonne of records in the postgis schema
         consumer.setIgnoreExtraRecords(true);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
 
         // need to wait for all the spatial_ref_sys to flow through and be ignored.
         // this exceeds the normal 2s timeout.
@@ -152,7 +153,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         TestHelper.executeDDL("postgis_create_tables.ddl");
         consumer = testConsumer(1, "public"); // spatial_ref_sys produces a tonne of records in the postgis schema
         consumer.setIgnoreExtraRecords(true);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
 
         // need to wait for all the spatial_ref_sys to flow through and be ignored.
         // this exceeds the normal 2s timeout.
@@ -180,7 +181,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         TestHelper.executeDDL("postgres_create_tables.ddl");
 
         consumer = testConsumer(1);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
 
         // Quoted column name
         assertInsert(INSERT_QUOTED_TYPES_STMT, schemasAndValuesForQuotedTypes());
@@ -191,7 +192,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         TestHelper.executeDDL("postgres_create_tables.ddl");
 
         consumer = testConsumer(1);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
 
         assertInsert(INSERT_ARRAY_TYPES_STMT, schemasAndValuesForArrayTypes());
     }
@@ -202,7 +203,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         TestHelper.executeDDL("postgres_create_tables.ddl");
 
         consumer = testConsumer(1);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
 
         assertInsert(INSERT_ARRAY_TYPES_WITH_NULL_VALUES_STMT, schemasAndValuesForArrayTypesWithNullValues());
     }
@@ -213,7 +214,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
                            "CREATE TABLE s1.a (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
                            "INSERT INTO s1.a (aa) VALUES (11);";
         consumer = testConsumer(1);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
         executeAndWait(statement);
         assertRecordInserted("s1.a", PK_FIELD, 1);
     }
@@ -224,7 +225,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
                            "ALTER TABLE test_table RENAME TO renamed_test_table;" +
                            "INSERT INTO renamed_test_table (text) VALUES ('new');";
         consumer = testConsumer(1);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
         executeAndWait(statement);
         assertRecordInserted("public.renamed_test_table", PK_FIELD, 2);
     }
@@ -232,7 +233,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     @Test
     public void shouldReceiveChangesForUpdates() throws Exception {
         consumer = testConsumer(1);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
         executeAndWait("UPDATE test_table set text='update' WHERE pk=1");
 
         // the update record should be the last record
@@ -272,7 +273,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
                             "UPDATE test_table SET uvc ='aa' WHERE pk = 1;";
 
         consumer = testConsumer(1);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
         executeAndWait(statements);
 
         // the update should be the last record
@@ -343,7 +344,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     @Test
     public void shouldReceiveChangesForUpdatesWithPKChanges() throws Exception {
         consumer = testConsumer(3);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
         executeAndWait("UPDATE test_table SET text = 'update', pk = 2");
 
         String topicName = topicName("public.test_table");
@@ -370,7 +371,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
                             "ALTER TABLE test_table ADD COLUMN default_column TEXT DEFAULT 'default';" +
                             "INSERT INTO test_table (text) VALUES ('update');";
         consumer = testConsumer(1);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
         executeAndWait(statements);
 
         SourceRecord insertRecord = consumer.remove();
@@ -390,7 +391,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
                             "UPDATE test_table SET num_val = 123.45 WHERE pk = 1;";
 
         consumer = testConsumer(1);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
         executeAndWait(statements);
 
         // the update should be the last record
@@ -473,7 +474,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         String statements = "INSERT INTO test_table (text) VALUES ('insert2');" +
                             "DELETE FROM test_table WHERE pk > 0;";
         consumer = testConsumer(5);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
         executeAndWait(statements);
 
 
@@ -513,7 +514,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         TestHelper.executeDDL("postgres_create_tables.ddl");
 
         consumer = testConsumer(1);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
 
         assertInsert(INSERT_NUMERIC_DECIMAL_TYPES_STMT, schemasAndValuesForImpreciseNumericDecimalType());
     }
@@ -527,7 +528,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
                 "DELETE FROM table_with_interval WHERE id = 1;";
 
         consumer = testConsumer(4);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
         executeAndWait(statements);
 
         final String topicPrefix = "public.table_with_interval";
@@ -551,7 +552,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     @FixFor("DBZ-501")
     public void shouldNotStartAfterStop() throws Exception {
         recordsProducer.stop();
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
 
         // Need to remove record created in @Before
         PostgresConnectorConfig config = new PostgresConnectorConfig(TestHelper.defaultConfig().with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true).build());
@@ -559,7 +560,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         recordsProducer = new RecordsStreamProducer(context, new SourceInfo(config.serverName()));
 
         consumer = testConsumer(1);
-        recordsProducer.start(consumer);
+        recordsProducer.start(consumer, blackHole);
     }
 
     private void assertInsert(String statement, List<SchemaAndValueField> expectedSchemaAndValuesByColumn) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotWithOverridesProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotWithOverridesProducerIT.java
@@ -28,7 +28,7 @@ import io.debezium.config.Configuration;
 public class SnapshotWithOverridesProducerIT extends AbstractRecordsProducerTest {
 
     private static final String STATEMENTS =
-            "CREATE SCHEMA over;" + 
+            "CREATE SCHEMA over;" +
             "CREATE TABLE over.t1 (pk INT, PRIMARY KEY(pk));" +
             "CREATE TABLE over.t2 (pk INT, PRIMARY KEY(pk));" +
             "INSERT INTO over.t1 VALUES (1);" +
@@ -74,7 +74,7 @@ public class SnapshotWithOverridesProducerIT extends AbstractRecordsProducerTest
         TestHelper.execute(STATEMENTS);
         TestConsumer consumer = testConsumer(expectedRecordsCount, "over");
 
-        snapshotProducer.start(consumer);
+        snapshotProducer.start(consumer, e -> {});
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
 
         final Map<String, List<SourceRecord>> recordsByTopic = recordsByTopic(expectedRecordsCount, consumer);
@@ -96,7 +96,7 @@ public class SnapshotWithOverridesProducerIT extends AbstractRecordsProducerTest
         TestHelper.execute(STATEMENTS);
         TestConsumer consumer = testConsumer(expectedRecordsCount, "over");
 
-        snapshotProducer.start(consumer);
+        snapshotProducer.start(consumer, e -> {});
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
 
         final Map<String, List<SourceRecord>> recordsByTopic = recordsByTopic(expectedRecordsCount, consumer);

--- a/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
+++ b/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.base;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.function.Supplier;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.ConfigurationDefaults;
+import io.debezium.time.Temporals;
+import io.debezium.util.Clock;
+import io.debezium.util.LoggingContext;
+import io.debezium.util.LoggingContext.PreviousContext;
+import io.debezium.util.Metronome;
+import io.debezium.util.Threads;
+import io.debezium.util.Threads.Timer;
+
+/**
+ * A queue which serves as handover point between producer threads (e.g. MySQL's
+ * binlog reader thread) and the Kafka Connect polling loop.
+ * <p>
+ * The queue is configurable in different aspects, e.g. its maximum size and the
+ * time to sleep (block) between two subsequent poll calls. See the
+ * {@link Builder} for the different options. The queue applies back-pressure
+ * semantics, i.e. if it holds the maximum number of elements, subsequent calls
+ * to {@link #enqueue(Object)} will block until elements have been removed from
+ * the queue.
+ * <p>
+ * If an exception occurs on the producer side, the producer should make that
+ * exception known by calling {@link #producerFailure} before stopping its
+ * operation. Upon the next call to {@link #poll()}, that exception will be
+ * raised, causing Kafka Connect to stop the connector and mark it as
+ * {@code FAILED}.
+ *
+ * @author Gunnar Morling
+ *
+ * @param <T>
+ *            the type of events in this queue. Usually {@link SourceRecord} is
+ *            used, but in cases where additional metadata must be passed from
+ *            producers to the consumer, a custom type wrapping source records
+ *            may be used.
+ */
+public class ChangeEventQueue<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChangeEventQueue.class);
+
+    private final Duration pollInterval;
+    private final int maxBatchSize;
+    private final BlockingQueue<T> queue;
+    private final Metronome metronome;
+    private final Supplier<PreviousContext> loggingContextSupplier;
+
+    private volatile Throwable producerFailure;
+
+    private ChangeEventQueue(Duration pollInterval, int maxQueueSize, int maxBatchSize, Supplier<LoggingContext.PreviousContext> loggingContextSupplier) {
+        this.pollInterval = pollInterval;
+        this.maxBatchSize = maxBatchSize;
+        this.queue = new LinkedBlockingDeque<>(maxQueueSize);
+        this.metronome = Metronome.sleeper(pollInterval, Clock.SYSTEM);
+        this.loggingContextSupplier = loggingContextSupplier;
+    }
+
+    public static class Builder<T> {
+
+        private Duration pollInterval;
+        private int maxQueueSize;
+        private int maxBatchSize;
+        private Supplier<LoggingContext.PreviousContext> loggingContextSupplier;
+
+        public Builder<T> pollInterval(Duration pollInterval) {
+            this.pollInterval = pollInterval;
+            return this;
+        }
+
+        public Builder<T> maxQueueSize(int maxQueueSize) {
+            this.maxQueueSize = maxQueueSize;
+            return this;
+        }
+
+        public Builder<T> maxBatchSize(int maxBatchSize) {
+            this.maxBatchSize = maxBatchSize;
+            return this;
+        }
+
+        public Builder<T> loggingContextSupplier(Supplier<LoggingContext.PreviousContext> loggingContextSupplier) {
+            this.loggingContextSupplier = loggingContextSupplier;
+            return this;
+        }
+
+        public ChangeEventQueue<T> build() {
+            return new ChangeEventQueue<T>(pollInterval, maxQueueSize, maxBatchSize, loggingContextSupplier);
+        }
+    }
+
+    public void enqueue(T record) {
+        LoggingContext.PreviousContext previousContext = loggingContextSupplier.get();
+
+        try {
+            queue.put(record);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Placed source record '{}' into queue", record);
+            }
+        } catch (InterruptedException e) {
+            LOGGER.debug("received interrupt request");
+            // clear the interrupted status
+            Thread.interrupted();
+        } finally {
+            previousContext.restore();
+        }
+    }
+
+    /**
+     * Returns the next batch of elements from this queue. May be empty in case no
+     * elements have arrived in the maximum waiting time.
+     *
+     * @throws InterruptedException
+     *             if this thread has been interrupted while waiting for more
+     *             elements to arrive
+     */
+    public List<T> poll() throws InterruptedException {
+        LoggingContext.PreviousContext previousContext = loggingContextSupplier.get();
+
+        try {
+            LOGGER.debug("polling records...");
+            List<T> records = new ArrayList<>();
+            final Timer timeout = Threads.timer(Clock.SYSTEM, Temporals.max(pollInterval, ConfigurationDefaults.RETURN_CONTROL_INTERVAL));
+            while (!timeout.expired() && queue.drainTo(records, maxBatchSize) == 0) {
+                throwProducerFailureIfPresent();
+
+                LOGGER.debug("no records available yet, sleeping a bit...");
+                // no records yet, so wait a bit
+                metronome.pause();
+                LOGGER.debug("checking for more records...");
+            }
+            return records;
+        } finally {
+            previousContext.restore();
+        }
+    }
+
+    public void producerFailure(final Throwable producerFailure) {
+        this.producerFailure = producerFailure;
+    }
+
+    private void throwProducerFailureIfPresent() {
+        if (producerFailure != null) {
+            throw new ConnectException("An exception ocurred in the change event producer. This connector will be stopped.", producerFailure);
+        }
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-580

@jpechane That's the queue implementation we were talking about. It's meant to be used by all connectors, in this PR I include the required changes for PG and MongoDB. I thought it'd be better to wait with doing the same change in MySQL until the DBZ-175 work has been merged, to avoid bigger merging trouble.