### PR TITLE
DBZ-640 SnapshotReaderMetrics bean unregisters when snapshot completes

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
@@ -82,6 +82,11 @@ public abstract class AbstractReader implements Reader {
     }
 
     @Override
+    public final void destroy() {
+        doDestroy();
+    }
+
+    @Override
     public void start() {
         if (this.running.compareAndSet(false, true)) {
             this.failure.set(null);
@@ -110,6 +115,15 @@ public abstract class AbstractReader implements Reader {
      * called once before {@link #doStart()}.
      */
     protected void doInitialize() {
+        // do nothing
+    }
+
+
+    /**
+     * The reader has been requested to de-initialize resources after stopping. This should only be
+     * called once after {@link #doStop()}.
+     */
+    protected void doDestroy() {
         // do nothing
     }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -241,6 +241,11 @@ public class BinlogReader extends AbstractReader {
     }
 
     @Override
+    public void doDestroy() {
+        metrics.unregister(logger);
+    }
+
+    @Override
     protected void doStart() {
         // Register our event handlers ...
         eventHandlers.put(EventType.STOP, this::handleServerStop);
@@ -352,10 +357,6 @@ public class BinlogReader extends AbstractReader {
             cleanupResources();
         } catch (IOException e) {
             logger.error("Unexpected error when disconnecting from the MySQL binary log reader", e);
-        } finally {
-            // We unregister our JMX metrics now, which means we won't record metrics for records that
-            // may be processed between now and complete shutdown. That's okay.
-            metrics.unregister(logger);
         }
     }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/ChainedReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/ChainedReader.java
@@ -85,6 +85,12 @@ public final class ChainedReader implements Reader {
     }
 
     @Override
+    public void destroy() {
+        // destroy all of the readers ...
+        readers.forEach(Reader::destroy);
+    }
+
+    @Override
     public synchronized void start() {
         if (running.compareAndSet(false, true)) {
             completed.set(false);
@@ -204,4 +210,5 @@ public final class ChainedReader implements Reader {
         Reader reader = currentReader.get();
         return reader != null ? reader.name() : "chained";
     }
+
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -241,6 +241,7 @@ public final class MySqlConnectorTask extends BaseSourceTask {
 
                 if (readers != null) {
                     readers.stop();
+                    readers.destroy();
                 }
             } finally {
                 prevLoggingContext.restore();

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Reader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Reader.java
@@ -21,7 +21,7 @@ import org.apache.kafka.connect.source.SourceRecord;
  * <p>
  * See {@link ChainedReader} if multiple {@link Reader} implementations are to be run in-sequence while keeping the
  * correct start, stop, and completion semantics.
- * 
+ *
  * @author Randall Hauch
  * @see ChainedReader
  */
@@ -50,14 +50,14 @@ public interface Reader {
 
     /**
      * Get the name of this reader.
-     * 
+     *
      * @return the reader's name; never null
      */
     public String name();
 
     /**
      * Get the current state of this reader.
-     * 
+     *
      * @return the state; never null
      */
     public State state();
@@ -68,7 +68,7 @@ public interface Reader {
      * method.
      * <p>
      * This method should only be called while the reader is in the {@link State#STOPPED} state.
-     * 
+     *
      * @param handler the function; may not be null
      */
     public void uponCompletion(Runnable handler);
@@ -79,6 +79,17 @@ public interface Reader {
      * initialization is completed.
      */
     public default void initialize() {
+        // do nothing
+    }
+
+    /**
+     * After the reader has stopped, there may still be some resources we want left available until the connector
+     * task is destroyed. This method is used to clean up those remaining resources upon shutdown.
+     * This method is effectively the opposite of {@link #initialize()}, performing any
+     * de-initialization of the reader entity before shutdown. This method should be called exactly
+     * once after {@link #stop()} is called, and it should block until all de-initialization is completed.
+     */
+    public default void destroy() {
         // do nothing
     }
 
@@ -101,7 +112,7 @@ public interface Reader {
      * this reader have been processed, following the natural or explicit {@link #stop() stopping} of this reader.
      * Note that this method may block if no additional records are available but the reader may produce more, thus
      * callers should call this method continually until this method returns {@code null}.
-     * 
+     *
      * @return the list of source records that may or may not be empty; or {@code null} when there will be no more records
      *         because the reader has completely {@link State#STOPPED}.
      * @throws InterruptedException if this thread is interrupted while waiting for more records

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -118,6 +118,11 @@ public class SnapshotReader extends AbstractReader {
         metrics.register(context, logger);
     }
 
+    @Override
+    public void doDestroy() {
+        metrics.unregister(logger);
+    }
+
     /**
      * Start the snapshot and return immediately. Once started, the records read from the database can be retrieved using
      * {@link #poll()} until that method returns {@code null}.
@@ -137,12 +142,8 @@ public class SnapshotReader extends AbstractReader {
 
     @Override
     protected void doCleanup() {
-        try {
-            executorService.shutdown();
-            logger.debug("Completed writing all snapshot records");
-        } finally {
-            metrics.unregister(logger);
-        }
+        executorService.shutdown();
+        logger.debug("Completed writing all snapshot records");
     }
 
     protected Object readField(ResultSet rs, int fieldNo, Column actualColumn) throws SQLException {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/ChainedReaderTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/ChainedReaderTest.java
@@ -160,6 +160,20 @@ public class ChainedReaderTest {
         }
     }
 
+    @Test
+    public void shouldInitAndDestroyResources() {
+        MockReader r1 = new MockReader("r1", records());
+        MockReader r2 = new MockReader("r2", records());
+
+        reader = new ChainedReader.Builder().addReader(r1).addReader(r2).build();
+        reader.initialize();
+        assertThat(r1.mockResource).isNotNull();
+        assertThat(r2.mockResource).isNotNull();
+        reader.destroy();
+        assertThat(r1.mockResource).isNull();
+        assertThat(r2.mockResource).isNull();
+    }
+
     /**
      * A {@link Reader} that returns records until manually stopped.
      */
@@ -169,6 +183,7 @@ public class ChainedReaderTest {
         private final AtomicReference<Runnable> completionHandler = new AtomicReference<>();
         private final AtomicBoolean running = new AtomicBoolean();
         private final AtomicBoolean completed = new AtomicBoolean();
+        private Object mockResource;
 
         public MockReader(String name, Supplier<List<SourceRecord>> pollResultsSupplier) {
             this.name = name;
@@ -223,6 +238,16 @@ public class ChainedReaderTest {
         @Override
         public void uponCompletion(Runnable handler) {
             completionHandler.set(handler);
+        }
+
+        @Override
+        public void initialize() {
+            mockResource = new String();
+        }
+
+        @Override
+        public void destroy() {
+            mockResource = null;
         }
     }
 


### PR DESCRIPTION
Added Reader.destroy() which is effectively the opposite of Reader.initialize().

Moved metrics unregister call into destroy() implementation.

Note: we would technically need to add this as a potential breaking change in the release notes since some clients may have instrumented code around the behavior of this defect.