### PR TITLE
DBZ-974 Update MongoDB Driver and Server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ cache:
 
 env:
   - MAVEN_CLI: '"clean install -pl debezium-connector-mysql -am -Passembly"'
+  - MAVEN_CLI: '"clean install -pl debezium-connector-mysql -am -Passembly,parser-antlr"'
   - MAVEN_CLI: '"clean install -pl debezium-connector-postgres -am -Passembly -Dversion.postgres.server=9.6-devel"'
+  - MAVEN_CLI: '"clean install -pl debezium-connector-postgres -am -Passembly,wal2json-decoder -Dversion.postgres.server=9.6-devel"'
   - MAVEN_CLI: '"clean install -pl debezium-connector-postgres -am -Passembly,postgres-10"'
   - MAVEN_CLI: '"clean install -pl debezium-connector-mongodb -am -Passembly"'
-  - MAVEN_CLI: '"clean install -pl debezium-connector-mysql -am -Passembly,parser-antlr"'
-  - MAVEN_CLI: '"clean install -pl debezium-connector-postgres -am -Passembly,wal2json-decoder -Dversion.postgres.server=9.6-devel"'
-  - MAVEN_CLI: '"clean install -pl debezium-connector-mongodb -am -Passembly -Dversion.mongo.server=3.2.19"'
+  - MAVEN_CLI: '"clean install -pl debezium-connector-mongodb -am -Passembly -Dversion.mongo.server=3.2"'
 
 sudo: required
 

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -130,7 +130,7 @@
                   </image>
                   <!-- A container that initiates the data replica set and adds it as shard to router -->
                   <image>
-                    <name>debezium/mongo-initiator:3.2</name>
+                    <name>debezium/mongo-initiator:${version.mongo.server}</name>
                     <run>
                       <namingStrategy>none</namingStrategy>
                       <env>

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ConnectionIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ConnectionIT.java
@@ -72,7 +72,7 @@ public class ConnectionIT extends AbstractMongoIT {
                 MongoCollection<Document> movies = collection;
                 InsertOneOptions insertOptions = new InsertOneOptions().bypassDocumentValidation(true);
                 movies.insertOne(Document.parse("{ \"name\":\"Starter Wars\"}"), insertOptions);
-                assertThat(collection.count()).isEqualTo(1);
+                assertThat(collection.countDocuments()).isEqualTo(1);
 
                 // Read the collection to make sure we can find our document ...
                 Bson filter = Filters.eq("name", "Starter Wars");

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ReplicatorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ReplicatorIT.java
@@ -58,7 +58,7 @@ public class ReplicatorIT extends AbstractMongoIT {
             MongoCollection<Document> contacts = db.getCollection("contacts");
             InsertOneOptions insertOptions = new InsertOneOptions().bypassDocumentValidation(true);
             contacts.insertOne(Document.parse("{ \"name\":\"Jon Snow\"}"), insertOptions);
-            assertThat(db.getCollection("contacts").count()).isEqualTo(1);
+            assertThat(db.getCollection("contacts").countDocuments()).isEqualTo(1);
 
             // Read the collection to make sure we can find our document ...
             Bson filter = Filters.eq("name", "Jon Snow");
@@ -92,7 +92,7 @@ public class ReplicatorIT extends AbstractMongoIT {
             MongoCollection<Document> contacts = db.getCollection("contacts");
             InsertOneOptions insertOptions = new InsertOneOptions().bypassDocumentValidation(true);
             contacts.insertOne(Document.parse("{ \"name\":\"Sally Hamm\"}"), insertOptions);
-            assertThat(db.getCollection("contacts").count()).isEqualTo(2);
+            assertThat(db.getCollection("contacts").countDocuments()).isEqualTo(2);
 
             // Read the collection to make sure we can find our documents ...
             FindIterable<Document> movieResults = db.getCollection("contacts").find();

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <version.mysql.driver>8.0.12</version.mysql.driver>
         <version.mysql.binlog>0.16.1</version.mysql.binlog>
         <version.mongo.server>3.6.3</version.mongo.server>
-        <version.mongo.driver>3.6.3</version.mongo.driver>
+        <version.mongo.driver>3.9.0</version.mongo.driver>
 
         <!-- Connectors -->
         <version.com.google.protobuf>2.6.1</version.com.google.protobuf>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <version.mysql.server>5.7</version.mysql.server>
         <version.mysql.driver>8.0.12</version.mysql.driver>
         <version.mysql.binlog>0.16.1</version.mysql.binlog>
-        <version.mongo.server>3.6.3</version.mongo.server>
+        <version.mongo.server>3.6</version.mongo.server>
         <version.mongo.driver>3.9.0</version.mongo.driver>
 
         <!-- Connectors -->


### PR DESCRIPTION
- [x] Update Driver to 3.9.0
- [x] Solve possible deprecation (One per commit for easy rollback and trace-ability)
- [x] Create jobs for testing multiple MongoDB server versions (Moved to a new PR https://github.com/debezium/debezium/pull/675)
- [x] Have mongo-initiator based on the servers version - Depends on https://github.com/debezium/docker-images/pull/105 and https://github.com/debezium/docker-images/pull/107
- [x] Add job for mongo 4.1 (This still doesn't work, is it worth to add it? can we put it in failure "allowed"?)
Edit: I think it's better not, 4.1 dev is still early stages, the previous commits allows us to test it locally but we can wait until 4.2 beta is available

If you try to run locally:
```console
$ mvn docker:build docker:run -pl debezium-connector-mongodb -Dversion.mongo.server=4.1
```

```log
[INFO] DOCKER> [mongo:4.1] "mongo1": Waited on log out '.*waiting for connections on port 27017' 1008 ms
[INFO] DOCKER> [debezium/mongo-initiator:3.2]: Start container 7a72764bd86b
21:43:28.047 mongo-initTesting connection to MongoDB primary node at 172.17.0.2:27017 ...
21:43:28.081 mongo12018-11-13T20:43:28.081+0000 I NETWORK  [listener] connection accepted from 172.17.0.3:54008 #1 (1 connection now open)
21:43:28.082 mongo12018-11-13T20:43:28.082+0000 E -        [conn1] Assertion: Location34348: cannot translate opcode 2010 src/mongo/rpc/message.h 121
21:43:28.082 mongo12018-11-13T20:43:28.082+0000 I NETWORK  [conn1] DBException handling request, closing client connection: Location34348: cannot translate opcode 2010
21:43:28.082 mongo12018-11-13T20:43:28.082+0000 I NETWORK  [conn1] end connection 172.17.0.3:54008 (0 connections now open)
Testing connection to MongoDB primary node at 172.17.0.2:27017 ...
exception: connect failed
7a7276Testing connection to MongoDB primary node at 172.17.0.2:27017 ...
7a7276exception: connect failed
[ERROR] DOCKER> [debezium/mongo-initiator:3.2]: Container stopped with exit code 1 unexpectedly after 507 ms while waiting on exit code 0
[ERROR] DOCKER> Error occurred during container startup, shutting down...
[INFO] DOCKER> [debezium/mongo-initiator:3.2]: Stop and removed container 7a72764bd86b after 0 ms
```

You'll see that the mongo-initiator will fail due to not being able to connect with the server, by having the initiator with a client with the same version as the server makes it work