### PR TITLE
DBZ-899 Bypass n+1 problem in Postgres JDBC metadata

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
@@ -8,7 +8,6 @@ package io.debezium.connector.postgresql;
 
 import java.sql.SQLException;
 import java.time.ZoneOffset;
-import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
@@ -42,7 +41,6 @@ public class PostgresSchema extends RelationalDatabaseSchema {
 
     private final Filters filters;
 
-    private Map<String, Integer> typeInfo;
     private final TypeRegistry typeRegistry;
 
     /**
@@ -75,10 +73,6 @@ public class PostgresSchema extends RelationalDatabaseSchema {
      * @throws SQLException if there is a problem obtaining the schema from the database server
      */
     protected PostgresSchema refresh(PostgresConnection connection, boolean printReplicaIdentityInfo) throws SQLException {
-        if (typeInfo == null) {
-            typeInfo = connection.readTypeInfo();
-        }
-
         // read all the information from the DB
         connection.readSchema(tables(), null, null, filters.tableFilter(), null, true);
         if (printReplicaIdentityInfo) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -11,12 +11,17 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.kafka.connect.errors.ConnectException;
 import org.postgresql.core.BaseConnection;
 import org.postgresql.core.TypeInfo;
+import org.postgresql.jdbc.PgDatabaseMetaData;
 import org.postgresql.replication.LogSequenceNumber;
 import org.postgresql.util.PSQLState;
 import org.slf4j.Logger;
@@ -29,6 +34,7 @@ import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
+import io.debezium.util.Collect;
 import io.debezium.util.Metronome;
 
 /**
@@ -49,6 +55,7 @@ public class PostgresConnection extends JdbcConnection {
     private static final String SQL_NON_ARRAY_TYPES = "SELECT t.oid AS oid, t.typname AS name "
             + "FROM pg_catalog.pg_type t JOIN pg_catalog.pg_namespace n ON (t.typnamespace = n.oid) "
             + "WHERE n.nspname != 'pg_toast' AND t.typcategory <> 'A'";
+
     private static final String SQL_ARRAY_TYPES = "SELECT t.oid AS oid, t.typname AS name, t.typelem AS element "
             + "FROM pg_catalog.pg_type t JOIN pg_catalog.pg_namespace n ON (t.typnamespace = n.oid) "
             + "WHERE n.nspname != 'pg_toast' AND t.typcategory = 'A'";
@@ -318,10 +325,12 @@ public class PostgresConnection extends JdbcConnection {
     }
 
     private static TypeRegistry initTypeRegistry(Connection db) {
-        final TypeInfo typeInfo = ((BaseConnection)db).getTypeInfo();
-
+        final TypeInfo typeInfo = ((BaseConnection) db).getTypeInfo();
         TypeRegistry.Builder typeRegistryBuilder = TypeRegistry.create(typeInfo);
+
         try {
+            SqlTypeMapper sqlTypeMapper = new SqlTypeMapper(db, typeInfo);
+
             try (final Statement statement = db.createStatement()) {
                 // Read non-array types
                 try (final ResultSet rs = statement.executeQuery(SQL_NON_ARRAY_TYPES)) {
@@ -333,7 +342,7 @@ public class PostgresConnection extends JdbcConnection {
                         typeRegistryBuilder.addType(new PostgresType(
                                 typeName,
                                 oid,
-                                typeInfo.getSQLType(typeName),
+                                sqlTypeMapper.getSqlType(typeName),
                                 typeInfo
                         ));
                     }
@@ -348,7 +357,7 @@ public class PostgresConnection extends JdbcConnection {
                         typeRegistryBuilder.addType(new PostgresType(
                                 typeName,
                                 oid,
-                                typeInfo.getSQLType(typeName),
+                                sqlTypeMapper.getSqlType(typeName),
                                 typeInfo,
                                 typeRegistryBuilder.get((int)rs.getLong("element"))
                         ));
@@ -364,5 +373,103 @@ public class PostgresConnection extends JdbcConnection {
 
     public TypeRegistry getTypeRegistry() {
         return typeRegistry;
+    }
+
+    /**
+     * Allows to obtain the SQL type corresponding to PG types. This uses a custom statement instead of going through
+     * {@link PgDatabaseMetaData#getTypeInfo()} as the latter causes N+1 SELECTs, making it very slow on installations
+     * with many custom types.
+     *
+     * @author Gunnar Morling
+     * @see DBZ-899
+     */
+    private static class SqlTypeMapper {
+
+        /**
+         * Based on org.postgresql.jdbc.TypeInfoCache.getSQLType(String). To emulate the original statement's behavior
+         * (which works for single types only), PG's DISTINCT ON extension is used to just return the first entry should a
+         * type exist in multiple schemas.
+         */
+        private static final String SQL_TYPE_DETAILS = "SELECT DISTINCT ON (typname) typname, typinput='array_in'::regproc, typtype, sp.r, pg_type.oid "
+                + "  FROM pg_catalog.pg_type "
+                + "  LEFT "
+                + "  JOIN (select ns.oid as nspoid, ns.nspname, r.r "
+                + "          from pg_namespace as ns "
+                // -- go with older way of unnesting array to be compatible with 8.0
+                + "          join ( select s.r, (current_schemas(false))[s.r] as nspname "
+                + "                   from generate_series(1, array_upper(current_schemas(false), 1)) as s(r) ) as r "
+                + "         using ( nspname ) "
+                + "       ) as sp "
+                + "    ON sp.nspoid = typnamespace "
+                + " ORDER BY typname, sp.r, pg_type.oid;";
+
+        private final TypeInfo typeInfo;
+        private final Set<String> preloadedSqlTypes;
+        private final Map<String, Integer> sqlTypesByPgTypeNames;
+
+        private SqlTypeMapper(Connection db, TypeInfo typeInfo) throws SQLException {
+            this.typeInfo = typeInfo;
+            this.preloadedSqlTypes = Collect.unmodifiableSet(typeInfo.getPGTypeNamesWithSQLTypes());
+            this.sqlTypesByPgTypeNames = getSqlTypes(db, typeInfo);
+        }
+
+        public int getSqlType(String typeName) throws SQLException {
+            boolean isCoreType = preloadedSqlTypes.contains(typeName);
+
+            // obtain core types such as bool, int2 etc. from the driver, as it correctly maps these types to the JDBC
+            // type codes. Also those values are cached in TypeInfoCache.
+            if (isCoreType) {
+                return typeInfo.getSQLType(typeName);
+            }
+            if (typeName.endsWith("[]")) {
+                return Types.ARRAY;
+            }
+            // get custom type mappings from the map which was built up with a single query
+            else {
+                try {
+                    return sqlTypesByPgTypeNames.get(typeName);
+                }
+                catch(Exception e) {
+                    LOGGER.warn("Failed to obtain SQL type information for type {} via custom statement, falling back to TypeInfo#getSQLType()", typeName, e);
+                    return typeInfo.getSQLType(typeName);
+                }
+            }
+        }
+
+        /**
+         * Builds up a map of SQL (JDBC) types by PG type name; contains only values for non-core types.
+         */
+        private static Map<String, Integer> getSqlTypes(Connection db, TypeInfo typeInfo) throws SQLException {
+            Map<String, Integer> sqlTypesByPgTypeNames = new HashMap<>();
+
+            try (final Statement statement = db.createStatement()) {
+                try (final ResultSet rs = statement.executeQuery(SQL_TYPE_DETAILS)) {
+                    while (rs.next()) {
+                        int type;
+                        boolean isArray = rs.getBoolean(2);
+                        String typtype = rs.getString(3);
+                        if (isArray) {
+                            type = Types.ARRAY;
+                        }
+                        else if ("c".equals(typtype)) {
+                            type = Types.STRUCT;
+                        }
+                        else if ("d".equals(typtype)) {
+                            type = Types.DISTINCT;
+                        }
+                        else if ("e".equals(typtype)) {
+                            type = Types.VARCHAR;
+                        }
+                        else {
+                            type = Types.OTHER;
+                        }
+
+                        sqlTypesByPgTypeNames.put(rs.getString(1), type);
+                    }
+                }
+            }
+
+            return sqlTypesByPgTypeNames;
+        }
     }
 }

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -998,23 +998,6 @@ public class JdbcConnection implements AutoCloseable {
         }
     }
 
-    /**
-     * Returns a map which contains information about how a database maps it's data types to JDBC data types.
-     *
-     * @return a {@link Map map of (localTypeName, jdbcType) pairs}
-     * @throws SQLException if anything unexpected fails
-     */
-    public Map<String, Integer> readTypeInfo() throws SQLException {
-        DatabaseMetaData metadata = connection().getMetaData();
-        Map<String, Integer> jdbcTypeByLocalTypeName = new HashMap<>();
-        try (ResultSet rs = metadata.getTypeInfo()) {
-           while (rs.next()) {
-               jdbcTypeByLocalTypeName.put(rs.getString("TYPE_NAME"), rs.getInt("DATA_TYPE"));
-           }
-        }
-        return jdbcTypeByLocalTypeName;
-    }
-
     private void cleanupPreparedStatement(PreparedStatement statement) {
         LOGGER.trace("Closing prepared statement '{}' removed from cache", statement);
         try {

--- a/debezium-core/src/main/java/io/debezium/util/Collect.java
+++ b/debezium-core/src/main/java/io/debezium/util/Collect.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +29,7 @@ public class Collect {
      * map will be able to contain no more than {@code maximumNumberOfEntries} entries, but the underlying map will have a
      * capacity that is the next power of larger than the supplied {@code maximumNumberOfEntries} value so that it can hold
      * the required number of entries.
-     * 
+     *
      * @param maximumNumberOfEntries the maximum number of entries allowed in the map; should be a power of 2
      * @return the map that is limited in size by the specified number of entries; never null
      */
@@ -81,6 +82,15 @@ public class Collect {
 
     public static <T> Set<T> unmodifiableSet(Set<T> values) {
         return Collections.unmodifiableSet(values);
+    }
+
+    public static <T> Set<T> unmodifiableSet(Iterator<T> values) {
+        Set<T> set = new HashSet<>();
+        while (values.hasNext()) {
+            set.add(values.next());
+        }
+
+        return Collections.unmodifiableSet(set);
     }
 
     public static <T> List<T> arrayListOf(T[] values) {
@@ -247,7 +257,7 @@ public class Collect {
      * Set the value at the given position in the list, expanding the list as required to accommodate the new position.
      * <p>
      * This is not a thread-safe operation
-     * 
+     *
      * @param list the list to be modified
      * @param index the index position of the new value
      * @param value the value

--- a/debezium-core/src/test/java/io/debezium/util/CollectTest.java
+++ b/debezium-core/src/test/java/io/debezium/util/CollectTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link Collect}.
+ *
+ * @author Gunnar Morling
+ */
+public class CollectTest {
+
+    @Test
+    public void unmodifiableSetForIteratorShouldReturnExpectedElements() {
+        Set<Integer> values = Collect.unmodifiableSet(Arrays.asList(1, 2, 3, 42).iterator());
+        assertThat(values).containsOnly(1, 2, 3, 42);
+    }
+
+    @Test(expected=UnsupportedOperationException.class)
+    public void unmodifiableSetForIteratorShouldRaiseExceptionUponModification() {
+        Set<Integer> values = Collect.unmodifiableSet(Arrays.asList(1, 2, 3, 42).iterator());
+        values.remove(1);
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-899

@jpechane I think I've found an acceptable solution which avoids hard-coding the core types' names.