### PR TITLE
DBZ-672 clean up mongo cursors

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
@@ -400,7 +400,6 @@ public class Replicator {
         FindIterable<Document> results = oplog.find(filter)
                                               .sort(new Document("$natural", 1)) // force forwards collection scan
                                               .oplogReplay(true) // tells Mongo to not rely on indexes
-                                              .noCursorTimeout(true) // don't timeout waiting for events
                                               .cursorType(CursorType.TailableAwait); // tail and await new data
         // Read as much of the oplog as we can ...
         ServerAddress primaryAddress = primary.getAddress();

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
@@ -133,6 +133,7 @@ public class Replicator {
      */
     public void stop() {
         this.copyThreads.shutdownNow();
+        this.running.set(false);
     }
 
     /**


### PR DESCRIPTION
* actually stop tailing the mongo oplog when a replicator is stopped and shut down the thread, thus closing the cursor to the oplog
* avoid using cursor with no timeout:
  - they are notorious for being unkillable without restarting the mongo database (https://stackoverflow.com/questions/28204140/how-to-kill-dead-cursors-in-mongodb) thus every hard connector crash would keep increasing their count until the database is restarted
  - as the oplog will contain periodic noop events at least every 10 seconds (https://github.com/mongodb/mongo/blob/3.6.3/src/mongo/db/repl/replication_coordinator_impl.cpp#L111) the timeout should be irrelevant