### PR TITLE
Fix unusable array information in Serialization

### DIFF
--- a/debezium-core/src/main/java/io/debezium/data/SchemaUtil.java
+++ b/debezium-core/src/main/java/io/debezium/data/SchemaUtil.java
@@ -119,7 +119,7 @@ public class SchemaUtil {
         return new RecordWriter().detailed(true).append(record).toString();
     }
 
-    protected static class RecordWriter {
+    public static class RecordWriter {
         private final StringBuilder sb = new StringBuilder();
         private boolean detailed = false;
 

--- a/debezium-core/src/main/java/io/debezium/data/SchemaUtil.java
+++ b/debezium-core/src/main/java/io/debezium/data/SchemaUtil.java
@@ -9,7 +9,7 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
-import java.util.Base64;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -175,10 +175,9 @@ public class SchemaUtil {
                 }
                 sb.append('}');
             } else if (obj instanceof ByteBuffer) {
-                ByteBuffer b = (ByteBuffer) obj;
-                sb.append('"').append(Base64.getEncoder().encode(b.array())).append('"');
+                append((ByteBuffer)obj);
             } else if (obj instanceof byte[]) {
-                sb.append('"').append(Base64.getEncoder().encode((byte[])obj)).append('"');
+                append((byte[])obj);
             } else if (obj instanceof Map<?, ?>) {
                 Map<?, ?> map = (Map<?, ?>) obj;
                 sb.append('{');
@@ -251,6 +250,15 @@ public class SchemaUtil {
                 append(obj.toString());
             }
             return this;
+        }
+
+        protected void append(ByteBuffer b) {
+            append(b.array());
+        }
+
+        protected void append(byte[] b) {
+            String arrayString = Arrays.toString(b);
+            sb.append('"').append(arrayString).append('"');
         }
 
         protected void appendFirst(String name, Object value) {

--- a/debezium-core/src/test/java/io/debezium/data/RecordWriterTest.java
+++ b/debezium-core/src/test/java/io/debezium/data/RecordWriterTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.data;
+
+import io.debezium.data.SchemaUtil.RecordWriter;
+import io.debezium.doc.FixFor;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * Test for {@link SchemaUtil.RecordWriter}.
+ * 
+ * @author Andreas Bergmeier
+ * 
+ */
+public class RecordWriterTest {
+
+    @Test
+    @FixFor("DBZ-759")
+    public void correctlySerializesByteArray() {
+        final RecordWriter recordWriter = new RecordWriter();
+        recordWriter.append(new byte[]{1, 3, 5, 7});
+        assertThat(recordWriter.toString()).isEqualTo("\"[1, 3, 5, 7]\"");
+    }
+
+    @Test
+    @FixFor("DBZ-759")
+    public void correctlySerializesByteBuffer() {
+        final RecordWriter recordWriter = new RecordWriter();
+        final ByteBuffer buffer = ByteBuffer.allocate(3);
+        buffer.put(new byte[]{11, 13, 17});
+        recordWriter.append(buffer);
+        assertThat(recordWriter.toString()).isEqualTo("\"[11, 13, 17]\"");
+    }
+}


### PR DESCRIPTION
According to ErrorProne, (implicitly) calling toString on the array does
not give useful information. Seems like these code paths are not unit
tested?