### PR TITLE
[DBZ-1273] Bumping JDBC and Mongo driver versions

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MetadataIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MetadataIT.java
@@ -131,7 +131,7 @@ public class MetadataIT implements Testing {
             assertThat(product.columnWithName("createdByDate").name()).isEqualTo("createdByDate");
             assertThat(product.columnWithName("createdByDate").typeName()).isEqualTo("DATETIME");
             assertThat(product.columnWithName("createdByDate").jdbcType()).isEqualTo(Types.TIMESTAMP);
-            assertThat(product.columnWithName("createdByDate").length()).isEqualTo(26);
+            assertThat(product.columnWithName("createdByDate").length()).isEqualTo(19);
             assertFalse(product.columnWithName("createdByDate").scale().isPresent());
             assertThat(product.columnWithName("createdByDate").position()).isEqualTo(2);
             assertThat(product.columnWithName("createdByDate").isAutoIncremented()).isFalse();
@@ -140,7 +140,7 @@ public class MetadataIT implements Testing {
             assertThat(product.columnWithName("modifiedDate").name()).isEqualTo("modifiedDate");
             assertThat(product.columnWithName("modifiedDate").typeName()).isEqualTo("DATETIME");
             assertThat(product.columnWithName("modifiedDate").jdbcType()).isEqualTo(Types.TIMESTAMP);
-            assertThat(product.columnWithName("modifiedDate").length()).isEqualTo(26);
+            assertThat(product.columnWithName("modifiedDate").length()).isEqualTo(19);
             assertFalse(product.columnWithName("modifiedDate").scale().isPresent());
             assertThat(product.columnWithName("modifiedDate").position()).isEqualTo(3);
             assertThat(product.columnWithName("modifiedDate").isAutoIncremented()).isFalse();
@@ -186,7 +186,7 @@ public class MetadataIT implements Testing {
             assertThat(purchased.columnWithName("purchaseDate").name()).isEqualTo("purchaseDate");
             assertThat(purchased.columnWithName("purchaseDate").typeName()).isEqualTo("DATETIME");
             assertThat(purchased.columnWithName("purchaseDate").jdbcType()).isEqualTo(Types.TIMESTAMP);
-            assertThat(purchased.columnWithName("purchaseDate").length()).isEqualTo(26);
+            assertThat(purchased.columnWithName("purchaseDate").length()).isEqualTo(19);
             assertFalse(purchased.columnWithName("purchaseDate").scale().isPresent());
             assertThat(purchased.columnWithName("purchaseDate").position()).isEqualTo(3);
             assertThat(purchased.columnWithName("purchaseDate").isAutoIncremented()).isFalse();

--- a/pom.xml
+++ b/pom.xml
@@ -68,11 +68,11 @@
         <!-- Databases -->
         <version.postgresql.driver>42.2.5</version.postgresql.driver>
         <version.mysql.server>5.7</version.mysql.server>
-        <version.mysql.driver>8.0.13</version.mysql.driver>
+        <version.mysql.driver>8.0.16</version.mysql.driver>
         <version.mysql.binlog>0.19.1</version.mysql.binlog>
         <version.mongo.server>3.6</version.mongo.server>
-        <version.mongo.driver>3.9.0</version.mongo.driver>
-        <version.sqlserver.driver>6.4.0.jre8</version.sqlserver.driver>
+        <version.mongo.driver>3.9.1</version.mongo.driver>
+        <version.sqlserver.driver>7.2.2.jre8</version.sqlserver.driver>
 
         <!-- Connectors -->
         <version.com.google.protobuf>2.6.1</version.com.google.protobuf>


### PR DESCRIPTION

From https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-16.html
> In the DatabaseMetaDataUsingInfoSchema interface, the getProcedureColumns() and getFunctionColumns() methods returned wrong results for the PRECISION column, and the getColumns() and getVersionColumns() methods returned wrong results for the COLUMN_SIZE column. The errors were due to the wrong handling of the temporal type precision by Connector/J, which has now been fixed. (Bug #29186870)

Mongo was bumped only to latest 3.9 release due to things breaking with 3.10.x -- since we are currently using a deprecated release distribution I will create Jira to upgrade to the latest driver (reactive might provide better performance, sync one  will have easier migration)