### PR TITLE
DBZ-1174: Convert commitTime from nanos to micros for wal2json

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
@@ -241,9 +241,9 @@ public class RecordsStreamProducer extends RecordsProducer {
         assert tableId != null;
 
         // update the source info with the coordinates for this message
-        long commitTimeNs = message.getCommitTime();
+        long commitTimeMicros = message.getCommitTime();
         long txId = message.getTransactionId();
-        sourceInfo.update(lsn, commitTimeNs, txId, tableId);
+        sourceInfo.update(lsn, commitTimeMicros, txId, tableId);
         if (logger.isDebugEnabled()) {
             logger.debug("received new message at position {}\n{}", ReplicationConnection.format(lsn), message);
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
@@ -13,6 +13,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 import org.apache.kafka.connect.data.Field;
@@ -85,7 +86,7 @@ class Wal2JsonReplicationMessage implements ReplicationMessage {
 
     @Override
     public long getCommitTime() {
-        return commitTime;
+        return TimeUnit.NANOSECONDS.toMicros(commitTime);
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -389,9 +389,9 @@ public abstract class AbstractRecordsProducerTest {
     }
 
     protected List<SchemaAndValueField> schemaAndValuesForTstzRangeTypes() {
-        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSxxx");
-        Instant begin = dateTimeFormatter.parse("2017-06-05 11:29:12.549426+00:00", Instant::from);
-        Instant end = dateTimeFormatter.parse("2017-06-05 12:34:56.789012+00:00", Instant::from);
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSx");
+        Instant begin = dateTimeFormatter.parse("2017-06-05 11:29:12.549426+00", Instant::from);
+        Instant end = dateTimeFormatter.parse("2017-06-05 12:34:56.789012+00", Instant::from);
 
         // Acknowledge timezone expectation of the system running the test
         String beginSystemTime = dateTimeFormatter.withZone(ZoneId.systemDefault()).format(begin);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -389,9 +389,9 @@ public abstract class AbstractRecordsProducerTest {
     }
 
     protected List<SchemaAndValueField> schemaAndValuesForTstzRangeTypes() {
-        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSx");
-        Instant begin = dateTimeFormatter.parse("2017-06-05 11:29:12.549426+00", Instant::from);
-        Instant end = dateTimeFormatter.parse("2017-06-05 12:34:56.789012+00", Instant::from);
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSSxxx");
+        Instant begin = dateTimeFormatter.parse("2017-06-05 11:29:12.549426+00:00", Instant::from);
+        Instant end = dateTimeFormatter.parse("2017-06-05 12:34:56.789012+00:00", Instant::from);
 
         // Acknowledge timezone expectation of the system running the test
         String beginSystemTime = dateTimeFormatter.withZone(ZoneId.systemDefault()).format(begin);


### PR DESCRIPTION
- wal2json sends the txn commitTime using a function from PostgreSQL's C
  library. The value that Debezium recevies is in **nanoseconds**.
- decoderbufs sends the txn commitTime in **microseconds**.
- `RecordsSnapshotProducer` updates `SourceInfo.ts_usec` by converting
  System.currentTimeMillis() to microseconds.
- `RecordsSnapshotProducer` updates the `SourceInfo.ts_usec` field using
  `message.getCommitTime()`.

This means that when using wal2json, the value of `SourceInfo.ts_usec`
is in microseconds since epoch during snapshot but is in nanoseconds
during streaming. To fix this, we changed
`Wal2JsonReplicationMessage.getCommitTime()` to return in microseconds.