### PR TITLE
 DBZ-1090 Change position consists of commit LSN and change LSN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - MAVEN_CLI: '"clean install -pl debezium-connector-postgres -am -Passembly"'
   - MAVEN_CLI: '"clean install -pl debezium-connector-postgres -am -Passembly,wal2json-decoder"'
   - MAVEN_CLI: '"clean install -pl debezium-connector-mongodb -am -Passembly"'
+  - MAVEN_CLI: '"clean install -pl debezium-connector-sqlserver -am -Passembly"'
 
 sudo: required
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/Lsn.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/Lsn.java
@@ -16,7 +16,7 @@ import io.debezium.util.Strings;
  * @author Jiri Pechanec
  *
  */
-public class Lsn implements Comparable<Lsn> {
+public class Lsn implements Comparable<Lsn>, Nullable {
     private static final String NULL_STRING = "NULL";
 
     public static final Lsn NULL = new Lsn(null); 
@@ -40,6 +40,7 @@ public class Lsn implements Comparable<Lsn> {
     /**
      * @return true if this is a real LSN or false it it is {@code NULL}
      */
+    @Override
     public boolean isAvailable() {
         return binary != null;
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/Nullable.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/Nullable.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+/**
+ * 
+ * @author Jiri Pechanec
+ *
+ */
+public interface Nullable {
+
+    /**
+     * @return true if this object has real value, false if it is NULL object
+     */
+    boolean isAvailable();
+
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/Nullable.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/Nullable.java
@@ -6,7 +6,7 @@
 package io.debezium.connector.sqlserver;
 
 /**
- * 
+ *
  * @author Jiri Pechanec
  *
  */

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SourceInfo.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SourceInfo.java
@@ -110,10 +110,10 @@ public class SourceInfo extends AbstractSourceInfo {
                 .put(LOG_TIMESTAMP_KEY, sourceTime == null ? null : sourceTime.toEpochMilli())
                 .put(SNAPSHOT_KEY, snapshot);
 
-        if (changeLsn.isAvailable()) {
+        if (changeLsn != null && changeLsn.isAvailable()) {
             ret.put(CHANGE_LSN_KEY, changeLsn.toString());
         }
-        if (commitLsn != null) {
+        if (commitLsn != null && commitLsn.isAvailable()) {
             ret.put(COMMIT_LSN_KEY, commitLsn.toString());
         }
         return ret;

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
@@ -134,7 +134,12 @@ public class SqlServerSnapshotChangeEventSource extends HistorizedRelationalSnap
 
     @Override
     protected void determineSnapshotOffset(SnapshotContext ctx) throws Exception {
-        ctx.offset = new SqlServerOffsetContext(connectorConfig.getLogicalName(), TxLogPosition.valueOf(jdbcConnection.getMaxLsn()), false, false);
+        ctx.offset = new SqlServerOffsetContext(
+                connectorConfig.getLogicalName(),
+                TxLogPosition.valueOf(jdbcConnection.getMaxLsn()),
+                false,
+                false
+        );
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
@@ -134,7 +134,7 @@ public class SqlServerSnapshotChangeEventSource extends HistorizedRelationalSnap
 
     @Override
     protected void determineSnapshotOffset(SnapshotContext ctx) throws Exception {
-        ctx.offset = new SqlServerOffsetContext(connectorConfig.getLogicalName(), jdbcConnection.getMaxLsn(), false, false);
+        ctx.offset = new SqlServerOffsetContext(connectorConfig.getLogicalName(), TxLogPosition.valueOf(jdbcConnection.getMaxLsn()), false, false);
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -75,7 +75,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
             final AtomicReference<ChangeTable[]> tablesSlot = new AtomicReference<ChangeTable[]>(getCdcTablesToQuery());
 
             final TxLogPosition lastProcessedPositionOnStart = offsetContext.getChangePosition();
-            LOGGER.info("Last Position recorded in offsets is {}", lastProcessedPositionOnStart);
+            LOGGER.info("Last position recorded in offsets is {}", lastProcessedPositionOnStart);
 
             TxLogPosition lastProcessedPosition = lastProcessedPositionOnStart;
             while (context.isRunning()) {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/TxLogPosition.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/TxLogPosition.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+/**
+ * Defines a position of change in the transaction log. The position is defined as a combination of commit LSN
+ * and sequence number of the change in the given transaction.
+ * The sequence number is monotonically increasing in transaction but it is not guaranteed across multiple
+ * transactions so the combination is necessary to get total order.
+ *
+ * @author Jiri Pechanec
+ *
+ */
+public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
+    public static final TxLogPosition NULL = new TxLogPosition(null, null);
+    private final Lsn commitLsn;
+    private final Lsn inTxLsn;
+
+    private TxLogPosition(Lsn commitLsn, Lsn inTxLsn) {
+        this.commitLsn = commitLsn;
+        this.inTxLsn = inTxLsn;
+    }
+
+    public Lsn getCommitLsn() {
+        return commitLsn;
+    }
+
+    public Lsn getInTxLsn() {
+        return inTxLsn;
+    }
+
+    @Override
+    public String toString() {
+        return this == NULL ? "NULL" : commitLsn + "(" + inTxLsn + ")";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((commitLsn == null) ? 0 : commitLsn.hashCode());
+        result = prime * result + ((inTxLsn == null) ? 0 : inTxLsn.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        TxLogPosition other = (TxLogPosition) obj;
+        if (commitLsn == null) {
+            if (other.commitLsn != null)
+                return false;
+        }
+        else if (!commitLsn.equals(other.commitLsn))
+            return false;
+        if (inTxLsn == null) {
+            if (other.inTxLsn != null)
+                return false;
+        }
+        else if (!inTxLsn.equals(other.inTxLsn))
+            return false;
+        return true;
+    }
+
+    @Override
+    public int compareTo(TxLogPosition o) {
+        final int comparison = commitLsn.compareTo(o.getCommitLsn());
+        return comparison == 0 ? inTxLsn.compareTo(inTxLsn) : comparison;
+    }
+
+    public static TxLogPosition valueOf(Lsn commitLsn, Lsn inTxLsn) {
+        return commitLsn == null && inTxLsn == null ? NULL
+                : new TxLogPosition(
+                        commitLsn == null ? Lsn.NULL : commitLsn,
+                        inTxLsn == null ? Lsn.NULL : inTxLsn
+        );
+    }
+
+    public static TxLogPosition valueOf(Lsn commitLsn) {
+        return valueOf(commitLsn, Lsn.NULL);
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return inTxLsn != null && commitLsn != null;
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/TxLogPosition.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/TxLogPosition.java
@@ -15,6 +15,7 @@ package io.debezium.connector.sqlserver;
  *
  */
 public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
+
     public static final TxLogPosition NULL = new TxLogPosition(null, null);
     private final Lsn commitLsn;
     private final Lsn inTxLsn;

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
@@ -173,9 +173,10 @@ public class SnapshotIT extends AbstractConnectorTest {
             final Struct value1 = (Struct)record1.value();
             assertRecord(key1, expectedKey1);
             assertRecord((Struct)value1.get("after"), expectedRow1);
-            assertThat(record1.sourceOffset()).hasSize(1);
+            assertThat(record1.sourceOffset()).hasSize(2);
 
             Assert.assertTrue(record1.sourceOffset().containsKey("change_lsn"));
+            Assert.assertTrue(record1.sourceOffset().containsKey("commit_lsn"));
             assertNull(value1.get("before"));
         }
     }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -282,7 +282,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         for (int i = 0; !connection.getMaxLsn().isAvailable(); i++) {
             if (i == 30) {
-                org.junit.Assert.fail("Initial changes not writtent to CDC structures");
+                org.junit.Assert.fail("Initial changes not written to CDC structures");
             }
             Testing.debug("Waiting for initial changes to be propagated to CDC structures");
             Thread.sleep(1000);

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -25,6 +25,7 @@ import io.debezium.util.Testing;
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
 public class TestHelper {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(TestHelper.class);
 
     public static final Path DB_HISTORY_PATH = Testing.Files.createTestingPath("file-db-history-connect.txt").toAbsolutePath();

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -10,6 +10,9 @@ import java.nio.file.Path;
 import java.sql.SQLException;
 import java.util.Objects;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.debezium.config.Configuration;
 import io.debezium.connector.sqlserver.SqlServerConnection;
 import io.debezium.connector.sqlserver.SqlServerConnectorConfig;
@@ -22,6 +25,7 @@ import io.debezium.util.Testing;
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
 public class TestHelper {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestHelper.class);
 
     public static final Path DB_HISTORY_PATH = Testing.Files.createTestingPath("file-db-history-connect.txt").toAbsolutePath();
     public static final String TEST_DATABASE = "testdb";
@@ -106,6 +110,7 @@ public class TestHelper {
             enableDbCdc(connection, "testDB");
         }
         catch (SQLException e) {
+            LOGGER.error("Error while initiating test database", e);
             throw new IllegalStateException("Error while initiating test database", e);
         }
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1090

Please see the linked issue. The problem is that LSN of each change is monotonically increasing inside transaction abut not accross transactions. I guess this huppens with concurrent transactions. So to get total ordered position we need to combine both commit LSN and change LSN and do comparison by it.

For this a new class `TxPositionLog` is introduced that effecivelly combines twose two LSNs and introduces ordering based first on commit LSN and then on change LSN.