### PR TITLE
DBZ-793 Using TableFilter consistently;

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
@@ -16,8 +16,6 @@ import io.debezium.config.Configuration;
 import io.debezium.relational.ColumnId;
 import io.debezium.relational.Selectors;
 import io.debezium.relational.TableId;
-import io.debezium.relational.Tables;
-import io.debezium.relational.Tables.TableNameFilter;
 import io.debezium.util.Collect;
 
 /**
@@ -106,10 +104,6 @@ public class Filters {
 
     public Predicate<TableId> tableFilter() {
         return tableFilter;
-    }
-
-    public TableNameFilter tableNameFilter() {
-        return Tables.filterFor(tableFilter);
     }
 
     public Predicate<TableId> builtInTableFilter() {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
@@ -30,6 +30,7 @@ import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchemaBuilder;
 import io.debezium.relational.Tables;
+import io.debezium.relational.Tables.TableFilter;
 import io.debezium.relational.ddl.DdlChanges;
 import io.debezium.relational.ddl.DdlChanges.DatabaseStatementStringConsumer;
 import io.debezium.relational.ddl.DdlParser;
@@ -85,7 +86,7 @@ public class MySqlSchema extends RelationalDatabaseSchema {
         super(
                 configuration,
                 topicSelector,
-                new Filters(configuration.getConfig()).tableFilter(),
+                TableFilter.fromPredicate(new Filters(configuration.getConfig()).tableFilter()),
                 new Filters(configuration.getConfig()).columnFilter(),
                 new TableSchemaBuilder(
                         getValueConverters(configuration.getConfig()), SchemaNameAdjuster.create(logger), SourceInfo.SCHEMA)

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -42,7 +42,7 @@ import io.debezium.relational.TableEditor;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
 import io.debezium.relational.Tables.ColumnNameFilter;
-import io.debezium.relational.Tables.TableNameFilter;
+import io.debezium.relational.Tables.TableFilter;
 import io.debezium.util.Collect;
 import io.debezium.util.Strings;
 
@@ -803,7 +803,7 @@ public class JdbcConnection implements AutoCloseable {
      * @throws SQLException if an error occurs while accessing the database metadata
      */
     public void readSchema(Tables tables, String databaseCatalog, String schemaNamePattern,
-                           TableNameFilter tableFilter, ColumnNameFilter columnFilter, boolean removeTablesNotFoundInJdbc)
+                           TableFilter tableFilter, ColumnNameFilter columnFilter, boolean removeTablesNotFoundInJdbc)
             throws SQLException {
         // Before we make any changes, get the copy of the set of table IDs ...
         Set<TableId> tableIdsBefore = new HashSet<>(tables.tableIds());
@@ -832,7 +832,7 @@ public class JdbcConnection implements AutoCloseable {
                 if (viewIds.contains(tableId)) {
                     continue;
                 }
-                if (tableFilter == null || tableFilter.matches(catalogName, schemaName, tableName)) {
+                if (tableFilter == null || tableFilter.isIncluded(tableId)) {
                     List<Column> cols = columnsByTable.computeIfAbsent(tableId, name -> new ArrayList<>());
                     String columnName = rs.getString(4);
                     if (columnFilter == null || columnFilter.matches(catalogName, schemaName, tableName, columnName)) {

--- a/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseSchema.java
+++ b/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseSchema.java
@@ -8,6 +8,7 @@ package io.debezium.relational;
 import java.util.function.Predicate;
 
 import io.debezium.config.CommonConnectorConfig;
+import io.debezium.relational.Tables.TableFilter;
 import io.debezium.schema.HistorizedDatabaseSchema;
 import io.debezium.schema.TopicSelector;
 
@@ -15,7 +16,7 @@ public abstract class HistorizedRelationalDatabaseSchema extends RelationalDatab
         implements HistorizedDatabaseSchema<TableId> {
 
     protected HistorizedRelationalDatabaseSchema(CommonConnectorConfig config, TopicSelector<TableId> topicSelector,
-            Predicate<TableId> tableFilter, Predicate<ColumnId> columnFilter, TableSchemaBuilder schemaBuilder,
+            TableFilter tableFilter, Predicate<ColumnId> columnFilter, TableSchemaBuilder schemaBuilder,
             boolean tableIdCaseInsensitive) {
         super(config, topicSelector, tableFilter, columnFilter, schemaBuilder, tableIdCaseInsensitive);
     }

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -5,8 +5,6 @@
  */
 package io.debezium.relational;
 
-import java.util.function.Predicate;
-
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
@@ -15,6 +13,7 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.config.Field.ValidationOutput;
+import io.debezium.relational.Tables.TableFilter;
 
 /**
  * Configuration options shared across the relational CDC connectors.
@@ -61,7 +60,7 @@ public class RelationalDatabaseConnectorConfig extends CommonConnectorConfig {
 
     private final RelationalTableFilters tableFilters;
 
-    protected RelationalDatabaseConnectorConfig(Configuration config, String logicalName, Predicate<TableId> systemTablesFilter) {
+    protected RelationalDatabaseConnectorConfig(Configuration config, String logicalName, TableFilter systemTablesFilter) {
         super(config, logicalName);
 
         this.tableFilters = new RelationalTableFilters(config, systemTablesFilter);

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseSchema.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseSchema.java
@@ -13,6 +13,7 @@ import java.util.function.Predicate;
 import org.apache.kafka.connect.data.Schema;
 
 import io.debezium.config.CommonConnectorConfig;
+import io.debezium.relational.Tables.TableFilter;
 import io.debezium.relational.mapping.ColumnMappers;
 import io.debezium.schema.DatabaseSchema;
 import io.debezium.schema.TopicSelector;
@@ -26,7 +27,7 @@ public abstract class RelationalDatabaseSchema implements DatabaseSchema<TableId
 
     private final TopicSelector<TableId> topicSelector;
     private final TableSchemaBuilder schemaBuilder;
-    private final Predicate<TableId> tableFilter;
+    private final TableFilter tableFilter;
     private final Predicate<ColumnId> columnFilter;
     private final ColumnMappers columnMappers;
 
@@ -35,7 +36,7 @@ public abstract class RelationalDatabaseSchema implements DatabaseSchema<TableId
     private final Tables tables;
 
     protected RelationalDatabaseSchema(CommonConnectorConfig config, TopicSelector<TableId> topicSelector,
-            Predicate<TableId> tableFilter, Predicate<ColumnId> columnFilter, TableSchemaBuilder schemaBuilder,
+            TableFilter tableFilter, Predicate<ColumnId> columnFilter, TableSchemaBuilder schemaBuilder,
             boolean tableIdCaseInsensitive) {
 
         this.topicSelector = topicSelector;
@@ -96,7 +97,7 @@ public abstract class RelationalDatabaseSchema implements DatabaseSchema<TableId
      *         or if the table has been excluded by the filters
      */
     public Table tableFor(TableId id) {
-        return tableFilter.test(id) ? tables.forTable(id) : null;
+        return tableFilter.isIncluded(id) ? tables.forTable(id) : null;
     }
 
     protected Tables tables() {
@@ -108,7 +109,7 @@ public abstract class RelationalDatabaseSchema implements DatabaseSchema<TableId
     }
 
     protected void buildAndRegisterSchema(Table table) {
-        if (tableFilter.test(table.id())) {
+        if (tableFilter.isIncluded(table.id())) {
             TableSchema schema = schemaBuilder.create(schemaPrefix, getEnvelopeSchemaName(table), table, columnFilter, columnMappers);
             schemasByTableId.put(table.id(), schema);
         }

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalTableFilters.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalTableFilters.java
@@ -8,13 +8,14 @@ package io.debezium.relational;
 import java.util.function.Predicate;
 
 import io.debezium.config.Configuration;
+import io.debezium.relational.Tables.TableFilter;
 import io.debezium.schema.DataCollectionFilters;
 
 public class RelationalTableFilters implements DataCollectionFilters {
 
     private final TableFilter tableFilter;
 
-    public RelationalTableFilters(Configuration config, Predicate<TableId> systemTablesFilter) {
+    public RelationalTableFilters(Configuration config, TableFilter systemTablesFilter) {
         // Define the filter using the whitelists and blacklists for tables and database names ...
         Predicate<TableId> predicate = Selectors.tableSelector()
 //                                                  .includeDatabases(config.getString(RelationalDatabaseConnectorConfig.DATABASE_WHITELIST))
@@ -26,7 +27,7 @@ public class RelationalTableFilters implements DataCollectionFilters {
 
 
         Predicate<TableId> finalPredicate = config.getBoolean(RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN)
-                ? predicate.and(systemTablesFilter.negate())
+                ? predicate.and(systemTablesFilter::isIncluded)
                 : predicate;
 
         this.tableFilter = t -> finalPredicate.test(t);
@@ -35,12 +36,5 @@ public class RelationalTableFilters implements DataCollectionFilters {
     @Override
     public TableFilter dataCollectionFilter() {
         return tableFilter;
-    }
-
-    @FunctionalInterface
-    public interface TableFilter extends DataCollectionFilter<TableId>{
-
-        @Override
-        boolean isIncluded(TableId tableId);
     }
 }


### PR DESCRIPTION
Only the MySQL connector's Filters class still uses Predicate for the time being, so to avoid to much merging trouble with DBZ-175.

https://issues.jboss.org/browse/DBZ-793