### PR TITLE
DBZ-801 Parameterizing ChangeEventQueue<DataChangeEvent>

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -44,7 +44,7 @@ public class EventDispatcher<T extends DataCollectionId> {
     private final TopicSelector<T> topicSelector;
     private final DatabaseSchema<T> schema;
     private final HistorizedDatabaseSchema<T> historizedSchema;
-    private final ChangeEventQueue<Object> queue;
+    private final ChangeEventQueue<DataChangeEvent> queue;
     private final DataCollectionFilter<T> filter;
     private final ChangeEventCreator changeEventCreator;
 
@@ -54,7 +54,7 @@ public class EventDispatcher<T extends DataCollectionId> {
     private final StreamingChangeRecordReceiver streamingReceiver;
 
     public EventDispatcher(TopicSelector<T> topicSelector, DatabaseSchema<T> schema,
-            ChangeEventQueue<Object> queue,
+            ChangeEventQueue<DataChangeEvent> queue,
             DataCollectionFilter<T> filter,
             ChangeEventCreator changeEventCreator) {
         this.topicSelector = topicSelector;


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-801

@jpechane Ok, so for now I didn't specify that `ChangeEventQueue` should only accept `DataChangeEvent` and nothing else. The reason being that the a loop within `poll()` is needed to get the `List<ChangeRecord>`. That's not great indeed. The event dispatcher currently expects `DataChangeEvent`, though, so I cleaned it up there a bit. Probably worth re-visiting this entire topic later on, but it's not urgent right now.