### PR TITLE
DBZ-941 Add connectionCreated template method in HistorizedRelational…

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalSnapshotChangeEventSource.java
@@ -90,6 +90,7 @@ public abstract class HistorizedRelationalSnapshotChangeEventSource implements S
 
             connection = jdbcConnection.connection();
             connection.setAutoCommit(false);
+            connectionCreated(ctx);
 
             LOGGER.info("Snapshot step 2 - Determining captured tables");
 
@@ -162,6 +163,12 @@ public abstract class HistorizedRelationalSnapshotChangeEventSource implements S
      * Prepares the taking of a snapshot and returns an initial {@link SnapshotContext}.
      */
     protected abstract SnapshotContext prepare(ChangeEventSourceContext changeEventSourceContext) throws Exception;
+
+    /**
+     * Executes steps which have to be taken just after the database connection is created.
+     */
+    protected void connectionCreated(SnapshotContext snapshotContext) throws Exception {
+    }
 
     private void determineCapturedTables(SnapshotContext ctx) throws Exception {
         Set<TableId> allTableIds = getAllTableIds(ctx);


### PR DESCRIPTION
…SnapshotChangeEventSource

The method allows to define steps which have to be taken just after the
database connection is created (e.g. setting snapshot isolation level).

By default no operation is executed.