### PR TITLE
[DBZ-1221] create new metric getIsGtidModeEnabled

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -292,9 +292,12 @@ public class BinlogReader extends AbstractReader {
             eventHandlers.put(EventType.ROWS_QUERY, this::handleRowsQuery);
         }
 
+        final boolean isGtidModeEnabled = connectionContext.isGtidModeEnabled();
+        metrics.setIsGtidModeEnabled(isGtidModeEnabled);
+
         // Get the current GtidSet from MySQL so we can get a filtered/merged GtidSet based off of the last Debezium checkpoint.
         String availableServerGtidStr = connectionContext.knownGtidSet();
-        if (connectionContext.isGtidModeEnabled()) {
+        if (isGtidModeEnabled) {
             // The server is using GTIDs, so enable the handler ...
             eventHandlers.put(EventType.GTID, this::handleGtidEvent);
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReaderMetrics.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReaderMetrics.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.mysql;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -29,6 +30,7 @@ class BinlogReaderMetrics extends Metrics implements BinlogReaderMetricsMXBean {
     private final AtomicLong numberOfRolledBackTransactions = new AtomicLong();
     private final AtomicLong numberOfNotWellFormedTransactions = new AtomicLong();
     private final AtomicLong numberOfLargeTransactions = new AtomicLong();
+    private final AtomicBoolean isGtidModeEnabled = new AtomicBoolean(false);
     private final AtomicReference<String> lastTransactionId = new AtomicReference<>();
 
     public BinlogReaderMetrics(BinaryLogClient client, MySqlTaskContext taskContext, String name, ChangeEventQueueMetrics changeEventQueueMetrics) {
@@ -56,6 +58,11 @@ class BinlogReaderMetrics extends Metrics implements BinlogReaderMetricsMXBean {
     @Override
     public String getGtidSet() {
         return this.client.getGtidSet();
+    }
+
+    @Override
+    public boolean getIsGtidModeEnabled() {
+        return isGtidModeEnabled.get();
     }
 
     @Override
@@ -101,6 +108,7 @@ class BinlogReaderMetrics extends Metrics implements BinlogReaderMetricsMXBean {
         numberOfNotWellFormedTransactions.set(0);
         numberOfLargeTransactions.set(0);
         lastTransactionId.set(null);
+        isGtidModeEnabled.set(false);
     }
 
     @Override
@@ -141,6 +149,10 @@ class BinlogReaderMetrics extends Metrics implements BinlogReaderMetricsMXBean {
 
     public void onGtidChange(String gtid) {
         lastTransactionId.set(gtid);
+    }
+
+    public void setIsGtidModeEnabled(final boolean enabled) {
+        isGtidModeEnabled.set(enabled);
     }
 
     @Override

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReaderMetricsMXBean.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReaderMetricsMXBean.java
@@ -26,4 +26,10 @@ public interface BinlogReaderMetricsMXBean extends StreamingChangeEventSourceMet
     long getNumberOfRolledBackTransactions();
     long getNumberOfNotWellFormedTransactions();
     long getNumberOfLargeTransactions();
+
+    /**
+     * Tracks if the connector is running using Gtids to track current offset.
+     * @return true if using Gtids, false if not.
+     */
+    boolean getIsGtidModeEnabled();
 }


### PR DESCRIPTION
For [DBZ-1221](https://issues.jboss.org/browse/DBZ-1221) 

Currently debezium-mysql-connector indirectly exposes if the underlying binlog client is using GTIDs to maintain its position from MySQL via the GtidSet and SourceEventPosition metrics.

Rather than indirectly infer if the connector is using Gtids by presence or absence of values in these metrics, it'd be nice if the connector directly exposed this via a metric like:

`boolean getIsGtidModeEnabled();`