### PR TITLE
DBZ-1208 Support for TLSv1.2

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.mysql;
 
 import com.github.shyiko.mysql.binlog.network.DefaultSSLSocketFactory;
+import io.debezium.util.Strings;
 import java.io.IOException;
 import java.io.Serializable;
 import java.security.GeneralSecurityException;
@@ -59,8 +60,9 @@ import io.debezium.heartbeat.Heartbeat;
 import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
 import io.debezium.util.ElapsedTimeStrategy;
-import io.debezium.util.Strings;
 import io.debezium.util.Threads;
+
+import static io.debezium.util.Strings.isNullOrEmpty;
 
 /**
  * A component that reads the binlog of a MySQL server, and records any schema changes in {@link MySqlSchema}.
@@ -1055,7 +1057,7 @@ public class BinlogReader extends AbstractReader {
     protected void setBinlogSSLSocketFactory() {
         if (connectionContext.jdbc() != null) {
             String acceptedTLSVersion = connectionContext.getSessionVariableForSslVersion();
-            if (acceptedTLSVersion != null) {
+            if (!isNullOrEmpty(acceptedTLSVersion)) {
                 SSLMode sslMode = sslModeFor(connectionContext.sslMode());
 
                 if (sslMode == SSLMode.PREFERRED || sslMode == SSLMode.REQUIRED) {
@@ -1089,7 +1091,8 @@ public class BinlogReader extends AbstractReader {
                             }, null);
                         }
                     });
-                } else {
+                }
+                else {
                     client.setSslSocketFactory(new DefaultSSLSocketFactory(acceptedTLSVersion));
                 }
             }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -1053,16 +1053,13 @@ public class BinlogReader extends AbstractReader {
     }
 
     protected void setBinlogSSLSocketFactory() {
-        if (connectionContext.jdbc() != null &&
-            connectionContext.jdbc().config() != null) {
-
-            String enabledTLSProtocols = connectionContext.jdbc().config()
-                .getString(MySqlJdbcContext.JDBC_PROPERTY_ENABLE_TLS_PROTOCOLS);
-            if (enabledTLSProtocols != null) {
+        if (connectionContext.jdbc() != null) {
+            String acceptedTLSVersion = connectionContext.getSessionVariableForSslVersion();
+            if (acceptedTLSVersion != null) {
                 SSLMode sslMode = sslModeFor(connectionContext.sslMode());
 
                 if (sslMode == SSLMode.PREFERRED || sslMode == SSLMode.REQUIRED) {
-                    client.setSslSocketFactory(new DefaultSSLSocketFactory(enabledTLSProtocols) {
+                    client.setSslSocketFactory(new DefaultSSLSocketFactory(acceptedTLSVersion) {
 
                         @Override
                         protected void initSSLContext(SSLContext sc)
@@ -1093,7 +1090,7 @@ public class BinlogReader extends AbstractReader {
                         }
                     });
                 } else {
-                    client.setSslSocketFactory(new DefaultSSLSocketFactory(enabledTLSProtocols));
+                    client.setSslSocketFactory(new DefaultSSLSocketFactory(acceptedTLSVersion));
                 }
             }
         }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -359,11 +359,12 @@ public class MySqlJdbcContext implements AutoCloseable {
      * @return the session variables that are related to sessions ssl version
      */
     protected String getSessionVariableForSslVersion() {
+        final String SSL_VERSION = "Ssl_version";
         logger.debug("Reading MySQL Session variable for Ssl Version");
-        Map<String, String> systemVariableResults =
+        Map<String, String> sessionVariables =
             querySystemVariables(SQL_SHOW_SESSION_VARIABLE_SSL_VERSION);
-        if (!systemVariableResults.isEmpty() && systemVariableResults.containsKey("Ssl_version")) {
-            return systemVariableResults.get("Ssl_version");
+        if (!sessionVariables.isEmpty() && sessionVariables.containsKey(SSL_VERSION)) {
+            return sessionVariables.get(SSL_VERSION);
         }
         return null;
     }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -37,10 +37,10 @@ public class MySqlJdbcContext implements AutoCloseable {
 
     protected static final String MYSQL_CONNECTION_URL = "jdbc:mysql://${hostname}:${port}/?useInformationSchema=true&nullCatalogMeansCurrent=false&useSSL=${useSSL}&useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8&zeroDateTimeBehavior=CONVERT_TO_NULL";
     protected static final String JDBC_PROPERTY_LEGACY_DATETIME = "useLegacyDatetimeCode";
-    protected static final String JDBC_PROPERTY_ENABLE_TLS_PROTOCOLS = "enabledTLSProtocols";
 
     private static final String SQL_SHOW_SYSTEM_VARIABLES = "SHOW VARIABLES";
     private static final String SQL_SHOW_SYSTEM_VARIABLES_CHARACTER_SET = "SHOW VARIABLES WHERE Variable_name IN ('character_set_server','collation_server')";
+    private static final String SQL_SHOW_SESSION_VARIABLE_SSL_VERSION = "SHOW SESSION STATUS LIKE 'Ssl_version'";
 
     protected static ConnectionFactory FACTORY = JdbcConnection.patternBasedFactory(MYSQL_CONNECTION_URL);
 
@@ -351,5 +351,20 @@ public class MySqlJdbcContext implements AutoCloseable {
                 // Otherwise, there was an existing property, and the value is exactly the same (so do nothing!)
             }
         }
+    }
+
+    /**
+     * Read the Ssl Version session variable.
+     *
+     * @return the session variables that are related to sessions ssl version
+     */
+    protected String getSessionVariableForSslVersion() {
+        logger.debug("Reading MySQL Session variable for Ssl Version");
+        Map<String, String> systemVariableResults =
+            querySystemVariables(SQL_SHOW_SESSION_VARIABLE_SSL_VERSION);
+        if (!systemVariableResults.isEmpty() && systemVariableResults.containsKey("Ssl_version")) {
+            return systemVariableResults.get("Ssl_version");
+        }
+        return null;
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -37,6 +37,9 @@ public class MySqlJdbcContext implements AutoCloseable {
 
     protected static final String MYSQL_CONNECTION_URL = "jdbc:mysql://${hostname}:${port}/?useInformationSchema=true&nullCatalogMeansCurrent=false&useSSL=${useSSL}&useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8&zeroDateTimeBehavior=CONVERT_TO_NULL";
     protected static final String JDBC_PROPERTY_LEGACY_DATETIME = "useLegacyDatetimeCode";
+    protected static final String JDBC_PROPERTY_VERIFY_SERVER_CERT = "verifyServerCertificate";
+    protected static final String JDBC_PROPERTY_ENABLE_TLS_PROTOCOLS = "enableTLSProtocols";
+
     private static final String SQL_SHOW_SYSTEM_VARIABLES = "SHOW VARIABLES";
     private static final String SQL_SHOW_SYSTEM_VARIABLES_CHARACTER_SET = "SHOW VARIABLES WHERE Variable_name IN ('character_set_server','collation_server')";
 
@@ -68,6 +71,14 @@ public class MySqlJdbcContext implements AutoCloseable {
         }
         else if ("true".equals(legacyDateTime)) {
             logger.warn("'" + JDBC_PROPERTY_LEGACY_DATETIME + "'" + " is set to 'true'. This setting is not recommended and can result in timezone issues.");
+        }
+
+        if (jdbcConfig.getString(JDBC_PROPERTY_VERIFY_SERVER_CERT) != null) {
+            jdbcConfigBuilder.with(JDBC_PROPERTY_VERIFY_SERVER_CERT, jdbcConfig.getString(JDBC_PROPERTY_VERIFY_SERVER_CERT));
+        }
+
+        if (jdbcConfig.getString(JDBC_PROPERTY_ENABLE_TLS_PROTOCOLS) != null) {
+            jdbcConfigBuilder.with(JDBC_PROPERTY_ENABLE_TLS_PROTOCOLS, jdbcConfig.getString(JDBC_PROPERTY_ENABLE_TLS_PROTOCOLS));
         }
 
         jdbcConfig = jdbcConfigBuilder.build();

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -37,7 +37,7 @@ public class MySqlJdbcContext implements AutoCloseable {
 
     protected static final String MYSQL_CONNECTION_URL = "jdbc:mysql://${hostname}:${port}/?useInformationSchema=true&nullCatalogMeansCurrent=false&useSSL=${useSSL}&useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8&zeroDateTimeBehavior=CONVERT_TO_NULL";
     protected static final String JDBC_PROPERTY_LEGACY_DATETIME = "useLegacyDatetimeCode";
-    protected static final String JDBC_PROPERTY_ENABLE_TLS_PROTOCOLS = "enableTLSProtocols";
+    protected static final String JDBC_PROPERTY_ENABLE_TLS_PROTOCOLS = "enabledTLSProtocols";
 
     private static final String SQL_SHOW_SYSTEM_VARIABLES = "SHOW VARIABLES";
     private static final String SQL_SHOW_SYSTEM_VARIABLES_CHARACTER_SET = "SHOW VARIABLES WHERE Variable_name IN ('character_set_server','collation_server')";

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -37,7 +37,6 @@ public class MySqlJdbcContext implements AutoCloseable {
 
     protected static final String MYSQL_CONNECTION_URL = "jdbc:mysql://${hostname}:${port}/?useInformationSchema=true&nullCatalogMeansCurrent=false&useSSL=${useSSL}&useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8&zeroDateTimeBehavior=CONVERT_TO_NULL";
     protected static final String JDBC_PROPERTY_LEGACY_DATETIME = "useLegacyDatetimeCode";
-    protected static final String JDBC_PROPERTY_VERIFY_SERVER_CERT = "verifyServerCertificate";
     protected static final String JDBC_PROPERTY_ENABLE_TLS_PROTOCOLS = "enableTLSProtocols";
 
     private static final String SQL_SHOW_SYSTEM_VARIABLES = "SHOW VARIABLES";
@@ -71,14 +70,6 @@ public class MySqlJdbcContext implements AutoCloseable {
         }
         else if ("true".equals(legacyDateTime)) {
             logger.warn("'" + JDBC_PROPERTY_LEGACY_DATETIME + "'" + " is set to 'true'. This setting is not recommended and can result in timezone issues.");
-        }
-
-        if (jdbcConfig.getString(JDBC_PROPERTY_VERIFY_SERVER_CERT) != null) {
-            jdbcConfigBuilder.with(JDBC_PROPERTY_VERIFY_SERVER_CERT, jdbcConfig.getString(JDBC_PROPERTY_VERIFY_SERVER_CERT));
-        }
-
-        if (jdbcConfig.getString(JDBC_PROPERTY_ENABLE_TLS_PROTOCOLS) != null) {
-            jdbcConfigBuilder.with(JDBC_PROPERTY_ENABLE_TLS_PROTOCOLS, jdbcConfig.getString(JDBC_PROPERTY_ENABLE_TLS_PROTOCOLS));
         }
 
         jdbcConfig = jdbcConfigBuilder.build();

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/BinlogReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/BinlogReaderIT.java
@@ -9,6 +9,7 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -50,6 +51,8 @@ public class BinlogReaderIT {
     private static final Path DB_HISTORY_PATH = Testing.Files.createTestingPath("file-db-history-binlog.txt").toAbsolutePath();
     private final UniqueDatabase DATABASE = new UniqueDatabase("logical_server_name", "connector_test_ro")
             .withDbHistoryPath(DB_HISTORY_PATH);
+
+    private static final String SET_TLS_PROTOCOLS = "database.enabledTLSProtocols";
 
     private Configuration config;
     private MySqlTaskContext context;
@@ -385,6 +388,52 @@ public class BinlogReaderIT {
         inconsistentSchema(EventProcessingFailureHandlingMode.IGNORE);
         int consumed = consumeAtLeast(2, 2, TimeUnit.SECONDS);
         assertThat(consumed).isZero();
+    }
+
+    @Test(expected = ConnectException.class)
+    @FixFor( "DBZ-1208" )
+    public void shouldFailOnUnknownTlsProtocol() {
+        final UniqueDatabase REGRESSION_DATABASE = new UniqueDatabase("logical_server_name", "regression_test")
+            .withDbHistoryPath(DB_HISTORY_PATH);
+        REGRESSION_DATABASE.createAndInitialize();
+
+        config = simpleConfig()
+            .with(MySqlConnectorConfig.SSL_MODE, SecureConnectionMode.REQUIRED)
+            .with(SET_TLS_PROTOCOLS, "TLSv1.7")
+            .build();
+        Filters filters = new Filters.Builder(config).build();
+        context = new MySqlTaskContext(config, filters);
+        context.start();
+        context.source().setBinlogStartPoint("", 0L); // start from beginning
+        context.initializeHistory();
+        reader = new BinlogReader("binlog", context, null);
+
+        // Start reading the binlog ...
+        reader.start();
+    }
+
+    @Test
+    @FixFor( "DBZ-1208" )
+    public void shouldAcceptTls12() {
+        final UniqueDatabase REGRESSION_DATABASE = new UniqueDatabase("logical_server_name", "regression_test")
+            .withDbHistoryPath(DB_HISTORY_PATH);
+        REGRESSION_DATABASE.createAndInitialize();
+
+        config = simpleConfig()
+            .with(MySqlConnectorConfig.SSL_MODE, SecureConnectionMode.REQUIRED)
+            .with(SET_TLS_PROTOCOLS, "TLSv1.2")
+            .build();
+        Filters filters = new Filters.Builder(config).build();
+        context = new MySqlTaskContext(config, filters);
+        context.start();
+        context.source().setBinlogStartPoint("", 0L); // start from beginning
+        context.initializeHistory();
+        reader = new BinlogReader("binlog", context, null);
+
+        // Start reading the binlog ...
+        reader.start();
+        String acceptedTlsVersion = context.getConnectionContext().getSessionVariableForSslVersion();
+        assertEquals("TLSv1.2", acceptedTlsVersion);
     }
 
     private void inconsistentSchema(EventProcessingFailureHandlingMode mode) throws InterruptedException, SQLException {


### PR DESCRIPTION
This fixed a few issues related to supporting TLSv.1.2.

### Key problem:
1. The BinaryLogClient from mysql-binlog-connector-java was used with default SSLSocketFactory settings, which ends up hard-coding the protocol to TLSv1.
2. Initial testing connection done by Debezium had issues agreeing on TLSv2 (at least in 0.8.3.Final) and required strict certificate checks.

### Fixes:
1. Did not ignore passing parameter for specifying the client side protocol (database.enableTLSProtocols=TLSv1.2)
2. Did not ignore passing parameter for specifying whether to do strict server certificate verification (database.verifyServerCertificates=false)
3. Used the property from #1 to also allow overriding the SSLSocketFactory for Shyiko's BinaryLogClient. Overridden one allows loose server certificate checking, which was the default used when using database.ssl.mode=required.