### PR TITLE
DBZ-1367 Handling "datum_missing" marker

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
@@ -140,6 +140,11 @@ class PgProtoReplicationMessage implements ReplicationMessage {
      * @return the value; may be null
      */
     public Object getValue(PgProto.DatumMessage datumMessage, PgConnectionSupplier connection, boolean includeUnknownDatatypes) {
+        if (datumMessage.hasDatumMissing()) {
+            LOGGER.trace("No value received for unchanged TOASTed column {}", datumMessage.getColumnName());
+            return null;
+        }
+
         int columnType = (int) datumMessage.getColumnType();
         switch (columnType) {
             case PgOid.BOOL:

--- a/debezium-connector-postgres/src/main/proto/pg_logicaldec.proto
+++ b/debezium-connector-postgres/src/main/proto/pg_logicaldec.proto
@@ -27,6 +27,7 @@ message DatumMessage {
       string datum_string = 8;
       bytes datum_bytes = 9;
       Point datum_point = 10;
+      bool datum_missing = 11;
     }
 }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1367

Requires https://github.com/debezium/postgres-decoderbufs/pull/20.

@jpechane, @Naros, the existing `COLUMNS_DIFF_EXCLUDE_UNCHANGED_TOAST` is a somewhat hacky solution for avoiding unneccessary schema updates due to missing values for non-updated TOASTed columns. This "optimization" isn't needed any longer for ProtoBuf with the accompanying change for the LD plug-in itself (and shouldn't be needed for pgoutput either). But I've got no good idea tbh. on testing this.