### PR TITLE
DBZ-1385 eventType can be configured as add field

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -146,7 +146,7 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
                 "UserCreated",
                 "User",
                 "10711fa5",
-                "{}",
+                "{\"email\": \"gh@mefi.in\"}",
                 ""
         ));
 
@@ -166,11 +166,11 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         assertThat(routedEvent).isNotNull();
         assertThat(routedEvent.topic()).isEqualTo("outbox.event.user");
 
-        Struct valueStruct = requireStruct(routedEvent.value(), "test payload");
+        Object value = routedEvent.value();
         assertThat(routedEvent.headers().lastWithName("eventType").value()).isEqualTo("UserCreated");
-        assertThat(valueStruct.schema().field("eventType")).isNull();
-        JsonNode payload = (new ObjectMapper()).readTree(valueStruct.getString("payload"));
-        assertThat(payload.get("email")).isEqualTo(null);
+        assertThat(value).isInstanceOf(String.class);
+        JsonNode payload = (new ObjectMapper()).readTree((String) value);
+        assertThat(payload.get("email").getTextValue()).isEqualTo("gh@mefi.in");
 
     }
 

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -41,7 +41,7 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EventRouter.class);
 
-    private static final String ENVELOPE_EVENT_TYPE = "eventType";
+    public static final String ENVELOPE_EVENT_TYPE = "eventType";
     private static final String ENVELOPE_PAYLOAD = "payload";
     private static final String RECORD_ENVELOPE_SCHEMA_NAME_SUFFIX = ".Envelope";
 
@@ -51,7 +51,6 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
 
     private String fieldEventId;
     private String fieldEventKey;
-    private String fieldEventType;
     private String fieldEventTimestamp;
     private String fieldPayload;
     private String fieldPayloadId;
@@ -106,7 +105,6 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
                 : eventStruct.getInt64(fieldEventTimestamp);
 
         Object eventId = eventStruct.get(fieldEventId);
-        Object eventType = eventStruct.get(fieldEventType);
         Object payload = eventStruct.get(fieldPayload);
         Object payloadId = eventStruct.get(fieldPayloadId);
 
@@ -118,7 +116,6 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
                 : getValueSchema(eventValueSchema, eventStruct.getInt32(fieldSchemaVersion));
 
         Struct value = new Struct(valueSchema)
-                .put(ENVELOPE_EVENT_TYPE, eventType)
                 .put(ENVELOPE_PAYLOAD, payload);
 
         additionalFields.forEach((additionalField -> {
@@ -211,7 +208,6 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
 
         fieldEventId = config.getString(EventRouterConfigDefinition.FIELD_EVENT_ID);
         fieldEventKey = config.getString(EventRouterConfigDefinition.FIELD_EVENT_KEY);
-        fieldEventType = config.getString(EventRouterConfigDefinition.FIELD_EVENT_TYPE);
         fieldEventTimestamp = config.getString(EventRouterConfigDefinition.FIELD_EVENT_TIMESTAMP);
         fieldPayload = config.getString(EventRouterConfigDefinition.FIELD_PAYLOAD);
         fieldPayloadId = config.getString(EventRouterConfigDefinition.FIELD_PAYLOAD_ID);
@@ -257,7 +253,6 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
 
         // Add default fields
         schemaBuilder
-                .field(ENVELOPE_EVENT_TYPE, debeziumEventSchema.field(fieldEventType).schema())
                 .field(ENVELOPE_PAYLOAD, debeziumEventSchema.field(fieldPayload).schema());
 
         // Add additional fields while keeping the schema inherited from Debezium based on the table column type


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1385

Current implementation expects that evetn type is mapped to field named `eventType`. If it is the case the configuration is completely taken from additional fields. If such add field does not exist then `eventType` field is added to payload.

Complete backward compatibility is ensured. `eventType` field is always first in the message struct.