### PR TITLE
DBZ-1162 - fix for HStore snapshot vs streams

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
@@ -289,6 +289,7 @@ public class RecordsStreamProducer extends RecordsProducer {
         TableSchema tableSchema = schema().schemaFor(tableId);
         assert tableSchema != null;
         Object key = tableSchema.keyFromColumnData(rowData);
+        logger.trace("key value is: {}", String.valueOf(key));
         Struct value = tableSchema.valueFromColumnData(rowData);
         if (value == null) {
             logger.warn("no values found for table '{}' from create message at '{}'; skipping record" , tableId, sourceInfo);

--- a/debezium-connector-sqlserver/src/test/resources/log4j.properties
+++ b/debezium-connector-sqlserver/src/test/resources/log4j.properties
@@ -12,4 +12,4 @@ log4j.logger.io.debezium=INFO
 log4j.logger.io.debezium.embedded.EmbeddedEngine$EmbeddedConfig=WARN
 #log4j.logger.io.debezium.embedded.EmbeddedEngine=DEBUG
 log4j.logger.io.debezium.core=DEBUG
-log4j.logger.io.debezium.connector.sqlserver=TRACE
+log4j.logger.io.debezium.connector.sqlserver=DEBUG

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
@@ -1160,9 +1160,12 @@ public class JdbcValueConverters implements ValueConverterProvider {
             final Object schemaDefault = fieldDefn.schema().defaultValue();
             return schemaDefault != null ? schemaDefault : fallback;
         }
+        logger.trace("Value from data object: *** {} ***", data.toString());
 
         final ResultReceiver r = ResultReceiver.create();
         callback.convert(r);
+        logger.trace("Callback toString: {}", callback.toString());
+        logger.trace("Value from ResultReceiver: {}", r.toString());
         return r.hasReceived() ? r.get() : handleUnknownData(column, fieldDefn, data);
     }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/TableSchema.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableSchema.java
@@ -16,6 +16,10 @@ import io.debezium.data.Envelope;
 import io.debezium.data.SchemaUtil;
 import io.debezium.schema.DataCollectionSchema;
 
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Defines the Kafka Connect {@link Schema} functionality associated with a given {@link Table table definition}, and which can
  * be used to send rows of data that match the table definition to Kafka Connect.
@@ -48,6 +52,8 @@ import io.debezium.schema.DataCollectionSchema;
  */
 @Immutable
 public class TableSchema implements DataCollectionSchema {
+
+    private static final Logger logger = LoggerFactory.getLogger(TableSchema.class);
 
     private final TableId id;
     private final Schema keySchema;
@@ -121,6 +127,8 @@ public class TableSchema implements DataCollectionSchema {
      * @return the key, or null if the {@code columnData}
      */
     public Object keyFromColumnData(Object[] columnData) {
+        logger.trace("columnData from current stack: {}", String.valueOf(columnData));
+        logger.trace("key from column data stack: " , new Throwable());
         return columnData == null ? null : keyGenerator.apply(columnData);
     }
 

--- a/debezium-core/src/main/java/io/debezium/relational/TableSchemaBuilder.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableSchemaBuilder.java
@@ -208,7 +208,16 @@ public class TableSchemaBuilder {
                 Struct result = new Struct(schema);
                 for (int i = 0; i != numFields; ++i) {
                     Object value = row[recordIndexes[i]];
+
                     ValueConverter converter = converters[i];
+
+                    if (converter != null) {
+                      LOGGER.trace("converter for value object: *** {} ***", converter.toString());
+                    }
+                    else {
+                      LOGGER.trace("converter is null...");
+                    }
+
                     if (converter != null) {
                         try {
                             value = converter.convert(value);


### PR DESCRIPTION
Within `convertHstoreToJsonString`, during the snapshot, column values arrive as HashMaps, rather than byte arrays or strings. This code checks for fixes that circumstance. 

A couple of notes: 
* There's a lot of debug statements in here, which I was using to introspect the values (I'm using vim as my code editor, rather than an IDE). I'm happy to remove all of these if you all wish.
* I haven't coded in java regularly in about a decade, just fyi 😛
* I am unclear as to whether the `data` object arriving in `convertHstoreToJsonString` _should_ be a HashMap. Some cursory investigation seemed to reveal that HashMap<String, String> is type [returned via the JDBC driver](https://stackoverflow.com/questions/35013800/postgres-hstore-casting-works-wrong)
