### PR TITLE
DBZ-1080 new API for EmbeddedEngine for batch/async

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -507,8 +507,8 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
             }
         }
         // Theoretically the LSN should change for each record but in reality there can be
-        // unfrotunate timings so let's suppose the chane will hapeni in 75 % of cases
-        Assertions.assertThat(flushLsn.size()).isGreaterThan((recordCount * 3) / 4);
+        // unfortunate timings so let's suppose the chane will happen in 75 % of cases
+        Assertions.assertThat(flushLsn.size()).isGreaterThanOrEqualTo((recordCount * 3) / 4);
     }
 
     private String getConfirmedFlushLsn(PostgresConnection connection) throws SQLException {

--- a/debezium-embedded/src/main/java/io/debezium/embedded/StopConnectorException.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/StopConnectorException.java
@@ -5,14 +5,19 @@
  */
 package io.debezium.embedded;
 
+import java.util.function.Consumer;
+
 import org.apache.kafka.connect.errors.ConnectException;
 
 /**
- * An exception that is used to tell the connector to process the last source record and to then stop.
- * 
+ * An exception that is used to tell the connector to process the last source record and to then stop. When raised by
+ * {@link Consumer} implementations passed to {@link EmbeddedEngine.Builder#notifying(Consumer)}, this exception should
+ * only be raised after that consumer has safely processed the passed event.
+ *
  * @author Randall Hauch
  */
 public class StopConnectorException extends ConnectException {
+
     private static final long serialVersionUID = 1L;
 
     public StopConnectorException(String msg) {

--- a/debezium-embedded/src/test/java/io/debezium/embedded/EmbeddedEngineTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/EmbeddedEngineTest.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.embedded;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -13,21 +15,20 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import io.debezium.util.LoggingContext;
 import org.apache.kafka.connect.file.FileStreamSourceConnector;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
-
 import io.debezium.config.Configuration;
+import io.debezium.doc.FixFor;
 import io.debezium.util.Collect;
+import io.debezium.util.LoggingContext;
 import io.debezium.util.Testing;
 
 /**
@@ -93,6 +94,7 @@ public class EmbeddedEngineTest extends AbstractConnectorTest {
     }
 
     @Test
+    @FixFor("DBZ-1080")
     public void shouldWorkToUseCustomChangeConsumer() throws Exception {
         // Add initial content to the file ...
         appendLinesToSource(NUMBER_OF_LINES);
@@ -115,7 +117,8 @@ public class EmbeddedEngineTest extends AbstractConnectorTest {
                     records.forEach((r) -> {
                         try {
                             committer.markProcessed(r);
-                        } catch (InterruptedException ex) {
+                        }
+                        catch (InterruptedException ex) {
                             Thread.interrupted();
                         }
                     });


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1080

This introduces a new API to the EmbeddedEngine, the ChangeConsumer,
which gives the user a more flexible option for consuming changes by
exposing groups of records as well as the ability to control the
comitting of those records.

This remainds completely backwards compatible with the old API as the
ChangeConsumer wraps the existing Consumer interface with a default
implementation.