### PR TITLE
DBZ-720 Generic RDBMS snapshotting

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/ChangeRecordEmitter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/ChangeRecordEmitter.java
@@ -11,12 +11,17 @@ import io.debezium.data.Envelope.Operation;
 import io.debezium.schema.DataCollectionSchema;
 
 /**
- * Emits one or more change records - specific to a given {@link DataCollectionSchema}.
+ * Represents a change applied to a source database and emits one or more corresponding change records. In most cases,
+ * there'll be one change record for one source change, but e.g. in case of updates involving a records PK, it may
+ * result in a deletion and re-insertion record.
  *
  * @author Gunnar Morling
  */
 public interface ChangeRecordEmitter {
 
+    /**
+     * Emits the change record(s) corresponding to data change represented by this emitter.
+     */
     void emitChangeRecords(DataCollectionSchema schema, Receiver receiver) throws InterruptedException;
 
     public interface Receiver {

--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
@@ -10,12 +10,46 @@ import java.util.Map;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
+/**
+ * Keeps track of the current offset within the source DB's change stream. This reflects in the offset as committed to
+ * Kafka and in the source info block contained within CDC messages themselves.
+ *
+ * @author Gunnar Morling
+ *
+ */
 public interface OffsetContext {
 
-    // load()
+    /**
+     * Implementations load a connector-specific offset context based on the offset values stored in Kafka.
+     */
+    interface Loader {
+        Map<String, ?> getPartition();
+        OffsetContext load(Map<String, ?> offset);
+    }
 
     Map<String, ?> getPartition();
     Map<String, ?> getOffset();
     Schema getSourceInfoSchema();
     Struct getSourceInfo();
+
+    /**
+     * Whether this offset indicates that an (uncompleted) snapshot is currently running or not.
+     * @return
+     */
+    boolean isSnapshotRunning();
+
+    /**
+     * Signals that a snapshot will begin, which should reflect in an updated offset state.
+     */
+    void preSnapshotStart();
+
+    /**
+     * Signals that a snapshot will complete, which should reflect in an updated offset state.
+     */
+    void preSnapshotCompletion();
+
+    /**
+     * Signals that a snapshot has been completed, which should reflect in an updated offset state.
+     */
+    void postSnapshotCompletion();
 }

--- a/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalSnapshotChangeEventSource.java
@@ -6,22 +6,34 @@
 package io.debezium.relational;
 
 import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.EventDispatcher.SnapshotReceiver;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
+import io.debezium.pipeline.spi.ChangeRecordEmitter;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.SnapshotResult;
 import io.debezium.schema.SchemaChangeEvent;
+import io.debezium.util.Clock;
+import io.debezium.util.Strings;
 
 /**
  * Base class for {@link SnapshotChangeEventSource} for relational databases with a schema history.
+ * <p>
+ * A transaction is managed by this base class, sub-classes shouldn't rollback or commit this transaction. They are free
+ * to use nested transactions or savepoints, though.
  *
  * @author Gunnar Morling
  */
@@ -35,19 +47,27 @@ public abstract class HistorizedRelationalSnapshotChangeEventSource implements S
     private final OffsetContext previousOffset;
     private final JdbcConnection jdbcConnection;
     private final HistorizedRelationalDatabaseSchema schema;
+    private final EventDispatcher<TableId> dispatcher;
+    private final Clock clock;
 
-    public HistorizedRelationalSnapshotChangeEventSource(RelationalDatabaseConnectorConfig connectorConfig, OffsetContext previousOffset, JdbcConnection jdbcConnection, HistorizedRelationalDatabaseSchema schema) {
+    public HistorizedRelationalSnapshotChangeEventSource(RelationalDatabaseConnectorConfig connectorConfig,
+            OffsetContext previousOffset, JdbcConnection jdbcConnection, HistorizedRelationalDatabaseSchema schema,
+            EventDispatcher<TableId> dispatcher, Clock clock) {
         this.connectorConfig = connectorConfig;
         this.previousOffset = previousOffset;
         this.jdbcConnection = jdbcConnection;
         this.schema = schema;
+        this.dispatcher = dispatcher;
+        this.clock = clock;
     }
 
     @Override
     public SnapshotResult execute(ChangeEventSourceContext context) throws InterruptedException {
+        SnapshottingTask snapshottingTask = getSnapshottingTask(previousOffset);
+
         // for now, just simple schema snapshotting is supported which just needs to be done once
-        if (previousOffset != null) {
-            LOGGER.debug("Found previous offset, skipping snapshotting");
+        if (!snapshottingTask.snapshotSchema() && !snapshottingTask.snapshotData()) {
+            LOGGER.debug("Skipping snapshotting");
             return SnapshotResult.completed(previousOffset);
         }
 
@@ -67,8 +87,10 @@ public abstract class HistorizedRelationalSnapshotChangeEventSource implements S
 
             LOGGER.info("Snapshot step 3 - Locking captured tables");
 
-            if (!lockTables(context, ctx)) {
-                return SnapshotResult.aborted();
+            if (snapshottingTask.snapshotSchema()) {
+                if (!lockTablesForSchemaSnapshot(context, ctx)) {
+                    return SnapshotResult.aborted();
+                }
             }
 
             LOGGER.info("Snapshot step 4 - Determining snapshot offset");
@@ -81,10 +103,29 @@ public abstract class HistorizedRelationalSnapshotChangeEventSource implements S
                 return SnapshotResult.aborted();
             }
 
-            LOGGER.info("Snapshot step 6 - Persisting schema history");
+            if (snapshottingTask.snapshotSchema()) {
+                LOGGER.info("Snapshot step 6 - Persisting schema history");
 
-            if (!createSchemaChangeEventsForTables(context, ctx)) {
-                return SnapshotResult.aborted();
+                if (!createSchemaChangeEventsForTables(context, ctx)) {
+                    return SnapshotResult.aborted();
+                }
+
+                // if we've returned before, the TX rollback will cause any locks to be released
+                releaseSchemaSnapshotLocks(ctx);
+            }
+            else {
+                LOGGER.info("Snapshot step 6 - Skipping persisting of schema history");
+            }
+
+            if (snapshottingTask.snapshotData()) {
+                LOGGER.info("Snapshot step 7 - Snapshotting data");
+
+                if (!createDataEvents(context, ctx)) {
+                    return SnapshotResult.aborted();
+                }
+            }
+            else {
+                LOGGER.info("Snapshot step 7 - Skipping snapshotting of data");
             }
 
             return SnapshotResult.completed(ctx.offset);
@@ -98,11 +139,16 @@ public abstract class HistorizedRelationalSnapshotChangeEventSource implements S
         finally {
             rollbackTransaction(connection);
 
-            LOGGER.info("Snapshot step 7 - Finalizing");
+            LOGGER.info("Snapshot step 8 - Finalizing");
 
             complete();
         }
     }
+
+    /**
+     * Returns the snapshotting task based on the previous offset (if available) and the connector's snapshotting mode.
+     */
+    protected abstract SnapshottingTask getSnapshottingTask(OffsetContext previousOffset);
 
     /**
      * Prepares the taking of a snapshot and returns an initial {@link SnapshotContext}.
@@ -116,10 +162,11 @@ public abstract class HistorizedRelationalSnapshotChangeEventSource implements S
 
         for (TableId tableId : allTableIds) {
             if (connectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId)) {
+                LOGGER.trace("Adding table {} to the list of captured tables", tableId);
                 capturedTables.add(tableId);
             }
             else {
-                LOGGER.trace("Skipping table {} as it's not included in the filter configuration", tableId);
+                LOGGER.trace("Ignoring table {} as it's not included in the filter configuration", tableId);
             }
         }
 
@@ -135,7 +182,7 @@ public abstract class HistorizedRelationalSnapshotChangeEventSource implements S
     /**
      * Locks all tables to be captured, so that no concurrent schema changes can be applied to them.
      */
-    protected abstract boolean lockTables(ChangeEventSourceContext sourceContext, SnapshotContext snapshotContext) throws Exception;
+    protected abstract boolean lockTablesForSchemaSnapshot(ChangeEventSourceContext sourceContext, SnapshotContext snapshotContext) throws Exception;
 
     /**
      * Determines the current offset (MySQL binlog position, Oracle SCN etc.), storing it into the passed context
@@ -149,6 +196,11 @@ public abstract class HistorizedRelationalSnapshotChangeEventSource implements S
      * Reads the structure of all the captured tables, writing it to {@link SnapshotContext#tables}.
      */
     protected abstract boolean readTableStructure(ChangeEventSourceContext sourceContext, SnapshotContext snapshotContext) throws Exception;
+
+    /**
+     * Releases all locks established in order to create a consistent schema snapshot.
+     */
+    protected abstract void releaseSchemaSnapshotLocks(SnapshotContext snapshotContext) throws Exception;
 
     private boolean createSchemaChangeEventsForTables(ChangeEventSourceContext sourceContext, SnapshotContext snapshotContext) throws Exception {
         for (TableId tableId : snapshotContext.capturedTables) {
@@ -170,6 +222,111 @@ public abstract class HistorizedRelationalSnapshotChangeEventSource implements S
      * Creates a {@link SchemaChangeEvent} representing the creation of the given table.
      */
     protected abstract SchemaChangeEvent getCreateTableEvent(SnapshotContext snapshotContext, Table table) throws Exception;
+
+    private boolean createDataEvents(ChangeEventSourceContext sourceContext, SnapshotContext snapshotContext) throws InterruptedException{
+        SnapshotReceiver snapshotReceiver = dispatcher.getSnapshotChangeEventReceiver();
+        snapshotContext.offset.preSnapshotStart();
+
+        for (TableId tableId : snapshotContext.capturedTables) {
+            if (!sourceContext.isRunning()) {
+                return false;
+            }
+
+            LOGGER.debug("Scanning table {}", tableId);
+
+            if (!createDataEventsForTable(snapshotContext, snapshotReceiver, snapshotContext.tables.forTable(tableId))) {
+                return false;
+            }
+        }
+
+        snapshotContext.offset.preSnapshotCompletion();
+        snapshotReceiver.completeSnapshot();
+        snapshotContext.offset.postSnapshotCompletion();
+
+        return true;
+    }
+
+    /**
+     * Dispatches the data change events for the records of a single table.
+     */
+    private boolean createDataEventsForTable(SnapshotContext snapshotContext, SnapshotReceiver snapshotReceiver,
+            Table table) throws InterruptedException {
+
+        long exportStart = clock.currentTimeInMillis();
+        LOGGER.info("\t Exporting data from table '{}'", table.id());
+
+        final String selectStatement = getSnapshotSelect(snapshotContext, table.id());
+        LOGGER.info("\t For table '{}' using select statement: '{}'", table.id(), selectStatement);
+
+        try (Statement statement = readTableStatement();
+                ResultSet rs = statement.executeQuery(selectStatement)) {
+
+            Column[] columns = getColumnsForResultSet(table, rs);
+            final int numColumns = table.columns().size();
+            int rows = 0;
+
+            while (rs.next()) {
+                rows++;
+                final Object[] row = new Object[numColumns];
+                for (int i = 0; i < numColumns; i++) {
+                    row[i] = getColumnValue(rs, i + 1, columns[i]);
+                }
+
+                if (rows % 10_000 == 0) {
+                    long stop = clock.currentTimeInMillis();
+                    LOGGER.info("\t Exported {} records for table '{}' after {}", rows, table.id(),
+                            Strings.duration(stop - exportStart));
+                }
+
+                dispatcher.dispatchSnapshotEvent(table.id(), getChangeRecordEmitter(snapshotContext, row),
+                        snapshotReceiver);
+            }
+
+            LOGGER.info("\t Finished exporting {} records for table '{}'; total duration '{}'", rows,
+                    table.id(), Strings.duration(clock.currentTimeInMillis() - exportStart));
+        }
+        catch(SQLException e) {
+            throw new ConnectException("Scanning of table " + table.id() + " failed", e);
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns a {@link ChangeRecordEmitter} producing the change records for the given table row.
+     */
+    protected abstract ChangeRecordEmitter getChangeRecordEmitter(SnapshotContext snapshotContext, Object[] row);
+
+    /**
+     * Returns the SELECT statement to be used for scanning the given table
+     */
+    // TODO Should it be Statement or similar?
+    // TODO Handle override option generically; a problem will be how to handle the dynamic part (Oracle's "... as of
+    // scn xyz")
+    protected abstract String getSnapshotSelect(SnapshotContext snapshotContext, TableId tableId);
+
+    private Column[] getColumnsForResultSet(Table table, ResultSet rs) throws SQLException {
+        ResultSetMetaData metaData = rs.getMetaData();
+        Column[] columns = new Column[metaData.getColumnCount()];
+
+        for(int i = 0; i < columns.length; i++) {
+            columns[i] = table.columnWithName(metaData.getColumnName(i + 1));
+        }
+
+        return columns;
+    }
+
+    private Object getColumnValue(ResultSet rs, int columnIndex, Column column) throws SQLException {
+        return rs.getObject(columnIndex);
+    }
+
+    private Statement readTableStatement() throws SQLException {
+        // TODO read option
+        int rowsFetchSize = 2000;
+        Statement statement = jdbcConnection.connection().createStatement(); // the default cursor is FORWARD_ONLY
+        statement.setFetchSize(rowsFetchSize);
+        return statement;
+    }
 
     /**
      * Completes the snapshot, doing any required clean-up (resource disposal etc.).
@@ -205,6 +362,34 @@ public abstract class HistorizedRelationalSnapshotChangeEventSource implements S
 
         @Override
         public void close() throws Exception {
+        }
+    }
+
+    /**
+     * A configuration describing the task to be performed during snapshotting.
+     */
+    public static class SnapshottingTask {
+
+        private final boolean snapshotSchema;
+        private final boolean snapshotData;
+
+        public SnapshottingTask(boolean snapshotSchema, boolean snapshotData) {
+            this.snapshotSchema = snapshotSchema;
+            this.snapshotData = snapshotData;
+        }
+
+        /**
+         * Whether data (rows in captured tables) should be snapshotted.
+         */
+        public boolean snapshotData() {
+            return snapshotData;
+        }
+
+        /**
+         * Whether the schema of captured tables should be snapshotted.
+         */
+        public boolean snapshotSchema() {
+            return snapshotSchema;
         }
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-720

Hey @jpechane, so here's the actual data snapshotting implementation. `HistorizedRelationalSnapshotChangeEventSource` defines a variety of hooks to be implemented by connector-specific sub-classes. I tried to make the overall flow in `execute()` somewhat generic, but of course it's driven by the needs for Oracle. I suppose we'll have to make some adjustments to make it work with other implementations, too, but we have to start somewhere :)

It's based on top of #569, only the last commit is new.