### PR TITLE
DBZ-713 Only getting collections for databases matching filters

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbTaskContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbTaskContext.java
@@ -5,8 +5,6 @@
  */
 package io.debezium.connector.mongodb;
 
-import java.util.function.Predicate;
-
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.common.CdcSourceTaskContext;
@@ -43,12 +41,8 @@ public class MongoDbTaskContext extends CdcSourceTaskContext {
         return topicSelector;
     }
 
-    public Predicate<String> databaseFilter() {
-        return filters.databaseFilter();
-    }
-
-    public Predicate<CollectionId> collectionFilter() {
-        return filters.collectionFilter();
+    public Filters filters() {
+        return filters;
     }
 
     public SourceInfo source() {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
@@ -86,6 +86,9 @@ import io.debezium.util.Threads;
 public class Replicator {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private static final String AUTHORIZATION_FAILURE_MESSAGE = "Command failed with error 13";
+
     private final MongoDbTaskContext context;
     private final ExecutorService copyThreads;
     private final ReplicaSet replicaSet;
@@ -168,7 +171,7 @@ public class Replicator {
                 context.filters(),
                 (desc, error) -> {
                     // propagate authorization failures
-                    if (error.getMessage() != null && error.getMessage().startsWith("Command failed with error 13")) {
+                    if (error.getMessage() != null && error.getMessage().startsWith(AUTHORIZATION_FAILURE_MESSAGE)) {
                         throw new ConnectException("Error while attempting to " + desc, error);
                     }
                     else {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/AbstractMongoIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/AbstractMongoIT.java
@@ -85,7 +85,7 @@ public abstract class AbstractMongoIT implements Testing {
         }
 
         // Get a connection to the primary ...
-        primary = context.getConnectionContext().primaryFor(replicaSet, connectionErrorHandler(3));
+        primary = context.getConnectionContext().primaryFor(replicaSet, context.filters(), connectionErrorHandler(3));
     }
 
     @After

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -343,7 +343,7 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
 
     protected MongoPrimary primary() {
         ReplicaSet replicaSet = ReplicaSet.parse(context.getConnectionContext().hosts());
-        return context.getConnectionContext().primaryFor(replicaSet, connectionErrorHandler(3));
+        return context.getConnectionContext().primaryFor(replicaSet, context.filters(), connectionErrorHandler(3));
     }
 
     protected void storeDocuments(String dbName, String collectionName, String pathOnClasspath) {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTestIT.java
@@ -154,7 +154,7 @@ public class UnwrapFromMongoDbEnvelopeTestIT extends AbstractConnectorTest {
 
     private MongoPrimary primary() {
         ReplicaSet replicaSet = ReplicaSet.parse(context.getConnectionContext().hosts());
-        return context.getConnectionContext().primaryFor(replicaSet, connectionErrorHandler(3));
+        return context.getConnectionContext().primaryFor(replicaSet, context.filters(), connectionErrorHandler(3));
     }
 
     private BiConsumer<String, Throwable> connectionErrorHandler(int numErrorsBeforeFailing) {


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-713
https://issues.jboss.org/browse/DBZ-782

@jpechane This fixes two issues, I noticed DBZ-782 while working on DBZ-713. It's best reviewed commit by commit, as they are largely independent and I did some clean-up not strictly related to the original issue. Also disable whitelist differences to further ease the diff. Thanks!

In terms of testing, it seems all the MongoDB ITs we have don't deal with authentication/authorization at all. It seems worth to have some tests for that, but let's handle it separately. I tested the original issue manually successfully, i.e. collections from a DB the connector user isn't authorized for won't cause any harm if that other DB is not part of the filter config. I've added some basic tests which make sure that the methods of `MongoPrimary` only return the databases/collections matching the given filter config.
