### PR TITLE
DBZ-1082 Add new custom recovery mode, more metadata

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTaskContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTaskContext.java
@@ -13,8 +13,13 @@ import io.debezium.annotation.ThreadSafe;
 import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.ReplicationConnection;
+import io.debezium.connector.postgresql.spi.SlotState;
 import io.debezium.relational.TableId;
 import io.debezium.schema.TopicSelector;
+import io.debezium.util.Clock;
+import io.debezium.util.ElapsedTimeStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The context of a {@link PostgresConnectorTask}. This deals with most of the brunt of reading various configuration options
@@ -25,14 +30,22 @@ import io.debezium.schema.TopicSelector;
 @ThreadSafe
 public class PostgresTaskContext extends CdcSourceTaskContext {
 
+    protected final static Logger LOGGER = LoggerFactory.getLogger(PostgresTaskContext.class);
+
     private final PostgresConnectorConfig config;
     private final TopicSelector<TableId> topicSelector;
     private final PostgresSchema schema;
+
+    private ElapsedTimeStrategy refreshXmin;
+    private Long lastXmin;
 
     protected PostgresTaskContext(PostgresConnectorConfig config, PostgresSchema schema, TopicSelector<TableId> topicSelector) {
         super("Postgres", config.getLogicalName(), Collections::emptySet);
 
         this.config = config;
+        if (config.xminFetchInterval().toMillis() > 0) {
+            this.refreshXmin = ElapsedTimeStrategy.constant(Clock.SYSTEM, config.xminFetchInterval().toMillis());
+        }
         this.topicSelector = topicSelector;
         assert schema != null;
         this.schema = schema;
@@ -54,6 +67,37 @@ public class PostgresTaskContext extends CdcSourceTaskContext {
         try (final PostgresConnection connection = createConnection()) {
             schema.refresh(connection, printReplicaIdentityInfo);
         }
+    }
+
+    protected Long getSlotXmin() throws SQLException {
+        // when xmin fetch is set to 0, we don't track it to ignore any performance of querying the
+        // slot periodically
+        if (config.xminFetchInterval().toMillis() <= 0) {
+            return null;
+        }
+        assert(this.refreshXmin != null);
+
+        if (this.refreshXmin.hasElapsed()) {
+            lastXmin = getCurrentSlotInfo().slotCatalogXmin();
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Fetched new xmin from slot of {}", lastXmin);
+            }
+        }
+        else {
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace("reusing xmin value of {}", lastXmin);
+            }
+        }
+
+        return lastXmin;
+    }
+
+    protected SlotState getCurrentSlotInfo() throws SQLException {
+        SlotState slotInfo;
+        try (final PostgresConnection connection = createConnection()) {
+            slotInfo = connection.getReplicationSlotInfo(config.slotName(), config.plugin().getPostgresPluginName());
+        }
+        return slotInfo;
     }
 
     protected ReplicationConnection createReplicationConnection() throws SQLException {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
@@ -155,11 +155,11 @@ public class RecordsStreamProducer extends RecordsProducer {
         LoggingContext.PreviousContext previousContext = taskContext.configureLoggingContext(CONTEXT_NAME);
         try {
             ReplicationStream replicationStream = this.replicationStream.get();
+
             if (replicationStream != null) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Flushing LSN to server: {}", LogSequenceNumber.valueOf(lsn));
                 }
-
                 // tell the server the point up to which we've processed data, so it can be free to recycle WAL segments
                 replicationStream.flushLsn(lsn);
             }
@@ -249,7 +249,7 @@ public class RecordsStreamProducer extends RecordsProducer {
         // update the source info with the coordinates for this message
         Instant commitTime = message.getCommitTime();
         long txId = message.getTransactionId();
-        sourceInfo.update(lsn, commitTime, txId, tableId);
+        sourceInfo.update(lsn, commitTime, txId, tableId, taskContext.getSlotXmin());
         if (logger.isDebugEnabled()) {
             logger.debug("received new message at position {}\n{}", ReplicationConnection.format(lsn), message);
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -153,14 +153,14 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                 }
             });
 
-            if (shouldCreateSlot || !slotInfo.hasValidFlushedLSN()) {
+            if (shouldCreateSlot || !slotInfo.hasValidFlushedLsn()) {
                 // this is a new slot or we weren't able to read a valid flush LSN pos, so we always start from the xlog pos that was reported
                 this.defaultStartingPos = xlogStart.get();
             } else {
-                Long latestFlushedLSN = slotInfo.latestFlushedLSN();
-                this.defaultStartingPos = latestFlushedLSN < xlogStart.get() ? latestFlushedLSN : xlogStart.get();
+                Long latestFlushedLsn = slotInfo.latestFlushedLsn();
+                this.defaultStartingPos = latestFlushedLsn < xlogStart.get() ? latestFlushedLsn : xlogStart.get();
                 if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("found previous flushed LSN '{}'", ReplicationConnection.format(latestFlushedLSN));
+                    LOGGER.debug("found previous flushed LSN '{}'", ReplicationConnection.format(latestFlushedLsn));
                 }
             }
         } catch (SQLException e) {
@@ -242,7 +242,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             private int warningCheckCounter = CHECK_WARNINGS_AFTER_COUNT;
 
             // make sure this is volatile since multiple threads may be interested in this value
-            private volatile LogSequenceNumber lastReceivedLSN;
+            private volatile LogSequenceNumber lastReceivedLsn;
 
             @Override
             public void read(ReplicationMessageProcessor processor) throws SQLException, InterruptedException {
@@ -265,7 +265,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             }
 
             private void deserializeMessages(ByteBuffer buffer, ReplicationMessageProcessor processor) throws SQLException, InterruptedException {
-                lastReceivedLSN = stream.getLastReceiveLSN();
+                lastReceivedLsn = stream.getLastReceiveLSN();
                 messageDecoder.processMessage(buffer, processor, typeRegistry);
             }
 
@@ -277,12 +277,12 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
             @Override
             public void flushLastReceivedLsn() throws SQLException {
-                if (lastReceivedLSN == null) {
+                if (lastReceivedLsn == null) {
                     // nothing to flush yet, since we haven't read anything...
                     return;
                 }
 
-                doFlushLsn(lastReceivedLSN);
+                doFlushLsn(lastReceivedLsn);
             }
 
             @Override
@@ -299,7 +299,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
             @Override
             public Long lastReceivedLsn() {
-                return lastReceivedLSN != null ? lastReceivedLSN.asLong() : null;
+                return lastReceivedLsn != null ? lastReceivedLsn.asLong() : null;
             }
 
             private void processWarnings(final boolean forced) throws SQLException {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/AlwaysSnapshotter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/AlwaysSnapshotter.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.snapshot;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AlwaysSnapshotter extends QueryingSnapshotter {
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(AlwaysSnapshotter.class);
+
+
+    @Override
+    public boolean shouldStream() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldSnapshot() {
+        LOGGER.info("Taking a new snapshot as per configuration");
+        return true;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/InitialOnlySnapshotter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/InitialOnlySnapshotter.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.snapshot;
+
+public class InitialOnlySnapshotter extends QueryingSnapshotter {
+    @Override
+    public boolean shouldStream() {
+        return false;
+    }
+
+    @Override
+    public boolean shouldSnapshot() {
+        return true;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/InitialSnapshotter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/InitialSnapshotter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.snapshot;
+
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.spi.OffsetState;
+import io.debezium.connector.postgresql.spi.SlotState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InitialSnapshotter extends QueryingSnapshotter {
+    private OffsetState sourceInfo;
+    private final static Logger LOGGER = LoggerFactory.getLogger(InitialSnapshotter.class);
+
+    @Override
+    public void init(PostgresConnectorConfig config, OffsetState sourceInfo, SlotState slotState) {
+        super.init(config, sourceInfo, slotState);
+        this.sourceInfo = sourceInfo;
+    }
+
+    @Override
+    public boolean shouldStream() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldSnapshot() {
+        if (sourceInfo == null) {
+            LOGGER.info("Taking initial snapshot for new datasource");
+            return true;
+        }
+        else if (sourceInfo.snapshotInEffect()) {
+            LOGGER.info("Found previous incomplete snapshot");
+            return true;
+        } else {
+            LOGGER.info(
+                    "Previous snapshot has completed successfully, streaming logical changes from last known position");
+            return false;
+        }
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/NeverSnapshotter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/NeverSnapshotter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.snapshot;
+
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.spi.Snapshotter;
+import io.debezium.connector.postgresql.spi.OffsetState;
+import io.debezium.connector.postgresql.spi.SlotState;
+import io.debezium.relational.TableId;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+public class NeverSnapshotter implements Snapshotter {
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(NeverSnapshotter.class);
+
+    @Override
+    public void init(PostgresConnectorConfig config, OffsetState sourceInfo, SlotState slotState) {
+        if (sourceInfo != null && sourceInfo.snapshotInEffect()) {
+            String msg = "The connector previously stopped while taking a snapshot, but now the connector is configured "
+                    + "to never allow snapshots. Reconfigure the connector to use snapshots initially or when needed.";
+            LOGGER.error(msg);
+            throw new ConnectException(msg);
+        }
+        else {
+            LOGGER.info("Snapshots are not allowed as per configuration, starting streaming logical changes only");
+        }
+    }
+
+    @Override
+    public boolean shouldStream() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldSnapshot() {
+        return false;
+    }
+
+    @Override
+    public Optional<String> buildSnapshotQuery(TableId tableId) {
+        throw new UnsupportedOperationException("'never' snapshot mode cannot build queries");
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/QueryingSnapshotter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/QueryingSnapshotter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.snapshot;
+
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.spi.Snapshotter;
+import io.debezium.connector.postgresql.spi.OffsetState;
+import io.debezium.connector.postgresql.spi.SlotState;
+import io.debezium.relational.TableId;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public abstract class QueryingSnapshotter implements Snapshotter {
+
+    private PostgresConnectorConfig config;
+    private Map<TableId, String> snapshotOverrides;
+
+    @Override
+    public void init(PostgresConnectorConfig config, OffsetState sourceInfo, SlotState slotState) {
+        this.config = config;
+        this.snapshotOverrides = getSnapshotSelectOverridesByTable();
+    }
+
+    public Optional<String> buildSnapshotQuery(TableId tableId) {
+        if (snapshotOverrides.containsKey(tableId)) {
+            return Optional.of(snapshotOverrides.get(tableId));
+        }
+        else {
+            // DBZ-298 Quoting name in case it has been quoted originally; it doesn't do harm if it hasn't been quoted
+            StringBuilder q = new StringBuilder();
+            q.append("SELECT * FROM ");
+            q.append(tableId.toDoubleQuotedString());
+            return Optional.of(q.toString());
+        }
+    }
+
+    /**
+     * Returns any SELECT overrides, if present.
+     */
+    private Map<TableId, String> getSnapshotSelectOverridesByTable() {
+        String tableList = config.snapshotSelectOverrides();
+
+        if (tableList == null) {
+            return Collections.emptyMap();
+        }
+
+        Map<TableId, String> snapshotSelectOverridesByTable = new HashMap<>();
+
+        for (String table : tableList.split(",")) {
+            snapshotSelectOverridesByTable.put(
+                    TableId.parse(table),
+                    config.snapshotSelectOverrideForTable(table)
+            );
+        }
+
+        return snapshotSelectOverridesByTable;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/OffsetState.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/OffsetState.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.spi;
+
+import io.debezium.annotation.Incubating;
+
+import java.time.Instant;
+
+/**
+ * A simple data container that represents the last seen offset
+ * which was written by debezium.
+ *
+ * This data may differ based on decoding plugin and settings, such as
+ * lastSeenXmin being null if xmin tracking isn't enabled
+ */
+@Incubating
+public class OffsetState {
+    private final Long lsn;
+    private final Long txId;
+    private final Long xmin;
+    private final Instant commitTs;
+    private final boolean snapshotting;
+
+    public OffsetState(Long lsn, Long txId, Long xmin, Instant lastCommitTs, boolean isSnapshot) {
+        this.lsn = lsn;
+        this.txId = txId;
+        this.xmin = xmin;
+        this.commitTs = lastCommitTs;
+        this.snapshotting = isSnapshot;
+    }
+
+    /**
+     * @return the last LSN seen by debezium
+     */
+    public Long lastSeenLsn() {
+        return lsn;
+    }
+
+    /**
+     * @return the last txid seen by debezium
+     */
+    public Long lastSeenTxId() {
+        return txId;
+    }
+
+    /**
+     * @return the last xmin seen by debezium
+     */
+    public Long lastSeenXmin() {
+        return xmin;
+    }
+
+    /**
+     * @return the last commit timestamp seen by debezium
+     */
+    public Instant lastCommitTs() {
+        return commitTs;
+    }
+
+    /**
+     * @return indicates if a snapshot is happening
+     */
+    public boolean snapshotInEffect() {
+        return snapshotting;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/SlotState.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/SlotState.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.spi;
+
+import io.debezium.annotation.Incubating;
+
+/**
+ * A simple data container that holds the state of the current slot
+ */
+@Incubating
+public class SlotState {
+    private final Long latestFlushedLsn;
+    private final Long restartLsn;
+    private final Long catalogXmin;
+    private final boolean active;
+
+
+    public SlotState(Long lastFlushLsn, Long restartLsn, Long catXmin, boolean active) {
+        this.active = active;
+        this.latestFlushedLsn = lastFlushLsn;
+        this.restartLsn = restartLsn;
+        this.catalogXmin = catXmin;
+    }
+
+    /**
+     * @return the slot's `confirmed_flushed_lsn` value
+     */
+    public Long slotLastFlushedLsn() {
+        return latestFlushedLsn;
+    }
+
+    /**
+     * @return the slot's `restart_lsn` value
+     */
+    public Long slotRestartLsn() {
+        return restartLsn;
+    }
+
+    /**
+     * @return the slot's `catalog_xmin` value
+     */
+    public Long slotCatalogXmin() {
+        return catalogXmin;
+    }
+
+    /**
+     * @return if the slot is active
+     */
+    public boolean slotIsActive() {
+        return active;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/Snapshotter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/Snapshotter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.spi;
+
+import io.debezium.annotation.Incubating;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.relational.TableId;
+
+import java.util.Optional;
+
+/**
+ * This interface is used to determine details about the snapshot process:
+ *
+ * Namely:
+ * - Should a snapshot occur at all
+ * - Should streaming occur
+ * - What queries should be used to snapshot
+ *
+ * While many default snapshot modes are provided with debezium (see documentation for details)
+ * a custom implementation of this interface can be provided by the implementor which
+ * can provide more advanced functionality, such as partial snapshots
+ *
+ * Implementor's must return true for either {@link #shouldSnapshot()} or {@link #shouldStream()}
+ * or true for both.
+ */
+@Incubating
+public interface Snapshotter {
+    void init(PostgresConnectorConfig config, OffsetState sourceInfo,
+              SlotState slotState);
+
+    /**
+     * @return true if the snapshotter should take a snapshot
+     */
+    boolean shouldSnapshot();
+    /**
+     * @return true if the snapshotter should stream after taking a snapshot
+     */
+    boolean shouldStream();
+
+    /**
+     * Generate a valid postgres query string for the specified table, or an empty {@link Optional}
+     * to skip snapshotting this table (but that table will still be streamed from)
+     *
+     * @param tableId the table to generate a query for
+     * @return a valid query string, or none to skip snapshotting this table
+     */
+    Optional<String> buildSnapshotQuery(TableId tableId);
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomTestSnapshot.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomTestSnapshot.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import io.debezium.connector.postgresql.spi.Snapshotter;
+import io.debezium.connector.postgresql.spi.OffsetState;
+import io.debezium.connector.postgresql.spi.SlotState;
+import io.debezium.relational.TableId;
+
+import java.util.Optional;
+
+/**
+ * This is a small class used in PostgresConnectorIT to test a custom snapshot
+ *
+ * It is tightly coupled to the test there, but needs to be placed here in order
+ * to allow for class loading to work
+ */
+public class CustomTestSnapshot implements Snapshotter {
+    private boolean hasState;
+    @Override
+    public void init(PostgresConnectorConfig config, OffsetState sourceInfo, SlotState slotState) {
+        hasState = (sourceInfo != null);
+    }
+
+    @Override
+    public boolean shouldSnapshot() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldStream() {
+        return true;
+    }
+
+    @Override
+    public Optional<String> buildSnapshotQuery(TableId tableId) {
+        // on an empty state, don't read from s2 schema, but afterwards, do
+        if (!hasState && tableId.schema().equals("s2")) {
+            return Optional.empty();
+        }
+        else {
+            return Optional.of("select * from " + tableId.toDoubleQuotedString());
+        }
+    }
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -6,10 +6,7 @@
 
 package io.debezium.connector.postgresql;
 
-import static io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode.ALWAYS;
-import static io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode.INITIAL;
-import static io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode.INITIAL_ONLY;
-import static io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode.NEVER;
+import static io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
 import static io.debezium.connector.postgresql.TestHelper.PK_FIELD;
 import static io.debezium.connector.postgresql.TestHelper.topicName;
 import static junit.framework.TestCase.assertEquals;
@@ -151,7 +148,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         validateField(validatedConfig, PostgresConnectorConfig.TABLE_WHITELIST, null);
         validateField(validatedConfig, PostgresConnectorConfig.TABLE_BLACKLIST, null);
         validateField(validatedConfig, PostgresConnectorConfig.COLUMN_BLACKLIST, null);
-        validateField(validatedConfig, PostgresConnectorConfig.SNAPSHOT_MODE, INITIAL);
+        validateField(validatedConfig, PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL);
         validateField(validatedConfig, PostgresConnectorConfig.SNAPSHOT_LOCK_TIMEOUT_MS, PostgresConnectorConfig.DEFAULT_SNAPSHOT_LOCK_TIMEOUT_MILLIS);
         validateField(validatedConfig, PostgresConnectorConfig.TIME_PRECISION_MODE, TemporalPrecisionMode.ADAPTIVE);
         validateField(validatedConfig, PostgresConnectorConfig.DECIMAL_HANDLING_MODE, PostgresConnectorConfig.DecimalHandlingMode.PRECISE);
@@ -188,7 +185,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     public void shouldProduceEventsWithInitialSnapshot() throws Exception {
         TestHelper.execute(SETUP_TABLES_STMT);
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
-                                               .with(PostgresConnectorConfig.SNAPSHOT_MODE, INITIAL.getValue())
+                                               .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL.getValue())
                                                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE);
         start(PostgresConnector.class, configBuilder.build());
         assertConnectorIsRunning();
@@ -253,7 +250,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
             TestHelper.execute(INSERT_STMT);
         }
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
-                                               .with(PostgresConnectorConfig.SNAPSHOT_MODE, INITIAL.getValue())
+                                               .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL.getValue())
                                                .with(PostgresConnectorConfig.MAX_QUEUE_SIZE, recordCount / 2)
                                                .with(PostgresConnectorConfig.MAX_BATCH_SIZE, 10)
                                                .with(PostgresConnectorConfig.SCHEMA_WHITELIST, "s1");
@@ -358,7 +355,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     public void shouldIgnoreEventsForDeletedTable() throws Exception {
         TestHelper.execute(SETUP_TABLES_STMT);
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
-                                               .with(PostgresConnectorConfig.SNAPSHOT_MODE, INITIAL.getValue())
+                                               .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL.getValue())
                                                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE);
         start(PostgresConnector.class, configBuilder.build());
         assertConnectorIsRunning();
@@ -393,7 +390,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
                 "CREATE VIEW s1.myview AS SELECT * from s1.a;"
         );
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
-                                               .with(PostgresConnectorConfig.SNAPSHOT_MODE, INITIAL.getValue())
+                                               .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL.getValue())
                                                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE);
         start(PostgresConnector.class, configBuilder.build());
         assertConnectorIsRunning();
@@ -425,7 +422,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     public void shouldExecuteOnConnectStatements() throws Exception {
         TestHelper.execute(SETUP_TABLES_STMT);
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
-                                               .with(PostgresConnectorConfig.SNAPSHOT_MODE, INITIAL.getValue())
+                                               .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL.getValue())
                                                .with(PostgresConnectorConfig.ON_CONNECT_STATEMENTS, "INSERT INTO s1.a (aa) VALUES (2); INSERT INTO s2.a (aa, bb) VALUES (2, 'hello;; world');")
                                                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE);
         start(PostgresConnector.class, configBuilder.build());
@@ -445,7 +442,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     public void shouldProduceEventsWhenSnapshotsAreNeverAllowed() throws InterruptedException {
         TestHelper.execute(SETUP_TABLES_STMT);
         Configuration config = TestHelper.defaultConfig()
-                                         .with(PostgresConnectorConfig.SNAPSHOT_MODE, NEVER.getValue())
+                                         .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.getValue())
                                          .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                                          .build();
         start(PostgresConnector.class, config);
@@ -463,7 +460,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     public void shouldNotProduceEventsWithInitialOnlySnapshot() throws InterruptedException {
         TestHelper.execute(SETUP_TABLES_STMT);
         Configuration config = TestHelper.defaultConfig()
-                                         .with(PostgresConnectorConfig.SNAPSHOT_MODE, INITIAL_ONLY.getValue())
+                                         .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_ONLY.getValue())
                                          .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                                          .build();
         start(PostgresConnector.class, config);
@@ -483,7 +480,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     public void shouldProduceEventsWhenAlwaysTakingSnapshots() throws InterruptedException {
         TestHelper.execute(SETUP_TABLES_STMT);
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
-                                               .with(PostgresConnectorConfig.SNAPSHOT_MODE, ALWAYS.getValue())
+                                               .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.ALWAYS.getValue())
                                                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE);
         start(PostgresConnector.class, configBuilder.build());
         assertConnectorIsRunning();
@@ -512,7 +509,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         String setupStmt = SETUP_TABLES_STMT + INSERT_STMT;
         TestHelper.execute(setupStmt);
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
-                                                        .with(PostgresConnectorConfig.SNAPSHOT_MODE, INITIAL.getValue())
+                                                        .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL.getValue())
                                                         .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE);
         EmbeddedEngine.CompletionCallback completionCallback = (success, message, error) -> {
             if (error != null) {
@@ -558,7 +555,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
                            "INSERT INTO s2.a (aa) VALUES (5);";
         TestHelper.execute(setupStmt);
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
-                                                        .with(PostgresConnectorConfig.SNAPSHOT_MODE, INITIAL.getValue())
+                                                        .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL.getValue())
                                                         .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                                                         .with(PostgresConnectorConfig.SCHEMA_BLACKLIST, "s2")
                                                         .with(PostgresConnectorConfig.TABLE_BLACKLIST, ".+b")
@@ -597,7 +594,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
 
         TestHelper.execute(setupStmt);
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
-                                                        .with(PostgresConnectorConfig.SNAPSHOT_MODE, INITIAL.getValue())
+                                                        .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL.getValue())
                                                         .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                                                         .with(PostgresConnectorConfig.SCHEMA_WHITELIST, "s1")
                                                         .with(PostgresConnectorConfig.TABLE_WHITELIST, "s1\\.dbz_878_some\\|test@data");
@@ -623,7 +620,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         final int recordCount = 10;
         TestHelper.execute(SETUP_TABLES_STMT);
         Configuration config = TestHelper.defaultConfig()
-                                         .with(PostgresConnectorConfig.SNAPSHOT_MODE, NEVER.getValue())
+                                         .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.getValue())
                                          .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
                                          .with(PostgresConnectorConfig.TABLE_WHITELIST, "s1.a")
                                          .build();
@@ -650,6 +647,60 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         // Theoretically the LSN should change for each record but in reality there can be
         // unfortunate timings so let's suppose the chane will happen in 75 % of cases
         Assertions.assertThat(flushLsn.size()).isGreaterThanOrEqualTo((recordCount * 3) / 4);
+    }
+
+    @Test
+    @FixFor("DBZ-1082")
+    public void shouldAllowForCustomSnapshot() throws InterruptedException {
+        TestHelper.execute(SETUP_TABLES_STMT);
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.CUSTOM.getValue())
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE_CLASS, CustomTestSnapshot.class.getName())
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
+                .build();
+        start(PostgresConnector.class, config);
+        assertConnectorIsRunning();
+
+        SourceRecords actualRecords = consumeRecordsByTopic(1);
+
+        List<SourceRecord> s1recs = actualRecords.recordsForTopic(topicName("s1.a"));
+        List<SourceRecord> s2recs = actualRecords.recordsForTopic(topicName("s2.a"));
+        assertThat(s1recs.size()).isEqualTo(1);
+        assertThat(s2recs).isNull();
+
+        SourceRecord record = s1recs.get(0);
+        VerifyRecord.isValidRead(record, PK_FIELD, 1);
+
+        TestHelper.execute(INSERT_STMT);
+        actualRecords = consumeRecordsByTopic(2);
+
+        s1recs = actualRecords.recordsForTopic(topicName("s1.a"));
+        s2recs = actualRecords.recordsForTopic(topicName("s2.a"));
+        assertThat(s1recs.size()).isEqualTo(1);
+        assertThat(s2recs.size()).isEqualTo(1);
+        record = s1recs.get(0);
+        VerifyRecord.isValidInsert(record, PK_FIELD, 2);
+        record = s2recs.get(0);
+        VerifyRecord.isValidInsert(record, PK_FIELD, 2);
+        stopConnector();
+
+        config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.CUSTOM.getValue())
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE_CLASS, CustomTestSnapshot.class.getName())
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+                .build();
+        start(PostgresConnector.class, config);
+        assertConnectorIsRunning();
+        actualRecords = consumeRecordsByTopic(4);
+
+        s1recs = actualRecords.recordsForTopic(topicName("s1.a"));
+        s2recs = actualRecords.recordsForTopic(topicName("s2.a"));
+        assertThat(s1recs.size()).isEqualTo(2);
+        assertThat(s2recs.size()).isEqualTo(2);
+        VerifyRecord.isValidRead(s1recs.get(0), PK_FIELD, 1);
+        VerifyRecord.isValidRead(s1recs.get(1), PK_FIELD, 2);
+        VerifyRecord.isValidRead(s2recs.get(0), PK_FIELD, 1);
+        VerifyRecord.isValidRead(s2recs.get(1), PK_FIELD, 2);
     }
 
     private String getConfirmedFlushLsn(PostgresConnection connection) throws SQLException {
@@ -687,7 +738,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         TestHelper.dropAllSchemas();
         TestHelper.executeDDL("postgres_create_tables.ddl");
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
-                                                        .with(PostgresConnectorConfig.SNAPSHOT_MODE, NEVER.getValue())
+                                                        .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.getValue())
                                                         .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE);
         start(PostgresConnector.class, configBuilder.build());
         assertConnectorIsRunning();
@@ -721,7 +772,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         TestHelper.dropAllSchemas();
         TestHelper.executeDDL("postgres_create_tables.ddl");
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
-                                                        .with(PostgresConnectorConfig.SNAPSHOT_MODE, INITIAL_ONLY.getValue())
+                                                        .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_ONLY.getValue())
                                                         .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE);
         final long recordsCount = 1000000;
         final int batchSize = 1000;

--- a/debezium-core/src/main/java/io/debezium/annotation/Incubating.java
+++ b/debezium-core/src/main/java/io/debezium/annotation/Incubating.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Marks the annotated element as incubating. The contract of incubating elements (e.g. packages, types, methods,
+ * constants etc.) is under active development and may be incompatibly altered - or removed - in subsequent releases.
+ * <p>
+ * Usage of incubating API/SPI members is encouraged (so the development team can get feedback on these new features)
+ * but you should be prepared for updating code which is using them as needed.
+ *
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+public @interface Incubating {
+}

--- a/debezium-core/src/main/java/io/debezium/time/Conversions.java
+++ b/debezium-core/src/main/java/io/debezium/time/Conversions.java
@@ -242,4 +242,8 @@ public final class Conversions {
     public static Instant toInstant(long epochNanos) {
         return Instant.ofEpochSecond(0, epochNanos);
     }
+
+    public static Instant toInstantFromMicros(long epochMicros) {
+        return toInstant(TimeUnit.MICROSECONDS.toNanos(epochMicros));
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/util/Clock.java
+++ b/debezium-core/src/main/java/io/debezium/util/Clock.java
@@ -28,6 +28,11 @@ public interface Clock {
         public long currentTimeInNanos() {
             return System.nanoTime();
         }
+
+        @Override
+        public Instant currentTimeAsInstant() {
+            return Instant.now();
+        }
     };
 
     /**
@@ -55,6 +60,15 @@ public interface Clock {
      */
     default long currentTimeInMicros() {
         return TimeUnit.MICROSECONDS.convert(currentTimeInMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Get the current time as an instant
+     *
+     * @return the current time as an instant.
+     */
+    default Instant currentTimeAsInstant() {
+        return Instant.ofEpochMilli(currentTimeInMillis());
     }
 
     /**

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -159,7 +159,7 @@ public final class EmbeddedEngine implements Runnable {
     public static final Field OFFSET_COMMIT_POLICY = Field.create("offset.commit.policy")
                                                           .withDescription("The fully-qualified class name of the commit policy type. This class must implement the interface "
                                                                       + OffsetCommitPolicy.class.getName()
-                                                                      + ". The default is a periodic commity policy based upon time intervals.")
+                                                                      + ". The default is a periodic commit policy based upon time intervals.")
                                                           .withDefault(OffsetCommitPolicy.PeriodicCommitOffsetPolicy.class.getName())
                                                           .withValidation(Field::isClassName);
 


### PR DESCRIPTION
This commit does a few things:

- Refactors snapshot modes to be encapsulated by an interface and
to only use that interface in determining when to snapshot and in
determing the type of the `RecordProducer` interface to instantiate
- Refactors the configuration of existing snapshot modes to tie the
existing snapshot modes to their aligned implementation
- Adds a new snapshot.mode, custom, and a new configuration option to
specify a custom implementation that will be loaded by the class loader
- Changes the visibility of some classes to allow for custom snapshot
modes to get enough context to make an informed choice
- Adds some metadata about slots (the catalog_xmin) to give a full idea
of the state of slots which can be useful in implementing snapshot
modes (which is also configurable, as it can add some overhead)

Together, these changes allow for a much broader flexibility got end
users to implement a snapshot mode that can do more advanced snapshots,
such as partial recovery or for partial snapshots for tables where not
all records are needed.

This could also be seen as superseeding the
`snapshot.select.statement.overrides` to allow for users to dynamically
build queries based on the state of the slot and the offsets consumed.
