### PR TITLE
DBZ-1394 Add SMT to extract inner value field

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/ExtractConnectField.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ExtractConnectField.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms;
+
+import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+public class ExtractConnectField<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    private static final String FIELD_CONFIG = "field";
+    private static final String TOPICS_CONFIG = "topics";
+
+    private static final ConfigDef CONFIG_DEF = new ConfigDef()
+            .define(
+                    FIELD_CONFIG,
+                    ConfigDef.Type.STRING,
+                    null,
+                    ConfigDef.Importance.MEDIUM,
+                    "Field name to be extracted ")
+            .define(
+                    TOPICS_CONFIG,
+                    ConfigDef.Type.LIST,
+                    Collections.emptyList(),
+                    ConfigDef.Importance.HIGH,
+                    "Topic names for which this transformation will be applied."
+            );
+    private static final String PURPOSE = "get after value fieldToExtract as seperate fieldToExtract in record";
+
+    private List<String> topics;
+    private String fieldToExtract;
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        final SimpleConfig config = new SimpleConfig(CONFIG_DEF, configs);
+        fieldToExtract = config.getString(FIELD_CONFIG);
+        topics = config.getList(TOPICS_CONFIG);
+    }
+
+    @Override
+    public R apply(R record) {
+        if (!topics.isEmpty() && !topics.contains(record.topic())) {
+            return record;
+        }
+
+        if (record.valueSchema() == null) {
+            return applySchemaless(record);
+        } else {
+            return applyWithSchema(record);
+        }
+    }
+
+    private R applySchemaless(final R record) {
+        final Map<String, Object> value = requireMap(record.value(), PURPOSE);
+        final Map<String, Object> afterValue = getMap(value, "after");
+        final Map<String, Object> innerValue = afterValue != null ? afterValue : getMap(value, "before");
+
+        if (innerValue == null) {
+            throw new UnsupportedOperationException("Applying on records that do not have 'before' and 'after' fields is not defined.");
+        }
+
+        value.put(fieldToExtract, innerValue.get(fieldToExtract));
+
+        return record;
+    }
+
+    private Map<String, Object> getMap(final Map<String, Object> value, final String after) {
+        try {
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> result = (Map<String, Object>) value.get(after);
+            return result;
+        } catch (ClassCastException e) {
+            return null;
+        }
+    }
+
+    private R applyWithSchema(final R record) {
+        final Struct value = requireStruct(record.value(), PURPOSE);
+        final Struct innerValue = value.getStruct("after") != null
+                ? value.getStruct("after")
+                : value.getStruct("before");
+
+        if (innerValue == null) {
+            throw new UnsupportedOperationException("Applying on records that do not have 'before' and 'after' fields is not defined.");
+        }
+
+        final Object extractedValue = innerValue.get(fieldToExtract);
+        final Schema extractedFieldSchema = innerValue.schema().field(fieldToExtract).schema();
+
+        final Schema newSchema = rebuildSchemaWithNewField(value, extractedFieldSchema);
+        final Struct newValues = rebuildValuesWithNewField(value, extractedValue, newSchema);
+
+        return record.newRecord(
+                record.topic(),
+                record.kafkaPartition(),
+                record.keySchema(),
+                record.key(),
+                newSchema,
+                newValues,
+                record.timestamp());
+    }
+
+    private Struct rebuildValuesWithNewField(Struct value, Object extractedValue, Schema newSchema) {
+        Struct newValues = new Struct(newSchema);
+        for (Field field : value.schema().fields()) {
+            newValues.put(field.name(), value.get(field));
+        }
+
+        newValues.put(fieldToExtract, extractedValue);
+        return newValues;
+    }
+
+    private Schema rebuildSchemaWithNewField(Struct value, Schema extractedFieldSchema) {
+        SchemaBuilder newSchemaBuilder = SchemaBuilder.struct();
+        for (Field field : value.schema().fields()) {
+            newSchemaBuilder.field(field.name(), field.schema());
+        }
+
+        newSchemaBuilder.field(fieldToExtract, extractedFieldSchema);
+        return newSchemaBuilder.build();
+    }
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    @Override
+    public void close() {}
+
+}

--- a/debezium-core/src/main/java/io/debezium/transforms/ExtractConnectField.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ExtractConnectField.java
@@ -5,8 +5,8 @@
  */
 package io.debezium.transforms;
 
-import static org.apache.kafka.connect.transforms.util.Requirements.requireMap;
-import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireMapOrNull;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStructOrNull;
 
 import java.util.Collections;
 import java.util.List;
@@ -65,7 +65,12 @@ public class ExtractConnectField<R extends ConnectRecord<R>> implements Transfor
     }
 
     private R applySchemaless(final R record) {
-        final Map<String, Object> value = requireMap(record.value(), PURPOSE);
+        final Map<String, Object> value = requireMapOrNull(record.value(), PURPOSE);
+
+        if (value == null) {
+            return record;
+        }
+
         final Map<String, Object> afterValue = getMap(value, "after");
         final Map<String, Object> innerValue = afterValue != null ? afterValue : getMap(value, "before");
 
@@ -89,7 +94,12 @@ public class ExtractConnectField<R extends ConnectRecord<R>> implements Transfor
     }
 
     private R applyWithSchema(final R record) {
-        final Struct value = requireStruct(record.value(), PURPOSE);
+        final Struct value = requireStructOrNull(record.value(), PURPOSE);
+
+        if (value == null) {
+            return record;
+        }
+
         final Struct innerValue = value.getStruct("after") != null
                 ? value.getStruct("after")
                 : value.getStruct("before");

--- a/debezium-core/src/test/java/io/debezium/transforms/ExtractConnectFieldSchemaTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ExtractConnectFieldSchemaTest.java
@@ -171,6 +171,27 @@ public class ExtractConnectFieldSchemaTest {
         assertEquals(inputValue, transformedRecord.value());
     }
 
+    @Test
+    public void tombstoneRecordsWillNotBeTransformed() {
+        final Schema valueSchema = buildEnvelopeSchema(buildInnerSchema());
+        final SinkRecord record = new SinkRecord(
+                "myLittleTopic",
+                0,
+                null,
+                null,
+                valueSchema,
+                null,
+                0
+        );
+
+        final SinkRecord transformedRecord = transform.apply(record);
+
+        assertNull(transformedRecord.keySchema());
+        assertNull(transformedRecord.key());
+        assertEquals(valueSchema, transformedRecord.valueSchema());
+        assertNull(transformedRecord.value());
+    }
+
     private Schema buildInnerSchema() {
         return SchemaBuilder.struct()
                 .field(EXTRACTED_FIELD_NAME, Schema.STRING_SCHEMA)

--- a/debezium-core/src/test/java/io/debezium/transforms/ExtractConnectFieldSchemaTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ExtractConnectFieldSchemaTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExtractConnectFieldSchemaTest {
+
+    private static final String EXTRACTED_FIELD_NAME = "extractedField";
+    private ExtractConnectField<SinkRecord> transform = new ExtractConnectField<>();
+
+    @After
+    public void teardown() {
+        transform.close();
+    }
+
+    @Before
+    public void setup() {
+        final Map<String, String> fields = new HashMap<>();
+        fields.put("field", EXTRACTED_FIELD_NAME);
+        fields.put("topics", "myLittleTopic");
+
+        transform = new ExtractConnectField<>();
+        transform.configure(fields);
+    }
+
+    @Test
+    public void createRecordWithSchema() {
+        final Schema innerSchema = buildInnerSchema();
+        final Schema valueSchema = buildEnvelopeSchema(innerSchema);
+        final Struct afterValue = buildInnerValue(innerSchema, "new payload");
+        final Struct inputValue = buildInputValue(
+                valueSchema,
+                null,
+                afterValue
+        );
+        final SinkRecord record = new SinkRecord(
+                "myLittleTopic",
+                0,
+                null,
+                null,
+                valueSchema,
+                inputValue,
+                0
+        );
+
+        final SinkRecord transformedRecord = transform.apply(record);
+
+        final Schema expectedSchema = buildTransformedSchema(valueSchema);
+        final Struct expectedValue = buildTransformedValue(
+                expectedSchema,
+                null,
+                inputValue.getStruct("after"),
+                "new payload"
+        );
+
+        assertNull(transformedRecord.keySchema());
+        assertNull(transformedRecord.key());
+        assertEquals(expectedSchema, transformedRecord.valueSchema());
+        assertEquals(expectedValue, transformedRecord.value());
+    }
+
+    @Test
+    public void changeRecordWithSchema() {
+        final Schema innerSchema = buildInnerSchema();
+        final Schema valueSchema = buildEnvelopeSchema(innerSchema);
+        final Struct inputValue = buildInputValue(
+                valueSchema,
+                buildInnerValue(innerSchema, "old payload"),
+                buildInnerValue(innerSchema, "new payload")
+        );
+        final SinkRecord record = new SinkRecord(
+                "myLittleTopic",
+                0,
+                null,
+                null,
+                valueSchema,
+                inputValue,
+                0
+        );
+
+        final SinkRecord transformedRecord = transform.apply(record);
+
+        final Schema expectedSchema = buildTransformedSchema(valueSchema);
+        final Struct expectedValue = buildTransformedValue(
+                expectedSchema,
+                inputValue.getStruct("before"),
+                inputValue.getStruct("after"),
+                "new payload"
+        );
+
+        assertNull(transformedRecord.keySchema());
+        assertNull(transformedRecord.key());
+        assertEquals(expectedSchema, transformedRecord.valueSchema());
+        assertEquals(expectedValue, transformedRecord.value());
+    }
+
+    @Test
+    public void deleteRecordWithSchema() {
+        final Schema innerSchema = buildInnerSchema();
+        final Schema valueSchema = buildEnvelopeSchema(innerSchema);
+        final Struct inputValue = buildInputValue(
+                valueSchema,
+                buildInnerValue(innerSchema, "old payload"),
+                null
+        );
+        final SinkRecord record = new SinkRecord(
+                "myLittleTopic",
+                0,
+                null,
+                null,
+                valueSchema,
+                inputValue,
+                0
+        );
+
+        final SinkRecord transformedRecord = transform.apply(record);
+
+        final Schema expectedSchema = buildTransformedSchema(valueSchema);
+        final Struct expectedValue = buildTransformedValue(
+                expectedSchema,
+                inputValue.getStruct("before"),
+                null,
+                "old payload"
+        );
+
+        assertNull(transformedRecord.keySchema());
+        assertNull(transformedRecord.key());
+        assertEquals(expectedSchema, transformedRecord.valueSchema());
+        assertEquals(expectedValue, transformedRecord.value());
+    }
+
+    @Test
+    public void recordsWithoutSpecifiedTopicWillNotBeTransformed() {
+        final Schema innerSchema = buildInnerSchema();
+        final Schema valueSchema = buildEnvelopeSchema(innerSchema);
+        final Struct inputValue = buildInputValue(
+                valueSchema,
+                buildInnerValue(innerSchema, "old payload"),
+                buildInnerValue(innerSchema, "new payload")
+        );
+        final SinkRecord record = new SinkRecord(
+                "unrelatedTopic",
+                0,
+                null,
+                null,
+                valueSchema,
+                inputValue,
+                0
+        );
+
+        final SinkRecord transformedRecord = transform.apply(record);
+
+        assertNull(transformedRecord.keySchema());
+        assertNull(transformedRecord.key());
+        assertEquals(valueSchema, transformedRecord.valueSchema());
+        assertEquals(inputValue, transformedRecord.value());
+    }
+
+    private Schema buildInnerSchema() {
+        return SchemaBuilder.struct()
+                .field(EXTRACTED_FIELD_NAME, Schema.STRING_SCHEMA)
+                .optional()
+                .build();
+    }
+
+    private static Schema buildEnvelopeSchema(final Schema innerSchema) {
+        return SchemaBuilder.struct()
+                .field("before", innerSchema)
+                .field("after", innerSchema)
+                .build();
+    }
+
+    private static Schema buildTransformedSchema(final Schema inputSchema) {
+        return SchemaBuilder.struct()
+                .field("before", inputSchema.field("before").schema())
+                .field("after", inputSchema.field("after").schema())
+                .field(EXTRACTED_FIELD_NAME, Schema.STRING_SCHEMA)
+                .build();
+    }
+
+    private static Struct buildInputValue(
+            final Schema inputMessageSchema,
+            final Struct valueBefore,
+            final Struct valueAfter
+    ) {
+        final Struct connectValue = new Struct(inputMessageSchema);
+        connectValue.put("before", valueBefore);
+        connectValue.put("after", valueAfter);
+
+        return connectValue;
+    }
+
+    private static Struct buildInnerValue(final Schema schema, final String payload) {
+        final Struct valueBefore = new Struct(schema);
+        valueBefore.put(EXTRACTED_FIELD_NAME, payload);
+        return valueBefore;
+    }
+
+    private Struct buildTransformedValue(
+            final Schema schema,
+            final Struct beforeValue,
+            final Struct afterValue,
+            final String extractedFieldValue
+    ) {
+        final Struct expectedValue = new Struct(schema);
+        expectedValue.put("before", beforeValue);
+        expectedValue.put("after", afterValue);
+        expectedValue.put(EXTRACTED_FIELD_NAME, extractedFieldValue);
+        return expectedValue;
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/transforms/ExtractConnectFieldSchemalessTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ExtractConnectFieldSchemalessTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.transforms;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExtractConnectFieldSchemalessTest {
+
+    private static final String EXTRACTED_FIELD_NAME = "extractedField";
+    private ExtractConnectField<SinkRecord> transform = new ExtractConnectField<>();
+
+    @After
+    public void teardown() {
+        transform.close();
+    }
+
+    @Before
+    public void setup() {
+        final Map<String, String> fields = new HashMap<>();
+        fields.put("field", EXTRACTED_FIELD_NAME);
+        fields.put("topics", "myLittleTopic");
+
+        transform = new ExtractConnectField<>();
+        transform.configure(fields);
+    }
+
+    @Test
+    public void createRecordWithoutSchema() {
+        final Map<String, Object> after = buildInnerValue("new payload");
+        final Map<String, Object> currentValue = buildInputValue(null, after);
+        final SinkRecord record = new SinkRecord(
+                "myLittleTopic",
+                0, null,
+                null,
+                null,
+                currentValue,
+                0
+        );
+
+        final SinkRecord transformedRecord = transform.apply(record);
+
+        final HashMap<String, Object> expectedValue = buildExpectedValue(
+                null,
+                after,
+                "new payload"
+        );
+        assertNull(transformedRecord.keySchema());
+        assertNull(transformedRecord.key());
+        assertNull(transformedRecord.valueSchema());
+        assertEquals(expectedValue, transformedRecord.value());
+    }
+
+    @Test
+    public void changeRecordWithoutSchema() {
+        final Map<String, Object> before = buildInnerValue("old payload");
+        final Map<String, Object> after = buildInnerValue("new payload");
+        final Map<String, Object> currentValue = buildInputValue(before, after);
+        final SinkRecord record = new SinkRecord(
+                "myLittleTopic",
+                0, null,
+                null,
+                null,
+                currentValue,
+                0
+        );
+
+        final SinkRecord transformedRecord = transform.apply(record);
+
+        final HashMap<String, Object> expectedValue = buildExpectedValue(before, after, "new payload");
+        assertNull(transformedRecord.keySchema());
+        assertNull(transformedRecord.key());
+        assertNull(transformedRecord.valueSchema());
+        assertEquals(expectedValue, transformedRecord.value());
+    }
+
+    @Test
+    public void deleteRecordWithoutSchema() {
+        final Map<String, Object> before = buildInnerValue("old payload");
+        final Map<String, Object> currentValue = buildInputValue(before, null);
+        final SinkRecord record = new SinkRecord(
+                "myLittleTopic",
+                0, null,
+                null,
+                null,
+                currentValue,
+                0
+        );
+
+        final SinkRecord transformedRecord = transform.apply(record);
+
+        final HashMap<String, Object> expectedValue = buildExpectedValue(
+                before,
+                null,
+                "old payload"
+        );
+        assertNull(transformedRecord.keySchema());
+        assertNull(transformedRecord.key());
+        assertNull(transformedRecord.valueSchema());
+        assertEquals(expectedValue, transformedRecord.value());
+    }
+
+    @Test
+    public void recordsWithoutSpecifiedTopicWillNotBeTransformed() {
+        final Map<String, Object> before = buildInnerValue("old payload");
+        final Map<String, Object> after = buildInnerValue("new payload");
+        final Map<String, Object> inputValue = buildInputValue(before, after);
+        final SinkRecord record = new SinkRecord(
+                "unrelatedTopic",
+                0,
+                null,
+                null,
+                null,
+                inputValue,
+                0
+        );
+
+        final SinkRecord transformedRecord = transform.apply(record);
+
+        assertNull(transformedRecord.keySchema());
+        assertNull(transformedRecord.key());
+        assertNull(transformedRecord.valueSchema());
+        assertEquals(inputValue, transformedRecord.value());
+    }
+
+    private static Map<String, Object> buildInnerValue(final String payload) {
+        return Collections.singletonMap(EXTRACTED_FIELD_NAME, payload);
+    }
+
+    private static Map<String, Object> buildInputValue(
+            final Object before,
+            final Object after
+    ) {
+        final Map<String, Object> result = new HashMap<>();
+        result.put("before", before);
+        result.put("after", after);
+        return result;
+    }
+
+    private static HashMap<String, Object> buildExpectedValue(
+            final Map<String, Object> beforeValue,
+            final Map<String, Object> afterValue,
+            final String extractedFieldValue
+    ) {
+        final HashMap<String, Object> expectedValue = new HashMap<>();
+        expectedValue.put("before", beforeValue);
+        expectedValue.put("after", afterValue);
+        expectedValue.put(EXTRACTED_FIELD_NAME, extractedFieldValue);
+        return expectedValue;
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/transforms/ExtractConnectFieldSchemalessTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ExtractConnectFieldSchemalessTest.java
@@ -134,6 +134,25 @@ public class ExtractConnectFieldSchemalessTest {
         assertEquals(inputValue, transformedRecord.value());
     }
 
+    @Test
+    public void tombstoneRecordsWillNotBeTransformed() {
+        final SinkRecord record = new SinkRecord(
+                "myLittleTopic",
+                0,  null,
+                null,
+                null,
+                null,
+                0
+        );
+
+        final SinkRecord transformedRecord = transform.apply(record);
+
+        assertNull(transformedRecord.keySchema());
+        assertNull(transformedRecord.key());
+        assertNull(transformedRecord.valueSchema());
+        assertNull(transformedRecord.value());
+    }
+
     private static Map<String, Object> buildInnerValue(final String payload) {
         return Collections.singletonMap(EXTRACTED_FIELD_NAME, payload);
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1394

Accessing inner values of records (inside before/after, depending of the event type) in other transforms (e.g. to change the records key) is currently not possible without applying event flattening with io.debezium.transforms.ExtractNewRecordState.

It would therefore be great if Debezium comes with a transform that allows extracting a field from the inner value (from before on delete operation, otherwise from after without the need to loose information through flattening.