### PR TITLE
DBZ-1367 DBZ-1368 DBZ-1399 Toasted column not read out-of-bands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ cache:
 
 env:
   - MAVEN_CLI: '"clean install -B -pl debezium-connector-mysql -am -Passembly"'
-  - MAVEN_CLI: '"clean install -B -pl debezium-connector-postgres -am -Passembly"'
-  - MAVEN_CLI: '"clean install -B -pl debezium-connector-postgres -am -Passembly,wal2json-decoder"'
-  - MAVEN_CLI: '"clean install -B -pl debezium-connector-postgres -am -Passembly,pgoutput-decoder,postgres-10 -Ddebezium.test.records.waittime=5"'
+  - MAVEN_CLI: '"clean install -B -pl debezium-connector-postgres -am -Passembly -Dversion.postgres.server=10-dev"'
+  - MAVEN_CLI: '"clean install -B -pl debezium-connector-postgres -am -Passembly,wal2json-decoder -Dversion.postgres.server=10-dev"'
+  - MAVEN_CLI: '"clean install -B -pl debezium-connector-postgres -am -Passembly,pgoutput-decoder -Dversion.postgres.server=10-dev -Ddebezium.test.records.waittime=5"'
   - MAVEN_CLI: '"clean install -B -pl debezium-connector-mongodb -am -Passembly"'
   - MAVEN_CLI: '"clean install -B -pl debezium-connector-sqlserver -am -Passembly"'
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
@@ -167,7 +167,7 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
                 if (position != -1) {
                     values[position] = ToastedReplicationMessageColumn.ToastedValue.TOAST;
                 }
-            };
+            }
         }
         return values;
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
@@ -144,9 +144,9 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
         // based on the replication message without toasted columns for now
         List<ReplicationMessage.Column> columnsWithoutToasted = columns.stream().filter(Predicates.not(ReplicationMessage.Column::isToastedColumn)).collect(Collectors.toList());
         // JSON does not deliver a list of all columns for REPLICA IDENTITY DEFAULT
-        Object[] values = new Object[columnsWithoutToasted.size() < schemaColumns.size() ? schemaColumns.size() : columnsWithoutToasted.size()];
+        Object[] values = new Object[schemaColumns.size()];
 
-        for (ReplicationMessage.Column column: columnsWithoutToasted) {
+        for (ReplicationMessage.Column column: columns) {
             //DBZ-298 Quoted column names will be sent like that in messages, but stored unquoted in the column names
             final String columnName = Strings.unquoteIdentifierPart(column.getName());
             final Column tableColumn = table.columnWithName(columnName);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
@@ -48,7 +48,7 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
     private final PostgresConnectorConfig connectorConfig;
     private final PostgresConnection connection;
     private final TableId tableId;
-    private final boolean isJsonPlugin;
+    private final boolean unchangedToastColumnMarkerMissing;
     private Object[] cachedOldColumnValues;
     private final Map<String, Object> cachedOldToastedValues = new HashMap<>();
 
@@ -61,7 +61,7 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
         this.connection = connection;
 
         this.tableId = PostgresSchema.parse(message.getTable());
-        this.isJsonPlugin = "wal2json".equals(connectorConfig.plugin().getPostgresPluginName());
+        this.unchangedToastColumnMarkerMissing = !connectorConfig.plugin().hasUnchangedToastColumnMarker();
         Objects.requireNonNull(tableId);
     }
 
@@ -181,7 +181,7 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
                 values[position] = value;
             }
         }
-        if (isJsonPlugin) {
+        if (unchangedToastColumnMarkerMissing) {
             for (String columnName: undeliveredToastableColumns) {
                 int position = getPosition(columnName, table, values);
                 if (position != -1) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -776,7 +776,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withDisplayName("Toasted value placeholder")
             .withType(Type.STRING)
             .withWidth(Width.MEDIUM)
-            .withDefault("__DEBEZIUM_TOASTED_VALUE__")
+            .withDefault("__debezium_unavailable_value")
             .withImportance(Importance.MEDIUM)
             .withDescription("Specify the constant that will be provided by Debezium to indicate that " +
                     "the original value is a toasted value not provided by the database." + 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -921,7 +921,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     protected byte[] toastedValuePlaceholder() {
         final String placeholder = getConfig().getString(TOASTED_VALUE_PLACEHOLDER);
         if (placeholder.startsWith("hex:")) {
-            Strings.hexStringToByteArray(placeholder.substring(4));
+            return Strings.hexStringToByteArray(placeholder.substring(4));
         }
         return placeholder.getBytes();
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -322,6 +322,11 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             public String getPostgresPluginName() {
                 return "wal2json";
             }
+
+            @Override
+            public boolean hasUnchangedToastColumnMarker() {
+                return false;
+            }
         },
         WAL2JSON_RDS_STREAMING("wal2json_rds_streaming") {
             @Override
@@ -338,6 +343,11 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             public String getPostgresPluginName() {
                 return "wal2json";
             }
+
+            @Override
+            public boolean hasUnchangedToastColumnMarker() {
+                return false;
+            }
         },
         WAL2JSON("wal2json") {
             @Override
@@ -348,6 +358,11 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             @Override
             public String getPostgresPluginName() {
                 return "wal2json";
+            }
+
+            @Override
+            public boolean hasUnchangedToastColumnMarker() {
+                return false;
             }
         },
         WAL2JSON_RDS("wal2json_rds") {
@@ -365,6 +380,11 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             public String getPostgresPluginName() {
                 return "wal2json";
             }
+
+            @Override
+            public boolean hasUnchangedToastColumnMarker() {
+                return false;
+            }
         };
 
         private final String decoderName;
@@ -377,6 +397,10 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
 
         public boolean forceRds() {
             return false;
+        }
+
+        public boolean hasUnchangedToastColumnMarker() {
+            return true;
         }
 
         public static LogicalDecoder parse(String s) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
@@ -69,8 +69,17 @@ public class PostgresSchema extends RelationalDatabaseSchema {
     }
 
     private static TableSchemaBuilder getTableSchemaBuilder(PostgresConnectorConfig config, TypeRegistry typeRegistry, Charset databaseCharset) {
-        PostgresValueConverter valueConverter = new PostgresValueConverter(databaseCharset, config.getDecimalMode(), config.getTemporalPrecisionMode(),
-                ZoneOffset.UTC, null, config.includeUnknownDatatypes(), typeRegistry, config.hStoreHandlingMode());
+        PostgresValueConverter valueConverter = new PostgresValueConverter(
+                databaseCharset,
+                config.getDecimalMode(),
+                config.getTemporalPrecisionMode(),
+                ZoneOffset.UTC,
+                null,
+                config.includeUnknownDatatypes(),
+                typeRegistry,
+                config.hStoreHandlingMode(),
+                config.toastedValuePlaceholder()
+        );
 
         return new TableSchemaBuilder(valueConverter, SchemaNameAdjuster.create(LOGGER), config.getSourceInfoStructMaker().schema(), config.getSanitizeFieldNames());
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -793,7 +793,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
      */
     @Override
     protected Object convertBinary(Column column, Field fieldDefn, Object data) {
-        if (data instanceof ToastedReplicationMessageColumn.ToastedValue) {
+        if (data == ToastedReplicationMessageColumn.UNCHANGED_TOAST_VALUE) {
             return toastPlaceholderBinary;
     }
         if (data instanceof PgArray) {
@@ -813,7 +813,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
      */
     @Override
     protected Object convertString(Column column, Field fieldDefn, Object data) {
-        if (data instanceof ToastedReplicationMessageColumn.ToastedValue) {
+        if (data == ToastedReplicationMessageColumn.UNCHANGED_TOAST_VALUE) {
                 return toastPlaceholderString;
         }
         return super.convertString(column, fieldDefn, data);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/ToastedReplicationMessageColumn.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/ToastedReplicationMessageColumn.java
@@ -18,9 +18,7 @@ import io.debezium.connector.postgresql.connection.AbstractReplicationMessageCol
  */
 public class ToastedReplicationMessageColumn extends AbstractReplicationMessageColumn {
 
-    public static enum ToastedValue {
-        TOAST
-    };
+    public static final Object UNCHANGED_TOAST_VALUE = new Object();
 
     public ToastedReplicationMessageColumn(String columnName, PostgresType type, String typeWithModifiers, boolean optional, boolean hasMetadata) {
         super(columnName, type, typeWithModifiers, optional, hasMetadata);
@@ -33,6 +31,6 @@ public class ToastedReplicationMessageColumn extends AbstractReplicationMessageC
 
     @Override
     public Object getValue(PostgresStreamingChangeEventSource.PgConnectionSupplier connection, boolean includeUnknownDatatypes) {
-        return ToastedValue.TOAST;
+        return UNCHANGED_TOAST_VALUE;
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/ToastedReplicationMessageColumn.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/ToastedReplicationMessageColumn.java
@@ -18,6 +18,10 @@ import io.debezium.connector.postgresql.connection.AbstractReplicationMessageCol
  */
 public class ToastedReplicationMessageColumn extends AbstractReplicationMessageColumn {
 
+    public static enum ToastedValue {
+        TOAST
+    };
+
     public ToastedReplicationMessageColumn(String columnName, PostgresType type, String typeWithModifiers, boolean optional, boolean hasMetadata) {
         super(columnName, type, typeWithModifiers, optional, hasMetadata);
     }
@@ -29,6 +33,6 @@ public class ToastedReplicationMessageColumn extends AbstractReplicationMessageC
 
     @Override
     public Object getValue(PostgresStreamingChangeEventSource.PgConnectionSupplier connection, boolean includeUnknownDatatypes) {
-        throw new UnsupportedOperationException("A toasted column does not supply a value");
+        return ToastedValue.TOAST;
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/MessageDecoder.java
@@ -53,16 +53,6 @@ public interface MessageDecoder {
     ChainedLogicalStreamBuilder optionsWithoutMetadata(ChainedLogicalStreamBuilder builder);
 
     /**
-     * Allows a message decoder to configure optional options that might or might not be present on the server-side LD
-     * plug-in. So these options will be tried once, and that causes an exception, the connection will be built without
-     * them.
-     *
-     * @param builder the builder to modify
-     * @return the amended builder instance
-     */
-    ChainedLogicalStreamBuilder tryOnceOptions(ChainedLogicalStreamBuilder builder);
-
-    /**
      * Signals to this decoder whether messages contain type metadata or not.
      */
     // TODO DBZ-508 Remove once we only support LD plug-ins always sending the metadata

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -331,8 +331,8 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             try {
                 s = startPgReplicationStream(startLsn,
                         plugin.forceRds()
-                                ? x -> messageDecoder.optionsWithoutMetadata(messageDecoder.tryOnceOptions(x))
-                                : x -> messageDecoder.optionsWithMetadata(messageDecoder.tryOnceOptions(x)));
+                                ? messageDecoder::optionsWithoutMetadata
+                                : messageDecoder::optionsWithMetadata);
                 messageDecoder.setContainsMetadata(plugin.forceRds() ? false : true);
             }
             catch (PSQLException e) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -183,11 +183,6 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         return builder;
     }
 
-    @Override
-    public ChainedLogicalStreamBuilder tryOnceOptions(ChainedLogicalStreamBuilder builder) {
-        return builder;
-    }
-
     /**
      * Callback handler for the 'B' begin replication message.
      *

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoMessageDecoder.java
@@ -65,9 +65,4 @@ public class PgProtoMessageDecoder extends AbstractMessageDecoder {
     public ChainedLogicalStreamBuilder optionsWithoutMetadata(ChainedLogicalStreamBuilder builder) {
         return builder;
     }
-
-    @Override
-    public ChainedLogicalStreamBuilder tryOnceOptions(ChainedLogicalStreamBuilder builder) {
-        return builder;
-    }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
@@ -145,7 +145,7 @@ class PgProtoReplicationMessage implements ReplicationMessage {
      */
     public Object getValue(PgProto.DatumMessage datumMessage, PgConnectionSupplier connection, boolean includeUnknownDatatypes) {
         if (datumMessage.hasDatumMissing()) {
-            return ToastedReplicationMessageColumn.ToastedValue.TOAST;
+            return ToastedReplicationMessageColumn.UNCHANGED_TOAST_VALUE;
         }
 
         int columnType = (int) datumMessage.getColumnType();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
@@ -140,6 +140,11 @@ class PgProtoReplicationMessage implements ReplicationMessage {
      * @return the value; may be null
      */
     public Object getValue(PgProto.DatumMessage datumMessage, PgConnectionSupplier connection, boolean includeUnknownDatatypes) {
+        if (datumMessage.hasDatumMissing()) {
+            LOGGER.trace("No value received for unchanged TOASTed column {}", datumMessage.getColumnName());
+            return null;
+        }
+
         int columnType = (int) datumMessage.getColumnType();
         switch (columnType) {
             case PgOid.BOOL:

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/NonStreamingWal2JsonMessageDecoder.java
@@ -90,11 +90,6 @@ public class NonStreamingWal2JsonMessageDecoder extends AbstractMessageDecoder {
     }
 
     @Override
-    public ChainedLogicalStreamBuilder tryOnceOptions(ChainedLogicalStreamBuilder builder) {
-        return builder.withSlotOption("include-unchanged-toast", 0);
-    }
-
-    @Override
     public void setContainsMetadata(boolean containsMetadata) {
         this.containsMetadata = containsMetadata;
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/wal2json/StreamingWal2JsonMessageDecoder.java
@@ -272,11 +272,6 @@ public class StreamingWal2JsonMessageDecoder extends AbstractMessageDecoder {
     }
 
     @Override
-    public ChainedLogicalStreamBuilder tryOnceOptions(ChainedLogicalStreamBuilder builder) {
-        return builder.withSlotOption("include-unchanged-toast", 0);
-    }
-
-    @Override
     public void setContainsMetadata(boolean containsMetadata) {
         this.containsMetadata = containsMetadata;
     }

--- a/debezium-connector-postgres/src/main/proto/pg_logicaldec.proto
+++ b/debezium-connector-postgres/src/main/proto/pg_logicaldec.proto
@@ -27,6 +27,7 @@ message DatumMessage {
       string datum_string = 8;
       bytes datum_bytes = 9;
       Point datum_point = 10;
+      bool datum_missing = 11;
     }
 }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DecoderDifferences.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DecoderDifferences.java
@@ -15,7 +15,7 @@ import java.util.function.Supplier;
  *
  */
 public class DecoderDifferences {
-    static final String TOASTED_VALUE_PLACEHOLDER = "__DEBEZIUM_TOASTED_VALUE__";
+    static final String TOASTED_VALUE_PLACEHOLDER = "__debezium_unavailable_value";
 
     /**
      * wal2json plugin does not send events for updates on tables that does not define primary key.

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DecoderDifferences.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DecoderDifferences.java
@@ -15,6 +15,7 @@ import java.util.function.Supplier;
  *
  */
 public class DecoderDifferences {
+    static final String TOASTED_VALUE_PLACEHOLDER = "__DEBEZIUM_TOASTED_VALUE__";
 
     /**
      * wal2json plugin does not send events for updates on tables that does not define primary key.
@@ -68,12 +69,20 @@ public class DecoderDifferences {
     }
 
     /**
-     * wal2json plugin nor pgoutput include toasted column in the update
+     * wal2json plugin include toasted column in the update
      *
      * @author Jiri Pechanec
      *
      */
     public static boolean areToastedValuesPresentInSchema() {
-        return !wal2Json() && !pgoutput();
+        return !wal2Json();
+    }
+
+    public static String optionalToastedValuePlaceholder() {
+        return TOASTED_VALUE_PLACEHOLDER;
+    }
+
+    public static String mandatoryToastedValuePlaceholder() {
+        return TOASTED_VALUE_PLACEHOLDER;
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -70,6 +70,8 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     @Rule
     public TestRule conditionalFail = new ConditionalFail();
 
+    private static final String TOASTED_VALUE_PLACEHOLDER = "__DEBEZIUM_TOASTED_VALUE__";
+
     @Before
     public void before() throws Exception {
         // ensure the slot is deleted for each test
@@ -1090,8 +1092,6 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     @Test
     @FixFor("DBZ-842")
     public void shouldNotPropagateUnchangedToastedData() throws Exception {
-        final String toastedValuePlaceholder = "__DEBEZIUM_TOASTED_VALUE__";
-
         startConnector(config -> config
                 .with(PostgresConnectorConfig.SCHEMA_REFRESH_MODE, PostgresConnectorConfig.SchemaRefreshMode.COLUMNS_DIFF_EXCLUDE_UNCHANGED_TOAST)
         );
@@ -1142,13 +1142,13 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         ), consumer.remove(), Envelope.FieldName.AFTER);
         assertRecordSchemaAndValues(Arrays.asList(
                 new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 2),
-                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, toastedValuePlaceholder),
-                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, toastedValuePlaceholder)
+                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER),
+                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER)
         ), consumer.remove(), Envelope.FieldName.AFTER);
         assertRecordSchemaAndValues(Arrays.asList(
                 new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 2),
-                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, toastedValuePlaceholder),
-                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, toastedValuePlaceholder)
+                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER),
+                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER)
         ), consumer.remove(), Envelope.FieldName.AFTER);
         assertRecordSchemaAndValues(Arrays.asList(
                 new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 3),
@@ -1157,13 +1157,13 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         ), consumer.remove(), Envelope.FieldName.AFTER);
         assertRecordSchemaAndValues(Arrays.asList(
                 new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 3),
-                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, toastedValuePlaceholder),
-                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, toastedValuePlaceholder)
+                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER),
+                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER)
         ), consumer.remove(), Envelope.FieldName.AFTER);
         assertRecordSchemaAndValues(Arrays.asList(
                 new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 3),
-                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, toastedValuePlaceholder),
-                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, toastedValuePlaceholder)
+                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER),
+                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER)
         ), consumer.remove(), Envelope.FieldName.AFTER);
     }
 
@@ -1415,7 +1415,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
             assertRecordSchemaAndValues(Arrays.asList(
                     new SchemaAndValueField("id", SchemaBuilder.INT32_SCHEMA, 1),
                     new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 20),
-                    new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, null)
+                    new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER)
             ), updatedRecord, Envelope.FieldName.AFTER);
         }
         else {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -1090,6 +1090,8 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     @Test
     @FixFor("DBZ-842")
     public void shouldNotPropagateUnchangedToastedData() throws Exception {
+        final String toastedValuePlaceholder = "__DEBEZIUM_TOASTED_VALUE__";
+
         startConnector(config -> config
                 .with(PostgresConnectorConfig.SCHEMA_REFRESH_MODE, PostgresConnectorConfig.SchemaRefreshMode.COLUMNS_DIFF_EXCLUDE_UNCHANGED_TOAST)
         );
@@ -1140,13 +1142,13 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         ), consumer.remove(), Envelope.FieldName.AFTER);
         assertRecordSchemaAndValues(Arrays.asList(
                 new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 2),
-                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, null),
-                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, "")
+                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, toastedValuePlaceholder),
+                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, toastedValuePlaceholder)
         ), consumer.remove(), Envelope.FieldName.AFTER);
         assertRecordSchemaAndValues(Arrays.asList(
                 new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 2),
-                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, null),
-                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, "")
+                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, toastedValuePlaceholder),
+                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, toastedValuePlaceholder)
         ), consumer.remove(), Envelope.FieldName.AFTER);
         assertRecordSchemaAndValues(Arrays.asList(
                 new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 3),
@@ -1155,13 +1157,13 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         ), consumer.remove(), Envelope.FieldName.AFTER);
         assertRecordSchemaAndValues(Arrays.asList(
                 new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 3),
-                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, null),
-                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, "")
+                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, toastedValuePlaceholder),
+                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, toastedValuePlaceholder)
         ), consumer.remove(), Envelope.FieldName.AFTER);
         assertRecordSchemaAndValues(Arrays.asList(
                 new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 3),
-                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, null),
-                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, "")
+                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, toastedValuePlaceholder),
+                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, toastedValuePlaceholder)
         ), consumer.remove(), Envelope.FieldName.AFTER);
     }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -70,8 +70,6 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     @Rule
     public TestRule conditionalFail = new ConditionalFail();
 
-    private static final String TOASTED_VALUE_PLACEHOLDER = "__DEBEZIUM_TOASTED_VALUE__";
-
     @Before
     public void before() throws Exception {
         // ensure the slot is deleted for each test
@@ -1142,13 +1140,13 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         ), consumer.remove(), Envelope.FieldName.AFTER);
         assertRecordSchemaAndValues(Arrays.asList(
                 new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 2),
-                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER),
-                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER)
+                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, DecoderDifferences.optionalToastedValuePlaceholder()),
+                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, DecoderDifferences.mandatoryToastedValuePlaceholder())
         ), consumer.remove(), Envelope.FieldName.AFTER);
         assertRecordSchemaAndValues(Arrays.asList(
                 new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 2),
-                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER),
-                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER)
+                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, DecoderDifferences.optionalToastedValuePlaceholder()),
+                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, DecoderDifferences.mandatoryToastedValuePlaceholder())
         ), consumer.remove(), Envelope.FieldName.AFTER);
         assertRecordSchemaAndValues(Arrays.asList(
                 new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 3),
@@ -1157,13 +1155,13 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         ), consumer.remove(), Envelope.FieldName.AFTER);
         assertRecordSchemaAndValues(Arrays.asList(
                 new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 3),
-                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER),
-                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER)
+                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, DecoderDifferences.optionalToastedValuePlaceholder()),
+                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, DecoderDifferences.mandatoryToastedValuePlaceholder())
         ), consumer.remove(), Envelope.FieldName.AFTER);
         assertRecordSchemaAndValues(Arrays.asList(
                 new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 3),
-                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER),
-                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER)
+                new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, DecoderDifferences.optionalToastedValuePlaceholder()),
+                new SchemaAndValueField("mandatory_text", SchemaBuilder.STRING_SCHEMA, DecoderDifferences.mandatoryToastedValuePlaceholder())
         ), consumer.remove(), Envelope.FieldName.AFTER);
     }
 
@@ -1406,7 +1404,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         executeAndWait("UPDATE test_table set not_toast = 20");
         SourceRecord updatedRecord = consumer.remove();
 
-        if (DecoderDifferences.areToastedValuesPresentInSchema()) {
+        if (DecoderDifferences.areToastedValuesPresentInSchema() || mode == SchemaRefreshMode.COLUMNS_DIFF_EXCLUDE_UNCHANGED_TOAST) {
             assertRecordSchemaAndValues(Arrays.asList(
                     new SchemaAndValueField("id", SchemaBuilder.INT32_SCHEMA, 1),
                     new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 10),
@@ -1415,7 +1413,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
             assertRecordSchemaAndValues(Arrays.asList(
                     new SchemaAndValueField("id", SchemaBuilder.INT32_SCHEMA, 1),
                     new SchemaAndValueField("not_toast", SchemaBuilder.OPTIONAL_INT32_SCHEMA, 20),
-                    new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, TOASTED_VALUE_PLACEHOLDER)
+                    new SchemaAndValueField("text", SchemaBuilder.OPTIONAL_STRING_SCHEMA, DecoderDifferences.optionalToastedValuePlaceholder())
             ), updatedRecord, Envelope.FieldName.AFTER);
         }
         else {

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1301,6 +1301,18 @@ Debezium copies the old value into the new value.
 ** `UPDATE` and `DELETE` messages does not contain toasted value thata were not updated.
 As Debezium cannot safely provide the value it returns a placeholder value defined in configuration option `toasted.value.placeholder`.
 
+[IMPORTANT]
+====
+There is a specific problem related to Amazon RDS instances.
+`wal2json` plugin has evolved over the time and there were releases that provided out-of-band toasted values.
+Amazon supports different versions of the plugin for different PostgreSQL versions.
+Please consult Amazon's https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html[documentation] to obtain version to version mapping.
+For consistent toasted values handling we recommend to
+
+* use `pgoutput` plugin for PostgreSQL 10+ instances
+* set `include-unchanged-toast=0` for older versions of `wal2json` plugin using `slot.stream.params` configuration option
+====
+
 [[fault-tolerance]]
 [[when-things-go-wrong]]
 === When Things Go Wrong

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1287,19 +1287,16 @@ Please see http://www.opengeospatial.org/standards/sfa[Open Geospatial Consortiu
 [[toasted-values]]
 ==== Toasted values
 PostgreSQL has a hard limit on the page size.
-This means that values larger than cca 8 KB needs to be stored using https://www.postgresql.org/docs/current/storage-toast.html[TOAST storage].
-This impacts replication messages coming from database as the values that were stored using TOAST mechanism and have not been changed are not included in the message in new value section.
-There is no safe way for Debezium to read the missing value out-of-bands directly from database as this would lead into race condition.
-Debezium thus follows these rules to handle the toasted values
+This means that values larger than ca. 8 KB need to be stored using https://www.postgresql.org/docs/current/storage-toast.html[TOAST storage].
+This impacts replication messages coming from database, as the values that were stored using the TOAST mechanism and have not been changed are not included in the message, unless they are part of the table's replica identity.
+There is no safe way for Debezium to read the missing value out-of-bands directly from database, as this would lead into race conditions potentially.
+Debezium thus follows these rules to handle the toasted values:
 
-* tables with `REPLICA IDENTITY FULL`
-** `INSERT` and `DELETE` messages contain unchanged toasted values
-** `UPDATE` messages contain original toasted value in part with old values and nothing in new values.
-Debezium copies the old value into the new value.
-* tables with `REPLICA IDENTITY DEFAULT`
-** `INSERT` messages contain unchanged toasted values
-** `UPDATE` and `DELETE` messages does not contain toasted value thata were not updated.
-As Debezium cannot safely provide the value it returns a placeholder value defined in configuration option `toasted.value.placeholder`.
+* tables with `REPLICA IDENTITY FULL`: TOAST column values are part of the `before` and `after` blocks of change events as any other column
+* tables with `REPLICA IDENTITY DEFAULT`: when receiving an `UPDATE` event from the database,
+any unchanged TOAST column value which is not part of the replica identity will not be part of that event;
+similarly, when receiving a `DELETE` event, any such TOAST column will not be part of the `before` block.
+As Debezium cannot safely provide the column value in this case, it returns a placeholder value defined in configuration option `toasted.value.placeholder`.
 
 [IMPORTANT]
 ====

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1284,6 +1284,23 @@ Please see http://www.opengeospatial.org/standards/sfa[Open Geospatial Consortiu
 
 |=======================
 
+[[toasted-values]]
+==== Toasted values
+PostgreSQL has a hard limit on the page size.
+This means that values larger than cca 8 KB needs to be stored using https://www.postgresql.org/docs/current/storage-toast.html[TOAST storage].
+This impacts replication messages coming from database as the values that were stored using TOAST mechanism and have not been changed are not included in the message in new value section.
+There is no safe way for Debezium to read the missing value out-of-bands directly from database as this would lead into race condition.
+Debezium thus follows these rules to handle the toasted values
+
+* tables with `REPLICA IDENTITY FULL`
+** `INSERT` and `DELETE` messages contain unchanged toasted values
+** `UPDATE` messages contain original toasted value in part with old values and nothing in new values.
+Debezium copies the old value into the new value.
+* tables with `REPLICA IDENTITY DEFAULT`
+** `INSERT` messages contain unchanged toasted values
+** `UPDATE` and `DELETE` messages does not contain toasted value thata were not updated.
+As Debezium cannot safely provide the value it returns a placeholder value defined in configuration option `toasted.value.placeholder`.
+
 [[fault-tolerance]]
 [[when-things-go-wrong]]
 === When Things Go Wrong
@@ -1658,6 +1675,12 @@ See xref:configuration/avro.adoc#names[Avro naming] for more details.
 |`slot.retry.delay.ms` +
 |10000 (10 seconds)
 |The number of milli-seconds to wait between retry attempts when the connector fails to connect to a replication slot.
+
+|`toasted.value.placeholder`
+|`__DEBEZIUM_TOASTED_VALUE__`
+|Specify the constant that will be provided by Debezium to indicate that the original value is a toasted value not provided by the database.
+If starts with `hex:` prefix it is expected that the rest of the string repesents hexadecimally encoded octets.
+See link:#toasted-values[section] with additional details.
 
 |=======================
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1686,7 +1686,7 @@ See xref:configuration/avro.adoc#names[Avro naming] for more details.
 |The number of milli-seconds to wait between retry attempts when the connector fails to connect to a replication slot.
 
 |`toasted.value.placeholder`
-|`__DEBEZIUM_TOASTED_VALUE__`
+|`__debezium_unavailable_value`
 |Specify the constant that will be provided by Debezium to indicate that the original value is a toasted value not provided by the database.
 If starts with `hex:` prefix it is expected that the rest of the string repesents hexadecimally encoded octets.
 See link:#toasted-values[section] with additional details.


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1367
https://issues.jboss.org/browse/DBZ-1368
https://issues.jboss.org/browse/DBZ-1399

Depends on https://github.com/debezium/postgres-decoderbufs/pull/20
The code now expects that bot pgoutput and protobuf signals fields that contain unchanged toasted values. wal2json with `columns_diff_exclude_unchanged_toast` supposes that missing toasted column means exactly the same thing.
The code replaces missing value with a string or binary placeholder. In case of update messages when non-toasted column is updated the PR will read old toasted value if available in the message and write it into the new value instead of placeholder.