### PR TITLE
DBZ-1383 Fix PostgreSQL tests that fail intermittently

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -1108,6 +1108,10 @@ public abstract class AbstractRecordsProducerTest extends AbstractConnectorTest 
         }
     }
 
+    protected void waitForSnapshotToBeCompleted() throws InterruptedException {
+        waitForSnapshotToBeCompleted("postgres", "test_server");
+    }
+
     protected void waitForStreamingToStart() throws InterruptedException {
         waitForStreamingRunning("postgres", "test_server");
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -461,12 +461,15 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         Configuration.Builder configBuilder = getConfigurationBuilder(SnapshotMode.INITIAL);
         start(PostgresConnector.class, configBuilder.build());
         assertConnectorIsRunning();
+        waitForSnapshotToBeCompleted("postgres", TestHelper.TEST_SERVER);
 
         SourceRecords snapshotRecords = consumeRecordsByTopic(1);
         assertThat(snapshotRecords.allRecordsInOrder().size()).isEqualTo(1);
 
         List<SourceRecord> recordsFromOutbox = snapshotRecords.recordsForTopic(topicName("outboxsmtit.outbox"));
         assertThat(recordsFromOutbox.size()).isEqualTo(1);
+
+        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
     }
 
     private void startConnectorWithNoSnapshot() throws InterruptedException {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -94,6 +94,9 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
 
     @Before
     public void beforeEach() throws InterruptedException {
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.dropPublication();
+
         outboxEventRouter = new EventRouter<>();
         outboxEventRouter.configure(Collections.emptyMap());
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -461,15 +461,12 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         Configuration.Builder configBuilder = getConfigurationBuilder(SnapshotMode.INITIAL);
         start(PostgresConnector.class, configBuilder.build());
         assertConnectorIsRunning();
-        waitForSnapshotToBeCompleted("postgres", TestHelper.TEST_SERVER);
 
         SourceRecords snapshotRecords = consumeRecordsByTopic(1);
         assertThat(snapshotRecords.allRecordsInOrder().size()).isEqualTo(1);
 
         List<SourceRecord> recordsFromOutbox = snapshotRecords.recordsForTopic(topicName("outboxsmtit.outbox"));
         assertThat(recordsFromOutbox.size()).isEqualTo(1);
-
-        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
     }
 
     private void startConnectorWithNoSnapshot() throws InterruptedException {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -310,6 +310,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         start(PostgresConnector.class, configBuilder.build());
         assertConnectorIsRunning();
 
+        waitForSnapshotToBeCompleted();
         SourceRecords records = consumeRecordsByTopic(recordCount);
         Assertions.assertThat(records.recordsForTopic("test_server.s1.a")).hasSize(recordCount);
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -425,9 +425,11 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
                                                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE);
         start(PostgresConnector.class, configBuilder.build());
         assertConnectorIsRunning();
+        waitForSnapshotToBeCompleted();
 
         //check the records from the snapshot
         assertRecordsFromSnapshot(2, 1, 1);
+        waitForStreamingRunning();
 
         // insert 2 new records
         TestHelper.execute(INSERT_STMT);
@@ -443,6 +445,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
 
         start(PostgresConnector.class, configBuilder.with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE).build());
         assertConnectorIsRunning();
+        waitForStreamingRunning();
 
         SourceRecords actualRecords = consumeRecordsByTopic(1);
         assertThat(actualRecords.topics()).hasSize(1);
@@ -462,9 +465,11 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
                 .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE);
         start(PostgresConnector.class, configBuilder.build());
         assertConnectorIsRunning();
+        waitForSnapshotToBeCompleted();
 
         //check the records from the snapshot
         assertRecordsFromSnapshot(2, 1, 1);
+        waitForStreamingRunning();
 
         // insert 2 new records
         TestHelper.execute(INSERT_STMT);
@@ -480,6 +485,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
 
         start(PostgresConnector.class, configBuilder.with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE).build());
         assertConnectorIsRunning();
+        waitForStreamingRunning();
 
         SourceRecords actualRecords = consumeRecordsByTopic(2);
         assertThat(actualRecords.topics()).hasSize(2);
@@ -501,9 +507,11 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
                                                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE);
         start(PostgresConnector.class, configBuilder.build());
         assertConnectorIsRunning();
+        waitForSnapshotToBeCompleted();
 
         //check the records from the snapshot
         assertRecordsFromSnapshot(2, 1, 1);
+        waitForStreamingRunning();
 
         // insert 2 new records
         TestHelper.execute(INSERT_STMT);
@@ -520,6 +528,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         //but the 2 records that we were inserted while we were down will be retrieved
         start(PostgresConnector.class, configBuilder.with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE).build());
         assertConnectorIsRunning();
+        waitForStreamingRunning();
 
         assertRecordsAfterInsert(2, 3, 3);
 
@@ -1227,5 +1236,13 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         assertThat(key.orderInGroup).isGreaterThan(0);
         assertThat(key.validator).isNull();
         assertThat(key.recommender).isNull();
+    }
+
+    private void waitForSnapshotToBeCompleted() throws InterruptedException {
+        waitForSnapshotToBeCompleted("postgres", TestHelper.TEST_SERVER);
+    }
+
+    private void waitForStreamingRunning() throws InterruptedException {
+        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -772,7 +772,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
                                          .build();
         start(PostgresConnector.class, config);
         assertConnectorIsRunning();
-        waitForAvailableRecords(100, TimeUnit.MILLISECONDS);
+        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
         // there shouldn't be any snapshot records
         assertNoRecordsToConsume();
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PublicGeometryIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PublicGeometryIT.java
@@ -131,6 +131,6 @@ public class PublicGeometryIT extends AbstractRecordsProducerTest {
 
     private void executeAndWait(String statements) throws Exception {
         TestHelper.execute(statements);
-        consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
+        consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -120,6 +120,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         buildWithStreamProducer(TestHelper.defaultConfig());
 
         TestConsumer consumer = testConsumer(2, "s1", "s2");
+        waitForSnapshotToBeCompleted();
 
         // first make sure we get the initial records from both schemas...
         consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
@@ -151,6 +152,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         // start a new producer back up, take a new snapshot (we expect all the records to be read back)
         int expectedRecordsCount = 6;
         buildWithStreamProducer(TestHelper.defaultConfig());
+        waitForSnapshotToBeCompleted();
 
         consumer = testConsumer(expectedRecordsCount, "s1", "s2");
         consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
@@ -170,7 +172,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
         TestHelper.execute(insertStmt);
         consumer.expects(2);
 
-        consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
+        consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
         first = consumer.remove();
         VerifyRecord.isValidInsert(first, PK_FIELD, 4);
         assertRecordOffsetAndSnapshotSource(first, false, false);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -1503,6 +1503,6 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
     private void executeAndWait(String statements) throws Exception {
         TestHelper.execute(statements);
-        consumer.await(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
+        consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -262,11 +262,13 @@ public final class TestHelper {
     }
 
     protected static void dropPublication(String publicationName) {
-        try {
-            execute("DROP PUBLICATION " + publicationName);
-        }
-        catch (Exception e) {
-            LOGGER.debug("Error while dropping publication: '" + publicationName + "'", e);
+        if (decoderPlugin().equals(PostgresConnectorConfig.LogicalDecoder.PGOUTPUT)) {
+            try {
+                execute("DROP PUBLICATION " + publicationName);
+            }
+            catch (Exception e) {
+                LOGGER.debug("Error while dropping publication: '" + publicationName + "'", e);
+            }
         }
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1383

This is a first pass at addressing test stability for the PostgreSQL connector.  There are further changes I'm looking into but this at least addresses a few of the known tests so far that fail randomly.