### PR TITLE
Allow the entire range of Postgresql timestamp without time zone values

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/DateParser.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/DateParser.java
@@ -1,0 +1,72 @@
+package io.debezium.connector.postgresql.connection.wal2json;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.format.TextStyle;
+import java.time.temporal.ChronoField;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DateParser {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DateParser.class);
+
+    private static final List<DateTimeFormatter> dateTimeFormatters = initializeDateTimeFormatters();
+
+    private static List<DateTimeFormatter> initializeDateTimeFormatters() {
+        // Postgresql years can be as large as 6 digits. See https://www.postgresql.org/docs/9.6/datatype-datetime.html
+        // Try parsing it with 4 digits first since that will be the common case. Then try up to 6 digits.
+        List<Integer> yearDigitsOrder = Arrays.asList(4, 1, 2, 3, 5, 6);
+
+        return yearDigitsOrder
+                .stream()
+                .map(DateParser::createDateTimeFormatter)
+                .collect(Collectors.toList());
+    }
+
+    private static DateTimeFormatter createDateTimeFormatter(int yearDigits) {
+        StringBuilder pattern = new StringBuilder();
+        for (int i = 0; i < yearDigits; i++) {
+            pattern.append("y");
+        }
+
+        pattern.append("-MM-dd HH:mm:ss");
+
+        return new DateTimeFormatterBuilder()
+                .appendPattern(pattern.toString())
+                .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 6, true)
+                .optionalStart()
+                .appendLiteral(" ")
+                .appendText(ChronoField.ERA, TextStyle.SHORT)
+                .optionalEnd()
+                .toFormatter();
+    }
+
+    private static LocalDateTime tryParseLocalDateTime(String text, DateTimeFormatter dateTimeFormatter) {
+        try {
+            return LocalDateTime.parse(text, dateTimeFormatter);
+        } catch (DateTimeParseException e) {
+            LOGGER.warn("Could not parse {} with {}", text, dateTimeFormatter);
+            return null;
+        }
+    }
+
+    public static LocalDateTime parsePostgresTimestampWithoutTimeZone(String text) {
+        LocalDateTime localDateTime;
+
+        for (DateTimeFormatter dateTimeFormatter : dateTimeFormatters) {
+            localDateTime = tryParseLocalDateTime(text, dateTimeFormatter);
+
+            if (localDateTime != null) {
+                return localDateTime;
+            }
+        }
+
+        throw new RuntimeException("Could not successfully parse: " + text);
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
@@ -6,31 +6,6 @@
 
 package io.debezium.connector.postgresql.connection.wal2json;
 
-import java.math.BigDecimal;
-import java.sql.SQLException;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.regex.Matcher;
-
-import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.errors.ConnectException;
-import org.postgresql.geometric.PGbox;
-import org.postgresql.geometric.PGcircle;
-import org.postgresql.geometric.PGline;
-import org.postgresql.geometric.PGlseg;
-import org.postgresql.geometric.PGpath;
-import org.postgresql.geometric.PGpoint;
-import org.postgresql.geometric.PGpolygon;
-import org.postgresql.jdbc.PgArray;
-import org.postgresql.util.PGInterval;
-import org.postgresql.util.PGmoney;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.debezium.connector.postgresql.PostgresType;
 import io.debezium.connector.postgresql.PostgresValueConverter;
 import io.debezium.connector.postgresql.RecordsStreamProducer.PgConnectionSupplier;
@@ -41,8 +16,25 @@ import io.debezium.data.SpecialValueDecimal;
 import io.debezium.document.Array;
 import io.debezium.document.Document;
 import io.debezium.document.Value;
-import io.debezium.time.Conversions;
 import io.debezium.util.Strings;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.postgresql.geometric.*;
+import org.postgresql.jdbc.PgArray;
+import org.postgresql.util.PGInterval;
+import org.postgresql.util.PGmoney;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
 
 /**
  * Replication message representing message sent by the wal2json logical decoding plug-in.
@@ -265,8 +257,8 @@ class Wal2JsonReplicationMessage implements ReplicationMessage {
 
             case "timestamp":
             case "timestamp without time zone":
-                final LocalDateTime serverLocal = Conversions.fromNanosToLocalDateTimeUTC(DateTimeFormat.get().timestamp(rawValue.asString()));
-                return Conversions.toEpochNanos(serverLocal.toInstant(ZoneOffset.UTC));
+                final LocalDateTime serverLocal = DateParser.parsePostgresTimestampWithoutTimeZone(rawValue.asString());
+                return serverLocal.atZone(ZoneOffset.UTC).toInstant();
 
             case "time":
             case "time without time zone":

--- a/debezium-core/src/main/java/io/debezium/time/Timestamp.java
+++ b/debezium-core/src/main/java/io/debezium/time/Timestamp.java
@@ -5,11 +5,14 @@
  */
 package io.debezium.time;
 
-import java.time.LocalDateTime;
-import java.time.temporal.TemporalAdjuster;
-
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjuster;
 
 /**
  * A utility for converting various Java time representations into the signed {@link SchemaBuilder#int64() INT64} number of
@@ -68,6 +71,11 @@ public class Timestamp {
         if (value instanceof Long) {
             return (Long) value;
         }
+
+        if (value instanceof Instant) {
+            return ((Instant) value).toEpochMilli();
+        }
+
         LocalDateTime dateTime = Conversions.toLocalDateTime(value);
         if (adjuster != null) {
             dateTime = dateTime.with(adjuster);


### PR DESCRIPTION
The Debezium Postgres Connector does not handle Postgres timestamps that have more than 4 digits. This is a problem because Postgres allows a wide range of timestamp values (4713 BC to 294276 AD). See https://www.postgresql.org/docs/9.6/datatype-datetime.html.

Our database has these values in it and when the connector comes across them, it does not know how to parse them and dies.

In addition to being able to parse these values, it's important that we set Kafka Connect property, `time.precision.mode=connect` which is not the default.

This will tell Kafka Connect to always use milliseconds since epoch and not microseconds. The reason this is important is that with microseconds, we cannot properly represent large years such as 294276 and the long will wrap.