### PR TITLE
DBZ-612 DBZ-987 DBZ-989 DBZ-563 DBZ-971 MongoDB bug fixes  

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
@@ -51,11 +51,11 @@ public class MongoDataConverter {
         String key = keyvalueforStruct.getKey();
         BsonType type = keyvalueforStruct.getValue().getBsonType();
 
-        if (type == BsonType.NULL) {
-            LOG.warn("Field of type NULL is not added to the struct");
-            return;
-        }
         switch (type) {
+
+        case NULL:
+            colValue = null;
+            break;
 
         case STRING:
             colValue = keyvalueforStruct.getValue().asString().getValue().toString();
@@ -233,9 +233,6 @@ public class MongoDataConverter {
         switch (type) {
 
         case NULL:
-            LOG.warn("Data type {} not currently supported", type);
-            break;
-
         case STRING:
         case JAVASCRIPT:
         case OBJECT_ID:
@@ -321,9 +318,6 @@ public class MongoDataConverter {
 
                     switch (valueType) {
                         case NULL:
-                            LOG.warn("Data type {} not currently supported", valueType);
-                            break;
-
                         case STRING:
                         case JAVASCRIPT:
                         case OBJECT_ID:

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelope.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelope.java
@@ -282,17 +282,17 @@ public class UnwrapFromMongoDbEnvelope<R extends ConnectRecord<R>> implements Tr
 
         if (flattenStruct) {
            final R flattenRecord = recordFlattener.apply(r.newRecord(r.topic(), r.kafkaPartition(), finalKeySchema,
-               finalKeyStruct, finalValueSchema, finalValueStruct,r.timestamp()));
+               finalKeyStruct, finalValueSchema, finalValueStruct, r.timestamp(), r.headers()));
            return flattenRecord;
         }
         else {
             if (finalValueSchema.fields().isEmpty()) {
-                    return r.newRecord(r.topic(), r.kafkaPartition(), finalKeySchema, finalKeyStruct, null, null,
-                            r.timestamp());
+                    return r.newRecord(r.topic(), r.kafkaPartition(), finalKeySchema,
+                            finalKeyStruct, null, null, r.timestamp(), r.headers());
                 }
                 else {
-                    return r.newRecord(r.topic(), r.kafkaPartition(), finalKeySchema, finalKeyStruct, finalValueSchema, finalValueStruct,
-                            r.timestamp());
+                    return r.newRecord(r.topic(), r.kafkaPartition(), finalKeySchema,
+                            finalKeyStruct, finalValueSchema, finalValueStruct, r.timestamp());
                 }
         }
     }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelope.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelope.java
@@ -142,7 +142,16 @@ public class UnwrapFromMongoDbEnvelope<R extends ConnectRecord<R>> implements Tr
             // update
             if (patchRecord.value() != null) {
                 document = BsonDocument.parse(patchRecord.value().toString());
-                valueDocument = document.getDocument("$set");
+
+                if (!document.containsKey("$set") && !document.containsKey("$unset")) {
+                    throw new ConnectException("Unable to process Mongo Operation, a '$set' or '$unset' is necessary.");
+                }
+
+                valueDocument = new BsonDocument();
+
+                if (document.containsKey("$set")) {
+                    valueDocument = document.getDocument("$set");
+                }
 
                 if (document.containsKey("$unset")) {
                     Set<Entry<String, BsonValue>> unsetDocumentEntry = document.getDocument("$unset").entrySet();

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
@@ -158,6 +158,7 @@ public class MongoDataConverterTest {
             SchemaBuilder.struct().name("withnull")
                 .field("_id", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("delivery", SchemaBuilder.struct().name("withnull.delivery").optional()
+                        .field("hour", Schema.OPTIONAL_STRING_SCHEMA)
                         .field("hourId", Schema.OPTIONAL_INT32_SCHEMA)
                         .build()
                 )

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTest.java
@@ -166,6 +166,7 @@ public class UnwrapFromMongoDbEnvelopeTest {
         assertThat(value.schema().field("name").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().fields()).hasSize(2);
     }
+
     @Test
     public void shouldGenerateRecordForUpdateEvent() throws InterruptedException {
         BsonTimestamp ts = new BsonTimestamp(1000, 1);
@@ -204,6 +205,42 @@ public class UnwrapFromMongoDbEnvelopeTest {
         assertThat(value.schema().field("id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("name").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().fields()).hasSize(2);
+    }
+
+    @Test
+    public void shouldGenerateRecordForUpdateEventWithUnset() throws InterruptedException {
+        BsonTimestamp ts = new BsonTimestamp(1000, 1);
+        CollectionId collectionId = new CollectionId("rs0", "dbA", "c1");
+        ObjectId objId = new ObjectId();
+        Document obj = new Document()
+                .append("$set", new Document("name", "Sally"))
+                .append("$unset", new Document().append("phone", true).append("active", false))
+                ;
+
+        // given
+        Document event = new Document().append("o", obj)
+                .append("o2", objId)
+                .append("ns", "dbA.c1")
+                .append("ts", ts)
+                .append("h", Long.valueOf(12345678))
+                .append("op", "u");
+        RecordsForCollection records = recordMakers.forCollection(collectionId);
+        records.recordEvent(event, 1002);
+        assertThat(produced.size()).isEqualTo(1);
+        SourceRecord record = produced.get(0);
+
+        // when
+        SourceRecord transformed = transformation.apply(record);
+
+        Struct value = (Struct) transformed.value();
+
+        // and then assert value and its schema
+        assertThat(value.schema()).isSameAs(transformed.valueSchema());
+        assertThat(value.get("name")).isEqualTo("Sally");
+        assertThat(value.get("phone")).isEqualTo(null);
+
+        assertThat(value.schema().field("phone").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        assertThat(value.schema().fields()).hasSize(3);
     }
 
     @Test

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTest.java
@@ -52,6 +52,7 @@ public class UnwrapFromMongoDbEnvelopeTest {
     private static final String FLATTEN_STRUCT = "flatten.struct";
     private static final String DELIMITER = "flatten.struct.delimiter";
     private static final String OPERATION_HEADER = "operation.header";
+    private static final String HANDLE_DELETES = "delete.handling.mode";
 
     private Filters filters;
     private SourceInfo source;
@@ -323,6 +324,10 @@ public class UnwrapFromMongoDbEnvelopeTest {
 
         SourceRecord record = produced.get(0);
 
+        final Map<String, String> props = new HashMap<>();
+        props.put(HANDLE_DELETES, "none");
+        transformation.configure(props);
+
         // when
         SourceRecord transformed = transformation.apply(record);
 
@@ -358,6 +363,7 @@ public class UnwrapFromMongoDbEnvelopeTest {
 
         final Map<String, String> props = new HashMap<>();
         props.put(OPERATION_HEADER, "true");
+        props.put(HANDLE_DELETES, "none");
         transformation.configure(props);
 
         // when

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTestIT.java
@@ -10,6 +10,8 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
@@ -45,6 +47,8 @@ public class UnwrapFromMongoDbEnvelopeTestIT extends AbstractConnectorTest {
     private static final String DB_NAME = "transform";
     private static final String COLLECTION_NAME = "source";
     private static final String TOPIC_NAME = "mongo.transform.source";
+
+    private static final String CONFIG_DROP_TOMBSTONES = "drop.tombstones";
 
     private Configuration config;
     private MongoDbTaskContext context;
@@ -90,6 +94,10 @@ public class UnwrapFromMongoDbEnvelopeTestIT extends AbstractConnectorTest {
 
         // Start the connector ...
         start(MongoDbConnector.class, config);
+
+        final Map<String, String> transformationConfig = new HashMap<>();
+        transformationConfig.put(CONFIG_DROP_TOMBSTONES, "false");
+        transformation.configure(transformationConfig);
 
         // Test insert
         primary().execute("insert", client -> {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTestIT.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
+import io.debezium.data.SchemaUtil;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -198,21 +199,31 @@ public class UnwrapFromMongoDbEnvelopeTestIT extends AbstractConnectorTest {
         assertThat(transformedFullUpdateValue.get("id")).isEqualTo(1);
         assertThat(transformedFullUpdateValue.get("dataStr")).isEqualTo("Hi again");
 
-        // Test update
+        // Test Delete
         primary().execute("delete", client -> {
             client.getDatabase(DB_NAME).getCollection(COLLECTION_NAME).deleteOne(RawBsonDocument.parse("{'_id' : 1}"));
         });
 
         records = consumeRecordsByTopic(2);
-
         assertThat(records.recordsForTopic(TOPIC_NAME).size()).isEqualTo(2);
+
+        // Test mongo Deletion operation
         final SourceRecord deleteRecord = records.recordsForTopic(TOPIC_NAME).get(0);
         final SourceRecord transformedDelete = transformation.apply(deleteRecord);
         final Struct transformedDeleteValue = (Struct)transformedDelete.value();
 
         assertThat(transformedDeleteValue).isNull();
-        assertThat(records.recordsForTopic(TOPIC_NAME).get(1).value()).isNull();
-    }
+
+        // Test tombstone record
+        final SourceRecord tombstoneRecord = records.recordsForTopic(TOPIC_NAME).get(1);
+        final SourceRecord transformedTombstone = transformation.apply(tombstoneRecord);
+
+        assertThat(transformedTombstone.value()).isNull();
+
+        // Assert deletion preserves key
+        assertThat(SchemaUtil.asString(transformedDelete.keySchema())).isEqualTo(SchemaUtil.asString(transformedTombstone.keySchema()));
+        assertThat(transformedDelete.key().toString()).isEqualTo(transformedTombstone.key().toString());
+}
 
     private MongoPrimary primary() {
         ReplicaSet replicaSet = ReplicaSet.parse(context.getConnectionContext().hosts());

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTestIT.java
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
 import io.debezium.data.SchemaUtil;
+import io.debezium.doc.FixFor;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -74,6 +75,51 @@ public class UnwrapFromMongoDbEnvelopeTestIT extends AbstractConnectorTest {
             if (context != null) context.getConnectionContext().shutdown();
         }
         transformation.close();
+    }
+
+    @Test
+    @FixFor("DBZ-563")
+    public void shouldDropTombstoneByDefault() throws InterruptedException {
+        // Use the DB configuration to define the connector's configuration ...
+        config = TestHelper.getConfiguration().edit()
+                .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
+                .with(MongoDbConnectorConfig.COLLECTION_WHITELIST, "transform.*")
+                .with(MongoDbConnectorConfig.LOGICAL_NAME, "mongo")
+                .build();
+
+        // Set up the replication context for connections ...
+        context = new MongoDbTaskContext(config);
+
+        // Cleanup database
+        TestHelper.cleanDatabase(primary(), DB_NAME);
+
+        // Start the connector ...
+        start(MongoDbConnector.class, config);
+
+        // First insert
+        primary().execute("insert", client -> {
+            client.getDatabase(DB_NAME).getCollection(COLLECTION_NAME)
+                    .insertOne(Document.parse("{'_id': 1, 'dataStr': 'hello', 'dataInt': 123, 'dataLong': 80000000000}"));
+        });
+
+        SourceRecords records = consumeRecordsByTopic(1);
+
+        assertThat(records.recordsForTopic(TOPIC_NAME).size()).isEqualTo(1);
+
+        // Test Delete
+        primary().execute("delete", client -> {
+            client.getDatabase(DB_NAME).getCollection(COLLECTION_NAME).deleteOne(RawBsonDocument.parse("{'_id' : 1}"));
+        });
+
+        records = consumeRecordsByTopic(2);
+        assertThat(records.recordsForTopic(TOPIC_NAME).size()).isEqualTo(2);
+
+        // Test tombstone record is dropped
+        // Note we're getting the second record which is the tombstone
+        final SourceRecord tombstoneRecord = records.recordsForTopic(TOPIC_NAME).get(1);
+        final SourceRecord transformedTombstone = transformation.apply(tombstoneRecord);
+
+        assertThat(transformedTombstone).isNull();
     }
 
     @Test

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTestIT.java
@@ -50,6 +50,7 @@ public class UnwrapFromMongoDbEnvelopeTestIT extends AbstractConnectorTest {
     private static final String TOPIC_NAME = "mongo.transform.source";
 
     private static final String CONFIG_DROP_TOMBSTONES = "drop.tombstones";
+    private static final String HANDLE_DELETES = "delete.handling.mode";
 
     private Configuration config;
     private MongoDbTaskContext context;
@@ -143,6 +144,7 @@ public class UnwrapFromMongoDbEnvelopeTestIT extends AbstractConnectorTest {
 
         final Map<String, String> transformationConfig = new HashMap<>();
         transformationConfig.put(CONFIG_DROP_TOMBSTONES, "false");
+        transformationConfig.put(HANDLE_DELETES, "none");
         transformation.configure(transformationConfig);
 
         // Test insert

--- a/debezium-core/src/main/java/io/debezium/transforms/UnwrapFromEnvelope.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/UnwrapFromEnvelope.java
@@ -9,8 +9,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.debezium.config.EnumeratedValue;
+import io.debezium.data.Envelope;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.transforms.ExtractField;
 import org.apache.kafka.connect.transforms.InsertField;
@@ -38,6 +40,8 @@ import io.debezium.config.Field;
  * @author Jiri Pechanec
  */
 public class UnwrapFromEnvelope<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    final static String DEBEZIUM_OPERATION_HEADER_KEY = "__debezium-operation";
 
     public static enum DeleteHandling implements EnumeratedValue {
         DROP("drop"),
@@ -115,9 +119,19 @@ public class UnwrapFromEnvelope<R extends ConnectRecord<R>> implements Transform
                     + "drop - records are removed,"
                     + "rewrite - __deleted field is added to records.");
 
+    private static final Field OPERATION_HEADER = Field.create("operation.header")
+            .withDisplayName("Adds the debezium operation into the message header")
+            .withType(ConfigDef.Type.BOOLEAN)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDefault(false)
+            .withDescription("Adds the operation {@link FieldName#OPERATION operation} as a header." +
+                    "Its key is '" + DEBEZIUM_OPERATION_HEADER_KEY +"'");
+
     private boolean dropTombstones;
     private boolean dropDeletes;
     private DeleteHandling handleDeletes;
+    private boolean addOperationHeader;
     private final ExtractField<R> afterDelegate = new ExtractField.Value<R>();
     private final ExtractField<R> beforeDelegate = new ExtractField.Value<R>();
     private final InsertField<R> removedDelegate = new InsertField.Value<R>();
@@ -143,6 +157,8 @@ public class UnwrapFromEnvelope<R extends ConnectRecord<R>> implements Transform
             }
         }
 
+        addOperationHeader = config.getBoolean(OPERATION_HEADER);
+
         Map<String, String> delegateConfig = new HashMap<>();
         delegateConfig.put("field", "before");
         beforeDelegate.configure(delegateConfig);
@@ -164,13 +180,30 @@ public class UnwrapFromEnvelope<R extends ConnectRecord<R>> implements Transform
 
     @Override
     public R apply(final R record) {
+        Envelope.Operation operation;
         if (record.value() == null) {
             if (dropTombstones) {
                 logger.trace("Tombstone {} arrived and requested to be dropped", record.key());
                 return null;
             }
+            operation = Envelope.Operation.DELETE;
+            if (addOperationHeader) {
+                record.headers().addString(DEBEZIUM_OPERATION_HEADER_KEY, operation.toString());
+            }
             return record;
         }
+
+        if (addOperationHeader) {
+            String operationString = ((Struct) record.value()).getString("op");
+            operation = Envelope.Operation.forCode(operationString);
+
+            if (operationString.isEmpty() || operation == null) {
+                logger.warn("Unknown operation thus unable to add the operation header into the message");
+            } else {
+                record.headers().addString(DEBEZIUM_OPERATION_HEADER_KEY, operation.code());
+            }
+        }
+
         if (record.valueSchema() == null ||
                 record.valueSchema().name() == null ||
                 !record.valueSchema().name().endsWith(ENVELOPE_SCHEMA_NAME_SUFFIX)) {
@@ -206,7 +239,7 @@ public class UnwrapFromEnvelope<R extends ConnectRecord<R>> implements Transform
     @Override
     public ConfigDef config() {
         final ConfigDef config = new ConfigDef();
-        Field.group(config, null, DROP_TOMBSTONES, DROP_DELETES, HANDLE_DELETES);
+        Field.group(config, null, DROP_TOMBSTONES, DROP_DELETES, HANDLE_DELETES, OPERATION_HEADER);
         return config;
     }
 


### PR DESCRIPTION
## Why this big PR

This PR packs together multiple DBZ issues, since the code being changed is almost always the same I had to stack many PRs, thus this new approach.

**Important** Please [review by commit](https://github.com/debezium/debezium/pull/682/commits), check commit messages and if necessary also check the related PR below, thanks!

## Tickets involved and their past PRs

You can go to the PRs and tickets for full context since many discussions happened already

- [DBZ-612](https://issues.jboss.org/browse/DBZ-612) Support `$unset` operator: #669 
  - This entails in supporting `$rename`, `$unset` and other mongo queries
  - Null values support is required to achieve this
- [DBZ-987](https://issues.jboss.org/browse/DBZ-987) Support full document updates: #679 
- [DBZ-989](https://issues.jboss.org/browse/DBZ-989) Support tombstone messages within `UnwrapFromMongoDbEnvelope`: #681 
- [DBZ-563](https://issues.jboss.org/browse/DBZ-563) Support _drop_ tombstone messages within `UnwrapFromMongoDbEnvelope`: #681 
- [DBZ-971](https://issues.jboss.org/browse/DBZ-971) Add option to set operation header within all Unwrappers: #671 