### PR TITLE
DBZ-911 Don't refresh schema on absent TOAST cols

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
@@ -223,6 +223,6 @@ public class PostgresSchema extends RelationalDatabaseSchema {
     }
 
     public List<String> getToastableColumnsForTableId(TableId tableId) {
-        return tableIdToToastableColumns.getOrDefault(tableId, Collections.unmodifiableList(new ArrayList<>()));
+        return tableIdToToastableColumns.getOrDefault(tableId, Collections.emptyList());
     }
 }


### PR DESCRIPTION
Improves PostgreSQL RecordsStreamProducer performance for processing updates to a table with TOASTable columns, where those updates do not affect said columns. Prior to this fix, these updates would trigger a refresh of the in-memory table schema. In the worst case, this means a query for every update. This puts significant load on the database server and adds tens of milliseconds to the processing of each update record.

The fix requires a new configuration option, called 'schema.refresh.mode'. This option has values 'columns_diff' (the default) and 'columns_diff_exclude_unchanged_toast'. 'columns_diff' maintains the pre-fix behavior. 'columns_diff_exclude_unchanged_toast' activates the fix.

The fix must be toggleable because it decreases the consistency guarantees Debezium provides, since in-memory table schemas may not stay synchronized with their remote counterparts. With type metadata included in the replication message, inconsistencies are limited to the unchanged toast columns.