### PR TITLE
Fix InterruptedException handling

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoUtil.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoUtil.java
@@ -153,7 +153,7 @@ public class MongoUtil {
                     try {
                         documentOperation.accept(cursor.next());
                     } catch (InterruptedException e) {
-                        Thread.interrupted();
+                        Thread.currentThread().interrupt();
                         break;
                     }
                 }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSetMonitorThread.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSetMonitorThread.java
@@ -110,7 +110,7 @@ public final class ReplicaSetMonitorThread implements Runnable {
                 return replicaSets;
             }
         } catch (InterruptedException e) {
-            Thread.interrupted(); // but do nothing else
+            Thread.currentThread().interrupt(); // but do nothing else
         }
         return null;
     }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
@@ -343,7 +343,7 @@ public class Replicator {
         try {
             latch.await();
         } catch (InterruptedException e) {
-            Thread.interrupted();
+            Thread.currentThread().interrupt();
             aborted.set(true);
         }
         this.copyThreads.shutdown();
@@ -566,7 +566,7 @@ public class Replicator {
                 try {
                     factory.recordEvent(event, clock.currentTimeInMillis());
                 } catch (InterruptedException e) {
-                    Thread.interrupted();
+                    Thread.currentThread().interrupt();
                     return false;
                 }
             }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -528,7 +528,7 @@ public class BinlogReader extends AbstractReader {
             logger.info("Error processing binlog event, and propagating to Kafka Connect so it stops this connector. Future binlog events read before connector is shutdown will be ignored.");
         } catch (InterruptedException e) {
             // Most likely because this reader was stopped and our thread was interrupted ...
-            Thread.interrupted();
+            Thread.currentThread().interrupt();
             eventHandlers.clear();
             logger.info("Stopped processing binlog events due to thread interruption");
         }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -266,7 +266,7 @@ public final class MySqlConnectorTask extends BaseSourceTask {
                 logger.error("Failed to start the connector (see other exception), but got this error while cleaning up", s);
             }
             if (e instanceof InterruptedException) {
-                Thread.interrupted();
+                Thread.currentThread().interrupt();
                 throw new ConnectException("Interrupted while starting the connector", e);
             }
             if (e instanceof ConnectException) {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -620,7 +620,7 @@ public class SnapshotReader extends AbstractReader {
                                             metrics.rowsScanned(tableId, rowNum.get());
                                         }
                                     } catch (InterruptedException e) {
-                                        Thread.interrupted();
+                                        Thread.currentThread().interrupt();
                                         // We were not able to finish all rows in all tables ...
                                         logger.info("Step {}: Stopping the snapshot due to thread interruption", stepNum);
                                         interrupted.set(true);
@@ -654,7 +654,7 @@ public class SnapshotReader extends AbstractReader {
                                         step, totalRowCount, capturedTableIds.size(), Strings.duration(stop - startScan));
                         }
                     } catch (InterruptedException e) {
-                        Thread.interrupted();
+                        Thread.currentThread().interrupt();
                         // We were not able to finish all rows in all tables ...
                         if (logger.isInfoEnabled()) {
                             logger.info("Step {}: aborting the snapshot after {} rows in {} of {} tables {}",

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/AbstractMySqlConnectorOutputTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/AbstractMySqlConnectorOutputTest.java
@@ -93,7 +93,7 @@ public class AbstractMySqlConnectorOutputTest extends ConnectorOutputTest {
                     Thread.sleep(100);
                 }
             } catch (InterruptedException e) {
-                Thread.interrupted();
+                Thread.currentThread().interrupt();
             } finally {
                 latch.countDown();
             }
@@ -108,7 +108,7 @@ public class AbstractMySqlConnectorOutputTest extends ConnectorOutputTest {
             }
             Testing.print("Waited a total of " + sw.durations().statistics().getTotalAsString() + " for the replica to catch up to the master.");
         } catch (InterruptedException e) {
-            Thread.interrupted();
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -195,7 +195,7 @@ public class SqlServerConnectorTask extends BaseSourceTask {
             }
         }
         catch (InterruptedException e) {
-            Thread.interrupted();
+            Thread.currentThread().interrupt();
             LOGGER.error("Interrupted while stopping coordinator", e);
             throw new ConnectException("Interrupted while stopping coordinator, failing the task");
         }
@@ -206,7 +206,7 @@ public class SqlServerConnectorTask extends BaseSourceTask {
             }
         }
         catch (InterruptedException e) {
-            Thread.interrupted();
+            Thread.currentThread().interrupt();
             LOGGER.error("Interrupted while stopping", e);
         }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -92,7 +92,7 @@ public class ChangeEventSourceCoordinator {
                 }
             }
             catch (InterruptedException e) {
-                Thread.interrupted();
+                Thread.currentThread().interrupt();
                 LOGGER.warn("Change event source executor was interrupted", e);
             }
             catch (Throwable e) {
@@ -117,7 +117,7 @@ public class ChangeEventSourceCoordinator {
         running = false;
 
         executor.shutdown();
-        Thread.interrupted();
+        Thread.currentThread().interrupt();
         boolean isShutdown = executor.awaitTermination(SHUTDOWN_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
 
         if (!isShutdown) {

--- a/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
@@ -199,7 +199,7 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
             }
         } catch( InterruptedException e) {
             logger.trace("Interrupted before record was written into database history: {}", record);
-            Thread.interrupted();
+            Thread.currentThread().interrupt();
             throw new DatabaseHistoryException(e);
         } catch (ExecutionException e) {
             throw new DatabaseHistoryException(e);

--- a/debezium-core/src/main/java/io/debezium/util/DelayStrategy.java
+++ b/debezium-core/src/main/java/io/debezium/util/DelayStrategy.java
@@ -57,7 +57,7 @@ public interface DelayStrategy {
             try {
                 Thread.sleep(delayInMilliseconds);
             } catch (InterruptedException e) {
-                Thread.interrupted();
+                Thread.currentThread().interrupt();
             }
             return true;
         };
@@ -89,7 +89,7 @@ public interface DelayStrategy {
                 try {
                     Thread.sleep(misses * delayInMilliseconds);
                 } catch (InterruptedException e) {
-                    Thread.interrupted();
+                    Thread.currentThread().interrupt();
                 }
                 return true;
             }
@@ -148,7 +148,7 @@ public interface DelayStrategy {
                 try {
                     Thread.sleep(previousDelay);
                 } catch (InterruptedException e) {
-                    Thread.interrupted();
+                    Thread.currentThread().interrupt();
                 }
                 return true;
             }

--- a/debezium-core/src/main/java/io/debezium/util/Threads.java
+++ b/debezium-core/src/main/java/io/debezium/util/Threads.java
@@ -222,7 +222,7 @@ public class Threads {
                     Thread.sleep(sleepTimeInMillis);
                 } catch (InterruptedException e) {
                     // awoke from sleep
-                    Thread.interrupted();
+                    Thread.currentThread().interrupt();
                     return;
                 }
             }

--- a/debezium-core/src/test/java/io/debezium/kafka/ZookeeperServer.java
+++ b/debezium-core/src/test/java/io/debezium/kafka/ZookeeperServer.java
@@ -85,7 +85,7 @@ public class ZookeeperServer {
             return this;
         } catch (InterruptedException e) {
             factory = null;
-            Thread.interrupted();
+            Thread.currentThread().interrupt();
             throw new IOException(e);
         }
     }

--- a/debezium-embedded/README.md
+++ b/debezium-embedded/README.md
@@ -130,7 +130,7 @@ The engine's connector will stop reading information from the source system, for
             logger.info("Wating another 30 seconds for the embedded enging to shut down");            
         }
     } catch ( InterruptedException e ) {
-        Thread.interrupted();
+        Thread.currentThread().interrupt();
     }
 
 Recall that when the JVM shuts down, it only waits for daemon threads. Therefore, if your application exits, be sure to wait for completion of the engine or alternatively run the engine on a daemon thread.

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -817,7 +817,12 @@ public final class EmbeddedEngine implements Runnable {
                             catch (InterruptedException e) {
                                 // Interrupted while polling ...
                                 logger.debug("Embedded engine interrupted on thread {} while polling the task for records", runningThread.get());
-                                Thread.interrupted();
+                                if (this.runningThread.get() == Thread.currentThread()) {
+                                    // this thread is still set as the running thread -> we were not interrupted
+                                    // due the stop() call -> probably someone else called the interrupt on us ->
+                                    // -> we should raise the interrupt flag
+                                    Thread.currentThread().interrupt();
+                                }
                                 break;
                             }
                             try {

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -148,7 +148,7 @@ public abstract class AbstractConnectorTest implements Testing {
                     engine.await(60, TimeUnit.SECONDS);
                 } catch (InterruptedException e) {
                     logger.warn("Engine has not stopped on time");
-                    Thread.interrupted();
+                    Thread.currentThread().interrupt();
                 }
             }
             if (executor != null) {
@@ -160,7 +160,7 @@ public abstract class AbstractConnectorTest implements Testing {
                     }
                 } catch (InterruptedException e) {
                     logger.warn("Executor has not stopped on time");
-                    Thread.interrupted();
+                    Thread.currentThread().interrupt();
                 }
             }
             if (engine != null && engine.isRunning()) {
@@ -170,7 +170,7 @@ public abstract class AbstractConnectorTest implements Testing {
                     }
                 } catch (InterruptedException e) {
                     logger.warn("Connector has not stopped on time");
-                    Thread.interrupted();
+                    Thread.currentThread().interrupt();
                 }
             }
             if (callback != null){


### PR DESCRIPTION
It appears there is an intent to restore the interruption flag
when catching InterruptedException. However the old code was just
checking the current state of the flag instead of raising it.