### PR TITLE
DBZ-191 Adding record validations

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MysqlDefaultValueIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MysqlDefaultValueIT.java
@@ -21,10 +21,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 
-import io.debezium.jdbc.TemporalPrecisionMode;
-import io.debezium.time.MicroTimestamp;
-import io.debezium.time.Timestamp;
-import io.debezium.time.ZonedTimestamp;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.After;
@@ -34,6 +30,10 @@ import org.junit.Test;
 import io.debezium.config.Configuration;
 import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.jdbc.JdbcValueConverters;
+import io.debezium.jdbc.TemporalPrecisionMode;
+import io.debezium.time.MicroTimestamp;
+import io.debezium.time.Timestamp;
+import io.debezium.time.ZonedTimestamp;
 import io.debezium.util.Testing;
 
 /**
@@ -75,6 +75,8 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(EVENT_COUNT);
         SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("UNSIGNED_TINYINT_TABLE")).get(0);
+        validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         Schema schemaC = record.valueSchema().fields().get(1).schema().fields().get(2).schema();
@@ -105,6 +107,8 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(EVENT_COUNT);
         SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("UNSIGNED_SMALLINT_TABLE")).get(0);
+        validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         Schema schemaC = record.valueSchema().fields().get(1).schema().fields().get(2).schema();
@@ -135,6 +139,8 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(EVENT_COUNT);
         SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("UNSIGNED_MEDIUMINT_TABLE")).get(0);
+        validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         Schema schemaC = record.valueSchema().fields().get(1).schema().fields().get(2).schema();
@@ -165,6 +171,8 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(EVENT_COUNT);
         SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("UNSIGNED_INT_TABLE")).get(0);
+        validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         Schema schemaC = record.valueSchema().fields().get(1).schema().fields().get(2).schema();
@@ -195,6 +203,8 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(EVENT_COUNT);
         SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("UNSIGNED_BIGINT_TABLE")).get(0);
+        validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         Schema schemaC = record.valueSchema().fields().get(1).schema().fields().get(2).schema();
@@ -226,6 +236,11 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(EVENT_COUNT);
         SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("UNSIGNED_BIGINT_TABLE")).get(0);
+
+        // TODO can't validate due to https://github.com/confluentinc/schema-registry/issues/833
+        // enable once that's resolved upstream
+        // validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         Schema schemaC = record.valueSchema().fields().get(1).schema().fields().get(2).schema();
@@ -256,6 +271,8 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(EVENT_COUNT);
         SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("STRING_TABLE")).get(0);
+        validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         Schema schemaC = record.valueSchema().fields().get(1).schema().fields().get(2).schema();
@@ -285,6 +302,8 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(EVENT_COUNT);
         SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("BIT_TABLE")).get(0);
+        validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         Schema schemaC = record.valueSchema().fields().get(1).schema().fields().get(2).schema();
@@ -318,6 +337,8 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(EVENT_COUNT);
         SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("BOOLEAN_TABLE")).get(0);
+        validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         Schema schemaC = record.valueSchema().fields().get(1).schema().fields().get(2).schema();
@@ -341,6 +362,8 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(EVENT_COUNT);
         SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("NUMBER_TABLE")).get(0);
+        validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         Schema schemaC = record.valueSchema().fields().get(1).schema().fields().get(2).schema();
@@ -364,6 +387,8 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(EVENT_COUNT);
         SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("FlOAT_DOUBLE_TABLE")).get(0);
+        validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         assertThat(schemaA.defaultValue()).isEqualTo(0d);
@@ -381,6 +406,8 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(EVENT_COUNT);
         SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("REAL_TABLE")).get(0);
+        validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         assertThat(schemaA.defaultValue()).isEqualTo(1d);
@@ -399,6 +426,8 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(EVENT_COUNT);
         SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("NUMERIC_DECIMAL_TABLE")).get(0);
+        validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         Schema schemaC = record.valueSchema().fields().get(1).schema().fields().get(2).schema();
@@ -419,6 +448,11 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(EVENT_COUNT);
         SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("NUMERIC_DECIMAL_TABLE")).get(0);
+
+        // TODO can't validate due to https://github.com/confluentinc/schema-registry/issues/833
+        // enable once that's resolved upstream
+        // validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         assertThat(schemaA.defaultValue()).isEqualTo(BigDecimal.valueOf(1.23));
@@ -437,6 +471,8 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(7);
         final SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("DATE_TIME_TABLE")).get(0);
+        validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         Schema schemaC = record.valueSchema().fields().get(1).schema().fields().get(2).schema();
@@ -492,6 +528,8 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(7);
         final SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("DATE_TIME_TABLE")).get(0);
+        validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         Schema schemaC = record.valueSchema().fields().get(1).schema().fields().get(2).schema();
@@ -540,6 +578,11 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         SourceRecords records = consumeRecordsByTopic(7);
         final SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("DATE_TIME_TABLE")).get(0);
+
+        // TODO can't validate due to https://github.com/confluentinc/schema-registry/issues/833
+        // enable once that's resolved upstream
+        // validate(record);
+
         Schema schemaA = record.valueSchema().fields().get(1).schema().fields().get(0).schema();
         Schema schemaB = record.valueSchema().fields().get(1).schema().fields().get(1).schema();
         Schema schemaC = record.valueSchema().fields().get(1).schema().fields().get(2).schema();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -51,6 +51,7 @@ import io.debezium.data.Bits;
 import io.debezium.data.Json;
 import io.debezium.data.Uuid;
 import io.debezium.data.VariableScaleDecimal;
+import io.debezium.data.VerifyRecord;
 import io.debezium.data.Xml;
 import io.debezium.data.geometry.Geography;
 import io.debezium.data.geometry.Geometry;
@@ -547,12 +548,12 @@ public abstract class AbstractRecordsProducerTest {
     }
 
     protected static class SchemaAndValueField {
-        private final Object schema;
+        private final Schema schema;
         private final Object value;
         private final String fieldName;
         private Supplier<Boolean> assertValueOnlyIf = null;
 
-        public SchemaAndValueField(String fieldName, Object schema, Object value) {
+        public SchemaAndValueField(String fieldName, Schema schema, Object value) {
             this.schema = schema;
             this.value = value;
             this.fieldName = fieldName;
@@ -632,7 +633,7 @@ public abstract class AbstractRecordsProducerTest {
             Schema schema = content.schema();
             Field field = schema.field(fieldName);
             assertNotNull(fieldName + " not found in schema " + schema, field);
-            assertEquals("Schema for " + field.name() + " does not match the actual value", this.schema, field.schema());
+            VerifyRecord.assertConnectSchemasAreEqual(this.schema, field.schema());
         }
     }
 


### PR DESCRIPTION
@jpechane That's a side product of my explorations that led to DBZ-727. It's verifying the records now (including their default values).

It uncovered a bug in Kafka Connect ([KAFKA-7058](https://issues.apache.org/jira/browse/KAFKA-7058)) and one in the Avro converter (https://github.com/confluentinc/schema-registry/issues/833). To work around those, schema comparison is done manually in the code instead of relying on `ConnectSchema#equals()` and record validation is commented out for a few records.