### PR TITLE
Updated MySQL connector Jenkins job to use custom ports for MySQL

### DIFF
--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -782,7 +782,6 @@ public final class EmbeddedEngine implements Runnable {
                                 return offsetReader;
                             }
 
-                            @Override
                             public Map<String, String> configs() {
                                 // TODO Auto-generated method stub
                                 return null;

--- a/jenkins-jobs/mysql-matrix-test.yaml
+++ b/jenkins-jobs/mysql-matrix-test.yaml
@@ -49,7 +49,7 @@
     builders:
       - maven-target:
           maven-version: (Default)
-          goals: clean install -U -s $HOME/.m2/settings-snapshots.xml -pl debezium-connector-mysql -am -fae -Dmaven.test.failure.ignore=true -Dversion.mysql.server=$MYSQL_VERSION -P$PROFILE
+          goals: clean install -U -s $HOME/.m2/settings-snapshots.xml -pl debezium-connector-mysql -am -fae -Dmaven.test.failure.ignore=true -Dversion.mysql.server=$MYSQL_VERSION -Dmysql.port=4301 -Dmysql.replica.port=4301 -Dmysql.gtid.port=4302 -Dmysql.gtid.replica.port=4303 -P$PROFILE
     publishers:
       - junit:
           results: "**/target/surefire-reports/*.xml,**/target/failsafe-reports/*.xml"


### PR DESCRIPTION
1) Jenkins slaves in http://ci.hibernate.org have a MySQL server already running at port 3306 (probably with root permissions).
2) SourceTaskContext#configs() wasn't present in Kafka API v1.x, thus removing @Override annotation