### PR TITLE
DBZ-595 Making sure resources are cleaned up when snapshotting fails;

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
@@ -141,6 +141,7 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
                                     .withDefault(ProducerConfig.BUFFER_MEMORY_CONFIG, 1024 * 1024) // 1MB
                                     .withDefault(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
                                     .withDefault(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+                                    .withDefault(ProducerConfig.MAX_BLOCK_MS_CONFIG, 10_000) // wait at most this if we can't reach Kafka
                                     .build();
         logger.info("KafkaDatabaseHistory Consumer config: " + consumerConfig.withMaskedPasswords());
         logger.info("KafkaDatabaseHistory Producer config: " + producerConfig.withMaskedPasswords());


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-595

* shutting down the snapshotting thread and the DB history producer client
  if the connector is stopped while trying to write to the history topic
* reducing the time that KafkaProducer#send() will block if Kafka isn't
  available; this will release the producer thread quicker in case the
  connector is stopped during snapshotting
* not returning from finally block (!) in case the TX is rolled back; This
  prevented the failed state to be set by the outer catch clause in execute()

@jpechane that's best reviewed [ignoring whitespace](https://github.com/debezium/debezium/pull/432/files?w=1) differences as I wrapped an entire block of the snapshotting routine in try/catch block without any actual changes to this code (step 6).

We were leaking both the snapshotting thread and the history topic producer thread if the connector was shut down after Kafka isn't available (or something else went wrong during writing history entries). That's fixed now by calling the cleanup method from within stop. Overall I feel all these lifecycle methods of the readers are super-complex and we need to find a way to simplify all this. cleanup() is called multiple times now, but this shouldn't matter.