### PR TITLE
DBZ-934 Temporary replication slots with Postgres >= 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
 env:
   - MAVEN_CLI: '"clean install -pl debezium-connector-mysql -am -Passembly"'
   - MAVEN_CLI: '"clean install -pl debezium-connector-postgres -am -Passembly -Dversion.postgres.server=9.6-devel"'
+  - MAVEN_CLI: '"clean install -pl debezium-connector-postgres -am -Passembly,postgres-10"'
   - MAVEN_CLI: '"clean install -pl debezium-connector-mongodb -am -Passembly"'
   - MAVEN_CLI: '"clean install -pl debezium-connector-mysql -am -Passembly,parser-antlr"'
   - MAVEN_CLI: '"clean install -pl debezium-connector-postgres -am -Passembly,wal2json-decoder -Dversion.postgres.server=9.6-devel"'

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -40,6 +40,7 @@ Omar Al-Safi
 Ori Popowski
 Orr Ganani
 Peter Goransson
+Philip Sanetra
 Prannoy Mittal
 Raf Liwoch
 Ramesh Reddy

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -304,6 +304,12 @@
             </properties>
         </profile>
         <profile>
+            <id>postgres-10</id>
+            <properties>
+                <version.postgres.server>10</version.postgres.server>
+            </properties>
+        </profile>
+        <profile>
             <id>wal2json-decoder</id>
             <properties>
                 <decoder.plugin.name>wal2json</decoder.plugin.name>

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
@@ -18,18 +18,19 @@ import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import io.debezium.jdbc.JdbcConnection;
 import org.junit.After;
 import org.junit.Test;
+import org.postgresql.jdbc.PgConnection;
 
 import io.debezium.connector.postgresql.TestHelper;
+import io.debezium.doc.FixFor;
+import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.TableId;
 import io.debezium.util.Testing;
-import org.postgresql.jdbc.PgConnection;
 
 /**
  * Integration test for {@link PostgresConnection}
- * 
+ *
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
 public class PostgresConnectionIT {
@@ -45,7 +46,7 @@ public class PostgresConnectionIT {
             connection.connect();
             assertTrue(connection.currentTransactionId() > 0);
         }
-        
+
         try (PostgresConnection connection = TestHelper.create()) {
             connection.connect();
             connection.setAutoCommit(false);
@@ -115,6 +116,7 @@ public class PostgresConnectionIT {
     }
 
     @Test
+    @FixFor("DBZ-934")
     public void temporaryReplicationSlotsShouldGetDroppedAutomatically() throws Exception {
         try(ReplicationConnection replicationConnection = TestHelper.createForReplication("test", true)) {
             PgConnection pgConnection = getUnderlyingConnection(replicationConnection);


### PR DESCRIPTION
This PR adds support for temporary replication slots if Postgres >= 10 is used and `slot.drop_on_stop` is enabled. This ensures that the slot is dropped even if the debezium connector is shutdown ungracefully or communication is not possible anymore because of a network outage.

I've added a `postgres-10` build profile which can be used to execute the tests with a Postgres 10 instance.

Documentation on temporary replication slots: https://www.postgresql.org/docs/10/static/protocol-replication.html#PROTOCOL-REPLICATION-CREATE-SLOT