### PR TITLE
DBZ-1081 Fallback to restart_lsn in pg 9.5

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -80,7 +80,7 @@ public final class TestHelper {
     /**
      * @return the decoder plugin used for testing and configured by system property
      */
-    static PostgresConnectorConfig.LogicalDecoder decoderPlugin() {
+    public static PostgresConnectorConfig.LogicalDecoder decoderPlugin() {
         final String s = System.getProperty(PostgresConnectorConfig.PLUGIN_NAME.name());
         return (s == null || s.length() == 0) ? PostgresConnectorConfig.LogicalDecoder.DECODERBUFS : PostgresConnectorConfig.LogicalDecoder.parse(s);
     }
@@ -174,7 +174,7 @@ public final class TestHelper {
         }
     }
 
-    private static JdbcConfiguration defaultJdbcConfig() {
+    public static JdbcConfiguration defaultJdbcConfig() {
         return JdbcConfiguration.copy(Configuration.fromSystemProperties("database."))
                                 .withDefault(JdbcConfiguration.DATABASE, "postgres")
                                 .withDefault(JdbcConfiguration.HOSTNAME, "localhost")


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1081

In pg 9.5, confirmed_flush_lsn is not availiable. However, there is
restart_lsn, which should be safe to use with a downside of producing
some extra duplicate records.

This page: https://paquier.xyz/postgresql-2/postgres-9-6-feature-highlight-replication-slot-improvements/
indicates as such and this allows for DBZ to support PG 9.5
