### PR TITLE
DBZ-1083 Passing "include-unchanged-toast" option only for wal2json

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoder.java
@@ -30,7 +30,7 @@ public interface MessageDecoder {
      * @param processor - message processing on arrival
      * @param typeRegistry - registry with known types
      */
-    void processMessage(final ByteBuffer buffer, ReplicationMessageProcessor processor, TypeRegistry typeRegistry) throws SQLException, InterruptedException;
+    void processMessage(ByteBuffer buffer, ReplicationMessageProcessor processor, TypeRegistry typeRegistry) throws SQLException, InterruptedException;
 
     /**
      * Allows MessageDecoder to configure options with which the replication stream is started.
@@ -40,7 +40,7 @@ public interface MessageDecoder {
      * @param builder
      * @return the builder instance
      */
-    ChainedLogicalStreamBuilder optionsWithMetadata(final ChainedLogicalStreamBuilder builder);
+    ChainedLogicalStreamBuilder optionsWithMetadata(ChainedLogicalStreamBuilder builder);
 
     /**
      * Allows MessageDecoder to configure options with which the replication stream is started.
@@ -50,7 +50,17 @@ public interface MessageDecoder {
      * @param builder
      * @return the builder instance
      */
-    ChainedLogicalStreamBuilder optionsWithoutMetadata(final ChainedLogicalStreamBuilder builder);
+    ChainedLogicalStreamBuilder optionsWithoutMetadata(ChainedLogicalStreamBuilder builder);
+
+    /**
+     * Allows a message decoder to configure optional options that might or might not be present on the server-side LD
+     * plug-in. So these options will be tried once, and that causes an exception, the connection will be built without
+     * them.
+     *
+     * @param builder the builder to modify
+     * @return the amended builder instance
+     */
+    ChainedLogicalStreamBuilder tryOnceOptions(ChainedLogicalStreamBuilder builder);
 
     /**
      * Signals to this decoder whether messages contain type metadata or not.

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoMessageDecoder.java
@@ -60,4 +60,9 @@ public class PgProtoMessageDecoder implements MessageDecoder {
     public ChainedLogicalStreamBuilder optionsWithoutMetadata(ChainedLogicalStreamBuilder builder) {
         return builder;
     }
+
+    @Override
+    public ChainedLogicalStreamBuilder tryOnceOptions(ChainedLogicalStreamBuilder builder) {
+        return builder;
+    }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
@@ -82,6 +82,11 @@ public class NonStreamingWal2JsonMessageDecoder implements MessageDecoder {
     }
 
     @Override
+    public ChainedLogicalStreamBuilder tryOnceOptions(ChainedLogicalStreamBuilder builder) {
+        return builder.withSlotOption("include-unchanged-toast", 0);
+    }
+
+    @Override
     public void setContainsMetadata(boolean containsMetadata) {
         this.containsMetadata = containsMetadata;
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
@@ -258,6 +258,11 @@ public class StreamingWal2JsonMessageDecoder implements MessageDecoder {
     }
 
     @Override
+    public ChainedLogicalStreamBuilder tryOnceOptions(ChainedLogicalStreamBuilder builder) {
+        return builder.withSlotOption("include-unchanged-toast", 0);
+    }
+
+    @Override
     public void setContainsMetadata(boolean containsMetadata) {
         this.containsMetadata = containsMetadata;
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1083

@jpechane, so this passes the "include-unchanged-toast" option only for wal2json but not for decoderbufs. ``MessageDecoder``s have a way now to provide optional "try once" options, which is used by wal2json for that purpose.