### PR TITLE
DBZ-766 Implement PgOutput logical decoder for Postgres 10+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ cache:
   - $HOME/.m2/repository
 
 env:
-  - MAVEN_CLI: '"clean install -pl debezium-connector-mysql -am -Passembly"'
-  - MAVEN_CLI: '"clean install -pl debezium-connector-postgres -am -Passembly"'
-  - MAVEN_CLI: '"clean install -pl debezium-connector-postgres -am -Passembly,wal2json-decoder"'
-  - MAVEN_CLI: '"clean install -pl debezium-connector-mongodb -am -Passembly"'
-  - MAVEN_CLI: '"clean install -pl debezium-connector-sqlserver -am -Passembly"'
+  - MAVEN_CLI: '"clean install -B -pl debezium-connector-mysql -am -Passembly"'
+  - MAVEN_CLI: '"clean install -B -pl debezium-connector-postgres -am -Passembly"'
+  - MAVEN_CLI: '"clean install -B -pl debezium-connector-postgres -am -Passembly,wal2json-decoder"'
+  - MAVEN_CLI: '"clean install -B -pl debezium-connector-postgres -am -Passembly,pgoutput-decoder,postgres-10 -Ddebezium.test.records.waittime=5"'
+  - MAVEN_CLI: '"clean install -B -pl debezium-connector-mongodb -am -Passembly"'
+  - MAVEN_CLI: '"clean install -B -pl debezium-connector-sqlserver -am -Passembly"'
 
 sudo: required
 
@@ -17,6 +18,10 @@ jdk:
 
 services:
   - docker
+
+# Do this to avoid log limit problems
+git:
+  quiet: true
 
 # First stop MySQL and PostgreSQL that run by default (see DBZ-163). Then check Docker status. Finally,
 # install Maven 3.3.9, since the Jolokia Maven plugin requires 3.2.1 or later but Travis current runs 3.1.x

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -322,6 +322,12 @@
             </properties>
         </profile>
         <profile>
+            <id>pgoutput-decoder</id>
+            <properties>
+                <decoder.plugin.name>pgoutput</decoder.plugin.name>
+            </properties>
+        </profile>
+        <profile>
             <id>charset-8bit</id>
             <properties>
                 <postgres.system.lang>${cs_CZ.iso-8859-2}</postgres.system.lang>

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTaskContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTaskContext.java
@@ -108,6 +108,7 @@ public class PostgresTaskContext extends CdcSourceTaskContext {
                                     .statusUpdateInterval(config.statusUpdateInterval())
                                     .withTypeRegistry(schema.getTypeRegistry())
                                     .exportSnapshotOnCreate(exportSnapshot)
+                                    .withSchema(schema)
                                     .build();
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresType.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresType.java
@@ -125,6 +125,14 @@ public class PostgresType {
     }
 
     /**
+     * Get the underlying postgres type information object
+     * @return the type information object; may be null
+     */
+    public TypeInfo getTypeInfo() {
+        return typeInfo;
+    }
+
+    /**
      * @param modifier - type modifier coming from decoder
      * @return scale of the type based on the modifier
      */

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/ToastedReplicationMessageColumn.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/ToastedReplicationMessageColumn.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import io.debezium.connector.postgresql.connection.AbstractReplicationMessageColumn;
+
+/**
+ * Represents a toasted column in a {@link io.debezium.connector.postgresql.connection.ReplicationStream}.
+ *
+ * Some decoder implementations may stream information about a column but provide an indicator that the field was not
+ * changed and therefore toasted.  This implementation acts as an indicator for such fields that are contained within
+ * a {@link io.debezium.connector.postgresql.connection.ReplicationMessage}.
+ *
+ * @author Chris Cranford
+ */
+public class ToastedReplicationMessageColumn extends AbstractReplicationMessageColumn {
+
+    public ToastedReplicationMessageColumn(String columnName, PostgresType type, String typeWithModifiers, boolean optional, boolean hasMetadata) {
+        super(columnName, type, typeWithModifiers, optional, hasMetadata);
+    }
+
+    @Override
+    public boolean isToastedColumn() {
+        return true;
+    }
+
+    @Override
+    public Object getValue(RecordsStreamProducer.PgConnectionSupplier connection, boolean includeUnknownDatatypes) {
+        throw new UnsupportedOperationException("A toasted column does not supply a value");
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractColumnValue.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractColumnValue.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.connection;
+
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.postgresql.geometric.PGbox;
+import org.postgresql.geometric.PGcircle;
+import org.postgresql.geometric.PGline;
+import org.postgresql.geometric.PGlseg;
+import org.postgresql.geometric.PGpath;
+import org.postgresql.geometric.PGpoint;
+import org.postgresql.geometric.PGpolygon;
+import org.postgresql.util.PGInterval;
+import org.postgresql.util.PGmoney;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.connector.postgresql.connection.wal2json.DateTimeFormat;
+import io.debezium.time.Conversions;
+
+/**
+ * @author Chris Cranford
+ */
+public abstract class AbstractColumnValue<T> implements ReplicationMessage.ColumnValue<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractColumnValue.class);
+
+    @Override
+    public LocalDate asLocalDate() {
+        return DateTimeFormat.get().date(asString());
+    }
+
+    @Override
+    public LocalTime asLocalTime() {
+        return DateTimeFormat.get().time(asString());
+    }
+
+    @Override
+    public OffsetTime asOffsetTime() {
+        return DateTimeFormat.get().timeWithTimeZone(asString());
+    }
+
+    @Override
+    public long asTimestampWithTimeZone() {
+        return DateTimeFormat.get().timestampWithTimeZone(asString());
+    }
+
+    @Override
+    public long asTimestampWithoutTimeZone() {
+        final LocalDateTime serverLocal = Conversions.fromNanosToLocalDateTimeUTC(DateTimeFormat.get().timestamp(asString()));
+        return Conversions.toEpochNanos(serverLocal.toInstant(ZoneOffset.UTC));
+    }
+
+    @Override
+    public PGbox asBox() {
+        try {
+            return new PGbox(asString());
+        }
+        catch (final SQLException e) {
+            LOGGER.error("Failed to parse point {}, {}", asString(), e);
+            throw new ConnectException(e);
+        }
+    }
+
+    @Override
+    public PGcircle asCircle() {
+        try {
+            return new PGcircle(asString());
+        }
+        catch (final SQLException e) {
+            LOGGER.error("Failed to parse circle {}, {}", asString(), e);
+            throw new ConnectException(e);
+        }
+    }
+
+    @Override
+    public PGInterval asInterval() {
+        try {
+            return new PGInterval(asString());
+        }
+        catch (final SQLException e) {
+            LOGGER.error("Failed to parse point {}, {}", asString(), e);
+            throw new ConnectException(e);
+        }
+    }
+
+    @Override
+    public PGline asLine() {
+        try {
+            return new PGline(asString());
+        }
+        catch (final SQLException e) {
+            LOGGER.error("Failed to parse point {}, {}", asString(), e);
+            throw new ConnectException(e);
+        }
+    }
+
+    @Override
+    public PGlseg asLseg() {
+        try {
+            return new PGlseg(asString());
+        }
+        catch (final SQLException e) {
+            LOGGER.error("Failed to parse point {}, {}", asString(), e);
+            throw new ConnectException(e);
+        }
+    }
+
+    @Override
+    public PGmoney asMoney() {
+        try {
+            return new PGmoney(asString());
+        }
+        catch (final SQLException e) {
+            LOGGER.error("Failed to parse money {}, {}", asString(), e);
+            throw new ConnectException(e);
+        }
+    }
+
+    @Override
+    public PGpath asPath() {
+        try {
+            return new PGpath(asString());
+        }
+        catch (final SQLException e) {
+            LOGGER.error("Failed to parse point {}, {}", asString(), e);
+            throw new ConnectException(e);
+        }
+    }
+
+    @Override
+    public PGpoint asPoint() {
+        try {
+            return new PGpoint(asString());
+        }
+        catch (final SQLException e) {
+            LOGGER.error("Failed to parse point {}, {}", asString(), e);
+            throw new ConnectException(e);
+        }
+    }
+
+    @Override
+    public PGpolygon asPolygon() {
+        try {
+            return new PGpolygon(asString());
+        }
+        catch (final SQLException e) {
+            LOGGER.error("Failed to parse point {}, {}", asString(), e);
+            throw new ConnectException(e);
+        }
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractMessageDecoder.java
@@ -23,7 +23,7 @@ public abstract class AbstractMessageDecoder implements MessageDecoder {
     public boolean shouldMessageBeSkipped(ByteBuffer buffer, Long lastReceivedLsn, Long startLsn, boolean skipFirstFlushRecord) {
         // the lsn we started from is inclusive, so we need to avoid sending back the same message twice
         // but for the first record seen ever it is possible we received the same LSN as the one obtained from replication slot
-        if (startLsn > lastReceivedLsn || (startLsn.equals(lastReceivedLsn) && skipFirstFlushRecord)) {
+        if (startLsn.compareTo(lastReceivedLsn) > 0 || (startLsn.equals(lastReceivedLsn) && skipFirstFlushRecord)) {
             LOGGER.info("Streaming requested from LSN {} but received LSN {} that is same or smaller so skipping the message", startLsn, lastReceivedLsn);
             return true;
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractMessageDecoder.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.connection;
+
+import java.nio.ByteBuffer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract implementation of {@link MessageDecoder} that all decoders should inherit from.
+ *
+ * @author Chris Cranford
+ */
+public abstract class AbstractMessageDecoder implements MessageDecoder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractMessageDecoder.class);
+
+    @Override
+    public boolean shouldMessageBeSkipped(ByteBuffer buffer, Long lastReceivedLsn, Long startLsn, boolean skipFirstFlushRecord) {
+        // the lsn we started from is inclusive, so we need to avoid sending back the same message twice
+        // but for the first record seen ever it is possible we received the same LSN as the one obtained from replication slot
+        if (startLsn > lastReceivedLsn || (startLsn.equals(lastReceivedLsn) && skipFirstFlushRecord)) {
+            LOGGER.info("Streaming requested from LSN {} but received LSN {} that is same or smaller so skipping the message", startLsn, lastReceivedLsn);
+            return true;
+        }
+        return false;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoder.java
@@ -68,4 +68,16 @@ public interface MessageDecoder {
     // TODO DBZ-508 Remove once we only support LD plug-ins always sending the metadata
     default void setContainsMetadata(boolean flag) {
     }
+
+    /**
+     * A callback into the decoder allowing it to decide whether the supplied message should be processed
+     * by the decoder or whether it can be skipped.
+     *
+     * @param buffer the replication stream buffer
+     * @param lastReceivedLsn the last LSN reported by the replication stream
+     * @param startLsn the starting LSN reported by the streaming producer
+     * @param skipFirstFlushRecord whether first flush record should be skipped
+     * @return {@code true} if the incoming message should be skipped, {@code false} otherwise
+     */
+    boolean shouldMessageBeSkipped(ByteBuffer buffer, Long lastReceivedLsn, Long startLsn, boolean skipFirstFlushRecord);
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoderConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoderConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.connection;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.postgresql.PostgresSchema;
+
+/**
+ * Configuration parameter object for a {@link MessageDecoder}
+ *
+ * @author Chris Cranford
+ */
+public class MessageDecoderConfig {
+
+    private final Configuration configuration;
+    private final PostgresSchema schema;
+
+    public MessageDecoderConfig(Configuration configuration, PostgresSchema schema) {
+        this.configuration = configuration;
+        this.schema = schema;
+    }
+
+    public Configuration getConfiguration() {
+        return configuration;
+    }
+
+    public PostgresSchema getSchema() {
+        return schema;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -314,6 +314,29 @@ public class PostgresConnection extends JdbcConnection {
         }
     }
 
+    /**
+     * Drops the debezium publication that was created.
+     *
+     * @param publicationName the publication name, may not be null
+     * @return {@code true} if the publication was dropped, {@code false} otherwise
+     */
+    public boolean dropPublication(String publicationName) {
+        try {
+            LOGGER.debug("Dropping publication '{}'", publicationName);
+            execute("DROP PUBLICATION " + publicationName);
+            return true;
+        }
+        catch (SQLException e) {
+            if (PSQLState.UNDEFINED_OBJECT.getState().equals(e.getSQLState())) {
+                LOGGER.debug("Publication {} has already been dropped", publicationName);
+            }
+            else {
+                LOGGER.error("Unexpected error while attempting to drop publication", e);
+            }
+            return false;
+        }
+    }
+
     @Override
     public synchronized void close() {
         try {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
@@ -16,6 +16,7 @@ import org.postgresql.replication.PGReplicationStream;
 import io.debezium.annotation.NotThreadSafe;
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.PostgresSchema;
 import io.debezium.connector.postgresql.TypeRegistry;
 import io.debezium.connector.postgresql.spi.SlotCreationResult;
 
@@ -110,6 +111,7 @@ public interface ReplicationConnection extends AutoCloseable {
          * Default replication settings
          */
         String DEFAULT_SLOT_NAME = "debezium";
+        String DEFAULT_PUBLICATION_NAME = "dbz_publication";
         boolean DEFAULT_DROP_SLOT_ON_CLOSE = true;
         boolean DEFAULT_EXPORT_SNAPSHOT = false;
 
@@ -121,6 +123,15 @@ public interface ReplicationConnection extends AutoCloseable {
          * @see #DEFAULT_SLOT_NAME
          */
         Builder withSlot(final String slotName);
+
+        /**
+         * Sets the publication name for the PG logical publication
+         *
+         * @param publicationName the name of the publication, may not be null.
+         * @return this instance
+         * @see #DEFAULT_PUBLICATION_NAME
+         */
+        Builder withPublication(final String publicationName);
 
         /**
          * Sets the instance for the PG logical decoding plugin
@@ -149,6 +160,14 @@ public interface ReplicationConnection extends AutoCloseable {
         Builder statusUpdateInterval(final Duration statusUpdateInterval);
 
         Builder withTypeRegistry(TypeRegistry typeRegistry);
+
+        /**
+         * Sets the schema instance
+         *
+         * @param schema the schema, must not be null
+         * @return this instance
+         */
+        Builder withSchema(PostgresSchema schema);
 
         /**
          * Optional parameters to pass to the logical decoder when the stream starts.

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
@@ -7,10 +7,24 @@
 package io.debezium.connector.postgresql.connection;
 
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetTime;
 import java.util.List;
+
+import org.postgresql.geometric.PGbox;
+import org.postgresql.geometric.PGcircle;
+import org.postgresql.geometric.PGline;
+import org.postgresql.geometric.PGlseg;
+import org.postgresql.geometric.PGpath;
+import org.postgresql.geometric.PGpoint;
+import org.postgresql.geometric.PGpolygon;
+import org.postgresql.util.PGInterval;
+import org.postgresql.util.PGmoney;
 
 import io.debezium.connector.postgresql.PostgresType;
 import io.debezium.connector.postgresql.RecordsStreamProducer.PgConnectionSupplier;
+import io.debezium.data.SpecialValueDecimal;
 
 /**
  * An abstract representation of a replication message that is sent by a PostgreSQL logical decoding plugin and
@@ -44,11 +58,42 @@ public interface ReplicationMessage {
         ColumnTypeMetadata getTypeMetadata();
         Object getValue(final PgConnectionSupplier connection, boolean includeUnknownDatatypes);
         boolean isOptional();
+
+        default boolean isToastedColumn() {
+            return false;
+        }
     }
 
     public interface ColumnTypeMetadata {
         int getLength();
         int getScale();
+    }
+
+    public interface ColumnValue<T> {
+        T getRawValue();
+        boolean isNull();
+        String asString();
+        Boolean asBoolean();
+        Integer asInteger();
+        Long asLong();
+        Float asFloat();
+        Double asDouble();
+        SpecialValueDecimal asDecimal();
+        LocalDate asLocalDate();
+        long asTimestampWithTimeZone();
+        long asTimestampWithoutTimeZone();
+        LocalTime asLocalTime();
+        OffsetTime asOffsetTime();
+        byte[] asByteArray();
+        PGbox asBox();
+        PGcircle asCircle();
+        PGInterval asInterval();
+        PGline asLine();
+        PGlseg asLseg();
+        PGmoney asMoney();
+        PGpath asPath();
+        PGpoint asPoint();
+        PGpolygon asPolygon();
     }
 
     /**
@@ -90,4 +135,11 @@ public interface ReplicationMessage {
      * @return true if this is the last message in the batch of messages with same LSN
      */
     boolean isLastEventForLsn();
+
+    /**
+     * @return true if the stream producer should synchronize the schema when processing messages, false otherwise
+     */
+    default boolean shouldSchemaBeSynchronized() {
+        return true;
+    }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessageColumnValueResolver.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessageColumnValueResolver.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.connection;
+
+import java.sql.SQLException;
+
+import org.postgresql.jdbc.PgArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.connector.postgresql.PostgresType;
+import io.debezium.connector.postgresql.RecordsStreamProducer.PgConnectionSupplier;
+import io.debezium.connector.postgresql.connection.ReplicationMessage.ColumnValue;
+
+/**
+ * @author Chris Cranford
+ */
+public class ReplicationMessageColumnValueResolver {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReplicationMessageColumnValueResolver.class);
+
+    /**
+     * Resolve the value of a {@link ColumnValue}.
+     *
+     * @param columnName the column name
+     * @param type the postgres type
+     * @param fullType the full type-name for the column
+     * @param value the column value
+     * @param connection a postgres connection supplier
+     * @param includeUnknownDatatypes true to include unknown data types, false otherwise
+     * @return
+     */
+    public static Object resolveValue(String columnName, PostgresType type, String fullType, ColumnValue value, final PgConnectionSupplier connection, boolean includeUnknownDatatypes) {
+        if (value.isNull()) {
+            // nulls are null
+            return null;
+        }
+
+        if (type.isArrayType()) {
+            try {
+                final String dataString = value.asString();
+                return new PgArray(connection.get(), type.getOid(), dataString);
+            }
+            catch (SQLException e) {
+                LOGGER.warn("Unexpected exception trying to process PgArray ({}) column '{}', {}", fullType, columnName, e);
+            }
+            return null;
+        }
+
+        switch(type.getName()) {
+            // include all types from https://www.postgresql.org/docs/current/static/datatype.html#DATATYPE-TABLE
+            // plus aliases from the shorter names produced by older wal2json
+            case "boolean":
+            case "bool":
+                return value.asBoolean();
+
+            case "hstore":
+                return value.asString();
+
+            case "integer":
+            case "int":
+            case "int4":
+            case "smallint":
+            case "int2":
+            case "smallserial":
+            case "serial":
+            case "serial2":
+            case "serial4":
+            case "oid":
+                return value.asInteger();
+
+            case "bigint":
+            case "bigserial":
+            case "int8":
+                return value.asLong();
+
+            case "real":
+            case "float4":
+                return value.asFloat();
+
+            case "double precision":
+            case "float8":
+                return value.asDouble();
+
+            case "numeric":
+            case "decimal":
+                return value.asDecimal();
+
+            case "character":
+            case "char":
+            case "character varying":
+            case "varchar":
+            case "bpchar":
+            case "text":
+                return value.asString();
+
+            case "date":
+                return value.asLocalDate();
+
+            case "timestamp with time zone":
+            case "timestamptz":
+                return value.asTimestampWithTimeZone();
+
+            case "timestamp":
+            case "timestamp without time zone":
+                return value.asTimestampWithoutTimeZone();
+
+            case "time":
+                return value.asString();
+
+            case "time without time zone":
+                return value.asLocalTime();
+
+            case "time with time zone":
+            case "timetz":
+                return value.asOffsetTime();
+
+            case "bytea":
+                return value.asByteArray();
+
+            // these are all PG-specific types and we use the JDBC representations
+            // note that, with the exception of point, no converters for these types are implemented yet,
+            // i.e. those values won't actually be propagated to the outbound message until that's the case
+            case "box":
+                return value.asBox();
+            case "circle":
+                return value.asCircle();
+            case "interval":
+                return value.asInterval();
+            case "line":
+                return value.asLine();
+            case "lseg":
+                return value.asLseg();
+            case "money":
+                return value.asMoney().val;
+            case "path":
+                return value.asPath();
+            case "point":
+                return value.asPoint();
+            case "polygon":
+                return value.asPolygon();
+
+                // PostGIS types are HexEWKB strings
+                // ValueConverter turns them into the correct types
+            case "geometry":
+            case "geography":
+                return value.asString();
+
+            case "citext":
+            case "bit":
+            case "bit varying":
+            case "varbit":
+            case "json":
+            case "jsonb":
+            case "xml":
+            case "uuid":
+            case "tsrange":
+            case "tstzrange":
+            case "daterange":
+            case "inet":
+            case "cidr":
+            case "macaddr":
+            case "macaddr8":
+            case "int4range":
+            case "numrange":
+            case "int8range":
+                return value.asString();
+
+            // catch-all for other known/builtin PG types
+            // TODO: improve with more specific/useful classes here?
+            case "pg_lsn":
+            case "tsquery":
+            case "tsvector":
+            case "txid_snapshot":
+                // catch-all for unknown (extension module/custom) types
+            default:
+                break;
+        }
+
+        if (includeUnknownDatatypes) {
+            // this includes things like PostGIS geometries or other custom types.
+            // leave up to the downstream message recipient to deal with.
+            LOGGER.debug("processing column '{}' with unknown data type '{}' as byte array", columnName,
+                         fullType);
+            return value.asString();
+        }
+        LOGGER.debug("Unknown column type {} for column {} – ignoring", fullType, columnName);
+        return null;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/ColumnMetaData.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/ColumnMetaData.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.connection.pgoutput;
+
+import io.debezium.annotation.Immutable;
+import io.debezium.connector.postgresql.PostgresType;
+import io.debezium.connector.postgresql.TypeRegistry;
+
+/**
+ * Defines the relational column mapping for a table.
+ *
+ * @author Gunnar Morling
+ * @author Chris Cranford
+ */
+@Immutable
+public class ColumnMetaData {
+    private final String columnName;
+    private final PostgresType postgresType;
+    private final boolean key;
+    private final boolean optional;
+    private final int length;
+    private final int scale;
+    private final String typeName;
+
+    /**
+     * Create a metadata structure representing a column.
+     *
+     * @param columnName name of the column; must not be null
+     * @param postgresType postgres database type; must not be null
+     * @param key {@code true} if column is part of the primary key, {@code false} otherwise
+     * @param optional {@code true} if the column is considered optional, {@code false} otherwise
+     * @param typeModifier the attribute type modifier
+     */
+    ColumnMetaData(String columnName, PostgresType postgresType, boolean key, boolean optional, int typeModifier) {
+        this.columnName = columnName;
+        this.postgresType = postgresType;
+        this.key = key;
+        this.optional = optional;
+
+        // todo: investigate whether this can be removed and PostgresType updated to always delegate
+        //      Currently PostgresType only delegates calls to length and scale with an attribute modifier
+        //      for specific types and ideally for PgOutput, we should always delegate if a modifier
+        //      is provided.  For now, I've allowed PostgresType to expose the TypeInfo object where
+        //      I will use it here for now until further research can be done.
+        if (TypeRegistry.NO_TYPE_MODIFIER != typeModifier && postgresType.getTypeInfo() != null) {
+            length = postgresType.getTypeInfo().getPrecision(postgresType.getOid(), typeModifier);
+            scale = postgresType.getTypeInfo().getScale(postgresType.getOid(), typeModifier);
+        }
+        else {
+            length = postgresType.getDefaultLength();
+            scale = postgresType.getDefaultScale();
+        }
+
+        // Constructs a fully qualified type name, including dimensions if applicable
+        String type = postgresType.getName();
+        if (!(length == postgresType.getDefaultLength() && scale == 0)) {
+            type += "(" + length + "," + scale + ")";
+        }
+        this.typeName = type;
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public PostgresType getPostgresType() {
+        return postgresType;
+    }
+
+    public boolean isKey() {
+        return key;
+    }
+
+    public boolean isOptional() {
+        return optional;
+    }
+
+    public int getLength() {
+        return length;
+    }
+
+    public int getScale() {
+        return scale;
+    }
+
+    public String getTypeName() {
+        return typeName;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputColumnValue.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputColumnValue.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.connection.pgoutput;
+
+import java.math.BigDecimal;
+
+import io.debezium.connector.postgresql.connection.AbstractColumnValue;
+import io.debezium.data.SpecialValueDecimal;
+import io.debezium.util.Strings;
+
+/**
+ * @author Chris Cranford
+ */
+class PgOutputColumnValue extends AbstractColumnValue<String> {
+
+    private String value;
+
+    PgOutputColumnValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String getRawValue() {
+        return value;
+    }
+
+    @Override
+    public boolean isNull() {
+        return value == null;
+    }
+
+    @Override
+    public String asString() {
+        return value;
+    }
+
+    @Override
+    public Boolean asBoolean() {
+        return "t".equalsIgnoreCase(value);
+    }
+
+    @Override
+    public Integer asInteger() {
+        return Integer.valueOf(value);
+    }
+
+    @Override
+    public Long asLong() {
+        return Long.valueOf(value);
+    }
+
+    @Override
+    public Float asFloat() {
+        return Float.valueOf(value);
+    }
+
+    @Override
+    public Double asDouble() {
+        return Double.valueOf(value);
+    }
+
+    @Override
+    public SpecialValueDecimal asDecimal() {
+        if ("NaN".equals(value)) {
+            return SpecialValueDecimal.NOT_A_NUMBER;
+        }
+        else {
+            return new SpecialValueDecimal(new BigDecimal(value));
+        }
+    }
+
+    @Override
+    public byte[] asByteArray() {
+        return Strings.hexStringToByteArray(value.substring(2));
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -1,0 +1,569 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.connection.pgoutput;
+
+import java.nio.ByteBuffer;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.postgresql.replication.fluent.logical.ChainedLogicalStreamBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.connector.postgresql.PostgresType;
+import io.debezium.connector.postgresql.RecordsStreamProducer.PgConnectionSupplier;
+import io.debezium.connector.postgresql.ToastedReplicationMessageColumn;
+import io.debezium.connector.postgresql.TypeRegistry;
+import io.debezium.connector.postgresql.connection.AbstractMessageDecoder;
+import io.debezium.connector.postgresql.connection.AbstractReplicationMessageColumn;
+import io.debezium.connector.postgresql.connection.MessageDecoderConfig;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.connector.postgresql.connection.ReplicationMessage.Column;
+import io.debezium.connector.postgresql.connection.ReplicationMessage.Operation;
+import io.debezium.connector.postgresql.connection.ReplicationStream.ReplicationMessageProcessor;
+import io.debezium.relational.ColumnEditor;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.util.HexConverter;
+import io.debezium.util.Strings;
+
+/**
+ * Decodes messages from the PG logical replication plug-in ("pgoutput").
+ * See https://www.postgresql.org/docs/10/protocol-logicalrep-message-formats.html for the protocol specification.
+ *
+ * @author Gunnar Morling
+ * @author Chris Cranford
+ *
+ */
+public class PgOutputMessageDecoder extends AbstractMessageDecoder {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PgOutputMessageDecoder.class);
+    private static final Instant PG_EPOCH = LocalDate.of(2000, 1, 1).atStartOfDay().toInstant(ZoneOffset.UTC);
+    private static final byte SPACE = 32;
+
+    private Instant commitTimestamp;
+    private int transactionId;
+
+    private final MessageDecoderConfig config;
+
+    public enum MessageType {
+        RELATION,
+        BEGIN,
+        COMMIT,
+        INSERT,
+        UPDATE,
+        DELETE,
+        TYPE,
+        ORIGIN;
+
+        public static MessageType forType(char type) {
+            switch (type) {
+                case 'R': return RELATION;
+                case 'B': return BEGIN;
+                case 'C': return COMMIT;
+                case 'I': return INSERT;
+                case 'U': return UPDATE;
+                case 'D': return DELETE;
+                case 'Y': return TYPE;
+                case 'O': return ORIGIN;
+                default: throw new IllegalArgumentException("Unsupported message type: " + type);
+            }
+        }
+    }
+
+    public PgOutputMessageDecoder(MessageDecoderConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public boolean shouldMessageBeSkipped(ByteBuffer buffer, Long lastReceivedLsn, Long startLsn, boolean skipFirstFlushRecord) {
+        // Cache position as we're going to peak at the first byte to determine message type
+        // We need to reprocess all BEGIN/COMMIT messages regardless.
+        int position = buffer.position();
+        try {
+            MessageType type = MessageType.forType((char) buffer.get());
+            LOGGER.trace("Message Type: {}", type);
+            switch(type) {
+                case COMMIT:
+                    // For now skip these message types so that the LSN associated with the message won't
+                    // be flushed back to PostgreSQL.  There is a potential LSN assignment concern with
+                    // ReplicationConnectionIT#testHowRelationMessagesAreReceived where the first COMMIT
+                    // in the stream has the same LSN as the following BEGIN and INSERT, which leads to
+                    // the stream ignoring the first INSERT in the second set of statements processed.
+                    // Since COMMIT does not alter decoder state, this is likely fine for now.
+                    return true;
+                case BEGIN:
+                case RELATION:
+                    // BEGIN
+                    // These types should always be processed due to the nature that they provide
+                    // the stream with pertinent per-transaction boundary state we will need to
+                    // always cache as we potentially might reprocess the stream from an earlier
+                    // LSN point.
+                    //
+                    // RELATION
+                    // These messages are always sent with a lastReceivedLSN=0; and we need to
+                    // always accept these to keep per-stream table state cached properly.
+                    LOGGER.trace("{} messages are always reprocessed", type);
+                    return false;
+                default:
+                    // INSERT/UPDATE/DELETE/TYPE/ORIGIN
+                    // These should be excluded based on the normal behavior, delegating to default method
+                    return super.shouldMessageBeSkipped(buffer, lastReceivedLsn, startLsn, skipFirstFlushRecord);
+            }
+        }
+        finally {
+            // Reset buffer position
+            buffer.position(position);
+        }
+    }
+
+    @Override
+    public void processMessage(ByteBuffer buffer, ReplicationMessageProcessor processor, TypeRegistry typeRegistry) throws SQLException, InterruptedException {
+        if (LOGGER.isTraceEnabled()) {
+            if (!buffer.hasArray()) {
+                throw new IllegalStateException("Invalid buffer received from PG server during streaming replication");
+            }
+            final byte[] source = buffer.array();
+            // Extend the array by two as we might need to append two chars and set them to space by default
+            final byte[] content = Arrays.copyOfRange(source, buffer.arrayOffset(), source.length + 2);
+            final int lastPos = content.length - 1;
+            content[lastPos - 1] = SPACE;
+            content[lastPos] = SPACE;
+            LOGGER.trace("Message arrived from database {}", HexConverter.convertToHexString(content));
+        }
+
+        final MessageType messageType = MessageType.forType((char) buffer.get());
+        switch(messageType) {
+            case BEGIN:
+                handleBeginMessage(buffer);
+                break;
+            case COMMIT:
+                handleCommitMessage(buffer);
+                break;
+            case RELATION:
+                handleRelationMessage(buffer, typeRegistry);
+                break;
+            case INSERT:
+                decodeInsert(buffer, typeRegistry, processor);
+                break;
+            case UPDATE:
+                decodeUpdate(buffer, typeRegistry, processor);
+                break;
+            case DELETE:
+                decodeDelete(buffer, typeRegistry, processor);
+                break;
+            default:
+                LOGGER.trace("Message Type {} skipped, not processed.", messageType);
+                break;
+        }
+    }
+
+    @Override
+    public ChainedLogicalStreamBuilder optionsWithMetadata(ChainedLogicalStreamBuilder builder) {
+        return builder.withSlotOption("proto_version", 1)
+                .withSlotOption("publication_names", "dbz_publication");
+    }
+
+    @Override
+    public ChainedLogicalStreamBuilder optionsWithoutMetadata(ChainedLogicalStreamBuilder builder) {
+        return builder;
+    }
+
+    @Override
+    public ChainedLogicalStreamBuilder tryOnceOptions(ChainedLogicalStreamBuilder builder) {
+        return builder;
+    }
+
+    /**
+     * Callback handler for the 'B' begin replication message.
+     *
+     * @param buffer The replication stream buffer
+     */
+    private void handleBeginMessage(ByteBuffer buffer) {
+        long lsn = buffer.getLong(); // LSN
+        this.commitTimestamp = PG_EPOCH.plus(buffer.getLong(), ChronoUnit.MICROS);
+        this.transactionId = buffer.getInt();
+        LOGGER.trace("Event: {}", MessageType.BEGIN);
+        LOGGER.trace("Final LSN of transaction: {}", lsn);
+        LOGGER.trace("Commit timestamp of transaction: {}", commitTimestamp);
+        LOGGER.trace("XID of transaction: {}", transactionId);
+    }
+
+    /**
+     * Callback handler for the 'C' commit replication message.
+     *
+     * @param buffer The replication stream buffer
+     */
+    private void handleCommitMessage(ByteBuffer buffer) {
+        int flags = buffer.get(); // flags, currently unused
+        long lsn = buffer.getLong(); // LSN of the commit
+        long endLsn = buffer.getLong(); // End LSN of the transaction
+        Instant commitTimestamp = PG_EPOCH.plus(buffer.getLong(), ChronoUnit.MICROS);
+        LOGGER.trace("Event: {}", MessageType.COMMIT);
+        LOGGER.trace("Flags: {} (currently unused and most likely 0)", flags);
+        LOGGER.trace("Commit LSN: {}", lsn);
+        LOGGER.trace("End LSN of transaction: {}", endLsn);
+        LOGGER.trace("Commit timestamp of transaction: {}", commitTimestamp);
+    }
+
+    /**
+     * Callback handler for the 'R' relation replication message.
+     *
+     * @param buffer The replication stream buffer
+     * @param typeRegistry The postgres type registry
+     */
+    private void handleRelationMessage(ByteBuffer buffer, TypeRegistry typeRegistry) throws SQLException {
+        int relationId = buffer.getInt();
+        String schemaName = readString(buffer);
+        String tableName = readString(buffer);
+        int replicaIdentityId = buffer.get();
+        short columnCount = buffer.getShort();
+
+        LOGGER.trace("Event: {}, RelationId: {}, Replica Identity: {}, Columns: {}", MessageType.RELATION, relationId, replicaIdentityId, columnCount);
+        LOGGER.trace("Schema: '{}', Table: '{}'", schemaName, tableName);
+
+        // Perform several out-of-bands database metadata queries
+        Map<String, Boolean> columnOptionality = getTableColumnOptionalityFromDatabase(schemaName, tableName);
+        Set<String> primaryKeyColumns = getTablePrimaryKeyColumnNamesFromDatabase(schemaName, tableName);
+
+        List<ColumnMetaData> columns = new ArrayList<>();
+        for (short i = 0; i < columnCount; ++i) {
+            byte flags = buffer.get();
+            String columnName = Strings.unquoteIdentifierPart(readString(buffer));
+            int columnType = buffer.getInt();
+            int attypmod = buffer.getInt();
+
+            final PostgresType postgresType = typeRegistry.get(columnType);
+            boolean key = isColumnInPrimaryKey(schemaName, tableName, columnName, primaryKeyColumns);
+
+            Boolean optional = columnOptionality.get(columnName);
+            if (optional == null) {
+                LOGGER.warn("Column '{}' optionality could not be determined, defaulting to true", columnName);
+                optional = true;
+            }
+
+            columns.add(new ColumnMetaData(columnName, postgresType, key, optional, attypmod));
+        }
+
+        Table table = resolveRelationFromMetadata(new PgOutputRelationMetaData(relationId, schemaName, tableName, columns));
+        config.getSchema().applySchemaChangesForTable(relationId, table);
+    }
+
+    private Map<String, Boolean> getTableColumnOptionalityFromDatabase(String schemaName, String tableName) {
+        Map<String, Boolean> columnOptionality = new HashMap<>();
+        try (final PostgresConnection connection = new PostgresConnection(config.getConfiguration())) {
+            try {
+                try (ResultSet resultSet = connection.connection().getMetaData().getColumns(null, schemaName, tableName, null)) {
+                    while (resultSet.next()) {
+                        columnOptionality.put(resultSet.getString("COLUMN_NAME"), resultSet.getString("IS_NULLABLE").equals("YES"));
+                    }
+                }
+            }
+            catch (SQLException e) {
+                LOGGER.warn("Failed to read column optionality metadata for '{}.{}'", schemaName, tableName);
+                // todo: DBZ-766 Should this throw the exception or just log the warning?
+            }
+        }
+        return columnOptionality;
+    }
+
+    private Set<String> getTablePrimaryKeyColumnNamesFromDatabase(String schemaName, String tableName) {
+        Set<String> primaryKeyColumns = new HashSet<>();
+        try (final PostgresConnection connection = new PostgresConnection(config.getConfiguration())) {
+            try (ResultSet resultSet = connection.connection().getMetaData().getPrimaryKeys(null, schemaName, tableName)) {
+                while (resultSet.next()) {
+                    primaryKeyColumns.add(resultSet.getString("COLUMN_NAME"));
+                }
+            }
+            catch (SQLException e) {
+                LOGGER.warn("Failed to read table {}.{} primary keys", schemaName, tableName);
+            }
+        }
+        return primaryKeyColumns;
+    }
+
+    private boolean isColumnInPrimaryKey(String schemaName, String tableName, String columnName, Set<String> primaryKeyColumns) {
+        // todo (DBZ-766) - Discuss this logic with team as there may be a better way to handle this
+        //      Personally I think its sufficient enough to resolve the PK based on the out-of-bands call
+        //      and should any test fail due to this it should be rewritten or excluded from the pgoutput
+        //      scope.
+        //
+        //      In RecordsStreamProducerIT#shouldReceiveChangesForInsertsIndependentOfReplicaIdentity, we have
+        //      a situation where the table is replica identity full, the primary key is dropped but the replica
+        //      identity is kept and later the replica identity is changed to default.  In order to support this
+        //      use case, the following abides by these rules:
+        //
+        if (!primaryKeyColumns.isEmpty() && primaryKeyColumns.contains(columnName)) {
+            return true;
+        }
+        else if (primaryKeyColumns.isEmpty()) {
+            // The table's metadata was either not fetched or table no longer has a primary key
+            // Lets attempt to use the known schema primary key configuration as a fallback
+            Table existingTable = config.getSchema().tableFor(new TableId(null, schemaName, tableName));
+            if (existingTable != null && existingTable.primaryKeyColumnNames().contains(columnName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Callback handler for the 'I' insert replication stream message.
+     *
+     * @param buffer The replication stream buffer
+     * @param typeRegistry The postgres type registry
+     * @param processor The replication message processor
+     */
+    private void decodeInsert(ByteBuffer buffer, TypeRegistry typeRegistry, ReplicationMessageProcessor processor) throws SQLException, InterruptedException {
+        int relationId = buffer.getInt();
+        char tupleType = (char) buffer.get(); // Always 'N" for inserts
+
+        LOGGER.trace("Event: {}, Relation Id: {}, Tuple Type: {}", MessageType.INSERT, relationId, tupleType);
+
+        Optional<Table> resolvedTable = resolveRelation(relationId);
+        if (!resolvedTable.isPresent()) {
+            return;
+        }
+
+        Table table = resolvedTable.get();
+        List<Column> columns = resolveColumnsFromStreamTupleData(buffer, typeRegistry, table);
+
+        processor.process(new PgOutputReplicationMessage(
+                Operation.INSERT,
+                table.id().toDoubleQuotedString(),
+                commitTimestamp,
+                transactionId,
+                null,
+                columns));
+    }
+
+    /**
+     * Callback handler for the 'U' update replication stream message.
+     *
+     * @param buffer The replication stream buffer
+     * @param typeRegistry The postgres type registry
+     * @param processor The replication message processor
+     */
+    private void decodeUpdate(ByteBuffer buffer, TypeRegistry typeRegistry, ReplicationMessageProcessor processor) throws SQLException, InterruptedException  {
+        int relationId = buffer.getInt();
+
+        LOGGER.trace("Event: {}, RelationId: {}", MessageType.UPDATE, relationId);
+
+        Optional<Table> resolvedTable = resolveRelation(relationId);
+        if (!resolvedTable.isPresent()) {
+            return;
+        }
+
+        Table table = resolvedTable.get();
+
+        // When reading the tuple-type, we could get 3 different values, 'O', 'K', or 'N'.
+        // 'O' (Optional) - States the following tuple-data is the key, only for replica identity index configs.
+        // 'K' (Optional) - States the following tuple-data is the old tuple, only for replica identity full configs.
+        //
+        // 'N' (Not-Optional) - States the following tuple-data is the new tuple.
+        // This is always present.
+        List<Column> oldColumns = null;
+        char tupleType = (char) buffer.get();
+        if ('O' == tupleType || 'K' == tupleType) {
+            oldColumns = resolveColumnsFromStreamTupleData(buffer, typeRegistry, table);
+            // Read the 'N' tuple type
+            // This is necessary so the stream position is accurate for resolving the column tuple data
+            tupleType = (char) buffer.get();
+        }
+
+        List<Column> columns = resolveColumnsFromStreamTupleData(buffer, typeRegistry, table);
+
+        processor.process(new PgOutputReplicationMessage(
+                Operation.UPDATE,
+                table.id().toDoubleQuotedString(),
+                commitTimestamp,
+                transactionId,
+                oldColumns,
+                columns));
+    }
+
+    /**
+     * Callback handler for the 'D' delete replication stream message.
+     *
+     * @param buffer The replication stream buffer
+     * @param typeRegistry The postgres type registry
+     * @param processor The replication message processor
+     */
+    private void decodeDelete(ByteBuffer buffer, TypeRegistry typeRegistry, ReplicationMessageProcessor processor) throws SQLException, InterruptedException  {
+        int relationId = buffer.getInt();
+
+        char tupleType = (char) buffer.get();
+
+        LOGGER.trace("Event: {}, RelationId: {}, Tuple Type: {}", MessageType.DELETE, relationId, tupleType);
+
+        Optional<Table> resolvedTable = resolveRelation(relationId);
+        if (!resolvedTable.isPresent()) {
+            return;
+        }
+
+        Table table = resolvedTable.get();
+        List<Column> columns = resolveColumnsFromStreamTupleData(buffer, typeRegistry, table);
+        processor.process(new PgOutputReplicationMessage(
+                Operation.DELETE,
+                table.id().toDoubleQuotedString(),
+                commitTimestamp,
+                transactionId,
+                columns,
+                null));
+    }
+
+    /**
+     * Resolves a given replication message relation identifier to a {@link Table}.
+     *
+     * @param relationId The replication message stream's relation identifier
+     * @return table resolved from a prior relation message or direct lookup from the schema
+     */
+    private Optional<Table> resolveRelation(int relationId) {
+        return Optional.ofNullable(config.getSchema().tableFor(relationId));
+    }
+
+    /**
+     * Constructs a {@link Table} based on the supplied {@link PgOutputRelationMetaData}.
+     *
+     * @param metadata The relation metadata collected from previous 'R' replication stream messages
+     * @return table based on a prior replication relation message
+     */
+    private Table resolveRelationFromMetadata(PgOutputRelationMetaData metadata) {
+        List<String> pkColumnNames = new ArrayList<>();
+        List<io.debezium.relational.Column> columns = new ArrayList<>();
+        for (ColumnMetaData columnMetadata : metadata.getColumns()) {
+            ColumnEditor editor = io.debezium.relational.Column.editor()
+                    .name(columnMetadata.getColumnName())
+                    .jdbcType(columnMetadata.getPostgresType().getJdbcId())
+                    .nativeType(columnMetadata.getPostgresType().getOid())
+                    .optional(columnMetadata.isOptional())
+                    .type(columnMetadata.getPostgresType().getName(), columnMetadata.getTypeName())
+                    .length(columnMetadata.getLength())
+                    .scale(columnMetadata.getScale());
+
+            columns.add(editor.create());
+
+            if (columnMetadata.isKey()) {
+                pkColumnNames.add(columnMetadata.getColumnName());
+            }
+        }
+
+        Table table = Table.editor()
+                .addColumns(columns)
+                .setPrimaryKeyNames(pkColumnNames)
+                .tableId(metadata.getTableId())
+                .create();
+
+        LOGGER.trace("Resolved '{}' as '{}'", table.id(), table);
+
+        return table;
+    }
+
+    /**
+     * Reads the replication stream up to the next null-terminator byte and returns the contents as a string.
+     *
+     * @param buffer The replication stream buffer
+     * @return string read from the replication stream
+     */
+    private static String readString(ByteBuffer buffer) {
+        StringBuilder sb = new StringBuilder();
+        byte b = 0;
+        while ((b = buffer.get()) != 0){
+            sb.append((char) b);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Reads the replication stream where the column stream specifies a length followed by the value.
+     *
+     * @param buffer The replication stream buffer
+     * @return the column value as a string read from the replication stream
+     */
+    private static String readColumnValueAsString(ByteBuffer buffer) {
+        int length = buffer.getInt();
+        byte[] value = new byte[length];
+        buffer.get(value, 0, length);
+        return new String(value);
+    }
+
+    /**
+     * Resolve the replication stream's tuple data to a list of replication message columns.
+     *
+     * @param buffer The replication stream buffer
+     * @param typeRegistry The database type registry
+     * @param table The database table
+     * @return list of replication message columns
+     */
+    private static List<Column> resolveColumnsFromStreamTupleData(ByteBuffer buffer, TypeRegistry typeRegistry, Table table) {
+        // Read number of the columns
+        short numberOfColumns = buffer.getShort();
+
+        List<Column> columns = new ArrayList<>(numberOfColumns);
+        for (short i = 0; i < numberOfColumns; ++i) {
+
+            final io.debezium.relational.Column column = table.columns().get(i);
+            final String columnName = column.name();
+            final String typeName = column.typeName();
+            final PostgresType columnType = typeRegistry.get(typeName);
+            final String typeExpression = column.typeExpression();
+            final boolean optional = column.isOptional();
+
+            // Read the sub-message type
+            // 't' : Value is represented as text
+            // 'u' : An unchanged TOAST-ed value, actual value is not sent.
+            // 'n' : Value is null.
+            char type = (char) buffer.get();
+            if (type == 't') {
+                final String valueStr = readColumnValueAsString(buffer);
+                columns.add(
+                        new AbstractReplicationMessageColumn(columnName, columnType, typeExpression, optional, true) {
+                            @Override
+                            public Object getValue(PgConnectionSupplier connection, boolean includeUnknownDatatypes) {
+                                return PgOutputReplicationMessage.getValue(columnName, columnType, typeExpression, valueStr, connection, includeUnknownDatatypes);
+                            }
+
+                            @Override
+                            public String toString() {
+                                return columnName + "(" + typeExpression + ")=" + valueStr;
+                            }
+                        });
+            }
+            else if (type == 'u') {
+                columns.add(
+                        new ToastedReplicationMessageColumn(columnName, columnType, typeExpression, optional, true) {
+                            @Override
+                            public String toString() {
+                                return columnName + "(" + typeExpression + ") - Unchanged toasted column";
+                            }
+                        });
+            }
+            else if (type == 'n') {
+                columns.add(
+                        new AbstractReplicationMessageColumn(columnName, columnType, typeExpression, true, true) {
+                            @Override
+                            public Object getValue(PgConnectionSupplier connection, boolean includeUnknownDatatypes) {
+                                return null;
+                            }
+                        });
+            }
+        }
+
+        columns.forEach(c -> LOGGER.trace("Column: {}", c));
+        return columns;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputRelationMetaData.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputRelationMetaData.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.connection.pgoutput;
+
+import java.util.List;
+
+import io.debezium.annotation.Immutable;
+import io.debezium.relational.TableId;
+
+/**
+ * Defines the relational information for a relation-id mapping.
+ *
+ * @author Chris Cranford
+ */
+@Immutable
+public class PgOutputRelationMetaData {
+    private final int relationId;
+    private final String schema;
+    private final String name;
+    private final List<ColumnMetaData> columns;
+
+    /**
+     * Construct a pgoutput relation metadata object representing a relational table.
+     *
+     * @param relationId the postgres relation identifier, unique provided by the pgoutput stream
+     * @param schema the schema the table exists within; should never be null
+     * @param name the name of the table; should never be null
+     * @param columns list of column metadata instances describing the state of each column
+     */
+    PgOutputRelationMetaData(int relationId, String schema, String name, List<ColumnMetaData> columns) {
+        this.relationId = relationId;
+        this.schema = schema;
+        this.name = name;
+        this.columns = columns;
+    }
+
+    public int getRelationId() {
+        return relationId;
+    }
+
+    public String getSchema() {
+        return schema;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<ColumnMetaData> getColumns() {
+        return columns;
+    }
+
+    public TableId getTableId() {
+        return new TableId(null, schema, name);
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputReplicationMessage.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.connection.pgoutput;
+
+import java.time.Instant;
+import java.util.List;
+
+import io.debezium.connector.postgresql.PostgresType;
+import io.debezium.connector.postgresql.RecordsStreamProducer.PgConnectionSupplier;
+import io.debezium.connector.postgresql.connection.ReplicationMessage;
+import io.debezium.connector.postgresql.connection.ReplicationMessageColumnValueResolver;
+
+/**
+ * @author Gunnar Morling
+ * @author Chris Cranford
+ */
+public class PgOutputReplicationMessage implements ReplicationMessage {
+
+    private Operation op;
+    private Instant commitTimestamp;
+    private long transactionId;
+    private String table;
+    private List<Column> oldColumns;
+    private List<Column> newColumns;
+
+    public PgOutputReplicationMessage(Operation op, String table, Instant commitTimestamp, long transactionId, List<Column> oldColumns, List<Column> newColumns) {
+        this.op = op;
+        this.commitTimestamp = commitTimestamp;
+        this.transactionId = transactionId;
+        this.table = table;
+        this.oldColumns = oldColumns;
+        this.newColumns = newColumns;
+    }
+
+    @Override
+    public Operation getOperation() {
+        return op;
+    }
+
+    @Override
+    public Instant getCommitTime() {
+        return commitTimestamp;
+    }
+
+    @Override
+    public long getTransactionId() {
+        return transactionId;
+    }
+
+    @Override
+    public String getTable() {
+        return table;
+    }
+
+    @Override
+    public List<Column> getOldTupleList() {
+        return oldColumns;
+    }
+
+    @Override
+    public List<Column> getNewTupleList() {
+        return newColumns;
+    }
+
+    @Override
+    public boolean hasTypeMetadata() {
+        return true;
+    }
+
+    @Override
+    public boolean isLastEventForLsn() {
+        return true;
+    }
+
+    @Override
+    public boolean shouldSchemaBeSynchronized() {
+        return false;
+    }
+
+    /**
+     * Converts the value (string representation) coming from PgOutput plugin to
+     * a Java value based on the type of the column from the message.  This value will be converted later on if necessary by the
+     * connector's value converter to match whatever the Connect schema type expects.
+     *
+     * Note that the logic here is tightly coupled on the pgoutput plugin logic which writes the actual value.
+     *
+     * @return the value; may be null
+     */
+    public static Object getValue(String columnName, PostgresType type, String fullType, String rawValue, final PgConnectionSupplier connection, boolean includeUnknownDataTypes) {
+        final PgOutputColumnValue columnValue = new PgOutputColumnValue(rawValue);
+        return ReplicationMessageColumnValueResolver.resolveValue(columnName, type, fullType, columnValue, connection, includeUnknownDataTypes);
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoMessageDecoder.java
@@ -15,7 +15,7 @@ import org.postgresql.replication.fluent.logical.ChainedLogicalStreamBuilder;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import io.debezium.connector.postgresql.TypeRegistry;
-import io.debezium.connector.postgresql.connection.MessageDecoder;
+import io.debezium.connector.postgresql.connection.AbstractMessageDecoder;
 import io.debezium.connector.postgresql.connection.ReplicationStream.ReplicationMessageProcessor;
 import io.debezium.connector.postgresql.proto.PgProto;
 import io.debezium.connector.postgresql.proto.PgProto.RowMessage;
@@ -27,7 +27,7 @@ import io.debezium.connector.postgresql.proto.PgProto.RowMessage;
  * @author Jiri Pechanec
  *
  */
-public class PgProtoMessageDecoder implements MessageDecoder {
+public class PgProtoMessageDecoder extends AbstractMessageDecoder {
 
     @Override
     public void processMessage(final ByteBuffer buffer, ReplicationMessageProcessor processor, TypeRegistry typeRegistry) throws SQLException, InterruptedException {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
@@ -18,7 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.postgresql.TypeRegistry;
-import io.debezium.connector.postgresql.connection.MessageDecoder;
+import io.debezium.connector.postgresql.connection.AbstractMessageDecoder;
 import io.debezium.connector.postgresql.connection.ReplicationStream.ReplicationMessageProcessor;
 import io.debezium.document.Array;
 import io.debezium.document.Array.Entry;
@@ -36,7 +36,7 @@ import io.debezium.time.Conversions;
  *
  */
 
-public class NonStreamingWal2JsonMessageDecoder implements MessageDecoder {
+public class NonStreamingWal2JsonMessageDecoder extends AbstractMessageDecoder {
 
     private static final  Logger LOGGER = LoggerFactory.getLogger(NonStreamingWal2JsonMessageDecoder.class);
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
@@ -17,7 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.postgresql.TypeRegistry;
-import io.debezium.connector.postgresql.connection.MessageDecoder;
+import io.debezium.connector.postgresql.connection.AbstractMessageDecoder;
 import io.debezium.connector.postgresql.connection.ReplicationStream.ReplicationMessageProcessor;
 import io.debezium.document.Document;
 import io.debezium.document.DocumentReader;
@@ -78,7 +78,7 @@ import io.debezium.time.Conversions;
  * @author Jiri Pechanec
  *
  */
-public class StreamingWal2JsonMessageDecoder implements MessageDecoder {
+public class StreamingWal2JsonMessageDecoder extends AbstractMessageDecoder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StreamingWal2JsonMessageDecoder.class);
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonColumnValue.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonColumnValue.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql.connection.wal2json;
+
+import java.math.BigDecimal;
+
+import io.debezium.connector.postgresql.connection.AbstractColumnValue;
+import io.debezium.data.SpecialValueDecimal;
+import io.debezium.document.Value;
+import io.debezium.util.Strings;
+
+/**
+ * @author Chris Cranford
+ */
+class Wal2JsonColumnValue extends AbstractColumnValue<Value> {
+
+    private Value value;
+
+    Wal2JsonColumnValue(Value value) {
+        this.value = value;
+    }
+
+    @Override
+    public Value getRawValue() {
+        return value;
+    }
+
+    @Override
+    public boolean isNull() {
+        return value.isNull();
+    }
+
+    @Override
+    public String asString() {
+        return value.asString();
+    }
+
+    @Override
+    public Boolean asBoolean() {
+        return value.asBoolean();
+    }
+
+    @Override
+    public Integer asInteger() {
+        return value.asInteger();
+    }
+
+    @Override
+    public Long asLong() {
+        return value.asLong();
+    }
+
+    @Override
+    public Float asFloat() {
+        return value.isNumber() ? value.asFloat() : Float.valueOf(value.asString());
+    }
+
+    @Override
+    public Double asDouble() {
+        return value.isNumber() ? value.asDouble() : Double.valueOf(value.asString());
+    }
+
+    @Override
+    public SpecialValueDecimal asDecimal() {
+        if (value.isInteger()) {
+            return new SpecialValueDecimal(new BigDecimal(value.asInteger()));
+        }
+        else if (value.isLong()) {
+            return new SpecialValueDecimal(new BigDecimal(value.asLong()));
+        }
+        else if (value.isBigInteger()) {
+            return new SpecialValueDecimal(new BigDecimal(value.asBigInteger()));
+        }
+        return SpecialValueDecimal.valueOf(value.asString());
+    }
+
+    @Override
+    public byte[] asByteArray() {
+        return Strings.hexStringToByteArray(value.asString());
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/Wal2JsonReplicationMessage.java
@@ -6,27 +6,13 @@
 
 package io.debezium.connector.postgresql.connection.wal2json;
 
-import java.math.BigDecimal;
-import java.sql.SQLException;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.postgresql.geometric.PGbox;
-import org.postgresql.geometric.PGcircle;
-import org.postgresql.geometric.PGline;
-import org.postgresql.geometric.PGlseg;
-import org.postgresql.geometric.PGpath;
-import org.postgresql.geometric.PGpoint;
-import org.postgresql.geometric.PGpolygon;
-import org.postgresql.jdbc.PgArray;
-import org.postgresql.util.PGInterval;
-import org.postgresql.util.PGmoney;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,12 +22,10 @@ import io.debezium.connector.postgresql.RecordsStreamProducer.PgConnectionSuppli
 import io.debezium.connector.postgresql.TypeRegistry;
 import io.debezium.connector.postgresql.connection.AbstractReplicationMessageColumn;
 import io.debezium.connector.postgresql.connection.ReplicationMessage;
-import io.debezium.data.SpecialValueDecimal;
+import io.debezium.connector.postgresql.connection.ReplicationMessageColumnValueResolver;
 import io.debezium.document.Array;
 import io.debezium.document.Document;
 import io.debezium.document.Value;
-import io.debezium.time.Conversions;
-import io.debezium.util.Strings;
 
 /**
  * Replication message representing message sent by the wal2json logical decoding plug-in.
@@ -181,216 +165,8 @@ class Wal2JsonReplicationMessage implements ReplicationMessage {
      * @return the value; may be null
      */
     public Object getValue(String columnName, PostgresType type, String fullType, Value rawValue, final PgConnectionSupplier connection, boolean includeUnknownDatatypes) {
-        if (rawValue.isNull()) {
-            // nulls are null
-            return null;
-        }
-
-        if (type.isArrayType()) {
-            try {
-                final String dataString = rawValue.asString();
-                return new PgArray(connection.get(), type.getOid(), dataString);
-            }
-            catch (SQLException e) {
-                LOGGER.warn("Unexpected exception trying to process PgArray ({}) column '{}', {}", fullType, columnName, e);
-            }
-            return null;
-        }
-        switch (type.getName()) {
-
-            // include all types from https://www.postgresql.org/docs/current/static/datatype.html#DATATYPE-TABLE
-            // plus aliases from the shorter names produced by older wal2json
-            case "boolean":
-            case "bool":
-                return rawValue.asBoolean();
-
-            case "hstore":
-                return rawValue.asString();
-
-            case "integer":
-            case "int":
-            case "int4":
-            case "smallint":
-            case "int2":
-            case "smallserial":
-            case "serial":
-            case "serial2":
-            case "serial4":
-            case "oid":
-                return rawValue.asInteger();
-
-            case "bigint":
-            case "bigserial":
-            case "int8":
-                return rawValue.asLong();
-
-            case "real":
-            case "float4":
-                return rawValue.isNumber() ? rawValue.asFloat() : Float.valueOf(rawValue.asString());
-
-            case "double precision":
-            case "float8":
-                return rawValue.isNumber() ? rawValue.asDouble() : Double.valueOf(rawValue.asString());
-
-            case "numeric":
-            case "decimal":
-                if (rawValue.isInteger()) {
-                    return new SpecialValueDecimal(new BigDecimal(rawValue.asInteger()));
-                }
-                else if (rawValue.isLong()) {
-                    return new SpecialValueDecimal(new BigDecimal(rawValue.asLong()));
-                }
-                else if (rawValue.isBigInteger()) {
-                    return new SpecialValueDecimal(new BigDecimal(rawValue.asBigInteger()));
-                }
-                return SpecialValueDecimal.valueOf(rawValue.asString());
-
-            case "character":
-            case "char":
-            case "character varying":
-            case "varchar":
-            case "bpchar":
-            case "text":
-                return rawValue.asString();
-
-            case "date":
-                return DateTimeFormat.get().date(rawValue.asString());
-
-            case "timestamp with time zone":
-            case "timestamptz":
-                return DateTimeFormat.get().timestampWithTimeZone(rawValue.asString());
-
-            case "timestamp":
-            case "timestamp without time zone":
-                final LocalDateTime serverLocal = Conversions.fromNanosToLocalDateTimeUTC(DateTimeFormat.get().timestamp(rawValue.asString()));
-                return Conversions.toEpochNanos(serverLocal.toInstant(ZoneOffset.UTC));
-
-            case "time":
-                return rawValue.asString();
-
-            case "time without time zone":
-                return DateTimeFormat.get().time(rawValue.asString());
-
-            case "time with time zone":
-            case "timetz":
-                return DateTimeFormat.get().timeWithTimeZone(rawValue.asString());
-
-            case "bytea":
-                return Strings.hexStringToByteArray(rawValue.asString());
-
-            // these are all PG-specific types and we use the JDBC representations
-            // note that, with the exception of point, no converters for these types are implemented yet,
-            // i.e. those values won't actually be propagated to the outbound message until that's the case
-            case "box":
-                try {
-                    return new PGbox(rawValue.asString());
-                } catch (final SQLException e) {
-                    LOGGER.error("Failed to parse point {}, {}", rawValue.asString(), e);
-                    throw new ConnectException(e);
-                }
-            case "circle":
-                try {
-                    return new PGcircle(rawValue.asString());
-                } catch (final SQLException e) {
-                    LOGGER.error("Failed to parse circle {}, {}", rawValue.asString(), e);
-                    throw new ConnectException(e);
-                }
-            case "interval":
-                try {
-                    return new PGInterval(rawValue.asString());
-                } catch (final SQLException e) {
-                    LOGGER.error("Failed to parse point {}, {}", rawValue.asString(), e);
-                    throw new ConnectException(e);
-                }
-            case "line":
-                try {
-                    return new PGline(rawValue.asString());
-                } catch (final SQLException e) {
-                    LOGGER.error("Failed to parse point {}, {}", rawValue.asString(), e);
-                    throw new ConnectException(e);
-                }
-            case "lseg":
-                try {
-                    return new PGlseg(rawValue.asString());
-                } catch (final SQLException e) {
-                    LOGGER.error("Failed to parse point {}, {}", rawValue.asString(), e);
-                    throw new ConnectException(e);
-                }
-            case "money":
-                try {
-                    return new PGmoney(rawValue.asString()).val;
-                } catch (final SQLException e) {
-                    LOGGER.error("Failed to parse money {}, {}", rawValue.asString(), e);
-                    throw new ConnectException(e);
-                }
-            case "path":
-                try {
-                    return new PGpath(rawValue.asString());
-                } catch (final SQLException e) {
-                    LOGGER.error("Failed to parse point {}, {}", rawValue.asString(), e);
-                    throw new ConnectException(e);
-                }
-            case "point":
-                try {
-                    return new PGpoint(rawValue.asString());
-                } catch (final SQLException e) {
-                    LOGGER.error("Failed to parse point {}, {}", rawValue.asString(), e);
-                    throw new ConnectException(e);
-                }
-            case "polygon":
-                try {
-                    return new PGpolygon(rawValue.asString());
-                } catch (final SQLException e) {
-                    LOGGER.error("Failed to parse point {}, {}", rawValue.asString(), e);
-                    throw new ConnectException(e);
-                }
-
-            // PostGIS types are HexEWKB strings
-            // ValueConverter turns them into the correct types
-            case "geometry":
-            case "geography":
-                return rawValue.asString();
-
-            case "citext":
-            case "bit":
-            case "bit varying":
-            case "varbit":
-            case "json":
-            case "jsonb":
-            case "xml":
-            case "uuid":
-            case "tsrange":
-            case "tstzrange":
-            case "daterange":
-            case "inet":
-            case "cidr":
-            case "macaddr":
-            case "macaddr8":
-            case "int4range":
-            case "numrange":
-            case "int8range":
-            return rawValue.asString();
-
-            // catch-all for other known/builtin PG types
-            // TODO: improve with more specific/useful classes here?
-            case "pg_lsn":
-            case "tsquery":
-            case "tsvector":
-            case "txid_snapshot":
-            // catch-all for unknown (extension module/custom) types
-            default:
-                break;
-        }
-
-        if (includeUnknownDatatypes) {
-            // this includes things like PostGIS geometries or other custom types.
-            // leave up to the downstream message recipient to deal with.
-            LOGGER.debug("processing column '{}' with unknown data type '{}' as byte array", columnName,
-                    fullType);
-            return rawValue.asString();
-        }
-        LOGGER.debug("Unknown column type {} for column {} – ignoring", fullType, columnName);
-        return null;
+        final Wal2JsonColumnValue columnValue = new Wal2JsonColumnValue(rawValue);
+        return ReplicationMessageColumnValueResolver.resolveValue(columnName, type, fullType, columnValue, connection, includeUnknownDatatypes);
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DecoderDifferences.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DecoderDifferences.java
@@ -53,6 +53,10 @@ public class DecoderDifferences {
                 || TestHelper.decoderPlugin() == PostgresConnectorConfig.LogicalDecoder.WAL2JSON_RDS_STREAMING;
     }
 
+    private static boolean pgoutput() {
+        return TestHelper.decoderPlugin() == PostgresConnectorConfig.LogicalDecoder.PGOUTPUT;
+    }
+
     /**
      * wal2json plugin is not currently able to encode and parse NaN and Inf values
      *
@@ -64,12 +68,12 @@ public class DecoderDifferences {
     }
 
     /**
-     * wal2json plugin does not include toasted column in the update
+     * wal2json plugin nor pgoutput include toasted column in the update
      *
      * @author Jiri Pechanec
      *
      */
     public static boolean areToastedValuesPresentInSchema() {
-        return !wal2Json();
+        return !wal2Json() && !pgoutput();
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
@@ -89,7 +89,8 @@ public class PostgresSchemaIT {
             Arrays.stream(TEST_TABLES).forEach(tableId -> assertKeySchema(tableId, "pk", Schema.INT32_SCHEMA));
             assertTableSchema("public.numeric_table", "si, i, bi, r, db, ss, bs, b",
                               Schema.OPTIONAL_INT16_SCHEMA, Schema.OPTIONAL_INT32_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA, Schema.OPTIONAL_FLOAT32_SCHEMA,
-                              Schema.OPTIONAL_FLOAT64_SCHEMA, Schema.INT16_SCHEMA, Schema.INT64_SCHEMA, Schema.OPTIONAL_BOOLEAN_SCHEMA);
+                              Schema.OPTIONAL_FLOAT64_SCHEMA, Schema.INT16_SCHEMA,
+                              Schema.INT64_SCHEMA, Schema.OPTIONAL_BOOLEAN_SCHEMA);
             assertTableSchema("public.numeric_decimal_table", "d, dzs, dvs, n, nzs, nvs",
                     Decimal.builder(2).parameter(TestHelper.PRECISION_PARAMETER_KEY, "3").optional().build(),
                     Decimal.builder(0).parameter(TestHelper.PRECISION_PARAMETER_KEY, "4").optional().build(),

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -76,12 +76,14 @@ public final class TestHelper {
      */
     public static ReplicationConnection createForReplication(String slotName, boolean dropOnClose) throws SQLException {
         final PostgresConnectorConfig.LogicalDecoder plugin = decoderPlugin();
+        final PostgresConnectorConfig config = new PostgresConnectorConfig(defaultConfig().build());
         return ReplicationConnection.builder(defaultJdbcConfig())
                                     .withPlugin(plugin)
                                     .withSlot(slotName)
                                     .withTypeRegistry(getTypeRegistry())
                                     .dropSlotOnClose(dropOnClose)
                                     .statusUpdateInterval(Duration.ofSeconds(10))
+                                    .withSchema(getSchema(config))
                                     .build();
     }
 
@@ -252,6 +254,15 @@ public final class TestHelper {
         }
         catch (Exception e) {
             LOGGER.debug("Error while dropping default replication slot", e);
+        }
+    }
+
+    protected static void dropPublication() {
+        try {
+            execute("DROP PUBLICATION " + ReplicationConnection.Builder.DEFAULT_PUBLICATION_NAME);
+        }
+        catch (Exception e) {
+            LOGGER.debug("Error while dropping default publication", e);
         }
     }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipTestDependingOnDecoderPluginNameRule.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipTestDependingOnDecoderPluginNameRule.java
@@ -21,13 +21,13 @@ public class SkipTestDependingOnDecoderPluginNameRule extends AnnotationBasedTes
     public Statement apply(Statement base, Description description) {
         SkipWhenDecoderPluginNameIs skipHasName = hasAnnotation(description, SkipWhenDecoderPluginNameIs.class);
         if (skipHasName != null && skipHasName.value().isEqualTo(pluginName)) {
-            String reasonForSkipping = "Decoder plugin name is " + skipHasName.value();
+            String reasonForSkipping = "Decoder plugin name is " + skipHasName.value() + System.lineSeparator() + skipHasName.reason();
             return emptyStatement(reasonForSkipping, description);
         }
 
         SkipWhenDecoderPluginNameIsNot skipNameIsNot = hasAnnotation(description, SkipWhenDecoderPluginNameIsNot.class);
         if (skipNameIsNot != null && skipNameIsNot.value().isNotEqualTo(pluginName)) {
-            String reasonForSkipping = "Decoder plugin name is not " + skipNameIsNot.value();
+            String reasonForSkipping = "Decoder plugin name is not " + skipNameIsNot.value() + System.lineSeparator() + skipNameIsNot.reason();
             return emptyStatement(reasonForSkipping, description);
         }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipWhenDecoderPluginNameIs.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipWhenDecoderPluginNameIs.java
@@ -19,6 +19,11 @@ import java.lang.annotation.Target;
 public @interface SkipWhenDecoderPluginNameIs {
     SkipWhenDecoderPluginNameIs.DecoderPluginName value();
 
+    /**
+     * Returns the reason why the test should be skipped.
+     */
+    String reason() default "";
+
     enum DecoderPluginName {
         WAL2JSON {
             @Override
@@ -48,6 +53,12 @@ public @interface SkipWhenDecoderPluginNameIs {
             @Override
             boolean isEqualTo(String pluginName) {
                 return pluginName.equals("decoderbufs");
+            }
+        },
+        PGOUTPUT {
+            @Override
+            boolean isEqualTo(String pluginName) {
+                return pluginName.equals("pgoutput");
             }
         };
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipWhenDecoderPluginNameIsNot.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/junit/SkipWhenDecoderPluginNameIsNot.java
@@ -19,6 +19,11 @@ import java.lang.annotation.Target;
 public @interface SkipWhenDecoderPluginNameIsNot {
     SkipWhenDecoderPluginNameIsNot.DecoderPluginName value();
 
+    /**
+     * Returns the reason why the test should be skipped.
+     */
+    String reason();
+
     enum DecoderPluginName {
         WAL2JSON {
             @Override
@@ -48,6 +53,12 @@ public @interface SkipWhenDecoderPluginNameIsNot {
             @Override
             boolean isNotEqualTo(String pluginName) {
                 return !pluginName.equals("decoderbufs");
+            }
+        },
+        PGOUTPUT {
+            @Override
+            boolean isNotEqualTo(String pluginName) {
+                return !pluginName.equals("pgoutput");
             }
         };
 


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-766

@gunnarmorling @jpechane, this PR is very much still a WIP but I wanted to go ahead and get my work out in the open with you guys so you could go ahead and begin digesting the changes and potentially offering some feedback on some choices I've made which I'd like to find better alternatives for.

That said there are a few caveats:

1. The `dbz_publication` right now gets created automatically still using `for all tables`.  We obviously want to change this for the long-term but for the sake of having a PoC I left it as is.  It should be simple enough to hook into the `PostgresSchema` and build the publication based on the list of filtered tables should the publication not yet exist during connector startup.

2. Since the `pgoutput` logical replication stream does not indicate a column's optionality state and we discussed simply setting all columns as optional, a number of tests were modified to alter the optionality of the built schema based on whether this decoder was being used or one of the others.  I'm not sure if either of you have an opinion on that, but just wanted to point it out.

3. The `PgOutputMessageDecoder` maintains some schema map-based lookup state that I have not yet integrated with the actual `PostgresSchema`.  I felt since this was isolated to this particular decoder, it made more sense to keep it in the decoder until we were sure this satisfies all our needs.  

    There are 2 maps maintained by the decoder, `relationIdMetadata` and `tableIdByRelationId`.  The former map acts as a `RELATION` message cache so when relation messages are received they'll be stored in this map and as an `INSERT`, `UPDATE`, or `DELETE` operation comes over the stream for that relation-id, the entry will be consumed.  In theory this former map should always be empty over the complete duration of the replication connection.  The latter map is used to maintain the lookup between a relation-id provided by the pgoutput decoder stream and a schema `TableId`.  This is the part that we discussed integrating with `PostgresSchema` long-term.

There are also a few other things I want to point out here that you guys may have better suggestions on how to do these things that are cleaner and more appropriate.

1. Inside `ColumnMetaData` I ended up doing some type modifier calculations with the `PostgresType`.  I'd like to somehow consolidate this better with `TypeMetadataImpl` and `PostgresType`.  The reason I did it slightly different for now was that we only delegate length/scale calls to the postgres `TypeInfo` inside `PostgresType` for specific OIDs.  I wanted to better understand why this limitation exists in the first place so rather than impact other decoders, I exposed a slight one-off for this PoC.

2. I have some code dupe from `RecordsStreamProducer` in the `PgOutputMessageDecoder` which I don't particularly like.  I need to spend some time trying to find a better way to handle this, any insight or suggestion here would be very welcomed.

3. The `PgOutputMessageDecoder` several constructor arguments that are only applicable to it and not the other implementations.  I'm wondering if we could come up with a better way to feed these into the decoders?   I was thinking perhaps a `MessageDecoderContext` object.  I'm a much bigger fan of parameter objects rather than a long list of passed arguments.  Other ideas?

Look forward to hearing your feedback.