### PR TITLE
DBZ-1169 Outbox support

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -7,18 +7,28 @@
 package io.debezium.connector.postgresql;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
+import io.debezium.data.Uuid;
 import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.transforms.outbox.EventRouter;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
-import static io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode.INITIAL;
 import static io.debezium.connector.postgresql.TestHelper.topicName;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
 import static org.fest.assertions.Assertions.assertThat;
 
 /**
@@ -48,7 +58,8 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
             String eventType,
             String aggregateType,
             String aggregateId,
-            String payloadJson
+            String payloadJson,
+            String additional
     ) {
         return String.format("INSERT INTO outboxsmtit.outbox VALUES (" +
                         "'%s'" +
@@ -56,12 +67,14 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
                         ", '%s'" +
                         ", '%s'" +
                         ", '%s'::jsonb" +
+                        "%s" +
                         ");",
                 eventId,
                 aggregateType,
                 aggregateId,
                 eventType,
-                payloadJson);
+                payloadJson,
+                additional);
     }
 
     @Before
@@ -73,7 +86,7 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         TestHelper.execute(SETUP_OUTOBOX_TABLE);
 
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
-                .with(PostgresConnectorConfig.SNAPSHOT_MODE, INITIAL.getValue())
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.getValue())
                 .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
                 .with(PostgresConnectorConfig.SCHEMA_WHITELIST, "outboxsmtit")
                 .with(PostgresConnectorConfig.TABLE_WHITELIST, "outboxsmtit\\.outbox");
@@ -96,7 +109,8 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
                 "UserCreated",
                 "User",
                 "10711fa5",
-                "{}"
+                "{}",
+                ""
         ));
 
         SourceRecords actualRecords = consumeRecordsByTopic(1);
@@ -107,5 +121,88 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
 
         assertThat(routedEvent).isNotNull();
         assertThat(routedEvent.topic()).isEqualTo("outbox.event.user");
+    }
+
+    @Test
+    public void shouldRespectJsonFormatAsString() throws Exception {
+        TestHelper.execute(createEventInsert(
+                UUID.fromString("f9171eb6-19f3-4579-9206-0e179d2ebad7"),
+                "UserCreated",
+                "User",
+                "7bdf2e9e",
+                "{\"email\": \"gh@mefi.in\"}",
+                ""
+        ));
+
+        SourceRecords actualRecords = consumeRecordsByTopic(1);
+        assertThat(actualRecords.topics().size()).isEqualTo(1);
+
+        SourceRecord newEventRecord = actualRecords.recordsForTopic(topicName("outboxsmtit.outbox")).get(0);
+        SourceRecord routedEvent = outboxEventRouter.apply(newEventRecord);
+
+        Struct valueStruct = requireStruct(routedEvent.value(), "test payload");
+        JsonNode payload = (new ObjectMapper()).readTree(valueStruct.getString("payload"));
+        assertThat(payload.get("email").getTextValue()).isEqualTo("gh@mefi.in");
+    }
+
+    @Test
+    public void shouldSupportAllFeatures() throws Exception {
+        outboxEventRouter = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        config.put("table.field.schema.version", "version");
+        config.put("table.field.event.timestamp", "createdat");
+        config.put(
+                "table.fields.additional.placement",
+                "version:envelope:eventVersion," +
+                        "aggregatetype:envelope:aggregateType," +
+                        "somebooltype:envelope:someBoolType," +
+                        "somebooltype:header"
+        );
+        outboxEventRouter.configure(config);
+
+        TestHelper.execute("ALTER TABLE outboxsmtit.outbox add version int not null;");
+        TestHelper.execute("ALTER TABLE outboxsmtit.outbox add somebooltype boolean not null;");
+        TestHelper.execute("ALTER TABLE outboxsmtit.outbox add createdat timestamp without time zone not null;");
+
+        TestHelper.execute(createEventInsert(
+                UUID.fromString("f9171eb6-19f3-4579-9206-0e179d2ebad7"),
+                "UserUpdated",
+                "UserEmail",
+                "7bdf2e9e",
+                "{\"email\": \"gh@mefi.in\"}",
+                ", 1, true, TIMESTAMP '2019-03-24 20:52:59'"
+        ));
+
+        SourceRecords actualRecords = consumeRecordsByTopic(1);
+        assertThat(actualRecords.topics().size()).isEqualTo(1);
+
+        SourceRecord newEventRecord = actualRecords.recordsForTopic(topicName("outboxsmtit.outbox")).get(0);
+        SourceRecord eventRouted = outboxEventRouter.apply(newEventRecord);
+
+        // Validate metadata
+        assertThat(eventRouted.valueSchema().version()).isEqualTo(1);
+        assertThat(eventRouted.timestamp()).isEqualTo(1553460779000000L);
+        assertThat(eventRouted.topic()).isEqualTo("outbox.event.useremail");
+
+        // Validate headers
+        Headers headers = eventRouted.headers();
+        assertThat(headers.size()).isEqualTo(2);
+        Header headerId = headers.lastWithName("id");
+        assertThat(headerId.schema()).isEqualTo(Uuid.schema());
+        assertThat(headerId.value()).isEqualTo("f9171eb6-19f3-4579-9206-0e179d2ebad7");
+        Header headerBool = headers.lastWithName("somebooltype");
+        assertThat(headerBool.schema()).isEqualTo(SchemaBuilder.BOOLEAN_SCHEMA);
+        assertThat(headerBool.value()).isEqualTo(true);
+
+        // Validate Key
+        assertThat(eventRouted.keySchema()).isEqualTo(SchemaBuilder.STRING_SCHEMA);
+        assertThat(eventRouted.key()).isEqualTo("7bdf2e9e");
+
+        // Validate message body
+        Struct valueStruct = requireStruct(eventRouted.value(), "test envelope");
+        assertThat(valueStruct.getString("eventType")).isEqualTo("UserUpdated");
+        assertThat(valueStruct.getString("aggregateType")).isEqualTo("UserEmail");
+        assertThat(valueStruct.getInt32("eventVersion")).isEqualTo(1);
+        assertThat(valueStruct.getBoolean("someBoolType")).isEqualTo(true);
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -104,6 +104,8 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
 
         SourceRecord newEventRecord = actualRecords.recordsForTopic(topicName("outboxsmtit.outbox")).get(0);
         SourceRecord routedEvent = outboxEventRouter.apply(newEventRecord);
+
         assertThat(routedEvent).isNotNull();
+        assertThat(routedEvent.topic()).isEqualTo("user");
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -106,6 +106,6 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         SourceRecord routedEvent = outboxEventRouter.apply(newEventRecord);
 
         assertThat(routedEvent).isNotNull();
-        assertThat(routedEvent.topic()).isEqualTo("user");
+        assertThat(routedEvent.topic()).isEqualTo("outbox.event.user");
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.postgresql;
+
+import io.debezium.config.Configuration;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.transforms.outbox.EventRouter;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode.INITIAL;
+import static io.debezium.connector.postgresql.TestHelper.topicName;
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * Integration test for {@link io.debezium.transforms.outbox.EventRouter} with {@link PostgresConnector}
+ *
+ * @author Renato Mefi (gh@mefi.in)
+ */
+public class OutboxEventRouterIT extends AbstractConnectorTest {
+
+    private static final String SETUP_OUTBOX_SCHEMA = "DROP SCHEMA IF EXISTS outboxsmtit CASCADE;" +
+            "CREATE SCHEMA outboxsmtit;";
+
+    private static final String SETUP_OUTOBOX_TABLE = "CREATE TABLE outboxsmtit.outbox " +
+            "(" +
+            "  id            uuid         not null" +
+            "    constraint outbox_pk primary key," +
+            "  aggregatetype varchar(255) not null," +
+            "  aggregateid   varchar(255) not null," +
+            "  type          varchar(255) not null," +
+            "  payload       jsonb        not null" +
+            ");";
+
+    private EventRouter<SourceRecord> outboxEventRouter;
+
+    private static String createEventInsert(
+            UUID eventId,
+            String eventType,
+            String aggregateType,
+            String aggregateId,
+            String payloadJson
+    ) {
+        return String.format("INSERT INTO outboxsmtit.outbox VALUES (" +
+                        "'%s'" +
+                        ", '%s'" +
+                        ", '%s'" +
+                        ", '%s'" +
+                        ", '%s'::jsonb" +
+                        ");",
+                eventId,
+                aggregateType,
+                aggregateId,
+                eventType,
+                payloadJson);
+    }
+
+    @Before
+    public void beforeEach() {
+        outboxEventRouter = new EventRouter<>();
+        outboxEventRouter.configure(Collections.emptyMap());
+
+        TestHelper.execute(SETUP_OUTBOX_SCHEMA);
+        TestHelper.execute(SETUP_OUTOBOX_TABLE);
+
+        Configuration.Builder configBuilder = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, INITIAL.getValue())
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
+                .with(PostgresConnectorConfig.SCHEMA_WHITELIST, "outboxsmtit")
+                .with(PostgresConnectorConfig.TABLE_WHITELIST, "outboxsmtit\\.outbox");
+        start(PostgresConnector.class, configBuilder.build());
+
+        assertConnectorIsRunning();
+    }
+
+    @After
+    public void afterEach() {
+        stopConnector();
+        assertNoRecordsToConsume();
+        outboxEventRouter.close();
+    }
+
+    @Test
+    public void shouldConsumeRecordsFromInsert() throws Exception {
+        TestHelper.execute(createEventInsert(
+                UUID.fromString("59a42efd-b015-44a9-9dde-cb36d9002425"),
+                "UserCreated",
+                "User",
+                "10711fa5",
+                "{}"
+        ));
+
+        SourceRecords actualRecords = consumeRecordsByTopic(1);
+        assertThat(actualRecords.topics().size()).isEqualTo(1);
+
+        SourceRecord newEventRecord = actualRecords.recordsForTopic(topicName("outboxsmtit.outbox")).get(0);
+        SourceRecord routedEvent = outboxEventRouter.apply(newEventRecord);
+        assertThat(routedEvent).isNotNull();
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -6,6 +6,7 @@
 package io.debezium.transforms.outbox;
 
 import io.debezium.config.Configuration;
+import io.debezium.config.Field;
 import io.debezium.data.Envelope;
 import io.debezium.transforms.outbox.EventRouterConfigDefinition.AdditionalField;
 import org.apache.kafka.common.config.ConfigDef;
@@ -13,6 +14,7 @@ import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.transforms.ExtractField;
 import org.apache.kafka.connect.transforms.RegexRouter;
@@ -171,6 +173,10 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
     @Override
     public void configure(Map<String, ?> configMap) {
         final Configuration config = Configuration.from(configMap);
+        Field.Set allFields = Field.setOf(EventRouterConfigDefinition.CONFIG_FIELDS);
+        if (!config.validateAndRecord(allFields, LOGGER::error)) {
+            throw new ConnectException("Unable to validate config.");
+        }
 
         invalidOperationBehavior = EventRouterConfigDefinition.InvalidOperationBehavior.parse(
                 config.getString(EventRouterConfigDefinition.OPERATION_INVALID_BEHAVIOR)

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -5,11 +5,18 @@
  */
 package io.debezium.transforms.outbox;
 
+import io.debezium.config.Configuration;
+import io.debezium.data.Envelope;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.transforms.Transformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
 
 /**
  * Debezium Outbox Transform Event Router
@@ -18,9 +25,47 @@ import java.util.Map;
  */
 public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventRouter.class);
+
+    private EventRouterConfigDefinition.InvalidOperationBehavior invalidOperationBehavior;
+
     @Override
     public R apply(R r) {
-        return null;
+        // Ignoring tombstones
+        if (r.value() == null) {
+            LOGGER.info("Tombstone message {} ignored", r.key());
+            return null;
+        }
+
+        Struct value = requireStruct(r.value(), "b");
+        String op = value.getString(Envelope.FieldName.OPERATION);
+
+        // Skipping deletes
+        if (op.equals(Envelope.Operation.DELETE.code())) {
+            LOGGER.info("Delete message {} ignored", r.key());
+            return null;
+        }
+
+        // Dealing with unexpected update operations
+        if (op.equals(Envelope.Operation.UPDATE.code())) {
+            handleUnexpectedOperation(r);
+            return null;
+        }
+
+        return r;
+    }
+
+    private void handleUnexpectedOperation(R r) {
+        switch (invalidOperationBehavior) {
+            case SKIP_AND_WARN:
+                LOGGER.warn("Unexpected update message received {} and ignored", r.key());
+                break;
+            case SKIP_AND_ERROR:
+                LOGGER.error("Unexpected update message received {} and ignored", r.key());
+                break;
+            case FATAL:
+                throw new IllegalStateException(String.format("Unexpected update message received %s, fail.", r.key()));
+        }
     }
 
     @Override
@@ -34,7 +79,11 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
     }
 
     @Override
-    public void configure(Map<String, ?> configs) {
+    public void configure(Map<String, ?> configMap) {
+        final Configuration config = Configuration.from(configMap);
 
+        invalidOperationBehavior = EventRouterConfigDefinition.InvalidOperationBehavior.parse(
+                config.getString(EventRouterConfigDefinition.OPERATION_INVALID_BEHAVIOR)
+        );
     }
 }

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -40,6 +40,7 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
     private String fieldEventId;
     private String fieldEventKey;
     private String fieldEventType;
+    private String fieldEventTimestamp;
     private String fieldPayload;
     private String fieldPayloadId;
 
@@ -73,7 +74,9 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         final R afterRecord = afterExtractor.apply(r);
         Struct eventStruct = requireStruct(afterRecord.value(), "Read Outbox Event");
 
-        Long timestamp = debeziumEventValue.getInt64("ts_ms");
+        Long timestamp = fieldEventTimestamp == null
+                ? debeziumEventValue.getInt64("ts_ms")
+                : eventStruct.getInt64(fieldEventTimestamp);
 
         String eventId = eventStruct.getString(fieldEventId);
         String eventType = eventStruct.getString(fieldEventType);
@@ -143,6 +146,7 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         fieldEventId = config.getString(EventRouterConfigDefinition.FIELD_EVENT_ID);
         fieldEventKey = config.getString(EventRouterConfigDefinition.FIELD_EVENT_KEY);
         fieldEventType = config.getString(EventRouterConfigDefinition.FIELD_EVENT_TYPE);
+        fieldEventTimestamp = config.getString(EventRouterConfigDefinition.FIELD_EVENT_TIMESTAMP);
         fieldPayload = config.getString(EventRouterConfigDefinition.FIELD_PAYLOAD);
         fieldPayloadId = config.getString(EventRouterConfigDefinition.FIELD_PAYLOAD_ID);
 

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.transforms.outbox;
 
+import io.debezium.annotation.Incubating;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.data.Envelope;
@@ -34,6 +35,7 @@ import static org.apache.kafka.connect.transforms.util.Requirements.requireStruc
  *
  * @author Renato mefi (gh@mefi.in)
  */
+@Incubating
 public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EventRouter.class);

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -9,11 +9,16 @@ import io.debezium.config.Configuration;
 import io.debezium.data.Envelope;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.transforms.ExtractField;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
@@ -27,7 +32,17 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EventRouter.class);
 
+    private final ExtractField<R> afterExtractor = new ExtractField.Value<>();
     private EventRouterConfigDefinition.InvalidOperationBehavior invalidOperationBehavior;
+
+    private String fieldEventId;
+    private String fieldEventKey;
+    private String fieldEventType;
+    private String fieldPayload;
+    private String fieldPayloadId;
+    private String fieldPayloadType;
+
+    private Schema valueSchema;
 
     @Override
     public R apply(R r) {
@@ -37,8 +52,8 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
             return null;
         }
 
-        Struct value = requireStruct(r.value(), "b");
-        String op = value.getString(Envelope.FieldName.OPERATION);
+        Struct debeziumEventValue = requireStruct(r.value(), "Detect Debezium Operation");
+        String op = debeziumEventValue.getString(Envelope.FieldName.OPERATION);
 
         // Skipping deletes
         if (op.equals(Envelope.Operation.DELETE.code())) {
@@ -52,7 +67,43 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
             return null;
         }
 
-        return r;
+        final R afterRecord = afterExtractor.apply(r);
+        Struct eventStruct = requireStruct(afterRecord.value(), "Read Outbox Event");
+
+        Long timestamp = debeziumEventValue.getInt64("ts_ms");
+
+        String eventId = eventStruct.getString(fieldEventId);
+        String eventType = eventStruct.getString(fieldEventType);
+        String payload = eventStruct.getString(fieldPayload);
+        String payloadId = eventStruct.getString(fieldPayloadId);
+        String payloadType = eventStruct.getString(fieldPayloadType);
+
+        Headers headers = r.headers();
+        headers.addString("id", eventId);
+
+        Struct value = new Struct(valueSchema)
+                .put("eventType", eventType)
+                .put("payload", payload);
+
+        return r.newRecord(
+                payloadType.toLowerCase(),
+                null,
+                Schema.STRING_SCHEMA,
+                defineRecordKey(eventStruct, payloadId),
+                valueSchema,
+                value,
+                timestamp,
+                headers
+        );
+    }
+
+    private String defineRecordKey(Struct eventStruct, String fallbackKey) {
+        String eventKey = null;
+        if (fieldEventKey != null) {
+            eventKey = eventStruct.getString(fieldEventKey);
+        }
+
+        return (eventKey != null) ? eventKey : fallbackKey;
     }
 
     private void handleUnexpectedOperation(R r) {
@@ -75,7 +126,6 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
 
     @Override
     public void close() {
-
     }
 
     @Override
@@ -85,5 +135,22 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         invalidOperationBehavior = EventRouterConfigDefinition.InvalidOperationBehavior.parse(
                 config.getString(EventRouterConfigDefinition.OPERATION_INVALID_BEHAVIOR)
         );
+
+        fieldEventId = config.getString(EventRouterConfigDefinition.FIELD_EVENT_ID);
+        fieldEventKey = config.getString(EventRouterConfigDefinition.FIELD_EVENT_KEY);
+        fieldEventType = config.getString(EventRouterConfigDefinition.FIELD_EVENT_TYPE);
+        fieldPayload = config.getString(EventRouterConfigDefinition.FIELD_PAYLOAD);
+        fieldPayloadId = config.getString(EventRouterConfigDefinition.FIELD_PAYLOAD_ID);
+        fieldPayloadType = config.getString(EventRouterConfigDefinition.FIELD_PAYLOAD_TYPE);
+
+        final Map<String, String> afterExtractorConfig = new HashMap<>();
+        afterExtractorConfig.put("field", Envelope.FieldName.AFTER);
+
+        afterExtractor.configure(afterExtractorConfig);
+
+        valueSchema = SchemaBuilder.struct()
+                .field("eventType", Schema.STRING_SCHEMA)
+                .field("payload", Schema.STRING_SCHEMA)
+                .build();
     }
 }

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms.outbox;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.transforms.Transformation;
+
+import java.util.Map;
+
+/**
+ * Debezium Outbox Transform Event Router
+ *
+ * @author Renato mefi (gh@mefi.in)
+ */
+public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    @Override
+    public R apply(R r) {
+        return null;
+    }
+
+    @Override
+    public ConfigDef config() {
+        return EventRouterConfigDefinition.configDef();
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms.outbox;
+
+import io.debezium.config.EnumeratedValue;
+import io.debezium.config.Field;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.transforms.util.RegexValidator;
+
+/**
+ * Debezium Outbox Transform configuration definition
+ *
+ * @author Renato mefi (gh@mefi.in)
+ */
+public class EventRouterConfigDefinition {
+
+    public enum InvalidOperationBehavior implements EnumeratedValue {
+        SKIP_AND_WARN("warn"),
+        SKIP_AND_ERROR("error"),
+        FATAL("fatal");
+
+        private final String value;
+
+        InvalidOperationBehavior(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value the configuration property value; may not be null
+         * @return the matching option, or null if no match is found
+         */
+        public static InvalidOperationBehavior parse(String value) {
+            if (value == null) return null;
+            value = value.trim();
+            for (InvalidOperationBehavior option : InvalidOperationBehavior.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) return option;
+            }
+            return null;
+        }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value        the configuration property value; may not be null
+         * @param defaultValue the default value; may be null
+         * @return the matching option, or null if no match is found and the non-null default is invalid
+         */
+        public static InvalidOperationBehavior parse(String value, String defaultValue) {
+            InvalidOperationBehavior mode = parse(value);
+            if (mode == null && defaultValue != null) mode = parse(defaultValue);
+            return mode;
+        }
+    }
+
+    static final Field FIELD_EVENT_ID = Field.create("table.field.event.id")
+            .withDisplayName("Event ID Field")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDefault("id")
+            .withDescription("The column which contains the Event ID within the outbox table");
+
+    static final Field FIELD_EVENT_KEY = Field.create("table.field.event.key")
+            .withDisplayName("Event Key Field")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDescription("The column which contains the Event Key within the outbox table");
+
+    static final Field FIELD_EVENT_TYPE = Field.create("table.field.event.type")
+            .withDisplayName("Event Type Field")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDefault("type")
+            .withDescription("The column which contains the Event Type within the outbox table");
+
+    static final Field FIELD_PAYLOAD = Field.create("table.field.payload")
+            .withDisplayName("Event Payload Field")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDefault("payload")
+            .withDescription("The column which contains the Event Type within the outbox table");
+
+    static final Field FIELD_PAYLOAD_ID = Field.create("table.field.payload.id")
+            .withDisplayName("Event Payload ID Field")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDefault("aggregateid")
+            .withDescription("The column which contains the Payload ID within the outbox table");
+
+    static final Field FIELD_PAYLOAD_TYPE = Field.create("table.field.payload.type")
+            .withDisplayName("Event Payload Type Field")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDefault("aggregatetype")
+            .withDescription("The column which contains the Payload Type within the outbox table");
+
+    static final Field ROUTE_BY_FIELD = Field.create("route.by.field")
+            .withDisplayName("Field to route events by")
+            .withType(ConfigDef.Type.STRING)
+            .withDefault("aggregatetype")
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("The column which determines how the events will be routed, the value will become part of" +
+                    " the topic name");
+
+    static final Field ROUTE_TOPIC_REGEX = Field.create("route.topic.regex")
+            .withDisplayName("The name of the routed topic")
+            .withType(ConfigDef.Type.STRING)
+            .withValidation(Field::isRegex)
+            .withDefault("(?<routedByValue>.*)")
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDescription("The default regex to use within the RegexRouter, the default capture will allow" +
+                    " to replace the routed field into a new topic name defined in 'route.topic.replacement'");
+
+    static final Field ROUTE_TOPIC_REPLACEMENT = Field.create("route.topic.replacement")
+            .withDisplayName("The name of the routed topic")
+            .withType(ConfigDef.Type.STRING)
+            .withDefault("outbox.event.${routedByValue}")
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("The name of the topic in which the events will be routed, a replacement" +
+                    " '${routedByValue}' is available which is the value of The column configured" +
+                    " via 'route.by.field'");
+
+    static final Field OPERATION_INVALID_BEHAVIOR = Field.create("debezium.op.invalid.behavior")
+            .withDisplayName("Behavior when the route fails to apply")
+            .withEnum(InvalidOperationBehavior.class, InvalidOperationBehavior.SKIP_AND_WARN)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("While Debezium is monitoring the table, it's expecting only to see 'create' row events," +
+                    " in case something else is processed this transform can log it as warning, error or stop the" +
+                    " process");
+
+    /**
+     * There are 3 configuration groups available:
+     * - Table: Allows you to customize each of The column names in the outbox table for your convenience
+     * - Router: The behavior behind the events routing
+     * - Debezium: Specific to Debezium behavior which might impact the transform
+     *
+     * @return ConfigDef
+     */
+    public static ConfigDef configDef() {
+        ConfigDef config = new ConfigDef();
+        Field.group(
+                config,
+                "Table",
+                FIELD_EVENT_ID, FIELD_EVENT_KEY, FIELD_EVENT_TYPE, FIELD_PAYLOAD, FIELD_PAYLOAD_ID, FIELD_PAYLOAD_TYPE
+        );
+        Field.group(
+                config,
+                "Router",
+                ROUTE_BY_FIELD, ROUTE_TOPIC_REPLACEMENT
+        );
+        Field.group(
+                config,
+                "Debezium",
+                OPERATION_INVALID_BEHAVIOR
+        );
+        return config;
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
@@ -101,14 +101,6 @@ public class EventRouterConfigDefinition {
             .withDefault("aggregateid")
             .withDescription("The column which contains the Payload ID within the outbox table");
 
-    static final Field FIELD_PAYLOAD_TYPE = Field.create("table.field.payload.type")
-            .withDisplayName("Event Payload Type Field")
-            .withType(ConfigDef.Type.STRING)
-            .withWidth(ConfigDef.Width.MEDIUM)
-            .withImportance(ConfigDef.Importance.LOW)
-            .withDefault("aggregatetype")
-            .withDescription("The column which contains the Payload Type within the outbox table");
-
     static final Field ROUTE_BY_FIELD = Field.create("route.by.field")
             .withDisplayName("Field to route events by")
             .withType(ConfigDef.Type.STRING)
@@ -160,7 +152,7 @@ public class EventRouterConfigDefinition {
         Field.group(
                 config,
                 "Table",
-                FIELD_EVENT_ID, FIELD_EVENT_KEY, FIELD_EVENT_TYPE, FIELD_PAYLOAD, FIELD_PAYLOAD_ID, FIELD_PAYLOAD_TYPE
+                FIELD_EVENT_ID, FIELD_EVENT_KEY, FIELD_EVENT_TYPE, FIELD_PAYLOAD, FIELD_PAYLOAD_ID
         );
         Field.group(
                 config,

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
@@ -190,6 +190,13 @@ public class EventRouterConfigDefinition {
                     " is a list of colon-delimited pairs or trios when you desire to have aliases," +
                     " e.g. <code>id:header,field_name:envelope:alias</code> ");
 
+    static final Field FIELD_SCHEMA_VERSION = Field.create("table.field.schema.version")
+            .withDisplayName("Event Schema Version Field")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDescription("The column which contains the Schema version within the outbox table");
+
     static final Field ROUTE_BY_FIELD = Field.create("route.by.field")
             .withDisplayName("Field to route events by")
             .withType(ConfigDef.Type.STRING)
@@ -241,7 +248,7 @@ public class EventRouterConfigDefinition {
         Field.group(
                 config,
                 "Table",
-                FIELD_EVENT_ID, FIELD_EVENT_KEY, FIELD_EVENT_TYPE, FIELD_PAYLOAD, FIELD_PAYLOAD_ID, FIELD_EVENT_TIMESTAMP, FIELDS_ADDITIONAL_PLACEMENT
+                FIELD_EVENT_ID, FIELD_EVENT_KEY, FIELD_EVENT_TYPE, FIELD_PAYLOAD, FIELD_PAYLOAD_ID, FIELD_EVENT_TIMESTAMP, FIELDS_ADDITIONAL_PLACEMENT, FIELD_SCHEMA_VERSION
         );
         Field.group(
                 config,

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
@@ -235,6 +235,21 @@ public class EventRouterConfigDefinition {
                     " in case something else is processed this transform can log it as warning, error or stop the" +
                     " process");
 
+    static final Field[] CONFIG_FIELDS = {
+            FIELD_EVENT_ID,
+            FIELD_EVENT_KEY,
+            FIELD_EVENT_TYPE,
+            FIELD_PAYLOAD,
+            FIELD_PAYLOAD_ID,
+            FIELD_EVENT_TIMESTAMP,
+            FIELDS_ADDITIONAL_PLACEMENT,
+            FIELD_SCHEMA_VERSION,
+            ROUTE_BY_FIELD,
+            ROUTE_TOPIC_REGEX,
+            ROUTE_TOPIC_REPLACEMENT,
+            OPERATION_INVALID_BEHAVIOR
+    };
+
     /**
      * There are 3 configuration groups available:
      * - Table: Allows you to customize each of The column names in the outbox table for your convenience
@@ -253,7 +268,7 @@ public class EventRouterConfigDefinition {
         Field.group(
                 config,
                 "Router",
-                ROUTE_BY_FIELD, ROUTE_TOPIC_REPLACEMENT
+                ROUTE_BY_FIELD, ROUTE_TOPIC_REGEX, ROUTE_TOPIC_REPLACEMENT
         );
         Field.group(
                 config,
@@ -263,7 +278,7 @@ public class EventRouterConfigDefinition {
         return config;
     }
 
-    public static List<AdditionalField> parseAdditionalFieldsConfig(Configuration config) {
+    static List<AdditionalField> parseAdditionalFieldsConfig(Configuration config) {
         String extraFieldsMapping = config.getString(EventRouterConfigDefinition.FIELDS_ADDITIONAL_PLACEMENT);
 
         List<AdditionalField> additionalFields = new ArrayList<>();
@@ -272,7 +287,7 @@ public class EventRouterConfigDefinition {
             return additionalFields;
         }
 
-        for (String field: extraFieldsMapping.split(",")) {
+        for (String field : extraFieldsMapping.split(",")) {
             final String[] parts = field.split(":");
             AdditionalFieldPlacement placement = AdditionalFieldPlacement.parse(parts[1]);
             additionalFields.add(
@@ -286,6 +301,11 @@ public class EventRouterConfigDefinition {
     private static int isListOfStringPairs(Configuration config, Field field, Field.ValidationOutput problems) {
         List<String> value = config.getStrings(field, ",");
         int errors = 0;
+
+        if (value == null) {
+            return errors;
+        }
+
         for (String mapping : value) {
             final String[] parts = mapping.split(":");
             if (parts.length != 2 && parts.length != 3) {

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
@@ -43,25 +43,16 @@ public class EventRouterConfigDefinition {
          * @return the matching option, or null if no match is found
          */
         public static InvalidOperationBehavior parse(String value) {
-            if (value == null) return null;
+            if (value == null) {
+                return null;
+            }
             value = value.trim();
             for (InvalidOperationBehavior option : InvalidOperationBehavior.values()) {
-                if (option.getValue().equalsIgnoreCase(value)) return option;
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
             }
             return null;
-        }
-
-        /**
-         * Determine if the supplied value is one of the predefined options.
-         *
-         * @param value        the configuration property value; may not be null
-         * @param defaultValue the default value; may be null
-         * @return the matching option, or null if no match is found and the non-null default is invalid
-         */
-        public static InvalidOperationBehavior parse(String value, String defaultValue) {
-            InvalidOperationBehavior mode = parse(value);
-            if (mode == null && defaultValue != null) mode = parse(defaultValue);
-            return mode;
         }
     }
 
@@ -87,25 +78,16 @@ public class EventRouterConfigDefinition {
          * @return the matching option, or null if no match is found
          */
         public static AdditionalFieldPlacement parse(String value) {
-            if (value == null) return null;
+            if (value == null) {
+                return null;
+            }
             value = value.trim();
             for (AdditionalFieldPlacement option : AdditionalFieldPlacement.values()) {
-                if (option.getValue().equalsIgnoreCase(value)) return option;
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
             }
             return null;
-        }
-
-        /**
-         * Determine if the supplied value is one of the predefined options.
-         *
-         * @param value        the configuration property value; may not be null
-         * @param defaultValue the default value; may be null
-         * @return the matching option, or null if no match is found and the non-null default is invalid
-         */
-        public static AdditionalFieldPlacement parse(String value, String defaultValue) {
-            AdditionalFieldPlacement mode = parse(value);
-            if (mode == null && defaultValue != null) mode = parse(defaultValue);
-            return mode;
         }
     }
 

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
@@ -85,6 +85,14 @@ public class EventRouterConfigDefinition {
             .withDefault("type")
             .withDescription("The column which contains the Event Type within the outbox table");
 
+    static final Field FIELD_EVENT_TIMESTAMP = Field.create("table.field.event.timestamp")
+            .withDisplayName("Event Timestamp Field")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.MEDIUM)
+            .withDescription("Optionally you can override the Kafka message timestamp with a value from a chosen" +
+                    " field, otherwise it'll be the debezium event processed timestamp.");
+
     static final Field FIELD_PAYLOAD = Field.create("table.field.payload")
             .withDisplayName("Event Payload Field")
             .withType(ConfigDef.Type.STRING)
@@ -152,7 +160,7 @@ public class EventRouterConfigDefinition {
         Field.group(
                 config,
                 "Table",
-                FIELD_EVENT_ID, FIELD_EVENT_KEY, FIELD_EVENT_TYPE, FIELD_PAYLOAD, FIELD_PAYLOAD_ID
+                FIELD_EVENT_ID, FIELD_EVENT_KEY, FIELD_EVENT_TYPE, FIELD_PAYLOAD, FIELD_PAYLOAD_ID, FIELD_EVENT_TIMESTAMP
         );
         Field.group(
                 config,

--- a/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -9,6 +9,7 @@ import io.debezium.data.Envelope;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.header.Headers;
@@ -419,6 +420,38 @@ public class EventRouterTest {
         assertThat(value.get("payloadType")).isEqualTo("UserCreated");
         assertThat(value.get("payloadId")).isEqualTo("10711fa5");
         assertThat(eventRouted.headers().lastWithName("payloadType").value()).isEqualTo("UserCreated");
+    }
+
+    @Test(expected = ConnectException.class)
+    public void shouldFailOnInvalidConfigurationForTopicRegex() {
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        config.put(EventRouterConfigDefinition.ROUTE_TOPIC_REGEX.name(), " [[a-z]");
+        router.configure(config);
+    }
+
+    @Test(expected = ConnectException.class)
+    public void shouldFailOnInvalidConfigurationForAdditionalFields() {
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        config.put(EventRouterConfigDefinition.FIELDS_ADDITIONAL_PLACEMENT.name(), "type");
+        router.configure(config);
+    }
+
+    @Test(expected = ConnectException.class)
+    public void shouldFailOnInvalidConfigurationForAdditionalFieldsEmpty() {
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        config.put(EventRouterConfigDefinition.FIELDS_ADDITIONAL_PLACEMENT.name(), "");
+        router.configure(config);
+    }
+
+    @Test(expected = ConnectException.class)
+    public void shouldFailOnInvalidConfigurationForOperationBehavior() {
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        config.put(EventRouterConfigDefinition.OPERATION_INVALID_BEHAVIOR.name(), "invalidOption");
+        router.configure(config);
     }
 
     private SourceRecord createEventRecord() {

--- a/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms.outbox;
+
+import io.debezium.data.Envelope;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link EventRouter}
+ *
+ * @author Renato mefi (gh@mefi.in)
+ */
+public class EventRouterTest {
+
+    @Test
+    public void canSkipTombstone() {
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        router.configure(config);
+
+        final SourceRecord eventRecord = new SourceRecord(
+                new HashMap<>(),
+                new HashMap<>(),
+                "db.outbox",
+                null,
+                null
+        );
+        final SourceRecord eventRouted = router.apply(eventRecord);
+
+        assertThat(eventRouted).isNull();
+    }
+
+    @Test
+    public void canSkipDeletion() {
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        router.configure(config);
+
+        final Schema recordSchema = SchemaBuilder.struct().field("id", SchemaBuilder.string()).build();
+        Envelope envelope = Envelope.defineSchema()
+                .withName("dummy.Envelope")
+                .withRecord(recordSchema)
+                .withSource(SchemaBuilder.struct().build())
+                .build();
+        final Struct before = new Struct(recordSchema);
+        before.put("id", "772590bf-ef2d-4814-b4bf-ddc6f5f8b9c5");
+        final Struct payload = envelope.delete(before, null, System.nanoTime());
+        final SourceRecord eventRecord = new SourceRecord(new HashMap<>(), new HashMap<>(), "db.outbox", envelope.schema(), payload);
+
+        final SourceRecord eventRouted = router.apply(eventRecord);
+
+        assertThat(eventRouted).isNull();
+    }
+
+    @Test
+    public void canExtractTableFields() {
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        router.configure(config);
+
+        final SourceRecord eventRecord = createEventRecord();
+        final SourceRecord eventRouted = router.apply(eventRecord);
+
+        assertThat(eventRouted).isNotNull();
+        assertThat(((Struct) eventRouted.value()).getString("id")).isEqualTo("da8d6de6-3b77-45ff-8f44-57db55a7a06c");
+    }
+
+    private SourceRecord createEventRecord() {
+        final Schema recordSchema = SchemaBuilder.struct().field("id", SchemaBuilder.string()).build();
+        Envelope envelope = Envelope.defineSchema()
+                .withName("event.Envelope")
+                .withRecord(recordSchema)
+                .withSource(SchemaBuilder.struct().build())
+                .build();
+
+        final Struct before = new Struct(recordSchema);
+        before.put("id", "da8d6de6-3b77-45ff-8f44-57db55a7a06c");
+
+        final Struct payload = envelope.create(before, null, System.nanoTime());
+        return new SourceRecord(new HashMap<>(), new HashMap<>(), "db.outbox", envelope.schema(), payload);
+    }
+}


### PR DESCRIPTION
## Context
[DBZ-1169](https://issues.jboss.org/browse/DBZ-1169)

## This PR
This is a Draft PR which will try to reflect upon the decisions in the design of the outbox support by Debezium

Let's leave this PR for technical reviews, about the behavior let's centralize in [Jira](https://issues.jboss.org/browse/DBZ-1169).

## Todo
- [x] Configuration definition
  - [x] Configuration for Event Timestamp
  - [x] Configuration for extra fields translated to headers or message body
    - My idea here is to create a mapping where you can set the field and its destination: `event_id:header,my_extra_field:value`
  - [x] Validate configuration
- [x] Deal with unexpected operations
  - [x] Is `IllegalStateException` fine? We cannot throw `ConnectException` within `apply`
- [x] Ignore deletions and tombstones
- [x] Create Event Record with its values
- [x] Deal with Schema and Schemaless?
- [x] Route by field support
  - [x] Set record `Key` based on EventKey or fallback to AggregateId
- [x] Support Event Timestamp or fallback to `ts_ms`
- [x] Extra fields support (As header, payload or ignore)
- [x] Support Schema version
- [x] Integration tests