### PR TITLE
[DBZ-1193] Add support for network type MACADDR and MACADDR8 in PostgreSQL connector

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PgOid.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PgOid.java
@@ -23,6 +23,10 @@ public final class PgOid extends Oid {
     public static final int TSTZRANGE_OID = 3910;
     public static final int INET_OID = 869;
     public static final int INET_ARRAY = 1041;
-    public static final int CIDR_OID=650;
-    public static final int CIDR_ARRAY=651;
+    public static final int CIDR_OID = 650;
+    public static final int CIDR_ARRAY = 651;
+    public static final int MACADDR_OID = 829;
+    public static final int MACADDR_ARRAY = 1040;
+    public static final int MACADDR8_OID = 774;
+    public static final int MACADDR8_ARRAY = 775;
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -144,6 +144,8 @@ public class PostgresValueConverter extends JdbcValueConverters {
             case PgOid.TSTZRANGE_OID:
             case PgOid.INET_OID:
             case PgOid.CIDR_OID:
+            case PgOid.MACADDR_OID:
+            case PgOid.MACADDR8_OID:
                 return SchemaBuilder.string();
             case PgOid.UUID:
                 return Uuid.builder();
@@ -168,6 +170,8 @@ public class PostgresValueConverter extends JdbcValueConverters {
             case PgOid.BPCHAR_ARRAY:
             case PgOid.INET_ARRAY:
             case PgOid.CIDR_ARRAY:
+            case PgOid.MACADDR_ARRAY:
+            case PgOid.MACADDR8_ARRAY:
                 return SchemaBuilder.array(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
             case PgOid.NUMERIC_ARRAY:
                 return SchemaBuilder.array(numericSchema(column).optional().build());
@@ -278,6 +282,8 @@ public class PostgresValueConverter extends JdbcValueConverters {
             case PgOid.JSON:
             case PgOid.INET_OID:
             case PgOid.CIDR_OID:
+            case PgOid.MACADDR_OID:
+            case PgOid.MACADDR8_OID:
                 return data -> super.convertString(column, fieldDefn, data);
             case PgOid.POINT:
                 return data -> convertPoint(column, fieldDefn, data);
@@ -301,6 +307,8 @@ public class PostgresValueConverter extends JdbcValueConverters {
             case PgOid.DATE_ARRAY:
             case PgOid.INET_ARRAY:
             case PgOid.CIDR_ARRAY:
+            case PgOid.MACADDR_ARRAY:
+            case PgOid.MACADDR8_ARRAY:
                 return createArrayConverter(column, fieldDefn);
 
             // TODO DBZ-459 implement support for these array types; for now we just fall back to the default, i.e.

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
@@ -177,6 +177,8 @@ class PgProtoReplicationMessage implements ReplicationMessage {
             case PgOid.VARBIT:
             case PgOid.INET_OID:
             case PgOid.CIDR_OID:
+            case PgOid.MACADDR_OID:
+            case PgOid.MACADDR8_OID:
                 return datumMessage.hasDatumString() ? datumMessage.getDatumString() : null;
             case PgOid.DATE:
                 return datumMessage.hasDatumInt32() ? (long) datumMessage.getDatumInt32() : null;
@@ -244,6 +246,8 @@ class PgProtoReplicationMessage implements ReplicationMessage {
             case PgOid.REF_CURSOR_ARRAY:
             case PgOid.INET_ARRAY:
             case PgOid.CIDR_ARRAY:
+            case PgOid.MACADDR_ARRAY:
+            case PgOid.MACADDR8_ARRAY:
                 return getArray(datumMessage, connection, columnType);
 
             case PgOid.UNSPECIFIED:

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
@@ -363,11 +363,12 @@ class Wal2JsonReplicationMessage implements ReplicationMessage {
             case "tstzrange":
             case "inet":
             case "cidr":
-                return rawValue.asString();
-            // catch-all for other known/builtin PG types
-            // TODO: improve with more specific/useful classes here?
             case "macaddr":
             case "macaddr8":
+                return rawValue.asString();
+
+            // catch-all for other known/builtin PG types
+            // TODO: improve with more specific/useful classes here?
             case "pg_lsn":
             case "tsquery":
             case "tsvector":

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -96,6 +96,10 @@ public abstract class AbstractRecordsProducerTest {
                                                                       "VALUES ('192.168.2.0/12')";
     protected static final String INSERT_CIDR_NETWORK_ADDRESS_TYPE_STMT = "INSERT INTO cidr_network_address_table (i) " +
                                                                       "VALUES ('192.168.100.128/25');";
+    protected static final String INSERT_MACADDR_TYPE_STMT = "INSERT INTO macaddr_table (m) " +
+                                                                      "VALUES ('08:00:2b:01:02:03');";
+    protected static final String INSERT_MACADDR8_TYPE_STMT = "INSERT INTO macaddr8_table (m) " +
+                                                                      "VALUES ('08:00:2b:01:02:03:04:05');";
     protected static final String INSERT_NUMERIC_TYPES_STMT =
             "INSERT INTO numeric_table (si, i, bi, r, db, r_int, db_int, r_nan, db_nan, r_pinf, db_pinf, r_ninf, db_ninf, ss, bs, b) " +
              "VALUES (1, 123456, 1234567890123, 3.3, 4.44, 3, 4, 'NaN', 'NaN', 'Infinity', 'Infinity', '-Infinity', '-Infinity', 1, 123, true)";
@@ -123,11 +127,11 @@ public abstract class AbstractRecordsProducerTest {
     protected static final String INSERT_TSTZRANGE_TYPES_STMT = "INSERT INTO tstzrange_table (unbounded_exclusive_range, bounded_inclusive_range) " +
             "VALUES ('[2017-06-05 11:29:12.549426+00,)', '[2017-06-05 11:29:12.549426+00, 2017-06-05 12:34:56.789012+00]')";
 
-    protected static final String INSERT_ARRAY_TYPES_STMT = "INSERT INTO array_table (int_array, bigint_array, text_array, char_array, varchar_array, date_array, numeric_array, varnumeric_array, citext_array, inet_array, cidr_array) " +
-                                                             "VALUES ('{1,2,3}', '{1550166368505037572}', '{\"one\",\"two\",\"three\"}', '{\"cone\",\"ctwo\",\"cthree\"}', '{\"vcone\",\"vctwo\",\"vcthree\"}', '{2016-11-04,2016-11-05,2016-11-06}', '{1.2,3.4,5.6}', '{1.1,2.22,3.333}', '{\"four\",\"five\",\"six\"}', '{\"192.168.2.0/12\",\"192.168.1.1\",\"192.168.0.2/1\"}', '{\"192.168.100.128/25\", \"192.168.0.0/25\", \"192.168.1.0/24\"}')";
+    protected static final String INSERT_ARRAY_TYPES_STMT = "INSERT INTO array_table (int_array, bigint_array, text_array, char_array, varchar_array, date_array, numeric_array, varnumeric_array, citext_array, inet_array, cidr_array, macaddr_array) " +
+                                                             "VALUES ('{1,2,3}', '{1550166368505037572}', '{\"one\",\"two\",\"three\"}', '{\"cone\",\"ctwo\",\"cthree\"}', '{\"vcone\",\"vctwo\",\"vcthree\"}', '{2016-11-04,2016-11-05,2016-11-06}', '{1.2,3.4,5.6}', '{1.1,2.22,3.333}', '{\"four\",\"five\",\"six\"}', '{\"192.168.2.0/12\",\"192.168.1.1\",\"192.168.0.2/1\"}', '{\"192.168.100.128/25\", \"192.168.0.0/25\", \"192.168.1.0/24\"}', '{\"08:00:2b:01:02:03\", \"08-00-2b-01-02-03\", \"08002b:010203\"}')";
 
-    protected static final String INSERT_ARRAY_TYPES_WITH_NULL_VALUES_STMT = "INSERT INTO array_table_with_nulls (int_array, bigint_array, text_array, date_array, numeric_array, varnumeric_array, citext_array, inet_array, cidr_array) " +
-            "VALUES (null, null, null, null, null, null, null, null, null)";
+    protected static final String INSERT_ARRAY_TYPES_WITH_NULL_VALUES_STMT = "INSERT INTO array_table_with_nulls (int_array, bigint_array, text_array, date_array, numeric_array, varnumeric_array, citext_array, inet_array, cidr_array, macaddr_array) " +
+            "VALUES (null, null, null, null, null, null, null, null, null, null)";
 
     protected static final String INSERT_POSTGIS_TYPES_STMT = "INSERT INTO public.postgis_table (p, ml) " +
             "VALUES ('SRID=3187;POINT(174.9479 -36.7208)'::postgis.geometry, 'MULTILINESTRING((169.1321 -44.7032, 167.8974 -44.6414))'::postgis.geography)";
@@ -162,9 +166,9 @@ public abstract class AbstractRecordsProducerTest {
     protected static final String INSERT_HSTORE_TYPE_WITH_SPECIAL_CHAR_STMT = "INSERT INTO hstore_table_with_special (hs) VALUES ('\"key_#1\" => \"val 1\",\"key 2\" =>\" ##123 78\"')";
 
     protected static final Set<String> ALL_STMTS = new HashSet<>(Arrays.asList(INSERT_NUMERIC_TYPES_STMT, INSERT_NUMERIC_DECIMAL_TYPES_STMT_NO_NAN,
-                                                                 INSERT_DATE_TIME_TYPES_STMT,
-                                                                 INSERT_BIN_TYPES_STMT, INSERT_GEOM_TYPES_STMT, INSERT_TEXT_TYPES_STMT,
-                                                                 INSERT_CASH_TYPES_STMT, INSERT_STRING_TYPES_STMT, INSERT_CIDR_NETWORK_ADDRESS_TYPE_STMT, INSERT_NETWORK_ADDRESS_TYPES_STMT,
+                                                                 INSERT_DATE_TIME_TYPES_STMT, INSERT_BIN_TYPES_STMT, INSERT_GEOM_TYPES_STMT, INSERT_TEXT_TYPES_STMT,
+                                                                 INSERT_CASH_TYPES_STMT, INSERT_STRING_TYPES_STMT, INSERT_CIDR_NETWORK_ADDRESS_TYPE_STMT,
+                                                                 INSERT_NETWORK_ADDRESS_TYPES_STMT, INSERT_MACADDR_TYPE_STMT,
                                                                  INSERT_ARRAY_TYPES_STMT, INSERT_ARRAY_TYPES_WITH_NULL_VALUES_STMT, INSERT_QUOTED_TYPES_STMT,
                                                                  INSERT_POSTGIS_TYPES_STMT, INSERT_POSTGIS_ARRAY_TYPES_STMT));
 
@@ -327,6 +331,11 @@ public abstract class AbstractRecordsProducerTest {
         return Arrays.asList(new SchemaAndValueField("hs", Json.builder().optional().build(), expected));
     }
 
+    protected List<SchemaAndValueField> schemaAndValueForMacaddr8Type() {
+        final String expected = "08:00:2b:01:02:03:04:05";
+        return Arrays.asList(new SchemaAndValueField("m", Schema.OPTIONAL_STRING_SCHEMA, expected));
+    }
+
     protected List<SchemaAndValueField> schemasAndValuesForStringTypes() {
        return Arrays.asList(new SchemaAndValueField("vc", Schema.OPTIONAL_STRING_SCHEMA, "\u017E\u0161"),
                             new SchemaAndValueField("vcv", Schema.OPTIONAL_STRING_SCHEMA, "bb"),
@@ -367,8 +376,13 @@ public abstract class AbstractRecordsProducerTest {
     protected List<SchemaAndValueField> schemasAndValuesForNetworkAddressTypes() {
         return Arrays.asList(new SchemaAndValueField("i", Schema.OPTIONAL_STRING_SCHEMA, "192.168.2.0/12"));
     }
+
     protected List<SchemaAndValueField> schemasAndValueForCidrAddressType() {
         return Arrays.asList(new SchemaAndValueField("i", Schema.OPTIONAL_STRING_SCHEMA, "192.168.100.128/25"));
+    }
+
+    protected List<SchemaAndValueField> schemasAndValueForMacaddrType() {
+        return Arrays.asList(new SchemaAndValueField("m", Schema.OPTIONAL_STRING_SCHEMA, "08:00:2b:01:02:03"));
     }
 
     protected List<SchemaAndValueField> schemasAndValuesForNumericTypesWithSourceColumnTypeInfo() {
@@ -525,9 +539,10 @@ public abstract class AbstractRecordsProducerTest {
                                     Arrays.asList("four", "five", "six")),
                             new SchemaAndValueField("inet_array", SchemaBuilder.array(SchemaBuilder.OPTIONAL_STRING_SCHEMA).optional().build(),
                                     Arrays.asList("192.168.2.0/12", "192.168.1.1", "192.168.0.2/1")),
-
                            new SchemaAndValueField("cidr_array", SchemaBuilder.array(SchemaBuilder.OPTIONAL_STRING_SCHEMA).optional().build(),
-                                    Arrays.asList("192.168.100.128/25", "192.168.0.0/25", "192.168.1.0/24"))
+                                    Arrays.asList("192.168.100.128/25", "192.168.0.0/25", "192.168.1.0/24")),
+                            new SchemaAndValueField("macaddr_array", SchemaBuilder.array(SchemaBuilder.OPTIONAL_STRING_SCHEMA).optional().build(),
+                                    Arrays.asList("08:00:2b:01:02:03", "08:00:2b:01:02:03", "08:00:2b:01:02:03"))
                             );
     }
 
@@ -542,9 +557,9 @@ public abstract class AbstractRecordsProducerTest {
                 new SchemaAndValueField("numeric_array", SchemaBuilder.array(Decimal.builder(2).parameter(TestHelper.PRECISION_PARAMETER_KEY, "10").optional().build()).optional().build(), null),
                 new SchemaAndValueField("citext_array", SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build(), null),
                 new SchemaAndValueField("inet_array", SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build(), null),
-                new SchemaAndValueField("cidr_array", SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build(), null)
-
-        );
+                new SchemaAndValueField("cidr_array", SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build(), null),
+                new SchemaAndValueField("macaddr_array", SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build(), null)
+                );
     }
 
     protected List<SchemaAndValueField> schemaAndValuesForPostgisTypes() {
@@ -639,6 +654,8 @@ public abstract class AbstractRecordsProducerTest {
                 return schemasAndValuesForNetworkAddressTypes();
             case INSERT_CIDR_NETWORK_ADDRESS_TYPE_STMT:
                 return schemasAndValueForCidrAddressType();
+            case INSERT_MACADDR_TYPE_STMT:
+                return schemasAndValueForMacaddrType();
             case INSERT_TEXT_TYPES_STMT:
                 return schemasAndValuesForTextTypes();
             case INSERT_ARRAY_TYPES_STMT:

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
@@ -130,6 +130,7 @@ public class PostgresSchemaIT {
     }
 
     @Test
+    // MACADDR8 Postgres type is only supported since Postgres version 10
     @SkipWhenDatabaseVersionLessThan(POSTGRES_10)
     @FixFor("DBZ-1193")
     public void shouldLoadSchemaForMacaddr8PostgresType() throws Exception {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -512,4 +512,29 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
             assertRecordSchemaAndValues(schemaAndValueFields, record, Envelope.FieldName.AFTER);
         });
     }
+
+    @Test
+    @SkipWhenDatabaseVersionLessThan(POSTGRES_10)
+    @FixFor("DBZ-1193")
+    public void shouldGenerateSnapshotForMacaddr8Datatype() throws Exception {
+        TestHelper.dropAllSchemas();
+        TestHelper.execute("CREATE TABLE macaddr8_table(pk SERIAL, m MACADDR8, PRIMARY KEY(pk));");
+
+        PostgresConnectorConfig config = new PostgresConnectorConfig(TestHelper.defaultConfig()
+                .build());
+        snapshotProducer = buildNoStreamProducer(context, config);
+
+        final TestConsumer consumer = testConsumer(1, "public");
+
+        // insert macaddr8 data
+        TestHelper.execute(INSERT_MACADDR8_TYPE_STMT);
+
+        // then start the producer and validate the record are there
+        snapshotProducer.start(consumer, e -> {});
+        consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
+
+        final Map<String, List<SchemaAndValueField>> expectedValueByTopicName = Collect.hashMapOf("public.macaddr8_table", schemaAndValueForMacaddr8Type());
+
+        consumer.process(record -> assertReadRecord(record, expectedValueByTopicName));
+    }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -514,6 +514,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
     }
 
     @Test
+    // MACADDR8 Postgres type is only supported since Postgres version 10
     @SkipWhenDatabaseVersionLessThan(POSTGRES_10)
     @FixFor("DBZ-1193")
     public void shouldGenerateSnapshotForMacaddr8Datatype() throws Exception {

--- a/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
+++ b/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
@@ -16,6 +16,7 @@ CREATE TABLE numeric_decimal_table (pk SERIAL,
 CREATE TABLE string_table (pk SERIAL, vc VARCHAR(2), vcv CHARACTER VARYING(2), ch CHARACTER(4), c CHAR(3), t TEXT, b BYTEA, bnn BYTEA NOT NULL, ct CITEXT, PRIMARY KEY(pk));
 CREATE TABLE network_address_table (pk SERIAL, i INET, PRIMARY KEY(pk));
 CREATE TABLE cidr_network_address_table(pk SERIAL, i CIDR, PRIMARY KEY(pk));
+CREATE TABLE macaddr_table(pk SERIAL, m MACADDR, PRIMARY KEY(pk));
 CREATE TABLE cash_table (pk SERIAL, csh MONEY, PRIMARY KEY(pk));
 CREATE TABLE bitbin_table (pk SERIAL, ba BYTEA, bol BIT(1), bs BIT(2), bv BIT VARYING(2) , PRIMARY KEY(pk));
 CREATE TABLE time_table (pk SERIAL, ts TIMESTAMP, tsneg TIMESTAMP(6) WITHOUT TIME ZONE, ts_ms TIMESTAMP(3), ts_us TIMESTAMP(6), tz TIMESTAMPTZ, date DATE,
@@ -25,8 +26,8 @@ CREATE TABLE time_table (pk SERIAL, ts TIMESTAMP, tsneg TIMESTAMP(6) WITHOUT TIM
 CREATE TABLE text_table (pk SERIAL, j JSON, jb JSONB, x XML, u Uuid, PRIMARY KEY(pk));
 CREATE TABLE geom_table (pk SERIAL, p POINT, PRIMARY KEY(pk));
 CREATE TABLE tstzrange_table (pk serial, unbounded_exclusive_range tstzrange, bounded_inclusive_range tstzrange, PRIMARY KEY(pk));
-CREATE TABLE array_table (pk SERIAL, int_array INT[], bigint_array BIGINT[], text_array TEXT[], char_array CHAR(10)[], varchar_array VARCHAR(10)[], date_array DATE[], numeric_array NUMERIC(10, 2)[], varnumeric_array NUMERIC[3], citext_array CITEXT[], inet_array INET[], cidr_array CIDR[], PRIMARY KEY(pk));
-CREATE TABLE array_table_with_nulls (pk SERIAL, int_array INT[], bigint_array BIGINT[], text_array TEXT[], char_array CHAR(10)[], varchar_array VARCHAR(10)[], date_array DATE[], numeric_array NUMERIC(10, 2)[], varnumeric_array NUMERIC[3], citext_array CITEXT[], inet_array INET[], cidr_array CIDR[], PRIMARY KEY(pk));
+CREATE TABLE array_table (pk SERIAL, int_array INT[], bigint_array BIGINT[], text_array TEXT[], char_array CHAR(10)[], varchar_array VARCHAR(10)[], date_array DATE[], numeric_array NUMERIC(10, 2)[], varnumeric_array NUMERIC[3], citext_array CITEXT[], inet_array INET[], cidr_array CIDR[], macaddr_array MACADDR[], PRIMARY KEY(pk));
+CREATE TABLE array_table_with_nulls (pk SERIAL, int_array INT[], bigint_array BIGINT[], text_array TEXT[], char_array CHAR(10)[], varchar_array VARCHAR(10)[], date_array DATE[], numeric_array NUMERIC(10, 2)[], varnumeric_array NUMERIC[3], citext_array CITEXT[], inet_array INET[], cidr_array CIDR[], macaddr_array MACADDR[], PRIMARY KEY(pk));
 CREATE TABLE custom_table (pk serial, lt ltree, i isbn NOT NULL, n TEXT, PRIMARY KEY(pk));
 CREATE TABLE hstore_table (pk serial, hs hstore, PRIMARY KEY(pk));
 CREATE TABLE hstore_table_mul (pk serial, hs hstore, PRIMARY KEY(pk));


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1193

Add supoorts for network types `CIDR`, `MACADDR`, `MACADDR8`.

#### Tested on PostgreSQL 9.6, 10 and 11:

DDL (PostgreSQL 9.6): 
```
CREATE TABLE inventory.network (pk SERIAL, i INET, c CIDR, m MACADDR, PRIMARY KEY(pk));
```

DDL (PostgreSQL 10 and 11):
```
CREATE TABLE network_address_table (pk SERIAL, i INET, c CIDR, m MACADDR, m8 MACADDR8, PRIMARY KEY(pk));
```

DML (PostgreSQL 9.6): 
```
INSERT INTO inventory.network VALUES (1001, '192.168.2.0/12', '192.168.100.128/25', '08:00:2b:01:02:03');
```

DDL (PostgreSQL 10 and 11):
```
INSERT INTO network_address_table (i, c, m, m8) VALUES ('192.168.2.0/12', '192.168.100.128/25', '08:00:2b:01:02:03', '08:00:2b:01:02:03:04:05');
```

Before Patch:
```
{
    "schema": {
        "type": "struct",
        "fields": [
            {
                "type": "int32",
                "optional": false,
                "field": "pk"
            }
        ],
        "optional": false,
        "name": "servername.inventory.network.Key"
    },
    "payload": {
        "pk": 1001
    }
}	
{
    "schema": {
        "type": "struct",
        "fields": [
            {
                "type": "struct",
                "fields": [
                    {
                        "type": "int32",
                        "optional": false,
                        "field": "pk"
                    },
                    {
                        "type": "string",
                        "optional": true,
                        "field": "i"
                    }
                ],
                "optional": true,
                "name": "servername.inventory.network.Value",
                "field": "before"
            },
            {
                "type": "struct",
                "fields": [
                    {
                        "type": "int32",
                        "optional": false,
                        "field": "pk"
                    },
                    {
                        "type": "string",
                        "optional": true,
                        "field": "i"
                    }
                ],
                "optional": true,
                "name": "servername.inventory.network.Value",
                "field": "after"
            },
            {
                "type": "struct",
                "fields": [
                    {
                        "type": "string",
                        "optional": true,
                        "field": "version"
                    },
                    {
                        "type": "string",
                        "optional": true,
                        "field": "connector"
                    },
                    {
                        "type": "string",
                        "optional": false,
                        "field": "name"
                    },
                    {
                        "type": "string",
                        "optional": false,
                        "field": "db"
                    },
                    {
                        "type": "int64",
                        "optional": true,
                        "field": "ts_usec"
                    },
                    {
                        "type": "int64",
                        "optional": true,
                        "field": "txId"
                    },
                    {
                        "type": "int64",
                        "optional": true,
                        "field": "lsn"
                    },
                    {
                        "type": "string",
                        "optional": true,
                        "field": "schema"
                    },
                    {
                        "type": "string",
                        "optional": true,
                        "field": "table"
                    },
                    {
                        "type": "boolean",
                        "optional": true,
                        "default": false,
                        "field": "snapshot"
                    },
                    {
                        "type": "boolean",
                        "optional": true,
                        "field": "last_snapshot_record"
                    },
                    {
                        "type": "int64",
                        "optional": true,
                        "field": "xmin"
                    }
                ],
                "optional": false,
                "name": "io.debezium.connector.postgresql.Source",
                "field": "source"
            },
            {
                "type": "string",
                "optional": false,
                "field": "op"
            },
            {
                "type": "int64",
                "optional": true,
                "field": "ts_ms"
            }
        ],
        "optional": false,
        "name": "servername.inventory.network.Envelope"
    },
    "payload": {
        "before": null,
        "after": {
            "pk": 1001,
            "i": null
        },
        "source": {
            "version": "0.9.4-SNAPSHOT",
            "connector": "postgresql",
            "name": "servername",
            "db": "postgres",
            "ts_usec": 1554462087304494,
            "txId": 597,
            "lsn": 24620232,
            "schema": "inventory",
            "table": "network",
            "snapshot": true,
            "last_snapshot_record": true,
            "xmin": null
        },
        "op": "c",
        "ts_ms": 1554462087670
    }
}
```

After Patch (PostgreSQL 10 and 11):
```
{
    "schema": {
        "type": "struct",
        "fields": [
            {
                "type": "int32",
                "optional": false,
                "field": "pk"
            }
        ],
        "optional": false,
        "name": "fulfillment.public.network_address_table.Key"
    },
    "payload": {
        "pk": 1
    }
}	
{
    "schema": {
        "type": "struct",
        "fields": [
            {
                "type": "struct",
                "fields": [
                    {
                        "type": "int32",
                        "optional": false,
                        "field": "pk"
                    },
                    {
                        "type": "string",
                        "optional": true,
                        "field": "i"
                    },
                    {
                        "type": "string",
                        "optional": true,
                        "field": "c"
                    },
                    {
                        "type": "string",
                        "optional": true,
                        "field": "m"
                    },
                    {
                        "type": "string",
                        "optional": true,
                        "field": "m8"
                    }
                ],
                "optional": true,
                "name": "fulfillment.public.network_address_table.Value",
                "field": "before"
            },
            {
                "type": "struct",
                "fields": [
                    {
                        "type": "int32",
                        "optional": false,
                        "field": "pk"
                    },
                    {
                        "type": "string",
                        "optional": true,
                        "field": "i"
                    },
                    {
                        "type": "string",
                        "optional": true,
                        "field": "c"
                    },
                    {
                        "type": "string",
                        "optional": true,
                        "field": "m"
                    },
                    {
                        "type": "string",
                        "optional": true,
                        "field": "m8"
                    }
                ],
                "optional": true,
                "name": "fulfillment.public.network_address_table.Value",
                "field": "after"
            },
            {
                "type": "struct",
                "fields": [
                    {
                        "type": "string",
                        "optional": true,
                        "field": "version"
                    },
                    {
                        "type": "string",
                        "optional": true,
                        "field": "connector"
                    },
                    {
                        "type": "string",
                        "optional": false,
                        "field": "name"
                    },
                    {
                        "type": "string",
                        "optional": false,
                        "field": "db"
                    },
                    {
                        "type": "int64",
                        "optional": true,
                        "field": "ts_usec"
                    },
                    {
                        "type": "int64",
                        "optional": true,
                        "field": "txId"
                    },
                    {
                        "type": "int64",
                        "optional": true,
                        "field": "lsn"
                    },
                    {
                        "type": "string",
                        "optional": true,
                        "field": "schema"
                    },
                    {
                        "type": "string",
                        "optional": true,
                        "field": "table"
                    },
                    {
                        "type": "boolean",
                        "optional": true,
                        "default": false,
                        "field": "snapshot"
                    },
                    {
                        "type": "boolean",
                        "optional": true,
                        "field": "last_snapshot_record"
                    },
                    {
                        "type": "int64",
                        "optional": true,
                        "field": "xmin"
                    }
                ],
                "optional": false,
                "name": "io.debezium.connector.postgresql.Source",
                "field": "source"
            },
            {
                "type": "string",
                "optional": false,
                "field": "op"
            },
            {
                "type": "int64",
                "optional": true,
                "field": "ts_ms"
            }
        ],
        "optional": false,
        "name": "fulfillment.public.network_address_table.Envelope"
    },
    "payload": {
        "before": null,
        "after": {
            "pk": 1,
            "i": null,
            "c": null,
            "m": null,
            "m8": null
        },
        "source": {
            "version": "0.9.4-SNAPSHOT",
            "connector": "postgresql",
            "name": "fulfillment",
            "db": "postgres",
            "ts_usec": 1554561187637489,
            "txId": 558,
            "lsn": 24516152,
            "schema": "public",
            "table": "network_address_table",
            "snapshot": false,
            "last_snapshot_record": null,
            "xmin": null
        },
        "op": "c",
        "ts_ms": 1554561187750
    }
}
```