### PR TITLE
 DBZ-1228: MySQL connection with client authentication does not work

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -283,6 +283,7 @@ public class MySqlJdbcContext implements AutoCloseable {
     private Map<String, String> querySystemVariables(String statement) {
         Map<String, String> variables = new HashMap<>();
         try {
+            start();
             jdbc.connect().query(statement, rs -> {
                 while (rs.next()) {
                     String varName = rs.getString(1);


### PR DESCRIPTION
# Summary
A connection to SQL server with client-side SSL authentication (like Google Cloud SQL) cannot be established.

## Issue analysis
The issue is caused because of the [shutdown method](https://github.com/debezium/debezium/blob/7748be6056bb84edf77f63ad979e0bd61917f7d0/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnector.java#L107) being called here. This is why the connection test succeeds, but fails later. The next time when debezium attempts to connect to the database [here](https://github.com/debezium/debezium/blob/7748be6056bb84edf77f63ad979e0bd61917f7d0/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java#L286), these variables are not set and the connection fails.


## Solution
We can set the system variables before the call is made. Since the [start method](https://github.com/debezium/debezium/blob/7748be6056bb84edf77f63ad979e0bd61917f7d0/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java#L128) is coded in a way that it sets the values only if the configuration values are provided, we can simply reuse this. This solves the current issue but introduces another one.

On forcing debezium to have the system variables, we get an authentication error. In order to fix this, we need to create and pass a socket factory that provides the keystore config. The changes are made in a way such that any non-SSL connections are allowed when the required configurations are not provided, and the required values are only set if the keystore password is provided.