### PR TITLE
DBZ-1218 Close JDBC connection in SnapshotReader for MySQL Connector

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -719,6 +719,12 @@ public class SnapshotReader extends AbstractReader {
                 }
             }
             failed(e, "Aborting snapshot due to error when last running '" + sql.get() + "': " + e.getMessage());
+        } finally {
+            try {
+                mysql.close();
+            } catch (SQLException e) {
+                logger.warn("Failed to close the connection properly", e);
+            }
         }
     }
 


### PR DESCRIPTION
The JDBC connection is established but never closed at the end of a snapshot execution resulting in resource leak.