### PR TITLE
Modify halting predicate logic.

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
@@ -14,6 +14,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -48,18 +49,25 @@ public abstract class AbstractReader implements Reader {
     private final Metronome metronome;
     private final AtomicReference<Runnable> uponCompletion = new AtomicReference<>();
 
+    private final Predicate<SourceRecord> acceptAndContinue;
+
     /**
      * Create a snapshot reader.
      *
      * @param name the name of the reader
      * @param context the task context in which this reader is running; may not be null
+     * @param acceptAndContinue a predicate that returns true if the tested {@link SourceRecord} should be accepted and
+     *                          false if the record and all subsequent records should be ignored. The reader will stop
+     *                          accepting records once {@link #enqueueRecord(SourceRecord)} is called with a record
+     *                          that tests as false. Can be null. If null, all records will be accepted.
      */
-    public AbstractReader(String name, MySqlTaskContext context) {
+    public AbstractReader(String name, MySqlTaskContext context, Predicate<SourceRecord> acceptAndContinue) {
         this.name = name;
         this.context = context;
         this.records = new LinkedBlockingDeque<>(context.maxQueueSize());
         this.maxBatchSize = context.maxBatchSize();
         this.metronome = Metronome.parker(context.pollIntervalInMillseconds(), TimeUnit.MILLISECONDS, Clock.SYSTEM);
+        this.acceptAndContinue = acceptAndContinue == null? new AcceptAllPredicate() : acceptAndContinue;
     }
 
     @Override
@@ -275,14 +283,33 @@ public abstract class AbstractReader implements Reader {
      * queue is full.
      *
      * @param record the record to be enqueued
+     * @return true if the record was successfully enqueued, false if not.
      * @throws InterruptedException if interrupted while waiting for the queue to have room for this record
      */
-    protected void enqueueRecord(SourceRecord record) throws InterruptedException {
+    protected boolean enqueueRecord(SourceRecord record) throws InterruptedException {
         if (record != null) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("Enqueuing source record: {}", record);
+            if (acceptAndContinue.test(record)) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Enqueuing source record: {}", record);
+                }
+                this.records.put(record);
+                return true;
+            } else {
+                // if we found a record we should not accept, we are done.
+                completeSuccessfully();
             }
-            this.records.put(record);
+        }
+        return false;
+    }
+
+    /**
+     * A predicate that returns true for all sourceRecords
+     */
+    public static class AcceptAllPredicate implements Predicate<SourceRecord> {
+
+        @Override
+        public boolean test(SourceRecord sourceRecord) {
+            return true;
         }
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 
-import io.debezium.annotation.Immutable;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 
@@ -84,9 +83,6 @@ public class BinlogReader extends AbstractReader {
     private volatile Map<String, ?> lastOffset = null;
     private com.github.shyiko.mysql.binlog.GtidSet gtidSet;
 
-    // This reader will attempt to halt once this predicate returns true when given the current offset.
-    private final Predicate<Map<String, ?>> offsetHaltPredicate;
-
     public static class BinlogPosition {
         final String filename;
         final long position;
@@ -141,11 +137,10 @@ public class BinlogReader extends AbstractReader {
      *
      * @param name the name of this reader; may not be null
      * @param context the task context in which this reader is running; may not be null
-     * @param offsetHaltPredicate predicate for halting this reader once a particular offset has been reached; may be null.
+     * @param acceptAndContinue see {@link AbstractReader#AbstractReader(String, MySqlTaskContext, Predicate)}
      */
-    public BinlogReader(String name, MySqlTaskContext context, Predicate<Map<String, ?>> offsetHaltPredicate) {
-        super(name, context);
-        this.offsetHaltPredicate = offsetHaltPredicate == null ? new NeverHaltPredicate() : offsetHaltPredicate;
+    public BinlogReader(String name, MySqlTaskContext context, Predicate<SourceRecord> acceptAndContinue) {
+        super(name, context, acceptAndContinue);
 
         source = context.source();
         recordMakers = context.makeRecord();
@@ -336,18 +331,6 @@ public class BinlogReader extends AbstractReader {
     }
 
     /**
-     * Halting predicate that always returns false.
-     */
-    @Immutable
-    private static class NeverHaltPredicate implements Predicate<Map<String, ?>> {
-
-        @Override
-        public boolean test(Map<String, ?> offset) {
-            return false;
-        }
-    }
-
-    /**
      * @return a copy of the last offset of this reader.
      */
     public Map<String, ?> getLastOffset() {
@@ -397,9 +380,6 @@ public class BinlogReader extends AbstractReader {
                     recordCounter = 0;
                     previousOutputMillis += millisSinceLastOutput;
                 }
-            }
-            if (offsetHaltPredicate.test(lastOffset)) {
-                this.stop();
             }
         }
     }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -68,7 +68,7 @@ public class SnapshotReader extends AbstractReader {
      * @param context the task context in which this reader is running; may not be null
      */
     public SnapshotReader(String name, MySqlTaskContext context) {
-        super(name, context);
+        super(name, context, null);
         this.includeData = !context.isSchemaOnlySnapshot();
         recorder = this::recordRowAsRead;
         metrics = new SnapshotReaderMetrics(context.clock());


### PR DESCRIPTION
Halting predicates now force readers to immediately stop and do not read any records beyond their limits.
Logic is now contained in AbstractReader.