### PR TITLE
Using latest Kafka libs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- Kafka and it's dependencies MUST reflect what the Kafka version uses -->
-        <version.kafka>1.0.0</version.kafka>
+        <version.kafka>1.0.1</version.kafka>
         <version.kafka.scala>2.11</version.kafka.scala>
         <version.curator>2.11.0</version.curator>
         <version.zookeeper>3.4.10</version.zookeeper>


### PR DESCRIPTION
*Updating to Apache Kafka 1.0.1*

As discussed in [DBZ-647](https://issues.jboss.org/browse/DBZ-647), the used JARs need to be updated

__NOTE:__ I have one error, on MongoDB connector, locally w/ the build - that's happening w/o this PR too...