### PR TITLE
DBZ-1118 Postgres snapshot - On null records, clear prior value

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -38,6 +38,7 @@ Ivan Vucina
 Jiri Pechanec
 Joy Gao
 Jure Kajzer
+Kevin Pullin
 Listman Gamboa
 Liu Hanlin
 Maciej Bryński

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsSnapshotProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsSnapshotProducer.java
@@ -367,6 +367,9 @@ public class RecordsSnapshotProducer extends RecordsProducer {
     }
 
     protected void generateReadRecord(TableId tableId, Object[] rowData) {
+        // Clear the existing record to prevent reprocessing stale data.
+        currentRecord.set(null);
+
         if (rowData.length == 0) {
             return;
         }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -8,12 +8,13 @@ package io.debezium.connector.postgresql;
 
 import static io.debezium.connector.postgresql.TestHelper.PK_FIELD;
 import static io.debezium.connector.postgresql.TestHelper.topicName;
+import static io.debezium.connector.postgresql.junit.SkipWhenDatabaseVersionLessThan.PostgresVersion.POSTGRES_10;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.List;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -24,8 +25,12 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 
+import io.debezium.connector.postgresql.junit.SkipTestDependingOnDatabaseVersionRule;
+import io.debezium.connector.postgresql.junit.SkipWhenDatabaseVersionLessThan;
 import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
@@ -42,6 +47,9 @@ import io.debezium.util.Collect;
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
 public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
+
+    @Rule
+    public final TestRule skip = new SkipTestDependingOnDatabaseVersionRule();
 
     private RecordsSnapshotProducer snapshotProducer;
     private PostgresTaskContext context;
@@ -337,7 +345,8 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
 
     @Test
     @FixFor("DBZ-1118")
-    public void shouldGenerateSnapshotsForParitionedTables() throws Exception {
+    @SkipWhenDatabaseVersionLessThan(POSTGRES_10)
+    public void shouldGenerateSnapshotsForPartitionedTables() throws Exception {
         TestHelper.dropAllSchemas();
 
         String ddl = "CREATE TABLE first_table (pk integer, user_id integer, PRIMARY KEY(pk));" +

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipTestDependingOnDatabaseVersionRule.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipTestDependingOnDatabaseVersionRule.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.junit;
+
+import java.sql.SQLException;
+
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import io.debezium.connector.postgresql.TestHelper;
+import io.debezium.junit.AnnotationBasedTestRule;
+
+/**
+ * JUnit rule that skips a test based on the {@link SkipWhenDatabaseVersionLessThan} annotation either on a test method
+ * or on a test class.
+ *
+ * @author Gunnar Morling
+ */
+public class SkipTestDependingOnDatabaseVersionRule extends AnnotationBasedTestRule {
+
+    private static final int majorDbVersion = determineDbVersion();
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        SkipWhenDatabaseVersionLessThan skip = hasAnnotation(description, SkipWhenDatabaseVersionLessThan.class);
+
+        if (skip != null && skip.value().isLargerThan(majorDbVersion)) {
+            String reasonForSkipping = "Database version less than " + skip.value();
+            return emptyStatement(reasonForSkipping, description);
+        }
+
+        return base;
+    }
+
+    public static int determineDbVersion() {
+        try {
+            return TestHelper.create().connection().getMetaData().getDatabaseMajorVersion();
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipWhenDatabaseVersionLessThan.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipWhenDatabaseVersionLessThan.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation used together with the {@link SkipTestDependingOnDatabaseVersionRule} JUnit rule, that allows
+ * tests to be skipped based on the Postgres version used for testing.
+ *
+ * @author Gunnar Morling
+ */
+@Retention( RetentionPolicy.RUNTIME)
+@Target( {ElementType.METHOD, ElementType.TYPE})
+public @interface SkipWhenDatabaseVersionLessThan {
+
+    PostgresVersion value();
+
+    public enum PostgresVersion {
+        POSTGRES_10 {
+            @Override
+            boolean isLargerThan(int otherMajor) {
+                return otherMajor < 10;
+            }
+        };
+
+        abstract boolean isLargerThan(int otherMajor);
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/junit/AnnotationBasedTestRule.java
+++ b/debezium-core/src/test/java/io/debezium/junit/AnnotationBasedTestRule.java
@@ -13,8 +13,8 @@ import org.junit.runners.model.Statement;
 
 /**
  * A base {@link TestRule} that allows easy writing of test rules based on method annotations.
- * @author Jiri Pechanec
  *
+ * @author Jiri Pechanec
  */
 public abstract class AnnotationBasedTestRule implements TestRule {
 
@@ -27,6 +27,7 @@ public abstract class AnnotationBasedTestRule implements TestRule {
                 if (reason != null && !reason.trim().isEmpty()) {
                     messageBuilder.append(" because: ").append(reason);
                 }
+
                 System.out.println(messageBuilder.toString());
             }
         };
@@ -34,16 +35,14 @@ public abstract class AnnotationBasedTestRule implements TestRule {
 
     protected <T extends Annotation> T hasAnnotation(Description description, Class<T> annotationClass) {
         T annotation = description.getAnnotation(annotationClass);
+
         if (annotation != null) {
             return annotation;
-        } else if (description.isTest() && description.getTestClass().isAnnotationPresent(annotationClass)) {
+        }
+        else if (description.isTest() && description.getTestClass().isAnnotationPresent(annotationClass)) {
             return description.getTestClass().getAnnotation(annotationClass);
         }
+
         return null;
     }
-
-    public AnnotationBasedTestRule() {
-        super();
-    }
-
 }


### PR DESCRIPTION
When the postgres snapshot producer's `generateReadRecord` method is invoked, it must clear any existing value in `currentRecord`.  If it does not, and the method ends up returning early without setting a new value, the prior record is resent.

As detailed in https://issues.jboss.org/browse/DBZ-1118 this can occur when using postgres table partitions.  Since the parent partition table definition does not contain primary keys, when the base table is processed (e.g. `select * from base_partition`) the `generateReadRecord` method always ends up aborting early like this since the `key` object is `null`:

```
Object key = tableSchema.keyFromColumnData(rowData);
Struct value = tableSchema.valueFromColumnData(rowData);
if (key == null || value == null) {
    return;
}
```

Before this patch the previous record is resent to the topic for each row on the base partition (i.e. `select count(*) from base_partition` times).

Note that this isn't limited to partitioned tables.  It occurs for any table that lacks a defined `key`.