### PR TITLE
DBZ-853 Fix kafka database history storage miscount attemp number even if there are more records to consume.

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
@@ -251,11 +251,10 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
                 }
                 if (numRecordsProcessed == 0) {
                     logger.debug("No new records found in the database history; will retry");
+                    recoveryAttempts++;
                 } else {
                     logger.debug("Processed {} records from database history", numRecordsProcessed);
                 }
-
-                recoveryAttempts++;
             }
             while (lastProcessedOffset < endOffset - 1);
         }


### PR DESCRIPTION
- Fix kafka database history storage miscount attemp number even if there are more records to consume.
https://issues.jboss.org/browse/DBZ-853
