### PR TITLE
DBZ-673 txId must be long in wal2jon decoder

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsSnapshotProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsSnapshotProducer.java
@@ -167,7 +167,7 @@ public class RecordsSnapshotProducer extends RecordsProducer {
             // If rows are being inserted while we're doing the snapshot, the xlog pos should increase and so when
             // we start streaming, we should get back those changes
             long xlogStart = connection.currentXLogLocation();
-            int txId = connection.currentTransactionId().intValue();
+            long txId = connection.currentTransactionId().longValue();
             logger.info("\t read xlogStart at '{}' from transaction '{}'", ReplicationConnection.format(xlogStart), txId);
 
             // and mark the start of the snapshot

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
@@ -219,7 +219,7 @@ public class RecordsStreamProducer extends RecordsProducer {
 
         // update the source info with the coordinates for this message
         long commitTimeNs = message.getCommitTime();
-        int txId = message.getTransactionId();
+        long txId = message.getTransactionId();
         sourceInfo.update(lsn, commitTimeNs, txId);
         if (logger.isDebugEnabled()) {
             logger.debug("received new message at position {}\n{}", ReplicationConnection.format(lsn), message);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/SourceInfo.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/SourceInfo.java
@@ -90,7 +90,7 @@ final class SourceInfo extends AbstractSourceInfo {
                                                      .name("io.debezium.connector.postgresql.Source")
                                                      .field(SERVER_NAME_KEY, Schema.STRING_SCHEMA)
                                                      .field(TIMESTAMP_KEY, Schema.OPTIONAL_INT64_SCHEMA)
-                                                     .field(TXID_KEY, Schema.OPTIONAL_INT32_SCHEMA)
+                                                     .field(TXID_KEY, Schema.OPTIONAL_INT64_SCHEMA)
                                                      .field(LSN_KEY, Schema.OPTIONAL_INT64_SCHEMA)
                                                      .field(SNAPSHOT_KEY, SchemaBuilder.bool().optional().defaultValue(false).build())
                                                      .field(LAST_SNAPSHOT_RECORD_KEY, Schema.OPTIONAL_BOOLEAN_SCHEMA)
@@ -100,7 +100,7 @@ final class SourceInfo extends AbstractSourceInfo {
     private final Map<String, String> sourcePartition;
 
     private Long lsn;
-    private Integer txId;
+    private Long txId;
     private Long useconds;
     private boolean snapshot = false;
     private Boolean lastSnapshotRecord;
@@ -113,7 +113,7 @@ final class SourceInfo extends AbstractSourceInfo {
 
     protected void load(Map<String, Object> lastStoredOffset) {
         this.lsn = ((Number) lastStoredOffset.get(LSN_KEY)).longValue();
-        this.txId = ((Number) lastStoredOffset.get(TXID_KEY)).intValue();
+        this.txId = ((Number) lastStoredOffset.get(TXID_KEY)).longValue();
         this.useconds = (Long) lastStoredOffset.get(TIMESTAMP_KEY);
         this.snapshot = lastStoredOffset.containsKey(SNAPSHOT_KEY);
         if (this.snapshot) {
@@ -167,7 +167,7 @@ final class SourceInfo extends AbstractSourceInfo {
      * @param txId the ID of the transaction that generated the transaction; may be null if this information nis not available
      * @return this instance
      */
-    protected SourceInfo update(Long lsn, Long useconds, Integer txId) {
+    protected SourceInfo update(Long lsn, Long useconds, Long txId) {
         this.lsn = lsn;
         this.useconds = useconds;
         this.txId = txId;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
@@ -63,7 +63,7 @@ public interface ReplicationMessage {
     /**
      * @return An id of transaction to which this change belongs
      */
-    public int getTransactionId();
+    public long getTransactionId();
 
     /**
      * @return Table changed

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
@@ -70,8 +70,8 @@ class PgProtoReplicationMessage implements ReplicationMessage {
     }
 
     @Override
-    public int getTransactionId() {
-        return rawMessage.getTransactionId();
+    public long getTransactionId() {
+        return Integer.toUnsignedLong(rawMessage.getTransactionId());
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
@@ -51,7 +51,7 @@ public class NonStreamingWal2JsonMessageDecoder implements MessageDecoder {
             final byte[] content = Arrays.copyOfRange(source, buffer.arrayOffset(), source.length);
             final Document message = DocumentReader.floatNumbersAsTextReader().read(content);
             LOGGER.debug("Message arrived for decoding {}", message);
-            final int txId = message.getInteger("xid");
+            final long txId = message.getLong("xid");
             final String timestamp = message.getString("timestamp");
             final long commitTime = dateTime.systemTimestamp(timestamp);
             final Array changes = message.getArray("change");

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
@@ -99,7 +99,7 @@ public class StreamingWal2JsonMessageDecoder implements MessageDecoder {
      */
     private byte[] currentChunk;
 
-    private int txId;
+    private long txId;
 
     private String timestamp;
 
@@ -130,7 +130,7 @@ public class StreamingWal2JsonMessageDecoder implements MessageDecoder {
                     content[lastPos] = RIGHT_BRACE;
                 }
                 final Document message = DocumentReader.defaultReader().read(content);
-                txId = message.getInteger("xid");
+                txId = message.getLong("xid");
                 timestamp = message.getString("timestamp");
                 commitTime = dateTime.systemTimestamp(timestamp);
                 messageInProgress = true;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
@@ -49,14 +49,14 @@ class Wal2JsonReplicationMessage implements ReplicationMessage {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Wal2JsonReplicationMessage.class);
 
-    private final int txId;
+    private final long txId;
     private final long commitTime;
     private final Document rawMessage;
     private final boolean hasMetadata;
     private final boolean lastEventForLsn;
     private final TypeRegistry typeRegistry;
 
-    public Wal2JsonReplicationMessage(int txId, long commitTime, Document rawMessage, boolean hasMetadata, boolean lastEventForLsn, TypeRegistry typeRegistry) {
+    public Wal2JsonReplicationMessage(long txId, long commitTime, Document rawMessage, boolean hasMetadata, boolean lastEventForLsn, TypeRegistry typeRegistry) {
         this.txId = txId;
         this.commitTime = commitTime;
         this.rawMessage = rawMessage;
@@ -86,7 +86,7 @@ class Wal2JsonReplicationMessage implements ReplicationMessage {
     }
 
     @Override
-    public int getTransactionId() {
+    public long getTransactionId() {
         return txId;
     }
 


### PR DESCRIPTION
the getInteger method returns a null when the value txid is not integer
![37851938-b7568820-2eae-11e8-8760-3701f1314e97](https://user-images.githubusercontent.com/30837065/37854073-64f3e6fa-2eb7-11e8-953f-61661fdb7ec9.png)
