### PR TITLE
DBZ-1029 Revert back non-param method to require key

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -1076,7 +1076,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         consumer.expects(1);
         executeAndWait("UPDATE test_table set text='b' WHERE id=1");
         SourceRecord updatedRecord = consumer.remove();
-        VerifyRecord.isValidUpdate(updatedRecord);
+        VerifyRecord.isValidUpdate(updatedRecord, false);
 
         List<SchemaAndValueField> expectedBefore = Arrays.asList(
                 new SchemaAndValueField("id", SchemaBuilder.INT32_SCHEMA, 1),
@@ -1094,7 +1094,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         consumer.expects(2);
         executeAndWait("DELETE FROM test_table WHERE id=1");
         SourceRecord deletedRecord = consumer.remove();
-        VerifyRecord.isValidDelete(deletedRecord);
+        VerifyRecord.isValidDelete(deletedRecord, false);
 
         expectedBefore = Arrays.asList(
                 new SchemaAndValueField("id", SchemaBuilder.INT32_SCHEMA, 1),
@@ -1161,7 +1161,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
             VerifyRecord.isValidInsert(insertedRecord, pkColumn, pk);
         }
         else {
-            VerifyRecord.isValidInsert(insertedRecord);
+            VerifyRecord.isValidInsert(insertedRecord, false);
         }
 
         return insertedRecord;

--- a/debezium-core/src/test/java/io/debezium/data/VerifyRecord.java
+++ b/debezium-core/src/test/java/io/debezium/data/VerifyRecord.java
@@ -207,12 +207,12 @@ public class VerifyRecord {
     }
 
     /**
-     * Verify that the given {@link SourceRecord} is a {@link Operation#CREATE INSERT/CREATE} record without primary key.
+     * Verify that the given {@link SourceRecord} is a {@link Operation#CREATE INSERT/CREATE} record with primary key.
      *
      * @param record the source record; may not be null
      */
     public static void isValidInsert(SourceRecord record) {
-        isValidInsert(record, false);
+        isValidInsert(record, true);
     }
 
     /**
@@ -242,14 +242,14 @@ public class VerifyRecord {
     }
 
     /**
-     * Verify that the given {@link SourceRecord} is a {@link Operation#UPDATE UPDATE} record without PK.
+     * Verify that the given {@link SourceRecord} is a {@link Operation#UPDATE UPDATE} record with PK.
      *
      * @param record the source record; may not be null
      * @param pkField the single field defining the primary key of the struct; may not be null
      * @param pk the expected integer value of the primary key in the struct
      */
     public static void isValidUpdate(SourceRecord record) {
-        isValidUpdate(record, false);
+        isValidUpdate(record, true);
     }
 
     /**
@@ -266,7 +266,7 @@ public class VerifyRecord {
     }
 
     /**
-     * Verify that the given {@link SourceRecord} is a {@link Operation#DELETE DELETE} record without PK.
+     * Verify that the given {@link SourceRecord} is a {@link Operation#DELETE DELETE} record with PK.
      * matches the expected value.
      *
      * @param record the source record; may not be null
@@ -274,7 +274,7 @@ public class VerifyRecord {
      * @param pk the expected integer value of the primary key in the struct
      */
     public static void isValidDelete(SourceRecord record) {
-        isValidDelete(record, false);
+        isValidDelete(record, true);
     }
 
     /**


### PR DESCRIPTION
Restores behaviour redefined by https://github.com/debezium/debezium/commit/de356896c0ba35e36a5b1ea9e5cc4d82307be3dd
Oracle tests were broken