### PR TITLE
DBZ-1352 : Remove the unused Topic Selection Strategy on Postgres Connector 

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTopicSelector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTopicSelector.java
@@ -6,7 +6,6 @@
 
 package io.debezium.connector.postgresql;
 
-import io.debezium.connector.postgresql.PostgresConnectorConfig.TopicSelectionStrategy;
 import io.debezium.relational.TableId;
 import io.debezium.schema.TopicSelector;
 
@@ -18,9 +17,7 @@ import io.debezium.schema.TopicSelector;
 public class PostgresTopicSelector {
 
     public static TopicSelector<TableId> create(PostgresConnectorConfig connectorConfig) {
-        TopicSelectionStrategy topicSelectionStrategy = connectorConfig.topicSelectionStrategy();
-
         return TopicSelector.defaultSelector(connectorConfig,
-                (id, prefix, delimiter) -> topicSelectionStrategy.getTopicName(id, prefix, delimiter));
+                (id, prefix, delimiter) -> String.join(delimiter, prefix, id.schema(), id.table()));
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -137,7 +137,6 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         validateField(validatedConfig, PostgresConnectorConfig.SLOT_NAME, ReplicationConnection.Builder.DEFAULT_SLOT_NAME);
         validateField(validatedConfig, PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE);
         validateField(validatedConfig, PostgresConnectorConfig.PORT, PostgresConnectorConfig.DEFAULT_PORT);
-        validateField(validatedConfig, PostgresConnectorConfig.TOPIC_SELECTION_STRATEGY, PostgresConnectorConfig.TopicSelectionStrategy.TOPIC_PER_TABLE);
         validateField(validatedConfig, PostgresConnectorConfig.MAX_QUEUE_SIZE, PostgresConnectorConfig.DEFAULT_MAX_QUEUE_SIZE);
         validateField(validatedConfig, PostgresConnectorConfig.MAX_BATCH_SIZE, PostgresConnectorConfig.DEFAULT_MAX_BATCH_SIZE);
         validateField(validatedConfig, PostgresConnectorConfig.SNAPSHOT_FETCH_SIZE, null);


### PR DESCRIPTION
Remove the unused topic selection strategy configuration from Postgres connector as it was always the "topic_per_table" strategy which was applied. The general recommendation is to use an SMT to route CDC events to other topics.