### PR TITLE
DBZ-604 To avoid blocked when connector task stopping ,discard current record queue

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
@@ -98,7 +98,7 @@ public abstract class AbstractReader implements Reader {
     @Override
     public void stop() {
         try {
-            logger.warn("MySQL discard record queue when stopping, queue size: {}",records.size());
+            logger.warn("MySQL discard record when stopping, queue size: {}",records.size());
             records.clear();
             doStop();
             running.set(false);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
@@ -98,6 +98,8 @@ public abstract class AbstractReader implements Reader {
     @Override
     public void stop() {
         try {
+            logger.warn("MySQL discard record queue when stopping, queue size: {}",records.size());
+            records.clear();
             doStop();
             running.set(false);
         } finally {


### PR DESCRIPTION
In stop method ,even invoke records.drainTo(unsent) ,there still an chance that records become full and the stop method blocked