### PR TITLE
Make Debezium Connector compatible with Oracle 12.1.0.2.0 and earlier version

### DIFF
--- a/ekhan.html
+++ b/ekhan.html
@@ -1,0 +1,1 @@
+"Change Request for Oracle 12.1.2 or earliar compatibility"


### PR DESCRIPTION
The issue was logged in DBZ-1313: RE: https://groups.google.com/d/msgid/debezium/7f73b99d-0d8e-4e53-b4d5-f2eee756acd6%40googlegroups.com

Debezium is unable to work with Oracle 12.1.0.2.0. Produces ERROR as below:

ERROR Producer failure (io.debezium.pipeline.ErrorHandler:36)
java.lang.RuntimeException: java.lang.NoSuchMethodError: oracle.streams.XStreamUtility.convertSCNToPosition(Loracle/sql/NUMBER;I)[B

Here is the issue described at the Debezium Group by Chris Cranford:
Oracle 12.1 (RC1) version expects a single argument to be passed where-as the 12.2 (RC2) version expects two arguments. Ironically our code current attempts to pass two arguments, which would lead to this exception if you were using the 12.1.0.2 versions of the libraries. This at least appears like a compatibility issue. It would appears that using the ojdbc8.jar and xstreams.jar from 12.2.0.1 resolves the issue; however I'm not sure if those are necessarily compatible with your Oracle 12.1.0.2 (RC1) installation.

Please implement the required code change so that Debezium Connector for Oracle version 12.1 (RC1) and earlier works similarly to Oracle version 12.2 (RC2)

CC: @gunnarmorling