### PR TITLE
DBZ-838 Adding condition to interrupt initial sync if task is stopped

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
@@ -324,6 +324,8 @@ public class ConnectionContext implements AutoCloseable {
                 try {
                     operation.accept(primary);
                     return;
+                } catch (InterruptedException e) {
+                    throw e;
                 } catch (Throwable t) {
                     errorHandler.accept(desc, t);
                     errorMetronome.pause();

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
@@ -369,7 +369,7 @@ public class Replicator {
         MongoCollection<Document> docCollection = db.getCollection(collectionId.name());
         long counter = 0;
         try (MongoCursor<Document> cursor = docCollection.find().iterator()) {
-            while (cursor.hasNext()) {
+            while (running.get() && cursor.hasNext()) {
                 Document doc = cursor.next();
                 logger.trace("Found existing doc in {}: {}", collectionId, doc);
                 counter += factory.recordObject(collectionId, doc, timestamp);


### PR DESCRIPTION
Initial synchronization of MongoDb connector is not interrupted by stopping task.
This PR adds the following condition in the `while` loop:
```
while (running.get() && cursor.hasNext())
```
https://issues.jboss.org/browse/DBZ-838