### PR TITLE
DBZ-1255

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
@@ -433,12 +433,7 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
 
                 // '17:51:04.777'
                 java.util.Date c2 = (java.util.Date) after.get("c2"); // milliseconds past midnight
-                LocalTime c2Time = LocalTime.ofNanoOfDay(TimeUnit.MILLISECONDS.toNanos(c2.getTime()));
-                assertThat(c2Time.getHour()).isEqualTo(17);
-                assertThat(c2Time.getMinute()).isEqualTo(51);
-                assertThat(c2Time.getSecond()).isEqualTo(4);
-                assertThat(c2Time.getNano()).isEqualTo((int) TimeUnit.MILLISECONDS.toNanos(780));
-                assertThat(io.debezium.time.Time.toMilliOfDay(c2Time, ADJUSTER)).isEqualTo((int) c2.getTime());
+                assertThat(c2.toInstant()).isEqualTo(LocalDateTime.of(1970, 1, 1, 17, 51, 4, 780_000_000).atOffset(ZoneOffset.UTC).toInstant());
 
                 // '2014-09-08 17:51:04.777'
                 // DATETIME is a logical date and time, it doesn't contain any TZ information;
@@ -494,7 +489,6 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 assertThat(c2Time.getMinute() == 0 || c2Time.getMinute() == 1).isTrue();
                 assertThat(c2Time.getSecond()).isEqualTo(0);
                 assertThat(c2Time.getNano()).isEqualTo(0);
-                assertThat(io.debezium.time.Time.toMilliOfDay(c2Time, ADJUSTER)).isEqualTo((int) c2.getTime());
 
                 java.util.Date c3 = (java.util.Date) after.get("c3"); // epoch millis
                 assertThat(c3).isNull();

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MysqlDefaultValueIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MysqlDefaultValueIT.java
@@ -579,7 +579,7 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
     }
 
     @Test
-    public void timeTypeWithConnectMode() throws InterruptedException {
+    public void timeTypeWithConnectMode() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.INITIAL)
                 .with(MySqlConnectorConfig.TABLE_WHITELIST, DATABASE.qualifiedTableName("DATE_TIME_TABLE"))
@@ -631,10 +631,10 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
         assertThat(schemaG.defaultValue()).isEqualTo(date);
 
         Duration duration1 = Duration.between(LocalTime.MIN, LocalTime.from(DateTimeFormatter.ofPattern("HH:mm:ss.S").parse("23:00:00.7")));
-        assertThat(schemaH.defaultValue()).isEqualTo(new java.util.Date(io.debezium.time.Time.toMilliOfDay(duration1, MySqlValueConverters::adjustTemporal)));
+        assertThat(schemaH.defaultValue()).isEqualTo(new java.util.Date(io.debezium.time.Time.toMilliOfDay(duration1, false)));
 
         Duration duration2 = Duration.between(LocalTime.MIN, LocalTime.from(DateTimeFormatter.ofPattern("HH:mm:ss.SSSSSS").parse("23:00:00.123456")));
-        assertThat(schemaI.defaultValue()).isEqualTo(new java.util.Date(io.debezium.time.Time.toMilliOfDay(duration2, MySqlValueConverters::adjustTemporal)));
+        assertThat(schemaI.defaultValue()).isEqualTo(new java.util.Date(io.debezium.time.Time.toMilliOfDay(duration2, false)));
         assertEmptyFieldValue(record, "K");
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresEventMetadataProvider.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresEventMetadataProvider.java
@@ -33,7 +33,7 @@ class PostgresEventMetadataProvider implements EventMetadataProvider {
             return timestamp == null ? null : Conversions.toInstantFromMicros(timestamp);
         }
         final Long timestamp = sourceInfo.getInt64(SourceInfo.TIMESTAMP_KEY);
-        return timestamp == null ? null : Conversions.toInstantFromMillis(timestamp);
+        return timestamp == null ? null : Instant.ofEpochMilli(timestamp);
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractColumnValue.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractColumnValue.java
@@ -7,8 +7,8 @@ package io.debezium.connector.postgresql.connection;
 
 import java.sql.SQLException;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.postgresql.connection.wal2json.DateTimeFormat;
-import io.debezium.time.Conversions;
 
 /**
  * @author Chris Cranford
@@ -51,14 +50,13 @@ public abstract class AbstractColumnValue<T> implements ReplicationMessage.Colum
     }
 
     @Override
-    public long asTimestampWithTimeZone() {
-        return DateTimeFormat.get().timestampWithTimeZone(asString());
+    public OffsetDateTime asOffsetDateTime() {
+        return DateTimeFormat.get().timestampWithTimeZoneToOffsetDateTime(asString());
     }
 
     @Override
-    public long asTimestampWithoutTimeZone() {
-        final LocalDateTime serverLocal = Conversions.fromNanosToLocalDateTimeUTC(DateTimeFormat.get().timestamp(asString()));
-        return Conversions.toEpochNanos(serverLocal.toInstant(ZoneOffset.UTC));
+    public OffsetDateTime asOffsetDateTimeWithoutTimeZone() {
+        return DateTimeFormat.get().timestampToOffsetDateTime(asString(), ZoneOffset.UTC);
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractColumnValue.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractColumnValue.java
@@ -6,11 +6,11 @@
 package io.debezium.connector.postgresql.connection;
 
 import java.sql.SQLException;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
-import java.time.ZoneOffset;
 
 import org.apache.kafka.connect.errors.ConnectException;
 import org.postgresql.geometric.PGbox;
@@ -55,8 +55,8 @@ public abstract class AbstractColumnValue<T> implements ReplicationMessage.Colum
     }
 
     @Override
-    public OffsetDateTime asOffsetDateTimeWithoutTimeZone() {
-        return DateTimeFormat.get().timestampToOffsetDateTime(asString(), ZoneOffset.UTC);
+    public Instant asInstant() {
+        return DateTimeFormat.get().timestampToInstant(asString());
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractColumnValue.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractColumnValue.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.time.ZoneOffset;
 
 import org.apache.kafka.connect.errors.ConnectException;
 import org.postgresql.geometric.PGbox;
@@ -45,13 +46,13 @@ public abstract class AbstractColumnValue<T> implements ReplicationMessage.Colum
     }
 
     @Override
-    public OffsetTime asOffsetTime() {
+    public OffsetTime asOffsetTimeUtc() {
         return DateTimeFormat.get().timeWithTimeZone(asString());
     }
 
     @Override
-    public OffsetDateTime asOffsetDateTime() {
-        return DateTimeFormat.get().timestampWithTimeZoneToOffsetDateTime(asString());
+    public OffsetDateTime asOffsetDateTimeAtUtc() {
+        return DateTimeFormat.get().timestampWithTimeZoneToOffsetDateTime(asString()).withOffsetSameInstant(ZoneOffset.UTC);
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
@@ -81,10 +81,10 @@ public interface ReplicationMessage {
         Double asDouble();
         SpecialValueDecimal asDecimal();
         LocalDate asLocalDate();
-        OffsetDateTime asOffsetDateTime();
+        OffsetDateTime asOffsetDateTimeAtUtc();
         Instant asInstant();
         LocalTime asLocalTime();
-        OffsetTime asOffsetTime();
+        OffsetTime asOffsetTimeUtc();
         byte[] asByteArray();
         PGbox asBox();
         PGcircle asCircle();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
@@ -82,7 +82,7 @@ public interface ReplicationMessage {
         SpecialValueDecimal asDecimal();
         LocalDate asLocalDate();
         OffsetDateTime asOffsetDateTime();
-        OffsetDateTime asOffsetDateTimeWithoutTimeZone();
+        Instant asInstant();
         LocalTime asLocalTime();
         OffsetTime asOffsetTime();
         byte[] asByteArray();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
@@ -6,7 +6,11 @@
 
 package io.debezium.connector.postgresql.connection;
 
-import java.time.*;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 import java.util.List;
 
 import org.postgresql.geometric.PGbox;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
@@ -6,10 +6,7 @@
 
 package io.debezium.connector.postgresql.connection;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.OffsetTime;
+import java.time.*;
 import java.util.List;
 
 import org.postgresql.geometric.PGbox;
@@ -80,8 +77,8 @@ public interface ReplicationMessage {
         Double asDouble();
         SpecialValueDecimal asDecimal();
         LocalDate asLocalDate();
-        long asTimestampWithTimeZone();
-        long asTimestampWithoutTimeZone();
+        OffsetDateTime asOffsetDateTime();
+        OffsetDateTime asOffsetDateTimeWithoutTimeZone();
         LocalTime asLocalTime();
         OffsetTime asOffsetTime();
         byte[] asByteArray();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessageColumnValueResolver.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessageColumnValueResolver.java
@@ -102,11 +102,11 @@ public class ReplicationMessageColumnValueResolver {
 
             case "timestamp with time zone":
             case "timestamptz":
-                return value.asTimestampWithTimeZone();
+                return value.asOffsetDateTime();
 
             case "timestamp":
             case "timestamp without time zone":
-                return value.asTimestampWithoutTimeZone();
+                return value.asOffsetDateTimeWithoutTimeZone();
 
             case "time":
                 return value.asString();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessageColumnValueResolver.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessageColumnValueResolver.java
@@ -102,7 +102,7 @@ public class ReplicationMessageColumnValueResolver {
 
             case "timestamp with time zone":
             case "timestamptz":
-                return value.asOffsetDateTime();
+                return value.asOffsetDateTimeAtUtc();
 
             case "timestamp":
             case "timestamp without time zone":
@@ -116,7 +116,7 @@ public class ReplicationMessageColumnValueResolver {
 
             case "time with time zone":
             case "timetz":
-                return value.asOffsetTime();
+                return value.asOffsetTimeUtc();
 
             case "bytea":
                 return value.asByteArray();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessageColumnValueResolver.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessageColumnValueResolver.java
@@ -106,7 +106,7 @@ public class ReplicationMessageColumnValueResolver {
 
             case "timestamp":
             case "timestamp without time zone":
-                return value.asOffsetDateTimeWithoutTimeZone();
+                return value.asInstant();
 
             case "time":
                 return value.asString();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
@@ -25,7 +25,6 @@ import io.debezium.document.Array.Entry;
 import io.debezium.document.Document;
 import io.debezium.document.DocumentReader;
 import io.debezium.document.Value;
-import io.debezium.time.Conversions;
 
 /**
  * A non-streaming version of JSON deserialization of a message sent by
@@ -55,7 +54,7 @@ public class NonStreamingWal2JsonMessageDecoder extends AbstractMessageDecoder {
             final Document message = DocumentReader.floatNumbersAsTextReader().read(content);
             final long txId = message.getLong("xid");
             final String timestamp = message.getString("timestamp");
-            final Instant commitTime = Conversions.toInstant(dateTime.systemTimestamp(timestamp));
+            final Instant commitTime = dateTime.systemTimestampToOffsetDateTime(timestamp).toInstant();
             final Array changes = message.getArray("change");
 
             // WAL2JSON may send empty changes that still have a txid. These events are from things like vacuum,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
@@ -54,7 +54,7 @@ public class NonStreamingWal2JsonMessageDecoder extends AbstractMessageDecoder {
             final Document message = DocumentReader.floatNumbersAsTextReader().read(content);
             final long txId = message.getLong("xid");
             final String timestamp = message.getString("timestamp");
-            final Instant commitTime = dateTime.systemTimestampToOffsetDateTime(timestamp).toInstant();
+            final Instant commitTime = dateTime.systemTimestampToInstant(timestamp);
             final Array changes = message.getArray("change");
 
             // WAL2JSON may send empty changes that still have a txid. These events are from things like vacuum,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
@@ -21,7 +21,6 @@ import io.debezium.connector.postgresql.connection.AbstractMessageDecoder;
 import io.debezium.connector.postgresql.connection.ReplicationStream.ReplicationMessageProcessor;
 import io.debezium.document.Document;
 import io.debezium.document.DocumentReader;
-import io.debezium.time.Conversions;
 
 /**
  * <p>JSON deserialization of a message sent by
@@ -146,7 +145,7 @@ public class StreamingWal2JsonMessageDecoder extends AbstractMessageDecoder {
                         // Correct initial chunk
                         txId = message.getLong("xid");
                         final String timestamp = message.getString("timestamp");
-                        commitTime = Conversions.toInstant(dateTime.systemTimestamp(timestamp));
+                        commitTime = dateTime.systemTimestampToOffsetDateTime(timestamp).toInstant();
                         messageInProgress = true;
                         currentChunk = null;
                     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
@@ -145,7 +145,7 @@ public class StreamingWal2JsonMessageDecoder extends AbstractMessageDecoder {
                         // Correct initial chunk
                         txId = message.getLong("xid");
                         final String timestamp = message.getString("timestamp");
-                        commitTime = dateTime.systemTimestampToOffsetDateTime(timestamp).toInstant();
+                        commitTime = dateTime.systemTimestampToInstant(timestamp);
                         messageInProgress = true;
                         currentChunk = null;
                     }
@@ -193,7 +193,7 @@ public class StreamingWal2JsonMessageDecoder extends AbstractMessageDecoder {
      * This issue is very hard to reproduce so a precaution is taken and metadata are filled with
      * synthetic values.
      * <p>The new wal2json format will be resilient to this situation.
-     * 
+     *
      * @param content
      */
     protected void outOfOrderChunk(final byte[] content) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/wal2json/ISODateTimeFormatTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/wal2json/ISODateTimeFormatTest.java
@@ -8,8 +8,10 @@ package io.debezium.connector.postgresql.connection.wal2json;
 import org.fest.assertions.Assertions;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.time.chrono.IsoEra;
@@ -20,29 +22,52 @@ public class ISODateTimeFormatTest {
     private static final String BCE_DISPLAY_NAME = IsoEra.BCE.getDisplayName(TextStyle.SHORT, Locale.getDefault());
 
     @Test
-    public void testTimestamp() {
-        Assertions.assertThat(DateTimeFormat.get().timestamp("2016-11-04 13:51:30")).isEqualTo(1478267490_000_000_000l);
-        Assertions.assertThat(DateTimeFormat.get().timestamp("2016-11-04 13:51:30.123")).isEqualTo(1478267490_123_000_000l);
-        Assertions.assertThat(DateTimeFormat.get().timestamp("2016-11-04 13:51:30.123000")).isEqualTo(1478267490_123_000_000l);
-        Assertions.assertThat(DateTimeFormat.get().timestamp("2016-11-04 13:51:30.123456")).isEqualTo(1478267490_123_456_000l);
-        Assertions.assertThat(DateTimeFormat.get().timestamp("2016-11-04 13:51:30.123456")).isEqualTo(1478267490_123_456_000l);
-        Assertions.assertThat(DateTimeFormat.get().timestamp("0002-12-01 17:00:00 " + BCE_DISPLAY_NAME)).isEqualTo(-6829604178_871_345_152l);
+    public void testTimestampToOffsetDateTime() {
+        ZoneOffset offset = ZoneOffset.UTC;
+        ZoneOffset otherOffset = ZoneOffset.ofHoursMinutes(2, 30);
+        Assertions.assertThat(DateTimeFormat.get().timestampToOffsetDateTime("2016-11-04 13:51:30", offset))
+                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 0, offset));
+        Assertions.assertThat(DateTimeFormat.get().timestampToOffsetDateTime("2016-11-04 13:51:30.123", offset))
+                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 123_000_000, offset));
+        Assertions.assertThat(DateTimeFormat.get().timestampToOffsetDateTime("2016-11-04 13:51:30.123000", offset))
+                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 123_000_000, offset));
+        Assertions.assertThat(DateTimeFormat.get().timestampToOffsetDateTime("2016-11-04 13:51:30.123456", offset))
+                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 123_456_000, offset));
+        Assertions.assertThat(DateTimeFormat.get().timestampToOffsetDateTime("2016-11-04 13:51:30.123456", offset))
+                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 123_456_000, offset));
+        Assertions.assertThat(DateTimeFormat.get().timestampToOffsetDateTime("0002-12-01 17:00:00 " + BCE_DISPLAY_NAME, offset))
+                .isEqualTo(OffsetDateTime.of(-1, 12, 1, 17, 0, 0, 0, offset));
+        Assertions.assertThat(DateTimeFormat.get().timestampToOffsetDateTime("20160-11-04 13:51:30.123456", offset))
+                .isEqualTo(OffsetDateTime.of(20160, 11, 4, 13, 51, 30, 123_456_000, offset));
+        Assertions.assertThat(DateTimeFormat.get().timestampToOffsetDateTime("20160-11-04 13:51:30.123456", otherOffset))
+                .isEqualTo(OffsetDateTime.of(20160, 11, 4, 13, 51, 30, 123_456_000, otherOffset));
     }
 
     @Test
-    public void testTimestampWithTimeZone() {
-        Assertions.assertThat(DateTimeFormat.get().timestampWithTimeZone("2016-11-04 13:51:30+02")).isEqualTo(1478260290_000_000_000l);
-        Assertions.assertThat(DateTimeFormat.get().timestampWithTimeZone("2016-11-04 13:51:30.123+02")).isEqualTo(1478260290_123_000_000l);
-        Assertions.assertThat(DateTimeFormat.get().timestampWithTimeZone("2016-11-04 13:51:30.123000+02")).isEqualTo(1478260290_123_000_000l);
-        Assertions.assertThat(DateTimeFormat.get().timestampWithTimeZone("2016-11-04 13:51:30.123789+02")).isEqualTo(1478260290_123_789_000l);
-        Assertions.assertThat(DateTimeFormat.get().timestampWithTimeZone("2016-11-04 13:51:30.123789+02:30")).isEqualTo(1478258490_123_789_000l);
-        Assertions.assertThat(DateTimeFormat.get().timestampWithTimeZone("2016-11-04 13:51:30.123789+02:30 " + BCE_DISPLAY_NAME)).isEqualTo(3399351806_090_650_312l);
+    public void testTimestampWithTimeZoneToOffsetTime() {
+        Assertions.assertThat(DateTimeFormat.get().timestampWithTimeZoneToOffsetDateTime("2016-11-04 13:51:30+02"))
+                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 0, ZoneOffset.ofHours(2)));
+        Assertions.assertThat(DateTimeFormat.get().timestampWithTimeZoneToOffsetDateTime("2016-11-04 13:51:30.123+02"))
+                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 123_000_000, ZoneOffset.ofHours(2)));
+        Assertions.assertThat(DateTimeFormat.get().timestampWithTimeZoneToOffsetDateTime("2016-11-04 13:51:30.123000+02"))
+                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 123_000_000, ZoneOffset.ofHours(2)));
+        Assertions.assertThat(DateTimeFormat.get().timestampWithTimeZoneToOffsetDateTime("2016-11-04 13:51:30.123789+02"))
+                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 123_789_000, ZoneOffset.ofHours(2)));
+        Assertions.assertThat(DateTimeFormat.get().timestampWithTimeZoneToOffsetDateTime("2016-11-04 13:51:30.123789+02:30"))
+                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 123_789_000, ZoneOffset.ofHoursMinutes(2, 30)));
+        Assertions.assertThat(DateTimeFormat.get().timestampWithTimeZoneToOffsetDateTime("2016-11-04 13:51:30.123789+02:30 " + BCE_DISPLAY_NAME))
+                .isEqualTo(OffsetDateTime.of(-2015, 11, 4, 13, 51, 30, 123_789_000, ZoneOffset.ofHoursMinutes(2, 30)));
+        Assertions.assertThat(DateTimeFormat.get().timestampWithTimeZoneToOffsetDateTime("20160-11-04 13:51:30.123789+02:30 " + BCE_DISPLAY_NAME))
+                .isEqualTo(OffsetDateTime.of(-20159, 11, 4, 13, 51, 30, 123_789_000, ZoneOffset.ofHoursMinutes(2, 30)));
     }
 
     @Test
     public void testDate() {
         Assertions.assertThat(DateTimeFormat.get().date("2016-11-04")).isEqualTo(LocalDate.of(2016, 11, 4));
         Assertions.assertThat(DateTimeFormat.get().date("2016-11-04 " + BCE_DISPLAY_NAME)).isEqualTo(LocalDate.of(-2015, 11, 4));
+        Assertions.assertThat(DateTimeFormat.get().date("20160-11-04")).isEqualTo(LocalDate.of(20160, 11, 4));
+        Assertions.assertThat(DateTimeFormat.get().date("20160-11-04 " + BCE_DISPLAY_NAME)).isEqualTo(LocalDate.of(-20159, 11, 4));
+        Assertions.assertThat(DateTimeFormat.get().date("12345678-11-04")).isEqualTo(LocalDate.of(12345678, 11, 4));
     }
 
     @Test
@@ -56,13 +81,14 @@ public class ISODateTimeFormatTest {
     }
 
     @Test
-    public void testSystemTimestamp() {
-        Assertions.assertThat(DateTimeFormat.get().systemTimestamp("2017-10-17 13:51:30Z")).isEqualTo(1508248290_000_000_000l);
-        Assertions.assertThat(DateTimeFormat.get().systemTimestamp("2017-10-17 13:51:30.000Z")).isEqualTo(1508248290_000_000_000l);
-        Assertions.assertThat(DateTimeFormat.get().systemTimestamp("2017-10-17 13:51:30.456Z")).isEqualTo(1508248290_456_000_000l);
-        Assertions.assertThat(DateTimeFormat.get().systemTimestamp("2017-10-17 13:51:30.345123Z")).isEqualTo(1508248290_345_123_000l);
-        Assertions.assertThat(DateTimeFormat.get().systemTimestamp("2018-03-22 12:30:56.824452+05:30")).isEqualTo(1521702056_824_452_000l);
-        Assertions.assertThat(DateTimeFormat.get().systemTimestamp("2018-03-22 12:30:56.824452+05")).isEqualTo(1521703856_824_452_000l);
+    public void testSystemTimestampToOffsetDateTime() {
+        Assertions.assertThat(DateTimeFormat.get().systemTimestampToOffsetDateTime("2017-10-17 13:51:30Z")).isEqualTo(OffsetDateTime.of(2017, 10, 17, 13, 51, 30, 0, ZoneOffset.UTC));
+        Assertions.assertThat(DateTimeFormat.get().systemTimestampToOffsetDateTime("2017-10-17 13:51:30.000Z")).isEqualTo(OffsetDateTime.of(2017, 10, 17, 13, 51, 30, 0, ZoneOffset.UTC));
+        Assertions.assertThat(DateTimeFormat.get().systemTimestampToOffsetDateTime("2017-10-17 13:51:30.456Z")).isEqualTo(OffsetDateTime.of(2017, 10, 17, 13, 51, 30, Duration.ofMillis(456).getNano(), ZoneOffset.UTC));
+        Assertions.assertThat(DateTimeFormat.get().systemTimestampToOffsetDateTime("2017-10-17 13:51:30.345123Z")).isEqualTo(OffsetDateTime.of(2017, 10, 17, 13, 51, 30, 345_123_000, ZoneOffset.UTC));
+        Assertions.assertThat(DateTimeFormat.get().systemTimestampToOffsetDateTime("2018-03-22 12:30:56.824452+05:30")).isEqualTo(OffsetDateTime.of(2018, 3, 22, 12, 30, 56, 824_452_000, ZoneOffset.ofHoursMinutes(5, 30)));
+        Assertions.assertThat(DateTimeFormat.get().systemTimestampToOffsetDateTime("2018-03-22 12:30:56.824452+05")).isEqualTo(OffsetDateTime.of(2018, 3, 22, 12, 30, 56, 824_452_000, ZoneOffset.ofHours(5)));
+        Assertions.assertThat(DateTimeFormat.get().systemTimestampToOffsetDateTime("20180-03-22 12:30:56.824452+05")).isEqualTo(OffsetDateTime.of(20180, 3, 22, 12, 30, 56, 824_452_000, ZoneOffset.ofHours(5)));
     }
 
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/wal2json/ISODateTimeFormatTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/wal2json/ISODateTimeFormatTest.java
@@ -5,9 +5,6 @@
  */
 package io.debezium.connector.postgresql.connection.wal2json;
 
-import org.fest.assertions.Assertions;
-import org.junit.Test;
-
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -18,29 +15,29 @@ import java.time.chrono.IsoEra;
 import java.time.format.TextStyle;
 import java.util.Locale;
 
+import org.fest.assertions.Assertions;
+import org.junit.Test;
+
 public class ISODateTimeFormatTest {
     private static final String BCE_DISPLAY_NAME = IsoEra.BCE.getDisplayName(TextStyle.SHORT, Locale.getDefault());
 
     @Test
-    public void testTimestampToOffsetDateTime() {
+    public void testTimestampToInstant() {
         ZoneOffset offset = ZoneOffset.UTC;
-        ZoneOffset otherOffset = ZoneOffset.ofHoursMinutes(2, 30);
-        Assertions.assertThat(DateTimeFormat.get().timestampToOffsetDateTime("2016-11-04 13:51:30", offset))
-                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 0, offset));
-        Assertions.assertThat(DateTimeFormat.get().timestampToOffsetDateTime("2016-11-04 13:51:30.123", offset))
-                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 123_000_000, offset));
-        Assertions.assertThat(DateTimeFormat.get().timestampToOffsetDateTime("2016-11-04 13:51:30.123000", offset))
-                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 123_000_000, offset));
-        Assertions.assertThat(DateTimeFormat.get().timestampToOffsetDateTime("2016-11-04 13:51:30.123456", offset))
-                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 123_456_000, offset));
-        Assertions.assertThat(DateTimeFormat.get().timestampToOffsetDateTime("2016-11-04 13:51:30.123456", offset))
-                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 123_456_000, offset));
-        Assertions.assertThat(DateTimeFormat.get().timestampToOffsetDateTime("0002-12-01 17:00:00 " + BCE_DISPLAY_NAME, offset))
-                .isEqualTo(OffsetDateTime.of(-1, 12, 1, 17, 0, 0, 0, offset));
-        Assertions.assertThat(DateTimeFormat.get().timestampToOffsetDateTime("20160-11-04 13:51:30.123456", offset))
-                .isEqualTo(OffsetDateTime.of(20160, 11, 4, 13, 51, 30, 123_456_000, offset));
-        Assertions.assertThat(DateTimeFormat.get().timestampToOffsetDateTime("20160-11-04 13:51:30.123456", otherOffset))
-                .isEqualTo(OffsetDateTime.of(20160, 11, 4, 13, 51, 30, 123_456_000, otherOffset));
+        Assertions.assertThat(DateTimeFormat.get().timestampToInstant("2016-11-04 13:51:30"))
+                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 0, offset).toInstant());
+        Assertions.assertThat(DateTimeFormat.get().timestampToInstant("2016-11-04 13:51:30.123"))
+                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 123_000_000, offset).toInstant());
+        Assertions.assertThat(DateTimeFormat.get().timestampToInstant("2016-11-04 13:51:30.123000"))
+                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 123_000_000, offset).toInstant());
+        Assertions.assertThat(DateTimeFormat.get().timestampToInstant("2016-11-04 13:51:30.123456"))
+                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 123_456_000, offset).toInstant());
+        Assertions.assertThat(DateTimeFormat.get().timestampToInstant("2016-11-04 13:51:30.123456"))
+                .isEqualTo(OffsetDateTime.of(2016, 11, 4, 13, 51, 30, 123_456_000, offset).toInstant());
+        Assertions.assertThat(DateTimeFormat.get().timestampToInstant("0002-12-01 17:00:00 " + BCE_DISPLAY_NAME))
+                .isEqualTo(OffsetDateTime.of(-1, 12, 1, 17, 0, 0, 0, offset).toInstant());
+        Assertions.assertThat(DateTimeFormat.get().timestampToInstant("20160-11-04 13:51:30.123456"))
+                .isEqualTo(OffsetDateTime.of(20160, 11, 4, 13, 51, 30, 123_456_000, offset).toInstant());
     }
 
     @Test
@@ -81,14 +78,13 @@ public class ISODateTimeFormatTest {
     }
 
     @Test
-    public void testSystemTimestampToOffsetDateTime() {
-        Assertions.assertThat(DateTimeFormat.get().systemTimestampToOffsetDateTime("2017-10-17 13:51:30Z")).isEqualTo(OffsetDateTime.of(2017, 10, 17, 13, 51, 30, 0, ZoneOffset.UTC));
-        Assertions.assertThat(DateTimeFormat.get().systemTimestampToOffsetDateTime("2017-10-17 13:51:30.000Z")).isEqualTo(OffsetDateTime.of(2017, 10, 17, 13, 51, 30, 0, ZoneOffset.UTC));
-        Assertions.assertThat(DateTimeFormat.get().systemTimestampToOffsetDateTime("2017-10-17 13:51:30.456Z")).isEqualTo(OffsetDateTime.of(2017, 10, 17, 13, 51, 30, Duration.ofMillis(456).getNano(), ZoneOffset.UTC));
-        Assertions.assertThat(DateTimeFormat.get().systemTimestampToOffsetDateTime("2017-10-17 13:51:30.345123Z")).isEqualTo(OffsetDateTime.of(2017, 10, 17, 13, 51, 30, 345_123_000, ZoneOffset.UTC));
-        Assertions.assertThat(DateTimeFormat.get().systemTimestampToOffsetDateTime("2018-03-22 12:30:56.824452+05:30")).isEqualTo(OffsetDateTime.of(2018, 3, 22, 12, 30, 56, 824_452_000, ZoneOffset.ofHoursMinutes(5, 30)));
-        Assertions.assertThat(DateTimeFormat.get().systemTimestampToOffsetDateTime("2018-03-22 12:30:56.824452+05")).isEqualTo(OffsetDateTime.of(2018, 3, 22, 12, 30, 56, 824_452_000, ZoneOffset.ofHours(5)));
-        Assertions.assertThat(DateTimeFormat.get().systemTimestampToOffsetDateTime("20180-03-22 12:30:56.824452+05")).isEqualTo(OffsetDateTime.of(20180, 3, 22, 12, 30, 56, 824_452_000, ZoneOffset.ofHours(5)));
+    public void testSystemTimestampToInstant() {
+        Assertions.assertThat(DateTimeFormat.get().systemTimestampToInstant("2017-10-17 13:51:30Z")).isEqualTo(OffsetDateTime.of(2017, 10, 17, 13, 51, 30, 0, ZoneOffset.UTC).toInstant());
+        Assertions.assertThat(DateTimeFormat.get().systemTimestampToInstant("2017-10-17 13:51:30.000Z")).isEqualTo(OffsetDateTime.of(2017, 10, 17, 13, 51, 30, 0, ZoneOffset.UTC).toInstant());
+        Assertions.assertThat(DateTimeFormat.get().systemTimestampToInstant("2017-10-17 13:51:30.456Z")).isEqualTo(OffsetDateTime.of(2017, 10, 17, 13, 51, 30, Duration.ofMillis(456).getNano(), ZoneOffset.UTC).toInstant());
+        Assertions.assertThat(DateTimeFormat.get().systemTimestampToInstant("2017-10-17 13:51:30.345123Z")).isEqualTo(OffsetDateTime.of(2017, 10, 17, 13, 51, 30, 345_123_000, ZoneOffset.UTC).toInstant());
+        Assertions.assertThat(DateTimeFormat.get().systemTimestampToInstant("2018-03-22 12:30:56.824452+05:30")).isEqualTo(OffsetDateTime.of(2018, 3, 22, 12, 30, 56, 824_452_000, ZoneOffset.ofHoursMinutes(5, 30)).toInstant());
+        Assertions.assertThat(DateTimeFormat.get().systemTimestampToInstant("2018-03-22 12:30:56.824452+05")).isEqualTo(OffsetDateTime.of(2018, 3, 22, 12, 30, 56, 824_452_000, ZoneOffset.ofHours(5)).toInstant());
+        Assertions.assertThat(DateTimeFormat.get().systemTimestampToInstant("20180-03-22 12:30:56.824452+05")).isEqualTo(OffsetDateTime.of(20180, 3, 22, 12, 30, 56, 824_452_000, ZoneOffset.ofHours(5)).toInstant());
     }
-
 }

--- a/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
+++ b/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
@@ -7,22 +7,31 @@ CREATE TABLE numeric_table (pk SERIAL, si SMALLINT, i INTEGER, bi BIGINT,
     r_pinf REAL, db_pinf DOUBLE PRECISION,
     r_ninf REAL, db_ninf DOUBLE PRECISION,
     ss SMALLSERIAL, bs BIGSERIAL, b BOOLEAN, PRIMARY KEY(pk));
+
 -- no suffix -fixed scale, zs - zero scale, vs - variable scale
 CREATE TABLE numeric_decimal_table (pk SERIAL,
-	d DECIMAL(3,2), dzs DECIMAL(4), dvs DECIMAL, d_nn DECIMAL(3,2) NOT NULL, n NUMERIC(6,4), nzs NUMERIC(4), nvs NUMERIC,
-	d_int DECIMAL(3,2), dzs_int DECIMAL(4), dvs_int DECIMAL, n_int NUMERIC(6,4), nzs_int NUMERIC(4), nvs_int NUMERIC,
-	d_nan DECIMAL(3,2), dzs_nan DECIMAL(4), dvs_nan DECIMAL, n_nan NUMERIC(6,4), nzs_nan NUMERIC(4), nvs_nan NUMERIC,
-	PRIMARY KEY(pk));
+    d DECIMAL(3,2), dzs DECIMAL(4), dvs DECIMAL, d_nn DECIMAL(3,2) NOT NULL, n NUMERIC(6,4), nzs NUMERIC(4), nvs NUMERIC,
+    d_int DECIMAL(3,2), dzs_int DECIMAL(4), dvs_int DECIMAL, n_int NUMERIC(6,4), nzs_int NUMERIC(4), nvs_int NUMERIC,
+    d_nan DECIMAL(3,2), dzs_nan DECIMAL(4), dvs_nan DECIMAL, n_nan NUMERIC(6,4), nzs_nan NUMERIC(4), nvs_nan NUMERIC,
+    PRIMARY KEY(pk));
+
 CREATE TABLE string_table (pk SERIAL, vc VARCHAR(2), vcv CHARACTER VARYING(2), ch CHARACTER(4), c CHAR(3), t TEXT, b BYTEA, bnn BYTEA NOT NULL, ct CITEXT, PRIMARY KEY(pk));
 CREATE TABLE network_address_table (pk SERIAL, i INET, PRIMARY KEY(pk));
 CREATE TABLE cidr_network_address_table (pk SERIAL, i CIDR, PRIMARY KEY(pk));
 CREATE TABLE macaddr_table(pk SERIAL, m MACADDR, PRIMARY KEY(pk));
 CREATE TABLE cash_table (pk SERIAL, csh MONEY, PRIMARY KEY(pk));
 CREATE TABLE bitbin_table (pk SERIAL, ba BYTEA, bol BIT(1), bs BIT(2), bv BIT VARYING(2) , PRIMARY KEY(pk));
+
 CREATE TABLE time_table (pk SERIAL, ts TIMESTAMP, tsneg TIMESTAMP(6) WITHOUT TIME ZONE, ts_ms TIMESTAMP(3), ts_us TIMESTAMP(6), tz TIMESTAMPTZ, date DATE,
     ti TIME, tip TIME(3), ttf TIME,
     ttz TIME WITH TIME ZONE, tptz TIME(3) WITH TIME ZONE,
-    it INTERVAL, tsp TIMESTAMP (0) WITH TIME ZONE, PRIMARY KEY(pk));
+    it INTERVAL, tsp TIMESTAMP (0) WITH TIME ZONE,
+    ts_large TIMESTAMP,
+    ts_large_us TIMESTAMP(6),
+    ts_large_ms TIMESTAMP(3),
+    tz_large TIMESTAMPTZ,
+    PRIMARY KEY(pk));
+
 CREATE TABLE text_table (pk SERIAL, j JSON, jb JSONB, x XML, u Uuid, PRIMARY KEY(pk));
 CREATE TABLE geom_table (pk SERIAL, p POINT, PRIMARY KEY(pk));
 CREATE TABLE range_table (pk SERIAL, unbounded_exclusive_tsrange TSRANGE, bounded_inclusive_tsrange TSRANGE, unbounded_exclusive_tstzrange TSTZRANGE, bounded_inclusive_tstzrange TSTZRANGE, unbounded_exclusive_daterange DATERANGE, bounded_exclusive_daterange DATERANGE, int4_number_range INT4RANGE, numerange NUMRANGE, int8_number_range INT8RANGE, PRIMARY KEY(pk));

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
@@ -544,7 +544,7 @@ public class JdbcValueConverters implements ValueConverterProvider {
         // epoch is the fallback value
         return convertValue(column, fieldDefn, data, 0, (r) -> {
             try {
-                r.deliver(Time.toMilliOfDay(data, adjuster));
+                r.deliver(Time.toMilliOfDay(data, supportsLargeTimeValues()));
             } catch (IllegalArgumentException e) {
             }
         });
@@ -569,7 +569,7 @@ public class JdbcValueConverters implements ValueConverterProvider {
         // epoch is the fallback value
         return convertValue(column, fieldDefn, data, 0L, (r) -> {
             try {
-                r.deliver(MicroTime.toMicroOfDay(data, adjuster));
+                r.deliver(MicroTime.toMicroOfDay(data, supportsLargeTimeValues()));
             } catch (IllegalArgumentException e) {
             }
         });
@@ -594,7 +594,7 @@ public class JdbcValueConverters implements ValueConverterProvider {
         // epoch is the fallback value
         return convertValue(column, fieldDefn, data, 0L, (r) -> {
             try {
-                r.deliver(NanoTime.toNanoOfDay(data, adjuster));
+                r.deliver(NanoTime.toNanoOfDay(data, supportsLargeTimeValues()));
             } catch (IllegalArgumentException e) {
             }
         });
@@ -619,7 +619,7 @@ public class JdbcValueConverters implements ValueConverterProvider {
         // epoch is the fallback value
         return convertValue(column, fieldDefn, data, new java.util.Date(0L), (r) -> {
             try {
-                r.deliver(new java.util.Date(Time.toMilliOfDay(data, adjuster)));
+                r.deliver(new java.util.Date(Time.toMilliOfDay(data, supportsLargeTimeValues())));
             } catch (IllegalArgumentException e) {
             }
         });
@@ -1212,5 +1212,9 @@ public class JdbcValueConverters implements ValueConverterProvider {
         logger.trace("Callback is: {}", callback);
         logger.trace("Value from ResultReceiver: {}", r);
         return r.hasReceived() ? r.get() : handleUnknownData(column, fieldDefn, data);
+    }
+
+    private boolean supportsLargeTimeValues() {
+        return adaptiveTimePrecisionMode  || adaptiveTimeMicrosecondsPrecisionMode;
     }
 }

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
@@ -318,19 +318,7 @@ public class JdbcValueConverters implements ValueConverterProvider {
                 }
                 return (data) -> convertDateToEpochDaysAsDate(column, fieldDefn, data);
             case Types.TIME:
-                if(adaptiveTimeMicrosecondsPrecisionMode) {
-                    return data -> convertTimeToMicrosPastMidnight(column, fieldDefn, data);
-                }
-                if (adaptiveTimePrecisionMode) {
-                    if (getTimePrecision(column) <= 3) {
-                        return data -> convertTimeToMillisPastMidnight(column, fieldDefn, data);
-                    }
-                    if (getTimePrecision(column) <= 6) {
-                        return data -> convertTimeToMicrosPastMidnight(column, fieldDefn, data);
-                    }
-                    return (data) -> convertTimeToNanosPastMidnight(column, fieldDefn, data);
-                }
-                return (data) -> convertTimeToMillisPastMidnightAsDate(column, fieldDefn, data);
+                return (data) -> convertTime(column, fieldDefn, data);
             case Types.TIMESTAMP:
                 if (adaptiveTimePrecisionMode || adaptiveTimeMicrosecondsPrecisionMode) {
                     if (getTimePrecision(column) <= 3) {
@@ -420,6 +408,25 @@ public class JdbcValueConverters implements ValueConverterProvider {
             } catch (IllegalArgumentException e) {
             }
         });
+    }
+
+    protected Object convertTime(Column column, Field fieldDefn, Object data) {
+        if(adaptiveTimeMicrosecondsPrecisionMode) {
+            return convertTimeToMicrosPastMidnight(column, fieldDefn, data);
+        }
+        if (adaptiveTimePrecisionMode) {
+            if (getTimePrecision(column) <= 3) {
+                return convertTimeToMillisPastMidnight(column, fieldDefn, data);
+            }
+            if (getTimePrecision(column) <= 6) {
+                return convertTimeToMicrosPastMidnight(column, fieldDefn, data);
+            }
+            return convertTimeToNanosPastMidnight(column, fieldDefn, data);
+        }
+        // "connect" mode
+        else {
+            return convertTimeToMillisPastMidnightAsDate(column, fieldDefn, data);
+        }
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/time/Conversions.java
+++ b/debezium-core/src/main/java/io/debezium/time/Conversions.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.concurrent.TimeUnit;
 
@@ -119,6 +120,12 @@ public final class Conversions {
     protected static LocalDateTime toLocalDateTime(Object obj) {
         if ( obj == null ) {
             return null;
+        }
+        if (obj instanceof OffsetDateTime) {
+            return ((OffsetDateTime) obj).toLocalDateTime();
+        }
+        if (obj instanceof Instant) {
+            return ((Instant) obj).atOffset(ZoneOffset.UTC).toLocalDateTime();
         }
         if ( obj instanceof LocalDateTime) {
             return (LocalDateTime) obj;

--- a/debezium-core/src/main/java/io/debezium/time/Conversions.java
+++ b/debezium-core/src/main/java/io/debezium/time/Conversions.java
@@ -181,8 +181,4 @@ public final class Conversions {
                 TimeUnit.MICROSECONDS.toNanos(microsSinceEpoch % TimeUnit.SECONDS.toMicros(1))
         );
     }
-
-    public static Instant toInstantFromMillis(long epochMillis) {
-        return toInstant(TimeUnit.MILLISECONDS.toNanos(epochMillis));
-    }
 }

--- a/debezium-core/src/main/java/io/debezium/time/Conversions.java
+++ b/debezium-core/src/main/java/io/debezium/time/Conversions.java
@@ -109,10 +109,6 @@ public final class Conversions {
                 throw new IllegalArgumentException("Time values must use number of milliseconds greater than 0 and less than 86400000000000");
             }
         }
-        if ( obj instanceof Long) {
-            // Assume the value is the epoch day number
-            return LocalTime.ofNanoOfDay((Long) obj);
-        }
         throw new IllegalArgumentException("Unable to convert to LocalTime from unexpected value '" + obj + "' of type " + obj.getClass().getName());
     }
 
@@ -175,83 +171,15 @@ public final class Conversions {
         throw new IllegalArgumentException("Unable to convert to LocalTime from unexpected value '" + obj + "' of type " + obj.getClass().getName());
     }
 
-    /**
-     * Get the number of nanoseconds past epoch of the given {@link LocalDateTime}.
-     *
-     * @param timestamp the Java timestamp value
-     * @return the epoch nanoseconds
-     */
-    static long toEpochNanos(LocalDateTime timestamp) {
-        long nanoInDay = timestamp.toLocalTime().toNanoOfDay();
-        long nanosOfDay = toEpochNanos(timestamp.toLocalDate());
-        return nanosOfDay + nanoInDay;
-    }
-
-    /**
-     * Get the number of nanoseconds past epoch of the given {@link LocalDate}.
-     *
-     * @param date the Java date value
-     * @return the epoch nanoseconds
-     */
-    static long toEpochNanos(LocalDate date) {
-        long epochDay = date.toEpochDay();
-        return epochDay * Conversions.NANOSECONDS_PER_DAY;
-    }
-
-    /**
-     * Get the UTC-based {@link LocalDateTime} for given microseconds epoch
-     *
-     * @param microseconds - timestamp in microseconds
-     * @return timestamp in UTC timezone
-     */
-    public static LocalDateTime toLocalDateTimeUTC(long microseconds) {
-        long seconds = microseconds / MICROSECONDS_PER_SECOND;
-        // typecasting is safe as microseconds and nanoseconds in second fit in int range
-        int microsecondsOfSecond = (int) (microseconds % MICROSECONDS_PER_SECOND);
-        if (microsecondsOfSecond < 0) {
-            seconds--;
-            microsecondsOfSecond = (int) Conversions.MICROSECONDS_PER_SECOND + microsecondsOfSecond;
-        }
-        return LocalDateTime.ofEpochSecond(seconds, (int) (microsecondsOfSecond * NANOSECONDS_PER_MICROSECOND), ZoneOffset.UTC);
-    }
-
-    /**
-     * Get the UTC-based {@link LocalDateTime} for given nanoseconds epoch
-     *
-     * @param nanoseconds - timestamp in nanoseconds
-     * @return timestamp in UTC timezone
-     */
-    public static LocalDateTime fromNanosToLocalDateTimeUTC(long nanoseconds) {
-        long seconds = nanoseconds / NANOSECONDS_PER_SECOND;
-        // typecasting is safe as microseconds and nanoseconds in second fit in int range
-        int nanosecondsOfSecond = (int) (nanoseconds % NANOSECONDS_PER_SECOND);
-        if (nanosecondsOfSecond < 0) {
-            seconds--;
-            nanosecondsOfSecond = (int) Conversions.NANOSECONDS_PER_SECOND + nanosecondsOfSecond;
-        }
-        return LocalDateTime.ofEpochSecond(seconds, nanosecondsOfSecond, ZoneOffset.UTC);
-    }
-
-    /**
-     * Get the number of nanoseconds past epoch of the given {@link Instant}.
-     *
-     * @param instant the Java instant value
-     * @return the epoch nanoseconds
-     */
-    public static long toEpochNanos(Instant instant) {
-        return TimeUnit.NANOSECONDS.convert(instant.getEpochSecond() * MICROSECONDS_PER_SECOND + instant.getNano() / NANOSECONDS_PER_MICROSECOND, TimeUnit.MICROSECONDS);
-    }
-
     public static long toEpochMicros(Instant instant) {
         return TimeUnit.SECONDS.toMicros(instant.getEpochSecond()) + TimeUnit.NANOSECONDS.toMicros(instant.getNano());
     }
 
-    public static Instant toInstant(long epochNanos) {
-        return Instant.ofEpochSecond(0, epochNanos);
-    }
-
-    public static Instant toInstantFromMicros(long epochMicros) {
-        return toInstant(TimeUnit.MICROSECONDS.toNanos(epochMicros));
+    public static Instant toInstantFromMicros(long microsSinceEpoch) {
+        return Instant.ofEpochSecond(
+                TimeUnit.MICROSECONDS.toSeconds(microsSinceEpoch),
+                TimeUnit.MICROSECONDS.toNanos(microsSinceEpoch % TimeUnit.SECONDS.toMicros(1))
+        );
     }
 
     public static Instant toInstantFromMillis(long epochMillis) {

--- a/debezium-core/src/main/java/io/debezium/time/MicroTime.java
+++ b/debezium-core/src/main/java/io/debezium/time/MicroTime.java
@@ -67,7 +67,7 @@ public class MicroTime {
     public static long toMicroOfDay(Object value, TemporalAdjuster adjuster) {
         // conversion to nanos is fine as TIME values won't exceed long range
         if (value instanceof Duration) {
-            return ((Duration)value).toNanos() / 1_000;
+            return ((Duration) value).toNanos() / 1_000;
         }
 
         LocalTime time = Conversions.toLocalTime(value);

--- a/debezium-core/src/main/java/io/debezium/time/MicroTime.java
+++ b/debezium-core/src/main/java/io/debezium/time/MicroTime.java
@@ -7,7 +7,6 @@ package io.debezium.time;
 
 import java.time.Duration;
 import java.time.LocalTime;
-import java.time.temporal.TemporalAdjuster;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -24,6 +23,8 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 public class MicroTime {
 
     public static final String SCHEMA_NAME = "io.debezium.time.MicroTime";
+
+    private static final Duration ONE_DAY = Duration.ofDays(1);
 
     /**
      * Returns a {@link SchemaBuilder} for a {@link MicroTime}. The resulting schema will describe a field
@@ -54,26 +55,27 @@ public class MicroTime {
     }
 
     /**
-     * Get the number of microseconds past midnight of the given {@link java.time.LocalDateTime}, {@link java.time.LocalDate},
-     * {@link java.time.LocalTime}, {@link java.util.Date}, {@link java.sql.Date}, {@link java.sql.Time}, or
-     * {@link java.sql.Timestamp}, ignoring any date portions of the supplied value.
+     * Get the number of microseconds past midnight of the given {@link Duration}.
      *
-     * @param value the local or SQL date, time, or timestamp value; may not be null
-     * @param adjuster the optional component that adjusts the local date value before obtaining the epoch day; may be null if no
-     * adjustment is necessary
-     * @return the microseconds past midnight
-     * @throws IllegalArgumentException if the value is not an instance of the acceptable types
+     * @param value the duration value; may not be null
+     * @param acceptLargeValues whether to accept values less than 00:00:00 and larger than 24:00:00 or not
+     * @return the milliseconds past midnight
+     * @throws IllegalArgumentException if the value is not an instance of the acceptable types or it is out of the supported range
      */
-    public static long toMicroOfDay(Object value, TemporalAdjuster adjuster) {
-        // conversion to nanos is fine as TIME values won't exceed long range
+    public static long toMicroOfDay(Object value, boolean acceptLargeValues) {
         if (value instanceof Duration) {
+            Duration duration = (Duration) value;
+            if (!acceptLargeValues && (duration.isNegative() || duration.compareTo(ONE_DAY) > 0)) {
+                throw new IllegalArgumentException("Time values must be between 00:00:00 and 24:00:00 (inclusive): " + duration);
+            }
+
+            // conversion to nanos is fine as TIME values won't exceed long range
             return ((Duration) value).toNanos() / 1_000;
         }
 
+        // TODO only needed for SQL Server/Oracle, where we don't produce Duration right away;
+        // this should go eventually, as the conversion to LocalTime is superfluous
         LocalTime time = Conversions.toLocalTime(value);
-        if (adjuster != null) {
-            time = time.with(adjuster);
-        }
         return Math.floorDiv(time.toNanoOfDay(), Conversions.NANOSECONDS_PER_MICROSECOND);
     }
 

--- a/debezium-core/src/main/java/io/debezium/time/MicroTimestamp.java
+++ b/debezium-core/src/main/java/io/debezium/time/MicroTimestamp.java
@@ -6,6 +6,7 @@
 package io.debezium.time;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.TemporalAdjuster;
 
 import org.apache.kafka.connect.data.Schema;
@@ -15,7 +16,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
  * A utility for converting various Java time representations into the signed {@link SchemaBuilder#int64() INT64} number of
  * <em>microseconds</em> past epoch, and for defining a Kafka Connect {@link Schema} for timestamp values with no timezone
  * information.
- * 
+ *
  * @author Randall Hauch
  * @see Timestamp
  * @see NanoTimestamp
@@ -32,7 +33,7 @@ public class MicroTimestamp {
      * <p>
      * You can use the resulting SchemaBuilder to set or override additional schema settings such as required/optional, default
      * value, and documentation.
-     * 
+     *
      * @return the schema builder
      */
     public static SchemaBuilder builder() {
@@ -45,7 +46,7 @@ public class MicroTimestamp {
      * Returns a Schema for a {@link MicroTimestamp} but with all other default Schema settings. The schema describes a field
      * with the {@value #SCHEMA_NAME} as the {@link Schema#name() name} and {@link SchemaBuilder#int64() INT64} for the literal
      * type storing the number of <em>microseconds</em> past midnight.
-     * 
+     *
      * @return the schema
      * @see #builder()
      */
@@ -57,7 +58,7 @@ public class MicroTimestamp {
      * Get the number of microseconds past epoch of the given {@link java.time.LocalDateTime}, {@link java.time.LocalDate},
      * {@link java.time.LocalTime}, {@link java.util.Date}, {@link java.sql.Date}, {@link java.sql.Time}, or
      * {@link java.sql.Timestamp}.
-     * 
+     *
      * @param value the local or SQL date, time, or timestamp value; may not be null
      * @param adjuster the optional component that adjusts the local date value before obtaining the epoch day; may be null if no
      * adjustment is necessary
@@ -69,8 +70,7 @@ public class MicroTimestamp {
         if (adjuster != null) {
             dateTime = dateTime.with(adjuster);
         }
-        long epochNanos = Conversions.toEpochNanos(dateTime);
-        return Math.floorDiv(epochNanos, Conversions.NANOSECONDS_PER_MICROSECOND);
+        return Conversions.toEpochMicros(dateTime.toInstant(ZoneOffset.UTC));
     }
 
     private MicroTimestamp() {

--- a/debezium-core/src/main/java/io/debezium/time/NanoTime.java
+++ b/debezium-core/src/main/java/io/debezium/time/NanoTime.java
@@ -5,8 +5,8 @@
  */
 package io.debezium.time;
 
+import java.time.Duration;
 import java.time.LocalTime;
-import java.time.temporal.TemporalAdjuster;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -15,7 +15,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
  * A utility for converting various Java time representations into the {@link SchemaBuilder#int64() INT64} number of
  * <em>nanoseconds</em> since midnight, and for defining a Kafka Connect {@link Schema} for time values with no date or timezone
  * information.
- * 
+ *
  * @author Randall Hauch
  * @see Time
  * @see MicroTime
@@ -30,6 +30,8 @@ public class NanoTime {
 
     public static final String SCHEMA_NAME = "io.debezium.time.NanoTime";
 
+    private static final Duration ONE_DAY = Duration.ofDays(1);
+
     /**
      * Returns a {@link SchemaBuilder} for a {@link NanoTime}. The resulting schema will describe a field
      * with the {@value #SCHEMA_NAME} as the {@link Schema#name() name} and {@link SchemaBuilder#int64() INT64} for the literal
@@ -37,7 +39,7 @@ public class NanoTime {
      * <p>
      * You can use the resulting SchemaBuilder to set or override additional schema settings such as required/optional, default
      * value, and documentation.
-     * 
+     *
      * @return the schema builder
      */
     public static SchemaBuilder builder() {
@@ -50,7 +52,7 @@ public class NanoTime {
      * Returns a Schema for a {@link NanoTime} but with all other default Schema settings. The schema describes a field
      * with the {@value #SCHEMA_NAME} as the {@link Schema#name() name} and {@link SchemaBuilder#int64() INT64} for the literal
      * type storing the number of <em>nanoseconds</em> past midnight.
-     * 
+     *
      * @return the schema
      * @see #builder()
      */
@@ -59,21 +61,26 @@ public class NanoTime {
     }
 
     /**
-     * Get the number of nanoseconds past midnight of the given {@link java.time.LocalDateTime}, {@link java.time.LocalDate},
-     * {@link java.time.LocalTime}, {@link java.util.Date}, {@link java.sql.Date}, {@link java.sql.Time}, or
-     * {@link java.sql.Timestamp}, ignoring any date portions of the supplied value.
-     * 
-     * @param value the local or SQL date, time, or timestamp value; may not be null
-     * @param adjuster the optional component that adjusts the local date value before obtaining the epoch day; may be null if no
-     * adjustment is necessary
-     * @return the nanoseconds past midnight
-     * @throws IllegalArgumentException if the value is not an instance of the acceptable types
+     * Get the number of nanoseconds past midnight of the given {@link Duration}.
+     *
+     * @param value the duration value; may not be null
+     * @param acceptLargeValues whether to accept values less than 00:00:00 and larger than 24:00:00 or not
+     * @return the milliseconds past midnight
+     * @throws IllegalArgumentException if the value is not an instance of the acceptable types or it is out of the supported range
      */
-    public static long toNanoOfDay(Object value, TemporalAdjuster adjuster) {
-        LocalTime time = Conversions.toLocalTime(value);
-        if (adjuster !=null) {
-            time = time.with(adjuster);
+    public static long toNanoOfDay(Object value, boolean acceptLargeValues) {
+        if (value instanceof Duration) {
+            Duration duration = (Duration) value;
+            if (!acceptLargeValues && (duration.isNegative() || duration.compareTo(ONE_DAY) > 0)) {
+                throw new IllegalArgumentException("Time values must be between 00:00:00 and 24:00:00 (inclusive): " + duration);
+            }
+
+            return ((Duration) value).toNanos();
         }
+
+        // TODO only needed for SQL Server/Oracle, where we don't produce Duration right away;
+        // this should go eventually, as the conversion to LocalTime is superfluous
+        LocalTime time = Conversions.toLocalTime(value);
         return time.toNanoOfDay();
     }
 

--- a/debezium-core/src/main/java/io/debezium/time/NanoTimestamp.java
+++ b/debezium-core/src/main/java/io/debezium/time/NanoTimestamp.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.time;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjuster;
 
@@ -15,7 +16,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
  * A utility for converting various Java time representations into the signed {@link SchemaBuilder#int64() INT64} number of
  * <em>nanoseconds</em> past epoch, and for defining a Kafka Connect {@link Schema} for timestamp values with no timezone
  * information.
- * 
+ *
  * @author Randall Hauch
  * @see Timestamp
  * @see MicroTimestamp
@@ -32,7 +33,7 @@ public class NanoTimestamp {
      * <p>
      * You can use the resulting SchemaBuilder to set or override additional schema settings such as required/optional, default
      * value, and documentation.
-     * 
+     *
      * @return the schema builder
      */
     public static SchemaBuilder builder() {
@@ -45,7 +46,7 @@ public class NanoTimestamp {
      * Returns a Schema for a {@link NanoTimestamp} but with all other default Schema settings. The schema describes a field
      * with the {@value #SCHEMA_NAME} as the {@link Schema#name() name} and {@link SchemaBuilder#int64() INT64} for the literal
      * type storing the number of <em>nanoseconds</em> past midnight.
-     * 
+     *
      * @return the schema
      * @see #builder()
      */
@@ -57,7 +58,7 @@ public class NanoTimestamp {
      * Get the number of nanoseconds past epoch of the given {@link java.time.LocalDateTime}, {@link java.time.LocalDate},
      * {@link java.time.LocalTime}, {@link java.util.Date}, {@link java.sql.Date}, {@link java.sql.Time}, or
      * {@link java.sql.Timestamp}.
-     * 
+     *
      * @param value the local or SQL date, time, or timestamp value; may not be null
      * @param adjuster the optional component that adjusts the local date value before obtaining the epoch day; may be null if no
      * adjustment is necessary
@@ -69,7 +70,30 @@ public class NanoTimestamp {
         if ( adjuster != null) {
             dateTime = dateTime.with(adjuster);
         }
-        return Conversions.toEpochNanos(dateTime);
+        return toEpochNanos(dateTime);
+    }
+
+    /**
+     * Get the number of nanoseconds past epoch of the given {@link LocalDateTime}.
+     *
+     * @param timestamp the Java timestamp value
+     * @return the epoch nanoseconds
+     */
+    private static long toEpochNanos(LocalDateTime timestamp) {
+        long nanoInDay = timestamp.toLocalTime().toNanoOfDay();
+        long nanosOfDay = toEpochNanos(timestamp.toLocalDate());
+        return nanosOfDay + nanoInDay;
+    }
+
+    /**
+     * Get the number of nanoseconds past epoch of the given {@link LocalDate}.
+     *
+     * @param date the Java date value
+     * @return the epoch nanoseconds
+     */
+    private static long toEpochNanos(LocalDate date) {
+        long epochDay = date.toEpochDay();
+        return epochDay * Conversions.NANOSECONDS_PER_DAY;
     }
 
     private NanoTimestamp() {

--- a/debezium-core/src/main/java/io/debezium/time/Time.java
+++ b/debezium-core/src/main/java/io/debezium/time/Time.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.time;
 
+import java.time.Duration;
 import java.time.LocalTime;
 import java.time.temporal.TemporalAdjuster;
 
@@ -15,7 +16,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
  * A utility for converting various Java time representations into the {@link SchemaBuilder#int32() INT32} number of
  * <em>milliseconds</em> since midnight, and for defining a Kafka Connect {@link Schema} for time values with no date or timezone
  * information.
- * 
+ *
  * @author Randall Hauch
  * @see MicroTime
  * @see NanoTime
@@ -31,7 +32,7 @@ public class Time {
      * <p>
      * You can use the resulting SchemaBuilder to set or override additional schema settings such as required/optional, default
      * value, and documentation.
-     * 
+     *
      * @return the schema builder
      */
     public static SchemaBuilder builder() {
@@ -44,7 +45,7 @@ public class Time {
      * Returns a Schema for a {@link Time} but with all other default Schema settings. The schema describes a field
      * with the {@value #SCHEMA_NAME} as the {@link Schema#name() name} and {@link SchemaBuilder#int32() INT32} for the literal
      * type storing the number of <em>milliseconds</em> past midnight.
-     * 
+     *
      * @return the schema
      * @see #builder()
      */
@@ -56,7 +57,7 @@ public class Time {
      * Get the number of milliseconds past midnight of the given {@link java.time.LocalDateTime}, {@link java.time.LocalDate},
      * {@link java.time.LocalTime}, {@link java.util.Date}, {@link java.sql.Date}, {@link java.sql.Time}, or
      * {@link java.sql.Timestamp}, ignoring any date portions of the supplied value.
-     * 
+     *
      * @param value the local or SQL date, time, or timestamp value; may not be null
      * @param adjuster the optional component that adjusts the local date value before obtaining the epoch day; may be null if no
      * adjustment is necessary
@@ -64,6 +65,10 @@ public class Time {
      * @throws IllegalArgumentException if the value is not an instance of the acceptable types
      */
     public static int toMilliOfDay(Object value, TemporalAdjuster adjuster) {
+        if (value instanceof Duration) {
+            // int conversion is ok for the range of TIME
+            return (int) ((Duration) value).toMillis();
+        }
         LocalTime time = Conversions.toLocalTime(value);
         if (adjuster != null) {
             time = time.with(adjuster);

--- a/debezium-core/src/main/java/io/debezium/time/Timestamp.java
+++ b/debezium-core/src/main/java/io/debezium/time/Timestamp.java
@@ -6,6 +6,7 @@
 package io.debezium.time;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.TemporalAdjuster;
 
 import org.apache.kafka.connect.data.Schema;
@@ -15,7 +16,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
  * A utility for converting various Java time representations into the signed {@link SchemaBuilder#int64() INT64} number of
  * <em>milliseconds</em> past epoch, and for defining a Kafka Connect {@link Schema} for timestamp values with no timezone
  * information.
- * 
+ *
  * @author Randall Hauch
  * @see MicroTimestamp
  * @see NanoTimestamp
@@ -32,7 +33,7 @@ public class Timestamp {
      * <p>
      * You can use the resulting SchemaBuilder to set or override additional schema settings such as required/optional, default
      * value, and documentation.
-     * 
+     *
      * @return the schema builder
      */
     public static SchemaBuilder builder() {
@@ -45,7 +46,7 @@ public class Timestamp {
      * Returns a Schema for a {@link Timestamp} but with all other default Schema settings. The schema describes a field
      * with the {@value #SCHEMA_NAME} as the {@link Schema#name() name} and {@link SchemaBuilder#int64() INT64} for the literal
      * type storing the number of <em>milliseconds</em> past midnight.
-     * 
+     *
      * @return the schema
      * @see #builder()
      */
@@ -57,7 +58,7 @@ public class Timestamp {
      * Get the number of milliseconds past epoch of the given {@link java.time.LocalDateTime}, {@link java.time.LocalDate},
      * {@link java.time.LocalTime}, {@link java.util.Date}, {@link java.sql.Date}, {@link java.sql.Time}, or
      * {@link java.sql.Timestamp}.
-     * 
+     *
      * @param value the local or SQL date, time, or timestamp value; may not be null
      * @param adjuster the optional component that adjusts the local date value before obtaining the epoch day; may be null if no
      * adjustment is necessary
@@ -72,8 +73,8 @@ public class Timestamp {
         if (adjuster != null) {
             dateTime = dateTime.with(adjuster);
         }
-        long epochNanos = Conversions.toEpochNanos(dateTime);
-        return Math.floorDiv(epochNanos, Conversions.NANOSECONDS_PER_MILLISECOND);
+
+        return dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
     }
 
     private Timestamp() {


### PR DESCRIPTION
Supersedes https://github.com/debezium/debezium/pull/992

Took the value overflow issue as an opportunity for a larger clean-up.

* Generally avoiding conversion to nano-seconds to accomodate for larger values
* Generally avoiding the usage of long to convey temporal values internally:
  * Instant is used for TIMESTAMP
  * OffsetDateTime for TIMESTAMPTZ
  * Duration for TIME (LocalTime cannot be used as it doesn't support 24:00:00 as possible with Postgres)
  * OffsetTime for TIMETZ
* Avoiding usage of methods under test for calculating expected values in tests