### PR TITLE
DBZ-1464: fixed NPE when op is not u/i/d

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/RecordMakers.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/RecordMakers.java
@@ -94,6 +94,10 @@ public class RecordMakers {
         });
     }
 
+    public static boolean isValidOperation(String operation) {
+        return operationLiterals.containsKey(operation);
+    }
+
     /**
      * A record producer for a given collection.
      */

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
@@ -518,6 +518,7 @@ public class Replicator {
         }
         if (!RecordMakers.isValidOperation(event.getString("op"))) {
             // the op is not insert/update/delete
+            logger.debug("Skipping event with \"op={}\"", event.getString("op"));
             return true;
         }
         int delimIndex = ns.indexOf('.');

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
@@ -516,6 +516,10 @@ public class Replicator {
             }
             return true;
         }
+        if (!RecordMakers.isValidOperation(event.getString("op"))) {
+            // the op is not insert/update/delete
+            return true;
+        }
         int delimIndex = ns.indexOf('.');
         if (delimIndex > 0) {
             assert (delimIndex + 1) < ns.length();


### PR DESCRIPTION
if the received event from mongoDB has anything but `op=i`, `op=u`, or `op=d`, it can result in a NPE for example with `op=n` (no op).

https://issues.jboss.org/browse/DBZ-1464

an alternative fix would be to change `recordEvent()`in `RecordMaker` to return 0 if `op` is not found in `operationLiterals`

Can we backport this to `0.9` and release a patch on that branch?

Signed-off-by: Lev Zemlyanov <lev@confluent.io>