### PR TITLE
DBZ-1207 MySQL connection timeout after bootstrapping a new table

### DIFF
--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -752,9 +752,9 @@ public class JdbcConnection implements AutoCloseable {
     }
 
     public synchronized Connection connection(boolean executeOnConnect) throws SQLException {
-        if (conn == null) {
+        if (!isConnected()) {
             conn = factory.connect(JdbcConfiguration.adapt(config));
-            if (conn == null) {
+            if (!isConnected()) {
                 throw new SQLException("Unable to obtain a JDBC connection");
             }
             // Always run the initial operations on this new connection


### PR DESCRIPTION
The following error was encountered while bootstrapping a new table with the MySQLConnector.
```
March 30th 2019, 10:06:27.881 [2019-03-30 17:06:27,880] ERROR WorkerSourceTask{id=dbz-monolith-0} Task threw an uncaught and unrecoverable exception (org.apache.kafka.connect.runtime.WorkerTask:177)
March 30th 2019, 10:06:27.882 org.apache.kafka.connect.errors.ConnectException: Error reading MySQL variables: The last packet successfully received from the server was 171,318,974 milliseconds ago. The last packet sent successfully to the server was 171,318,978 milliseconds ago. is longer than the server configured value of 'wait_timeout'. You should consider either expiring and/or testing connection validity before use in your application, increasing the server configured values for client timeouts, or using the Connector/J connection property 'autoReconnect=true' to avoid this problem.
````
When a new table is detected, a ChainedReader is instantiated. The ChainedReader will included a UnifiedReader, which is instantiated but not used until bootstrapping is completed (i.e. last reader in the chain). However, the instantiation of the UnifiedReader requires establishing a connection via jdbc ( to get lower_case_table_names variable from MySQL). This connection is held on while bootstrapping is happening, and at the end of the bootstrap when another query is executed, it throws the above-mentioned error due to wait_timeout.

The proposed solution is that when establishing jdbc connection, check if connection is closed, and create a new connection if existing one is closed.