### PR TITLE
DBZ-923 config to use earliest available gtid set from mysql server

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -279,7 +279,13 @@ public class BinlogReader extends AbstractReader {
 
             // Now look at the GTID set from the server and what we've previously seen ...
             GtidSet availableServerGtidSet = new GtidSet(availableServerGtidStr);
-            GtidSet filteredGtidSet = context.filterGtidSet(availableServerGtidSet);
+
+            // also take into account purged GTID logs
+            String purgedServerGtidStr = connectionContext.purgedGtidSet();
+            GtidSet purgedServerGtidSet = new GtidSet(purgedServerGtidStr);
+            logger.info("GTID set purged on server: {}", purgedServerGtidSet);
+
+            GtidSet filteredGtidSet = context.filterGtidSet(availableServerGtidSet, purgedServerGtidSet);
             if (filteredGtidSet != null) {
                 // We've seen at least some GTIDs, so start reading from the filtered GTID set ...
                 logger.info("Registering binlog reader with GTID set: {}", filteredGtidSet);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/GtidSet.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/GtidSet.java
@@ -114,6 +114,21 @@ public final class GtidSet {
         return new GtidSet(newSet);
     }
 
+    /**
+     * Returns a copy with all intervals set to beginning
+     * @return
+     */
+    public GtidSet getGTIDSetBeginning() {
+        Map<String, UUIDSet> newSet = new HashMap<>();
+
+        for (UUIDSet uuidSet : uuidSetsByServerId.values()) {
+            newSet.put(uuidSet.getUUID(), uuidSet.asIntervalBeginning());
+        }
+
+
+        return new GtidSet(newSet);
+    }
+
     @Override
     public int hashCode() {
         return uuidSetsByServerId.keySet().hashCode();
@@ -164,6 +179,15 @@ public final class GtidSet {
                     }
                 }
             }
+        }
+        protected UUIDSet(String uuid, Interval interval) {
+            this.uuid = uuid;
+            this.intervals.add(interval);
+        }
+
+        public UUIDSet asIntervalBeginning() {
+            Interval start = new Interval(intervals.get(0).getStart(), intervals.get(0).getStart());
+            return new UUIDSet(this.uuid, start);
         }
 
         /**

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -404,6 +404,58 @@ public class MySqlConnectorConfig extends CommonConnectorConfig {
     }
 
     /**
+     * The set of predefined Gtid New Channel Position options.
+     */
+    public static enum GtidNewChannelPosition implements EnumeratedValue {
+
+        /**
+         * This mode will start reading new gtid channel from mysql servers last_executed position
+         */
+        LATEST("latest"),
+
+        /**
+         * This mode will start reading new gtid channel from earliest available position in server.
+         * This is needed when during active-passive failover the new gtid channel becomes active and receiving writes. #DBZ-923
+         */
+        EARLIEST("earliest");
+
+        private final String value;
+
+        private GtidNewChannelPosition(String value) { this.value = value; }
+
+        @Override
+        public String getValue() { return value; }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value the configuration property value; may not be null
+         * @return the matching option, or null if no match is found
+         */
+        public static GtidNewChannelPosition parse(String value) {
+            if (value == null) return null;
+            value = value.trim();
+            for (GtidNewChannelPosition option : GtidNewChannelPosition.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) return option;
+            }
+            return null;
+        }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value the configuration property value; may not be null
+         * @param defaultValue the default value; may be null
+         * @return the matching option, or null if no match is found and the non-null default is invalid
+         */
+        public static GtidNewChannelPosition parse(String value, String defaultValue) {
+            GtidNewChannelPosition mode = parse(value);
+            if (mode == null && defaultValue != null) mode = parse(defaultValue);
+            return mode;
+        }
+    }
+
+    /**
      * The set of predefined modes for dealing with failures during binlog event processing.
      */
     public static enum EventProcessingFailureHandlingMode implements EnumeratedValue {
@@ -770,13 +822,12 @@ public class MySqlConnectorConfig extends CommonConnectorConfig {
      *
      * When true, either {@link #GTID_SOURCE_INCLUDES} or {@link #GTID_SOURCE_EXCLUDES} must be set.
      */
-    public static final Field GTID_SOURCE_START_FROM_LATEST = Field.create("gtid.source.start.from.latest")
+    public static final Field GTID_NEW_CHANNEL_POSITION = Field.create("gtid.new.channel.position")
             .withDisplayName("GTID start position")
-            .withType(Type.BOOLEAN)
+            .withEnum(GtidNewChannelPosition.class, GtidNewChannelPosition.LATEST)
             .withWidth(Width.SHORT)
             .withImportance(Importance.MEDIUM)
-            .withDefault(true)
-            .withDescription("If set to true, when connector sees new GTID set, it will start consuming from server latest executed gtid position. If false, starts reading from earliest available (not purged) gtid position on server.");
+            .withDescription("If set to 'latest', when connector sees new GTID, it will start consuming gtid channel from the server latest executed gtid position. If 'earliest' connector starts reading channel from first available (not purged) gtid position on the server.");
 
 
     public static final Field CONNECTION_TIMEOUT_MS = Field.create("connect.timeout.ms")

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -761,6 +761,24 @@ public class MySqlConnectorConfig extends CommonConnectorConfig {
                                                           .withDefault(true)
                                                           .withDescription("If set to true, we will only produce DML events into Kafka for transactions that were written on mysql servers with UUIDs matching the filters defined by the gtid.source.includes or gtid.source.excludes configuration options, if they are specified.");
 
+    /**
+     * If set to true, connector when encountering new GTID channel after job restart will start reading it from the
+     * latest executed position (default). When set to false the connector will try to read this GTID channel from the first available offset.
+     * This is useful when in active-passive mysql setup during failover new GTID channel gets used, see #DBZ-923
+     *
+     * Defaults to true.
+     *
+     * When true, either {@link #GTID_SOURCE_INCLUDES} or {@link #GTID_SOURCE_EXCLUDES} must be set.
+     */
+    public static final Field GTID_SOURCE_START_FROM_LATEST = Field.create("gtid.source.start.from.latest")
+            .withDisplayName("GTID start position")
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.MEDIUM)
+            .withDefault(true)
+            .withDescription("If set to true, when connector sees new GTID set, it will start consuming from server latest executed gtid position. If false, starts reading from earliest available (not purged) gtid position on server.");
+
+
     public static final Field CONNECTION_TIMEOUT_MS = Field.create("connect.timeout.ms")
                                                            .withDisplayName("Connection Timeout (ms)")
                                                            .withType(Type.INT)

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -814,13 +814,11 @@ public class MySqlConnectorConfig extends CommonConnectorConfig {
                                                           .withDescription("If set to true, we will only produce DML events into Kafka for transactions that were written on mysql servers with UUIDs matching the filters defined by the gtid.source.includes or gtid.source.excludes configuration options, if they are specified.");
 
     /**
-     * If set to true, connector when encountering new GTID channel after job restart will start reading it from the
-     * latest executed position (default). When set to false the connector will try to read this GTID channel from the first available offset.
-     * This is useful when in active-passive mysql setup during failover new GTID channel gets used, see #DBZ-923
+     * If set to 'latest', connector when encountering new GTID channel after job restart will start reading it from the
+     * latest executed position (default). When set to 'earliest' the connector will start reading new GTID channels from the first available position.
+     * This is useful when in active-passive mysql setup during failover new GTID channel starts receiving writes, see #DBZ-923
      *
-     * Defaults to true.
-     *
-     * When true, either {@link #GTID_SOURCE_INCLUDES} or {@link #GTID_SOURCE_EXCLUDES} must be set.
+     * Defaults to latest.
      */
     public static final Field GTID_NEW_CHANNEL_POSITION = Field.create("gtid.new.channel.position")
             .withDisplayName("GTID start position")

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -421,10 +421,14 @@ public class MySqlConnectorConfig extends CommonConnectorConfig {
 
         private final String value;
 
-        private GtidNewChannelPosition(String value) { this.value = value; }
+        private GtidNewChannelPosition(String value) {
+            this.value = value;
+        }
 
         @Override
-        public String getValue() { return value; }
+        public String getValue() {
+            return value;
+        }
 
         /**
          * Determine if the supplied value is one of the predefined options.

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -178,6 +178,27 @@ public class MySqlJdbcContext implements AutoCloseable {
     }
 
     /**
+     * Get the purged gtid values from MySQL (gtid_purged value)
+     *
+     * @return string representation of GTID set or empty string
+     */
+    public String purgedGtidSet() {
+        AtomicReference<String> gtidSetStr = new AtomicReference<String>();
+        try {
+            jdbc.query("SHOW GLOBAL VARIABLES LIKE \"gtid_purged\"", rs -> {
+                if (rs.next() && rs.getMetaData().getColumnCount() > 1) {
+                    gtidSetStr.set(rs.getString(2));// GTID set, may be null, blank, or contain a GTID set
+                }
+            });
+        } catch (SQLException e) {
+            throw new ConnectException("Unexpected error while connecting to MySQL and looking at gtid_purged variable: ", e);
+        }
+
+        String result = gtidSetStr.get();
+        return result != null ? result : "";
+    }
+
+    /**
      * Determine if the current user has the named privilege. Note that if the user has the "ALL" privilege this method
      * returns {@code true}.
      *

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -19,6 +19,7 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
+import io.debezium.connector.mysql.MySqlConnectorConfig.GtidNewChannelPosition;
 import io.debezium.function.Predicates;
 import io.debezium.relational.TableId;
 import io.debezium.relational.history.DatabaseHistory;
@@ -243,6 +244,12 @@ public final class MySqlTaskContext extends CdcSourceTaskContext {
         return SnapshotMode.parse(value, MySqlConnectorConfig.SNAPSHOT_MODE.defaultValueAsString());
     }
 
+    protected GtidNewChannelPosition gtidNewChannelPosition() {
+        String value = config.getString(MySqlConnectorConfig.GTID_NEW_CHANNEL_POSITION);
+        return GtidNewChannelPosition.parse(value, MySqlConnectorConfig.GTID_NEW_CHANNEL_POSITION.defaultValueAsString());
+    }
+
+
     public String getSnapshotSelectOverrides() {
         return config.getString(MySqlConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE);
     }
@@ -328,14 +335,14 @@ public final class MySqlTaskContext extends CdcSourceTaskContext {
 
         GtidSet mergedGtidSet;
 
-        if (this.config.getBoolean(MySqlConnectorConfig.GTID_SOURCE_START_FROM_LATEST)) {
-            mergedGtidSet = availableServerGtidSet.with(filteredGtidSet);
-        } else {
+        if (this.gtidNewChannelPosition() == GtidNewChannelPosition.EARLIEST) {
             LOGGER.info("Using first available positions for new GTID channels");
             mergedGtidSet = availableServerGtidSet
                     .getGTIDSetBeginning()
                     .with(purgedServerGtid)
                     .with(filteredGtidSet);
+        } else {
+            mergedGtidSet = availableServerGtidSet.with(filteredGtidSet);
         }
 
         LOGGER.info("Final merged GTID set to use when connecting to MySQL: {}", mergedGtidSet);

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTaskContextTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTaskContextTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
+import io.debezium.connector.mysql.MySqlConnectorConfig.GtidNewChannelPosition;
 import io.debezium.document.Document;
 import io.debezium.relational.history.FileDatabaseHistory;
 import io.debezium.relational.history.HistoryRecord;
@@ -247,7 +248,7 @@ public class MySqlTaskContextTest {
 
         config = simpleConfig().with(MySqlConnectorConfig.GTID_SOURCE_INCLUDES,
                 "036d85a9-64e5-11e6-9b48-42010af0000c")
-                .with(MySqlConnectorConfig.GTID_SOURCE_START_FROM_LATEST, false)
+                .with(MySqlConnectorConfig.GTID_NEW_CHANNEL_POSITION, GtidNewChannelPosition.EARLIEST)
                 .build();
 
         context = new MySqlTaskContext(config, false);


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-923

This will fix data loss on failovers to servers with new active GTID's. GTID channel earliest available positions should only get used when connector has already existing offsets, not after snapshot.

...and I haven't yet actually tested this against production server. 