### PR TITLE
DBZ-632 Removing unused method parameter

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
@@ -364,7 +364,7 @@ public class MySqlSchema {
                 // schema change records.
                 try {
                     if (!storeOnlyMonitoredTablesDdl || changes.stream().anyMatch(filters().tableFilter()::test)) {
-                        dbHistory.record(source.partition(), source.offset(), databaseName, tables, ddlStatements);
+                        dbHistory.record(source.partition(), source.offset(), databaseName, ddlStatements);
                     } else {
                         logger.debug("Changes for DDL '{}' were filtered and not recorded in database history", ddlStatements);
                     }

--- a/debezium-core/src/main/java/io/debezium/relational/history/AbstractDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/AbstractDatabaseHistory.java
@@ -51,7 +51,7 @@ public abstract class AbstractDatabaseHistory implements DatabaseHistory {
     }
 
     @Override
-    public final void record(Map<String, ?> source, Map<String, ?> position, String databaseName, Tables schema, String ddl)
+    public final void record(Map<String, ?> source, Map<String, ?> position, String databaseName, String ddl)
             throws DatabaseHistoryException {
             storeRecord(new HistoryRecord(source, position, databaseName, ddl));
     }

--- a/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
@@ -71,7 +71,7 @@ public interface DatabaseHistory {
 
     /**
      * Configure this instance.
-     * 
+     *
      * @param config the configuration for this history store
      * @param comparator the function that should be used to compare history records during
      *            {@link #recover(Map, Map, Tables, DdlParser) recovery}; may be null if the
@@ -86,24 +86,23 @@ public interface DatabaseHistory {
 
     /**
      * Record a change to the schema of the named database, and store it in the schema storage.
-     * 
+     *
      * @param source the information about the source database; may not be null
      * @param position the point in history where these DDL changes were made, which may be used when
      *            {@link #recover(Map, Map, Tables, DdlParser) recovering} the schema to some point in history; may not be
      *            null
      * @param databaseName the name of the database whose schema is being changed; may be null
-     * @param schema the current definition of the database schema; may not be null
      * @param ddl the DDL statements that describe the changes to the database schema; may not be null
      * @throws DatabaseHistoryException if the record could not be written
      */
-    void record(Map<String, ?> source, Map<String, ?> position, String databaseName, Tables schema, String ddl) throws DatabaseHistoryException;
+    void record(Map<String, ?> source, Map<String, ?> position, String databaseName, String ddl) throws DatabaseHistoryException;
 
     /**
      * Recover the {@link Tables database schema} to a known point in its history. Note that it is possible to recover the
      * database schema to a point in history that is earlier than what has been {@link #record(Map, Map, String, Tables, String)
      * recorded}. Likewise, when recovering to a point in history <em>later</em> than what was recorded, the database schema will
      * reflect the latest state known to the history.
-     * 
+     *
      * @param source the information about the source database; may not be null
      * @param position the point in history at which the {@link Tables database schema} should be recovered; may not be null
      * @param schema the table definitions that should be changed to reflect the database schema at the desired point in history;

--- a/debezium-core/src/test/java/io/debezium/relational/history/AbstractDatabaseHistoryTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/history/AbstractDatabaseHistoryTest.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.relational.history;
 
+import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.Map;
@@ -12,8 +13,6 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
 
 import io.debezium.relational.Tables;
 import io.debezium.relational.ddl.DdlParser;
@@ -53,7 +52,7 @@ public abstract class AbstractDatabaseHistoryTest {
         source2 = server("xyz");
         history = createHistory();
     }
-    
+
     @After
     public void afterEach() {
         if (history != null) {
@@ -73,7 +72,7 @@ public abstract class AbstractDatabaseHistoryTest {
 
     protected void record(long pos, int entry, String ddl, Tables... update) {
         try {
-            history.record(source1, position("a.log", pos, entry), "db", tables, ddl);
+            history.record(source1, position("a.log", pos, entry), "db", ddl);
         } catch (Throwable t) {
             fail(t.getMessage());
         }

--- a/debezium-core/src/test/java/io/debezium/relational/history/KafkaDatabaseHistoryTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/history/KafkaDatabaseHistoryTest.java
@@ -132,7 +132,7 @@ public class KafkaDatabaseHistoryTest {
         ddl = "CREATE TABLE foo ( name VARCHAR(255) NOT NULL PRIMARY KEY); \n" +
                 "CREATE TABLE customers ( id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(100) NOT NULL ); \n" +
                 "CREATE TABLE products ( productId INTEGER NOT NULL PRIMARY KEY, desc VARCHAR(255) NOT NULL); \n";
-        history.record(source, position, "db1", tables1, ddl);
+        history.record(source, position, "db1", ddl);
 
         // Parse the DDL statement 3x and each time update a different Tables object ...
         ddlParser.parse(ddl, tables1);
@@ -145,7 +145,7 @@ public class KafkaDatabaseHistoryTest {
         // Record a drop statement and parse it for 2 of our 3 Tables...
         setLogPosition(39);
         ddl = "DROP TABLE foo;";
-        history.record(source, position, "db1", tables2, ddl);
+        history.record(source, position, "db1", ddl);
         ddlParser.parse(ddl, tables2);
         assertThat(tables2.size()).isEqualTo(2);
         ddlParser.parse(ddl, tables3);
@@ -154,7 +154,7 @@ public class KafkaDatabaseHistoryTest {
         // Record another DDL statement and parse it for 1 of our 3 Tables...
         setLogPosition(10003);
         ddl = "CREATE TABLE suppliers ( supplierId INTEGER NOT NULL PRIMARY KEY, name VARCHAR(255) NOT NULL);";
-        history.record(source, position, "db1", tables3, ddl);
+        history.record(source, position, "db1", ddl);
         ddlParser.parse(ddl, tables3);
         assertThat(tables3.size()).isEqualTo(3);
 


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-632

@jpechane, a quick clean-up in preparation of adding a non-DDL-based table representation to the schema history (which in turn I need for the Oracle support).