### PR TITLE
DBZ-1247 Adding property to specify snapshot fetch size

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -376,13 +376,14 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
     }
 
     /**
-     * Gets the number of documents to return per fetch. Default to {@code 0}, which indicates that the server chooses
-     * an appropriate fetch size.
+     * Returns the number of documents to return per fetch by default. Default to {@code 0}, which indicates
+     * that the server chooses an appropriate fetch size.
      *
-     * @return the fetch size
+     * @return the default fetch size
      */
-    public int getSnapshotFetchSize() {
-        return getSnapshotFetchSize(DEFAULT_SNAPSHOT_FETCH_SIZE);
+    @Override
+    protected int defaultSnapshotFetchSize() {
+        return DEFAULT_SNAPSHOT_FETCH_SIZE;
     }
 
     public SnapshotMode getSnapshotMode() {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -300,7 +300,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
                                                             .withImportance(Importance.MEDIUM)
                                                             .withDescription("The maximum number of documents that should be loaded into memory while performing a snapshot")
                                                             .withDefault(0)
-                                                            .withValidation(Field::isPositiveInteger);
+                                                            .withValidation(Field::isNonNegativeInteger);
 
     protected static final Field TASK_ID = Field.create("mongodb.task.id")
                                                 .withDescription("Internal use only")

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -327,8 +327,8 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
     public MongoDbConnectorConfig(Configuration config) {
         super(config, config.getString(LOGICAL_NAME));
 
-        String snapshotModeValue = config.getString(SNAPSHOT_MODE);
-        this.snapshotMode = SnapshotMode.parse(snapshotModeValue, SNAPSHOT_MODE.defaultValueAsString());
+        String snapshotModeValue = config.getString(MongoDbConnectorConfig.SNAPSHOT_MODE);
+        this.snapshotMode = SnapshotMode.parse(snapshotModeValue, MongoDbConnectorConfig.SNAPSHOT_MODE.defaultValueAsString());
     }
 
     protected static ConfigDef configDef() {
@@ -379,10 +379,11 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
      * Returns the number of documents to return per fetch by default. Default to {@code 0}, which indicates
      * that the server chooses an appropriate fetch size.
      *
+     * @param config configuration
      * @return the default fetch size
      */
     @Override
-    protected int defaultSnapshotFetchSize() {
+    protected int defaultSnapshotFetchSize(Configuration config) {
         return DEFAULT_SNAPSHOT_FETCH_SIZE;
     }
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -293,6 +293,14 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
                                                               + "'initial' (the default) to specify the connector should always perform an initial sync when required; "
                                                               + "'never' to specify the connector should never perform an initial sync ");
 
+    public static final Field DOCUMENTS_FETCH_SIZE = Field.create("documents.fetch.size")
+                                                            .withDisplayName("Cursor batch size")
+                                                            .withType(Type.INT)
+                                                            .withWidth(Width.MEDIUM)
+                                                            .withImportance(Importance.MEDIUM)
+                                                            .withDescription("The maximum number of documents that should be loaded into memory while performing a snapshot")
+                                                            .withDefault(0)
+                                                            .withValidation(Field::isPositiveInteger);
 
     protected static final Field TASK_ID = Field.create("mongodb.task.id")
                                                 .withDescription("Internal use only")
@@ -316,17 +324,20 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
                                                      DATABASE_BLACKLIST,
                                                      CommonConnectorConfig.TOMBSTONES_ON_DELETE,
                                                      CommonConnectorConfig.SNAPSHOT_DELAY_MS,
-                                                     SNAPSHOT_MODE);
+                                                     SNAPSHOT_MODE,
+                                                     DOCUMENTS_FETCH_SIZE);
 
     protected static Field.Set EXPOSED_FIELDS = ALL_FIELDS;
 
     private final SnapshotMode snapshotMode;
+    private final int documentsFetchSize;
 
     public MongoDbConnectorConfig(Configuration config) {
         super(config, config.getString(LOGICAL_NAME));
 
-        String snapshotModeValue = config.getString(MongoDbConnectorConfig.SNAPSHOT_MODE);
-        this.snapshotMode = SnapshotMode.parse(snapshotModeValue, MongoDbConnectorConfig.SNAPSHOT_MODE.defaultValueAsString());
+        String snapshotModeValue = config.getString(SNAPSHOT_MODE);
+        this.snapshotMode = SnapshotMode.parse(snapshotModeValue, SNAPSHOT_MODE.defaultValueAsString());
+        this.documentsFetchSize = config.getInteger(DOCUMENTS_FETCH_SIZE);
     }
 
     protected static ConfigDef configDef() {
@@ -337,7 +348,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
         Field.group(config, "Events", DATABASE_WHITELIST, DATABASE_BLACKLIST, COLLECTION_WHITELIST, COLLECTION_BLACKLIST, FIELD_BLACKLIST, FIELD_RENAMES, CommonConnectorConfig.TOMBSTONES_ON_DELETE);
         Field.group(config, "Connector", MAX_COPY_THREADS, CommonConnectorConfig.MAX_QUEUE_SIZE,
                 CommonConnectorConfig.MAX_BATCH_SIZE, CommonConnectorConfig.POLL_INTERVAL_MS,
-                CommonConnectorConfig.SNAPSHOT_DELAY_MS, SNAPSHOT_MODE);
+                CommonConnectorConfig.SNAPSHOT_DELAY_MS, SNAPSHOT_MODE, DOCUMENTS_FETCH_SIZE);
         return config;
     }
 
@@ -375,5 +386,15 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
 
     public SnapshotMode getSnapshotMode() {
         return snapshotMode;
+    }
+
+    /**
+     * Gets the number of documents to return per fetch. Default to {@code 0}, which indicates that the server chooses
+     * an appropriate fetch size.
+     *
+     * @return the fetch size
+     */
+    public int getDocumentsFetchSize() {
+        return documentsFetchSize;
     }
 }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
@@ -418,8 +418,8 @@ public class Replicator {
         MongoDatabase db = primary.getDatabase(collectionId.dbName());
         MongoCollection<Document> docCollection = db.getCollection(collectionId.name());
         long counter = 0;
-        int documentsFetchSize = context.getConnectorConfig().getDocumentsFetchSize();
-        try (MongoCursor<Document> cursor = docCollection.find().batchSize(documentsFetchSize).iterator()) {
+        int batchSize = context.getConnectorConfig().getSnapshotFetchSize();
+        try (MongoCursor<Document> cursor = docCollection.find().batchSize(batchSize).iterator()) {
             while (running.get() && cursor.hasNext()) {
                 Document doc = cursor.next();
                 logger.trace("Found existing doc in {}: {}", collectionId, doc);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
@@ -418,7 +418,8 @@ public class Replicator {
         MongoDatabase db = primary.getDatabase(collectionId.dbName());
         MongoCollection<Document> docCollection = db.getCollection(collectionId.name());
         long counter = 0;
-        try (MongoCursor<Document> cursor = docCollection.find().iterator()) {
+        int documentsFetchSize = context.getConnectorConfig().getDocumentsFetchSize();
+        try (MongoCursor<Document> cursor = docCollection.find().batchSize(documentsFetchSize).iterator()) {
             while (running.get() && cursor.hasNext()) {
                 Document doc = cursor.next();
                 logger.trace("Found existing doc in {}: {}", collectionId, doc);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -589,6 +589,12 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
         }
     }
 
+    /**
+     * {@link Integer#MIN_VALUE Minimum value} used for fetch size hint.
+     * See <a href="https://issues.jboss.org/browse/DBZ-94">DBZ-94</a> for details.
+     */
+    protected static final int DEFAULT_SNAPSHOT_FETCH_SIZE = Integer.MIN_VALUE;
+
     private static final String DATABASE_WHITELIST_NAME = "database.whitelist";
     private static final String DATABASE_BLACKLIST_NAME = "database.blacklist";
     private static final String TABLE_WHITELIST_NAME = "table.whitelist";
@@ -1195,6 +1201,11 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public SnapshotNewTables getSnapshotNewTables() {
         return snapshotNewTables;
+    }
+
+    @Override
+    protected int defaultSnapshotFetchSize() {
+        return DEFAULT_SNAPSHOT_FETCH_SIZE;
     }
 
     protected static ConfigDef configDef() {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -1134,6 +1134,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
                                                      EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE,
                                                      INCONSISTENT_SCHEMA_HANDLING_MODE,
                                                      CommonConnectorConfig.SNAPSHOT_DELAY_MS,
+                                                     CommonConnectorConfig.SNAPSHOT_FETCH_SIZE,
                                                      DDL_PARSER_MODE,
                                                      CommonConnectorConfig.TOMBSTONES_ON_DELETE, ENABLE_TIME_ADJUSTER);
 
@@ -1204,7 +1205,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
     }
 
     @Override
-    protected int defaultSnapshotFetchSize() {
+    protected int defaultSnapshotFetchSize(Configuration config) {
         return DEFAULT_SNAPSHOT_FETCH_SIZE;
     }
 
@@ -1225,7 +1226,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
         Field.group(config, "Connector", CONNECTION_TIMEOUT_MS, KEEP_ALIVE, KEEP_ALIVE_INTERVAL_MS, CommonConnectorConfig.MAX_QUEUE_SIZE,
                     CommonConnectorConfig.MAX_BATCH_SIZE, CommonConnectorConfig.POLL_INTERVAL_MS,
                     SNAPSHOT_MODE, SNAPSHOT_LOCKING_MODE, SNAPSHOT_NEW_TABLES, SNAPSHOT_MINIMAL_LOCKING, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE,
-                    BIGINT_UNSIGNED_HANDLING_MODE, SNAPSHOT_DELAY_MS, DDL_PARSER_MODE, ENABLE_TIME_ADJUSTER);
+                    BIGINT_UNSIGNED_HANDLING_MODE, SNAPSHOT_DELAY_MS, SNAPSHOT_FETCH_SIZE, DDL_PARSER_MODE, ENABLE_TIME_ADJUSTER);
         return config;
     }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -810,8 +810,9 @@ public class SnapshotReader extends AbstractReader {
      * @throws SQLException if there is a problem creating the statement
      */
     private Statement createStatementWithLargeResultSet(Connection connection) throws SQLException {
+        int fetchSize = context.getConnectorConfig().getSnapshotFetchSize();
         Statement stmt = connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
-        stmt.setFetchSize(Integer.MIN_VALUE);
+        stmt.setFetchSize(fetchSize);
         return stmt;
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -855,7 +855,6 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                                                      SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE, SCHEMA_REFRESH_MODE, CommonConnectorConfig.TOMBSTONES_ON_DELETE,
                                                      XMIN_FETCH_INTERVAL, SNAPSHOT_MODE_CLASS);
 
-    private final Configuration config;
     private final TemporalPrecisionMode temporalPrecisionMode;
     private final HStoreHandlingMode  hStoreHandlingMode;
     private final SnapshotMode snapshotMode;
@@ -870,7 +869,6 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                 null
         );
 
-        this.config = config;
         this.temporalPrecisionMode = TemporalPrecisionMode.parse(config.getString(TIME_PRECISION_MODE));
         String hstoreHandlingModeStr = config.getString(PostgresConnectorConfig.HSTORE_HANDLING_MODE);
         HStoreHandlingMode hStoreHandlingMode = HStoreHandlingMode.parse(hstoreHandlingModeStr);
@@ -890,35 +888,35 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     }
 
     protected String hostname() {
-        return config.getString(HOSTNAME);
+        return getConfig().getString(HOSTNAME);
     }
 
     protected int port() {
-        return config.getInteger(PORT);
+        return getConfig().getInteger(PORT);
     }
 
     protected String databaseName() {
-        return config.getString(DATABASE_NAME);
+        return getConfig().getString(DATABASE_NAME);
     }
 
     protected LogicalDecoder plugin() {
-        return LogicalDecoder.parse(config.getString(PLUGIN_NAME));
+        return LogicalDecoder.parse(getConfig().getString(PLUGIN_NAME));
     }
 
     protected String slotName() {
-        return config.getString(SLOT_NAME);
+        return getConfig().getString(SLOT_NAME);
     }
 
     protected boolean dropSlotOnStop() {
-        return config.getBoolean(DROP_SLOT_ON_STOP);
+        return getConfig().getBoolean(DROP_SLOT_ON_STOP);
     }
     
     protected String streamParams() {
-        return config.getString(STREAM_PARAMS);
+        return getConfig().getString(STREAM_PARAMS);
     }
 
     protected Integer statusUpdateIntervalMillis() {
-        return config.getInteger(STATUS_UPDATE_INTERVAL_MS, null);
+        return getConfig().getInteger(STATUS_UPDATE_INTERVAL_MS, null);
     }
 
     protected TemporalPrecisionMode temporalPrecisionMode() {
@@ -930,11 +928,11 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     }
 
     protected boolean includeUnknownDatatypes() {
-        return config.getBoolean(INCLUDE_UNKNOWN_DATATYPES);
+        return getConfig().getBoolean(INCLUDE_UNKNOWN_DATATYPES);
     }
 
     public Configuration jdbcConfig() {
-        return config.subset(DATABASE_CONFIG_PREFIX, true);
+        return getConfig().subset(DATABASE_CONFIG_PREFIX, true);
     }
 
     protected TopicSelectionStrategy topicSelectionStrategy() {
@@ -945,47 +943,47 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     }
 
     protected Map<String, ConfigValue> validate() {
-        return config.validate(ALL_FIELDS);
+        return getConfig().validate(ALL_FIELDS);
     }
 
     protected String schemaBlacklist() {
-        return config.getString(SCHEMA_BLACKLIST);
+        return getConfig().getString(SCHEMA_BLACKLIST);
     }
 
     protected String schemaWhitelist() {
-        return config.getString(SCHEMA_WHITELIST);
+        return getConfig().getString(SCHEMA_WHITELIST);
     }
 
     protected String tableBlacklist() {
-        return config.getString(TABLE_BLACKLIST);
+        return getConfig().getString(TABLE_BLACKLIST);
     }
 
     protected String tableWhitelist() {
-        return config.getString(TABLE_WHITELIST);
+        return getConfig().getString(TABLE_WHITELIST);
     }
 
     protected String columnBlacklist() {
-        return config.getString(COLUMN_BLACKLIST);
+        return getConfig().getString(COLUMN_BLACKLIST);
     }
 
     protected long snapshotLockTimeoutMillis() {
-        return config.getLong(PostgresConnectorConfig.SNAPSHOT_LOCK_TIMEOUT_MS);
+        return getConfig().getLong(PostgresConnectorConfig.SNAPSHOT_LOCK_TIMEOUT_MS);
     }
 
     protected Snapshotter getSnapshotter() {
-        return this.snapshotMode.getSnapshotter(config);
+        return this.snapshotMode.getSnapshotter(getConfig());
     }
 
     public String snapshotSelectOverrides() {
-        return config.getString(PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE);
+        return getConfig().getString(PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE);
     }
 
     public String snapshotSelectOverrideForTable(String table) {
-        return config.getString(PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + "." + table);
+        return getConfig().getString(PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + "." + table);
     }
 
     @Override
-    protected int defaultSnapshotFetchSize() {
+    protected int defaultSnapshotFetchSize(Configuration config) {
         // we use getString() method because it supports null as the return value
         String rowsFetchSize = config.getString(ROWS_FETCH_SIZE);
         if (rowsFetchSize != null) {
@@ -1004,7 +1002,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     }
 
     protected Duration xminFetchInterval() {
-        return Duration.ofMillis(config.getLong(PostgresConnectorConfig.XMIN_FETCH_INTERVAL));
+        return Duration.ofMillis(getConfig().getLong(PostgresConnectorConfig.XMIN_FETCH_INTERVAL));
     }
 
     protected static ConfigDef configDef() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -479,8 +479,8 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     }
 
     protected static final String DATABASE_CONFIG_PREFIX = "database.";
-    protected static final int DEFAULT_PORT = 5432;
-    protected static final int DEFAULT_ROWS_FETCH_SIZE = 10240;
+    protected static final int DEFAULT_PORT = 5_432;
+    protected static final int DEFAULT_SNAPSHOT_FETCH_SIZE = 10_240;
     protected static final long DEFAULT_SNAPSHOT_LOCK_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(10);
 
     private static final String TABLE_WHITELIST_NAME = "table.whitelist";
@@ -589,13 +589,16 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                                                       + "'table' (the default) each DB table will have a separate Kafka topic; "
                                                       + "'schema' there will be one Kafka topic per DB schema; events from multiple topics belonging to the same schema will be placed on the same topic");
 
+    /**
+     * @deprecated use {@link CommonConnectorConfig#SNAPSHOT_FETCH_SIZE} instead of
+     */
+    @Deprecated
     public static final Field ROWS_FETCH_SIZE = Field.create("rows.fetch.size")
                                                      .withDisplayName("Result set fetch size")
                                                      .withType(Type.INT)
                                                      .withWidth(Width.MEDIUM)
                                                      .withImportance(Importance.MEDIUM)
                                                      .withDescription("The maximum number of DB rows that should be loaded into memory while performing a snapshot")
-                                                     .withDefault(DEFAULT_ROWS_FETCH_SIZE)
                                                      .withValidation(Field::isPositiveLong);
 
     public static final Field SSL_MODE = Field.create(DATABASE_CONFIG_PREFIX + "sslmode")
@@ -837,7 +840,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                                                      DATABASE_NAME, USER, PASSWORD, HOSTNAME, PORT, ON_CONNECT_STATEMENTS, SERVER_NAME,
                                                      TOPIC_SELECTION_STRATEGY, CommonConnectorConfig.MAX_BATCH_SIZE,
                                                      CommonConnectorConfig.MAX_QUEUE_SIZE, CommonConnectorConfig.POLL_INTERVAL_MS,
-                                                     CommonConnectorConfig.SNAPSHOT_DELAY_MS,
+                                                     CommonConnectorConfig.SNAPSHOT_DELAY_MS, CommonConnectorConfig.SNAPSHOT_FETCH_SIZE,
                                                      Heartbeat.HEARTBEAT_INTERVAL,
                                                      Heartbeat.HEARTBEAT_TOPICS_PREFIX,
                                                      SCHEMA_WHITELIST,
@@ -962,8 +965,9 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         return config.getString(COLUMN_BLACKLIST);
     }
 
-    protected int rowsFetchSize() {
-        return config.getInteger(ROWS_FETCH_SIZE);
+    public int getSnapshotFetchSize() {
+        Integer fetchSize = config.getInteger(ROWS_FETCH_SIZE);
+        return (fetchSize == null) ? getSnapshotFetchSize(DEFAULT_SNAPSHOT_FETCH_SIZE) : fetchSize;
     }
 
     protected long snapshotLockTimeoutMillis() {
@@ -1000,7 +1004,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                     CommonConnectorConfig.TOMBSTONES_ON_DELETE, Heartbeat.HEARTBEAT_INTERVAL,
                     Heartbeat.HEARTBEAT_TOPICS_PREFIX);
         Field.group(config, "Connector", TOPIC_SELECTION_STRATEGY, CommonConnectorConfig.POLL_INTERVAL_MS, CommonConnectorConfig.MAX_BATCH_SIZE, CommonConnectorConfig.MAX_QUEUE_SIZE,
-                    CommonConnectorConfig.SNAPSHOT_DELAY_MS,
+                    CommonConnectorConfig.SNAPSHOT_DELAY_MS, CommonConnectorConfig.SNAPSHOT_FETCH_SIZE,
                     SNAPSHOT_MODE, SNAPSHOT_LOCK_TIMEOUT_MS, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE, HSTORE_HANDLING_MODE, SCHEMA_REFRESH_MODE, ROWS_FETCH_SIZE);
 
         return config;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -36,7 +36,8 @@ import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The configuration properties for the {@link PostgresConnector}
@@ -477,6 +478,8 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             return null;
         }
     }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresConnectorConfig.class);
 
     protected static final String DATABASE_CONFIG_PREFIX = "database.";
     protected static final int DEFAULT_PORT = 5_432;
@@ -965,11 +968,6 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         return config.getString(COLUMN_BLACKLIST);
     }
 
-    public int getSnapshotFetchSize() {
-        Integer fetchSize = config.getInteger(ROWS_FETCH_SIZE);
-        return (fetchSize == null) ? getSnapshotFetchSize(DEFAULT_SNAPSHOT_FETCH_SIZE) : fetchSize;
-    }
-
     protected long snapshotLockTimeoutMillis() {
         return config.getLong(PostgresConnectorConfig.SNAPSHOT_LOCK_TIMEOUT_MS);
     }
@@ -984,6 +982,21 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public String snapshotSelectOverrideForTable(String table) {
         return config.getString(PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + "." + table);
+    }
+
+    @Override
+    protected int defaultSnapshotFetchSize() {
+        // we use getString() method because it supports null as the return value
+        String rowsFetchSize = config.getString(ROWS_FETCH_SIZE);
+        if (rowsFetchSize != null) {
+            LOGGER.warn("Property '{}' will be removed in next releases, use property '{}' instead of",
+                ROWS_FETCH_SIZE.name(), SNAPSHOT_FETCH_SIZE.name());
+            try {
+                return Integer.valueOf(rowsFetchSize);
+            }
+            catch (NumberFormatException e) {}
+        }
+        return DEFAULT_SNAPSHOT_FETCH_SIZE;
     }
 
     protected boolean skipRefreshSchemaOnMissingToastableData() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -10,34 +10,33 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import io.debezium.config.CommonConnectorConfig;
-import io.debezium.config.Configuration;
-import io.debezium.config.EnumeratedValue;
-import io.debezium.config.Field;
-
-import io.debezium.connector.postgresql.snapshot.AlwaysSnapshotter;
-import io.debezium.connector.postgresql.snapshot.InitialOnlySnapshotter;
-import io.debezium.connector.postgresql.snapshot.InitialSnapshotter;
-import io.debezium.connector.postgresql.snapshot.NeverSnapshotter;
-import io.debezium.connector.postgresql.spi.Snapshotter;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.ConfigValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.config.EnumeratedValue;
+import io.debezium.config.Field;
 import io.debezium.connector.postgresql.connection.MessageDecoder;
 import io.debezium.connector.postgresql.connection.ReplicationConnection;
 import io.debezium.connector.postgresql.connection.pgproto.PgProtoMessageDecoder;
 import io.debezium.connector.postgresql.connection.wal2json.NonStreamingWal2JsonMessageDecoder;
 import io.debezium.connector.postgresql.connection.wal2json.StreamingWal2JsonMessageDecoder;
+import io.debezium.connector.postgresql.snapshot.AlwaysSnapshotter;
+import io.debezium.connector.postgresql.snapshot.InitialOnlySnapshotter;
+import io.debezium.connector.postgresql.snapshot.InitialSnapshotter;
+import io.debezium.connector.postgresql.snapshot.NeverSnapshotter;
+import io.debezium.connector.postgresql.spi.Snapshotter;
 import io.debezium.heartbeat.Heartbeat;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The configuration properties for the {@link PostgresConnector}
@@ -910,7 +909,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     protected boolean dropSlotOnStop() {
         return getConfig().getBoolean(DROP_SLOT_ON_STOP);
     }
-    
+
     protected String streamParams() {
         return getConfig().getString(STREAM_PARAMS);
     }
@@ -982,6 +981,11 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         return getConfig().getString(PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + "." + table);
     }
 
+    /**
+     * DBZ-1234 Obsolete once rows.fetch.size option has been removed;
+     * value can be passed to super constructor instead
+     */
+    @Deprecated
     @Override
     protected int defaultSnapshotFetchSize(Configuration config) {
         // we use getString() method because it supports null as the return value

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsSnapshotProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsSnapshotProducer.java
@@ -46,7 +46,6 @@ import io.debezium.util.Metronome;
 import io.debezium.util.Strings;
 import io.debezium.util.Threads;
 
-
 /**
  * Producer of {@link org.apache.kafka.connect.source.SourceRecord source records} from a database snapshot. Once completed,
  * this producer can optionally continue streaming records, using another {@link RecordsStreamProducer} instance.
@@ -318,9 +317,9 @@ public class RecordsSnapshotProducer extends RecordsProducer {
     }
 
     private Statement readTableStatement(Connection conn) throws SQLException {
-        int rowsFetchSize = taskContext.config().rowsFetchSize();
+        int fetchSize = taskContext.config().getSnapshotFetchSize();
         Statement statement = conn.createStatement(); // the default cursor is FORWARD_ONLY
-        statement.setFetchSize(rowsFetchSize);
+        statement.setFetchSize(fetchSize);
         return statement;
     }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -136,7 +136,8 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         validateField(validatedConfig, PostgresConnectorConfig.TOPIC_SELECTION_STRATEGY, PostgresConnectorConfig.TopicSelectionStrategy.TOPIC_PER_TABLE);
         validateField(validatedConfig, PostgresConnectorConfig.MAX_QUEUE_SIZE, PostgresConnectorConfig.DEFAULT_MAX_QUEUE_SIZE);
         validateField(validatedConfig, PostgresConnectorConfig.MAX_BATCH_SIZE, PostgresConnectorConfig.DEFAULT_MAX_BATCH_SIZE);
-        validateField(validatedConfig, PostgresConnectorConfig.ROWS_FETCH_SIZE, PostgresConnectorConfig.DEFAULT_ROWS_FETCH_SIZE);
+        validateField(validatedConfig, PostgresConnectorConfig.ROWS_FETCH_SIZE, null);
+        validateField(validatedConfig, PostgresConnectorConfig.SNAPSHOT_FETCH_SIZE, null);
         validateField(validatedConfig, PostgresConnectorConfig.POLL_INTERVAL_MS, PostgresConnectorConfig.DEFAULT_POLL_INTERVAL_MILLIS);
         validateField(validatedConfig, PostgresConnectorConfig.SSL_MODE, PostgresConnectorConfig.SecureConnectionMode.DISABLED);
         validateField(validatedConfig, PostgresConnectorConfig.SSL_CLIENT_CERT, null);

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -247,6 +247,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
             CommonConnectorConfig.MAX_BATCH_SIZE,
             CommonConnectorConfig.MAX_QUEUE_SIZE,
             CommonConnectorConfig.SNAPSHOT_DELAY_MS,
+            CommonConnectorConfig.SNAPSHOT_FETCH_SIZE,
             Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX
     );
 
@@ -264,7 +265,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
                 Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX
         );
         Field.group(config, "Connector", CommonConnectorConfig.POLL_INTERVAL_MS, CommonConnectorConfig.MAX_BATCH_SIZE,
-                CommonConnectorConfig.MAX_QUEUE_SIZE, CommonConnectorConfig.SNAPSHOT_DELAY_MS);
+                CommonConnectorConfig.MAX_QUEUE_SIZE, CommonConnectorConfig.SNAPSHOT_DELAY_MS, CommonConnectorConfig.SNAPSHOT_FETCH_SIZE);
 
         return config;
     }

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -69,22 +69,21 @@ public class CommonConnectorConfig {
             .withValidation(Field::isPositiveInteger);
 
     public static final Field SNAPSHOT_DELAY_MS = Field.create("snapshot.delay.ms")
-        .withDisplayName("Snapshot Delay (milliseconds)")
-        .withType(Type.LONG)
-        .withWidth(Width.MEDIUM)
-        .withImportance(Importance.LOW)
-        .withDescription("The number of milliseconds to delay before a snapshot will begin.")
-        .withDefault(0L)
-        .withValidation(Field::isNonNegativeLong);
+            .withDisplayName("Snapshot Delay (milliseconds)")
+            .withType(Type.LONG)
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.LOW)
+            .withDescription("The number of milliseconds to delay before a snapshot will begin.")
+            .withDefault(0L)
+            .withValidation(Field::isNonNegativeLong);
 
     public static final Field SNAPSHOT_FETCH_SIZE = Field.create("snapshot.fetch.size")
-        .withDisplayName("Snapshot fetch size")
-        .withType(Type.INT)
-        .withWidth(Width.MEDIUM)
-        .withImportance(Importance.MEDIUM)
-        .withDescription("The maximum number of records that should be loaded into memory while performing a snapshot")
-        .withValidation(Field::isNonNegativeInteger);
-
+            .withDisplayName("Snapshot fetch size")
+            .withType(Type.INT)
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.MEDIUM)
+            .withDescription("The maximum number of records that should be loaded into memory while performing a snapshot")
+            .withValidation(Field::isNonNegativeInteger);
 
     private final Configuration config;
     private final boolean emitTombstoneOnDelete;
@@ -105,16 +104,17 @@ public class CommonConnectorConfig {
         this.logicalName = logicalName;
         this.heartbeatTopicsPrefix = config.getString(Heartbeat.HEARTBEAT_TOPICS_PREFIX);
         this.snapshotDelayMs = Duration.ofMillis(config.getLong(SNAPSHOT_DELAY_MS));
-        this.snapshotFetchSize = config.getInteger(SNAPSHOT_FETCH_SIZE, this::defaultSnapshotFetchSize);
+        this.snapshotFetchSize = config.getInteger(SNAPSHOT_FETCH_SIZE, () -> defaultSnapshotFetchSize(config));
     }
 
     /**
      * Returns the number of records to return per fetch by default.
      * <p><b>Important:</b> Each connector config must override this method to specify its default value.</p>
      *
+     * @param config configuration
      * @return the default fetch size
      */
-    protected int defaultSnapshotFetchSize() {
+    protected int defaultSnapshotFetchSize(Configuration config) {
         throw new UnsupportedOperationException("not implemented");
     }
 

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -77,6 +77,15 @@ public class CommonConnectorConfig {
         .withDefault(0L)
         .withValidation(Field::isNonNegativeLong);
 
+    public static final Field SNAPSHOT_FETCH_SIZE = Field.create("snapshot.fetch.size")
+        .withDisplayName("Snapshot fetch size")
+        .withType(Type.INT)
+        .withWidth(Width.MEDIUM)
+        .withImportance(Importance.MEDIUM)
+        .withDescription("The maximum number of records that should be loaded into memory while performing a snapshot")
+        .withValidation(Field::isNonNegativeInteger);
+
+
     private final Configuration config;
     private final boolean emitTombstoneOnDelete;
     private final int maxQueueSize;
@@ -85,6 +94,7 @@ public class CommonConnectorConfig {
     private final String logicalName;
     private final String heartbeatTopicsPrefix;
     private final Duration snapshotDelayMs;
+    private final Integer snapshotFetchSize;
 
     protected CommonConnectorConfig(Configuration config, String logicalName) {
         this.config = config;
@@ -95,6 +105,7 @@ public class CommonConnectorConfig {
         this.logicalName = logicalName;
         this.heartbeatTopicsPrefix = config.getString(Heartbeat.HEARTBEAT_TOPICS_PREFIX);
         this.snapshotDelayMs = Duration.ofMillis(config.getLong(SNAPSHOT_DELAY_MS));
+        this.snapshotFetchSize = config.getInteger(SNAPSHOT_FETCH_SIZE);
     }
 
     /**
@@ -131,6 +142,10 @@ public class CommonConnectorConfig {
 
     public Duration getSnapshotDelay() {
         return snapshotDelayMs;
+    }
+
+    public int getSnapshotFetchSize(int defaultFetchSize) {
+        return (snapshotFetchSize == null) ? defaultFetchSize : snapshotFetchSize;
     }
 
     private static int validateMaxQueueSize(Configuration config, Field field, Field.ValidationOutput problems) {

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -94,7 +94,7 @@ public class CommonConnectorConfig {
     private final String logicalName;
     private final String heartbeatTopicsPrefix;
     private final Duration snapshotDelayMs;
-    private final Integer snapshotFetchSize;
+    private final int snapshotFetchSize;
 
     protected CommonConnectorConfig(Configuration config, String logicalName) {
         this.config = config;
@@ -105,7 +105,17 @@ public class CommonConnectorConfig {
         this.logicalName = logicalName;
         this.heartbeatTopicsPrefix = config.getString(Heartbeat.HEARTBEAT_TOPICS_PREFIX);
         this.snapshotDelayMs = Duration.ofMillis(config.getLong(SNAPSHOT_DELAY_MS));
-        this.snapshotFetchSize = config.getInteger(SNAPSHOT_FETCH_SIZE);
+        this.snapshotFetchSize = config.getInteger(SNAPSHOT_FETCH_SIZE, this::defaultSnapshotFetchSize);
+    }
+
+    /**
+     * Returns the number of records to return per fetch by default.
+     * <p><b>Important:</b> Each connector config must override this method to specify its default value.</p>
+     *
+     * @return the default fetch size
+     */
+    protected int defaultSnapshotFetchSize() {
+        throw new UnsupportedOperationException("not implemented");
     }
 
     /**
@@ -144,8 +154,8 @@ public class CommonConnectorConfig {
         return snapshotDelayMs;
     }
 
-    public int getSnapshotFetchSize(int defaultFetchSize) {
-        return (snapshotFetchSize == null) ? defaultFetchSize : snapshotFetchSize;
+    public int getSnapshotFetchSize() {
+        return snapshotFetchSize;
     }
 
     private static int validateMaxQueueSize(Configuration config, Field field, Field.ValidationOutput problems) {

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -13,8 +13,8 @@ import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 
-import io.debezium.heartbeat.Heartbeat;
 import io.debezium.config.Field.ValidationOutput;
+import io.debezium.heartbeat.Heartbeat;
 import io.debezium.relational.history.KafkaDatabaseHistory;
 
 /**
@@ -22,7 +22,7 @@ import io.debezium.relational.history.KafkaDatabaseHistory;
  *
  * @author Gunnar Morling
  */
-public class CommonConnectorConfig {
+public abstract class CommonConnectorConfig {
 
     public static final int DEFAULT_MAX_QUEUE_SIZE = 8192;
     public static final int DEFAULT_MAX_BATCH_SIZE = 2048;
@@ -114,9 +114,7 @@ public class CommonConnectorConfig {
      * @param config configuration
      * @return the default fetch size
      */
-    protected int defaultSnapshotFetchSize(Configuration config) {
-        throw new UnsupportedOperationException("not implemented");
-    }
+    protected abstract int defaultSnapshotFetchSize(Configuration config);
 
     /**
      * Provides access to the "raw" config instance. In most cases, access via typed getters for individual properties

--- a/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
@@ -82,7 +82,7 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
     protected abstract HistoryRecordComparator getHistoryRecordComparator();
 
     @Override
-    protected int defaultSnapshotFetchSize() {
+    protected int defaultSnapshotFetchSize(Configuration config) {
         return DEFAULT_SNAPSHOT_FETCH_SIZE;
     }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
@@ -25,6 +25,8 @@ import io.debezium.relational.history.KafkaDatabaseHistory;
  */
 public abstract class HistorizedRelationalDatabaseConnectorConfig extends RelationalDatabaseConnectorConfig {
 
+    protected static final int DEFAULT_SNAPSHOT_FETCH_SIZE = 2_000;
+
     /**
      * The database history class is hidden in the {@link #configDef()} since that is designed to work with a user interface,
      * and in these situations using Kafka is the only way to go.
@@ -78,4 +80,9 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
      * records have been persisted but no new offset has been committed yet).
      */
     protected abstract HistoryRecordComparator getHistoryRecordComparator();
+
+    @Override
+    protected int defaultSnapshotFetchSize() {
+        return DEFAULT_SNAPSHOT_FETCH_SIZE;
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalSnapshotChangeEventSource.java
@@ -386,10 +386,9 @@ public abstract class HistorizedRelationalSnapshotChangeEventSource implements S
     }
 
     private Statement readTableStatement() throws SQLException {
-        // TODO read option
-        int rowsFetchSize = 2000;
+        int fetchSize = connectorConfig.getSnapshotFetchSize(2_000);
         Statement statement = jdbcConnection.connection().createStatement(); // the default cursor is FORWARD_ONLY
-        statement.setFetchSize(rowsFetchSize);
+        statement.setFetchSize(fetchSize);
         return statement;
     }
 

--- a/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalSnapshotChangeEventSource.java
@@ -386,7 +386,7 @@ public abstract class HistorizedRelationalSnapshotChangeEventSource implements S
     }
 
     private Statement readTableStatement() throws SQLException {
-        int fetchSize = connectorConfig.getSnapshotFetchSize(2_000);
+        int fetchSize = connectorConfig.getSnapshotFetchSize();
         Statement statement = jdbcConnection.connection().createStatement(); // the default cursor is FORWARD_ONLY
         statement.setFetchSize(fetchSize);
         return statement;


### PR DESCRIPTION
The `documents.fetch.size` configuration property is an positive integer value that specifies the maximum number of documents that should be read in one go from each collection while taking a snapshot. The connector will read the collection contents in multiple batches of this size. Default to `0`, which indicates that the server chooses an appropriate fetch size.

https://issues.jboss.org/browse/DBZ-1247