### PR TITLE
DBZ-1181 - Process WAL2JSON Events with Empty Changes

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
@@ -233,6 +233,7 @@ public class RecordsStreamProducer extends RecordsProducer {
         // in some cases we can get null if PG gives us back a message earlier than the latest reported flushed LSN.
         // WAL2JSON can also send empty changes for DDL, materialized views, etc. and the heartbeat still needs to fire.
         if (message == null) {
+            logger.trace("Received empty message");
             lastCompletelyProcessedLsn = lsn;
             heartbeat.heartbeat(sourceInfo.partition(), sourceInfo.offset(),
                     r -> consumer.accept(new ChangeEvent(r, lsn)));

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
@@ -230,8 +230,12 @@ public class RecordsStreamProducer extends RecordsProducer {
     }
 
     private void process(ReplicationMessage message, Long lsn, BlockingConsumer<ChangeEvent> consumer) throws SQLException, InterruptedException {
+        // in some cases we can get null if PG gives us back a message earlier than the latest reported flushed LSN.
+        // WAL2JSON can also send empty changes for DDL, materialized views, etc. and the heartbeat still needs to fire.
         if (message == null) {
-            // in some cases we can get null if PG gives us back a message earlier than the latest reported flushed LSN
+            lastCompletelyProcessedLsn = lsn;
+            heartbeat.heartbeat(sourceInfo.partition(), sourceInfo.offset(),
+                    r -> consumer.accept(new ChangeEvent(r, lsn)));
             return;
         }
         if (message.isLastEventForLsn()) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
@@ -60,7 +60,7 @@ public class NonStreamingWal2JsonMessageDecoder implements MessageDecoder {
 
             // WAL2JSON may send empty changes that still have a txid. These events are from things like vacuum,
             // materialized view, DDL, etc. They still need to be processed for the heartbeat to fire.
-            if(changes.isEmpty()) {
+            if (changes.isEmpty()) {
                 processor.process(null);
             }
             else {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
@@ -58,10 +58,17 @@ public class NonStreamingWal2JsonMessageDecoder implements MessageDecoder {
             final Instant commitTime = Conversions.toInstant(dateTime.systemTimestamp(timestamp));
             final Array changes = message.getArray("change");
 
-            Iterator<Entry> it = changes.iterator();
-            while (it.hasNext()) {
-                Value value = it.next().getValue();
-                processor.process(new Wal2JsonReplicationMessage(txId, commitTime, value.asDocument(), containsMetadata, !it.hasNext(), typeRegistry));
+            // WAL2JSON may send empty changes that still have a txid. These events are from things like vacuum,
+            // materialized view, DDL, etc. They still need to be processed for the heartbeat to fire.
+            if(changes.isEmpty()) {
+                processor.process(null);
+            }
+            else {
+                Iterator<Entry> it = changes.iterator();
+                while (it.hasNext()) {
+                    Value value = it.next().getValue();
+                    processor.process(new Wal2JsonReplicationMessage(txId, commitTime, value.asDocument(), containsMetadata, !it.hasNext(), typeRegistry));
+                }
             }
         } catch (final IOException e) {
             throw new ConnectException(e);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
@@ -236,13 +236,12 @@ public class StreamingWal2JsonMessageDecoder implements MessageDecoder {
 
     private void doProcessMessage(ReplicationMessageProcessor processor, TypeRegistry typeRegistry, byte[] content, boolean lastMessage)
             throws IOException, SQLException, InterruptedException {
-        if(content != null) {
+        if (content != null) {
             final Document change = DocumentReader.floatNumbersAsTextReader().read(content);
             LOGGER.trace("Change arrived for decoding {}", change);
             processor.process(new Wal2JsonReplicationMessage(txId, commitTime, change, containsMetadata, lastMessage, typeRegistry));
         }
-        else
-        {
+        else {
             // If content is null then this is an empty change event that WAL2JSON can generate for events like DDL,
             // truncate table, materialized views, etc. The transaction still needs to be processed for the heartbeat
             // to fire.


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1181

PR to add support to the process events from wal2json that have no changes in them. Logic has been added for both streaming and non-streaming versions.