### PR TITLE
DBZ-849 Refact read mysql sytem variables methods to make them more readable

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -76,7 +76,7 @@ public final class MySqlTaskContext extends CdcSourceTaskContext {
                 : (gtidSetExcludes != null ? Predicates.excludesUuids(gtidSetExcludes) : null);
 
         if (tableIdCaseInsensitive == null) {
-            this.tableIdCaseInsensitive = !"0".equals(connectionContext.readMySqlSystemVariables(null).get(MySqlSystemVariables.LOWER_CASE_TABLE_NAMES));
+            this.tableIdCaseInsensitive = !"0".equals(connectionContext.readMySqlSystemVariables().get(MySqlSystemVariables.LOWER_CASE_TABLE_NAMES));
         } else {
             this.tableIdCaseInsensitive = tableIdCaseInsensitive;
         }
@@ -140,7 +140,7 @@ public final class MySqlTaskContext extends CdcSourceTaskContext {
      */
     public void initializeHistory() {
         // Read the system variables from the MySQL instance and get the current database name ...
-        Map<String, String> variables = connectionContext.readMySqlCharsetSystemVariables(null);
+        Map<String, String> variables = connectionContext.readMySqlCharsetSystemVariables();
         String ddlStatement = connectionContext.setStatementFor(variables);
 
         // And write them into the database history ...
@@ -156,7 +156,7 @@ public final class MySqlTaskContext extends CdcSourceTaskContext {
      */
     public void loadHistory(SourceInfo startingPoint) {
         // Read the system variables from the MySQL instance and load them into the DDL parser as defaults ...
-        Map<String, String> variables = connectionContext.readMySqlCharsetSystemVariables(null);
+        Map<String, String> variables = connectionContext.readMySqlCharsetSystemVariables();
         dbSchema.setSystemVariables(variables);
 
         // And then load the history ...
@@ -180,7 +180,7 @@ public final class MySqlTaskContext extends CdcSourceTaskContext {
      */
     public boolean historyExists() {
         // Read the system variables from the MySQL instance and load them into the DDL parser as defaults ...
-        Map<String, String> variables = connectionContext.readMySqlCharsetSystemVariables(null);
+        Map<String, String> variables = connectionContext.readMySqlCharsetSystemVariables();
         dbSchema.setSystemVariables(variables);
 
         // And then load the history ...

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -245,7 +245,7 @@ public class SnapshotReader extends AbstractReader {
             mysql.execute(sql.get());
 
             // Generate the DDL statements that set the charset-related system variables ...
-            Map<String, String> systemVariables = connectionContext.readMySqlCharsetSystemVariables(sql);
+            Map<String, String> systemVariables = connectionContext.readMySqlCharsetSystemVariables();
             String setSystemVariablesStatement = connectionContext.setStatementFor(systemVariables);
             AtomicBoolean interrupted = new AtomicBoolean(false);
             long lockAcquired = 0L;

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/AbstractMySqlConnectorOutputTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/AbstractMySqlConnectorOutputTest.java
@@ -129,7 +129,7 @@ public class AbstractMySqlConnectorOutputTest extends ConnectorOutputTest {
         Map<String, String> variables = new HashMap<>();
         try (MySqlJdbcContext context = new MySqlJdbcContext(config)) {
             // Read all of the system variables ...
-            variables.putAll(context.readMySqlSystemVariables(null));
+            variables.putAll(context.readMySqlSystemVariables());
             // Now get the master GTID source ...
             String serverUuid = variables.get("server_uuid");
             if (serverUuid != null && !serverUuid.trim().isEmpty()) {


### PR DESCRIPTION
1. Removed the unused param sql for the read system variables methods
2. Extract the duplicate block from the two read system variables methods into a reusable method
3. Extract the sql statement to be a field static final variable