### PR TITLE
DBZ-1029 handling messages from tables with replica identity full in postgres connector

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
@@ -248,9 +248,6 @@ public class RecordsStreamProducer extends RecordsProducer {
 
         TableSchema tableSchema = tableSchemaFor(tableId);
         if (tableSchema != null) {
-            if (tableSchema.keySchema() == null) {
-                logger.warn("ignoring message for table '{}' because it does not have a primary key defined", tableId);
-            }
 
             ReplicationMessage.Operation operation = message.getOperation();
             switch (operation) {
@@ -291,7 +288,8 @@ public class RecordsStreamProducer extends RecordsProducer {
         assert tableSchema != null;
         Object key = tableSchema.keyFromColumnData(rowData);
         Struct value = tableSchema.valueFromColumnData(rowData);
-        if (key == null || value == null) {
+        if (value == null) {
+            logger.warn("no values found for table '{}' from create message at '{}'; skipping record" , tableId, sourceInfo);
             return;
         }
         Schema keySchema = tableSchema.keySchema();
@@ -389,7 +387,8 @@ public class RecordsStreamProducer extends RecordsProducer {
         assert tableSchema != null;
         Object key = tableSchema.keyFromColumnData(oldRowData);
         Struct value = tableSchema.valueFromColumnData(oldRowData);
-        if (key == null || value == null) {
+        if (value == null) {
+            logger.warn("ignoring message from delete transaction for table '{}' because it does not have a primary key defined and replica identity for the table is not FULL", tableId);
             return;
         }
         Schema keySchema = tableSchema.keySchema();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
@@ -388,7 +388,7 @@ public class RecordsStreamProducer extends RecordsProducer {
         Object key = tableSchema.keyFromColumnData(oldRowData);
         Struct value = tableSchema.valueFromColumnData(oldRowData);
         if (value == null) {
-            logger.warn("ignoring message from delete transaction for table '{}' because it does not have a primary key defined and replica identity for the table is not FULL", tableId);
+            logger.warn("ignoring delete message for table '{}' because it does not have a primary key defined and replica identity for the table is not FULL", tableId);
             return;
         }
         Schema keySchema = tableSchema.keySchema();


### PR DESCRIPTION
With this fix all messages with replica identity full will be processed and emitted as events even if they do not have primary keys. 
Before that all messages without PK has been discarded despite they could have all necessary data in the 'before' and 'after' parts.