### PR TITLE
Config option to pass optional logical decoder stream params

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -467,7 +467,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                                                         .withWidth(Width.LONG)
                                                         .withImportance(Importance.LOW)
                                                         .withDescription(
-                                                                "Any optional parameters used by logical decoding plugin. Semi-colon separated. E.G. 'add-tables=public.table,public.table2;include-lsn=true'");
+                                                                "Any optional parameters used by logical decoding plugin. Semi-colon separated. E.g. 'add-tables=public.table,public.table2;include-lsn=true'");
 
     public static final Field HOSTNAME = Field.create(DATABASE_CONFIG_PREFIX + JdbcConfiguration.HOSTNAME)
                                               .withDisplayName("Hostname")

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -461,6 +461,14 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                                                                 "Whether or not to drop the logical replication slot when the connector finishes orderly" +
                                                                 "By default the replication is kept so that on restart progress can resume from the last recorded location");
 
+    public static final Field STREAM_PARAMS = Field.create("slot.stream_params")
+                                                        .withDisplayName("Optional parameters to pass to the logical decoder when the stream is started.")
+                                                        .withType(Type.STRING)
+                                                        .withWidth(Width.LONG)
+                                                        .withImportance(Importance.LOW)
+                                                        .withDescription(
+                                                                "Any optional parameters used by logical decoding plugin. Semi-colon separated. E.G. 'add-tables=public.table,public.table2;include-lsn=true'");
+
     public static final Field HOSTNAME = Field.create(DATABASE_CONFIG_PREFIX + JdbcConfiguration.HOSTNAME)
                                               .withDisplayName("Hostname")
                                               .withType(Type.STRING)
@@ -745,7 +753,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     /**
      * The set of {@link Field}s defined as part of this configuration.
      */
-    public static Field.Set ALL_FIELDS = Field.setOf(PLUGIN_NAME, SLOT_NAME, DROP_SLOT_ON_STOP,
+    public static Field.Set ALL_FIELDS = Field.setOf(PLUGIN_NAME, SLOT_NAME, DROP_SLOT_ON_STOP, STREAM_PARAMS,
                                                      DATABASE_NAME, USER, PASSWORD, HOSTNAME, PORT, ON_CONNECT_STATEMENTS, SERVER_NAME,
                                                      TOPIC_SELECTION_STRATEGY, CommonConnectorConfig.MAX_BATCH_SIZE,
                                                      CommonConnectorConfig.MAX_QUEUE_SIZE, CommonConnectorConfig.POLL_INTERVAL_MS,
@@ -817,6 +825,10 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     protected boolean dropSlotOnStop() {
         return config.getBoolean(DROP_SLOT_ON_STOP);
+    }
+    
+    protected String streamParams() {
+        return config.getString(STREAM_PARAMS);
     }
 
     protected Integer statusUpdateIntervalMillis() {
@@ -906,7 +918,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         ConfigDef config = new ConfigDef();
         Field.group(config, "Postgres", SLOT_NAME, PLUGIN_NAME, SERVER_NAME, DATABASE_NAME, HOSTNAME, PORT,
                     USER, PASSWORD, ON_CONNECT_STATEMENTS, SSL_MODE, SSL_CLIENT_CERT, SSL_CLIENT_KEY_PASSWORD, SSL_ROOT_CERT, SSL_CLIENT_KEY,
-                    DROP_SLOT_ON_STOP, SSL_SOCKET_FACTORY, STATUS_UPDATE_INTERVAL_MS, TCP_KEEPALIVE);
+                    DROP_SLOT_ON_STOP, STREAM_PARAMS, SSL_SOCKET_FACTORY, STATUS_UPDATE_INTERVAL_MS, TCP_KEEPALIVE);
         Field.group(config, "Events", SCHEMA_WHITELIST, SCHEMA_BLACKLIST, TABLE_WHITELIST, TABLE_BLACKLIST,
                     COLUMN_BLACKLIST, INCLUDE_UNKNOWN_DATATYPES, SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
                     CommonConnectorConfig.TOMBSTONES_ON_DELETE, Heartbeat.HEARTBEAT_INTERVAL,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -461,7 +461,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                                                                 "Whether or not to drop the logical replication slot when the connector finishes orderly" +
                                                                 "By default the replication is kept so that on restart progress can resume from the last recorded location");
 
-    public static final Field STREAM_PARAMS = Field.create("slot.stream_params")
+    public static final Field STREAM_PARAMS = Field.create("slot.stream.params")
                                                         .withDisplayName("Optional parameters to pass to the logical decoder when the stream is started.")
                                                         .withType(Type.STRING)
                                                         .withWidth(Width.LONG)

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTaskContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTaskContext.java
@@ -61,6 +61,7 @@ public class PostgresTaskContext extends CdcSourceTaskContext {
                                     .withSlot(config.slotName())
                                     .withPlugin(config.plugin())
                                     .dropSlotOnClose(config.dropSlotOnStop())
+                                    .streamParams(config.streamParams())
                                     .statusUpdateIntervalMillis(config.statusUpdateIntervalMillis())
                                     .withTypeRegistry(schema.getTypeRegistry())
                                     .build();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
@@ -130,6 +130,16 @@ public interface ReplicationConnection extends AutoCloseable {
         Builder withTypeRegistry(TypeRegistry typeRegistry);
 
         /**
+         * Optional parameters to pass to the logical decoder when the stream starts.
+         *
+         * @param streamParams String of key and value pairs declared with "=". Pairs are separated by ";".
+         *                     Example: "add-tables=public.table,public.table2;include-lsn=true"
+         * @return this instance
+         * @see #STREAM_PARAMS
+         */
+        Builder streamParams(final String streamParams);
+
+        /**
          * Creates a new {@link ReplicationConnection} instance
          * @return a connection, never null
          */

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -1103,6 +1103,22 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         assertRecordSchemaAndValues(expectedAfter, deletedRecord, Envelope.FieldName.AFTER);
     }
 
+    @Test()
+    public void testPassingStreamParams() throws Exception {
+        PostgresConnectorConfig config = new PostgresConnectorConfig(TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.STREAM_PARAMS, "debug-mode=1")
+                .build());
+        setupRecordsProducer(config);
+        String statement = "CREATE SCHEMA s1;" +
+                "CREATE TABLE s1.stream_test (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
+                "INSERT INTO s1.stream_test (aa) VALUES (11);";
+
+        consumer = testConsumer(0);
+        recordsProducer.start(consumer, blackHole);
+        executeAndWait(statement);
+        assertThat(consumer.isEmpty()).isTrue();
+    }
+
     private void assertHeartBeatRecordInserted() {
         assertFalse("records not generated", consumer.isEmpty());
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -19,6 +19,10 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import static io.debezium.connector.postgresql.junit.SkipWhenDecoderPluginNameIsNot.DecoderPluginName.WAL2JSON;
+
+import io.debezium.connector.postgresql.junit.SkipTestDependingOnDecoderPluginNameRule;
+import io.debezium.connector.postgresql.junit.SkipWhenDecoderPluginNameIsNot;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -53,6 +57,9 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     private RecordsStreamProducer recordsProducer;
     private TestConsumer consumer;
     private final Consumer<Throwable> blackHole = t -> {};
+
+    @Rule
+    public final TestRule skip = new SkipTestDependingOnDecoderPluginNameRule();
 
     @Rule
     public TestRule conditionalFail = new ConditionalFail();
@@ -1104,20 +1111,21 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     }
 
     @Test()
+    @FixFor("DBZ-1130")
+    @SkipWhenDecoderPluginNameIsNot(WAL2JSON)
     public void testPassingStreamParams() throws Exception {
         // Verify that passing stream parameters works by using the WAL2JSON add-tables parameter which acts as a
         // whitelist.
-
         PostgresConnectorConfig config = new PostgresConnectorConfig(TestHelper.defaultConfig()
-                .with(PostgresConnectorConfig.PLUGIN_NAME, "wal2json")
                 .with(PostgresConnectorConfig.STREAM_PARAMS, "add-tables=s1.should_stream")
                 .build());
         setupRecordsProducer(config);
         String statement = "CREATE SCHEMA s1;" +
                 "CREATE TABLE s1.should_stream (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
                 "CREATE TABLE s1.should_not_stream (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
-                "INSERT INTO s1.should_stream (aa) VALUES (123);" +
-                "INSERT INTO s1.should_not_stream (aa) VALUES (456);";
+                "INSERT INTO s1.should_not_stream (aa) VALUES (456);" +
+                "INSERT INTO s1.should_stream (aa) VALUES (123);";
+
 
         // Verify only one record made it
         consumer = testConsumer(1);
@@ -1126,6 +1134,37 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
         // Verify the record that made it was from the whitelisted table
         assertRecordInserted("s1.should_stream", PK_FIELD, 1);
+        assertThat(consumer.isEmpty()).isTrue();
+    }
+
+    @Test()
+    @FixFor("DBZ-1130")
+    @SkipWhenDecoderPluginNameIsNot(WAL2JSON)
+    public void testPassingStreamMultipleParams() throws Exception {
+        // Verify that passing multiple stream parameters and multiple parameter values works.
+        PostgresConnectorConfig config = new PostgresConnectorConfig(TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.STREAM_PARAMS, "add-tables=s1.should_stream,s2.*;filter-tables=s2.should_not_stream")
+                .build());
+        setupRecordsProducer(config);
+        String statement = "CREATE SCHEMA s1;" + "CREATE SCHEMA s2;" +
+                "CREATE TABLE s1.should_stream (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
+                "CREATE TABLE s2.should_stream (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
+                "CREATE TABLE s1.should_not_stream (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
+                "CREATE TABLE s2.should_not_stream (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
+                "INSERT INTO s1.should_not_stream (aa) VALUES (456);" +
+                "INSERT INTO s2.should_not_stream (aa) VALUES (111);" +
+                "INSERT INTO s1.should_stream (aa) VALUES (123);" +
+                "INSERT INTO s2.should_stream (aa) VALUES (999);";
+
+
+        // Verify only the whitelisted record from s1 and s2 made it.
+        consumer = testConsumer(2);
+        recordsProducer.start(consumer, blackHole);
+        executeAndWait(statement);
+
+        // Verify the record that made it was from the whitelisted table
+        assertRecordInserted("s1.should_stream", PK_FIELD, 1);
+        assertRecordInserted("s2.should_stream", PK_FIELD, 1);
         assertThat(consumer.isEmpty()).isTrue();
     }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipTestDependingOnDecoderPluginNameRule.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipTestDependingOnDecoderPluginNameRule.java
@@ -1,0 +1,35 @@
+package io.debezium.connector.postgresql.junit;
+
+import io.debezium.connector.postgresql.TestHelper;
+import io.debezium.junit.AnnotationBasedTestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * JUnit rule that skips a test based on the {@link SkipWhenDecoderPluginNameIs} annotation or the
+ * {@link SkipWhenDecoderPluginNameIsNot} annotation, on either a test method or a test class.
+ */
+public class SkipTestDependingOnDecoderPluginNameRule extends AnnotationBasedTestRule {
+    private static final String pluginName = determineDecoderPluginName();
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        SkipWhenDecoderPluginNameIs skipHasName = hasAnnotation(description, SkipWhenDecoderPluginNameIs.class);
+        if (skipHasName != null && skipHasName.value().isEqualTo(pluginName)) {
+            String reasonForSkipping = "Decoder plugin name is " + skipHasName.value();
+            return emptyStatement(reasonForSkipping, description);
+        }
+
+        SkipWhenDecoderPluginNameIsNot skipNameIsNot = hasAnnotation(description, SkipWhenDecoderPluginNameIsNot.class);
+        if (skipNameIsNot != null && skipNameIsNot.value().isNotEqualTo(pluginName)) {
+            String reasonForSkipping = "Decoder plugin name is not " + skipNameIsNot.value();
+            return emptyStatement(reasonForSkipping, description);
+        }
+
+        return base;
+    }
+
+    public static String determineDecoderPluginName() {
+        return TestHelper.decoderPlugin().getPostgresPluginName();
+    }
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipTestDependingOnDecoderPluginNameRule.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipTestDependingOnDecoderPluginNameRule.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.connector.postgresql.junit;
 
 import io.debezium.connector.postgresql.TestHelper;

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipWhenDecoderPluginNameIs.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipWhenDecoderPluginNameIs.java
@@ -1,0 +1,52 @@
+package io.debezium.connector.postgresql.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation used together with the {@link SkipTestDependingOnDecoderPluginNameRule} JUnit rule, that allows
+ * tests to be skipped based on the decoder plugin name that is being used for testing.
+ */
+@Retention( RetentionPolicy.RUNTIME)
+@Target( {ElementType.METHOD, ElementType.TYPE})
+public @interface SkipWhenDecoderPluginNameIs {
+    SkipWhenDecoderPluginNameIs.DecoderPluginName value();
+
+    enum DecoderPluginName {
+        WAL2JSON {
+            @Override
+            boolean isEqualTo(String pluginName) {
+                return pluginName.equals("wal2json");
+            }
+        },
+        WAL2JSON_STREAMING {
+            @Override
+            boolean isEqualTo(String pluginName) {
+                return pluginName.equals("wal2json_streaming");
+            }
+        },
+        WAL2JSON_RDS {
+            @Override
+            boolean isEqualTo(String pluginName) {
+                return pluginName.equals("wal2json_rds");
+            }
+        },
+        WAL2JSON_RDS_STREAMING {
+            @Override
+            boolean isEqualTo(String pluginName) {
+                return pluginName.equals("wal2json_rds_streaming");
+            }
+        },
+        DECODERBUFS {
+            @Override
+            boolean isEqualTo(String pluginName) {
+                return pluginName.equals("decoderbufs");
+            }
+        };
+
+        abstract boolean isEqualTo(String pluginName);
+    }
+
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipWhenDecoderPluginNameIs.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipWhenDecoderPluginNameIs.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.connector.postgresql.junit;
 
 import java.lang.annotation.ElementType;

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipWhenDecoderPluginNameIsNot.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipWhenDecoderPluginNameIsNot.java
@@ -1,0 +1,52 @@
+package io.debezium.connector.postgresql.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation used together with the {@link SkipTestDependingOnDecoderPluginNameRule} JUnit rule, that allows
+ * tests to be skipped based on the decoder plugin name that is not being used for testing.
+ */
+@Retention( RetentionPolicy.RUNTIME)
+@Target( {ElementType.METHOD, ElementType.TYPE})
+public @interface SkipWhenDecoderPluginNameIsNot {
+    SkipWhenDecoderPluginNameIsNot.DecoderPluginName value();
+
+    enum DecoderPluginName {
+        WAL2JSON {
+            @Override
+            boolean isNotEqualTo(String pluginName) {
+                return !pluginName.equals("wal2json");
+            }
+        },
+        WAL2JSON_STREAMING {
+            @Override
+            boolean isNotEqualTo(String pluginName) {
+                return !pluginName.equals("wal2json_streaming");
+            }
+        },
+        WAL2JSON_RDS {
+            @Override
+            boolean isNotEqualTo(String pluginName) {
+                return !pluginName.equals("wal2json_rds");
+            }
+        },
+        WAL2JSON_RDS_STREAMING {
+            @Override
+            boolean isNotEqualTo(String pluginName) {
+                return !pluginName.equals("wal2json_rds_streaming");
+            }
+        },
+        DECODERBUFS {
+            @Override
+            boolean isNotEqualTo(String pluginName) {
+                return !pluginName.equals("decoderbufs");
+            }
+        };
+
+        abstract boolean isNotEqualTo(String pluginName);
+    }
+
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipWhenDecoderPluginNameIsNot.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipWhenDecoderPluginNameIsNot.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.connector.postgresql.junit;
 
 import java.lang.annotation.ElementType;


### PR DESCRIPTION
Added config param "slot.stream_params" to the Postgres connector to allow passing optional params to logical decoder on stream start.

The format is key and values are separated by "=" and key value pairs are separated by ";". So for example "add-tables=public.table,public.table2;include-lsn=true'" would be the equivalent of passing "-o add-tables=public.table,public.table2 -o include-lsn=true" when streaming from the replication slot manually with pg_recvlogical etc.

I have this change (based of the latest 9.0 release) running against a PG server with the WAL2JSON decoder and the optional param to filter tables is working.