### PR TITLE
DBZ-632 Removing methods from HistoryRecord which where only used in …

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/history/HistoryRecord.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/HistoryRecord.java
@@ -38,36 +38,20 @@ public class HistoryRecord {
         return this.doc;
     }
 
-    public boolean isAtOrBefore(HistoryRecord other) {
-        if (other == this) return true;
-        return this.position().compareToUsingSimilarFields(other.position()) <= 0
-                && source().equals(other.source());
-    }
-
     protected Document source() {
-        return doc.getDocument("source");
+        return doc.getDocument(Fields.SOURCE);
     }
 
     protected Document position() {
-        return doc.getDocument("position");
+        return doc.getDocument(Fields.POSITION);
     }
 
     protected String databaseName() {
-        return doc.getString("databaseName");
+        return doc.getString(Fields.DATABASE_NAME);
     }
 
     protected String ddl() {
-        return doc.getString("ddl");
-    }
-
-    protected boolean hasSameSource(HistoryRecord other) {
-        if (this == other) return true;
-        return other != null && source().equals(other.source());
-    }
-
-    protected boolean hasSameDatabase(HistoryRecord other) {
-        if (this == other) return true;
-        return other != null && databaseName().equals(other.databaseName());
+        return doc.getString(Fields.DDL_STATEMENTS);
     }
 
     @Override


### PR DESCRIPTION
…tests;

Also adding a new test for HistoryRecord (de-)serialization

https://issues.jboss.org/browse/DBZ-632

Some more dead wood removal around the history handling. I've widened the scope of DBZ-632 accordingly.