### PR TITLE
DBZ-641 CREATE TABLE not being parsed with PARTITION... ENGINE=InnoDB

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
@@ -502,6 +502,10 @@ public class MySqlDdlParser extends DdlParser {
         if (tokens.canConsume('(')) {
             do {
                 parsePartitionDefinition(start, table);
+                if(tokens.canConsume("ENGINE")) {
+                        tokens.canConsume('=');
+                        tokens.consume();
+                    }
             } while (tokens.canConsume(','));
             tokens.consume(')');
         }
@@ -514,15 +518,6 @@ public class MySqlDdlParser extends DdlParser {
             if (tokens.canConsume("LESS", "THAN")) {
                 if (!tokens.canConsume("MAXVALUE")) {
                     consumeExpression(start);
-                    if(tokens.canConsume("ENGINE")) {
-                        tokens.canConsume('=');
-                        tokens.consume();
-                    }
-                } else {
-                    if(tokens.canConsume("ENGINE")) {
-                        tokens.canConsume('=');
-                        tokens.consume();
-                    }
                 }
             } else {
                 tokens.consume("IN");

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
@@ -502,6 +502,11 @@ public class MySqlDdlParser extends DdlParser {
         if (tokens.canConsume('(')) {
             do {
                 parsePartitionDefinition(start, table);
+                if(tokens.canConsume("ENGINE"))
+                {
+                    tokens.canConsume('=');
+                    tokens.consume();
+                }
             } while (tokens.canConsume(','));
             tokens.consume(')');
         }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
@@ -502,11 +502,6 @@ public class MySqlDdlParser extends DdlParser {
         if (tokens.canConsume('(')) {
             do {
                 parsePartitionDefinition(start, table);
-                if(tokens.canConsume("ENGINE"))
-                {
-                    tokens.canConsume('=');
-                    tokens.consume();
-                }
             } while (tokens.canConsume(','));
             tokens.consume(')');
         }
@@ -519,6 +514,15 @@ public class MySqlDdlParser extends DdlParser {
             if (tokens.canConsume("LESS", "THAN")) {
                 if (!tokens.canConsume("MAXVALUE")) {
                     consumeExpression(start);
+                    if(tokens.canConsume("ENGINE")) {
+                        tokens.canConsume('=');
+                        tokens.consume();
+                    }
+                } else {
+                    if(tokens.canConsume("ENGINE")) {
+                        tokens.canConsume('=');
+                        tokens.consume();
+                    }
                 }
             } else {
                 tokens.consume("IN");

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -1422,7 +1422,7 @@ public class MySqlDdlParserTest {
     public void parsePartitionReorganize() {
         String ddl =
                 "CREATE TABLE flat_view_request_log (id INT NOT NULL, myvalue INT DEFAULT -10, PRIMARY KEY (`id`));"
-              + "ALTER TABLE flat_view_request_log REORGANIZE PARTITION p_max INTO ( PARTITION p_2018_01_17 VALUES LESS THAN ('2018-01-17') ENGINE = InnoDB, PARTITION p_2018_01_18 VALUES LESS THAN ('2018-01-18'), PARTITION p_max VALUES LESS THAN MAXVALUE);";
+              + "ALTER TABLE flat_view_request_log REORGANIZE PARTITION p_max INTO ( PARTITION p_2018_01_17 VALUES LESS THAN ('2018-01-17'), PARTITION p_2018_01_18 VALUES LESS THAN ('2018-01-18'), PARTITION p_max VALUES LESS THAN MAXVALUE);";
         parser.parse(ddl, tables);
         assertThat(tables.size()).isEqualTo(1);
     }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -1431,7 +1431,7 @@ public class MySqlDdlParserTest {
     public void parsePartitionWithEngine() {
         String ddl =
                 "CREATE TABLE flat_view_request_log (id INT NOT NULL, myvalue INT DEFAULT -10, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=latin1 PARTITION BY RANGE (to_days(`CreationDate`))" +
-                        " ( PARTITION p_2018_01_17 VALUES LESS THAN ('2018-01-17') ENGINE = InnoDB, PARTITION p_2018_01_18 VALUES LESS THAN ('2018-01-18'), PARTITION p_max VALUES LESS THAN MAXVALUE);";
+                        " ( PARTITION p_2018_01_17 VALUES LESS THAN ('2018-01-17') ENGINE = InnoDB, PARTITION p_2018_01_18 VALUES LESS THAN ('2018-01-18') ENGINE = InnoDB, PARTITION p_max VALUES LESS THAN MAXVALUE ENGINE = InnoDB);";
         parser.parse(ddl, tables);
         assertThat(tables.size()).isEqualTo(1);
     }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -1422,10 +1422,20 @@ public class MySqlDdlParserTest {
     public void parsePartitionReorganize() {
         String ddl =
                 "CREATE TABLE flat_view_request_log (id INT NOT NULL, myvalue INT DEFAULT -10, PRIMARY KEY (`id`));"
-              + "ALTER TABLE flat_view_request_log REORGANIZE PARTITION p_max INTO ( PARTITION p_2018_01_17 VALUES LESS THAN ('2018-01-17'), PARTITION p_2018_01_18 VALUES LESS THAN ('2018-01-18'), PARTITION p_max VALUES LESS THAN MAXVALUE);";
+              + "ALTER TABLE flat_view_request_log REORGANIZE PARTITION p_max INTO ( PARTITION p_2018_01_17 VALUES LESS THAN ('2018-01-17') ENGINE = InnoDB, PARTITION p_2018_01_18 VALUES LESS THAN ('2018-01-18'), PARTITION p_max VALUES LESS THAN MAXVALUE);";
         parser.parse(ddl, tables);
         assertThat(tables.size()).isEqualTo(1);
     }
+
+    @Test
+    public void parsePartitionWithEngine() {
+        String ddl =
+                "CREATE TABLE flat_view_request_log (id INT NOT NULL, myvalue INT DEFAULT -10, PRIMARY KEY (`id`)) ENGINE=InnoDB DEFAULT CHARSET=latin1 PARTITION BY RANGE (to_days(`CreationDate`))" +
+                        " ( PARTITION p_2018_01_17 VALUES LESS THAN ('2018-01-17') ENGINE = InnoDB, PARTITION p_2018_01_18 VALUES LESS THAN ('2018-01-18'), PARTITION p_max VALUES LESS THAN MAXVALUE);";
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(1);
+    }
+
 
     protected void assertParseEnumAndSetOptions(String typeExpression, String optionString) {
         List<String> options = MySqlDdlParser.parseSetAndEnumOptions(typeExpression);


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-641

Have made required changes , for MysqlDDLParser to parse CREATE TABLE DLL, with PARTITION...ENGINE=InnoDB,

example:
Create Table: CREATE TABLE `members` (
`id` int(11) DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=latin1
/*!50100 PARTITION BY RANGE ( YEAR(dob))
(PARTITION n0 VALUES LESS THAN (1970) ENGINE = InnoDB,
PARTITION n1 VALUES LESS THAN (1980) ENGINE = InnoDB
)