### PR TITLE
DBZ-1082 Add a new Postgres Snapshot mode, WRITE_RECOVERY

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -108,7 +108,10 @@ public class PostgresConnectorTask extends BaseSourceTask {
                     }
                 } else if (connectorConfig.alwaysTakeSnapshot()) {
                     logger.info("Taking a new snapshot as per configuration");
-                    producer = new RecordsSnapshotProducer(taskContext, sourceInfo, true);
+                    producer = new RecordsSnapshotProducer(taskContext, sourceInfo, true, false);
+                } else if (connectorConfig.writeRecoverySnapshot()) {
+                    logger.info("Attempting a recovery snapshot as per configuration");
+                    producer = new RecordsSnapshotProducer(taskContext, sourceInfo, true, true);
                 } else {
                     logger.info(
                             "Previous snapshot has completed successfully, streaming logical changes from last known position");
@@ -135,10 +138,10 @@ public class PostgresConnectorTask extends BaseSourceTask {
     private void createSnapshotProducer(PostgresTaskContext taskContext, SourceInfo sourceInfo, boolean initialOnlySnapshot) {
         if (initialOnlySnapshot) {
             logger.info("Taking only a snapshot of the DB without streaming any changes afterwards...");
-            producer = new RecordsSnapshotProducer(taskContext, sourceInfo, false);
+            producer = new RecordsSnapshotProducer(taskContext, sourceInfo, false, false);
         } else {
             logger.info("Taking a new snapshot of the DB and streaming logical changes once the snapshot is finished...");
-            producer = new RecordsSnapshotProducer(taskContext, sourceInfo, true);
+            producer = new RecordsSnapshotProducer(taskContext, sourceInfo, true, false);
         }
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
@@ -152,11 +152,11 @@ public class RecordsStreamProducer extends RecordsProducer {
         LoggingContext.PreviousContext previousContext = taskContext.configureLoggingContext(CONTEXT_NAME);
         try {
             ReplicationStream replicationStream = this.replicationStream.get();
+
             if (replicationStream != null) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Flushing LSN to server: {}", LogSequenceNumber.valueOf(lsn));
                 }
-
                 // tell the server the point up to which we've processed data, so it can be free to recycle WAL segments
                 replicationStream.flushLsn(lsn);
             }
@@ -241,7 +241,7 @@ public class RecordsStreamProducer extends RecordsProducer {
         // update the source info with the coordinates for this message
         long commitTimeNs = message.getCommitTime();
         long txId = message.getTransactionId();
-        sourceInfo.update(lsn, commitTimeNs, txId, tableId);
+        sourceInfo.update(lsn, commitTimeNs, txId, tableId, taskContext.getSlotXmin());
         if (logger.isDebugEnabled()) {
             logger.debug("received new message at position {}\n{}", ReplicationConnection.format(lsn), message);
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -127,28 +127,55 @@ public class PostgresConnection extends JdbcConnection {
         return ServerInfo.ReplicaIdentity.parseFromDB(replIdentity.toString());
     }
 
+    /**
+     * Fetches the state of a replication stage given a slot name and plugin name
+     * @param slotName the name of the slot
+     * @param pluginName the name of the plugin used for the desired slot
+     * @return the {@link ServerInfo.ReplicationSlot} object or a {@link ServerInfo.ReplicationSlot#INVALID} if
+     *         the slot is not valid
+     * @throws SQLException is thrown by the underlying JDBC
+     */
+    public ServerInfo.ReplicationSlot fetchReplicationSlotInfo(String slotName, String pluginName) throws SQLException {
+        final String database = database();
+        final ServerInfo.ReplicationSlot slot = queryForSlot(slotName, database, pluginName,
+                rs -> {
+                    if (rs.next()) {
+                        boolean active = rs.getBoolean("active");
+                        Long confirmedFlushedLSN = parseConfirmedFlushLsn(slotName, pluginName, database, rs);
+                        if (confirmedFlushedLSN == null) {
+                            return null;
+                        }
+                        Long xmin = rs.getLong("catalog_xmin");
+                        return new ServerInfo.ReplicationSlot(active, confirmedFlushedLSN, xmin);
+                    }
+                    else {
+                        LOGGER.debug("No replication slot '{}' is present for plugin '{}' and database '{}'", slotName,
+                                pluginName, database);
+                        return ServerInfo.ReplicationSlot.INVALID;
+                    }
+                }
+        );
+        return slot;
+    }
+
+    /**
+     * Fetches a replication slot, repeating the query until either the slot is created or until
+     * the max number of attempts has been reached
+     *
+     * To fetch the slot without teh retries, use the {@link PostgresConnection#fetchReplicationSlotInfo} call
+     * @param slotName the slot name
+     * @param pluginName the name of the plugin
+     * @return the {@link ServerInfo.ReplicationSlot} object or a {@link ServerInfo.ReplicationSlot#INVALID} if
+     *         the slot is not valid
+     * @throws SQLException is thrown by the underyling jdbc driver
+     * @throws InterruptedException is thrown if we don't return an answer within the set number of retries
+     */
     protected ServerInfo.ReplicationSlot readReplicationSlotInfo(String slotName, String pluginName) throws SQLException, InterruptedException {
         final String database = database();
         final Metronome metronome = Metronome.parker(PAUSE_BETWEEN_REPLICATION_SLOT_RETRIEVAL_ATTEMPTS, Clock.SYSTEM);
 
         for (int attempt = 1; attempt <= MAX_ATTEMPTS_FOR_OBTAINING_REPLICATION_SLOT; attempt++) {
-            final ServerInfo.ReplicationSlot slot = queryForSlot(slotName, database, pluginName,
-                    rs -> {
-                        if (rs.next()) {
-                            boolean active = rs.getBoolean("active");
-                            Long confirmedFlushedLSN = parseConfirmedFlushLsn(slotName, pluginName, database, rs);
-                            if (confirmedFlushedLSN == null) {
-                                return null;
-                            }
-                            return new ServerInfo.ReplicationSlot(active, confirmedFlushedLSN);
-                        }
-                        else {
-                            LOGGER.debug("No replication slot '{}' is present for plugin '{}' and database '{}'", slotName,
-                                         pluginName, database);
-                            return ServerInfo.ReplicationSlot.INVALID;
-                        }
-                    }
-               );
+            final ServerInfo.ReplicationSlot slot = fetchReplicationSlotInfo(slotName, pluginName);
             if (slot != null) {
                 LOGGER.info("Obtained valid replication slot {}", slot);
                 return slot;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ServerInfo.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ServerInfo.java
@@ -138,32 +138,38 @@ public class ServerInfo {
     /**
      * Information about a server replication slot
      */
-    protected static class ReplicationSlot {
-        protected static final ReplicationSlot INVALID = new ReplicationSlot(false, null);
+    public static class ReplicationSlot {
+        static final ReplicationSlot INVALID = new ReplicationSlot(false, null, null);
         
         private boolean active;
         private Long latestFlushedLSN;
-        
-        protected ReplicationSlot(boolean active, Long latestFlushedLSN) {
+        private Long catalogXmin;
+
+        protected ReplicationSlot(boolean active, Long latestFlushedLSN, Long catalogXmin) {
             this.active = active;
             this.latestFlushedLSN = latestFlushedLSN;
+            this.catalogXmin = catalogXmin;
         }
         
-        protected boolean active() {
+        public boolean active() {
             return active;
         }
         
-        protected Long latestFlushedLSN() {
+        public Long latestFlushedLSN() {
             return latestFlushedLSN;
         }
+
+        public Long catalogXmin() {
+            return catalogXmin;
+        }
         
-        protected boolean hasValidFlushedLSN() {
+        public boolean hasValidFlushedLSN() {
             return latestFlushedLSN != null;
         }
 
         @Override
         public String toString() {
-            return "ReplicationSlot [active=" + active + ", latestFlushedLSN=" + latestFlushedLSN + "]";
+            return "ReplicationSlot [active=" + active + ", latestFlushedLSN=" + latestFlushedLSN + ", catalogXmin=" + catalogXmin + "]";
         }
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -12,12 +12,16 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import io.debezium.connector.postgresql.connection.PostgresConnection;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.After;
 import org.junit.Before;
@@ -69,7 +73,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
 
     @Test
     public void shouldGenerateSnapshotsForDefaultDatatypes() throws Exception {
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false);
+        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false, false);
 
         TestConsumer consumer = testConsumer(ALL_STMTS.size(), "public", "Quoted__");
 
@@ -105,7 +109,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
                 TestHelper.getSchema(config),
                 PostgresTopicSelector.create(config)
         );
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false);
+        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false, false);
 
         final TestConsumer consumer = testConsumer(1, "public");
 
@@ -143,7 +147,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
                             insertStmt;
         TestHelper.execute(statements);
 
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), true);
+        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), true, false);
         TestConsumer consumer = testConsumer(2, "s1", "s2");
         snapshotProducer.start(consumer, e -> {});
 
@@ -175,7 +179,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         // start a new producer back up, take a new snapshot (we expect all the records to be read back)
         int expectedRecordsCount = 6;
         consumer = testConsumer(expectedRecordsCount, "s1", "s2");
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), true);
+        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), true, false);
         snapshotProducer.start(consumer, e -> {});
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
 
@@ -226,7 +230,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
                 selector
         );
 
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), true);
+        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), true, false);
         TestConsumer consumer = testConsumer(2);
         snapshotProducer.start(consumer, e -> {});
 
@@ -236,13 +240,188 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         final SourceRecord first = consumer.remove();
         VerifyRecord.isValidRead(first, PK_FIELD, 1);
         assertRecordOffsetAndSnapshotSource(first, true, true);
-        System.out.println(first);
         final SourceRecord second = consumer.remove();
         assertThat(second.topic()).startsWith("__debezium-heartbeat");
         assertRecordOffsetAndSnapshotSource(second, false, false);
 
         // now shut down the producers and insert some more records
         snapshotProducer.stop();
+    }
+
+    @Test
+    public void shouldDoAPartialRecoveryWithXmin() throws Exception {
+        // this tests works by
+        // 1. creating some writes before on the previous slot
+        // 2. drop the previous slot
+        // 3. create a new slot
+        // 4. use the xmin in first slot and show it only fetches records >= that xmin
+        //
+        // However, we "fake" the first slot and first xmin as it is hard to force psql to advance
+        // the xmin of a slot. We do this by simply creating a record and using the xmin of that
+        // record as the lower bound for our new slot
+        //
+        TestHelper.dropAllSchemas();
+        // create the table and insert first fake record
+        TestHelper.execute("CREATE TABLE t1 (pk SERIAL, aa integer, PRIMARY KEY(pk)); INSERT INTO t1 VALUES (default, 11)");
+        // instead of using slot xmin, cheat and use the xmin from the newly inserted record as the
+        // the slots xmin
+        long xmin;
+        String xminSlotName = "xmin_recovery";
+        try (PostgresConnection conn = TestHelper.create()) {
+            Connection jconn = conn.connection();
+            Statement sxmin = jconn.createStatement();
+            ResultSet rs = sxmin.executeQuery("SELECT xmin::text::int FROM t1 where pk = 1");
+            assertThat(rs.next()).isTrue();
+            xmin = rs.getInt(1);
+            // just make sure our named slot is clear..
+            conn.dropReplicationSlot(xminSlotName);
+        }
+        // insert more records, theses ones we would have "missed" after the slot being dropped
+        String insertStmt = "INSERT INTO t1 VALUES (default, 12); INSERT INTO t1 VALUES (default, 13)";
+        TestHelper.execute(insertStmt);
+        // create a new slot after writes to simulate a failover of a slot
+        TestHelper.createForReplication("xmin_recovery", true);
+
+        PostgresConnectorConfig config = new PostgresConnectorConfig(
+                TestHelper.defaultConfig()
+                        .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.WRITE_RECOVERY)
+                        .with(PostgresConnectorConfig.SLOT_NAME, "xmin_recovery")
+                        .build()
+        );
+        TopicSelector<TableId> selector = PostgresTopicSelector.create(config);
+        context = new PostgresTaskContext(
+                config,
+                TestHelper.getSchema(config),
+                selector
+        );
+
+        SourceInfo source = new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE);
+        source.update(0L, null, 0L, null, xmin);
+        snapshotProducer = new RecordsSnapshotProducer(context, source, true, true);
+        // we only should expect records after our xmin
+        TestConsumer consumer = testConsumer(2);
+        snapshotProducer.start(consumer, e -> {});
+
+        consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
+
+        // assert we don't get our first record
+        final SourceRecord first = consumer.remove();
+        VerifyRecord.isValidRead(first, PK_FIELD, 2);
+        assertRecordOffsetAndSnapshotSource(first, true, false);
+        final SourceRecord second = consumer.remove();
+        assertRecordOffsetAndSnapshotSource(second, true, true);
+        VerifyRecord.isValidRead(second, PK_FIELD, 3);
+
+        consumer.clear();
+
+        // now insert two more records and check that we only get those back from the stream
+        TestHelper.execute(insertStmt);
+        consumer.expects(2);
+
+        consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
+        final SourceRecord third = consumer.remove();
+        VerifyRecord.isValidInsert(third, PK_FIELD, 4);
+        assertRecordOffsetAndSnapshotSource(third, false, false);
+        final SourceRecord fourth = consumer.remove();
+        VerifyRecord.isValidInsert(fourth, PK_FIELD, 5);
+        assertRecordOffsetAndSnapshotSource(fourth, false, false);
+        snapshotProducer.stop();
+    }
+
+    @Test
+    public void shouldSkipRecoveryWithXmin() throws Exception {
+        // This test simply shows that even with a SnapshotProducer we skip the need to
+        // do a recovery if the slot state persists, this should be doable simply by creating
+        // two consumers
+        String xminSlotName = "xmin_restart";
+        try (PostgresConnection conn = TestHelper.create()) {
+            // just make sure our named slot is clear..
+            conn.dropReplicationSlot(xminSlotName);
+        }
+        TestHelper.createForReplication(xminSlotName, false);
+        TestHelper.dropAllSchemas();
+        TestHelper.execute("CREATE TABLE t1 (pk SERIAL, aa integer, PRIMARY KEY(pk));");
+        String insertStmt = "INSERT INTO t1 VALUES (default, 12); INSERT INTO t1 VALUES (default, 13)";
+        TestHelper.execute(insertStmt);
+        PostgresConnectorConfig config = new PostgresConnectorConfig(
+                TestHelper.defaultConfig()
+                        .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.WRITE_RECOVERY)
+                        .with(PostgresConnectorConfig.SLOT_NAME, xminSlotName)
+                        .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, false)
+                        .build()
+        );
+        TopicSelector<TableId> selector = PostgresTopicSelector.create(config);
+        context = new PostgresTaskContext(
+                config,
+                TestHelper.getSchema(config),
+                selector
+        );
+        SourceInfo source = new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE);
+        snapshotProducer = new RecordsSnapshotProducer(context, source, true, true);
+        TestConsumer consumer = testConsumer(4);
+        snapshotProducer.start(consumer, e -> {});
+        // TODO: for some reason, this needs a sleep here when all together
+        // It seems like it is blocked on some underyling
+        // resource, perhaps a socket back to a thread pool?
+        Thread.sleep(100);
+
+        // insert more to ensure we have some non snaps too
+        TestHelper.execute(insertStmt);
+
+        consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
+
+        final SourceRecord first = consumer.remove();
+        VerifyRecord.isValidRead(first, PK_FIELD, 1);
+        assertRecordOffsetAndSnapshotSource(first, true, false);
+        final SourceRecord second = consumer.remove();
+        assertRecordOffsetAndSnapshotSource(second, true, true);
+        VerifyRecord.isValidRead(second, PK_FIELD, 2);
+
+        // first streamed records
+        final SourceRecord third = consumer.remove();
+        VerifyRecord.isValidInsert(third, PK_FIELD, 3);
+        assertRecordOffsetAndSnapshotSource(third, false, false);
+        final SourceRecord fourth = consumer.remove();
+        assertRecordOffsetAndSnapshotSource(fourth, false, false);
+        VerifyRecord.isValidInsert(fourth, PK_FIELD, 4);
+        // commit the last LSN to the slot, this allows us to restart in a proper spot
+        Long lsn = (Long) fourth.sourceOffset().get(SourceInfo.LSN_KEY);
+        snapshotProducer.commit(lsn);
+        Thread.sleep(1000);
+
+        // stop our producer and make a new one
+        snapshotProducer.stop();
+        consumer.clear();
+
+        // now insert two more records and check that we only get those back from the stream
+        TestHelper.execute(insertStmt);
+        consumer.expects(2);
+
+        // generate a new sourceinfo from our last record
+        // when we commit, the xmin may get advanced, so we need to advance our saved xmin to account for it
+        SourceInfo restartSource = new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE);
+        restartSource.update(lsn,
+                (Long) fourth.sourceOffset().get(SourceInfo.TIMESTAMP_KEY),
+                (Long) fourth.sourceOffset().get(SourceInfo.TXID_KEY),
+                (TableId) fourth.sourceOffset().get(SourceInfo.TABLE_NAME_KEY),
+                context.getCurrentSlotInfo().catalogXmin());
+
+        snapshotProducer = new RecordsSnapshotProducer(context, restartSource, true, true);
+        snapshotProducer.start(consumer, e -> {});
+        consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
+
+        final SourceRecord fifth = consumer.remove();
+        VerifyRecord.isValidInsert(fifth, PK_FIELD, 5);
+        assertRecordOffsetAndSnapshotSource(fifth, false, false);
+        final SourceRecord sixth = consumer.remove();
+        assertRecordOffsetAndSnapshotSource(sixth, false, false);
+        VerifyRecord.isValidInsert(sixth, PK_FIELD, 6);
+
+        snapshotProducer.stop();
+        try (PostgresConnection conn = TestHelper.create()) {
+            // just make sure our named slot is clear..
+            conn.dropReplicationSlot(xminSlotName);
+        }
     }
 
     private void assertReadRecord(SourceRecord record, Map<String, List<SchemaAndValueField>> expectedValuesByTopicName) {
@@ -268,7 +447,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
                 selector
         );
 
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false);
+        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false, false);
 
         TestConsumer consumer = testConsumer(ALL_STMTS.size(), "public", "Quoted__");
 
@@ -310,7 +489,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
                 selector
         );
 
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false);
+        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false, false);
 
         TestConsumer consumer = testConsumer(1, "public", "Quoted_\"");
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.connector.postgresql.connection.ReplicationConnection;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -60,6 +62,10 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
     @Before
     public void before() throws Exception {
+        // ensure the slot is deleted for each test
+        try (PostgresConnection conn = TestHelper.create()) {
+            conn.dropReplicationSlot(ReplicationConnection.Builder.DEFAULT_SLOT_NAME);
+        }
         TestHelper.dropAllSchemas();
         TestHelper.executeDDL("init_postgis.ddl");
         String statements =

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotWithOverridesProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotWithOverridesProducerIT.java
@@ -74,7 +74,7 @@ public class SnapshotWithOverridesProducerIT extends AbstractRecordsProducerTest
                 .with(PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE, "over.t1")
                 .with(PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE.name() + ".over.t1", "SELECT * FROM over.t1 WHERE pk > 100")
                 .build());
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false);
+        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false, false);
 
         final int expectedRecordsCount = 3 + 6;
 
@@ -96,7 +96,7 @@ public class SnapshotWithOverridesProducerIT extends AbstractRecordsProducerTest
                 .with(PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE.name() + ".over.t1", "SELECT * FROM over.t1 WHERE pk > 101")
                 .with(PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE.name() + ".over.t2", "SELECT * FROM over.t2 WHERE pk > 100")
                 .build());
-        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false);
+        snapshotProducer = new RecordsSnapshotProducer(context, new SourceInfo(TestHelper.TEST_SERVER, TestHelper.TEST_DATABASE), false, false);
 
         final int expectedRecordsCount = 2 + 3;
 

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -159,7 +159,7 @@ public final class EmbeddedEngine implements Runnable {
     public static final Field OFFSET_COMMIT_POLICY = Field.create("offset.commit.policy")
                                                           .withDescription("The fully-qualified class name of the commit policy type. This class must implement the interface "
                                                                       + OffsetCommitPolicy.class.getName()
-                                                                      + ". The default is a periodic commity policy based upon time intervals.")
+                                                                      + ". The default is a periodic commit policy based upon time intervals.")
                                                           .withDefault(OffsetCommitPolicy.PeriodicCommitOffsetPolicy.class.getName())
                                                           .withValidation(Field::isClassName);
 


### PR DESCRIPTION
This commit adds a new snapshot mode to postgres connector, WRITE_RECOVERY,
which is intended to allow the user to recover the writes in the event
of a lost postgres replication slot.

This works by keeping track of the "catalog_xmin" from the replication
slot and then using this to find any records that may have changed in
the event of losing a slot by searching for records only more
recent than the last known `catalog_xmin`

See the docs PR for more details: https://github.com/debezium/debezium.github.io/pull/241

Just to re-iterate on the limitations of this:
- It only gurantees you see the latest version of `INSERT` and `UPDATE`
opreations, `DELETE` may still be missed
- It may miss intermediate row states, in the event of multiple changes
to a row during the time period we are recovering from