### PR TITLE
DBZ-1179 Set the default replication factor property for history topic

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
@@ -19,6 +19,7 @@ import java.util.function.Consumer;
 
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -335,11 +336,13 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
         try (AdminClient admin = AdminClient.create(this.producerConfig.asProperties())) {
             // Find default replication factor
             Config brokerConfig = getKafkaBrokerConfig(admin);
+            String defaultReplicationFactorValue = brokerConfig.get(DEFAULT_TOPIC_REPLICATION_FACTOR_PROP_NAME).value();
             final short replicationFactor;
             // Ensure that the default replication factor property was returned by the Admin Client
-            if (brokerConfig.get(DEFAULT_TOPIC_REPLICATION_FACTOR_PROP_NAME).value() != null) {
-                replicationFactor = Short.parseShort(brokerConfig.get(DEFAULT_TOPIC_REPLICATION_FACTOR_PROP_NAME).value());
-            } else {
+            if (defaultReplicationFactorValue != null) {
+                replicationFactor = Short.parseShort(defaultReplicationFactorValue);
+            } 
+            else {
                 // Otherwise warn that no property was obtained and default it to 1 - users can increase this later if desired
                 logger.warn("Unable to obtain the default replication factor from the brokers at " + producerConfig.getString(BOOTSTRAP_SERVERS) + " - Setting value to 1 instead");
                 replicationFactor = 1;

--- a/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
@@ -335,7 +335,15 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
         try (AdminClient admin = AdminClient.create(this.producerConfig.asProperties())) {
             // Find default replication factor
             Config brokerConfig = getKafkaBrokerConfig(admin);
-            final short replicationFactor = Short.parseShort(brokerConfig.get(DEFAULT_TOPIC_REPLICATION_FACTOR_PROP_NAME).value());
+            final short replicationFactor;
+            // Ensure that the default replication factor property was returned by the Admin Client
+            if (brokerConfig.get(DEFAULT_TOPIC_REPLICATION_FACTOR_PROP_NAME).value() != null) {
+                replicationFactor = Short.parseShort(brokerConfig.get(DEFAULT_TOPIC_REPLICATION_FACTOR_PROP_NAME).value());
+            } else {
+                // Otherwise warn that no property was obtained and default it to 1 - users can increase this later if desired
+                logger.warn("Unable to obtain the default replication factor from the brokers at " + producerConfig.getString(BOOTSTRAP_SERVERS) + " - Setting value to 1 instead");
+                replicationFactor = 1;
+            }
 
             // Create topic
             final NewTopic topic = new NewTopic(topicName, (short)1, replicationFactor);

--- a/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
@@ -19,7 +19,6 @@ import java.util.function.Consumer;
 
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.Config;
-import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1179

When starting a Debezium connector, Debezium calls out to the AdminClient API to retrieve properties required to create the database history topic. When creating a connector that is to connect to remote brokers that are being hosted in Confluent Cloud, the AdminClient API currently does not return this property. This causes Debezium to fail on startup, and only throws a NPE.

This PR first checks to ensure the property was returned by the AdminClient, and if not logs a warning and sets a default value to ensure the initialization of the database history topic succeeds.