### PR TITLE
DBZ-1241 - allow null values again for commitTime

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/SourceInfo.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/SourceInfo.java
@@ -196,7 +196,9 @@ public final class SourceInfo extends AbstractSourceInfo {
      */
     protected SourceInfo update(Long lsn, Instant commitTime, Long txId, TableId tableId, Long xmin) {
         this.lsn = lsn;
-        this.useconds = Conversions.toEpochMicros(commitTime);
+        if (commitTime != null) {
+            this.useconds = Conversions.toEpochMicros(commitTime);
+        }
         this.txId = txId;
         this.xmin = xmin;
         if (tableId != null && tableId.schema() != null) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SourceInfoTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SourceInfoTest.java
@@ -7,6 +7,7 @@ package io.debezium.connector.postgresql;
 
 import static org.fest.assertions.Assertions.assertThat;
 
+import io.debezium.doc.FixFor;
 import io.debezium.relational.TableId;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,5 +34,11 @@ public class SourceInfoTest {
     @Test
     public void connectorIsPresent() {
         assertThat(source.source().getString(SourceInfo.DEBEZIUM_CONNECTOR_KEY)).isEqualTo(Module.name());
+    }
+
+    @Test
+    @FixFor("DBZ-934")
+    public void canHandleNullValues() {
+        source.update(null, null, null, null, null);
     }
 }


### PR DESCRIPTION
@gunnarmorling Could you verify if this change doesn't break the [DBZ-1082](https://github.com/debezium/debezium/commit/8e21139ca3ee140a07b99cbfb87b6a92b1253308#diff-f28bb7eecf710b4c4de5235a03902776R181)?
