### PR TITLE
Fix ColumnImpl.scale equality check

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/ColumnImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnImpl.java
@@ -145,7 +145,7 @@ final class ColumnImpl implements Column, Comparable<Column> {
                     Strings.equalsIgnoreCase(this.charsetName(),that.charsetName()) &&
                     this.position() == that.position() &&
                     this.length() == that.length() &&
-                    this.scale() == that.scale() &&
+                    this.scale().equals(that.scale()) &&
                     this.isOptional() == that.isOptional() &&
                     this.isAutoIncremented() == that.isAutoIncremented() &&
                     this.isGenerated() == that.isGenerated() &&


### PR DESCRIPTION
According to ErrorProne, checking Optional via operator == leads to
reference equality check. Probably want rather to check for contained
values.