### PR TITLE
Extract comparation of Column (producers) to own Comparator

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/ColumnComparator.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnComparator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import java.util.Comparator;
+
+/**
+ * A Comparator for {@link Column} instances and objects which create {@link Column) instances.
+ *
+ * @author Andreas Bergmeier
+ */
+final class ColumnComparator implements Comparator<Column> {
+
+    @Override
+    public int compare(Column lhs, Column rhs) {
+        return lhs.compareTo(rhs);
+    }
+
+    public int compare(ColumnEditor lhs, Column rhs) {
+        return lhs.create().compareTo(rhs);
+    }
+
+    public int compare(Column lhs, ColumnEditor rhs) {
+        return lhs.compareTo(rhs.create());
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/relational/ColumnEditor.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnEditor.java
@@ -16,7 +16,7 @@ import io.debezium.annotation.NotThreadSafe;
  * @author Randall Hauch
  */
 @NotThreadSafe
-public interface ColumnEditor extends Comparable<Column> {
+public interface ColumnEditor {
 
     /**
      * Get the name of the column.

--- a/debezium-core/src/main/java/io/debezium/relational/ColumnEditorImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnEditorImpl.java
@@ -203,11 +203,6 @@ final class ColumnEditorImpl implements ColumnEditor {
     }
 
     @Override
-    public int compareTo(Column that) {
-        return create().compareTo(that);
-    }
-
-    @Override
     public String toString() {
         return create().toString();
     }


### PR DESCRIPTION
According to ErrorProne, the implicit guarantees by Comparable need to be
uphold: sgn(x.compareTo(y)) == -sgn(y.compareTo(x)).
With the Java type system this seems most elegantly to be implemented by
a Comparator.