### PR TITLE
DBZ-1238 Allow more options for snapshot SPI

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -453,6 +453,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                                                                 "Whether or not to drop the logical replication slot when the connector finishes orderly" +
                                                                 "By default the replication is kept so that on restart progress can resume from the last recorded location");
 
+
     public static final Field STREAM_PARAMS = Field.create("slot.stream.params")
                                                         .withDisplayName("Optional parameters to pass to the logical decoder when the stream is started.")
                                                         .withType(Type.STRING)
@@ -733,6 +734,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                     "The bigger the value, the less likely this value is to be the current 'true' value, but the lower the performance penalty. " +
                     "The default is set to 0 ms, which disables tracking xmin.")
             .withValidation(Field::isNonNegativeLong);
+
     /**
      * The set of {@link Field}s defined as part of this configuration.
      */
@@ -847,8 +849,8 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         return getConfig().getString(COLUMN_BLACKLIST);
     }
 
-    protected long snapshotLockTimeoutMillis() {
-        return getConfig().getLong(PostgresConnectorConfig.SNAPSHOT_LOCK_TIMEOUT_MS);
+    protected Duration snapshotLockTimeout() {
+        return Duration.ofMillis(getConfig().getLong(PostgresConnectorConfig.SNAPSHOT_LOCK_TIMEOUT_MS));
     }
 
     protected Snapshotter getSnapshotter() {
@@ -877,14 +879,15 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         ConfigDef config = new ConfigDef();
         Field.group(config, "Postgres", SLOT_NAME, PLUGIN_NAME, RelationalDatabaseConnectorConfig.SERVER_NAME, DATABASE_NAME, HOSTNAME, PORT,
                     USER, PASSWORD, ON_CONNECT_STATEMENTS, SSL_MODE, SSL_CLIENT_CERT, SSL_CLIENT_KEY_PASSWORD, SSL_ROOT_CERT, SSL_CLIENT_KEY,
-                    DROP_SLOT_ON_STOP, STREAM_PARAMS, SSL_SOCKET_FACTORY, STATUS_UPDATE_INTERVAL_MS, TCP_KEEPALIVE, XMIN_FETCH_INTERVAL, SNAPSHOT_MODE_CLASS);
+                    DROP_SLOT_ON_STOP, STREAM_PARAMS, SSL_SOCKET_FACTORY, STATUS_UPDATE_INTERVAL_MS, TCP_KEEPALIVE, XMIN_FETCH_INTERVAL);
         Field.group(config, "Events", SCHEMA_WHITELIST, SCHEMA_BLACKLIST, TABLE_WHITELIST, TABLE_BLACKLIST,
                     COLUMN_BLACKLIST, INCLUDE_UNKNOWN_DATATYPES, SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
                     CommonConnectorConfig.TOMBSTONES_ON_DELETE, Heartbeat.HEARTBEAT_INTERVAL,
                     Heartbeat.HEARTBEAT_TOPICS_PREFIX, CommonConnectorConfig.SOURCE_STRUCT_MAKER_VERSION);
         Field.group(config, "Connector", CommonConnectorConfig.POLL_INTERVAL_MS, CommonConnectorConfig.MAX_BATCH_SIZE, CommonConnectorConfig.MAX_QUEUE_SIZE,
                     CommonConnectorConfig.SNAPSHOT_DELAY_MS, CommonConnectorConfig.SNAPSHOT_FETCH_SIZE,
-                    SNAPSHOT_MODE, SNAPSHOT_LOCK_TIMEOUT_MS, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE, HSTORE_HANDLING_MODE, SCHEMA_REFRESH_MODE);
+                    SNAPSHOT_MODE, SNAPSHOT_LOCK_TIMEOUT_MS, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE, HSTORE_HANDLING_MODE,
+                    SCHEMA_REFRESH_MODE, SNAPSHOT_MODE_CLASS);
 
         return config;
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTaskContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTaskContext.java
@@ -99,7 +99,7 @@ public class PostgresTaskContext extends CdcSourceTaskContext {
         }
     }
 
-    protected ReplicationConnection createReplicationConnection() throws SQLException {
+    protected ReplicationConnection createReplicationConnection(boolean exportSnapshot) throws SQLException {
         return ReplicationConnection.builder(config.jdbcConfig())
                                     .withSlot(config.slotName())
                                     .withPlugin(config.plugin())
@@ -107,6 +107,7 @@ public class PostgresTaskContext extends CdcSourceTaskContext {
                                     .streamParams(config.streamParams())
                                     .statusUpdateInterval(config.statusUpdateInterval())
                                     .withTypeRegistry(schema.getTypeRegistry())
+                                    .exportSnapshotOnCreate(exportSnapshot)
                                     .build();
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsSnapshotProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsSnapshotProducer.java
@@ -80,8 +80,7 @@ public class RecordsSnapshotProducer extends RecordsProducer {
                 // we need to create the slot before we start streaming if it doesn't exist
                 // otherwise we can't stream back changes happening while the snapshot is taking place
                 if (!snapWrapper.doesSlotExist()) {
-                    replConn.createReplicationSlot();
-                    slotCreatedInfo = replConn.getSlotCreationResult().orElse(null);
+                    slotCreatedInfo = replConn.createReplicationSlot().orElse(null);
                 }
                 else {
                     slotCreatedInfo = null;
@@ -200,7 +199,7 @@ public class RecordsSnapshotProducer extends RecordsProducer {
                         connection.database(), connection.username());
 
             String transactionStatement = snapshotter.snapshotTransactionIsolationLevelStatement(slotCreatedInfo);
-            logger.info("openining transaction with statement {}", transactionStatement);
+            logger.info("opening transaction with statement {}", transactionStatement);
             connection.executeWithoutCommitting(transactionStatement);
 
             //next refresh the schema which will load all the tables taking the filters into account
@@ -220,7 +219,8 @@ public class RecordsSnapshotProducer extends RecordsProducer {
                 // Let the user know
                 if (!snapshotter.exportSnapshot()) {
                     logger.warn("Step 2: skipping locking each table, this may result in inconsistent schema!");
-                } else {
+                }
+                else {
                     logger.info("Step 2: skipping locking each table in an exported snapshot");
                 }
             }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -14,6 +14,7 @@ import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -33,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.postgresql.TypeRegistry;
+import io.debezium.connector.postgresql.spi.SlotCreationResult;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.jdbc.JdbcConnectionException;
 import io.debezium.util.Clock;
@@ -51,6 +53,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     private final String slotName;
     private final PostgresConnectorConfig.LogicalDecoder plugin;
     private final boolean dropSlotOnClose;
+    private final boolean exportSnapshot;
     private final Configuration originalConfig;
     private final Duration statusUpdateInterval;
     private final MessageDecoder messageDecoder;
@@ -58,6 +61,8 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     private final Properties streamParams;
 
     private long defaultStartingPos;
+    private SlotCreationResult slotCreationInfo;
+    private boolean hasInitedSlot;
 
     /**
      * Creates a new replication connection with the given params.
@@ -67,6 +72,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
      * @param plugin decoder matching the server side plug-in used for streaming changes; may not be null
      * @param dropSlotOnClose whether the replication slot should be dropped once the connection is closed
      * @param statusUpdateInterval the interval at which the replication connection should periodically send status
+     * @param exportSnapshot whether the replication should export a snapshot when created
      * @param typeRegistry registry with PostgreSQL types
      *
      * updates to the server
@@ -75,6 +81,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                                          String slotName,
                                          PostgresConnectorConfig.LogicalDecoder plugin,
                                          boolean dropSlotOnClose,
+                                         boolean exportSnapshot,
                                          Duration statusUpdateInterval,
                                          TypeRegistry typeRegistry,
                                          Properties streamParams) {
@@ -85,64 +92,50 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         this.plugin = plugin;
         this.dropSlotOnClose = dropSlotOnClose;
         this.statusUpdateInterval = statusUpdateInterval;
+        this.exportSnapshot = exportSnapshot;
         this.messageDecoder = plugin.messageDecoder();
         this.typeRegistry = typeRegistry;
         this.streamParams = streamParams;
+        this.slotCreationInfo = null;
+        this.hasInitedSlot = false;
 
+        // to keep the same
         try {
-            initReplicationSlot();
-        }
-        catch (ConnectException e) {
-            close();
-            throw e;
+            ensureSlotNotActive(getSlotInfo());
         }
         catch (Throwable t) {
             close();
-            throw new ConnectException("Cannot create replication connection", t);
+            throw new ConnectException(t);
         }
     }
 
-    private void initReplicationSlot() throws SQLException, InterruptedException {
-        final String postgresPluginName = plugin.getPostgresPluginName();
-        ServerInfo.ReplicationSlot slotInfo;
+
+    private ServerInfo.ReplicationSlot getSlotInfo() throws SQLException, InterruptedException {
         try (PostgresConnection connection = new PostgresConnection(originalConfig)) {
-            slotInfo = connection.readReplicationSlotInfo(slotName, postgresPluginName);
+            return connection.readReplicationSlotInfo(slotName, plugin.getPostgresPluginName());
         }
+    }
+
+    private void ensureSlotNotActive(ServerInfo.ReplicationSlot slotInfo) throws IllegalStateException {
+        if (slotInfo.active()) {
+            throw new IllegalStateException(
+                    "A logical replication slot named '" + slotName + "' for plugin '" + plugin.getPostgresPluginName() + "' and database '" + database() + "' is already active on the server." +
+                    "You cannot have multiple slots with the same name active for the same database."
+            );
+        }
+    }
+
+    protected void initReplicationSlot() throws SQLException, InterruptedException {
+        final String postgresPluginName = plugin.getPostgresPluginName();
+        ServerInfo.ReplicationSlot slotInfo = getSlotInfo();
 
         boolean shouldCreateSlot = ServerInfo.ReplicationSlot.INVALID == slotInfo;
         try {
             // there's no info for this plugin and slot so create a new slot
             if (shouldCreateSlot) {
-                LOGGER.debug("Creating new replication slot '{}' for plugin '{}'", slotName, plugin);
-
-                // creating a temporary slot if it should be dropped an we're on 10 or newer;
-                // this is not supported through the API yet
-                // see https://github.com/pgjdbc/pgjdbc/issues/1305
-                if (useTemporarySlot()) {
-                    try (Statement stmt = pgConnection().createStatement()) {
-                        stmt.execute(String.format(
-                                "CREATE_REPLICATION_SLOT %s TEMPORARY LOGICAL %s",
-                                slotName,
-                                postgresPluginName
-                        ));
-                    }
-                }
-                else {
-                    pgConnection().getReplicationAPI()
-                        .createReplicationSlot()
-                        .logical()
-                        .withSlotName(slotName)
-                        .withOutputPlugin(postgresPluginName)
-                        .make();
-                }
+                this.createReplicationSlot();
             }
-            else if (slotInfo.active()) {
-                LOGGER.error(
-                        "A logical replication slot named '{}' for plugin '{}' and database '{}' is already active on the server." +
-                        "You cannot have multiple slots with the same name active for the same database",
-                        slotName, postgresPluginName, database());
-                throw new IllegalStateException();
-            }
+            ensureSlotNotActive(slotInfo);
 
             AtomicLong xlogStart = new AtomicLong();
             // replication connection does not support parsing of SQL statements so we need to create
@@ -161,32 +154,71 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                 }
             });
 
-            if (shouldCreateSlot || !slotInfo.hasValidFlushedLsn()) {
+            if (slotCreationInfo != null) {
+                this.defaultStartingPos = slotCreationInfo.startLsn();
+            }
+            else if (shouldCreateSlot || !slotInfo.hasValidFlushedLsn()) {
                 // this is a new slot or we weren't able to read a valid flush LSN pos, so we always start from the xlog pos that was reported
                 this.defaultStartingPos = xlogStart.get();
-            } else {
+            }
+            else {
                 Long latestFlushedLsn = slotInfo.latestFlushedLsn();
                 this.defaultStartingPos = latestFlushedLsn < xlogStart.get() ? latestFlushedLsn : xlogStart.get();
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("found previous flushed LSN '{}'", ReplicationConnection.format(latestFlushedLsn));
                 }
             }
+            hasInitedSlot = true;
         } catch (SQLException e) {
             throw new JdbcConnectionException(e);
         }
     }
 
     private boolean useTemporarySlot() throws SQLException {
-        return dropSlotOnClose && pgConnection().getServerMajorVersion() >= 10;
+        return dropSlotOnClose && isPg10OrGreater();
     }
 
+    private boolean exportSnapshotOnCreate() throws SQLException {
+        return exportSnapshot && isPg10OrGreater();
+    }
+
+    private boolean isPg10OrGreater() throws SQLException {
+        return pgConnection().getServerMajorVersion() >= 10;
+    }
+
+    /**
+     * creating a replication connection and starting to stream involves a few steps:
+     * 1. we create the connection and ensure that
+     * a. the slot exists
+     * b. the slot isn't currently being used
+     * 2. we query to get our potential start position in the slot (lsn)
+     * 3. we try and start streaming, depending on our options (such as in wal2json)
+     *    this may fail, which can result in the connection being killed and we need to start
+     *    the process over if we are using a temporary slot
+     * 4. actually start the streamer
+     *
+     * This method takes care of all of these and this method queries for a default starting position
+     * If you know where you are starting from you should call {@link #startStreaming(Long)}, this method
+     * delegates to that method
+     * @return
+     * @throws SQLException
+     * @throws InterruptedException
+     */
     @Override
     public ReplicationStream startStreaming() throws SQLException, InterruptedException {
+        // this ensures we have the right type of connection, creates the slot if needed,
+        // and sets the defaultStartingPos, so we must set it here
+        initConnection();
         return startStreaming(defaultStartingPos);
     }
 
     @Override
     public ReplicationStream startStreaming(Long offset) throws SQLException, InterruptedException {
+        // if this method is being called by startStreaming without an offset, this
+        // will already be called, but it is made idempotent to ensure we can safely call it
+        // multiple times
+        initConnection();
+
         connect();
         if (offset == null || offset <= 0) {
             offset = defaultStartingPos;
@@ -198,9 +230,79 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         return createReplicationStream(lsn);
     }
 
+    @Override
+    public void initConnection() throws SQLException, InterruptedException {
+        if (!hasInitedSlot) {
+            initReplicationSlot();
+        }
+    }
+
+    @Override
+    public void createReplicationSlot() throws SQLException {
+        // note that some of these options are only supported in pg10 or newer, additionally
+        // the options are not yet exported by the jdbc api wrapper, therefore, we just do this ourselves
+        // but eventually this should be moved back to the jdbc API
+        // see https://github.com/pgjdbc/pgjdbc/issues/1305
+
+        LOGGER.debug("Creating new replication slot '{}' for plugin '{}'", slotName, plugin);
+        String tempPart = "";
+        String exportPart = "";
+        Boolean isPg10 = isPg10OrGreater();
+        if ((dropSlotOnClose || exportSnapshot) && !isPg10OrGreater()) {
+            LOGGER.warn("A slot marked as temporary or with an exported snapshot was created, but not on a supported version of Postgres, ignoring!");
+        }
+        if (useTemporarySlot()) {
+            tempPart = "TEMPORARY";
+        }
+        if (exportSnapshotOnCreate()) {
+            exportPart = "EXPORT_SNAPSHOT";
+        }
+        try (Statement stmt = pgConnection().createStatement()) {
+            String createCommand = String.format(
+                    "CREATE_REPLICATION_SLOT %s %s LOGICAL %s %s",
+                    slotName,
+                    tempPart,
+                    plugin.getPostgresPluginName(),
+                    exportPart
+            );
+            LOGGER.info("Creating replication slot with command {}", createCommand);
+            stmt.execute(createCommand);
+            // when we are in pg10, we can parse the slot creation info, otherwise, it returns
+            // nothing
+            if (isPg10) {
+                this.slotCreationInfo = parseSlotCreation(stmt.getResultSet());
+            }
+        }
+    }
+
+    @Override
+    public Optional<SlotCreationResult> getSlotCreationResult() {
+        return Optional.ofNullable(slotCreationInfo);
+    }
+
     protected PgConnection pgConnection() throws SQLException {
         return (PgConnection) connection(false);
     }
+
+    private SlotCreationResult parseSlotCreation(ResultSet rs) {
+        try {
+            if (rs.next()) {
+                String slotName = rs.getString("slot_name");
+                String startPoint = rs.getString("consistent_point");
+                String snapName = rs.getString("snapshot_name");
+                String pluginName = rs.getString("output_plugin");
+
+                return new SlotCreationResult(slotName, startPoint, snapName, pluginName);
+            }
+            else {
+                throw new ConnectException("expected response to create_replication_slot");
+            }
+        }
+        catch (SQLException ex) {
+            throw new ConnectException("unable to parse create_replication_slot", ex);
+        }
+    }
+
 
     private ReplicationStream createReplicationStream(final LogSequenceNumber lsn) throws SQLException, InterruptedException {
         PGReplicationStream s;
@@ -216,6 +318,8 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             catch (PSQLException e) {
                 LOGGER.debug("Could not register for streaming, retrying without optional options", e);
 
+                // re-init the slot after a failed start of slot, as this
+                // may have closed the slot
                 if (useTemporarySlot()) {
                     initReplicationSlot();
                 }
@@ -229,6 +333,8 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                 // It is possible we are connecting to an old wal2json plug-in
                 LOGGER.warn("Could not register for streaming with metadata in messages, falling back to messages without metadata");
 
+                // re-init the slot after a failed start of slot, as this
+                // may have closed the slot
                 if (useTemporarySlot()) {
                     initReplicationSlot();
                 }
@@ -414,6 +520,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         private PostgresConnectorConfig.LogicalDecoder plugin = PostgresConnectorConfig.LogicalDecoder.DECODERBUFS;
         private boolean dropSlotOnClose = DEFAULT_DROP_SLOT_ON_CLOSE;
         private Duration statusUpdateIntervalVal;
+        private boolean exportSnapshot = DEFAULT_EXPORT_SNAPSHOT;
         private TypeRegistry typeRegistry;
         private Properties slotStreamParams = new Properties();
 
@@ -467,9 +574,17 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         }
 
         @Override
+        public Builder exportSnapshotOnCreate(boolean exportSnapshot) {
+            this.exportSnapshot = exportSnapshot;
+            return this;
+        }
+
+
+        @Override
         public ReplicationConnection build() {
             assert plugin != null : "Decoding plugin name is not set";
-            return new PostgresReplicationConnection(config, slotName, plugin, dropSlotOnClose, statusUpdateIntervalVal, typeRegistry, slotStreamParams);
+            return new PostgresReplicationConnection(config, slotName, plugin, dropSlotOnClose, exportSnapshot,
+                    statusUpdateIntervalVal, typeRegistry, slotStreamParams);
         }
 
         @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -187,17 +187,11 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
      */
     @Override
     public ReplicationStream startStreaming() throws SQLException, InterruptedException {
-        // this ensures we have the right type of connection, creates the slot if needed,
-        // and sets the defaultStartingPos, so we must set it here
-        initConnection();
-        return startStreaming(defaultStartingPos);
+        return startStreaming(null);
     }
 
     @Override
     public ReplicationStream startStreaming(Long offset) throws SQLException, InterruptedException {
-        // if this method is being called by startStreaming without an offset, this
-        // will already be called, but it is made idempotent to ensure we can safely call it
-        // multiple times
         initConnection();
 
         connect();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -238,7 +238,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     }
 
     @Override
-    public void createReplicationSlot() throws SQLException {
+    public Optional<SlotCreationResult> createReplicationSlot() throws SQLException {
         // note that some of these options are only supported in pg10 or newer, additionally
         // the options are not yet exported by the jdbc api wrapper, therefore, we just do this ourselves
         // but eventually this should be moved back to the jdbc API
@@ -272,12 +272,9 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             if (isPg10) {
                 this.slotCreationInfo = parseSlotCreation(stmt.getResultSet());
             }
-        }
-    }
 
-    @Override
-    public Optional<SlotCreationResult> getSlotCreationResult() {
-        return Optional.ofNullable(slotCreationInfo);
+            return Optional.ofNullable(slotCreationInfo);
+        }
     }
 
     protected PgConnection pgConnection() throws SQLException {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
@@ -8,6 +8,7 @@ package io.debezium.connector.postgresql.connection;
 
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.Optional;
 
 import org.postgresql.replication.LogSequenceNumber;
 import org.postgresql.replication.PGReplicationStream;
@@ -16,6 +17,7 @@ import io.debezium.annotation.NotThreadSafe;
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.postgresql.TypeRegistry;
+import io.debezium.connector.postgresql.spi.SlotCreationResult;
 
 /**
  * A Postgres logical streaming replication connection. Replication connections are established for a slot and a given plugin
@@ -56,6 +58,27 @@ public interface ReplicationConnection extends AutoCloseable {
     ReplicationStream startStreaming(Long offset) throws SQLException, InterruptedException;
 
     /**
+     * Creates a new replication slot with the given option and returns the result of the command, which
+     * may contain results (depending on postgres versions)
+     *
+     * @throws SQLException if anything fails
+     */
+    void createReplicationSlot() throws SQLException;
+
+    /**
+     *  Forces the connection to be created, is called by startStreaming, but can be called manually
+     *  in cases where we want the connection but not to to start streaming yet.
+     *
+     *  Can be called multiple times
+     */
+    void initConnection() throws SQLException, InterruptedException;
+
+    /**
+     * Returns the results of creating the slot, which may contain a snapshot id
+     */
+    Optional<SlotCreationResult> getSlotCreationResult();
+
+    /**
      * Checks whether this connection is open or not
      *
      * @return {@code true} if this connection is open, {@code false} otherwise
@@ -87,11 +110,13 @@ public interface ReplicationConnection extends AutoCloseable {
      * A builder for {@link ReplicationConnection}
      */
     interface Builder {
+
         /**
          * Default replication settings
          */
         String DEFAULT_SLOT_NAME = "debezium";
         boolean DEFAULT_DROP_SLOT_ON_CLOSE = true;
+        boolean DEFAULT_EXPORT_SNAPSHOT = false;
 
         /**
          * Sets the name for the PG logical replication slot
@@ -139,6 +164,14 @@ public interface ReplicationConnection extends AutoCloseable {
          * @see #STREAM_PARAMS
          */
         Builder streamParams(final String streamParams);
+
+        /**
+         * Whether or not to export the snapshot when creating the slot
+         * @param exportSnapshot true if a snapshot should be exported, false if otherwise
+         * @return this instance
+         * @see #DEFAULT_EXPORT_SNAPSHOT
+         */
+        Builder exportSnapshotOnCreate(final boolean exportSnapshot);
 
         /**
          * Creates a new {@link ReplicationConnection} instance

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
@@ -63,7 +63,7 @@ public interface ReplicationConnection extends AutoCloseable {
      *
      * @throws SQLException if anything fails
      */
-    void createReplicationSlot() throws SQLException;
+    Optional<SlotCreationResult> createReplicationSlot() throws SQLException;
 
     /**
      *  Forces the connection to be created, is called by startStreaming, but can be called manually
@@ -72,11 +72,6 @@ public interface ReplicationConnection extends AutoCloseable {
      *  Can be called multiple times
      */
     void initConnection() throws SQLException, InterruptedException;
-
-    /**
-     * Returns the results of creating the slot, which may contain a snapshot id
-     */
-    Optional<SlotCreationResult> getSlotCreationResult();
 
     /**
      * Checks whether this connection is open or not

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/InitialSnapshotter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/InitialSnapshotter.java
@@ -5,15 +5,17 @@
  */
 package io.debezium.connector.postgresql.snapshot;
 
-import io.debezium.connector.postgresql.PostgresConnectorConfig;
-import io.debezium.connector.postgresql.spi.OffsetState;
-import io.debezium.connector.postgresql.spi.SlotState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.spi.OffsetState;
+import io.debezium.connector.postgresql.spi.SlotState;
+
 public class InitialSnapshotter extends QueryingSnapshotter {
-    private OffsetState sourceInfo;
+
     private final static Logger LOGGER = LoggerFactory.getLogger(InitialSnapshotter.class);
+    private OffsetState sourceInfo;
 
     @Override
     public void init(PostgresConnectorConfig config, OffsetState sourceInfo, SlotState slotState) {
@@ -35,7 +37,8 @@ public class InitialSnapshotter extends QueryingSnapshotter {
         else if (sourceInfo.snapshotInEffect()) {
             LOGGER.info("Found previous incomplete snapshot");
             return true;
-        } else {
+        }
+        else {
             LOGGER.info(
                     "Previous snapshot has completed successfully, streaming logical changes from last known position");
             return false;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/SnapshotterWrapper.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/SnapshotterWrapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.snapshot;
+
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.spi.OffsetState;
+import io.debezium.connector.postgresql.spi.SlotState;
+import io.debezium.connector.postgresql.spi.Snapshotter;
+
+/**
+ * This class is a small wrapper around the snapshotter that takes care of initialization
+ * and also lets us access the slotState (which we don't track currently)
+ */
+public class SnapshotterWrapper {
+
+    private final Snapshotter snapshotter;
+    private final OffsetState offsetState;
+    private final SlotState slotState;
+    public SnapshotterWrapper(Snapshotter snapshotter, PostgresConnectorConfig config, OffsetState offsetState, SlotState slotState) {
+        this.snapshotter = snapshotter;
+        this.offsetState = offsetState;
+        this.slotState = slotState;
+        this.snapshotter.init(config, offsetState, slotState);
+    }
+
+    public Snapshotter getSnapshotter() {
+        return this.snapshotter;
+    }
+
+    public boolean doesSlotExist() {
+        return this.slotState != null;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/SnapshotterWrapper.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/snapshot/SnapshotterWrapper.java
@@ -17,11 +17,10 @@ import io.debezium.connector.postgresql.spi.Snapshotter;
 public class SnapshotterWrapper {
 
     private final Snapshotter snapshotter;
-    private final OffsetState offsetState;
     private final SlotState slotState;
+
     public SnapshotterWrapper(Snapshotter snapshotter, PostgresConnectorConfig config, OffsetState offsetState, SlotState slotState) {
         this.snapshotter = snapshotter;
-        this.offsetState = offsetState;
         this.slotState = slotState;
         this.snapshotter.init(config, offsetState, slotState);
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/SlotCreationResult.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/SlotCreationResult.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.spi;
+
+import org.postgresql.replication.LogSequenceNumber;
+
+import io.debezium.annotation.Incubating;
+
+/**
+ * A simple data container representing the creation of a newly created replication slot.
+ */
+@Incubating
+public class SlotCreationResult {
+
+    private final String slotName;
+    private final Long walStartLsn;
+    private final String snapshotName;
+    private final String pluginName;
+
+    public SlotCreationResult(String name, String startLsn, String snapshotName, String pluginName) {
+        this.slotName = name;
+        this.walStartLsn = LogSequenceNumber.valueOf(startLsn).asLong();
+        this.snapshotName = snapshotName;
+        this.pluginName = pluginName;
+    }
+
+
+    /**
+     * return the name of the created slot.
+     */
+    public String slotName() {
+        return slotName;
+    }
+
+    public Long startLsn() {
+        return walStartLsn;
+    }
+
+    public String snapshotName() {
+        return snapshotName;
+    }
+
+    public String pluginName() {
+        return pluginName;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/SlotState.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/SlotState.java
@@ -17,7 +17,6 @@ public class SlotState {
     private final Long catalogXmin;
     private final boolean active;
 
-
     public SlotState(Long lastFlushLsn, Long restartLsn, Long catXmin, boolean active) {
         this.active = active;
         this.latestFlushedLsn = lastFlushLsn;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/Snapshotter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/Snapshotter.java
@@ -30,6 +30,7 @@ import io.debezium.relational.TableId;
  */
 @Incubating
 public interface Snapshotter {
+
     void init(PostgresConnectorConfig config, OffsetState sourceInfo,
               SlotState slotState);
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/Snapshotter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/Snapshotter.java
@@ -5,11 +5,13 @@
  */
 package io.debezium.connector.postgresql.spi;
 
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Set;
+
 import io.debezium.annotation.Incubating;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.relational.TableId;
-
-import java.util.Optional;
 
 /**
  * This interface is used to determine details about the snapshot process:
@@ -41,6 +43,14 @@ public interface Snapshotter {
     boolean shouldStream();
 
     /**
+     * @return true if when creating a slot, a snapshot should be exported, which
+     * can be used as an alternative to taking a lock
+     */
+    default boolean exportSnapshot() {
+        return false;
+    }
+
+    /**
      * Generate a valid postgres query string for the specified table, or an empty {@link Optional}
      * to skip snapshotting this table (but that table will still be streamed from)
      *
@@ -48,4 +58,33 @@ public interface Snapshotter {
      * @return a valid query string, or none to skip snapshotting this table
      */
     Optional<String> buildSnapshotQuery(TableId tableId);
+
+    /**
+     * Return a new string that set up the transaction for snapshotting
+     *
+     * @param newSlotInfo if a new slow was created for snapshotting, this contains information from
+     *                    the `create_replication_slot` command
+     */
+    default String snapshotTransactionIsolationLevelStatement(SlotCreationResult newSlotInfo) {
+        // we're using the same isolation level that pg_backup uses
+        return "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE, READ ONLY, DEFERRABLE;";
+    }
+
+    /**
+     * Returns a SQL statement for locking the given tables during snapshotting, if required by the specific snapshotter
+     * implementation.
+     */
+    default Optional<String> snapshotTableLockingStatement(Duration lockTimeout, Set<TableId> tableIds) {
+        String lineSeparator = System.lineSeparator();
+        StringBuilder statements = new StringBuilder();
+        statements.append("SET lock_timeout = ").append(lockTimeout.toMillis()).append(";").append(lineSeparator);
+        // we're locking in SHARE UPDATE EXCLUSIVE MODE to avoid concurrent schema changes while we're taking the snapshot
+        // this does not prevent writes to the table, but prevents changes to the table's schema....
+        // DBZ-298 Quoting name in case it has been quoted originally; it doesn't do harm if it hasn't been quoted
+        tableIds.forEach(tableId -> statements.append("LOCK TABLE ")
+                .append(tableId.toDoubleQuotedString())
+                .append(" IN SHARE UPDATE EXCLUSIVE MODE;")
+                .append(lineSeparator));
+        return Optional.of(statements.toString());
+    }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomTestSnapshot.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomTestSnapshot.java
@@ -20,7 +20,9 @@ import io.debezium.relational.TableId;
  * to allow for class loading to work
  */
 public class CustomTestSnapshot implements Snapshotter {
+
     private boolean hasState;
+
     @Override
     public void init(PostgresConnectorConfig config, OffsetState sourceInfo, SlotState slotState) {
         hasState = (sourceInfo != null);
@@ -54,9 +56,6 @@ public class CustomTestSnapshot implements Snapshotter {
 
     @Override
     public String snapshotTransactionIsolationLevelStatement(SlotCreationResult newSlotInfo) {
-        // this actually is never used in the tests as we don't have any tests
-        // that run against pg10+, leaving it here anyways in hopes that
-        // someday there is a build against pg10
         if (newSlotInfo != null) {
             String snapSet = String.format("SET TRANSACTION SNAPSHOT '%s';", newSlotInfo.snapshotName());
             return "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; \n" + snapSet;

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomTestSnapshot.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomTestSnapshot.java
@@ -5,12 +5,13 @@
  */
 package io.debezium.connector.postgresql;
 
-import io.debezium.connector.postgresql.spi.Snapshotter;
-import io.debezium.connector.postgresql.spi.OffsetState;
-import io.debezium.connector.postgresql.spi.SlotState;
-import io.debezium.relational.TableId;
-
 import java.util.Optional;
+
+import io.debezium.connector.postgresql.spi.OffsetState;
+import io.debezium.connector.postgresql.spi.SlotCreationResult;
+import io.debezium.connector.postgresql.spi.SlotState;
+import io.debezium.connector.postgresql.spi.Snapshotter;
+import io.debezium.relational.TableId;
 
 /**
  * This is a small class used in PostgresConnectorIT to test a custom snapshot
@@ -36,6 +37,11 @@ public class CustomTestSnapshot implements Snapshotter {
     }
 
     @Override
+    public boolean exportSnapshot() {
+        return true;
+    }
+
+    @Override
     public Optional<String> buildSnapshotQuery(TableId tableId) {
         // on an empty state, don't read from s2 schema, but afterwards, do
         if (!hasState && tableId.schema().equals("s2")) {
@@ -43,6 +49,20 @@ public class CustomTestSnapshot implements Snapshotter {
         }
         else {
             return Optional.of("select * from " + tableId.toDoubleQuotedString());
+        }
+    }
+
+    @Override
+    public String snapshotTransactionIsolationLevelStatement(SlotCreationResult newSlotInfo) {
+        // this actually is never used in the tests as we don't have any tests
+        // that run against pg10+, leaving it here anyways in hopes that
+        // someday there is a build against pg10
+        if (newSlotInfo != null) {
+            String snapSet = String.format("SET TRANSACTION SNAPSHOT '%s';", newSlotInfo.snapshotName());
+            return "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ; \n" + snapSet;
+        }
+        else {
+            return "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE, READ ONLY, DEFERRABLE;";
         }
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -36,6 +36,7 @@ import io.debezium.connector.postgresql.junit.SkipTestDependingOnDatabaseVersion
 import io.debezium.connector.postgresql.junit.SkipWhenDatabaseVersionLessThan;
 import io.debezium.connector.postgresql.snapshot.AlwaysSnapshotter;
 import io.debezium.connector.postgresql.snapshot.InitialOnlySnapshotter;
+import io.debezium.connector.postgresql.snapshot.SnapshotterWrapper;
 import io.debezium.connector.postgresql.spi.Snapshotter;
 import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
@@ -268,14 +269,14 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
 
     private RecordsSnapshotProducer buildNoStreamProducer(PostgresTaskContext ctx, PostgresConnectorConfig config) {
         Snapshotter sn = new InitialOnlySnapshotter();
-        sn.init(config, null, null);
-        return new RecordsSnapshotProducer(ctx, TestHelper.sourceInfo(), sn);
+        SnapshotterWrapper snw = new SnapshotterWrapper(sn, config, null, null);
+        return new RecordsSnapshotProducer(ctx, TestHelper.sourceInfo(), snw);
     }
 
     private RecordsSnapshotProducer buildWithStreamProducer(PostgresTaskContext ctx, PostgresConnectorConfig config) {
         Snapshotter sn = new AlwaysSnapshotter();
-        sn.init(config, null, null);
-        return new RecordsSnapshotProducer(ctx, TestHelper.sourceInfo(), sn);
+        SnapshotterWrapper snw = new SnapshotterWrapper(sn, config, null, null);
+        return new RecordsSnapshotProducer(ctx, TestHelper.sourceInfo(), snw);
     }
 
     private void assertReadRecord(SourceRecord record, Map<String, List<SchemaAndValueField>> expectedValuesByTopicName) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotWithOverridesProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotWithOverridesProducerIT.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import io.debezium.connector.postgresql.snapshot.InitialOnlySnapshotter;
+import io.debezium.connector.postgresql.snapshot.SnapshotterWrapper;
 import io.debezium.connector.postgresql.spi.Snapshotter;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.fest.assertions.Assertions;
@@ -126,7 +127,7 @@ public class SnapshotWithOverridesProducerIT extends AbstractRecordsProducerTest
 
     private RecordsSnapshotProducer buildStreamProducer(PostgresTaskContext ctx, PostgresConnectorConfig config) {
         Snapshotter sn = new InitialOnlySnapshotter();
-        sn.init(config, null, null);
-        return new RecordsSnapshotProducer(ctx, TestHelper.sourceInfo(), sn);
+        SnapshotterWrapper snw = new SnapshotterWrapper(sn, config, null, null);
+        return new RecordsSnapshotProducer(ctx, TestHelper.sourceInfo(), snw);
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
@@ -107,6 +107,7 @@ public class PostgresConnectionIT {
         }
         // create a new replication slot via a replication connection
         try (ReplicationConnection connection = TestHelper.createForReplication("test", false)) {
+            connection.initConnection();
             assertTrue(connection.isConnected());
         }
         // drop the slot from the previous connection
@@ -120,6 +121,7 @@ public class PostgresConnectionIT {
     @FixFor("DBZ-934")
     public void temporaryReplicationSlotsShouldGetDroppedAutomatically() throws Exception {
         try(ReplicationConnection replicationConnection = TestHelper.createForReplication("test", true)) {
+            replicationConnection.initConnection();
             PgConnection pgConnection = getUnderlyingConnection(replicationConnection);
 
             // temporary replication slots are not supported by Postgres < 10
@@ -171,6 +173,7 @@ public class PostgresConnectionIT {
                 // Create a replication connection that is blocked till the concurrent TX is completed
                 try (ReplicationConnection replConnection = TestHelper.createForReplication(slotName, false)) {
                     Testing.print("Connecting with replication connection 1");
+                    replConnection.initConnection();
                     assertTrue(replConnection.isConnected());
                     Testing.print("Replication connection 1 - completed");
                 }
@@ -185,6 +188,7 @@ public class PostgresConnectionIT {
                 // Create a replication connection that receives confirmed_flush_lsn == null
                 try (ReplicationConnection replConnection = TestHelper.createForReplication(slotName, false)) {
                     Testing.print("Connecting with replication connection 2");
+                    replConnection.initConnection();
                     assertTrue(replConnection.isConnected());
                     Testing.print("Replication connection 2 - completed");
                 }
@@ -213,6 +217,7 @@ public class PostgresConnectionIT {
     public void shouldSupportPG95RestartLsn() throws Exception {
         String slotName = "pg95";
         try (ReplicationConnection replConnection = TestHelper.createForReplication(slotName, false)) {
+            replConnection.initConnection();
             assertTrue(replConnection.isConnected());
         }
         try (PostgresConnection conn = buildPG95PGConn("pg95")) {


### PR DESCRIPTION
https://issues.jboss.org/projects/DBZ/issues/DBZ-1238

This commit adds some more options to the Postgres Snapshottter SPI
interface, specifically, the ability to create the query for the start
of a snapshot, as well as the ability to generate a statement to lock
the tables.

Additionally, some rework is done to allow for the usage of an exported
snapshot in conjuction with the SPI taking metadata about a newly
created slot. This also changes how slots are initialized to allow for
the exported snapshot to be referenced, which requires adding a more
granular setup of a ReplicationConnection

Together, these options allow for a lot more flexibility, such as not
taking locks when snapshotting large databases as well as potentially to
use exported snapshots.

A future version should perhaps make some options possible without
implementing the SPI (such as using the exported snapshot by default)
but this commit is just trying to get all the groundwork in place to
allow for the Snapshotter SPI to have this functionality.