### PR TITLE
when connector task stopping ,discard current record queue

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
@@ -98,6 +98,8 @@ public abstract class AbstractReader implements Reader {
     @Override
     public void stop() {
         try {
+            logger.warn("MySQL discard record queue when stopping, queue size: {}",records.size());
+            records.clear();
             doStop();
             running.set(false);
         } finally {


### PR DESCRIPTION
When debezium connector task stopping ( because of kafka connectors reblancing ,or else),  kafka connector will not poll from  connector task ,but connector task continue to poll from MySQL and put event to the records ,i.e. BlockingQueue . The io.debezium.connector.mysql.enqueueRecord method will be blocked ,and connector task cannot stop ,running forever .
So before disconnect from BinaryLogClient ,we must clear the records. Because kafka connector stops before debezium io.debezium.connector.mysql.AbstractReader.stop method invoking，so records can be clear safely