### PR TITLE
DBZ-880 MySQLConnectorTask no longer always reports finding the binlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The Oracle connector was storing event timestamp in the `source` block in field 
 * Misleading timestamp field name [DBZ-795](https://issues.jboss.org/browse/DBZ-795)
 * Adjust scale of decimal values to column's scale if present [DBZ-818](https://issues.jboss.org/browse/DBZ-818)
 * Avoid NPE if commit is called before any offset is prepared [DBZ-826](https://issues.jboss.org/browse/DBZ-826)
+* MySQLConnectorTask no longer reports that it has found the binlog file when it hasn't [DBZ-880](https://issues.jboss.org/browse/DBZ-880)
 
 
 ### Other changes since 0.8.1.Final

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -326,8 +326,10 @@ public final class MySqlConnectorTask extends BaseSourceTask {
         boolean found = logNames.stream().anyMatch(binlogFilename::equals);
         if (!found) {
             logger.info("Connector requires binlog file '{}', but MySQL only has {}", binlogFilename, String.join(", ", logNames));
+        } else {
+            logger.info("MySQL has the binlog file '{}' required by the connector", binlogFilename);
         }
-        logger.info("MySQL has the binlog file '{}' required by the connector", binlogFilename);
+
         return found;
     }
 


### PR DESCRIPTION
Added an else block so that MySQLConnectorTask no longer logs that it has found the MySQL binlog file that it needs when it hasn't.

https://issues.jboss.org/browse/DBZ-880