### PR TITLE
DBZ-1079 Add a sortable ID to each message

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbTaskContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbTaskContext.java
@@ -34,7 +34,7 @@ public class MongoDbTaskContext extends CdcSourceTaskContext {
 
         final String serverName = config.getString(MongoDbConnectorConfig.LOGICAL_NAME);
         this.filters = new Filters(config);
-        this.source = new SourceInfo(serverName);
+        this.source = new SourceInfo(serverName, new MongoDbConnectorConfig(config).getIdBuilder());
         this.topicSelector = MongoDbTopicSelector.defaultSelector(serverName, config.getString(Heartbeat.HEARTBEAT_TOPICS_PREFIX));
         this.emitTombstoneOnDelete = config.getBoolean(CommonConnectorConfig.TOMBSTONES_ON_DELETE);
         this.serverName = config.getString(MongoDbConnectorConfig.LOGICAL_NAME);

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldBlacklistTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldBlacklistTest.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.mongodb;
 
 import io.debezium.schema.TopicSelector;
+import io.debezium.util.NoOpOrderedIdBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.bson.BsonTimestamp;
@@ -38,7 +39,7 @@ public class FieldBlacklistTest {
     @Before
     public void setup() {
         build = new Configurator();
-        source = new SourceInfo(SERVER_NAME);
+        source = new SourceInfo(SERVER_NAME, new NoOpOrderedIdBuilder());
         topicSelector = MongoDbTopicSelector.defaultSelector(SERVER_NAME, "__debezium-heartbeat");
     }
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldRenamesTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldRenamesTest.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.mongodb;
 
 import io.debezium.schema.TopicSelector;
+import io.debezium.util.NoOpOrderedIdBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.bson.BsonTimestamp;
@@ -38,7 +39,7 @@ public class FieldRenamesTest {
     @Before
     public void setup() {
         build = new Configurator();
-        source = new SourceInfo(SERVER_NAME);
+        source = new SourceInfo(SERVER_NAME, new NoOpOrderedIdBuilder());
         topicSelector = MongoDbTopicSelector.defaultSelector(SERVER_NAME, "__debezium-heartbeat");
     }
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/RecordMakersTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/RecordMakersTest.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 
+import io.debezium.util.NoOpOrderedIdBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.bson.BsonTimestamp;
@@ -52,7 +53,7 @@ public class RecordMakersTest {
     @Before
     public void beforeEach() {
         filters = new Configurator().createFilters();
-        source = new SourceInfo(SERVER_NAME);
+        source = new SourceInfo(SERVER_NAME, new NoOpOrderedIdBuilder());
         topicSelector = MongoDbTopicSelector.defaultSelector(PREFIX, "__debezium-heartbeat");
         produced = new ArrayList<>();
         recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/SourceInfoTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/SourceInfoTest.java
@@ -9,6 +9,7 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import java.util.Map;
 
+import io.debezium.util.CounterIdBuilder;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -29,7 +30,7 @@ public class SourceInfoTest {
 
     @Before
     public void beforeEach() {
-        source = new SourceInfo("serverX");
+        source = new SourceInfo("serverX", new CounterIdBuilder());
     }
 
     @Test
@@ -44,6 +45,7 @@ public class SourceInfoTest {
         assertThat(schema.field(SourceInfo.ORDER).schema()).isEqualTo(Schema.INT32_SCHEMA);
         assertThat(schema.field(SourceInfo.OPERATION_ID).schema()).isEqualTo(Schema.OPTIONAL_INT64_SCHEMA);
         assertThat(schema.field(SourceInfo.INITIAL_SYNC).schema()).isEqualTo(SchemaBuilder.bool().optional().defaultValue(false).build());
+        assertThat(schema.field(SourceInfo.ORDER_ID_KEY).schema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
     }
 
     @Test
@@ -74,16 +76,18 @@ public class SourceInfoTest {
         assertThat(offset.get(SourceInfo.TIMESTAMP)).isEqualTo(100);
         assertThat(offset.get(SourceInfo.ORDER)).isEqualTo(2);
         assertThat(offset.get(SourceInfo.OPERATION_ID)).isEqualTo(1987654321L);
+        assertThat(offset.get(SourceInfo.ORDER_ID_KEY)).isEqualTo("1");
 
         // Create a new source info and set the offset ...
         Map<String,String> partition = source.partition(REPLICA_SET_NAME);
-        source = new SourceInfo("serverX");
+        source = new SourceInfo("serverX", new CounterIdBuilder());
         source.setOffsetFor(partition, offset);
         
         offset = source.lastOffset(REPLICA_SET_NAME);
         assertThat(offset.get(SourceInfo.TIMESTAMP)).isEqualTo(100);
         assertThat(offset.get(SourceInfo.ORDER)).isEqualTo(2);
         assertThat(offset.get(SourceInfo.OPERATION_ID)).isEqualTo(1987654321L);
+        assertThat(offset.get(SourceInfo.ORDER_ID_KEY)).isEqualTo("1");
 
         BsonTimestamp ts = source.lastOffsetTimestamp(REPLICA_SET_NAME);
         assertThat(ts.getTime()).isEqualTo(100);
@@ -97,6 +101,7 @@ public class SourceInfoTest {
         assertThat(struct.getString(SourceInfo.REPLICA_SET_NAME)).isEqualTo(REPLICA_SET_NAME);
         assertThat(struct.getString(SourceInfo.SERVER_NAME)).isEqualTo("serverX");
         assertThat(struct.getBoolean(SourceInfo.INITIAL_SYNC)).isNull();
+        assertThat(struct.getString(SourceInfo.ORDER_ID_KEY)).isEqualTo("1");
     }
 
     @Test
@@ -107,6 +112,7 @@ public class SourceInfoTest {
         assertThat(offset.get(SourceInfo.TIMESTAMP)).isEqualTo(0);
         assertThat(offset.get(SourceInfo.ORDER)).isEqualTo(0);
         assertThat(offset.get(SourceInfo.OPERATION_ID)).isNull();
+        assertThat(offset.get(SourceInfo.ORDER_ID_KEY)).isEqualTo("0");
 
         BsonTimestamp ts = source.lastOffsetTimestamp(REPLICA_SET_NAME);
         assertThat(ts.getTime()).isEqualTo(0);
@@ -120,6 +126,7 @@ public class SourceInfoTest {
         assertThat(struct.getString(SourceInfo.REPLICA_SET_NAME)).isEqualTo(REPLICA_SET_NAME);
         assertThat(struct.getString(SourceInfo.SERVER_NAME)).isEqualTo("serverX");
         assertThat(struct.getBoolean(SourceInfo.INITIAL_SYNC)).isNull();
+        assertThat(struct.getString(SourceInfo.ORDER_ID_KEY)).isEqualTo("0");
 
         assertThat(source.hasOffset(REPLICA_SET_NAME)).isEqualTo(false);
     }
@@ -138,6 +145,7 @@ public class SourceInfoTest {
         assertThat(offset.get(SourceInfo.TIMESTAMP)).isEqualTo(100);
         assertThat(offset.get(SourceInfo.ORDER)).isEqualTo(2);
         assertThat(offset.get(SourceInfo.OPERATION_ID)).isEqualTo(1987654321L);
+        assertThat(offset.get(SourceInfo.ORDER_ID_KEY)).isEqualTo("1");
 
         BsonTimestamp ts = source.lastOffsetTimestamp(REPLICA_SET_NAME);
         assertThat(ts.getTime()).isEqualTo(100);
@@ -151,6 +159,7 @@ public class SourceInfoTest {
         assertThat(struct.getString(SourceInfo.REPLICA_SET_NAME)).isEqualTo(REPLICA_SET_NAME);
         assertThat(struct.getString(SourceInfo.SERVER_NAME)).isEqualTo("serverX");
         assertThat(struct.getBoolean(SourceInfo.INITIAL_SYNC)).isNull();
+        assertThat(struct.getString(SourceInfo.ORDER_ID_KEY)).isEqualTo("1");
     }
 
     @Test
@@ -162,6 +171,7 @@ public class SourceInfoTest {
         assertThat(offset.get(SourceInfo.TIMESTAMP)).isEqualTo(0);
         assertThat(offset.get(SourceInfo.ORDER)).isEqualTo(0);
         assertThat(offset.get(SourceInfo.OPERATION_ID)).isNull();
+        assertThat(offset.get(SourceInfo.ORDER_ID_KEY)).isEqualTo("0");
 
         BsonTimestamp ts = source.lastOffsetTimestamp(REPLICA_SET_NAME);
         assertThat(ts.getTime()).isEqualTo(0);
@@ -175,6 +185,7 @@ public class SourceInfoTest {
         assertThat(struct.getString(SourceInfo.REPLICA_SET_NAME)).isEqualTo(REPLICA_SET_NAME);
         assertThat(struct.getString(SourceInfo.SERVER_NAME)).isEqualTo("serverX");
         assertThat(struct.getBoolean(SourceInfo.INITIAL_SYNC)).isEqualTo(true);
+        assertThat(struct.getString(SourceInfo.ORDER_ID_KEY)).isEqualTo("0");
 
         assertThat(source.hasOffset(REPLICA_SET_NAME)).isEqualTo(false);
     }
@@ -195,6 +206,7 @@ public class SourceInfoTest {
         assertThat(offset.get(SourceInfo.TIMESTAMP)).isEqualTo(100);
         assertThat(offset.get(SourceInfo.ORDER)).isEqualTo(2);
         assertThat(offset.get(SourceInfo.OPERATION_ID)).isEqualTo(1987654321L);
+        assertThat(offset.get(SourceInfo.ORDER_ID_KEY)).isEqualTo("1");
 
         BsonTimestamp ts = source.lastOffsetTimestamp(REPLICA_SET_NAME);
         assertThat(ts.getTime()).isEqualTo(100);
@@ -208,6 +220,7 @@ public class SourceInfoTest {
         assertThat(struct.getString(SourceInfo.REPLICA_SET_NAME)).isEqualTo(REPLICA_SET_NAME);
         assertThat(struct.getString(SourceInfo.SERVER_NAME)).isEqualTo("serverX");
         assertThat(struct.getBoolean(SourceInfo.INITIAL_SYNC)).isEqualTo(true);
+        assertThat(struct.getString(SourceInfo.ORDER_ID_KEY)).isEqualTo("1");
     }
 
     @Test

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UnwrapFromMongoDbEnvelopeTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.debezium.data.Envelope;
+import io.debezium.util.NoOpOrderedIdBuilder;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -66,7 +67,7 @@ public class UnwrapFromMongoDbEnvelopeTest {
     @Before
     public void setup() {
         filters = new Configurator().createFilters();
-        source = new SourceInfo(SERVER_NAME);
+        source = new SourceInfo(SERVER_NAME, new NoOpOrderedIdBuilder());
         topicSelector = MongoDbTopicSelector.defaultSelector(SERVER_NAME, "__debezium-heartbeat");
         produced = new ArrayList<>();
         recordMakers = new RecordMakers(filters, source, topicSelector, produced::add, true);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -65,7 +65,7 @@ public final class MySqlTaskContext extends CdcSourceTaskContext {
         this.topicSelector = MySqlTopicSelector.defaultSelector(connectorConfig.getLogicalName(), connectorConfig.getHeartbeatTopicsPrefix());
 
         // Set up the source information ...
-        this.source = new SourceInfo();
+        this.source = new SourceInfo(connectorConfig.getIdBuilder());
         this.source.setServerName(connectorConfig.getLogicalName());
 
         // Set up the GTID filter ...

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import io.debezium.util.NoOpOrderedIdBuilder;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
@@ -710,7 +711,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         stopConnector();
 
         // Read the last committed offsets, and verify the binlog coordinates ...
-        SourceInfo persistedOffsetSource = new SourceInfo();
+        SourceInfo persistedOffsetSource = new SourceInfo(new NoOpOrderedIdBuilder());
         persistedOffsetSource.setServerName(config.getString(MySqlConnectorConfig.SERVER_NAME));
         Map<String, ?> lastCommittedOffset = readLastCommittedOffset(config, persistedOffsetSource.partition());
         persistedOffsetSource.setOffset(lastCommittedOffset);

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSchemaTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSchemaTest.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 
+import io.debezium.util.NoOpOrderedIdBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class MySqlSchemaTest {
         Testing.Files.delete(TEST_FILE_PATH);
         build = new Configurator();
         mysql = null;
-        source = new SourceInfo();
+        source = new SourceInfo(new NoOpOrderedIdBuilder());
     }
 
     @After

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import io.debezium.util.CounterIdBuilder;
 import org.apache.avro.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.fest.assertions.GenericAssert;
@@ -40,7 +41,7 @@ public class SourceInfoTest {
 
     @Before
     public void beforeEach() {
-        source = new SourceInfo();
+        source = new SourceInfo(new CounterIdBuilder());
         inTxn = false;
         positionOfBeginEvent = 0L;
         eventNumberInTxn = 0;
@@ -54,6 +55,7 @@ public class SourceInfoTest {
         assertThat(source.eventsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isFalse();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     @Test
@@ -63,6 +65,7 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(100);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isFalse();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     // -------------------------------------------------------------------------------------
@@ -77,6 +80,7 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(0);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isFalse();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     @Test
@@ -87,6 +91,7 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(100);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isFalse();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     @Test
@@ -97,6 +102,7 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(0);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isFalse();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     @Test
@@ -107,6 +113,7 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(100);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isFalse();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     @Test
@@ -117,6 +124,7 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(0);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isTrue();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     @Test
@@ -127,6 +135,7 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(100);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isTrue();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     @Test
@@ -137,6 +146,7 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(0);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isTrue();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     @Test
@@ -147,6 +157,7 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(100);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isTrue();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     @Test
@@ -157,6 +168,7 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(0);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isFalse();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     @Test
@@ -167,6 +179,7 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(0);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isFalse();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     @Test
@@ -177,6 +190,7 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(100);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isFalse();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     @Test
@@ -187,6 +201,7 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(100);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isFalse();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     @Test
@@ -197,6 +212,7 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(0);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isTrue();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     @Test
@@ -207,6 +223,7 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(0);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isTrue();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     @Test
@@ -217,6 +234,7 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(100);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(0);
         assertThat(source.isSnapshotInEffect()).isTrue();
+        assertThat(source.currentOrderId()).isEqualTo("0");
     }
 
     @Test
@@ -227,6 +245,18 @@ public class SourceInfoTest {
         assertThat(source.binlogPosition()).isEqualTo(100);
         assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
         assertThat(source.isSnapshotInEffect()).isTrue();
+        assertThat(source.currentOrderId()).isEqualTo("0");
+    }
+
+    @Test
+    public void shouldStartSourceInfoFromBinLongWithOrderId() {
+        sourceWith(offset(GTID_SET, 100, 5, true, "25"));
+        assertThat(source.gtidSet()).isEqualTo(GTID_SET);
+        assertThat(source.binlogFilename()).isEqualTo(FILENAME);
+        assertThat(source.binlogPosition()).isEqualTo(100);
+        assertThat(source.rowsToSkipUponRestart()).isEqualTo(5);
+        assertThat(source.isSnapshotInEffect()).isTrue();
+        assertThat(source.currentOrderId()).isEqualTo("25");
     }
 
     // -------------------------------------------------------------------------------------
@@ -239,41 +269,41 @@ public class SourceInfoTest {
 
         // Try a transactions with just one event ...
         handleTransactionBegin(150, 2);
-        handleNextEvent(200, 10, withRowCount(1));
+        handleNextEvent(200, 10, withRowCount(1), 1);
         handleTransactionCommit(210, 2);
 
         handleTransactionBegin(210, 2);
-        handleNextEvent(220, 10, withRowCount(1));
+        handleNextEvent(220, 10, withRowCount(1), 2);
         handleTransactionCommit(230, 3);
 
         handleTransactionBegin(240, 2);
-        handleNextEvent(250, 50, withRowCount(1));
+        handleNextEvent(250, 50, withRowCount(1), 3);
         handleTransactionCommit(300, 4);
 
         // Try a transactions with multiple events ...
         handleTransactionBegin(340, 2);
-        handleNextEvent(350, 20, withRowCount(1));
-        handleNextEvent(370, 30, withRowCount(1));
-        handleNextEvent(400, 40, withRowCount(1));
+        handleNextEvent(350, 20, withRowCount(1), 4);
+        handleNextEvent(370, 30, withRowCount(1), 5);
+        handleNextEvent(400, 40, withRowCount(1), 6);
         handleTransactionCommit(440, 4);
 
         handleTransactionBegin(500, 2);
-        handleNextEvent(510, 20, withRowCount(1));
-        handleNextEvent(540, 15, withRowCount(1));
-        handleNextEvent(560, 10, withRowCount(1));
+        handleNextEvent(510, 20, withRowCount(1), 7);
+        handleNextEvent(540, 15, withRowCount(1), 8);
+        handleNextEvent(560, 10, withRowCount(1), 9);
         handleTransactionCommit(580, 4);
 
         // Try another single event transaction ...
         handleTransactionBegin(600, 2);
-        handleNextEvent(610, 50, withRowCount(1));
+        handleNextEvent(610, 50, withRowCount(1), 10);
         handleTransactionCommit(660, 4);
 
         // Try event outside of a transaction ...
-        handleNextEvent(670, 10, withRowCount(1));
+        handleNextEvent(670, 10, withRowCount(1), 11);
 
         // Try another single event transaction ...
         handleTransactionBegin(700, 2);
-        handleNextEvent(710, 50, withRowCount(1));
+        handleNextEvent(710, 50, withRowCount(1), 12);
         handleTransactionCommit(760, 4);
     }
 
@@ -283,41 +313,41 @@ public class SourceInfoTest {
 
         // Try a transactions with just one event ...
         handleTransactionBegin(150, 2);
-        handleNextEvent(200, 10, withRowCount(3));
+        handleNextEvent(200, 10, withRowCount(3), 1);
         handleTransactionCommit(210, 2);
 
         handleTransactionBegin(210, 2);
-        handleNextEvent(220, 10, withRowCount(4));
+        handleNextEvent(220, 10, withRowCount(4), 4);
         handleTransactionCommit(230, 3);
 
         handleTransactionBegin(240, 2);
-        handleNextEvent(250, 50, withRowCount(5));
+        handleNextEvent(250, 50, withRowCount(5), 8);
         handleTransactionCommit(300, 4);
 
         // Try a transactions with multiple events ...
         handleTransactionBegin(340, 2);
-        handleNextEvent(350, 20, withRowCount(6));
-        handleNextEvent(370, 30, withRowCount(1));
-        handleNextEvent(400, 40, withRowCount(3));
+        handleNextEvent(350, 20, withRowCount(6), 13);
+        handleNextEvent(370, 30, withRowCount(1), 19);
+        handleNextEvent(400, 40, withRowCount(3), 20);
         handleTransactionCommit(440, 4);
 
         handleTransactionBegin(500, 2);
-        handleNextEvent(510, 20, withRowCount(8));
-        handleNextEvent(540, 15, withRowCount(9));
-        handleNextEvent(560, 10, withRowCount(1));
+        handleNextEvent(510, 20, withRowCount(8), 23);
+        handleNextEvent(540, 15, withRowCount(9), 31);
+        handleNextEvent(560, 10, withRowCount(1), 40);
         handleTransactionCommit(580, 4);
 
         // Try another single event transaction ...
         handleTransactionBegin(600, 2);
-        handleNextEvent(610, 50, withRowCount(1));
+        handleNextEvent(610, 50, withRowCount(1), 41);
         handleTransactionCommit(660, 4);
 
         // Try event outside of a transaction ...
-        handleNextEvent(670, 10, withRowCount(5));
+        handleNextEvent(670, 10, withRowCount(5), 42);
 
         // Try another single event transaction ...
         handleTransactionBegin(700, 2);
-        handleNextEvent(710, 50, withRowCount(3));
+        handleNextEvent(710, 50, withRowCount(3), 47);
         handleTransactionCommit(760, 4);
     }
 
@@ -359,13 +389,14 @@ public class SourceInfoTest {
         }
     }
 
-    protected void handleNextEvent(long positionOfEvent, long eventSize, int rowCount) {
+    protected void handleNextEvent(long positionOfEvent, long eventSize, int rowCount, int startOrderId) {
         if (inTxn) ++eventNumberInTxn;
         source.setEventPosition(positionOfEvent, eventSize);
         for (int row = 0; row != rowCount; ++row) {
             // Get the offset for this row (always first!) ...
             Map<String, ?> offset = source.offsetForRow(row, rowCount);
             assertThat(offset.get(SourceInfo.BINLOG_FILENAME_OFFSET_KEY)).isEqualTo(FILENAME);
+            assertThat(offset.get(SourceInfo.ORDER_ID_KEY)).isEqualTo(Integer.toString(startOrderId + row));
             if (source.gtidSet() != null) {
                 assertThat(offset.get(SourceInfo.GTID_SET_KEY)).isEqualTo(source.gtidSet());
             }
@@ -399,30 +430,37 @@ public class SourceInfoTest {
             if (source.gtidSet() != null) {
                 assertThat(recordSource.getString(SourceInfo.GTID_SET_KEY)).isEqualTo(source.gtidSet());
             }
+            assertThat(recordSource.getString(SourceInfo.ORDER_ID_KEY)).isEqualTo(Integer.toString(startOrderId + row));
         }
         source.completeEvent();
     }
 
     protected Map<String, String> offset(long position, int row) {
-        return offset(null, position, row, false);
+        return offset(null, position, row, false, null);
     }
 
     protected Map<String, String> offset(long position, int row, boolean snapshot) {
-        return offset(null, position, row, snapshot);
+        return offset(null, position, row, snapshot, null);
     }
 
     protected Map<String, String> offset(String gtidSet, long position, int row, boolean snapshot) {
+        return offset(gtidSet, position, row, snapshot, null);
+    }
+
+    protected Map<String, String> offset(String gtidSet, long position, int row, boolean snapshot,
+                                         String idState) {
         Map<String, String> offset = new HashMap<>();
         offset.put(SourceInfo.BINLOG_FILENAME_OFFSET_KEY, FILENAME);
         offset.put(SourceInfo.BINLOG_POSITION_OFFSET_KEY, Long.toString(position));
         offset.put(SourceInfo.BINLOG_ROW_IN_EVENT_OFFSET_KEY, Integer.toString(row));
         if (gtidSet != null) offset.put(SourceInfo.GTID_SET_KEY, gtidSet);
         if (snapshot) offset.put(SourceInfo.SNAPSHOT_KEY, Boolean.TRUE.toString());
+        if (idState != null) offset.put(SourceInfo.ORDER_ID_KEY, idState);
         return offset;
     }
 
     protected SourceInfo sourceWith(Map<String, String> offset) {
-        source = new SourceInfo();
+        source = new SourceInfo(new CounterIdBuilder());
         source.setOffset(offset);
         source.setServerName(SERVER_NAME);
         return source;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -75,7 +75,9 @@ public class PostgresConnectorTask extends BaseSourceTask {
         PostgresSchema schema = new PostgresSchema(connectorConfig, typeRegistry, databaseCharset, topicSelector);
         this.taskContext = new PostgresTaskContext(connectorConfig, schema, topicSelector);
 
-        SourceInfo sourceInfo = new SourceInfo(connectorConfig.getLogicalName(), connectorConfig.databaseName());
+        SourceInfo sourceInfo = new SourceInfo(connectorConfig.getLogicalName(),
+                connectorConfig.databaseName(),
+                connectorConfig.getIdBuilder());
         Map<String, Object> existingOffset = context.offsetStorageReader().offset(sourceInfo.partition());
         LoggingContext.PreviousContext previousContext = taskContext.configureLoggingContext(CONTEXT_NAME);
         try {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import io.debezium.util.NoOpOrderedIdBuilder;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.After;
 import org.junit.Before;
@@ -69,7 +70,9 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
 
     @Test
     public void shouldGenerateSnapshotsForDefaultDatatypes() throws Exception {
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false);
+        snapshotProducer = new RecordsSnapshotProducer(context,
+                new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE, new NoOpOrderedIdBuilder()),
+                false);
 
         TestConsumer consumer = testConsumer(ALL_STMTS.size(), "public", "Quoted__");
 
@@ -105,7 +108,9 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
                 TestHelper.getSchema(config),
                 PostgresTopicSelector.create(config)
         );
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false);
+        snapshotProducer = new RecordsSnapshotProducer(context,
+                new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE, new NoOpOrderedIdBuilder()),
+                false);
 
         final TestConsumer consumer = testConsumer(1, "public");
 
@@ -143,7 +148,9 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
                             insertStmt;
         TestHelper.execute(statements);
 
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), true);
+        snapshotProducer = new RecordsSnapshotProducer(context,
+                new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE, new NoOpOrderedIdBuilder()),
+                true);
         TestConsumer consumer = testConsumer(2, "s1", "s2");
         snapshotProducer.start(consumer, e -> {});
 
@@ -175,7 +182,9 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         // start a new producer back up, take a new snapshot (we expect all the records to be read back)
         int expectedRecordsCount = 6;
         consumer = testConsumer(expectedRecordsCount, "s1", "s2");
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), true);
+        snapshotProducer = new RecordsSnapshotProducer(context,
+                new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE, new NoOpOrderedIdBuilder()),
+                true);
         snapshotProducer.start(consumer, e -> {});
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
 
@@ -226,7 +235,9 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
                 selector
         );
 
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), true);
+        snapshotProducer = new RecordsSnapshotProducer(context,
+                new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE, new NoOpOrderedIdBuilder()),
+                true);
         TestConsumer consumer = testConsumer(2);
         snapshotProducer.start(consumer, e -> {});
 
@@ -268,7 +279,9 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
                 selector
         );
 
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false);
+        snapshotProducer = new RecordsSnapshotProducer(context,
+                new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE, new NoOpOrderedIdBuilder()),
+                false);
 
         TestConsumer consumer = testConsumer(ALL_STMTS.size(), "public", "Quoted__");
 
@@ -310,7 +323,9 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
                 selector
         );
 
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false);
+        snapshotProducer = new RecordsSnapshotProducer(context,
+                new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE, new NoOpOrderedIdBuilder()),
+                false);
 
         TestConsumer consumer = testConsumer(1, "public", "Quoted_\"");
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotWithOverridesProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotWithOverridesProducerIT.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import io.debezium.util.NoOpOrderedIdBuilder;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.fest.assertions.Assertions;
 import org.junit.After;
@@ -74,7 +75,9 @@ public class SnapshotWithOverridesProducerIT extends AbstractRecordsProducerTest
                 .with(PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE, "over.t1")
                 .with(PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE.name() + ".over.t1", "SELECT * FROM over.t1 WHERE pk > 100")
                 .build());
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false);
+        snapshotProducer = new RecordsSnapshotProducer(context,
+                new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE, new NoOpOrderedIdBuilder()),
+                false);
 
         final int expectedRecordsCount = 3 + 6;
 
@@ -96,7 +99,9 @@ public class SnapshotWithOverridesProducerIT extends AbstractRecordsProducerTest
                 .with(PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE.name() + ".over.t1", "SELECT * FROM over.t1 WHERE pk > 101")
                 .with(PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE.name() + ".over.t2", "SELECT * FROM over.t2 WHERE pk > 100")
                 .build());
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false);
+        snapshotProducer = new RecordsSnapshotProducer(context,
+                new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE, new NoOpOrderedIdBuilder()),
+                false);
 
         final int expectedRecordsCount = 2 + 3;
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SourceInfoTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SourceInfoTest.java
@@ -7,7 +7,10 @@ package io.debezium.connector.postgresql;
 
 import static org.fest.assertions.Assertions.assertThat;
 
+import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.relational.TableId;
+import io.debezium.util.CounterIdBuilder;
+import io.debezium.util.NoOpOrderedIdBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,7 +24,7 @@ public class SourceInfoTest {
 
     @Before
     public void beforeEach() {
-        source = new SourceInfo("serverX", "databaseX");
+        source = new SourceInfo("serverX", "databaseX", new NoOpOrderedIdBuilder());
         source.update(1L, new TableId("catalogNameX", "schemaNameX", "tableNameX"));
     }
 
@@ -33,5 +36,18 @@ public class SourceInfoTest {
     @Test
     public void connectorIsPresent() {
         assertThat(source.source().getString(SourceInfo.DEBEZIUM_CONNECTOR_KEY)).isEqualTo(Module.name());
+    }
+
+    @Test
+    public void idsGetIncrementedAsExpected() {
+        source = new SourceInfo("serverX", "databaseX", new CounterIdBuilder());
+        TableId t = new TableId("c", "s", "t");
+        source.update(1L, 1L, 1L, t, 1L);
+        source.offset();
+        assertThat(source.offset().get(AbstractSourceInfo.ORDER_ID_KEY)).isEqualTo("1");
+        assertThat(source.source().get(AbstractSourceInfo.ORDER_ID_KEY)).isEqualTo("1");
+        source.update(2L, t);
+        assertThat(source.offset().get(AbstractSourceInfo.ORDER_ID_KEY)).isEqualTo("2");
+        assertThat(source.source().get(AbstractSourceInfo.ORDER_ID_KEY)).isEqualTo("2");
     }
 }

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -31,6 +31,11 @@
             <artifactId>jackson-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>de.huxhorn.sulky</groupId>
+            <artifactId>de.huxhorn.sulky.ulid</artifactId>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/debezium-core/src/main/java/io/debezium/connector/AbstractSourceInfo.java
+++ b/debezium-core/src/main/java/io/debezium/connector/AbstractSourceInfo.java
@@ -5,8 +5,11 @@
  */
 package io.debezium.connector;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
+import io.debezium.util.OrderedIdBuilder;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -19,17 +22,21 @@ import org.apache.kafka.connect.data.Struct;
 public abstract class AbstractSourceInfo {
     public static final String DEBEZIUM_VERSION_KEY = "version";
     public static final String DEBEZIUM_CONNECTOR_KEY = "connector";
+    public static final String ORDER_ID_KEY = "order_id";
 
     private final String version;
+    private final OrderedIdBuilder idBuilder;
 
     protected static SchemaBuilder schemaBuilder() {
         return SchemaBuilder.struct()
                 .field(DEBEZIUM_VERSION_KEY, Schema.OPTIONAL_STRING_SCHEMA)
-                .field(DEBEZIUM_CONNECTOR_KEY, Schema.OPTIONAL_STRING_SCHEMA);
+                .field(DEBEZIUM_CONNECTOR_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                .field(ORDER_ID_KEY, OrderedIdBuilder.schema());
     }
 
-    protected AbstractSourceInfo(String version) {
+    protected AbstractSourceInfo(String version, OrderedIdBuilder idBuilder) {
         this.version = Objects.requireNonNull(version);
+        this.idBuilder = idBuilder;
     }
 
     /**
@@ -37,6 +44,28 @@ public abstract class AbstractSourceInfo {
      * {@link #schemaBuilder()} to add all shared fields to their schema.
      */
     protected abstract Schema schema();
+
+    /**
+     * Returns the OrderedIdBuilder for this class
+     */
+    protected OrderedIdBuilder idBuilder() {
+        return idBuilder;
+    }
+
+    /**
+     * Reset's the idBuilder state to a known value
+     * @param state the state to restore
+     */
+    protected void setIdState(String state) {
+        if (state == null) {
+            return;
+        }
+        idBuilder.restoreState(state);
+    }
+
+    protected String getNextId() {
+        return idBuilder.buildNextId();
+    }
 
     /**
      * Returns the string that identifies the connector relative to the database. Implementations should override
@@ -47,8 +76,20 @@ public abstract class AbstractSourceInfo {
     protected abstract String connector();
 
     protected Struct struct() {
-        return new Struct(schema())
+        Struct s = new Struct(schema())
                 .put(DEBEZIUM_VERSION_KEY, version)
                 .put(DEBEZIUM_CONNECTOR_KEY, connector());
+        if (idBuilder.shouldIncludeId()) {
+            s.put(ORDER_ID_KEY, idBuilder.lastId());
+        }
+        return s;
+    }
+
+    protected Map<String, Object> buildOffset() {
+        HashMap<String, Object> m = new HashMap<>();
+        if (idBuilder.shouldIncludeId()) {
+            m.put(ORDER_ID_KEY, idBuilder.lastId());
+        }
+        return m;
     }
 }

--- a/debezium-core/src/main/java/io/debezium/util/CounterIdBuilder.java
+++ b/debezium-core/src/main/java/io/debezium/util/CounterIdBuilder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class CounterIdBuilder extends OrderedIdBuilder {
+    private AtomicLong counter = new AtomicLong();
+    @Override
+    public Boolean shouldIncludeId() {
+        return true;
+    }
+
+    @Override
+    public String buildNextId() {
+        return Long.toString(counter.incrementAndGet());
+    }
+
+    @Override
+    public String lastId() {
+        return Long.toString(counter.get());
+    }
+
+    @Override
+    public void restoreState(String state) {
+        counter = new AtomicLong(Long.parseLong(state));
+    }
+
+    @Override
+    public OrderedIdBuilder clone() {
+        OrderedIdBuilder b = new CounterIdBuilder();
+        b.restoreState(this.lastId());
+        return b;
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/util/NoOpOrderedIdBuilder.java
+++ b/debezium-core/src/main/java/io/debezium/util/NoOpOrderedIdBuilder.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+public class NoOpOrderedIdBuilder extends OrderedIdBuilder {
+
+    @Override
+    public Boolean shouldIncludeId() {
+        return false;
+    }
+
+    @Override
+    public String buildNextId() {
+        return null;
+    }
+
+    @Override
+    public String lastId() {
+        return null;
+    }
+
+    @Override
+    public void restoreState(String state) {
+
+    }
+
+    @Override
+    public OrderedIdBuilder clone() {
+        return new NoOpOrderedIdBuilder();
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/util/OrderedIdBuilder.java
+++ b/debezium-core/src/main/java/io/debezium/util/OrderedIdBuilder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import org.apache.kafka.connect.data.Schema;
+
+public abstract class OrderedIdBuilder {
+    /**
+     * Indicates if this id builder should include an id
+     * @return true if it should include, otherwise false
+     */
+    public abstract Boolean shouldIncludeId();
+
+    /**
+     * builds the next id
+     * @return the next id
+     */
+    public abstract String buildNextId();
+
+    /**
+     * The last id that was generated
+     * @return the last id generated
+     */
+    public abstract String lastId();
+
+    /**
+     * restores to a previous id
+     * @param state the id to restore to
+     */
+    public abstract void restoreState(String state);
+
+    /**
+     * clones this id builder along with state.
+     *
+     * This is primarily used for connectors to track multiple
+     * sources simultaneously
+     * @return a new id builder with previous state
+     */
+    public abstract OrderedIdBuilder clone();
+
+    public static Schema schema() {
+        return Schema.OPTIONAL_STRING_SCHEMA;
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/util/UlidIdBuilder.java
+++ b/debezium-core/src/main/java/io/debezium/util/UlidIdBuilder.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import de.huxhorn.sulky.ulid.ULID;
+
+import java.util.Optional;
+
+public class UlidIdBuilder extends OrderedIdBuilder {
+    private final ULID idGen = new ULID();
+    private Clock clock = Clock.SYSTEM;
+
+    protected ULID.Value lastId = new ULID.Value(0, 0);
+
+    @Override
+    public Boolean shouldIncludeId() {
+        return true;
+    }
+
+    @Override
+    public String buildNextId() {
+        Optional<ULID.Value> n = next();
+        while(!n.isPresent()) {
+            // we just try and sleep here to next ms where
+            // we likely won't get a problem
+            // and ignore any interrupts, as we can just try
+            // again on the next loop
+            try {
+                Thread.sleep(1);
+            } catch (InterruptedException e) {
+                // do nothing
+            }
+            n = next();
+        }
+        lastId = n.get();
+
+        return lastId.toString();
+    }
+
+    @Override
+    public String lastId() {
+        return lastId.toString();
+    }
+
+    @Override
+    public void restoreState(String state) {
+        lastId = ULID.parseULID(state);
+    }
+
+    @Override
+    public OrderedIdBuilder clone() {
+        OrderedIdBuilder b = new UlidIdBuilder();
+        b.restoreState(this.lastId());
+        return b;
+    }
+
+    protected Optional<ULID.Value> next() {
+        return idGen.nextStrictlyMonotonicValue(lastId, clock.currentTimeInMillis());
+    }
+
+    protected void setClock(Clock clock) {
+        this.clock = clock;
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/data/VerifyRecord.java
+++ b/debezium-core/src/test/java/io/debezium/data/VerifyRecord.java
@@ -325,6 +325,25 @@ public class VerifyRecord {
     }
 
     /**
+     * Verify that the given {@link SourceRecord} has a valid order_id field.
+     *
+     * @param record the source record; may not be null
+     * @param idValue the id value that should match
+     */
+    public static void hasValidOrderId(final SourceRecord record, String idValue) {
+        assertValueField(record, "source/order_id", idValue);
+    }
+
+    /**
+     * Verify that the given {@link SourceRecord} has no order_id field
+     *
+     * @param record the source record; may not be null
+     */
+    public static void hasNoOrderId(final SourceRecord record) {
+        hasValidOrderId(record, null);
+    }
+
+    /**
      * Verify the given {@link SourceRecord} has the expected value in the given fieldPath.
      *
      * @param record the source record; may not be null
@@ -340,7 +359,7 @@ public class VerifyRecord {
             if (value instanceof Struct) {
                 value = ((Struct)value).get(fieldName);
             }
-            else {
+            else if (value != null) {
                 // We expected the value to be a struct ...
                 String path = pathSoFar == null ? "record value" : ("'" + pathSoFar + "'");
                 String msg = "Expected the " + path + " to be a Struct but was " + value.getClass().getSimpleName() + " in record: " + SchemaUtil.asString(record);
@@ -348,7 +367,7 @@ public class VerifyRecord {
             }
             pathSoFar = pathSoFar == null ? fieldName : pathSoFar + "/" + fieldName;
         }
-        assertSameValue(value,expectedValue);
+        assertSameValue(value, expectedValue);
     }
 
     /**

--- a/debezium-core/src/test/java/io/debezium/util/CounterIdBuilderTest.java
+++ b/debezium-core/src/test/java/io/debezium/util/CounterIdBuilderTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class CounterIdBuilderTest {
+    @Test
+    public void shouldAlwaysTryToBuildId() {
+        CounterIdBuilder b = new CounterIdBuilder();
+        assertThat(b.shouldIncludeId()).isTrue();
+    }
+
+    @Test
+    public void shouldBuildIdsMonotonically() {
+        CounterIdBuilder b = new CounterIdBuilder();
+        long lastId = 0L;
+        for (int i = 0; i < 100; i++) {
+            long newId = Long.parseLong(b.buildNextId());
+            assertThat(Long.parseLong(b.lastId())).isEqualTo(newId);
+            assertThat(newId).isEqualTo(lastId + 1);
+            lastId = newId;
+        }
+    }
+
+    @Test
+    public void shouldPersistAndRestoreState() {
+        CounterIdBuilder b1 = new CounterIdBuilder();
+        b1.buildNextId();
+        String state = b1.lastId();
+        CounterIdBuilder b2 = new CounterIdBuilder();
+
+        b2.restoreState(state);
+        assertThat(b2.lastId()).isEqualTo(b1.lastId());
+        assertThat(b1.buildNextId()).isEqualTo(b2.buildNextId());
+    }
+
+    @Test
+    public void shouldClone() {
+        CounterIdBuilder b1 = new CounterIdBuilder();
+        b1.buildNextId();
+        OrderedIdBuilder b2 = b1.clone();
+
+        assertThat(b2.lastId()).isEqualTo(b1.lastId());
+    }
+
+}

--- a/debezium-core/src/test/java/io/debezium/util/NoOpOrderedIdBuilderTest.java
+++ b/debezium-core/src/test/java/io/debezium/util/NoOpOrderedIdBuilderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class NoOpOrderedIdBuilderTest {
+
+    @Test
+    public void shouldIncludeId() {
+        assertThat(new NoOpOrderedIdBuilder().shouldIncludeId()).isFalse();
+    }
+
+    @Test
+    public void buildNextId() {
+        assertThat(new NoOpOrderedIdBuilder().buildNextId()).isNull();
+    }
+
+    @Test
+    public void lastId() {
+        NoOpOrderedIdBuilder b = new NoOpOrderedIdBuilder();
+        b.buildNextId();
+        assertThat(b.lastId()).isNull();
+    }
+
+    @Test
+    public void shouldPersistAndRestoreState() {
+        OrderedIdBuilder b = new NoOpOrderedIdBuilder();
+        b.buildNextId();
+        assertThat(b.lastId()).isNull();
+        // doesn't throw anything
+        b.restoreState(null);
+    }
+
+    @Test
+    public void shouldClone() {
+        CounterIdBuilder b1 = new CounterIdBuilder();
+        b1.buildNextId();
+        OrderedIdBuilder b2 = b1.clone();
+
+        assertThat(b2.lastId()).isEqualTo(b1.lastId());
+    }
+
+}

--- a/debezium-core/src/test/java/io/debezium/util/UlidIdBuilderTest.java
+++ b/debezium-core/src/test/java/io/debezium/util/UlidIdBuilderTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import de.huxhorn.sulky.ulid.ULID;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class UlidIdBuilderTest {
+
+    @Test
+    public void shouldAlwaysTryToBuildId() {
+        UlidIdBuilder b = new UlidIdBuilder();
+        assertThat(b.shouldIncludeId()).isTrue();
+    }
+
+    @Test
+    public void shouldBuildIdsMonotonically() {
+        UlidIdBuilder b = new UlidIdBuilder();
+        String lastId = "";
+        for (int i = 0; i < 100; i++) {
+            String newId = b.buildNextId();
+            assertThat(b.lastId()).isEqualTo(newId);
+            assertThat(newId.compareTo(lastId)).isGreaterThan(0);
+            lastId = newId;
+        }
+    }
+
+    @Test
+    public void shouldHandleOverflow() {
+        UlidIdBuilder b = new UlidIdBuilder() {
+            int count = 0;
+            @Override
+            protected Optional<ULID.Value> next() {
+                if (count < 5) {
+                    count++;
+                    return Optional.empty();
+                } else {
+                    return Optional.of(new ULID.Value(0, 0));
+                }
+            }
+        };
+        long st = System.currentTimeMillis();
+        char[] zeroes = new char[26];
+        Arrays.fill(zeroes, '0');
+        assertThat(b.buildNextId()).isEqualTo(new String(zeroes));
+        assertThat(System.currentTimeMillis() - st).isGreaterThan(4);
+    }
+
+    @Test
+    public void shouldPersistAndRestoreState() {
+        Clock sameClock = () -> 0;
+        UlidIdBuilder b1 = new UlidIdBuilder();
+        b1.setClock(sameClock);
+        // build id to trigger first state
+        b1.buildNextId();
+
+        String id1 = b1.buildNextId();
+        String state = b1.lastId();
+        UlidIdBuilder b2 = new UlidIdBuilder();
+        b2.setClock(sameClock);
+
+        b2.restoreState(state);
+        assertThat(b1.lastId()).isEqualTo(b2.lastId());
+
+        String id2 = b2.buildNextId();
+
+        assertThat(id2.compareTo(id1)).isGreaterThan(0);
+        // assert that they start with the same timestamp
+        assertThat(id1.substring(0, 11)).isEqualTo(id2.substring(0, 11));
+        // they should be one character different
+        assertThat(id1.substring(11, id1.length() - 1)).isEqualTo(id2.substring(11, id2.length() - 1));
+        assertThat(id1.charAt(id1.length() - 1) - id2.charAt(id2.length() - 1)).isEqualTo(-1);
+    }
+
+    @Test
+    public void shouldClone() {
+        CounterIdBuilder b1 = new CounterIdBuilder();
+        b1.buildNextId();
+        OrderedIdBuilder b2 = b1.clone();
+
+        assertThat(b2.lastId()).isEqualTo(b1.lastId());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,9 @@
         <!-- ANTLR -->
         <antlr.version>4.7</antlr.version>
 
+        <!-- ulid -->
+        <ulid.version>8.2.0</ulid.version>
+
         <!-- Testing -->
         <version.junit>4.12</version.junit>
         <version.fest>1.4</version.fest>
@@ -170,6 +173,11 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>${version.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>de.huxhorn.sulky</groupId>
+                <artifactId>de.huxhorn.sulky.ulid</artifactId>
+                <version>${ulid.version}</version>
             </dependency>
 
             <!-- Kafka Connect -->


### PR DESCRIPTION
This commit adds a new optional ID that can be used to order the
messages.

It introduces a new configuration option, `ADD_ORDERED_ID` that appends
a new field `ulid` which is a unique, lexigraphically sortable id.

This is tested in postgres, but should work in mysql as well.