### PR TITLE
DBZ-668 Change the key schema for the heartbeat messages from String to Struct

### DIFF
--- a/debezium-core/src/main/java/io/debezium/heartbeat/HeartbeatImpl.java
+++ b/debezium-core/src/main/java/io/debezium/heartbeat/HeartbeatImpl.java
@@ -46,7 +46,7 @@ class HeartbeatImpl implements Heartbeat {
      */
     static final String DEFAULT_HEARTBEAT_TOPICS_PREFIX = "__debezium-heartbeat";
 
-    private static final String SERVER_NAME_KEY = "name";
+    private static final String SERVER_NAME_KEY = "serverName";
     private static Schema KEY_SCHEMA = SchemaBuilder.struct()
                                                     .name(schemaNameAdjuster.adjust("io.debezium.connector.mysql.ServerNameKey"))
                                                     .field(SERVER_NAME_KEY,Schema.STRING_SCHEMA)
@@ -88,7 +88,7 @@ class HeartbeatImpl implements Heartbeat {
     }
 
     /**
-     * Produce a key struct for based on the server name and KEY_SCHEMA
+     * Produce a key struct based on the server name and KEY_SCHEMA
      *
      */
     private Struct serverNameKey(String serverName){


### PR DESCRIPTION
As @gunnarmorling recommended [here](https://issues.jboss.org/browse/DBZ-668?focusedCommentId=13548206&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13548206), I have changed the heartbeat key message to `Struct` from `String` in order to leverage the `ByLogicalTableRouter` SMT and route all heartbeat messages into a single topic instead of individual topics for each source task 