### PR TITLE
DBZ-898 Using 'Json' semantic type when encoding HSTORE column values…

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -239,13 +239,13 @@ public class PostgresValueConverter extends JdbcValueConverters {
 
     private SchemaBuilder hstoreSchema(){
         if (hStoreMode == PostgresConnectorConfig.HStoreHandlingMode.JSON) {
-            return SchemaBuilder.string();
+            return Json.builder();
         }
         else {
             // keys are not nullable, but values are
             return SchemaBuilder.map(
                     SchemaBuilder.STRING_SCHEMA,
-                    SchemaBuilder.string().optional().build()
+                    SchemaBuilder.OPTIONAL_STRING_SCHEMA
             );
         }
     }
@@ -443,7 +443,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
         return new String(data, databaseCharset);
     }
 
-    private Object convertHstoreToJsonString(Column column,Field fieldDefn, Object data){
+    private Object convertHstoreToJsonString(Column column, Field fieldDefn, Object data){
         if(data == null) {
             data = fieldDefn.schema().defaultValue();
         }
@@ -458,7 +458,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
         }
 
         if(data instanceof String) {
-            return changePlainStringRepresentationToJsonStringRepresentation(( (String) data));
+            return changePlainStringRepresentationToJsonStringRepresentation(((String) data));
         }
 
         if(data instanceof byte[]) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -295,22 +295,22 @@ public abstract class AbstractRecordsProducerTest {
 
     protected List<SchemaAndValueField> schemaAndValueFieldForJsonEncodedHStoreType(){
         final String expected = "{\"key\":\"val\"}";
-        return Arrays.asList(new SchemaAndValueField("hs", SchemaBuilder.OPTIONAL_STRING_SCHEMA, expected));
+        return Arrays.asList(new SchemaAndValueField("hs", Json.builder().optional().build(), expected));
     }
 
     protected List<SchemaAndValueField> schemaAndValueFieldForJsonEncodedHStoreTypeWithMultipleValues(){
         final String expected = "{\"key1\":\"val1\",\"key2\":\"val2\",\"key3\":\"val3\"}";
-        return Arrays.asList(new SchemaAndValueField("hs", SchemaBuilder.OPTIONAL_STRING_SCHEMA, expected));
+        return Arrays.asList(new SchemaAndValueField("hs", Json.builder().optional().build(), expected));
     }
 
     protected List<SchemaAndValueField> schemaAndValueFieldForJsonEncodedHStoreTypeWithNullValues(){
         final String expected = "{\"key1\":\"val1\",\"key2\":null}";
-        return Arrays.asList(new SchemaAndValueField("hs", SchemaBuilder.OPTIONAL_STRING_SCHEMA, expected));
+        return Arrays.asList(new SchemaAndValueField("hs", Json.builder().optional().build(), expected));
     }
 
     protected List<SchemaAndValueField> schemaAndValueFieldForJsonEncodedHStoreTypeWithSpcialCharacters(){
         final String expected = "{\"key_#1\":\"val 1\",\"key 2\":\" ##123 78\"}";
-        return Arrays.asList(new SchemaAndValueField("hs", SchemaBuilder.OPTIONAL_STRING_SCHEMA, expected));
+        return Arrays.asList(new SchemaAndValueField("hs", Json.builder().optional().build(), expected));
     }
 
     protected List<SchemaAndValueField> schemasAndValuesForStringTypes() {
@@ -605,7 +605,9 @@ public abstract class AbstractRecordsProducerTest {
         Struct content = ((Struct) record.value()).getStruct(envelopeFieldName);
         assertNotNull("expected there to be content in Envelope under " + envelopeFieldName, content);
 
-        expectedSchemaAndValuesByColumn.forEach(schemaAndValueField -> schemaAndValueField.assertFor(content));
+        expectedSchemaAndValuesByColumn.forEach(
+                schemaAndValueField -> schemaAndValueField.assertFor(content)
+        );
     }
 
     protected void assertRecordOffset(SourceRecord record, boolean expectSnapshot, boolean expectedLastSnapshotRecord) {
@@ -618,7 +620,8 @@ public abstract class AbstractRecordsProducerTest {
         if (expectSnapshot) {
             Assert.assertTrue("Snapshot marker expected but not found", (Boolean) snapshot);
             assertEquals("Last snapshot record marker mismatch", expectedLastSnapshotRecord, lastSnapshotRecord);
-        } else {
+        }
+        else {
             assertNull("Snapshot marker not expected, but found", snapshot);
             assertNull("Last snapshot marker not expected, but found", lastSnapshotRecord);
         }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -694,7 +694,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         setupRecordsProducer(config);
         TestHelper.executeDDL("postgres_create_tables.ddl");
         consumer = testConsumer(1);
-        recordsProducer.start(consumer,blackHole);
+        recordsProducer.start(consumer, blackHole);
 
         assertInsert(INSERT_HSTORE_TYPE_WITH_SPECIAL_CHAR_STMT, schemaAndValueFieldForJsonEncodedHStoreTypeWithSpcialCharacters());
     }
@@ -708,7 +708,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         setupRecordsProducer(config);
         TestHelper.executeDDL("postgres_create_tables.ddl");
         consumer = testConsumer(1);
-        recordsProducer.start(consumer,blackHole);
+        recordsProducer.start(consumer, blackHole);
 
         assertInsert(INSERT_HSTORE_TYPE_WITH_NULL_VALUES_STMT, schemaAndValueFieldForJsonEncodedHStoreTypeWithNullValues());
     }


### PR DESCRIPTION
… as string

@jpechane Some follow-up to DBZ-898 revealed by the doc update. /CC @SyedMuhammadSufyian.