### PR TITLE
Improved Oracle snapshot predicate by adding an option to replace scn…

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalSnapshotChangeEventSource.java
@@ -413,7 +413,17 @@ public abstract class HistorizedRelationalSnapshotChangeEventSource implements S
             overriddenSelect = connectorConfig.getSnapshotSelectOverridesByTable().get(new TableId(null, tableId.schema(), tableId.table()));
         }
 
-        return overriddenSelect != null ? overriddenSelect : getSnapshotSelect(snapshotContext, tableId);
+        return overriddenSelect != null ? enhanceOverriddenSelect(snapshotContext, overriddenSelect) : getSnapshotSelect(snapshotContext, tableId);
+    }
+
+    /**
+     * Default implementation. Return the query string. Oracle implementation overrides this and adds AS OF SCN logic
+     * @param snapshotContext
+     * @param overriddenSelect
+     * @return
+     */
+    protected String enhanceOverriddenSelect(HistorizedRelationalSnapshotChangeEventSource.SnapshotContext snapshotContext, String overriddenSelect) {
+        return overriddenSelect;
     }
 
     /**


### PR DESCRIPTION
I have made the changes based on the proposed solution under this ARGO:
DBZ-1415: Improve snapshot SELECT overrides for Oracle connector.

1. Create a protected method which returns the predicate as it is.
2. In Oracle implementation override it as follows (This is already ready in our Oracle implementation  incubator project under #AndreyIg/debezium-incubator)

    protected String enhanceOverriddenSelect(SnapshotContext snapshotContext, String overriddenSelect){
        long snapshotOffset = (Long) snapshotContext.offset.getOffset().get("scn");
        return overriddenSelect.replaceAll("#scn#", " AS OF SCN " + snapshotOffset);
    }

And the predicate string would be defined as:

predicate=#scn# WHERE column = 'abc'

The placeholder #scn# would then be substituted by the above logic. 
