### PR TITLE
[DBZ-1214] Ensure PG connection keep alive

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -764,6 +764,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     public static final Field STATUS_UPDATE_INTERVAL_MS = Field.create("status.update.interval.ms")
                                                           .withDisplayName("Status update interval (ms)")
                                                           .withType(Type.INT) // Postgres doesn't accept long for this value
+                                                          .withDefault(10_000)
                                                           .withWidth(Width.SHORT)
                                                           .withImportance(Importance.MEDIUM)
                                                           .withDescription("Frequency in milliseconds for sending replication connection status updates to the server. Defaults to 10 seconds (10000 ms).")

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -894,8 +894,8 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         return getConfig().getString(STREAM_PARAMS);
     }
 
-    protected Integer statusUpdateIntervalMillis() {
-        return getConfig().getInteger(STATUS_UPDATE_INTERVAL_MS, null);
+    protected Duration statusUpdateInterval() {
+        return Duration.ofMillis(getConfig().getLong(PostgresConnectorConfig.STATUS_UPDATE_INTERVAL_MS));
     }
 
     protected TemporalPrecisionMode temporalPrecisionMode() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTaskContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTaskContext.java
@@ -106,7 +106,7 @@ public class PostgresTaskContext extends CdcSourceTaskContext {
                                     .withPlugin(config.plugin())
                                     .dropSlotOnClose(config.dropSlotOnStop())
                                     .streamParams(config.streamParams())
-                                    .statusUpdateIntervalMillis(config.statusUpdateIntervalMillis())
+                                    .statusUpdateInterval(config.statusUpdateInterval())
                                     .withTypeRegistry(schema.getTypeRegistry())
                                     .build();
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
@@ -113,7 +113,7 @@ public class RecordsStreamProducer extends RecordsProducer {
 
             // for large databases with many tables, we can timeout the slot while refreshing schema
             // so we need to start a background thread that just responds to keep alive
-            replicationStream.get().startKeepAlive(Threads.newSingleThreadExecutor(PostgresConnector.class, taskContext.config().getLogicalName(), CONTEXT_NAME));
+            replicationStream.get().startKeepAlive(Threads.newSingleThreadExecutor(PostgresConnector.class, taskContext.config().getLogicalName(), CONTEXT_NAME + "-keep-alive"));
             // refresh the schema so we have a latest view of the DB tables
             taskContext.refreshSchema(true);
 
@@ -192,7 +192,7 @@ public class RecordsStreamProducer extends RecordsProducer {
             }
 
             ReplicationStream stream = this.replicationStream.get();
-            // if we have a stream, ensure that it hs been stopped
+            // if we have a stream, ensure that it has been stopped
             if (stream != null) {
                 stream.stopKeepAlive();
             }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
@@ -7,6 +7,7 @@
 package io.debezium.connector.postgresql.connection;
 
 import java.sql.SQLException;
+import java.time.Duration;
 
 import org.postgresql.replication.LogSequenceNumber;
 import org.postgresql.replication.PGReplicationStream;
@@ -122,10 +123,10 @@ public interface ReplicationConnection extends AutoCloseable {
         /**
          * The number of milli-seconds the replication connection should periodically send updates to the server.
          *
-         * @param statusUpdateIntervalMillis a number of milli-seconds; null or non-positive value causes Postgres' default to be applied
+         * @param statusUpdateInterval a duration; null or non-positive value causes Postgres' default to be applied
          * @return this instance
          */
-        Builder statusUpdateIntervalMillis(final Integer statusUpdateIntervalMillis);
+        Builder statusUpdateInterval(final Duration statusUpdateInterval);
 
         Builder withTypeRegistry(TypeRegistry typeRegistry);
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationStream.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationStream.java
@@ -7,6 +7,7 @@
 package io.debezium.connector.postgresql.connection;
 
 import java.sql.SQLException;
+import java.util.concurrent.ExecutorService;
 
 import org.postgresql.replication.PGReplicationStream;
 
@@ -75,6 +76,17 @@ public interface ReplicationStream extends AutoCloseable {
      * @return a {@link Long} value, possibly null if this is called before anything has been read
      */
     Long lastReceivedLsn();
+
+    /**
+     * Starts a background thread to ensure the slot is kept alive, useful for when temporarily
+     * stopping reads from the stream such as querying metadata, etc
+     */
+    void startKeepAlive(ExecutorService service);
+
+    /**
+     * Stops the background thread that is used to ensure the slot is kept alive.
+     */
+    void stopKeepAlive();
 
     /**
      * //TODO author=Horia Chiorean date=13/10/2016 description=Don't use this for now, because of the bug from the PG server

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -14,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.time.Duration;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -75,6 +76,7 @@ public final class TestHelper {
                                     .withSlot(slotName)
                                     .withTypeRegistry(getTypeRegistry())
                                     .dropSlotOnClose(dropOnClose)
+                                    .statusUpdateInterval(Duration.ofSeconds(10))
                                     .build();
     }
 


### PR DESCRIPTION
This adds a small change to the postgres connector which
works around a problem when large databases take more
than a minute to refresh the schema

This works by creating a simple background thread that ensures we send
statusUpdate messages periodically

I considered if we could refresh the schema before we create the
replication connection but I believe we choose our offset in the log
and then get the schema in order to ensure we don't get out of sync with
any potential schema changes