### PR TITLE
add before field to mongoDb connector + put patch field in MongoCore …

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/RecordMakers.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/RecordMakers.java
@@ -138,7 +138,8 @@ public class RecordMakers {
             this.valueSchema = SchemaBuilder.struct()
                                             .name(adjuster.adjust(topicName + ".Envelope"))
                                             .field(FieldName.AFTER, Json.builder().optional().build())
-                                            .field("patch", Json.builder().optional().build())
+                                            .field(FieldName.PATCH, Json.builder().optional().build())
+                                            .field(FieldName.BEFORE, Json.builder().optional().build())
                                             .field(FieldName.SOURCE, source.schema())
                                             .field(FieldName.OPERATION, Schema.OPTIONAL_STRING_SCHEMA)
                                             .field(FieldName.TIMESTAMP, Schema.OPTIONAL_INT64_SCHEMA)
@@ -213,11 +214,11 @@ public class RecordMakers {
                 case UPDATE:
                     // The object is the idempotent patch document ...
                     String patchStr = valueTransformer.apply(fieldFilter.apply(objectValue));
-                    value.put("patch", patchStr);
+                    value.put(FieldName.PATCH, patchStr);
                     break;
                 case DELETE:
-                    // The delete event has nothing of any use, other than the _id which we already have in our key.
-                    // So put nothing in the 'after' or 'patch' fields ...
+                    String beforeStr = valueTransformer.apply(fieldFilter.apply(objectValue));
+                    value.put(FieldName.BEFORE, beforeStr);
                     break;
             }
             value.put(FieldName.SOURCE, source);

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/RecordMakersTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/RecordMakersTest.java
@@ -92,7 +92,8 @@ public class RecordMakersTest {
         assertThat(key.schema()).isSameAs(record.keySchema());
         assertThat(key.get("id")).isEqualTo("{ \"$oid\" : \"" + objId + "\"}");
         assertThat(value.schema()).isSameAs(record.valueSchema());
-        // assertThat(value.getString(FieldName.BEFORE)).isNull();
+        assertThat(value.getString(FieldName.BEFORE)).isNull();
+        assertThat(value.getString(FieldName.PATCH)).isNull();
         assertThat(value.getString(FieldName.AFTER)).isEqualTo(obj.toJson(WRITER_SETTINGS));
         assertThat(value.getString(FieldName.OPERATION)).isEqualTo(Operation.CREATE.code());
         assertThat(value.getInt64(FieldName.TIMESTAMP)).isEqualTo(1002L);
@@ -122,9 +123,9 @@ public class RecordMakersTest {
         assertThat(key.schema()).isSameAs(record.keySchema());
         assertThat(key.get("id")).isEqualTo(JSONSerializers.getStrict().serialize(objId));
         assertThat(value.schema()).isSameAs(record.valueSchema());
-        // assertThat(value.getString(FieldName.BEFORE)).isNull();
+        assertThat(value.getString(FieldName.BEFORE)).isNull();
         assertThat(value.getString(FieldName.AFTER)).isNull();
-        assertThat(value.getString("patch")).isEqualTo(obj.toJson(WRITER_SETTINGS));
+        assertThat(value.getString(FieldName.PATCH)).isEqualTo(obj.toJson(WRITER_SETTINGS));
         assertThat(value.getString(FieldName.OPERATION)).isEqualTo(Operation.UPDATE.code());
         assertThat(value.getInt64(FieldName.TIMESTAMP)).isEqualTo(1002L);
         Struct actualSource = value.getStruct(FieldName.SOURCE);
@@ -154,7 +155,8 @@ public class RecordMakersTest {
         assertThat(key.get("id")).isEqualTo(JSONSerializers.getStrict().serialize(objId));
         assertThat(value.schema()).isSameAs(record.valueSchema());
         assertThat(value.getString(FieldName.AFTER)).isNull();
-        assertThat(value.getString("patch")).isNull();
+        assertThat(value.getString(FieldName.PATCH)).isNull();
+        assertThat(value.getString(FieldName.BEFORE)).isEqualTo(obj.toJson(WRITER_SETTINGS));
         assertThat(value.getString(FieldName.OPERATION)).isEqualTo(Operation.DELETE.code());
         assertThat(value.getInt64(FieldName.TIMESTAMP)).isEqualTo(1002L);
         Struct actualSource = value.getStruct(FieldName.SOURCE);

--- a/debezium-core/src/main/java/io/debezium/data/Envelope.java
+++ b/debezium-core/src/main/java/io/debezium/data/Envelope.java
@@ -77,6 +77,10 @@ public final class Envelope {
          */
         public static final String AFTER = "after";
         /**
+         * The {@code patch} field is used to store the state of a record after an update operation.
+         */
+        public static final String PATCH = "patch";
+        /**
          * The {@code op} field is used to store the kind of operation on a record.
          */
         public static final String OPERATION = "op";


### PR DESCRIPTION
Hi @gunnarmorling ,
For a need in our project, it will be usefull to have the payload of the deleted object in the move action of MongoDb.
The object contain references to do other action and the ID of the object is not enough.
I send the pull request to add a before payload when there is a remove action.
So for MongoDb connector we will have:
Create action -> after field with the content
Update action -> patch field with the content
Delete action -> before field with the action

Thanks