### PR TITLE
DBZ-606 Numeric NaN represented as null

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -311,6 +311,10 @@ public class PostgresValueConverter extends JdbcValueConverters {
           newDecimal = newDecimal.setScale(column.scale());
         }
         if (isVariableScaleDecimal(column)) {
+            newDecimal = newDecimal.stripTrailingZeros();
+            if (newDecimal.scale() < 0) {
+                newDecimal = newDecimal.setScale(0);
+            }
             return VariableScaleDecimal.fromLogical(fieldDefn.schema(), newDecimal);
         }
         return newDecimal;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsSnapshotProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsSnapshotProducer.java
@@ -292,6 +292,9 @@ public class RecordsSnapshotProducer extends RecordsProducer {
                     return new PGmoney(rs.getString(colIdx)).val;
                 case PgOid.BIT:
                     return rs.getString(colIdx);
+                case PgOid.NUMERIC:
+                    final String s = rs.getString(colIdx);
+                    return "NaN".equals(s) ? null : rs.getBigDecimal(colIdx);
                 default:
                     return rs.getObject(colIdx);
             }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DecoderDifferences.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DecoderDifferences.java
@@ -29,7 +29,7 @@ public class DecoderDifferences {
 
     /**
      * wal2json plugin is not currently able to encode and parse quoted identifiers
-     * 
+     *
      * @author Jiri Pechanec
      *
      */
@@ -44,4 +44,13 @@ public class DecoderDifferences {
         return TestHelper.decoderPlugin() == PostgresConnectorConfig.LogicalDecoder.WAL2JSON || TestHelper.decoderPlugin() == PostgresConnectorConfig.LogicalDecoder.WAL2JSON_RDS;
     }
 
+    /**
+     * wal2json plugin is not currently able to encode and parse NaN and Inf values
+     * 
+     * @author Jiri Pechanec
+     *
+     */
+    public static boolean areSpecialFPValuesUnupported() {
+        return wal2Json();
+    }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -84,17 +84,9 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         //numerical types
         assertInsert(INSERT_NUMERIC_TYPES_STMT, schemasAndValuesForNumericType());
 
-        //floating-point without decimals
-        consumer.expects(1);
-        assertInsert(INSERT_FP_TYPES_NO_DECIMAL_STMT, 2, schemasAndValuesForFpTypeWithoutDecimals());
-
         //numerical decimal types
         consumer.expects(1);
         assertInsert(INSERT_NUMERIC_DECIMAL_TYPES_STMT, schemasAndValuesForNumericDecimalType());
-
-        //numerical decimal types without decimals
-        consumer.expects(1);
-        assertInsert(INSERT_NUMERIC_DECIMAL_TYPES_NO_DECIMAL_STMT, 2, schemasAndValuesForNumericDecimalTypeWithoutDecimals());
 
         // string types
         consumer.expects(1);

--- a/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
+++ b/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
@@ -1,8 +1,17 @@
 -- noinspection SqlNoDataSourceInspectionForFile
 
-CREATE TABLE numeric_table (pk SERIAL, si SMALLINT, i INTEGER, bi BIGINT, r REAL, db DOUBLE PRECISION, ss SMALLSERIAL, bs BIGSERIAL, b BOOLEAN, PRIMARY KEY(pk));
+CREATE TABLE numeric_table (pk SERIAL, si SMALLINT, i INTEGER, bi BIGINT,
+    r REAL, db DOUBLE PRECISION,
+    r_nodec REAL, db_nodec DOUBLE PRECISION,
+    r_nan REAL, db_nan DOUBLE PRECISION,
+    r_inf REAL, db_inf DOUBLE PRECISION,
+    ss SMALLSERIAL, bs BIGSERIAL, b BOOLEAN, PRIMARY KEY(pk));
 -- no suffix -fixed scale, zs - zero scale, vs - variable scale
-CREATE TABLE numeric_decimal_table (pk SERIAL, d DECIMAL(3,2), dzs DECIMAL(4), dvs DECIMAL, n NUMERIC(6,4), nzs NUMERIC(4), nvs NUMERIC, PRIMARY KEY(pk));
+CREATE TABLE numeric_decimal_table (pk SERIAL,
+	d DECIMAL(3,2), dzs DECIMAL(4), dvs DECIMAL, n NUMERIC(6,4), nzs NUMERIC(4), nvs NUMERIC,
+	d_nodec DECIMAL(3,2), dzs_nodec DECIMAL(4), dvs_nodec DECIMAL, n_nodec NUMERIC(6,4), nzs_nodec NUMERIC(4), nvs_nodec NUMERIC,
+	d_nan DECIMAL(3,2), dzs_nan DECIMAL(4), dvs_nan DECIMAL, n_nan NUMERIC(6,4), nzs_nan NUMERIC(4), nvs_nan NUMERIC,
+	PRIMARY KEY(pk));
 CREATE TABLE string_table (pk SERIAL, vc VARCHAR(2), vcv CHARACTER VARYING(2), ch CHARACTER(4), c CHAR(3), t TEXT, b BYTEA, PRIMARY KEY(pk));
 CREATE TABLE cash_table (pk SERIAL, csh MONEY, PRIMARY KEY(pk));
 CREATE TABLE bitbin_table (pk SERIAL, ba BYTEA, bol BIT(1), bs BIT(2), bv BIT VARYING(2) , PRIMARY KEY(pk));


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-606

`NaN` is converted into `null` - it is not an ideal solution but `NaN`'s are coming from decoders as `null` too so I think we should make it the same now. DBZ-351 should ensure that `NaN` is sent correctl and we can then switch to another repsresentation like `BigDecimal.ZERO`.