### PR TITLE
[WIP] DBZ-1113 allow adding multiple partitions in a single statement

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -36,6 +36,7 @@ Ilia Bogdanov
 Ivan Kovbas
 Ivan Vucina
 Jiri Pechanec
+Joy Gao
 Jure Kajzer
 Listman Gamboa
 Liu Hanlin

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDdlParser.java
@@ -1268,7 +1268,9 @@ public class MySqlDdlParser extends LegacyDdlParser {
                 tokens.canConsume("COLUMN");
                 parseCreateDefinitionList(start, table);
             } else if (tokens.canConsume("PARTITION", "(")) {
-                parsePartitionDefinition(start, table);
+                do {
+                    parsePartitionDefinition(start, table);
+                } while (tokens.canConsume(','));
                 tokens.consume(')');
             } else {
                 parseCreateDefinition(start, table, true);

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -380,6 +380,16 @@ public class MySqlAntlrDdlParserTest extends MySqlDdlParserTest {
     }
 
     @Test
+    @FixFor("DBZ-1113")
+    public void parseAddMultiplePartitions() {
+        String ddl =
+                "CREATE TABLE test (id INT, PRIMARY KEY (id));"
+              + "ALTER TABLE test ADD PARTITION (PARTITION p1 VALUES LESS THAN (10), PARTITION p_max VALUES LESS THAN MAXVALUE);";
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(1);
+    }
+
+    @Test
     @FixFor("DBZ-688")
     public void parseGeomCollection() {
         String ddl = "CREATE TABLE geomtable (id int(11) PRIMARY KEY, collection GEOMCOLLECTION DEFAULT NULL)";

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -380,16 +380,6 @@ public class MySqlAntlrDdlParserTest extends MySqlDdlParserTest {
     }
 
     @Test
-    @FixFor("DBZ-1113")
-    public void parseAddMultiplePartitions() {
-        String ddl =
-                "CREATE TABLE test (id INT, PRIMARY KEY (id));"
-              + "ALTER TABLE test ADD PARTITION (PARTITION p1 VALUES LESS THAN (10), PARTITION p_max VALUES LESS THAN MAXVALUE);";
-        parser.parse(ddl, tables);
-        assertThat(tables.size()).isEqualTo(1);
-    }
-
-    @Test
     @FixFor("DBZ-688")
     public void parseGeomCollection() {
         String ddl = "CREATE TABLE geomtable (id int(11) PRIMARY KEY, collection GEOMCOLLECTION DEFAULT NULL)";

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -1547,6 +1547,16 @@ public class MySqlDdlParserTest {
     }
 
     @Test
+    @FixFor("DBZ-1113")
+    public void parseAddMultiplePartitions() {
+        String ddl =
+                "CREATE TABLE test (id INT, PRIMARY KEY (id));"
+              + "ALTER TABLE test ADD PARTITION (PARTITION p1 VALUES LESS THAN (10), PARTITION p_max VALUES LESS THAN MAXVALUE);";
+        parser.parse(ddl, tables);
+        assertThat(tables.size()).isEqualTo(1);
+    }
+
+    @Test
     @FixFor("DBZ-767")
     public void shouldParseChangeColumnAndKeepName() {
         final String create =

--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -644,7 +644,7 @@ alterSpecification
         ')'                                                         #alterByReorganizePartition
     | EXCHANGE PARTITION uid WITH TABLE tableName
       (validationFormat=(WITH | WITHOUT) VALIDATION)?               #alterByExchangePartition
-    | ANALYZE PARTITION (uidList | ALL)                             #alterByAnalyzePartitiion
+    | ANALYZE PARTITION (uidList | ALL)                             #alterByAnalyzePartition
     | CHECK PARTITION (uidList | ALL)                               #alterByCheckPartition
     | OPTIMIZE PARTITION (uidList | ALL)                            #alterByOptimizePartition
     | REBUILD PARTITION (uidList | ALL)                             #alterByRebuildPartition

--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -629,7 +629,10 @@ alterSpecification
     | IMPORT TABLESPACE                                             #alterByImportTablespace
     | FORCE                                                         #alterByForce
     | validationFormat=(WITHOUT | WITH) VALIDATION                  #alterByValidate
-    | ADD PARTITION '(' partitionDefinition ')'                     #alterByAddPartition
+    | ADD PARTITION
+        '('
+          partitionDefinition (',' partitionDefinition)*
+        ')'                                                         #alterByAddPartition
     | DROP PARTITION uidList                                        #alterByDropPartition
     | DISCARD PARTITION (uidList | ALL) TABLESPACE                  #alterByDiscardPartition
     | IMPORT PARTITION (uidList | ALL) TABLESPACE                   #alterByImportPartition


### PR DESCRIPTION
Currently MySqlDdlParser does not support adding multiple partitions in a single ALTER TABLE ... ADD PARTITION statement. It restricts that only a single partition can be added. Given it is a valid mysql command, the parser should support this as well.

For example:

It supports:
```
ALTER TABLE test ADD PARTITION (
PARTITION p1 VALUES LESS THAN (10)
);
ALTER TABLE test ADD PARTITION (
PARTITION p2 VALUES LESS THAN MAXVALUE
);
```

But it does not support:
```
ALTER TABLE test ADD PARTITION (
PARTITION p1 VALUES LESS THAN (10),
PARTITION p2 VALUES LESS THAN MAXVALUE
);
```