### PR TITLE
DBZ-918 Adding Debezium connector field to source info

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Module.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Module.java
@@ -21,4 +21,8 @@ public final class Module {
     public static String version() {
         return INFO.getProperty("version");
     }
+
+    public static String name() {
+        return "mongodb";
+    }
 }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/SourceInfo.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/SourceInfo.java
@@ -78,6 +78,8 @@ public final class SourceInfo extends AbstractSourceInfo {
     public static final String OPERATION_ID = "h";
     public static final String INITIAL_SYNC = "initsync";
 
+    public static final String DEBEZIUM_CONNECTOR = "mongodb";
+
     private static final BsonTimestamp INITIAL_TIMESTAMP = new BsonTimestamp();
     private static final Position INITIAL_POSITION = new Position(INITIAL_TIMESTAMP, null);
 
@@ -161,6 +163,11 @@ public final class SourceInfo extends AbstractSourceInfo {
     @Override
     public Schema schema() {
         return SOURCE_SCHEMA;
+    }
+
+    @Override
+    protected String connector() {
+        return DEBEZIUM_CONNECTOR;
     }
 
     /**

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/SourceInfo.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/SourceInfo.java
@@ -78,8 +78,6 @@ public final class SourceInfo extends AbstractSourceInfo {
     public static final String OPERATION_ID = "h";
     public static final String INITIAL_SYNC = "initsync";
 
-    public static final String DEBEZIUM_CONNECTOR = "mongodb";
-
     private static final BsonTimestamp INITIAL_TIMESTAMP = new BsonTimestamp();
     private static final Position INITIAL_POSITION = new Position(INITIAL_TIMESTAMP, null);
 
@@ -167,7 +165,7 @@ public final class SourceInfo extends AbstractSourceInfo {
 
     @Override
     protected String connector() {
-        return DEBEZIUM_CONNECTOR;
+        return Module.name();
     }
 
     /**

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/SourceInfoTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/SourceInfoTest.java
@@ -217,6 +217,6 @@ public class SourceInfoTest {
 
     @Test
     public void connectorIsPresent() {
-        assertThat(source.offsetStructForEvent("rs", null).getString(SourceInfo.DEBEZIUM_CONNECTOR_KEY)).isEqualTo(SourceInfo.DEBEZIUM_CONNECTOR);
+        assertThat(source.offsetStructForEvent("rs", null).getString(SourceInfo.DEBEZIUM_CONNECTOR_KEY)).isEqualTo(Module.name());
     }
 }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/SourceInfoTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/SourceInfoTest.java
@@ -17,8 +17,6 @@ import org.bson.Document;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.debezium.connector.AbstractSourceInfo;
-
 /**
  * @author Randall Hauch
  *
@@ -214,6 +212,11 @@ public class SourceInfoTest {
 
     @Test
     public void versionIsPresent() {
-        assertThat(source.offsetStructForEvent("rs", null).getString(AbstractSourceInfo.DEBEZIUM_VERSION_KEY)).isEqualTo(Module.version());
+        assertThat(source.offsetStructForEvent("rs", null).getString(SourceInfo.DEBEZIUM_VERSION_KEY)).isEqualTo(Module.version());
+    }
+
+    @Test
+    public void connectorIsPresent() {
+        assertThat(source.offsetStructForEvent("rs", null).getString(SourceInfo.DEBEZIUM_CONNECTOR_KEY)).isEqualTo(SourceInfo.DEBEZIUM_CONNECTOR);
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Module.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Module.java
@@ -21,4 +21,8 @@ public class Module {
     public static String version() {
         return INFO.getProperty("version");
     }
+
+    public static String name() {
+        return "mysql";
+    }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
@@ -112,6 +112,8 @@ final class SourceInfo extends AbstractSourceInfo {
     public static final String TABLE_NAME_KEY = "table";
     public static final String QUERY_KEY = "query";
 
+    public static final String DEBEZIUM_CONNECTOR = "mysql";
+
     /**
      * A {@link Schema} definition for a {@link Struct} used to store the {@link #partition()} and {@link #offset()} information.
      */
@@ -295,6 +297,11 @@ final class SourceInfo extends AbstractSourceInfo {
     @Override
     public Schema schema() {
         return SCHEMA;
+    }
+
+    @Override
+    protected String connector() {
+        return DEBEZIUM_CONNECTOR;
     }
 
     /**

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
@@ -112,8 +112,6 @@ final class SourceInfo extends AbstractSourceInfo {
     public static final String TABLE_NAME_KEY = "table";
     public static final String QUERY_KEY = "query";
 
-    public static final String DEBEZIUM_CONNECTOR = "mysql";
-
     /**
      * A {@link Schema} definition for a {@link Struct} used to store the {@link #partition()} and {@link #offset()} information.
      */
@@ -301,7 +299,7 @@ final class SourceInfo extends AbstractSourceInfo {
 
     @Override
     protected String connector() {
-        return DEBEZIUM_CONNECTOR;
+        return Module.name();
     }
 
     /**

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import static org.fest.assertions.Assertions.assertThat;
 
 import io.confluent.connect.avro.AvroData;
-import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.doc.FixFor;
 import io.debezium.document.Document;
 
@@ -568,7 +567,13 @@ public class SourceInfoTest {
     @Test
     public void versionIsPresent() {
         sourceWith(offset(100, 5, true));
-        assertThat(source.struct().getString(AbstractSourceInfo.DEBEZIUM_VERSION_KEY)).isEqualTo(Module.version());
+        assertThat(source.struct().getString(SourceInfo.DEBEZIUM_VERSION_KEY)).isEqualTo(Module.version());
+    }
+
+    @Test
+    public void connectorIsPresent() {
+        sourceWith(offset(100, 5, true));
+        assertThat(source.struct().getString(SourceInfo.DEBEZIUM_CONNECTOR_KEY)).isEqualTo(SourceInfo.DEBEZIUM_CONNECTOR);
     }
 
     protected Document positionWithGtids(String gtids) {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
@@ -573,7 +573,7 @@ public class SourceInfoTest {
     @Test
     public void connectorIsPresent() {
         sourceWith(offset(100, 5, true));
-        assertThat(source.struct().getString(SourceInfo.DEBEZIUM_CONNECTOR_KEY)).isEqualTo(SourceInfo.DEBEZIUM_CONNECTOR);
+        assertThat(source.struct().getString(SourceInfo.DEBEZIUM_CONNECTOR_KEY)).isEqualTo(Module.name());
     }
 
     protected Document positionWithGtids(String gtids) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/Module.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/Module.java
@@ -3,7 +3,6 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-
 package io.debezium.connector.postgresql;
 
 import java.util.Properties;
@@ -21,5 +20,9 @@ public final class Module {
 
     public static String version() {
         return INFO.getProperty("version");
+    }
+
+    public static String name() {
+        return "postgresql";
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/SourceInfo.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/SourceInfo.java
@@ -87,8 +87,6 @@ final class SourceInfo extends AbstractSourceInfo {
     public static final String SNAPSHOT_KEY = "snapshot";
     public static final String LAST_SNAPSHOT_RECORD_KEY = "last_snapshot_record";
 
-    public static final String DEBEZIUM_CONNECTOR = "postgresql";
-
     /**
      * A {@link Schema} definition for a {@link Struct} used to store the {@link #partition()} and {@link #offset()} information.
      */
@@ -223,7 +221,7 @@ final class SourceInfo extends AbstractSourceInfo {
 
     @Override
     protected String connector() {
-        return DEBEZIUM_CONNECTOR;
+        return Module.name();
     }
 
     /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/SourceInfo.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/SourceInfo.java
@@ -87,6 +87,8 @@ final class SourceInfo extends AbstractSourceInfo {
     public static final String SNAPSHOT_KEY = "snapshot";
     public static final String LAST_SNAPSHOT_RECORD_KEY = "last_snapshot_record";
 
+    public static final String DEBEZIUM_CONNECTOR = "postgresql";
+
     /**
      * A {@link Schema} definition for a {@link Struct} used to store the {@link #partition()} and {@link #offset()} information.
      */
@@ -217,6 +219,11 @@ final class SourceInfo extends AbstractSourceInfo {
     @Override
     protected Schema schema() {
         return SCHEMA;
+    }
+
+    @Override
+    protected String connector() {
+        return DEBEZIUM_CONNECTOR;
     }
 
     /**

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SourceInfoTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SourceInfoTest.java
@@ -32,6 +32,6 @@ public class SourceInfoTest {
 
     @Test
     public void connectorIsPresent() {
-        assertThat(source.source().getString(SourceInfo.DEBEZIUM_CONNECTOR_KEY)).isEqualTo(SourceInfo.DEBEZIUM_CONNECTOR);
+        assertThat(source.source().getString(SourceInfo.DEBEZIUM_CONNECTOR_KEY)).isEqualTo(Module.name());
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SourceInfoTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SourceInfoTest.java
@@ -11,8 +11,6 @@ import io.debezium.relational.TableId;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.debezium.connector.AbstractSourceInfo;
-
 /**
  * @author Jiri Pechanec
  *
@@ -29,6 +27,11 @@ public class SourceInfoTest {
 
     @Test
     public void versionIsPresent() {
-        assertThat(source.source().getString(AbstractSourceInfo.DEBEZIUM_VERSION_KEY)).isEqualTo(Module.version());
+        assertThat(source.source().getString(SourceInfo.DEBEZIUM_VERSION_KEY)).isEqualTo(Module.version());
+    }
+
+    @Test
+    public void connectorIsPresent() {
+        assertThat(source.source().getString(SourceInfo.DEBEZIUM_CONNECTOR_KEY)).isEqualTo(SourceInfo.DEBEZIUM_CONNECTOR);
     }
 }

--- a/debezium-core/src/main/java/io/debezium/connector/AbstractSourceInfo.java
+++ b/debezium-core/src/main/java/io/debezium/connector/AbstractSourceInfo.java
@@ -3,7 +3,6 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-
 package io.debezium.connector;
 
 import java.util.Objects;
@@ -19,11 +18,14 @@ import org.apache.kafka.connect.data.Struct;
  */
 public abstract class AbstractSourceInfo {
     public static final String DEBEZIUM_VERSION_KEY = "version";
+    public static final String DEBEZIUM_CONNECTOR_KEY = "connector";
 
     private final String version;
 
     protected static SchemaBuilder schemaBuilder() {
-        return SchemaBuilder.struct().field(DEBEZIUM_VERSION_KEY, Schema.OPTIONAL_STRING_SCHEMA);
+        return SchemaBuilder.struct()
+                .field(DEBEZIUM_VERSION_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                .field(DEBEZIUM_CONNECTOR_KEY, Schema.OPTIONAL_STRING_SCHEMA);
     }
 
     protected AbstractSourceInfo(String version) {
@@ -36,9 +38,17 @@ public abstract class AbstractSourceInfo {
      */
     protected abstract Schema schema();
 
+    /**
+     * Returns the string that identifies the connector relative to the database. Implementations should override
+     * this method to specify the connector identifier.
+     *
+     * @return the connector identifier
+     */
+    protected abstract String connector();
+
     protected Struct struct() {
-        Struct result = new Struct(schema());
-        result.put(DEBEZIUM_VERSION_KEY, version);
-        return result;
+        return new Struct(schema())
+                .put(DEBEZIUM_VERSION_KEY, version)
+                .put(DEBEZIUM_CONNECTOR_KEY, connector());
     }
 }


### PR DESCRIPTION
This will allow consumers to recognize the Debezium connector used for creating a given message, helping them to adjust their behavior for a variety of connectors.

https://issues.jboss.org/browse/DBZ-918