### PR TITLE
DBZ-1462 Upgraded PostgreSQL driver to 42.2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <version.confluent.platform>5.1.2</version.confluent.platform>
 
         <!-- Databases -->
-        <version.postgresql.driver>42.2.5</version.postgresql.driver>
+        <version.postgresql.driver>42.2.7</version.postgresql.driver>
         <version.mysql.server>5.7</version.mysql.server>
         <version.mysql.driver>8.0.16</version.mysql.driver>
         <version.mysql.binlog>0.19.1</version.mysql.binlog>


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1462

Looks like there is a hold-up in the 42.2.7 publication; so we'll have to wait for the artifact to become available but this specific version includes the fixes mentioned in DBZ-1462.