### PR TITLE
DBZ-800 Add heartbeat events to postgres connector

### DIFF
--- a/debezium-core/src/main/java/io/debezium/heartbeat/Heartbeat.java
+++ b/debezium-core/src/main/java/io/debezium/heartbeat/Heartbeat.java
@@ -52,21 +52,11 @@ public interface Heartbeat {
      * No-op Heartbeat implementation
      */
     public static final Heartbeat NULL = new Heartbeat() {
+
         @Override
         public void heartbeat(BlockingConsumer<SourceRecord> consumer) throws InterruptedException {
         }
-
-        @Override
-        public void heartbeat(Consumer<SourceRecord> consumer) {
-        }
     };
-
-    /**
-     * Generates a heartbeat record if defined time has elapsed
-     *
-     * @param consumer - a code to place record among others to be sent into Connect
-     */
-    void heartbeat(Consumer<SourceRecord> consumer);
 
     /**
      * Generates a heartbeat record if defined time has elapsed

--- a/debezium-core/src/main/java/io/debezium/heartbeat/HeartbeatImpl.java
+++ b/debezium-core/src/main/java/io/debezium/heartbeat/HeartbeatImpl.java
@@ -7,22 +7,21 @@ package io.debezium.heartbeat;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.source.SourceRecord;
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.config.Configuration;
 import io.debezium.function.BlockingConsumer;
 import io.debezium.util.Clock;
+import io.debezium.util.SchemaNameAdjuster;
 import io.debezium.util.Threads;
 import io.debezium.util.Threads.Timer;
-import io.debezium.util.SchemaNameAdjuster;
 
 /**
  * Default implementation of Heartbeat
@@ -67,15 +66,6 @@ class HeartbeatImpl implements Heartbeat {
 
         heartbeatInterval = configuration.getDuration(HeartbeatImpl.HEARTBEAT_INTERVAL, ChronoUnit.MILLIS);
         heartbeatTimeout = resetHeartbeat();
-    }
-
-    @Override
-    public void heartbeat(Consumer<SourceRecord> consumer) {
-        if (heartbeatTimeout.expired()) {
-            LOGGER.debug("Generating heartbeat event");
-            consumer.accept(heartbeatRecord());
-            heartbeatTimeout = resetHeartbeat();
-        }
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/heartbeat/HeartbeatImpl.java
+++ b/debezium-core/src/main/java/io/debezium/heartbeat/HeartbeatImpl.java
@@ -47,7 +47,7 @@ class HeartbeatImpl implements Heartbeat {
 
     private static final String SERVER_NAME_KEY = "serverName";
     private static Schema KEY_SCHEMA = SchemaBuilder.struct()
-                                                    .name(schemaNameAdjuster.adjust("io.debezium.connector.mysql.ServerNameKey"))
+                                                    .name(schemaNameAdjuster.adjust("io.debezium.connector.common.ServerNameKey"))
                                                     .field(SERVER_NAME_KEY,Schema.STRING_SCHEMA)
                                                     .build();
 

--- a/debezium-core/src/main/java/io/debezium/heartbeat/OffsetPosition.java
+++ b/debezium-core/src/main/java/io/debezium/heartbeat/OffsetPosition.java
@@ -17,7 +17,7 @@ public interface OffsetPosition {
      *
      * @return the source partition information; never null
      */
-    Map<String, String> partition();
+    Map<String, ?> partition();
 
     /**
      * Get the Kafka Connect detail about the source "offset", which describes the position within the source where we last
@@ -27,11 +27,11 @@ public interface OffsetPosition {
      */
     Map<String, ?> offset();
 
-    static OffsetPosition build(Map<String, String> partition, Map<String, ?> offset) {
+    static OffsetPosition build(Map<String, ?> partition, Map<String, ?> offset) {
         return new OffsetPosition() {
 
             @Override
-            public Map<String, String> partition() {
+            public Map<String, ?> partition() {
                 return partition;
             }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -149,7 +149,7 @@ public class EventDispatcher<T extends DataCollectionId> {
 
     private final class StreamingChangeRecordReceiver implements ChangeRecordEmitter.Receiver {
 
-        private Map<String, String> lastPartition;
+        private Map<String, ?> lastPartition;
         private Map<String, ?> lastOffset;
 
         @Override

--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
@@ -27,7 +27,7 @@ public interface OffsetContext {
         OffsetContext load(Map<String, ?> offset);
     }
 
-    Map<String, ?> getPartition();
+    Map<String, String> getPartition();
     Map<String, ?> getOffset();
     Schema getSourceInfoSchema();
     Struct getSourceInfo();

--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
@@ -27,7 +27,7 @@ public interface OffsetContext {
         OffsetContext load(Map<String, ?> offset);
     }
 
-    Map<String, String> getPartition();
+    Map<String, ?> getPartition();
     Map<String, ?> getOffset();
     Schema getSourceInfoSchema();
     Struct getSourceInfo();


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-800

@jpechane So I think this could be enough actually to add the heartbeat to Postgres and Oracle/SQL Server. En passent, this will also resolve the original issue of not committing offsets for a longer time if no whitelisted table receives changes.

I'm unsure about testing, though. Do you see any viable approach other than some manual verification?