### PR TITLE
DBZ-601 Snapshots fail if launching multiple connectors at once

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BlockingReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BlockingReader.java
@@ -29,10 +29,12 @@ public class BlockingReader implements Reader {
     private final Metronome metronome;
 
     private final String name;
+    private final String runningLogMessage;
 
-    public BlockingReader(String name) {
+    public BlockingReader(String name, String runningLogMessage) {
         this.name = name;
         this.metronome = Metronome.parker(ConfigurationDefaults.RETURN_CONTROL_INTERVAL, Clock.SYSTEM);
+        this.runningLogMessage = runningLogMessage;
 
     }
 
@@ -65,7 +67,7 @@ public class BlockingReader implements Reader {
     @Override
     public void start() {
         state.set(State.RUNNING);
-        logger.info("Connector has completed all of its work but will continue in the running state. It can be shut down at any time.");
+        logger.info(runningLogMessage);
     }
 
     @Override

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -882,13 +882,13 @@ public class MySqlConnectorConfig extends CommonConnectorConfig {
                     "The value of those properties is the select statement to use when retrieving data from the specific table during snapshotting. " +
                     "A possible use case for large append-only tables is setting a specific point where to start (resume) snapshotting, in case a previous snapshotting was interrupted.");
 
-    public static final Field SNAPSHOT_DELAY_MINUTES = Field.createInternal("snapshot.delay.minutes")
-            .withDisplayName("Snapshot Delay (minutes)")
+    public static final Field SNAPSHOT_DELAY_MS = Field.createInternal("snapshot.delay.ms")
+            .withDisplayName("Snapshot Delay (milliseconds)")
             .withType(Type.LONG)
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.LOW)
-            .withDescription("The number of minutes to delay before a snapshot will begin.")
-            .withDefault(0l)
+            .withDescription("The number of milliseconds to delay before a snapshot will begin.")
+            .withDefault(0L)
             .withValidation(Field::isNonNegativeLong);
 
     /**
@@ -944,7 +944,7 @@ public class MySqlConnectorConfig extends CommonConnectorConfig {
                                                      BIGINT_UNSIGNED_HANDLING_MODE,
                                                      EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE,
                                                      INCONSISTENT_SCHEMA_HANDLING_MODE,
-                                                     SNAPSHOT_DELAY_MINUTES,
+                                                     SNAPSHOT_DELAY_MS,
                                                      CommonConnectorConfig.TOMBSTONES_ON_DELETE);
 
     /**
@@ -1001,7 +1001,7 @@ public class MySqlConnectorConfig extends CommonConnectorConfig {
         Field.group(config, "Connector", CONNECTION_TIMEOUT_MS, KEEP_ALIVE, KEEP_ALIVE_INTERVAL_MS, CommonConnectorConfig.MAX_QUEUE_SIZE,
                     CommonConnectorConfig.MAX_BATCH_SIZE, CommonConnectorConfig.POLL_INTERVAL_MS,
                     SNAPSHOT_MODE, SNAPSHOT_LOCKING_MODE, SNAPSHOT_MINIMAL_LOCKING, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE,
-                    BIGINT_UNSIGNED_HANDLING_MODE, SNAPSHOT_DELAY_MINUTES);
+                    BIGINT_UNSIGNED_HANDLING_MODE, SNAPSHOT_DELAY_MS);
         return config;
     }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -882,6 +882,15 @@ public class MySqlConnectorConfig extends CommonConnectorConfig {
                     "The value of those properties is the select statement to use when retrieving data from the specific table during snapshotting. " +
                     "A possible use case for large append-only tables is setting a specific point where to start (resume) snapshotting, in case a previous snapshotting was interrupted.");
 
+    public static final Field SNAPSHOT_DELAY_MINUTES = Field.createInternal("snapshot.delay.minutes")
+            .withDisplayName("Snapshot Delay (minutes)")
+            .withType(Type.LONG)
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.LOW)
+            .withDescription("The number of minutes to delay before a snapshot will begin.")
+            .withDefault(0l)
+            .withValidation(Field::isNonNegativeLong);
+
     /**
      * Method that generates a Field for specifying that string columns whose names match a set of regular expressions should
      * have their values truncated to be no longer than the specified number of characters.
@@ -935,6 +944,7 @@ public class MySqlConnectorConfig extends CommonConnectorConfig {
                                                      BIGINT_UNSIGNED_HANDLING_MODE,
                                                      EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE,
                                                      INCONSISTENT_SCHEMA_HANDLING_MODE,
+                                                     SNAPSHOT_DELAY_MINUTES,
                                                      CommonConnectorConfig.TOMBSTONES_ON_DELETE);
 
     /**
@@ -991,7 +1001,7 @@ public class MySqlConnectorConfig extends CommonConnectorConfig {
         Field.group(config, "Connector", CONNECTION_TIMEOUT_MS, KEEP_ALIVE, KEEP_ALIVE_INTERVAL_MS, CommonConnectorConfig.MAX_QUEUE_SIZE,
                     CommonConnectorConfig.MAX_BATCH_SIZE, CommonConnectorConfig.POLL_INTERVAL_MS,
                     SNAPSHOT_MODE, SNAPSHOT_LOCKING_MODE, SNAPSHOT_MINIMAL_LOCKING, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE,
-                    BIGINT_UNSIGNED_HANDLING_MODE);
+                    BIGINT_UNSIGNED_HANDLING_MODE, SNAPSHOT_DELAY_MINUTES);
         return config;
     }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -6,7 +6,6 @@
 package io.debezium.connector.mysql;
 
 import java.sql.SQLException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -167,9 +166,9 @@ public final class MySqlConnectorTask extends BaseSourceTask {
                 SnapshotReader snapshotReader = new SnapshotReader("snapshot", taskContext);
                 if (snapshotEventsAreInserts) snapshotReader.generateInsertEvents();
 
-                if (taskContext.snapshotDelayMinutes() > 0) {
+                if (!taskContext.snapshotDelay().isZero()) {
                     // Adding a timed blocking reader to delay the snapshot, can help to avoid initial rebalancing interruptions
-                    chainedReaderBuilder.addReader(new TimedBlockingReader("timed-blocker", Duration.ofMinutes(taskContext.snapshotDelayMinutes())));
+                    chainedReaderBuilder.addReader(new TimedBlockingReader("timed-blocker", taskContext.snapshotDelay()));
                 }
                 chainedReaderBuilder.addReader(snapshotReader);
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -169,7 +169,7 @@ public final class MySqlConnectorTask extends BaseSourceTask {
 
                 if (taskContext.snapshotDelayMinutes() > 0) {
                     // Adding a timed blocking reader to delay the snapshot, can help to avoid initial rebalancing interruptions
-                    chainedReaderBuilder.addReader(new TimedBlockingReader("blocker", Duration.ofMinutes(taskContext.snapshotDelayMinutes())));
+                    chainedReaderBuilder.addReader(new TimedBlockingReader("timed-blocker", Duration.ofMinutes(taskContext.snapshotDelayMinutes())));
                 }
                 chainedReaderBuilder.addReader(snapshotReader);
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -249,6 +249,10 @@ public final class MySqlTaskContext extends CdcSourceTaskContext {
         return config.getString(Heartbeat.HEARTBEAT_TOPICS_PREFIX);
     }
 
+    public long snapshotDelayMinutes() {
+        return config.getLong(MySqlConnectorConfig.SNAPSHOT_DELAY_MINUTES);
+    }
+
     public void start() {
         connectionContext.start();
         // Start the MySQL database history, which simply starts up resources but does not recover the history to a specific point

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.mysql;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -249,8 +250,8 @@ public final class MySqlTaskContext extends CdcSourceTaskContext {
         return config.getString(Heartbeat.HEARTBEAT_TOPICS_PREFIX);
     }
 
-    public long snapshotDelayMinutes() {
-        return config.getLong(MySqlConnectorConfig.SNAPSHOT_DELAY_MINUTES);
+    public Duration snapshotDelay() {
+        return Duration.ofMillis(config.getLong(MySqlConnectorConfig.SNAPSHOT_DELAY_MS));
     }
 
     public void start() {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/TimedBlockingReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/TimedBlockingReader.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.ConfigurationDefaults;
+
+/**
+ * A component that blocks doing nothing for a specified period of time or until the connector task is stopped
+ *
+ * @author Peter Goransson
+ */
+public class TimedBlockingReader extends BlockingReader {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    // calculated number of ticks until this TimedBlockingReader should stop
+    private long ticks;
+
+    /**
+     * @param name Name of the reader
+     * @param timeout Duration of time until this TimedBlockingReader should stop
+     */
+    public TimedBlockingReader(String name, Duration timeoutMinutes) {
+        super(name, "The connector will wait for " + timeoutMinutes.toMinutes() + " minutes before proceeding");
+
+        // number of ticks calculated based upon the BlockingReader's metronome period
+        ticks = timeoutMinutes.toMillis() / ConfigurationDefaults.RETURN_CONTROL_INTERVAL.toMillis();
+    }
+
+    @Override
+    public List<SourceRecord> poll() throws InterruptedException {
+        super.poll();
+
+        // Stop when we've reached the timeout threshold
+        if (--ticks <= 0) {
+            stop();
+        }
+
+        return null;
+    }
+
+
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-601

Provides a snapshot delay configuration. This is currently implemented as an internal / undocumented configuration but I might suggest this should indeed be exposed and documented given the known limitations of kicking off multiple snapshots in parallel within a kafka connect cluster. I'm interested in any feedback on this.