### PR TITLE
DBZ-612 Support $unset operations on MongoDB CDC

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
@@ -51,11 +51,11 @@ public class MongoDataConverter {
         String key = keyvalueforStruct.getKey();
         BsonType type = keyvalueforStruct.getValue().getBsonType();
 
-        if (type == BsonType.NULL) {
-            LOG.warn("Field of type NULL is not added to the struct");
-            return;
-        }
         switch (type) {
+
+        case NULL:
+            colValue = null;
+            break;
 
         case STRING:
             colValue = keyvalueforStruct.getValue().asString().getValue().toString();
@@ -233,9 +233,6 @@ public class MongoDataConverter {
         switch (type) {
 
         case NULL:
-            LOG.warn("Data type {} not currently supported", type);
-            break;
-
         case STRING:
         case JAVASCRIPT:
         case OBJECT_ID:
@@ -321,9 +318,6 @@ public class MongoDataConverter {
 
                     switch (valueType) {
                         case NULL:
-                            LOG.warn("Data type {} not currently supported", valueType);
-                            break;
-
                         case STRING:
                         case JAVASCRIPT:
                         case OBJECT_ID:

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelope.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelope.java
@@ -142,7 +142,16 @@ public class UnwrapFromMongoDbEnvelope<R extends ConnectRecord<R>> implements Tr
             // update
             if (patchRecord.value() != null) {
                 document = BsonDocument.parse(patchRecord.value().toString());
-                valueDocument = document.getDocument("$set");
+
+                if (!document.containsKey("$set") && !document.containsKey("$unset")) {
+                    throw new ConnectException("Unable to process Mongo Operation, a '$set' or '$unset' is necessary.");
+                }
+
+                valueDocument = new BsonDocument();
+
+                if (document.containsKey("$set")) {
+                    valueDocument = document.getDocument("$set");
+                }
 
                 if (document.containsKey("$unset")) {
                     Set<Entry<String, BsonValue>> unsetDocumentEntry = document.getDocument("$unset").entrySet();

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
@@ -158,6 +158,7 @@ public class MongoDataConverterTest {
             SchemaBuilder.struct().name("withnull")
                 .field("_id", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("delivery", SchemaBuilder.struct().name("withnull.delivery").optional()
+                        .field("hour", Schema.OPTIONAL_STRING_SCHEMA)
                         .field("hourId", Schema.OPTIONAL_INT32_SCHEMA)
                         .build()
                 )

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTest.java
@@ -166,6 +166,7 @@ public class UnwrapFromMongoDbEnvelopeTest {
         assertThat(value.schema().field("name").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().fields()).hasSize(2);
     }
+
     @Test
     public void shouldGenerateRecordForUpdateEvent() throws InterruptedException {
         BsonTimestamp ts = new BsonTimestamp(1000, 1);
@@ -204,6 +205,42 @@ public class UnwrapFromMongoDbEnvelopeTest {
         assertThat(value.schema().field("id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("name").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().fields()).hasSize(2);
+    }
+
+    @Test
+    public void shouldGenerateRecordForUpdateEventWithUnset() throws InterruptedException {
+        BsonTimestamp ts = new BsonTimestamp(1000, 1);
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document("name", "Sally"))
+                .append("$unset", new Document().append("phone", true).append("active", false))
+                ;
+
+        // given
+        Document event = new Document().append("o", obj)
+                .append("o2", objId)
+                .append("ns", "dbA.c1")
+                .append("ts", ts)
+                .append("h", Long.valueOf(12345678))
+                .append("op", "u");
+        RecordsForCollection records = recordMakers.forCollection(collectionId);
+        records.recordEvent(event, 1002);
+        assertThat(produced.size()).isEqualTo(1);
+        SourceRecord record = produced.get(0);
+
+        // when
+        SourceRecord transformed = transformation.apply(record);
+
+        Struct value = (Struct) transformed.value();
+
+        // and then assert value and its schema
+        assertThat(value.schema()).isSameAs(transformed.valueSchema());
+        assertThat(value.get("name")).isEqualTo("Sally");
+        assertThat(value.get("phone")).isEqualTo(null);
+
+        assertThat(value.schema().field("phone").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        assertThat(value.schema().fields()).hasSize(3);
     }
 
     @Test


### PR DESCRIPTION
Hello,

This PR tries to address the issue https://issues.jboss.org/browse/DBZ-612

In MongoDB `$unset` operations means a certain key should be removed from the schema, since on CDC we flatten those into an understandable document the approach has to be shifted.
The strategy consists in:
- In case an `$unset` is present:
-- If the value is `true` sets the value of the field to `null`
-- If the value is `false` ignores since there's not actionable to be done
- Drawbacks are:
-- Consumers/sinkers don't know the field should be removed, but they assume that risk by using the CDC, only the new value should matter to them (document this is important imho)
-- We don't know how to deal with `null` values in the message schema (https://kafka.apache.org/11/javadoc/org/apache/kafka/connect/data/Schema.html). Since there's no special null type and we can't trace back the original value if makes it hard to come up with a decision, I'd say we could create an special schema type for null values thus the consumers can act upon. I need opinions here in order to refactor or not the first commit.

Thanks for considering and all feedback is welcome!