### PR TITLE
DBZ-712. ignore initsync offset during connector start.

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/SourceInfo.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/SourceInfo.java
@@ -296,6 +296,10 @@ public final class SourceInfo extends AbstractSourceInfo {
         if (replicaSetName == null) throw new IllegalArgumentException("The replica set name may not be null");
         if (sourceOffset == null) return false;
         // We have previously recorded at least one offset for this database ...
+        boolean initSync = booleanOffsetValue(sourceOffset, INITIAL_SYNC);
+        if (initSync) {
+            return false;
+        }
         int time = intOffsetValue(sourceOffset, TIMESTAMP);
         int order = intOffsetValue(sourceOffset, ORDER);
         Long operationId = longOffsetValue(sourceOffset, OPERATION_ID);
@@ -366,5 +370,13 @@ public final class SourceInfo extends AbstractSourceInfo {
         } catch (NumberFormatException e) {
             throw new ConnectException("Source offset '" + key + "' parameter value " + obj + " could not be converted to a long");
         }
+    }
+
+    private static boolean booleanOffsetValue(Map<String, ?> values, String key) {
+        Object obj = values.get(key);
+        if (obj != null && obj instanceof Boolean) {
+            return ((Boolean) obj).booleanValue();
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Ignore the offset with `initsync:true` during connector start since that indicates the initial sync is not completed, see https://issues.jboss.org/browse/DBZ-712.