### PR TITLE
WIP DBZ-354 Define a centralized approach for SSL settings that are shared by all connectors

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -236,7 +236,11 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
                                                      DATABASE_WHITELIST,
                                                      DATABASE_BLACKLIST,
                                                      CommonConnectorConfig.TOMBSTONES_ON_DELETE,
-                                                     CommonConnectorConfig.SNAPSHOT_DELAY_MS);
+                                                     CommonConnectorConfig.SNAPSHOT_DELAY_MS,
+                                                     CommonConnectorConfig.SSL_KEYSTORE,
+                                                     CommonConnectorConfig.SSL_KEYSTORE_PASSWORD,
+                                                     CommonConnectorConfig.SSL_TRUSTSTORE,
+                                                     CommonConnectorConfig.SSL_TRUSTSTORE_PASSWORD);
 
     protected static Field.Set EXPOSED_FIELDS = ALL_FIELDS;
 
@@ -252,7 +256,9 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
         Field.group(config, "Events", DATABASE_WHITELIST, DATABASE_BLACKLIST, COLLECTION_WHITELIST, COLLECTION_BLACKLIST, FIELD_BLACKLIST, FIELD_RENAMES, CommonConnectorConfig.TOMBSTONES_ON_DELETE);
         Field.group(config, "Connector", MAX_COPY_THREADS, CommonConnectorConfig.MAX_QUEUE_SIZE,
                 CommonConnectorConfig.MAX_BATCH_SIZE, CommonConnectorConfig.POLL_INTERVAL_MS,
-                CommonConnectorConfig.SNAPSHOT_DELAY_MS);
+                CommonConnectorConfig.SNAPSHOT_DELAY_MS, CommonConnectorConfig.SSL_TRUSTSTORE,
+                CommonConnectorConfig.SSL_TRUSTSTORE_PASSWORD, CommonConnectorConfig.SSL_KEYSTORE,
+                CommonConnectorConfig.SSL_KEYSTORE_PASSWORD);
         return config;
     }
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -269,7 +269,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
             return 1;
         }
         int count = 0;
-        if (ReplicaSets.parse(hosts) == null) {
+        if (ReplicaSets.parse(hosts).all().isEmpty()) {
             problems.accept(field, hosts, "Invalid host specification");
             ++count;
         }
@@ -277,20 +277,18 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
     }
 
     private static int validateCollectionBlacklist(Configuration config, Field field, ValidationOutput problems) {
-        String whitelist = config.getString(COLLECTION_WHITELIST);
-        String blacklist = config.getString(COLLECTION_BLACKLIST);
-        if (whitelist != null && blacklist != null) {
-            problems.accept(COLLECTION_BLACKLIST, blacklist, "Whitelist is already specified");
-            return 1;
-        }
-        return 0;
+        return validateBlacklistField(config, problems, COLLECTION_WHITELIST, COLLECTION_BLACKLIST);
     }
 
     private static int validateDatabaseBlacklist(Configuration config, Field field, ValidationOutput problems) {
-        String whitelist = config.getString(DATABASE_WHITELIST);
-        String blacklist = config.getString(DATABASE_BLACKLIST);
+        return validateBlacklistField(config, problems, DATABASE_WHITELIST, DATABASE_BLACKLIST);
+    }
+
+    private static int validateBlacklistField(Configuration config, ValidationOutput problems, Field fieldWhitelist, Field fieldBlacklist) {
+        String whitelist = config.getString(fieldWhitelist);
+        String blacklist = config.getString(fieldBlacklist);
         if (whitelist != null && blacklist != null) {
-            problems.accept(DATABASE_BLACKLIST, blacklist, "Whitelist is already specified");
+            problems.accept(fieldBlacklist, blacklist, "Whitelist is already specified");
             return 1;
         }
         return 0;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -132,7 +132,7 @@ public class MySqlJdbcContext implements AutoCloseable {
             systemProperties.setSystemProperty("javax.net.ssl.keyStore", MySqlConnectorConfig.SSL_KEYSTORE, true);
             systemProperties.setSystemProperty("javax.net.ssl.keyStorePassword", MySqlConnectorConfig.SSL_KEYSTORE_PASSWORD, false);
             systemProperties.setSystemProperty("javax.net.ssl.trustStore", MySqlConnectorConfig.SSL_TRUSTSTORE, true);
-            systemProperties.setSystemProperty("javax.net.ssl.trustStorePassword", MySqlConnectorConfig.SSL_KEYSTORE_PASSWORD, false);
+            systemProperties.setSystemProperty("javax.net.ssl.trustStorePassword", MySqlConnectorConfig.SSL_TRUSTSTORE_PASSWORD, false);
         }
     }
 

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -77,6 +77,35 @@ public class CommonConnectorConfig {
         .withDefault(0L)
         .withValidation(Field::isNonNegativeLong);
 
+    public static final Field SSL_KEYSTORE = Field.create("ssl.keystore")
+            .withDisplayName("SSL Keystore")
+            .withType(Type.STRING)
+            .withWidth(Width.LONG)
+            .withImportance(Importance.MEDIUM)
+            .withDescription("Location of the Java keystore file containing an application process's own certificate and private key.");
+
+    public static final Field SSL_KEYSTORE_PASSWORD = Field.create("ssl.keystore.password")
+            .withDisplayName("SSL Keystore Password")
+            .withType(Type.PASSWORD)
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.MEDIUM)
+            .withDescription("Password to access the private key from the keystore file specified by 'ssl.keystore' configuration property or the 'javax.net.ssl.keyStore' system or JVM property. "
+                    + "This password is used to unlock the keystore file (store password), and to decrypt the private key stored in the keystore (key password).");
+
+    public static final Field SSL_TRUSTSTORE = Field.create("ssl.truststore")
+            .withDisplayName("SSL Truststore")
+            .withType(Type.STRING)
+            .withWidth(Width.LONG)
+            .withImportance(Importance.MEDIUM)
+            .withDescription("Location of the Java truststore file containing the collection of CA certificates trusted by this application process (trust store).");
+
+    public static final Field SSL_TRUSTSTORE_PASSWORD = Field.create("ssl.truststore.password")
+            .withDisplayName("SSL Truststore Password")
+            .withType(Type.PASSWORD)
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.MEDIUM)
+            .withDescription("Password to unlock the keystore file (store password) specified by 'ssl.trustore' configuration property or the 'javax.net.ssl.trustStore' system or JVM property.");
+
     private final Configuration config;
     private final boolean emitTombstoneOnDelete;
     private final int maxQueueSize;

--- a/debezium-core/src/main/java/io/debezium/config/SystemProperties.java
+++ b/debezium-core/src/main/java/io/debezium/config/SystemProperties.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.config;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A {@link Configuration} often can become a System Property, this helper allows to set them in case there isn't a
+ * previously effective value and keeps record of the changes for a later reset.
+ *
+ * @author Renato Mefi
+ */
+public class SystemProperties {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Map<String, String> originalSystemProperties = new HashMap<>();
+    private final Configuration config;
+
+    public SystemProperties(Configuration config) {
+        this.config = config;
+    }
+
+    public void setSystemProperty(String property, Field field, boolean showValueInError) {
+        String value = config.getString(field);
+        if (value == null)
+            return;
+
+        value = value.trim();
+        String valueOrMask = showValueInError ? value : "*********";
+
+        String existingValue = System.getProperty(property);
+        if (existingValue == null) {
+            // There was no existing property ...
+            String existing = System.setProperty(property, value);
+            originalSystemProperties.put(property, existing); // the existing value may be null
+            logger.info(String.format("Setting System property '%s' with '%s'.", property, valueOrMask));
+            return;
+        }
+
+        existingValue = existingValue.trim();
+        if (!existingValue.equalsIgnoreCase(value)) {
+            // There was an existing property, and the value is different ...
+            String msg = String.format("System or JVM property '%s' is already defined, but the configuration property '%s' defines a different value", property, field.name());
+            if (showValueInError) {
+                msg = String.format("System or JVM property '%s' is already defined as %s, but the configuration property '%s' defines a different value '%s'", property, existingValue, field.name(), value);
+            }
+            throw new ConnectException(msg);
+        }
+
+        logger.debug(String.format("Skipping setting System property '%s' since current value '%s' was already set ", property, valueOrMask));
+    }
+
+    public void resetToOriginalSystemProperties() {
+        originalSystemProperties.forEach((name, value) -> {
+            if (value != null) {
+                System.setProperty(name, value);
+            } else {
+                System.clearProperty(name);
+            }
+        });
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/config/SystemProperties.java
+++ b/debezium-core/src/main/java/io/debezium/config/SystemProperties.java
@@ -67,4 +67,8 @@ public class SystemProperties {
             }
         });
     }
+
+    public void clearOriginalSystemProperties() {
+        originalSystemProperties.clear();
+    }
 }


### PR DESCRIPTION
## Context
https://issues.jboss.org/browse/DBZ-354
https://issues.jboss.org/browse/DBZ-1061 - For MongoDB
https://issues.jboss.org/browse/DBZ-1062 - Fix for MySQL trustStore password

## Todo
- [x] Extract SystemProperties setter
- [x] Migrate MySQL Connector to use the helper
- [x] Fix MySQL trustStore password [DBZ-1062](https://issues.jboss.org/browse/DBZ-1062)
- [x] Implement in MongoDB
- [ ] Implement in Oracle
- [ ] Implement in MySQL (Migration path should be taken in account)
- [ ] Implement in SQLServer
- [ ] Implement in PostgresSQL

## Obs
Please review commit by commit in order!