### PR TITLE
DBZ-633 Adding "field.blacklist" and "field.renames" properties for MongoDB connector

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/FieldSelector.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/FieldSelector.java
@@ -12,101 +12,152 @@ import org.bson.Document;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
- * This filter selector is designed to determine the filter to exclude fields from document.
+ * This filter selector is designed to determine the filter to exclude or rename fields in a document.
  */
 @ThreadSafe
 public final class FieldSelector {
+
     /**
-     * This filter is designed to exclude fields from document.
+     * This filter is designed to exclude or rename fields in a document.
      */
     @ThreadSafe
     @FunctionalInterface
     public static interface FieldFilter {
+
         /**
-         * Apply this filter to the given document to exclude fields.
+         * Applies this filter to the given document to exclude or rename fields.
          *
-         * @param doc document to exclude fields
+         * @param doc document to exclude or rename fields
          * @return modified document
          */
         Document apply(Document doc);
     }
 
-    private static final FieldSelector EMPTY = new FieldSelector();
-    private final List<Filter> filters;
+    private final List<Path> paths;
 
-    private FieldSelector() {
-        filters = Collections.emptyList();
-    }
-
-    private FieldSelector(List<Filter> filters) {
-        this.filters = filters;
+    private FieldSelector(List<Path> paths) {
+        this.paths = paths;
     }
 
     /**
-     * Builds the filter selector that returns the field filter for a given collection identifier, using the given comma-separated
-     * list of fully-qualified field names (for details, see {@link MongoDbConnectorConfig#FIELD_BLACKLIST}) defining
-     * which fields (if any) should be <i>excluded</i>.
-     *
-     * @param fullyQualifiedFieldNames the comma-separated list of fully-qualified field names to exclude; may be null or
-     *            empty
-     * @return the filter selector that returns the filter to exclude fields from document
+     * A builder of a field selector.
      */
-    public static FieldSelector excludeFields(String fullyQualifiedFieldNames) {
-        if (Strings.isNullOrEmpty(fullyQualifiedFieldNames)) {
-            return EMPTY;
+    public static class FieldSelectorBuilder {
+
+        private String fullyQualifiedFieldNames;
+        private String fullyQualifiedFieldReplacements;
+
+        private FieldSelectorBuilder() {
         }
-        String[] names = fullyQualifiedFieldNames.split(",");
-        List<Filter> filters = new ArrayList<>(names.length);
-        for (String name : names) {
-            String[] parts = name.split(":");
-            if (parts.length != 2 || Strings.isNullOrEmpty(parts[0]) || Strings.isNullOrEmpty(parts[1])) {
+
+        /**
+         * Specifies the comma-separated list of fully-qualified field names that should be included.
+         *
+         * @param fullyQualifiedFieldNames the comma-separated list of fully-qualified field names to exclude; may be
+         *            {@code null} or empty
+         * @return this builder so that methods can be chained together; never {@code null}
+         */
+        public FieldSelectorBuilder excludeFields(String fullyQualifiedFieldNames) {
+            this.fullyQualifiedFieldNames = fullyQualifiedFieldNames;
+            return this;
+        }
+
+        /**
+         * Specifies the comma-separated list of fully-qualified field replacements to rename fields.
+         *
+         * @param fullyQualifiedFieldReplacements the comma-separated list of fully-qualified field replacements to rename
+         *            fields; may be {@code null} or empty
+         * @return this builder so that methods can be chained together; never {@code null}
+         */
+        public FieldSelectorBuilder renameFields(String fullyQualifiedFieldReplacements) {
+            this.fullyQualifiedFieldReplacements = fullyQualifiedFieldReplacements;
+            return this;
+        }
+
+        /**
+         * Builds the filter selector that returns the field filter for a given collection identifier, using the comma-separated
+         * list of fully-qualified field names (for details, see {@link MongoDbConnectorConfig#FIELD_BLACKLIST}) defining
+         * which fields (if any) should be excluded, and using the comma-separated list of fully-qualified field replacements
+         * (for details, see {@link MongoDbConnectorConfig#FIELD_RENAMES}) defining which fields (if any) should be
+         * renamed.
+         *
+         * @return the filter selector that returns the filter to exclude or rename fields in a document
+         */
+        public FieldSelector build() {
+            List<Path> result = new ArrayList<>();
+            parse(fullyQualifiedFieldNames, name -> {
+                String[] fieldNodes = parseIntoParts(name, name, length -> length < 3, "\\.");
+                return new RemovePath(fieldNodes);
+            }, result);
+            parse(fullyQualifiedFieldReplacements, name -> {
+                String[] renameMapping = parseIntoParts(name, name, length -> length != 2, "=");
+                String[] fieldNodes = parseIntoParts(name, renameMapping[0], length -> length < 3, "\\.");
+                return new RenamePath(fieldNodes, renameMapping[1]);
+            }, result);
+            return new FieldSelector(result);
+        }
+
+        private void parse(String value, Function<String, Path> pathCreator, List<Path> result) {
+            if (!Strings.isNullOrEmpty(value)) {
+                Arrays.stream(value.split(",")).forEach(name -> result.add(pathCreator.apply(name)));
+            }
+        }
+
+        private String[] parseIntoParts(String name, String value, Predicate<Integer> lengthPredicate, String delimiter) {
+            String[] fieldNodes = value.split(delimiter);
+            if (lengthPredicate.test(fieldNodes.length) || Arrays.stream(fieldNodes).anyMatch(Strings::isNullOrEmpty)) {
                 throw new ConfigException("Invalid format: " + name);
             }
-            Pattern pattern = Pattern.compile(parts[0], Pattern.CASE_INSENSITIVE);
-            String[] fields = parts[1].split("\\|");
-            List<Path> paths = new ArrayList<>(fields.length);
-            for (String field : fields) {
-                paths.add(new Path(field));
-            }
-            filters.add(new Filter(pattern, paths));
+            return fieldNodes;
         }
-        return new FieldSelector(filters);
+    }
+
+    /**
+     * Returns a new {@link FieldSelectorBuilder builder} for a field selector.
+     *
+     * @return the builder; never {@code null}
+     */
+    public static FieldSelectorBuilder builder() {
+        return new FieldSelectorBuilder();
     }
 
     /**
      * Returns the field filter for a given collection identifier.
      *
      * <p>
-     * Note that the field filter is completely independent of the collection selection predicate, so it is expected that this filter
-     * be used only <i>after</i> the collection selection predicate determined the collection containing documents with
-     * the field(s) is to be used.
+     * Note that the field filter is completely independent of the collection selection predicate, so it is expected that this
+     * filter be used only after the collection selection predicate determined the collection containing documents
+     * with the field(s) is to be used.
      *
      * @param id the collection identifier, never {@code null}
      * @return the field filter, never {@code null}
      */
     public FieldFilter fieldFilterFor(CollectionId id) {
-        if (!filters.isEmpty()) {
-            List<Path> paths = new ArrayList<>();
+        if (!paths.isEmpty()) {
             String namespace = id.namespace();
-            for (Filter filter : filters) {
-                if (filter.pattern.matcher(namespace).matches()) {
-                    paths.addAll(filter.paths);
-                }
-            }
-            if (paths.size() == 1) {
-                return paths.get(0)::remove;
-            } else if (paths.size() > 1) {
+            List<Path> result = paths.stream().filter(path -> path.supports(namespace)).collect(Collectors.toList());
+            if (result.size() == 1) {
                 return doc -> {
                     Document setDoc = doc.get("$set", Document.class);
                     Document unsetDoc = doc.get("$unset", Document.class);
-                    paths.forEach(path -> path.remove(doc, setDoc, unsetDoc));
+                    result.get(0).modify(doc, setDoc, unsetDoc);
+                    return doc;
+                };
+            } else if (result.size() > 1) {
+                return doc -> {
+                    Document setDoc = doc.get("$set", Document.class);
+                    Document unsetDoc = doc.get("$unset", Document.class);
+                    result.forEach(path -> path.modify(doc, setDoc, unsetDoc));
                     return doc;
                 };
             }
@@ -114,77 +165,92 @@ public final class FieldSelector {
         return doc -> doc;
     }
 
-    @ThreadSafe
-    private static final class Filter {
-        private final Pattern pattern;
-        private final List<Path> paths;
+    private static final class Entry {
 
-        private Filter(Pattern pattern, List<Path> paths) {
-            this.pattern = pattern;
-            this.paths = paths;
+        private final String key;
+        private final Object value;
+
+        private Entry(String key, Object value) {
+            this.key = key;
+            this.value = value;
         }
     }
 
     @ThreadSafe
-    private static final class Path {
+    private static interface Path {
 
-        private final String field;
-        private final String[] fieldNodes;
+        boolean supports(String namespace);
 
-        private Path(String field) {
-            this.field = field;
-            this.fieldNodes = field.split("\\.");
+        void modify(Document doc, Document setDoc, Document unsetDoc);
+    }
+
+    @ThreadSafe
+    private static abstract class AbstractPath implements Path {
+
+        final Pattern namespacePattern;
+        final String[] fieldNodes;
+        final String field;
+
+        private AbstractPath(String[] fieldNodes) {
+            this.namespacePattern = namespacePattern(fieldNodes[0], fieldNodes[1]);
+            this.fieldNodes = Arrays.copyOfRange(fieldNodes, 2, fieldNodes.length);
+            StringJoiner field = new StringJoiner(".");
+            Arrays.stream(fieldNodes).forEach(field::add);
+            this.field = field.toString();
         }
 
-        private Document remove(Document doc) {
-            Document setDoc = doc.get("$set", Document.class);
-            Document unsetDoc = doc.get("$unset", Document.class);
-            remove(doc, setDoc, unsetDoc);
-            return doc;
+        private Pattern namespacePattern(String databaseName, String collectionName) {
+            String namespaceRegex = toRegex(databaseName) + "\\." + toRegex(collectionName);
+            return Pattern.compile(namespaceRegex, Pattern.CASE_INSENSITIVE);
         }
 
-        private void remove(Document doc, Document setDoc, Document unsetDoc) {
+        private String toRegex(String value) {
+            return value.replace("*", ".*");
+        }
+
+        @Override
+        public boolean supports(String namespace) {
+            return namespacePattern.matcher(namespace).matches();
+        }
+
+        @Override
+        public void modify(Document doc, Document setDoc, Document unsetDoc) {
             if (setDoc == null && unsetDoc == null) {
-                removeFields(doc, fieldNodes, 0);
+                modifyFields(doc, fieldNodes, 0);
             } else {
                 if (setDoc != null) {
-                    removeFieldsWithDotNotation(setDoc);
+                    modifyFieldsWithDotNotation(setDoc);
                 }
                 if (unsetDoc != null) {
-                    removeFieldsWithDotNotation(unsetDoc);
+                    modifyFieldsWithDotNotation(unsetDoc);
                 }
             }
         }
 
         /**
-         * Removes fields from the document by the given path nodes start with the begin index.
+         * Modifies fields in the document by the given path nodes start with the begin index.
          *
          * <p>
-         *  Note that the path does not support removing fields inside arrays of arrays.
+         * Note that the path doesn't support modification of fields inside arrays of arrays.
          *
-         * @param doc document to remove fields
-         * @param nodes path nodes
-         * @param beginIndex begin index
+         * @param doc        the document to modify fields
+         * @param nodes      the path nodes
+         * @param beginIndex the begin index
          */
-        private void removeFields(Document doc, String[] nodes, int beginIndex) {
+        private void modifyFields(Document doc, String[] nodes, int beginIndex) {
             Document current = doc;
-            int stop = nodes.length - 1;
+            int stopIndex = nodes.length - 1;
             for (int i = beginIndex; i < nodes.length; i++) {
                 String node = nodes[i];
-                if (i == stop) {
-                    current.remove(node);
+                if (i == stopIndex) {
+                    modifyField(current, node);
+                    break;
                 } else {
                     Object next = current.get(node);
                     if (next instanceof Document) {
                         current = (Document) next;
                     } else {
-                        if (next instanceof List) {
-                            for (Object item : (List) next) {
-                                if (item instanceof Document) {
-                                    removeFields((Document) item, nodes, i + 1);
-                                }
-                            }
-                        }
+                        modifyFields(next, nodes, i + 1);
                         break;
                     }
                 }
@@ -192,27 +258,30 @@ public final class FieldSelector {
         }
 
         /**
-         * Removes fields that uses the dot notation, like {@code 'a.b'} or {@code 'a.0.b'}.
+         * Modifies fields that use the dot notation, like {@code 'a.b'} or {@code 'a.0.b'}.
          *
          * <p>
-         * First, we try to delete field that exactly matches the current path. Then, if the field is not found, we try to find
+         * First, we try to modify field that exactly matches the current path. Then, if the field isn't found, we try to find
          * fields that start with the current path or fields that are part of the current path.
          *
-         * @param doc document to remove fields
+         * @param doc the document to modify fields
          */
-        private void removeFieldsWithDotNotation(Document doc) {
+        private void modifyFieldsWithDotNotation(Document doc) {
             // document can contain null value by key
             if (doc.containsKey(field)) {
-                doc.remove(field);
+                modifyFieldWithDotNotation(doc, field);
                 return;
             }
+            List<Entry> deferred = null;
             Iterator<Map.Entry<String, Object>> it = doc.entrySet().iterator();
             while (it.hasNext()) {
                 Map.Entry<String, Object> entry = it.next();
-                String[] keyNodes = buildKeyNodes(entry.getKey());
+                String[] originKeyNodes = entry.getKey().split("\\.");
+                String[] keyNodes = excludeNumericItems(originKeyNodes);
                 if (keyNodes.length > fieldNodes.length) {
                     // field is a prefix of key, e.g. field is 'a' and key is 'a.b'
                     if (startsWith(fieldNodes, keyNodes)) {
+                        deferred = modifyFieldDeferred(deferred, originKeyNodes, entry.getValue());
                         it.remove();
                     }
                 } else if (keyNodes.length < fieldNodes.length) {
@@ -220,68 +289,77 @@ public final class FieldSelector {
                     if (startsWith(keyNodes, fieldNodes)) {
                         Object value = entry.getValue();
                         if (value instanceof Document) {
-                            removeFields((Document) value, fieldNodes, keyNodes.length);
-                        } else if (value instanceof List) {
-                            for (Object item : (List) value) {
-                                if (item instanceof Document) {
-                                    removeFields((Document) item, fieldNodes, keyNodes.length);
-                                }
-                            }
+                            modifyFields((Document) value, fieldNodes, keyNodes.length);
+                        } else {
+                            modifyFields(value, fieldNodes, keyNodes.length);
                         }
                         break;
                     }
                 } else {
                     // key is equal to field, e.g. field is 'a' and key is 'a'
                     if (Arrays.equals(keyNodes, fieldNodes)) {
+                        deferred = modifyFieldDeferred(deferred, originKeyNodes, entry.getValue());
                         it.remove();
+                    }
+                }
+            }
+            if (deferred != null) {
+                deferred.forEach(entry -> doc.put(checkFieldExists(doc, entry.key), entry.value));
+            }
+        }
+
+        private void modifyFields(Object value, String[] fieldNodes, int length) {
+            if (value instanceof List) {
+                for (Object item : (List) value) {
+                    if (item instanceof Document) {
+                        modifyFields((Document) item, fieldNodes, length);
                     }
                 }
             }
         }
 
         /**
-         * Builds key nodes from which numeric nodes are excluded.
+         * Excludes numeric items from a given array.
          *
          * <p>
-         * If the key has consecutive numeric nodes, like {@code 'a.0.0.b'}, then the numeric nodes are not excluded.
-         * It is necessary because the path does not support removing fields inside arrays of arrays.
+         * If the array has consecutive numeric items, like {@code 'a.0.0.b'}, then the numeric items aren't excluded.
+         * It is necessary because the modification of fields inside arrays of arrays isn't supported.
          *
-         * @param key the key to build nodes
-         * @return key nodes
+         * @param items the array to exclude numeric items
+         * @return filtered items
          */
-        private String[] buildKeyNodes(String key) {
-            String[] nodes = key.split("\\.");
-            if (nodes.length > 1) {
-                List<String> newNodes = null;
+        private String[] excludeNumericItems(String[] items) {
+            if (items.length > 1) {
+                List<String> newItems = null;
                 boolean previousNumerical = false;
                 int offset = 0;
-                for (int i = 0; i < nodes.length; i++) {
-                    if (Strings.isNumeric(nodes[i])) {
+                for (int i = 0; i < items.length; i++) {
+                    if (Strings.isNumeric(items[i])) {
                         if (previousNumerical) {
-                            return nodes;
+                            return items;
                         }
                         previousNumerical = true;
-                        if (newNodes == null) {
-                            newNodes = new ArrayList<>(Arrays.asList(nodes));
+                        if (newItems == null) {
+                            newItems = new ArrayList<>(Arrays.asList(items));
                         }
-                        newNodes.remove(i - offset++);
+                        newItems.remove(i - offset++);
                     } else {
                         previousNumerical = false;
                     }
                 }
-                if (newNodes != null) {
-                    String[] result = new String[newNodes.size()];
-                    return newNodes.toArray(result);
+                if (newItems != null) {
+                    String[] result = new String[newItems.size()];
+                    return newItems.toArray(result);
                 }
             }
-            return nodes;
+            return items;
         }
 
         /**
          * Returns {@code true} if the source array starts with the specified array.
          *
-         * @param begin array from which the source array begins
-         * @param source source array to check
+         * @param begin  the array from which the source array begins
+         * @param source the source array to check
          * @return {@code true} if the source array starts with the specified array
          */
         private boolean startsWith(String[] begin, String[] source) {
@@ -296,9 +374,115 @@ public final class FieldSelector {
             return true;
         }
 
+        String checkFieldExists(Document doc, String field) {
+            if (doc.containsKey(field)) {
+                throw new IllegalArgumentException("Document already contains field : " + field);
+            }
+            return field;
+        }
+
+        abstract List<Entry> modifyFieldDeferred(List<Entry> deferred, String[] fieldNodes, Object value);
+
+        abstract void modifyField(Document doc, String field);
+
+        abstract void modifyFieldWithDotNotation(Document doc, String field);
+
         @Override
         public String toString() {
             return field;
+        }
+    }
+
+    @ThreadSafe
+    private static final class RemovePath extends AbstractPath {
+
+        private RemovePath(String[] fieldNodes) {
+            super(fieldNodes);
+        }
+
+        @Override
+        List<Entry> modifyFieldDeferred(List<Entry> deferred, String[] fieldNodes, Object value) {
+            // this path doesn't support deferred field modification
+            return deferred;
+        }
+
+        @Override
+        void modifyField(Document doc, String field) {
+            doc.remove(field);
+        }
+
+        @Override
+        void modifyFieldWithDotNotation(Document doc, String field) {
+            doc.remove(field);
+        }
+    }
+
+    @ThreadSafe
+    private static final class RenamePath extends AbstractPath {
+
+        // field node that is used to change the old field in document. It can't be nested field
+        private final String newFieldNode;
+        // field that is used to replace the old field in document. It can be top level or nested field
+        private final String newField;
+
+        private RenamePath(String[] oldFieldNodes, String newFieldNode) {
+            super(oldFieldNodes);
+            this.newFieldNode = newFieldNode;
+            this.newField = replaceLastNameNode(oldFieldNodes, newFieldNode);
+        }
+
+        @Override
+        void modifyField(Document doc, String field) {
+            doc.put(checkFieldExists(doc, newFieldNode), doc.remove(field));
+        }
+
+        @Override
+        void modifyFieldWithDotNotation(Document doc, String field) {
+            doc.put(checkFieldExists(doc, newField), doc.remove(field));
+        }
+
+        @Override
+        List<Entry> modifyFieldDeferred(List<Entry> deferred, String[] fieldNodes, Object value) {
+            String newField = rename(fieldNodes);
+            if (deferred == null) {
+                deferred = new ArrayList<>();
+            }
+            deferred.add(new Entry(newField, value));
+            return deferred;
+        }
+
+        /**
+         * Replaces a last name node in the given name nodes, if the name nodes contain only one node,
+         * the last name node is returned.
+         *
+         * @param nameNodes    the name nodes to replace
+         * @param lastNameNode the last name node
+         * @return replaced name or last name node
+         */
+        private String replaceLastNameNode(String[] nameNodes, String lastNameNode) {
+            if (nameNodes.length > 1) {
+                StringJoiner newName = new StringJoiner(".");
+                int replaceIndex = nameNodes.length - 1;
+                for (int i = 0; i < nameNodes.length; i++) {
+                    newName.add((i == replaceIndex) ? lastNameNode : nameNodes[i]);
+                }
+            }
+            return lastNameNode;
+        }
+
+        private String rename(String[] nameNodes) {
+            StringJoiner newName = new StringJoiner(".");
+            int replaceIndex = fieldNodes.length - 1;
+            int i = 0;
+            for (String nameNode : nameNodes) {
+                if (Strings.isNumeric(nameNode)) {
+                    newName.add(nameNode);
+                } else {
+                    newName.add((i == replaceIndex) ? newFieldNode : nameNode);
+                    i++;
+                }
+            }
+            return newName.toString();
         }
     }
 }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/FieldSelector.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/FieldSelector.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import io.debezium.annotation.ThreadSafe;
+import io.debezium.util.Strings;
+import org.apache.kafka.common.config.ConfigException;
+import org.bson.Document;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * This filter selector is designed to determine the filter to exclude fields from document.
+ */
+@ThreadSafe
+public final class FieldSelector {
+    /**
+     * This filter is designed to exclude fields from document.
+     */
+    @ThreadSafe
+    @FunctionalInterface
+    public static interface FieldFilter {
+        /**
+         * Apply this filter to the given document to exclude fields.
+         *
+         * @param doc document to exclude fields
+         * @return modified document
+         */
+        Document apply(Document doc);
+    }
+
+    private static final FieldSelector EMPTY = new FieldSelector();
+    private final List<Filter> filters;
+
+    private FieldSelector() {
+        filters = Collections.emptyList();
+    }
+
+    private FieldSelector(List<Filter> filters) {
+        this.filters = filters;
+    }
+
+    /**
+     * Builds the filter selector that returns the field filter for a given collection identifier, using the given comma-separated
+     * list of fully-qualified field names (for details, see {@link MongoDbConnectorConfig#FIELD_BLACKLIST}) defining
+     * which fields (if any) should be <i>excluded</i>.
+     *
+     * @param fullyQualifiedFieldNames the comma-separated list of fully-qualified field names to exclude; may be null or
+     *            empty
+     * @return the filter selector that returns the filter to exclude fields from document
+     */
+    public static FieldSelector excludeFields(String fullyQualifiedFieldNames) {
+        if (Strings.isNullOrEmpty(fullyQualifiedFieldNames)) {
+            return EMPTY;
+        }
+        String[] names = fullyQualifiedFieldNames.split(",");
+        List<Filter> filters = new ArrayList<>(names.length);
+        for (String name : names) {
+            String[] parts = name.split(":");
+            if (parts.length != 2 || Strings.isNullOrEmpty(parts[0]) || Strings.isNullOrEmpty(parts[1])) {
+                throw new ConfigException("Invalid format: " + name);
+            }
+            Pattern pattern = Pattern.compile(parts[0], Pattern.CASE_INSENSITIVE);
+            String[] fields = parts[1].split("\\|");
+            List<Path> paths = new ArrayList<>(fields.length);
+            for (String field : fields) {
+                paths.add(new Path(field));
+            }
+            filters.add(new Filter(pattern, paths));
+        }
+        return new FieldSelector(filters);
+    }
+
+    /**
+     * Returns the field filter for a given collection identifier.
+     *
+     * <p>
+     * Note that the field filter is completely independent of the collection selection predicate, so it is expected that this filter
+     * be used only <i>after</i> the collection selection predicate determined the collection containing documents with
+     * the field(s) is to be used.
+     *
+     * @param id the collection identifier, never {@code null}
+     * @return the field filter, never {@code null}
+     */
+    public FieldFilter fieldFilterFor(CollectionId id) {
+        if (!filters.isEmpty()) {
+            List<Path> paths = new ArrayList<>();
+            String namespace = id.namespace();
+            for (Filter filter : filters) {
+                if (filter.pattern.matcher(namespace).matches()) {
+                    paths.addAll(filter.paths);
+                }
+            }
+            if (paths.size() == 1) {
+                return paths.get(0)::remove;
+            } else if (paths.size() > 1) {
+                return doc -> {
+                    Document setDoc = doc.get("$set", Document.class);
+                    Document unsetDoc = doc.get("$unset", Document.class);
+                    paths.forEach(path -> path.remove(doc, setDoc, unsetDoc));
+                    return doc;
+                };
+            }
+        }
+        return doc -> doc;
+    }
+
+    @ThreadSafe
+    private static final class Filter {
+        private final Pattern pattern;
+        private final List<Path> paths;
+
+        private Filter(Pattern pattern, List<Path> paths) {
+            this.pattern = pattern;
+            this.paths = paths;
+        }
+    }
+
+    @ThreadSafe
+    private static final class Path {
+
+        private final String field;
+        private final String[] fieldNodes;
+
+        private Path(String field) {
+            this.field = field;
+            this.fieldNodes = field.split("\\.");
+        }
+
+        private Document remove(Document doc) {
+            Document setDoc = doc.get("$set", Document.class);
+            Document unsetDoc = doc.get("$unset", Document.class);
+            remove(doc, setDoc, unsetDoc);
+            return doc;
+        }
+
+        private void remove(Document doc, Document setDoc, Document unsetDoc) {
+            if (setDoc == null && unsetDoc == null) {
+                removeFields(doc, fieldNodes, 0);
+            } else {
+                if (setDoc != null) {
+                    removeFieldsWithDotNotation(setDoc);
+                }
+                if (unsetDoc != null) {
+                    removeFieldsWithDotNotation(unsetDoc);
+                }
+            }
+        }
+
+        /**
+         * Removes fields from the document by the given path nodes start with the begin index.
+         *
+         * <p>
+         *  Note that the path does not support removing fields inside arrays of arrays.
+         *
+         * @param doc document to remove fields
+         * @param nodes path nodes
+         * @param beginIndex begin index
+         */
+        private void removeFields(Document doc, String[] nodes, int beginIndex) {
+            Document current = doc;
+            int stop = nodes.length - 1;
+            for (int i = beginIndex; i < nodes.length; i++) {
+                String node = nodes[i];
+                if (i == stop) {
+                    current.remove(node);
+                } else {
+                    Object next = current.get(node);
+                    if (next instanceof Document) {
+                        current = (Document) next;
+                    } else {
+                        if (next instanceof List) {
+                            for (Object item : (List) next) {
+                                if (item instanceof Document) {
+                                    removeFields((Document) item, nodes, i + 1);
+                                }
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        /**
+         * Removes fields that uses the dot notation, like {@code 'a.b'} or {@code 'a.0.b'}.
+         *
+         * <p>
+         * First, we try to delete field that exactly matches the current path. Then, if the field is not found, we try to find
+         * fields that start with the current path or fields that are part of the current path.
+         *
+         * @param doc document to remove fields
+         */
+        private void removeFieldsWithDotNotation(Document doc) {
+            // document can contain null value by key
+            if (doc.containsKey(field)) {
+                doc.remove(field);
+                return;
+            }
+            Iterator<Map.Entry<String, Object>> it = doc.entrySet().iterator();
+            while (it.hasNext()) {
+                Map.Entry<String, Object> entry = it.next();
+                String[] keyNodes = buildKeyNodes(entry.getKey());
+                if (keyNodes.length > fieldNodes.length) {
+                    // field is a prefix of key, e.g. field is 'a' and key is 'a.b'
+                    if (startsWith(fieldNodes, keyNodes)) {
+                        it.remove();
+                    }
+                } else if (keyNodes.length < fieldNodes.length) {
+                    // key is a prefix of field, e.g. field is 'a.b' and key is 'a'
+                    if (startsWith(keyNodes, fieldNodes)) {
+                        Object value = entry.getValue();
+                        if (value instanceof Document) {
+                            removeFields((Document) value, fieldNodes, keyNodes.length);
+                        } else if (value instanceof List) {
+                            for (Object item : (List) value) {
+                                if (item instanceof Document) {
+                                    removeFields((Document) item, fieldNodes, keyNodes.length);
+                                }
+                            }
+                        }
+                        break;
+                    }
+                } else {
+                    // key is equal to field, e.g. field is 'a' and key is 'a'
+                    if (Arrays.equals(keyNodes, fieldNodes)) {
+                        it.remove();
+                    }
+                }
+            }
+        }
+
+        /**
+         * Builds key nodes from which numeric nodes are excluded.
+         *
+         * <p>
+         * If the key has consecutive numeric nodes, like {@code 'a.0.0.b'}, then the numeric nodes are not excluded.
+         * It is necessary because the path does not support removing fields inside arrays of arrays.
+         *
+         * @param key the key to build nodes
+         * @return key nodes
+         */
+        private String[] buildKeyNodes(String key) {
+            String[] nodes = key.split("\\.");
+            if (nodes.length > 1) {
+                List<String> newNodes = null;
+                boolean previousNumerical = false;
+                int offset = 0;
+                for (int i = 0; i < nodes.length; i++) {
+                    if (Strings.isNumeric(nodes[i])) {
+                        if (previousNumerical) {
+                            return nodes;
+                        }
+                        previousNumerical = true;
+                        if (newNodes == null) {
+                            newNodes = new ArrayList<>(Arrays.asList(nodes));
+                        }
+                        newNodes.remove(i - offset++);
+                    } else {
+                        previousNumerical = false;
+                    }
+                }
+                if (newNodes != null) {
+                    String[] result = new String[newNodes.size()];
+                    return newNodes.toArray(result);
+                }
+            }
+            return nodes;
+        }
+
+        /**
+         * Returns {@code true} if the source array starts with the specified array.
+         *
+         * @param begin array from which the source array begins
+         * @param source source array to check
+         * @return {@code true} if the source array starts with the specified array
+         */
+        private boolean startsWith(String[] begin, String[] source) {
+            if (begin.length > source.length) {
+                return false;
+            }
+            for (int i = 0; i < begin.length; i++) {
+                if (!source[i].equals(begin[i])) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return field;
+        }
+    }
+}

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Filters.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Filters.java
@@ -55,8 +55,11 @@ public final class Filters {
         Predicate<CollectionId> isNotBuiltIn = this::isNotBuiltIn;
         this.collectionFilter = isNotBuiltIn.and(collectionFilter);
 
-        // Define the field selector that provides the field filter to exclude fields from document ...
-        fieldSelector = FieldSelector.excludeFields(config.getString(MongoDbConnectorConfig.FIELD_BLACKLIST));
+        // Define the field selector that provides the field filter to exclude or rename fields in a document ...
+        fieldSelector = FieldSelector.builder()
+                .excludeFields(config.getString(MongoDbConnectorConfig.FIELD_BLACKLIST))
+                .renameFields(config.getString(MongoDbConnectorConfig.FIELD_RENAMES))
+                .build();
     }
     
     /**

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -210,9 +210,9 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
     /**
      * A comma-separated list of the fully-qualified replacements of fields that should be used to rename fields in change
      * event message values. Fully-qualified replacements for fields are of the form {@code
-     * <databaseName>.<collectionName>.<fieldName>.<nestedFieldName>=<newNestedFieldName>}, where
+     * <databaseName>.<collectionName>.<fieldName>.<nestedFieldName>:<newNestedFieldName>}, where
      * {@code <databaseName>} and {@code <collectionName>} may contain the wildcard ({@code *}) which matches
-     * any characters, the equal character ({@code =}) is used to determine rename mapping of field.
+     * any characters, the colon character ({@code :}) is used to determine rename mapping of field.
      */
     public static final Field FIELD_RENAMES = Field.create("field.renames")
                                                      .withDisplayName("Rename Fields")

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -173,7 +173,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
 
     /**
      * A comma-separated list of regular expressions that match the fully-qualified namespaces of collections to be monitored.
-     * Fully-qualified namespaces for collections are of the form {@code '<databaseName>.<collectionName>'}.
+     * Fully-qualified namespaces for collections are of the form {@code <databaseName>.<collectionName>}.
      * May not be used with {@link #COLLECTION_BLACKLIST}.
      */
     public static final Field COLLECTION_WHITELIST = Field.create("collection.whitelist")
@@ -194,6 +194,20 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
                                                           .withValidation(Field::isListOfRegex)
                                                           .withInvisibleRecommender();
 
+    /**
+     * A comma-separated list of the fully-qualified names of fields that should be excluded from change event message values.
+     * Fully-qualified names for fields are of the form {@code
+     * <databaseName>.<collectionName>:<fieldName>.<nestedFieldName>|<fieldNameN>}. Where the part {@code
+     * <databaseName>.<collectionName>} is a regular expression, the dot character ({@code .}) is used to access fields
+     * of embedded documents and the pipe character ({@code |}) is used to delimit set of fields.
+     */
+    public static final Field FIELD_BLACKLIST = Field.create("field.blacklist")
+                                                     .withDisplayName("Exclude Fields")
+                                                     .withType(Type.STRING)
+                                                     .withWidth(Width.LONG)
+                                                     .withImportance(Importance.MEDIUM)
+                                                     .withDescription("");
+
     protected static final Field TASK_ID = Field.create("mongodb.task.id")
                                                 .withDescription("Internal use only")
                                                 .withValidation(Field::isInteger)
@@ -209,6 +223,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
                                                      CONNECT_BACKOFF_MAX_DELAY_MS,
                                                      COLLECTION_WHITELIST,
                                                      COLLECTION_BLACKLIST,
+                                                     FIELD_BLACKLIST,
                                                      AUTO_DISCOVER_MEMBERS,
                                                      DATABASE_WHITELIST,
                                                      DATABASE_BLACKLIST,
@@ -225,7 +240,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
         Field.group(config, "MongoDB", HOSTS, USER, PASSWORD, LOGICAL_NAME, CONNECT_BACKOFF_INITIAL_DELAY_MS,
                     CONNECT_BACKOFF_MAX_DELAY_MS, MAX_FAILED_CONNECTIONS, AUTO_DISCOVER_MEMBERS,
                     SSL_ENABLED, SSL_ALLOW_INVALID_HOSTNAMES);
-        Field.group(config, "Events", DATABASE_WHITELIST, DATABASE_BLACKLIST, COLLECTION_WHITELIST, COLLECTION_BLACKLIST, CommonConnectorConfig.TOMBSTONES_ON_DELETE);
+        Field.group(config, "Events", DATABASE_WHITELIST, DATABASE_BLACKLIST, COLLECTION_WHITELIST, COLLECTION_BLACKLIST, FIELD_BLACKLIST, CommonConnectorConfig.TOMBSTONES_ON_DELETE);
         Field.group(config, "Connector", MAX_COPY_THREADS, CommonConnectorConfig.MAX_QUEUE_SIZE, CommonConnectorConfig.MAX_BATCH_SIZE, CommonConnectorConfig.POLL_INTERVAL_MS);
         return config;
     }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -197,12 +197,25 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
     /**
      * A comma-separated list of the fully-qualified names of fields that should be excluded from change event message values.
      * Fully-qualified names for fields are of the form {@code
-     * <databaseName>.<collectionName>:<fieldName>.<nestedFieldName>|<fieldNameN>}. Where the part {@code
-     * <databaseName>.<collectionName>} is a regular expression, the dot character ({@code .}) is used to access fields
-     * of embedded documents and the pipe character ({@code |}) is used to delimit set of fields.
+     * <databaseName>.<collectionName>.<fieldName>.<nestedFieldName>}, where {@code <databaseName>} and
+     * {@code <collectionName>} may contain the wildcard ({@code *}) which matches any characters.
      */
     public static final Field FIELD_BLACKLIST = Field.create("field.blacklist")
                                                      .withDisplayName("Exclude Fields")
+                                                     .withType(Type.STRING)
+                                                     .withWidth(Width.LONG)
+                                                     .withImportance(Importance.MEDIUM)
+                                                     .withDescription("");
+
+    /**
+     * A comma-separated list of the fully-qualified replacements of fields that should be used to rename fields in change
+     * event message values. Fully-qualified replacements for fields are of the form {@code
+     * <databaseName>.<collectionName>.<fieldName>.<nestedFieldName>=<newNestedFieldName>}, where
+     * {@code <databaseName>} and {@code <collectionName>} may contain the wildcard ({@code *}) which matches
+     * any characters, the equal character ({@code =}) is used to determine rename mapping of field.
+     */
+    public static final Field FIELD_RENAMES = Field.create("field.renames")
+                                                     .withDisplayName("Rename Fields")
                                                      .withType(Type.STRING)
                                                      .withWidth(Width.LONG)
                                                      .withImportance(Importance.MEDIUM)
@@ -224,6 +237,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
                                                      COLLECTION_WHITELIST,
                                                      COLLECTION_BLACKLIST,
                                                      FIELD_BLACKLIST,
+                                                     FIELD_RENAMES,
                                                      AUTO_DISCOVER_MEMBERS,
                                                      DATABASE_WHITELIST,
                                                      DATABASE_BLACKLIST,
@@ -240,7 +254,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
         Field.group(config, "MongoDB", HOSTS, USER, PASSWORD, LOGICAL_NAME, CONNECT_BACKOFF_INITIAL_DELAY_MS,
                     CONNECT_BACKOFF_MAX_DELAY_MS, MAX_FAILED_CONNECTIONS, AUTO_DISCOVER_MEMBERS,
                     SSL_ENABLED, SSL_ALLOW_INVALID_HOSTNAMES);
-        Field.group(config, "Events", DATABASE_WHITELIST, DATABASE_BLACKLIST, COLLECTION_WHITELIST, COLLECTION_BLACKLIST, FIELD_BLACKLIST, CommonConnectorConfig.TOMBSTONES_ON_DELETE);
+        Field.group(config, "Events", DATABASE_WHITELIST, DATABASE_BLACKLIST, COLLECTION_WHITELIST, COLLECTION_BLACKLIST, FIELD_BLACKLIST, FIELD_RENAMES, CommonConnectorConfig.TOMBSTONES_ON_DELETE);
         Field.group(config, "Connector", MAX_COPY_THREADS, CommonConnectorConfig.MAX_QUEUE_SIZE, CommonConnectorConfig.MAX_BATCH_SIZE, CommonConnectorConfig.POLL_INTERVAL_MS);
         return config;
     }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
@@ -77,7 +77,7 @@ import io.debezium.util.Threads;
  * This replicator does each of its tasks using a connection to the primary. If the replicator is not able to establish a
  * connection to the primary (e.g., there is no primary, or the replicator cannot communicate with the primary), the replicator
  * will continue to try to establish a connection, using an exponential back-off strategy to prevent saturating the system.
- * After a {@link MongoDbTaskContext#maxConnectionAttemptsForPrimary() configurable} number of failed attempts, the replicator
+ * After a {@link ConnectionContext#maxConnectionAttemptsForPrimary() configurable} number of failed attempts, the replicator
  * will fail by throwing a {@link ConnectException}.
  *
  * @author Randall Hauch
@@ -118,7 +118,7 @@ public class Replicator {
         final String copyThreadName = "copy-" + (replicaSet.hasReplicaSetName() ? replicaSet.replicaSetName() : "main");
         this.copyThreads = Threads.newFixedThreadPool(MongoDbConnector.class, context.serverName(), copyThreadName, context.getConnectionContext().maxNumberOfCopyThreads());
         this.bufferedRecorder = new BufferableRecorder(recorder);
-        this.recordMakers = new RecordMakers(this.source, context.topicSelector(), this.bufferedRecorder, context.isEmitTombstoneOnDelete());
+        this.recordMakers = new RecordMakers(context.filters(), this.source, context.topicSelector(), this.bufferedRecorder, context.isEmitTombstoneOnDelete());
         this.clock = this.context.getClock();
         this.onFailure = onFailure;
     }
@@ -195,7 +195,7 @@ public class Replicator {
 
     /**
      * Determine if an initial sync should be performed. An initial sync is expected if the {@link #source} has no previously
-     * recorded offsets for this replica set, or if {@link MongoDbTaskContext#performSnapshotEvenIfNotNeeded() a snapshot should
+     * recorded offsets for this replica set, or if {@link ConnectionContext#performSnapshotEvenIfNotNeeded() a snapshot should
      * always be performed}.
      *
      * @return {@code true} if the initial sync should be performed, or {@code false} otherwise

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/Configurator.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/Configurator.java
@@ -64,6 +64,10 @@ public class Configurator {
         return with(MongoDbConnectorConfig.FIELD_BLACKLIST, blacklist);
     }
 
+    public Configurator renameFields(String renames) {
+        return with(MongoDbConnectorConfig.FIELD_RENAMES, renames);
+    }
+
     public Filters createFilters() {
         return new Filters(configBuilder.build());
     }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/Configurator.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/Configurator.java
@@ -60,6 +60,10 @@ public class Configurator {
         return with(MongoDbConnectorConfig.COLLECTION_BLACKLIST, regexList);
     }
 
+    public Configurator excludeFields(String blacklist) {
+        return with(MongoDbConnectorConfig.FIELD_BLACKLIST, blacklist);
+    }
+
     public Filters createFilters() {
         return new Filters(configBuilder.build());
     }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldBlacklistTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldBlacklistTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import static io.debezium.data.Envelope.FieldName.AFTER;
 import static org.fest.assertions.Assertions.assertThat;
 
-public class FieldFilterTest {
+public class FieldBlacklistTest {
     private static final String SERVER_NAME = "serverX";
     private static final String PATCH = "patch";
     private static final JsonWriterSettings WRITER_SETTINGS =
@@ -52,7 +52,7 @@ public class FieldFilterTest {
                 .append("phone", 123L)
                 .append("active", true)
                 .append("scores", Arrays.asList(1.2, 3.4, 5.6));
-        Filters filters = build.excludeFields(".*\\.c2:name|active").createFilters();
+        Filters filters = build.excludeFields("*.c2.name,*.c2.active").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -75,7 +75,7 @@ public class FieldFilterTest {
                 .append("phone", 123L)
                 .append("active", true)
                 .append("scores", Arrays.asList(1.2, 3.4, 5.6));
-        Filters filters = build.excludeFields(".*\\.c1:name|active").createFilters();
+        Filters filters = build.excludeFields("*.c1.name,*.c1.active").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -103,7 +103,7 @@ public class FieldFilterTest {
                 .append("phone", 123L)
                 .append("active", true)
                 .append("scores", Arrays.asList(1.2, 3.4, 5.6));
-        Filters filters = build.excludeFields(".*\\.c1:missing").createFilters();
+        Filters filters = build.excludeFields("*.c1.missing").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -130,7 +130,7 @@ public class FieldFilterTest {
                         .append("city", "Amsterdam"))
                 .append("active", true)
                 .append("scores", Arrays.asList(1.2, 3.4, 5.6));
-        Filters filters = build.excludeFields(".*\\.c1:name|active|address.number").createFilters();
+        Filters filters = build.excludeFields("*.c1.name,*.c1.active,*.c1.address.number").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -166,7 +166,7 @@ public class FieldFilterTest {
                         .append("city", "Amsterdam"))
                 .append("active", true)
                 .append("scores", Arrays.asList(1.2, 3.4, 5.6));
-        Filters filters = build.excludeFields(".*\\.c1:address.missing").createFilters();
+        Filters filters = build.excludeFields("*.c1.address.missing").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -189,7 +189,7 @@ public class FieldFilterTest {
                 .append("phone", 123L)
                 .append("active", true)
                 .append("scores", Arrays.asList(1.2, 3.4, 5.6));
-        Filters filters = build.excludeFields(".*\\.c1:name|active").createFilters();
+        Filters filters = build.excludeFields("*.c1.name,*.c1.active").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -217,7 +217,7 @@ public class FieldFilterTest {
                 .append("phone", 123L)
                 .append("active", true)
                 .append("scores", Arrays.asList(1.2, 3.4, 5.6));
-        Filters filters = build.excludeFields(".*\\.c1:missing").createFilters();
+        Filters filters = build.excludeFields("*.c1.missing").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -244,7 +244,7 @@ public class FieldFilterTest {
                         .append("city", "Amsterdam"))
                 .append("active", true)
                 .append("scores", Arrays.asList(1.2, 3.4, 5.6));
-        Filters filters = build.excludeFields(".*\\.c1:name|active|address.number").createFilters();
+        Filters filters = build.excludeFields("*.c1.name,*.c1.active,*.c1.address.number").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -280,7 +280,7 @@ public class FieldFilterTest {
                         .append("city", "Amsterdam"))
                 .append("active", true)
                 .append("scores", Arrays.asList(1.2, 3.4, 5.6));
-        Filters filters = build.excludeFields(".*\\.c1:address.missing").createFilters();
+        Filters filters = build.excludeFields("*.c1.address.missing").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -303,7 +303,7 @@ public class FieldFilterTest {
                 .append("phone", 123L)
                 .append("active", true)
                 .append("scores", Arrays.asList(1.2, 3.4, 5.6));
-        Filters filters = build.excludeFields(".*\\.c1:name|active").createFilters();
+        Filters filters = build.excludeFields("*.c1.name,*.c1.active").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -331,7 +331,7 @@ public class FieldFilterTest {
                 .append("phone", 123L)
                 .append("active", true)
                 .append("scores", Arrays.asList(1.2, 3.4, 5.6));
-        Filters filters = build.excludeFields(".*\\.c1:missing").createFilters();
+        Filters filters = build.excludeFields("*.c1.missing").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -358,7 +358,7 @@ public class FieldFilterTest {
                         .append("city", "Amsterdam"))
                 .append("active", true)
                 .append("scores", Arrays.asList(1.2, 3.4, 5.6));
-        Filters filters = build.excludeFields(".*\\.c1:name|active|address.number").createFilters();
+        Filters filters = build.excludeFields("*.c1.name,*.c1.active,*.c1.address.number").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -394,7 +394,7 @@ public class FieldFilterTest {
                         .append("city", "Amsterdam"))
                 .append("active", true)
                 .append("scores", Arrays.asList(1.2, 3.4, 5.6));
-        Filters filters = build.excludeFields(".*\\.c1:address.missing").createFilters();
+        Filters filters = build.excludeFields("*.c1.address.missing").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -426,7 +426,7 @@ public class FieldFilterTest {
                                 .append("city", "Athens")))
                 .append("active", true)
                 .append("scores", Arrays.asList(1.2, 3.4, 5.6));
-        Filters filters = build.excludeFields(".*\\.c1:name|addresses.number").createFilters();
+        Filters filters = build.excludeFields("*.c1.name,*.c1.addresses.number").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -474,7 +474,7 @@ public class FieldFilterTest {
                                 .append("city", "Athens"))))
                 .append("active", true)
                 .append("scores", Arrays.asList(1.2, 3.4, 5.6));
-        Filters filters = build.excludeFields(".*\\.c1:name|addresses.number").createFilters();
+        Filters filters = build.excludeFields("*.c1.name,*.c1.addresses.number").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -517,7 +517,7 @@ public class FieldFilterTest {
                 .append("$set", new Document()
                         .append("name", "Sally")
                         .append("phone", 123L));
-        Filters filters = build.excludeFields(".*\\.c1:name").createFilters();
+        Filters filters = build.excludeFields("*.c1.name").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -543,7 +543,7 @@ public class FieldFilterTest {
                 .append("$unset", new Document()
                         .append("name", "")
                         .append("phone", ""));
-        Filters filters = build.excludeFields(".*\\.c1:name").createFilters();
+        Filters filters = build.excludeFields("*.c1.name").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -573,7 +573,7 @@ public class FieldFilterTest {
                                 .append("number", 34L)
                                 .append("street", "Claude Debussylaan")
                                 .append("city", "Amsterdam")));
-        Filters filters = build.excludeFields(".*\\.c1:name|address.number").createFilters();
+        Filters filters = build.excludeFields("*.c1.name,*.c1.address.number").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -612,7 +612,7 @@ public class FieldFilterTest {
                                         .append("number", 7L)
                                         .append("street", "Fragkokklisias")
                                         .append("city", "Athens"))));
-        Filters filters = build.excludeFields(".*\\.c1:name|addresses.number").createFilters();
+        Filters filters = build.excludeFields("*.c1.name,*.c1.addresses.number").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -657,7 +657,7 @@ public class FieldFilterTest {
                                         .append("number", 7L)
                                         .append("street", "Fragkokklisias")
                                         .append("city", "Athens")))));
-        Filters filters = build.excludeFields(".*\\.c1:name|addresses.number").createFilters();
+        Filters filters = build.excludeFields("*.c1.name,*.c1.addresses.number").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -701,7 +701,7 @@ public class FieldFilterTest {
                         .append("address.number", 34L)
                         .append("address.street", "Claude Debussylaan")
                         .append("address.city", "Amsterdam"));
-        Filters filters = build.excludeFields(".*\\.c1:name|address.number").createFilters();
+        Filters filters = build.excludeFields("*.c1.name,*.c1.address.number").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -730,7 +730,7 @@ public class FieldFilterTest {
                         .append("addresses.0.number", 34L)
                         .append("addresses.0.street", "Claude Debussylaan")
                         .append("addresses.0.city", "Amsterdam"));
-        Filters filters = build.excludeFields(".*\\.c1:addresses.number").createFilters();
+        Filters filters = build.excludeFields("*.c1.addresses.number").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -760,7 +760,7 @@ public class FieldFilterTest {
                         .append("addresses.0.0.number", 34L)
                         .append("addresses.0.0.street", "Claude Debussylaan")
                         .append("addresses.0.0.city", "Amsterdam"));
-        Filters filters = build.excludeFields(".*\\.c1:addresses.number").createFilters();
+        Filters filters = build.excludeFields("*.c1.addresses.number").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -783,7 +783,7 @@ public class FieldFilterTest {
                         .append("addresses.0.second.0.number", 34L)
                         .append("addresses.0.second.0.street", "Claude Debussylaan")
                         .append("addresses.0.second.0.city", "Amsterdam"));
-        Filters filters = build.excludeFields(".*\\.c1:addresses.second.number").createFilters();
+        Filters filters = build.excludeFields("*.c1.addresses.second.number").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -813,7 +813,36 @@ public class FieldFilterTest {
                         .append("addresses.0.number", 34L)
                         .append("addresses.0.street", "Claude Debussylaan")
                         .append("addresses.0.city", "Amsterdam"));
-        Filters filters = build.excludeFields(".*\\.c1:addresses").createFilters();
+        Filters filters = build.excludeFields("*.c1.addresses").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"name\" : \"Sally\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldExcludeFieldsForSetToArrayFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("addresses.0", new Document()
+                                .append("number", 34L)
+                                .append("street", "Claude Debussylaan")
+                                .append("city", "Amsterdam")));
+        Filters filters = build.excludeFields("*.c1.addresses").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -841,7 +870,7 @@ public class FieldFilterTest {
                         .append("address.number", "")
                         .append("address.street", "")
                         .append("address.city", ""));
-        Filters filters = build.excludeFields(".*\\.c1:name|address.number").createFilters();
+        Filters filters = build.excludeFields("*.c1.name,*.c1.address.number").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -870,7 +899,7 @@ public class FieldFilterTest {
                         .append("addresses.0.number", "")
                         .append("addresses.0.street", "")
                         .append("addresses.0.city", ""));
-        Filters filters = build.excludeFields(".*\\.c1:addresses.number").createFilters();
+        Filters filters = build.excludeFields("*.c1.addresses.number").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -900,7 +929,7 @@ public class FieldFilterTest {
                         .append("addresses.0.0.number", "")
                         .append("addresses.0.0.street", "")
                         .append("addresses.0.0.city", ""));
-        Filters filters = build.excludeFields(".*\\.c1:addresses.number").createFilters();
+        Filters filters = build.excludeFields("*.c1.addresses.number").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -923,7 +952,7 @@ public class FieldFilterTest {
                         .append("addresses.0.second.0.number", "")
                         .append("addresses.0.second.0.street", "")
                         .append("addresses.0.second.0.city", ""));
-        Filters filters = build.excludeFields(".*\\.c1:addresses.second.number").createFilters();
+        Filters filters = build.excludeFields("*.c1.addresses.second.number").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -943,7 +972,7 @@ public class FieldFilterTest {
     }
 
     @Test
-    public void shouldExcludeFieldsForUnsetNestedFieldUpdateEventWithEmbeddedDocument() throws InterruptedException {
+    public void shouldExcludeFieldsForUnsetNestedFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
         // given
         CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
         ObjectId objId = new ObjectId();
@@ -953,7 +982,7 @@ public class FieldFilterTest {
                         .append("addresses.0.number", "")
                         .append("addresses.0.street", "")
                         .append("addresses.0.city", ""));
-        Filters filters = build.excludeFields(".*\\.c1:addresses").createFilters();
+        Filters filters = build.excludeFields("*.c1.addresses").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -976,7 +1005,7 @@ public class FieldFilterTest {
         CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
         ObjectId objId = new ObjectId();
         Document obj = new Document("_id", objId);
-        Filters filters = build.excludeFields(".*\\.c1:name|active").createFilters();
+        Filters filters = build.excludeFields("*.c1.name,*.c1.active").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 
@@ -998,7 +1027,7 @@ public class FieldFilterTest {
         CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
         ObjectId objId = new ObjectId();
         Document obj = new Document("_id", objId);
-        Filters filters = build.excludeFields(".*\\.c1:name|active").createFilters();
+        Filters filters = build.excludeFields("*.c1.name,*.c1.active").createFilters();
         List<SourceRecord> produced = new ArrayList<>();
         RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldBlacklistTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldBlacklistTest.java
@@ -25,6 +25,7 @@ import static io.debezium.data.Envelope.FieldName.AFTER;
 import static org.fest.assertions.Assertions.assertThat;
 
 public class FieldBlacklistTest {
+
     private static final String SERVER_NAME = "serverX";
     private static final String PATCH = "patch";
     private static final JsonWriterSettings WRITER_SETTINGS =
@@ -721,6 +722,18 @@ public class FieldBlacklistTest {
 
     @Test
     public void shouldExcludeNestedFieldsForSetNestedFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // source document can have the following structure:
+        // {
+        //   "name": "Sally",
+        //   "addresses": [
+        //      {
+        //         "number": 34,
+        //         "street": "Claude Debussylaan",
+        //         "city": "Amsterdam"
+        //      }
+        //   ]
+        // }
+
         // given
         CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
         ObjectId objId = new ObjectId();
@@ -751,6 +764,20 @@ public class FieldBlacklistTest {
 
     @Test
     public void shouldNotExcludeNestedFieldsForSetNestedFieldUpdateEventWithArrayOfArrays() throws InterruptedException {
+        // source document can have the following structure:
+        // {
+        //   "name": "Sally",
+        //   "addresses": [
+        //      [
+        //         {
+        //            "number": 34,
+        //            "street": "Claude Debussylaan",
+        //            "city": "Amsterdam"
+        //         }
+        //      ]
+        //   ]
+        // }
+
         // given
         CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
         ObjectId objId = new ObjectId();
@@ -774,6 +801,22 @@ public class FieldBlacklistTest {
 
     @Test
     public void shouldExcludeNestedFieldsForSetNestedFieldUpdateEventWithSeveralArrays() throws InterruptedException {
+        // source document can have the following structure:
+        // {
+        //   "name": "Sally",
+        //   "addresses": [
+        //      {
+        //         "second": [
+        //            {
+        //               "number": 34,
+        //               "street": "Claude Debussylaan",
+        //               "city": "Amsterdam"
+        //            }
+        //         ]
+        //      }
+        //   ]
+        // }
+
         // given
         CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
         ObjectId objId = new ObjectId();
@@ -804,6 +847,18 @@ public class FieldBlacklistTest {
 
     @Test
     public void shouldExcludeFieldsForSetNestedFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // source document can have the following structure:
+        // {
+        //   "name": "Sally",
+        //   "addresses": [
+        //      {
+        //         "number": 34,
+        //         "street": "Claude Debussylaan",
+        //         "city": "Amsterdam"
+        //      }
+        //   ]
+        // }
+
         // given
         CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
         ObjectId objId = new ObjectId();
@@ -832,6 +887,18 @@ public class FieldBlacklistTest {
 
     @Test
     public void shouldExcludeFieldsForSetToArrayFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // source document can have the following structure:
+        // {
+        //   "name": "Sally",
+        //   "addresses": [
+        //      {
+        //         "number": 34,
+        //         "street": "Claude Debussylaan",
+        //         "city": "Amsterdam"
+        //      }
+        //   ]
+        // }
+
         // given
         CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
         ObjectId objId = new ObjectId();
@@ -890,6 +957,18 @@ public class FieldBlacklistTest {
 
     @Test
     public void shouldExcludeNestedFieldsForUnsetNestedFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // source document can have the following structure:
+        // {
+        //   "name": "Sally",
+        //   "addresses": [
+        //      {
+        //         "number": 34,
+        //         "street": "Claude Debussylaan",
+        //         "city": "Amsterdam"
+        //      }
+        //   ]
+        // }
+
         // given
         CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
         ObjectId objId = new ObjectId();
@@ -920,6 +999,20 @@ public class FieldBlacklistTest {
 
     @Test
     public void shouldNotExcludeNestedFieldsForUnsetNestedFieldUpdateEventWithArrayOfArrays() throws InterruptedException {
+        // source document can have the following structure:
+        // {
+        //   "name": "Sally",
+        //   "addresses": [
+        //      [
+        //         {
+        //            "number": 34,
+        //            "street": "Claude Debussylaan",
+        //            "city": "Amsterdam"
+        //         }
+        //      ]
+        //   ]
+        // }
+
         // given
         CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
         ObjectId objId = new ObjectId();
@@ -943,6 +1036,22 @@ public class FieldBlacklistTest {
 
     @Test
     public void shouldExcludeNestedFieldsForUnsetNestedFieldUpdateEventWithSeveralArrays() throws InterruptedException {
+        // source document can have the following structure:
+        // {
+        //   "name": "Sally",
+        //   "addresses": [
+        //      {
+        //         "second": [
+        //            {
+        //               "number": 34,
+        //               "street": "Claude Debussylaan",
+        //               "city": "Amsterdam"
+        //            }
+        //         ]
+        //      }
+        //   ]
+        // }
+
         // given
         CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
         ObjectId objId = new ObjectId();
@@ -973,6 +1082,18 @@ public class FieldBlacklistTest {
 
     @Test
     public void shouldExcludeFieldsForUnsetNestedFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // source document can have the following structure:
+        // {
+        //   "name": "Sally",
+        //   "addresses": [
+        //      {
+        //         "number": 34,
+        //         "street": "Claude Debussylaan",
+        //         "city": "Amsterdam"
+        //      }
+        //   ]
+        // }
+
         // given
         CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
         ObjectId objId = new ObjectId();

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldFilterTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldFilterTest.java
@@ -1,0 +1,1038 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import io.debezium.schema.TopicSelector;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.bson.BsonTimestamp;
+import org.bson.Document;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+import org.bson.types.ObjectId;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static io.debezium.data.Envelope.FieldName.AFTER;
+import static org.fest.assertions.Assertions.assertThat;
+
+public class FieldFilterTest {
+    private static final String SERVER_NAME = "serverX";
+    private static final String PATCH = "patch";
+    private static final JsonWriterSettings WRITER_SETTINGS =
+            new JsonWriterSettings(JsonMode.STRICT, "", ""); // most compact JSON
+
+    private Configurator build;
+    private SourceInfo source;
+    private TopicSelector<CollectionId> topicSelector;
+
+    @Before
+    public void setup() {
+        build = new Configurator();
+        source = new SourceInfo(SERVER_NAME);
+        topicSelector = MongoDbTopicSelector.defaultSelector(SERVER_NAME, "__debezium-heartbeat");
+    }
+
+    @Test
+    public void shouldNotExcludeFieldsForEventOfOtherCollection() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.excludeFields(".*\\.c2:name|active").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordObject(collectionId, obj, 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldExcludeFieldsForReadEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.excludeFields(".*\\.c1:name|active").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordObject(collectionId, obj, 1002);
+
+        // then
+        String expected = "{"
+                +     "\"_id\" : {\"$oid\" : \"" + objId + "\"},"
+                +     "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +     "\"scores\" : [1.2, 3.4, 5.6]"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotExcludeMissingFieldsForReadEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.excludeFields(".*\\.c1:missing").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordObject(collectionId, obj, 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldExcludeNestedFieldsForReadEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("address", new Document()
+                        .append("number", 34L)
+                        .append("street", "Claude Debussylaan")
+                        .append("city", "Amsterdam"))
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.excludeFields(".*\\.c1:name|active|address.number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordObject(collectionId, obj, 1002);
+
+        // then
+        String expected = "{"
+                +     "\"_id\" : {\"$oid\" : \"" + objId + "\"},"
+                +     "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +     "\"address\" : {"
+                +         "\"street\" : \"Claude Debussylaan\","
+                +         "\"city\" : \"Amsterdam\""
+                +     "},"
+                +     "\"scores\" : [1.2, 3.4, 5.6]"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotExcludeNestedMissingFieldsForReadEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("address", new Document()
+                        .append("number", 34L)
+                        .append("street", "Claude Debussylaan")
+                        .append("city", "Amsterdam"))
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.excludeFields(".*\\.c1:address.missing").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordObject(collectionId, obj, 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldExcludeFieldsForInsertEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.excludeFields(".*\\.c1:name|active").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createEvent(obj, "i"), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"_id\" : {\"$oid\" : \"" + objId + "\"},"
+                +     "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +     "\"scores\" : [1.2, 3.4, 5.6]"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotExcludeMissingFieldsForInsertEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.excludeFields(".*\\.c1:missing").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createEvent(obj, "i"), 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldExcludeNestedFieldsForInsertEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("address", new Document()
+                        .append("number", 34L)
+                        .append("street", "Claude Debussylaan")
+                        .append("city", "Amsterdam"))
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.excludeFields(".*\\.c1:name|active|address.number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createEvent(obj, "i"), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"_id\" : {\"$oid\" : \"" + objId + "\"},"
+                +     "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +     "\"address\" : {"
+                +         "\"street\" : \"Claude Debussylaan\","
+                +         "\"city\" : \"Amsterdam\""
+                +     "},"
+                +     "\"scores\" : [1.2, 3.4, 5.6]"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotExcludeNestedMissingFieldsForInsertEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("address", new Document()
+                        .append("number", 34L)
+                        .append("street", "Claude Debussylaan")
+                        .append("city", "Amsterdam"))
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.excludeFields(".*\\.c1:address.missing").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createEvent(obj, "i"), 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldExcludeFieldsForUpdateEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.excludeFields(".*\\.c1:name|active").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"_id\" : {\"$oid\" : \"" + objId + "\"},"
+                +     "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +     "\"scores\" : [1.2, 3.4, 5.6]"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotExcludeMissingFieldsForUpdateEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.excludeFields(".*\\.c1:missing").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldExcludeNestedFieldsForUpdateEventWithEmbeddedDocument() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("address", new Document()
+                        .append("number", 34L)
+                        .append("street", "Claude Debussylaan")
+                        .append("city", "Amsterdam"))
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.excludeFields(".*\\.c1:name|active|address.number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"_id\" : {\"$oid\" : \"" + objId + "\"},"
+                +     "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +     "\"address\" : {"
+                +         "\"street\" : \"Claude Debussylaan\","
+                +         "\"city\" : \"Amsterdam\""
+                +     "},"
+                +     "\"scores\" : [1.2, 3.4, 5.6]"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotExcludeNestedMissingFieldsForUpdateEventWithEmbeddedDocument() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("address", new Document()
+                        .append("number", 34L)
+                        .append("street", "Claude Debussylaan")
+                        .append("city", "Amsterdam"))
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.excludeFields(".*\\.c1:address.missing").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldExcludeNestedFieldsForUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("addresses", Arrays.asList(
+                        new Document()
+                                .append("number", 34L)
+                                .append("street", "Claude Debussylaan")
+                                .append("city", "Amsterdam"),
+                        new Document()
+                                .append("number", 7L)
+                                .append("street", "Fragkokklisias")
+                                .append("city", "Athens")))
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.excludeFields(".*\\.c1:name|addresses.number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"_id\" : {\"$oid\" : \"" + objId + "\"},"
+                +     "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +     "\"addresses\" : ["
+                +         "{"
+                +             "\"street\" : \"Claude Debussylaan\","
+                +             "\"city\" : \"Amsterdam\""
+                +         "}, "
+                +         "{"
+                +             "\"street\" : \"Fragkokklisias\","
+                +             "\"city\" : \"Athens\""
+                +         "}"
+                +     "],"
+                +     "\"active\" : true,"
+                +     "\"scores\" : [1.2, 3.4, 5.6]"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotExcludeNestedFieldsForUpdateEventWithArrayOfArrays() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("addresses", Arrays.asList(
+                        Collections.singletonList(new Document()
+                                .append("number", 34L)
+                                .append("street", "Claude Debussylaan")
+                                .append("city", "Amsterdam")),
+                        Collections.singletonList(new Document()
+                                .append("number", 7L)
+                                .append("street", "Fragkokklisias")
+                                .append("city", "Athens"))))
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.excludeFields(".*\\.c1:name|addresses.number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"_id\" : {\"$oid\" : \"" + objId + "\"},"
+                +     "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +     "\"addresses\" : ["
+                +         "["
+                +             "{"
+                +                 "\"number\" : {\"$numberLong\" : \"34\"},"
+                +                 "\"street\" : \"Claude Debussylaan\","
+                +                 "\"city\" : \"Amsterdam\""
+                +             "}"
+                +         "], "
+                +         "["
+                +             "{"
+                +                 "\"number\" : {\"$numberLong\" : \"7\"},"
+                +                 "\"street\" : \"Fragkokklisias\","
+                +                 "\"city\" : \"Athens\""
+                +             "}"
+                +         "]"
+                +     "],"
+                +     "\"active\" : true,"
+                +     "\"scores\" : [1.2, 3.4, 5.6]"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldExcludeFieldsForSetTopLevelFieldUpdateEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("phone", 123L));
+        Filters filters = build.excludeFields(".*\\.c1:name").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"phone\" : {\"$numberLong\" : \"123\"}"
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldExcludeFieldsForUnsetTopLevelFieldUpdateEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$unset", new Document()
+                        .append("name", "")
+                        .append("phone", ""));
+        Filters filters = build.excludeFields(".*\\.c1:name").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$unset\" : {"
+                +         "\"phone\" : \"\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldExcludeNestedFieldsForSetTopLevelFieldUpdateEventWithEmbeddedDocument() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("phone", 123L)
+                        .append("address", new Document()
+                                .append("number", 34L)
+                                .append("street", "Claude Debussylaan")
+                                .append("city", "Amsterdam")));
+        Filters filters = build.excludeFields(".*\\.c1:name|address.number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +         "\"address\" : {"
+                +             "\"street\" : \"Claude Debussylaan\","
+                +             "\"city\" : \"Amsterdam\""
+                +         "}"
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldExcludeNestedFieldsForSetTopLevelFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("phone", 123L)
+                        .append("addresses", Arrays.asList(
+                                new Document()
+                                        .append("number", 34L)
+                                        .append("street", "Claude Debussylaan")
+                                        .append("city", "Amsterdam"),
+                                new Document()
+                                        .append("number", 7L)
+                                        .append("street", "Fragkokklisias")
+                                        .append("city", "Athens"))));
+        Filters filters = build.excludeFields(".*\\.c1:name|addresses.number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +         "\"addresses\" : ["
+                +             "{"
+                +                 "\"street\" : \"Claude Debussylaan\","
+                +                 "\"city\" : \"Amsterdam\""
+                +             "}, "
+                +             "{"
+                +                 "\"street\" : \"Fragkokklisias\","
+                +                 "\"city\" : \"Athens\""
+                +             "}"
+                +         "]"
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotExcludeNestedFieldsForSetTopLevelFieldUpdateEventWithArrayOfArrays() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("phone", 123L)
+                        .append("addresses", Arrays.asList(
+                                Collections.singletonList(new Document()
+                                        .append("number", 34L)
+                                        .append("street", "Claude Debussylaan")
+                                        .append("city", "Amsterdam")),
+                                Collections.singletonList(new Document()
+                                        .append("number", 7L)
+                                        .append("street", "Fragkokklisias")
+                                        .append("city", "Athens")))));
+        Filters filters = build.excludeFields(".*\\.c1:name|addresses.number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +         "\"addresses\" : ["
+                +             "["
+                +                 "{"
+                +                     "\"number\" : {\"$numberLong\" : \"34\"},"
+                +                     "\"street\" : \"Claude Debussylaan\","
+                +                     "\"city\" : \"Amsterdam\""
+                +                 "}"
+                +             "], "
+                +             "["
+                +                 "{"
+                +                     "\"number\" : {\"$numberLong\" : \"7\"},"
+                +                     "\"street\" : \"Fragkokklisias\","
+                +                     "\"city\" : \"Athens\""
+                +                 "}"
+                +             "]"
+                +         "]"
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldExcludeNestedFieldsForSetNestedFieldUpdateEventWithEmbeddedDocument() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("address.number", 34L)
+                        .append("address.street", "Claude Debussylaan")
+                        .append("address.city", "Amsterdam"));
+        Filters filters = build.excludeFields(".*\\.c1:name|address.number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"address.street\" : \"Claude Debussylaan\","
+                +         "\"address.city\" : \"Amsterdam\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldExcludeNestedFieldsForSetNestedFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("addresses.0.number", 34L)
+                        .append("addresses.0.street", "Claude Debussylaan")
+                        .append("addresses.0.city", "Amsterdam"));
+        Filters filters = build.excludeFields(".*\\.c1:addresses.number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"name\" : \"Sally\","
+                +         "\"addresses.0.street\" : \"Claude Debussylaan\","
+                +         "\"addresses.0.city\" : \"Amsterdam\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotExcludeNestedFieldsForSetNestedFieldUpdateEventWithArrayOfArrays() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("addresses.0.0.number", 34L)
+                        .append("addresses.0.0.street", "Claude Debussylaan")
+                        .append("addresses.0.0.city", "Amsterdam"));
+        Filters filters = build.excludeFields(".*\\.c1:addresses.number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldExcludeNestedFieldsForSetNestedFieldUpdateEventWithSeveralArrays() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("addresses.0.second.0.number", 34L)
+                        .append("addresses.0.second.0.street", "Claude Debussylaan")
+                        .append("addresses.0.second.0.city", "Amsterdam"));
+        Filters filters = build.excludeFields(".*\\.c1:addresses.second.number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"name\" : \"Sally\","
+                +         "\"addresses.0.second.0.street\" : \"Claude Debussylaan\","
+                +         "\"addresses.0.second.0.city\" : \"Amsterdam\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldExcludeFieldsForSetNestedFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("addresses.0.number", 34L)
+                        .append("addresses.0.street", "Claude Debussylaan")
+                        .append("addresses.0.city", "Amsterdam"));
+        Filters filters = build.excludeFields(".*\\.c1:addresses").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"name\" : \"Sally\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldExcludeNestedFieldsForUnsetNestedFieldUpdateEventWithEmbeddedDocument() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$unset", new Document()
+                        .append("name", "")
+                        .append("address.number", "")
+                        .append("address.street", "")
+                        .append("address.city", ""));
+        Filters filters = build.excludeFields(".*\\.c1:name|address.number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$unset\" : {"
+                +         "\"address.street\" : \"\","
+                +         "\"address.city\" : \"\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldExcludeNestedFieldsForUnsetNestedFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$unset", new Document()
+                        .append("name", "")
+                        .append("addresses.0.number", "")
+                        .append("addresses.0.street", "")
+                        .append("addresses.0.city", ""));
+        Filters filters = build.excludeFields(".*\\.c1:addresses.number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$unset\" : {"
+                +         "\"name\" : \"\","
+                +         "\"addresses.0.street\" : \"\","
+                +         "\"addresses.0.city\" : \"\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotExcludeNestedFieldsForUnsetNestedFieldUpdateEventWithArrayOfArrays() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$unset", new Document()
+                        .append("name", "")
+                        .append("addresses.0.0.number", "")
+                        .append("addresses.0.0.street", "")
+                        .append("addresses.0.0.city", ""));
+        Filters filters = build.excludeFields(".*\\.c1:addresses.number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldExcludeNestedFieldsForUnsetNestedFieldUpdateEventWithSeveralArrays() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$unset", new Document()
+                        .append("name", "")
+                        .append("addresses.0.second.0.number", "")
+                        .append("addresses.0.second.0.street", "")
+                        .append("addresses.0.second.0.city", ""));
+        Filters filters = build.excludeFields(".*\\.c1:addresses.second.number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$unset\" : {"
+                +         "\"name\" : \"\","
+                +         "\"addresses.0.second.0.street\" : \"\","
+                +         "\"addresses.0.second.0.city\" : \"\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldExcludeFieldsForUnsetNestedFieldUpdateEventWithEmbeddedDocument() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$unset", new Document()
+                        .append("name", "")
+                        .append("addresses.0.number", "")
+                        .append("addresses.0.street", "")
+                        .append("addresses.0.city", ""));
+        Filters filters = build.excludeFields(".*\\.c1:addresses").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$unset\" : {"
+                +         "\"name\" : \"\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldExcludeFieldsForDeleteEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document("_id", objId);
+        Filters filters = build.excludeFields(".*\\.c1:name|active").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createEvent(obj, "d"), 1002);
+
+        // then
+        Struct value = getValue(produced);
+        String json = value.getString(AFTER);
+        if (json == null) {
+            json = value.getString(PATCH);
+        }
+        assertThat(json).isNull();
+    }
+
+    @Test
+    public void shouldExcludeFieldsForDeleteTombstoneEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document("_id", objId);
+        Filters filters = build.excludeFields(".*\\.c1:name|active").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createEvent(obj, "d"), 1002);
+
+        // then
+        SourceRecord record = produced.get(1);
+        assertThat(record.value()).isNull();
+    }
+
+    private Struct getValue(List<SourceRecord> produced) {
+        SourceRecord record = produced.get(0);
+        return (Struct) record.value();
+    }
+
+    private Document createEvent(Document obj, String op) {
+        BsonTimestamp ts = new BsonTimestamp(1000, 1);
+        return new Document()
+                .append("o", obj)
+                .append("ns", "dbA.c1")
+                .append("ts", ts)
+                .append("h", 12345678L)
+                .append("op", op);
+    }
+
+    private Document createUpdateEvent(Document obj, ObjectId objId) {
+        BsonTimestamp ts = new BsonTimestamp(1000, 1);
+        return new Document()
+                .append("o", obj)
+                .append("o2", objId)
+                .append("ns", "dbA.c1")
+                .append("ts", ts)
+                .append("h", 12345678L)
+                .append("op", "u");
+    }
+}

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldRenamesTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldRenamesTest.java
@@ -1,0 +1,1113 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import io.debezium.schema.TopicSelector;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.bson.BsonTimestamp;
+import org.bson.Document;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+import org.bson.types.ObjectId;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static io.debezium.data.Envelope.FieldName.AFTER;
+import static org.fest.assertions.Assertions.assertThat;
+
+public class FieldRenamesTest {
+    private static final String SERVER_NAME = "serverX";
+    private static final String PATCH = "patch";
+    private static final JsonWriterSettings WRITER_SETTINGS =
+            new JsonWriterSettings(JsonMode.STRICT, "", ""); // most compact JSON
+
+    private Configurator build;
+    private SourceInfo source;
+    private TopicSelector<CollectionId> topicSelector;
+
+    @Before
+    public void setup() {
+        build = new Configurator();
+        source = new SourceInfo(SERVER_NAME);
+        topicSelector = MongoDbTopicSelector.defaultSelector(SERVER_NAME, "__debezium-heartbeat");
+    }
+
+    @Test
+    public void shouldNotRenameFieldsForEventOfOtherCollection() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.renameFields("*.c2.name=new_name,*.c2.active=new_active").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordObject(collectionId, obj, 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldRenameFieldsForReadEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.renameFields("*.c1.name=new_name,*.c1.active=new_active").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordObject(collectionId, obj, 1002);
+
+        // then
+        String expected = "{"
+                +     "\"_id\" : {\"$oid\" : \"" + objId + "\"},"
+                +     "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +     "\"scores\" : [1.2, 3.4, 5.6],"
+                +     "\"new_name\" : \"Sally\","
+                +     "\"new_active\" : true"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotRenameMissingFieldsForReadEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.renameFields("*.c1.missing=new_missing").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordObject(collectionId, obj, 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldRenameNestedFieldsForReadEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("address", new Document()
+                        .append("number", 34L)
+                        .append("street", "Claude Debussylaan")
+                        .append("city", "Amsterdam"))
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.renameFields("*.c1.name=new_name,*.c1.active=new_active,*.c1.address.number=new_number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordObject(collectionId, obj, 1002);
+
+        // then
+        String expected = "{"
+                +     "\"_id\" : {\"$oid\" : \"" + objId + "\"},"
+                +     "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +     "\"address\" : {"
+                +         "\"street\" : \"Claude Debussylaan\","
+                +         "\"city\" : \"Amsterdam\","
+                +         "\"new_number\" : {\"$numberLong\" : \"34\"}"
+                +     "},"
+                +     "\"scores\" : [1.2, 3.4, 5.6],"
+                +     "\"new_name\" : \"Sally\","
+                +     "\"new_active\" : true"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotRenameNestedMissingFieldsForReadEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("address", new Document()
+                        .append("number", 34L)
+                        .append("street", "Claude Debussylaan")
+                        .append("city", "Amsterdam"))
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.renameFields("*.c1.address.missing=new_missing").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordObject(collectionId, obj, 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldRenameFieldsForInsertEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.renameFields("*.c1.name=new_name,*.c1.active=new_active").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createEvent(obj, "i"), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"_id\" : {\"$oid\" : \"" + objId + "\"},"
+                +     "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +     "\"scores\" : [1.2, 3.4, 5.6],"
+                +     "\"new_name\" : \"Sally\","
+                +     "\"new_active\" : true"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotRenameMissingFieldsForInsertEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.renameFields("*.c1.missing=new_missing").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createEvent(obj, "i"), 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldRenameNestedFieldsForInsertEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("address", new Document()
+                        .append("number", 34L)
+                        .append("street", "Claude Debussylaan")
+                        .append("city", "Amsterdam"))
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.renameFields("*.c1.name=new_name,*.c1.active=new_active,*.c1.address.number=new_number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createEvent(obj, "i"), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"_id\" : {\"$oid\" : \"" + objId + "\"},"
+                +     "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +     "\"address\" : {"
+                +         "\"street\" : \"Claude Debussylaan\","
+                +         "\"city\" : \"Amsterdam\","
+                +         "\"new_number\" : {\"$numberLong\" : \"34\"}"
+                +     "},"
+                +     "\"scores\" : [1.2, 3.4, 5.6],"
+                +     "\"new_name\" : \"Sally\","
+                +     "\"new_active\" : true"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotRenameNestedMissingFieldsForInsertEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("address", new Document()
+                        .append("number", 34L)
+                        .append("street", "Claude Debussylaan")
+                        .append("city", "Amsterdam"))
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.renameFields("*.c1.address.missing=new_missing").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createEvent(obj, "i"), 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(AFTER)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldRenameFieldsForUpdateEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.renameFields("*.c1.name=new_name,*.c1.active=new_active").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"_id\" : {\"$oid\" : \"" + objId + "\"},"
+                +     "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +     "\"scores\" : [1.2, 3.4, 5.6],"
+                +     "\"new_name\" : \"Sally\","
+                +     "\"new_active\" : true"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotRenameMissingFieldsForUpdateEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.renameFields("*.c1.missing=new_missing").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldRenameNestedFieldsForUpdateEventWithEmbeddedDocument() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("address", new Document()
+                        .append("number", 34L)
+                        .append("street", "Claude Debussylaan")
+                        .append("city", "Amsterdam"))
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.renameFields("*.c1.name=new_name,*.c1.active=new_active,*.c1.address.number=new_number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"_id\" : {\"$oid\" : \"" + objId + "\"},"
+                +     "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +     "\"address\" : {"
+                +         "\"street\" : \"Claude Debussylaan\","
+                +         "\"city\" : \"Amsterdam\","
+                +         "\"new_number\" : {\"$numberLong\" : \"34\"}"
+                +     "},"
+                +     "\"scores\" : [1.2, 3.4, 5.6],"
+                +     "\"new_name\" : \"Sally\","
+                +     "\"new_active\" : true"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotRenameNestedMissingFieldsForUpdateEventWithEmbeddedDocument() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("address", new Document()
+                        .append("number", 34L)
+                        .append("street", "Claude Debussylaan")
+                        .append("city", "Amsterdam"))
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.renameFields("*.c1.address.missing=new_missing").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldRenameNestedFieldsForUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("addresses", Arrays.asList(
+                        new Document()
+                                .append("number", 34L)
+                                .append("street", "Claude Debussylaan")
+                                .append("city", "Amsterdam"),
+                        new Document()
+                                .append("number", 7L)
+                                .append("street", "Fragkokklisias")
+                                .append("city", "Athens")))
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.renameFields("*.c1.name=new_name,*.c1.addresses.number=new_number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"_id\" : {\"$oid\" : \"" + objId + "\"},"
+                +     "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +     "\"addresses\" : ["
+                +         "{"
+                +             "\"street\" : \"Claude Debussylaan\","
+                +             "\"city\" : \"Amsterdam\","
+                +             "\"new_number\" : {\"$numberLong\" : \"34\"}"
+                +         "}, "
+                +         "{"
+                +             "\"street\" : \"Fragkokklisias\","
+                +             "\"city\" : \"Athens\","
+                +             "\"new_number\" : {\"$numberLong\" : \"7\"}"
+                +         "}"
+                +     "],"
+                +     "\"active\" : true,"
+                +     "\"scores\" : [1.2, 3.4, 5.6],"
+                +     "\"new_name\" : \"Sally\""
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotRenameNestedFieldsForUpdateEventWithArrayOfArrays() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("_id", objId)
+                .append("name", "Sally")
+                .append("phone", 123L)
+                .append("addresses", Arrays.asList(
+                        Collections.singletonList(new Document()
+                                .append("number", 34L)
+                                .append("street", "Claude Debussylaan")
+                                .append("city", "Amsterdam")),
+                        Collections.singletonList(new Document()
+                                .append("number", 7L)
+                                .append("street", "Fragkokklisias")
+                                .append("city", "Athens"))))
+                .append("active", true)
+                .append("scores", Arrays.asList(1.2, 3.4, 5.6));
+        Filters filters = build.renameFields("*.c1.name=new_name,*.c1.addresses.number=new_number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"_id\" : {\"$oid\" : \"" + objId + "\"},"
+                +     "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +     "\"addresses\" : ["
+                +         "["
+                +             "{"
+                +                 "\"number\" : {\"$numberLong\" : \"34\"},"
+                +                 "\"street\" : \"Claude Debussylaan\","
+                +                 "\"city\" : \"Amsterdam\""
+                +             "}"
+                +         "], "
+                +         "["
+                +             "{"
+                +                 "\"number\" : {\"$numberLong\" : \"7\"},"
+                +                 "\"street\" : \"Fragkokklisias\","
+                +                 "\"city\" : \"Athens\""
+                +             "}"
+                +         "]"
+                +     "],"
+                +     "\"active\" : true,"
+                +     "\"scores\" : [1.2, 3.4, 5.6],"
+                +     "\"new_name\" : \"Sally\""
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldRenameFieldsForSetTopLevelFieldUpdateEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("phone", 123L));
+        Filters filters = build.renameFields("*.c1.name=new_name").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +         "\"new_name\" : \"Sally\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldRenameFieldsForUnsetTopLevelFieldUpdateEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$unset", new Document()
+                        .append("name", "")
+                        .append("phone", ""));
+        Filters filters = build.renameFields("*.c1.name=new_name").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$unset\" : {"
+                +         "\"phone\" : \"\","
+                +         "\"new_name\" : \"\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldRenameNestedFieldsForSetTopLevelFieldUpdateEventWithEmbeddedDocument() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("phone", 123L)
+                        .append("address", new Document()
+                                .append("number", 34L)
+                                .append("street", "Claude Debussylaan")
+                                .append("city", "Amsterdam")));
+        Filters filters = build.renameFields("*.c1.name=new_name,*.c1.address.number=new_number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +         "\"address\" : {"
+                +             "\"street\" : \"Claude Debussylaan\","
+                +             "\"city\" : \"Amsterdam\","
+                +             "\"new_number\" : {\"$numberLong\" : \"34\"}"
+                +         "},"
+                +         "\"new_name\" : \"Sally\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldRenameNestedFieldsForSetTopLevelFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("phone", 123L)
+                        .append("addresses", Arrays.asList(
+                                new Document()
+                                        .append("number", 34L)
+                                        .append("street", "Claude Debussylaan")
+                                        .append("city", "Amsterdam"),
+                                new Document()
+                                        .append("number", 7L)
+                                        .append("street", "Fragkokklisias")
+                                        .append("city", "Athens"))));
+        Filters filters = build.renameFields("*.c1.name=new_name,*.c1.addresses.number=new_number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +         "\"addresses\" : ["
+                +             "{"
+                +                 "\"street\" : \"Claude Debussylaan\","
+                +                 "\"city\" : \"Amsterdam\","
+                +                 "\"new_number\" : {\"$numberLong\" : \"34\"}"
+                +             "}, "
+                +             "{"
+                +                 "\"street\" : \"Fragkokklisias\","
+                +                 "\"city\" : \"Athens\","
+                +                 "\"new_number\" : {\"$numberLong\" : \"7\"}"
+                +             "}"
+                +         "],"
+                +         "\"new_name\" : \"Sally\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotRenameNestedFieldsForSetTopLevelFieldUpdateEventWithArrayOfArrays() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("phone", 123L)
+                        .append("addresses", Arrays.asList(
+                                Collections.singletonList(new Document()
+                                        .append("number", 34L)
+                                        .append("street", "Claude Debussylaan")
+                                        .append("city", "Amsterdam")),
+                                Collections.singletonList(new Document()
+                                        .append("number", 7L)
+                                        .append("street", "Fragkokklisias")
+                                        .append("city", "Athens")))));
+        Filters filters = build.renameFields("*.c1.name=new_name,*.c1.addresses.number=new_number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"phone\" : {\"$numberLong\" : \"123\"},"
+                +         "\"addresses\" : ["
+                +             "["
+                +                 "{"
+                +                     "\"number\" : {\"$numberLong\" : \"34\"},"
+                +                     "\"street\" : \"Claude Debussylaan\","
+                +                     "\"city\" : \"Amsterdam\""
+                +                 "}"
+                +             "], "
+                +             "["
+                +                 "{"
+                +                     "\"number\" : {\"$numberLong\" : \"7\"},"
+                +                     "\"street\" : \"Fragkokklisias\","
+                +                     "\"city\" : \"Athens\""
+                +                 "}"
+                +             "]"
+                +         "],"
+                +         "\"new_name\" : \"Sally\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldRenameNestedFieldsForSetNestedFieldUpdateEventWithEmbeddedDocument() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("address.number", 34L)
+                        .append("address.street", "Claude Debussylaan")
+                        .append("address.city", "Amsterdam"));
+        Filters filters = build.renameFields("*.c1.name=new_name,*.c1.address.number=new_number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"address.street\" : \"Claude Debussylaan\","
+                +         "\"address.city\" : \"Amsterdam\","
+                +         "\"new_name\" : \"Sally\","
+                +         "\"address.new_number\" : {\"$numberLong\" : \"34\"}"
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldRenameNestedFieldsForSetNestedFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("addresses.0.number", 34L)
+                        .append("addresses.0.street", "Claude Debussylaan")
+                        .append("addresses.0.city", "Amsterdam"));
+        Filters filters = build.renameFields("*.c1.addresses.number=new_number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"name\" : \"Sally\","
+                +         "\"addresses.0.street\" : \"Claude Debussylaan\","
+                +         "\"addresses.0.city\" : \"Amsterdam\","
+                +         "\"addresses.0.new_number\" : {\"$numberLong\" : \"34\"}"
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotRenameNestedFieldsForSetNestedFieldUpdateEventWithArrayOfArrays() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("addresses.0.0.number", 34L)
+                        .append("addresses.0.0.street", "Claude Debussylaan")
+                        .append("addresses.0.0.city", "Amsterdam"));
+        Filters filters = build.renameFields("*.c1.addresses.number=new_number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldRenameNestedFieldsForSetNestedFieldUpdateEventWithSeveralArrays() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("addresses.0.second.0.number", 34L)
+                        .append("addresses.0.second.0.street", "Claude Debussylaan")
+                        .append("addresses.0.second.0.city", "Amsterdam"));
+        Filters filters = build.renameFields("*.c1.addresses.second.number=new_number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"name\" : \"Sally\","
+                +         "\"addresses.0.second.0.street\" : \"Claude Debussylaan\","
+                +         "\"addresses.0.second.0.city\" : \"Amsterdam\","
+                +         "\"addresses.0.second.0.new_number\" : {\"$numberLong\" : \"34\"}"
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldRenameFieldsForSetNestedFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("addresses.0.number", 34L)
+                        .append("addresses.0.street", "Claude Debussylaan")
+                        .append("addresses.0.city", "Amsterdam"));
+        Filters filters = build.renameFields("*.c1.addresses=new_addresses").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"name\" : \"Sally\","
+                +         "\"new_addresses.0.number\" : {\"$numberLong\" : \"34\"},"
+                +         "\"new_addresses.0.street\" : \"Claude Debussylaan\","
+                +         "\"new_addresses.0.city\" : \"Amsterdam\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldRenameFieldsForSetToArrayFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document()
+                        .append("name", "Sally")
+                        .append("addresses.0", new Document()
+                                .append("number", 34L)
+                                .append("street", "Claude Debussylaan")
+                                .append("city", "Amsterdam")));
+        Filters filters = build.renameFields("*.c1.addresses=new_addresses").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$set\" : {"
+                +         "\"name\" : \"Sally\","
+                +         "\"new_addresses.0\" : {"
+                +             "\"number\" : {\"$numberLong\" : \"34\"},"
+                +             "\"street\" : \"Claude Debussylaan\","
+                +             "\"city\" : \"Amsterdam\""
+                +         "}"
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldRenameNestedFieldsForUnsetNestedFieldUpdateEventWithEmbeddedDocument() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$unset", new Document()
+                        .append("name", "")
+                        .append("address.number", "")
+                        .append("address.street", "")
+                        .append("address.city", ""));
+        Filters filters = build.renameFields("*.c1.name=new_name,*.c1.address.number=new_number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$unset\" : {"
+                +         "\"address.street\" : \"\","
+                +         "\"address.city\" : \"\","
+                +         "\"new_name\" : \"\","
+                +         "\"address.new_number\" : \"\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldRenameNestedFieldsForUnsetNestedFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$unset", new Document()
+                        .append("name", "")
+                        .append("addresses.0.number", "")
+                        .append("addresses.0.street", "")
+                        .append("addresses.0.city", ""));
+        Filters filters = build.renameFields("*.c1.addresses.number=new_number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$unset\" : {"
+                +         "\"name\" : \"\","
+                +         "\"addresses.0.street\" : \"\","
+                +         "\"addresses.0.city\" : \"\","
+                +         "\"addresses.0.new_number\" : \"\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldNotRenameNestedFieldsForUnsetNestedFieldUpdateEventWithArrayOfArrays() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$unset", new Document()
+                        .append("name", "")
+                        .append("addresses.0.0.number", "")
+                        .append("addresses.0.0.street", "")
+                        .append("addresses.0.0.city", ""));
+        Filters filters = build.renameFields("*.c1.addresses.number=new_number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(obj.toJson(WRITER_SETTINGS));
+    }
+
+    @Test
+    public void shouldRenameNestedFieldsForUnsetNestedFieldUpdateEventWithSeveralArrays() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$unset", new Document()
+                        .append("name", "")
+                        .append("addresses.0.second.0.number", "")
+                        .append("addresses.0.second.0.street", "")
+                        .append("addresses.0.second.0.city", ""));
+        Filters filters = build.renameFields("*.c1.addresses.second.number=new_number").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$unset\" : {"
+                +         "\"name\" : \"\","
+                +         "\"addresses.0.second.0.street\" : \"\","
+                +         "\"addresses.0.second.0.city\" : \"\","
+                +         "\"addresses.0.second.0.new_number\" : \"\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldRenameFieldsForUnsetNestedFieldUpdateEventWithArrayOfEmbeddedDocuments() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$unset", new Document()
+                        .append("name", "")
+                        .append("addresses.0.number", "")
+                        .append("addresses.0.street", "")
+                        .append("addresses.0.city", ""));
+        Filters filters = build.renameFields("*.c1.addresses=new_addresses").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createUpdateEvent(obj, objId), 1002);
+
+        // then
+        String expected = "{"
+                +     "\"$unset\" : {"
+                +         "\"name\" : \"\","
+                +         "\"new_addresses.0.number\" : \"\","
+                +         "\"new_addresses.0.street\" : \"\","
+                +         "\"new_addresses.0.city\" : \"\""
+                +     "}"
+                + "}";
+        Struct value = getValue(produced);
+        assertThat(value.get(PATCH)).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldRenameFieldsForDeleteEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document("_id", objId);
+        Filters filters = build.renameFields("*.c1.name=new_name,*.c1.active=new_active").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createEvent(obj, "d"), 1002);
+
+        // then
+        Struct value = getValue(produced);
+        String json = value.getString(AFTER);
+        if (json == null) {
+            json = value.getString(PATCH);
+        }
+        assertThat(json).isNull();
+    }
+
+    @Test
+    public void shouldRenameFieldsForDeleteTombstoneEvent() throws InterruptedException {
+        // given
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document("_id", objId);
+        Filters filters = build.renameFields("*.c1.name=new_name,*.c1.active=new_active").createFilters();
+        List<SourceRecord> produced = new ArrayList<>();
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
+
+        // when
+        recordMakers.forCollection(collectionId).recordEvent(createEvent(obj, "d"), 1002);
+
+        // then
+        SourceRecord record = produced.get(1);
+        assertThat(record.value()).isNull();
+    }
+
+    private Struct getValue(List<SourceRecord> produced) {
+        SourceRecord record = produced.get(0);
+        return (Struct) record.value();
+    }
+
+    private Document createEvent(Document obj, String op) {
+        BsonTimestamp ts = new BsonTimestamp(1000, 1);
+        return new Document()
+                .append("o", obj)
+                .append("ns", "dbA.c1")
+                .append("ts", ts)
+                .append("h", 12345678L)
+                .append("op", op);
+    }
+
+    private Document createUpdateEvent(Document obj, ObjectId objId) {
+        BsonTimestamp ts = new BsonTimestamp(1000, 1);
+        return new Document()
+                .append("o", obj)
+                .append("o2", objId)
+                .append("ns", "dbA.c1")
+                .append("ts", ts)
+                .append("h", 12345678L)
+                .append("op", "u");
+    }
+}

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FiltersTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FiltersTest.java
@@ -7,6 +7,7 @@ package io.debezium.connector.mongodb;
 
 import static org.fest.assertions.Assertions.assertThat;
 
+import org.apache.kafka.common.config.ConfigException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -161,14 +162,29 @@ public class FiltersTest {
         assertCollectionIncluded("db2.collectionA");
     }
 
-    protected void assertCollectionIncluded(String fullyQualifiedTableName) {
-        CollectionId id = CollectionId.parse("rs1." + fullyQualifiedTableName);
+    @Test(expected = ConfigException.class)
+    public void shouldThrowExceptionWhenFieldBlacklistRegexPartIsMissing() {
+        build.excludeFields(":name").createFilters();
+    }
+
+    @Test(expected = ConfigException.class)
+    public void shouldThrowExceptionWhenFieldBlacklistFieldsPartIsMissing() {
+        build.excludeFields("db1.collectionA:").createFilters();
+    }
+
+    @Test(expected = ConfigException.class)
+    public void shouldThrowExceptionWhenFieldBlacklistPartSeparatorIsMissing() {
+        build.excludeFields("db1.collectionAname").createFilters();
+    }
+
+    protected void assertCollectionIncluded(String fullyQualifiedCollectionName) {
+        CollectionId id = CollectionId.parse("rs1." + fullyQualifiedCollectionName);
         assertThat(id).isNotNull();
         assertThat(filters.collectionFilter().test(id)).isTrue();
     }
 
-    protected void assertCollectionExcluded(String fullyQualifiedTableName) {
-        CollectionId id = CollectionId.parse("rs1." + fullyQualifiedTableName);
+    protected void assertCollectionExcluded(String fullyQualifiedCollectionName) {
+        CollectionId id = CollectionId.parse("rs1." + fullyQualifiedCollectionName);
         assertThat(id).isNotNull();
         assertThat(filters.collectionFilter().test(id)).isFalse();
     }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FiltersTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FiltersTest.java
@@ -163,18 +163,38 @@ public class FiltersTest {
     }
 
     @Test(expected = ConfigException.class)
-    public void shouldThrowExceptionWhenFieldBlacklistRegexPartIsMissing() {
-        build.excludeFields(":name").createFilters();
+    public void shouldThrowExceptionWhenFieldBlacklistDatabaseAndCollectionPartsAreMissing() {
+        build.excludeFields(".name").createFilters();
     }
 
     @Test(expected = ConfigException.class)
-    public void shouldThrowExceptionWhenFieldBlacklistFieldsPartIsMissing() {
-        build.excludeFields("db1.collectionA:").createFilters();
+    public void shouldThrowExceptionWhenFieldBlacklistFieldPartIsMissing() {
+        build.excludeFields("db1.collectionA.").createFilters();
     }
 
     @Test(expected = ConfigException.class)
-    public void shouldThrowExceptionWhenFieldBlacklistPartSeparatorIsMissing() {
-        build.excludeFields("db1.collectionAname").createFilters();
+    public void shouldThrowExceptionWhenFieldRenamesDatabaseAndCollectionPartsAreMissing() {
+        build.renameFields(".name=new_name").createFilters();
+    }
+
+    @Test(expected = ConfigException.class)
+    public void shouldThrowExceptionWhenFieldRenamesReplacementPartIsMissing() {
+        build.renameFields("db1.collectionA.").createFilters();
+    }
+
+    @Test(expected = ConfigException.class)
+    public void shouldThrowExceptionWhenFieldRenamesReplacementPartSeparatorIsMissing() {
+        build.renameFields("db1.collectionA.namenew_name").createFilters();
+    }
+
+    @Test(expected = ConfigException.class)
+    public void shouldThrowExceptionWhenFieldRenamesRenameMappingKeyIsMissing() {
+        build.renameFields("db1.collectionA.=new_name").createFilters();
+    }
+
+    @Test(expected = ConfigException.class)
+    public void shouldThrowExceptionWhenFieldRenamesRenameMappingValueIsMissing() {
+        build.renameFields("db1.collectionA.name=").createFilters();
     }
 
     protected void assertCollectionIncluded(String fullyQualifiedCollectionName) {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/RecordMakersTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/RecordMakersTest.java
@@ -43,20 +43,19 @@ public class RecordMakersTest {
     private static final JsonWriterSettings WRITER_SETTINGS = new JsonWriterSettings(JsonMode.STRICT, "", ""); // most compact
                                                                                                                // JSON
 
+    private Filters filters;
     private SourceInfo source;
     private RecordMakers recordMakers;
     private TopicSelector<CollectionId> topicSelector;
     private List<SourceRecord> produced;
-    private boolean emitTombstonesOnDelete;
-
 
     @Before
     public void beforeEach() {
+        filters = new Configurator().createFilters();
         source = new SourceInfo(SERVER_NAME);
         topicSelector = MongoDbTopicSelector.defaultSelector(PREFIX, "__debezium-heartbeat");
         produced = new ArrayList<>();
-        emitTombstonesOnDelete = true;
-        recordMakers = new RecordMakers(source, topicSelector, produced::add, emitTombstonesOnDelete);
+        recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);
     }
 
     @Test
@@ -169,7 +168,7 @@ public class RecordMakersTest {
     @Test
     @FixFor("DBZ-582")
     public void shouldGenerateRecordForDeleteEventWithoutTombstone() throws InterruptedException {
-        RecordMakers recordMakers = new RecordMakers(source, topicSelector, produced::add, false);
+        RecordMakers recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, false);
 
         BsonTimestamp ts = new BsonTimestamp(1000, 1);
         CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -713,7 +713,6 @@ public class MySqlConnectorConfig extends CommonConnectorConfig {
                                                       .withType(Type.STRING)
                                                       .withWidth(Width.LONG)
                                                       .withImportance(Importance.MEDIUM)
-                                                      .withValidation(MySqlConnectorConfig::validateColumnBlacklist)
                                                       .withDescription("");
 
     /**
@@ -1181,11 +1180,6 @@ public class MySqlConnectorConfig extends CommonConnectorConfig {
         }
 
         // Everything checks out ok.
-        return 0;
-    }
-
-    private static int validateColumnBlacklist(Configuration config, Field field, ValidationOutput problems) {
-        // String blacklist = config.getString(COLUMN_BLACKLIST);
         return 0;
     }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
@@ -77,7 +77,7 @@ public class MySqlSchema extends RelationalDatabaseSchema {
     /**
      * Create a schema component given the supplied {@link MySqlConnectorConfig MySQL connector configuration}.
      *
-     * @param config the connector configuration, which is presumed to be valid
+     * @param configuration the connector configuration, which is presumed to be valid
      * @param gtidFilter the predicate function that should be applied to GTID sets in database history, and which
      *          returns {@code true} if a GTID source is to be included, or {@code false} if a GTID source is to be excluded;
      *          may be null if not needed

--- a/debezium-core/src/main/java/io/debezium/relational/Selectors.java
+++ b/debezium-core/src/main/java/io/debezium/relational/Selectors.java
@@ -284,11 +284,11 @@ public class Selectors {
      * Note that this predicate is completely independent of the table selection predicate, so it is expected that this predicate
      * be used only <i>after</i> the table selection predicate determined the table containing the column(s) is to be used.
      * 
-     * @param columnNames the comma-separated list of column names names to exclude; may be null or
+     * @param fullyQualifiedColumnNames the comma-separated list of fully-qualified column names to exclude; may be null or
      *            empty
      * @return this builder so that methods can be chained together; never null
      */
-    public static Predicate<ColumnId> excludeColumns(String columnNames) {
-        return Predicates.excludes(columnNames, ColumnId::toString);
+    public static Predicate<ColumnId> excludeColumns(String fullyQualifiedColumnNames) {
+        return Predicates.excludes(fullyQualifiedColumnNames, ColumnId::toString);
     }
 }

--- a/debezium-core/src/main/java/io/debezium/util/Strings.java
+++ b/debezium-core/src/main/java/io/debezium/util/Strings.java
@@ -833,8 +833,33 @@ public final class Strings {
         }
     }
 
+    /**
+     * Check if the string is empty or null.
+     *
+     * @param str the string to check
+     * @return {@code true} if the string is empty or null
+     */
     public static boolean isNullOrEmpty(String str) {
         return str == null || str.isEmpty();
+    }
+
+    /**
+     * Check if the string contains only digits.
+     *
+     * @param str the string to check
+     * @return {@code true} if only contains digits
+     */
+    public static boolean isNumeric(String str) {
+        if (isNullOrEmpty(str)) {
+            return false;
+        }
+        final int sz = str.length();
+        for (int i = 0; i < sz; i++) {
+            if (!Character.isDigit(str.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
The `field.blacklist` configuration property is an optional comma-separated list of the fully-qualified names of fields that should be excluded from change event message values. Fully-qualified names for fields are of the form `databaseName.collectionName:fieldName.nestedFieldName|fieldNameN`. Where the part `databaseName.collectionName` is a regular expression, the dot character (`.`) is used to access fields of embedded documents, e.g. `inventory\\.ports:device.id`, and the pipe character (`|`) is used to delimit set of top level or nested fields, e.g. `inventory\\.ports:name|device`.

Although the `field.blacklist` configuration property allows you to remove fields from the event values, the `_id` field is always included in the event’s key.

https://issues.jboss.org/browse/DBZ-633