### PR TITLE
[DBZ-1457] Fix NPE when trying to commit without offsets

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -67,7 +67,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
     @Override
     public void execute(ChangeEventSourceContext context) throws InterruptedException {
         if (!snapshotter.shouldStream()) {
-            LOGGER.info("Streaming is not enabled in currect configuration");
+            LOGGER.info("Streaming is not enabled in correct configuration");
             return;
         }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -105,7 +105,7 @@ public class ChangeEventSourceCoordinator {
     }
 
     public void commitOffset(Map<String, ?> offset) {
-        if (streamingSource != null) {
+        if (streamingSource != null && offset != null) {
             streamingSource.commitOffset(offset);
         }
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1457

@gunnarmorling I couldn't really write a test, it was really hard to find a scenario where the task is started and the `coordinator` has value but no offset in here: https://github.com/debezium/debezium/blob/f4246df6e436343b3c08080452be92542ad39859/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java#L182

I tried some things, check the last commit, maybe you have a tip for me, otherwise let me know if I should remove the test or what to do! Thanks

Update: I've remove the test commit, here is how the code looked like:
```java
    @Test
    @FixFor("DBZ-1457")
    public void shouldNotThrowExceptionWhenACommitIsAttemptedWithoutOffsets() {
        Configuration config = TestHelper.defaultConfig().build();
        start(PostgresConnector.class, config);
        engine.runWithTask(task -> {
            final PostgresConnectorTask taskContext = ((PostgresConnectorTask) task);
            taskContext.start(config);
            try {
                taskContext.commit();
            } catch (InterruptedException e) {
                fail("Commit should not throw Exception when there is no last offset.");
            }
        });
    }
```