### PR TITLE
DBZ-1448 Source fields for rewrite

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java
@@ -144,8 +144,10 @@ public class ExtractNewRecordState<R extends ConnectRecord<R>> implements Transf
                     return null;
                 case REWRITE:
                     LOGGER.trace("Delete message {} requested to be rewritten", record.key());
-                    final R oldRecord = beforeDelegate.apply(record);
-                    return removedDelegate.apply(oldRecord);
+                    R oldRecord = beforeDelegate.apply(record);
+                    oldRecord = addSourceFields(addSourceFields, record, oldRecord);
+                    final R deleteRecord = removedDelegate.apply(oldRecord);
+                    return deleteRecord;
                 default:
                     return newRecord;
             }


### PR DESCRIPTION
We are using the CDC connector to replicate into S3 and I noticed that delete rewrites are not receiving the source fields added to their rewrite message when specified. This was causing the records to be written to S3 with essentially 2 schemas. Inserts and updates did receive the source fields and the order of the message was {original_fields, source_fields, __deleted}. Deletes came through like {original_fields, __deleted}. This fix puts the source fields back into delete rewrites in the correct order so messages have a consistent schema regardless of transaction type.