### PR TITLE
Adds warning for 'bin_log' property in RDS MySQL

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -58,6 +58,11 @@ where:
 Running a MySQL server with binary logging enabled does slightly reduce performance of the MySQL server, but the benefits generally outweigh the costs. Each binlog reader will also place a small load on the server, so using Debezium is a great way to minimize this load while providing the change events to a large variety and number of consumers.
 ====
 
+[WARNING]
+====
+RDS MySQL manages directly the log_bin parameter through enabling/disabling product features like read replicas and automated backups. Make sure to enable one of them in any RDS MySQL node from where a connector consumes data. Otherwise, it will fail while performing a snapshot.
+====
+
 [[enabling-gtids]]
 [[enabling-gtids-optional]]
 === Enabling GTIDs (optional)


### PR DESCRIPTION
Should solve the issue with this exception when pointing to a RDS MySQL read replica:

```
Caused by: java.lang.IllegalStateException: Cannot read the binlog filename and position via 'SHOW MASTER STATUS'. Make sure your server is correctly configured
    at io.debezium.connector.mysql.SnapshotReader.lambda$readBinlogPosition$16(SnapshotReader.java:761)
    at io.debezium.jdbc.JdbcConnection.query(JdbcConnection.java:444)
    at io.debezium.jdbc.JdbcConnection.query(JdbcConnection.java:385)
    at io.debezium.connector.mysql.SnapshotReader.readBinlogPosition(SnapshotReader.java:745)
    at io.debezium.connector.mysql.SnapshotReader.execute(SnapshotReader.java:370)
```

Will open up another PR in the FAQ repo with the stack trace and more details, if it makes sense.