### PR TITLE
Parent JBoss POM upgrade | Checkstyle fixes and support checks upgrade

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSet.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSet.java
@@ -197,7 +197,7 @@ public final class ReplicaSet implements Comparable<ReplicaSet> {
             return 0;
         }
         if (str1 == null) {
-            return str2 == null?0:- 1;
+            return str2 == null ? 0 : -1;
         }
         if (str2 == null) {
             return 1;

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Replicator.java
@@ -400,7 +400,7 @@ public class Replicator {
         Threads.Timer timer = Threads.timer(Clock.SYSTEM, delay);
         Metronome metronome = Metronome.parker(ConfigurationDefaults.RETURN_CONTROL_INTERVAL, Clock.SYSTEM);
 
-        while(!timer.expired()) {
+        while (!timer.expired()) {
             if (!running.get()) {
                 throw new InterruptedException("Interrupted while awaiting initial snapshot delay");
             }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -256,7 +256,7 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
         // ---------------------------------------------------------------------------------------------------------------
         //Testing.Debug.enable();
         AtomicReference<String> id = new AtomicReference<>();
-        primary().execute("create", mongo->{
+        primary().execute("create", mongo-> {
             MongoDatabase db1 = mongo.getDatabase("dbit");
             MongoCollection<Document> coll = db1.getCollection("arbitrary");
             coll.drop();
@@ -273,7 +273,7 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
             Testing.debug("Document ID: " + id.get());
         });
 
-        primary().execute("update", mongo->{
+        primary().execute("update", mongo-> {
             MongoDatabase db1 = mongo.getDatabase("dbit");
             MongoCollection<Document> coll = db1.getCollection("arbitrary");
 
@@ -329,7 +329,7 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
         // Cleanup database
         TestHelper.cleanDatabase(primary(), "dbit");
 
-        primary().execute("create", mongo->{
+        primary().execute("create", mongo-> {
             MongoDatabase db1 = mongo.getDatabase("dbit");
             MongoCollection<Document> coll = db1.getCollection("dbz865_my@collection");
             coll.drop();
@@ -383,7 +383,7 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
         // Cleanup database
         TestHelper.cleanDatabase(primary(), "dbit");
 
-        primary().execute("create", mongo->{
+        primary().execute("create", mongo-> {
             MongoDatabase db1 = mongo.getDatabase("dbit");
             MongoCollection<Document> coll = db1.getCollection("dbz865_my@collection");
             coll.drop();
@@ -530,7 +530,7 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
         // Cleanup database
         TestHelper.cleanDatabase(primary(), "dbit");
 
-        primary().execute("create", mongo->{
+        primary().execute("create", mongo-> {
             MongoDatabase db1 = mongo.getDatabase("dbit");
             MongoCollection<Document> coll1 = db1.getCollection("mhb");
             coll1.drop();
@@ -548,7 +548,7 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
         assertThat(records.allRecordsInOrder()).hasSize(1);
         assertThat(records.recordsForTopic("mongo.dbit.mhb")).hasSize(1);
 
-        primary().execute("insert-monitored", mongo->{
+        primary().execute("insert-monitored", mongo-> {
             MongoDatabase db1 = mongo.getDatabase("dbit");
             MongoCollection<Document> coll = db1.getCollection("mhb");
 
@@ -568,7 +568,7 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
         assertThat(monitoredTs).isEqualTo((Integer) hbAfterMonitoredOffset.get(SourceInfo.TIMESTAMP));
         assertThat(monitoredOrd).isEqualTo((Integer) hbAfterMonitoredOffset.get(SourceInfo.ORDER));
 
-        primary().execute("insert-nonmonitored", mongo->{
+        primary().execute("insert-nonmonitored", mongo-> {
             MongoDatabase db1 = mongo.getDatabase("dbit");
             MongoCollection<Document> coll = db1.getCollection("nmhb");
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/MongoDataConverterTest.java
@@ -176,7 +176,7 @@ public class MongoDataConverterTest {
 
     @Test
     @FixFor("DBZ-1315")
-    public void shouldProcessUnsupportedValue(){
+    public void shouldProcessUnsupportedValue() {
         val = BsonDocument.parse("{\n" +
                 "    \"_id\" : ObjectId(\"518cc94bc27cfa20d9693e5d\"),\n" +
                 "    \"name\" : undefined,\n" +

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
@@ -72,7 +72,7 @@ public abstract class AbstractReader implements Reader {
         this.maxBatchSize = context.getConnectorConfig().getMaxBatchSize();
         this.pollInterval = context.getConnectorConfig().getPollInterval();
         this.metronome = Metronome.parker(pollInterval, Clock.SYSTEM);
-        this.acceptAndContinue = acceptAndContinue == null? new AcceptAllPredicate() : acceptAndContinue;
+        this.acceptAndContinue = acceptAndContinue == null ? new AcceptAllPredicate() : acceptAndContinue;
         this.changeEventQueueMetrics = new ChangeEventQueueMetrics() {
 
             @Override

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -250,7 +250,7 @@ public class BinlogReader extends AbstractReader {
                     header.setTimestamp(edde.getEventHeader().getTimestamp());
                     header.setServerId(edde.getEventHeader().getServerId());
 
-                    if(edde.getEventHeader() instanceof EventHeaderV4) {
+                    if (edde.getEventHeader() instanceof EventHeaderV4) {
                         header.setEventLength(((EventHeaderV4) edde.getEventHeader()).getEventLength());
                         header.setNextPosition(((EventHeaderV4) edde.getEventHeader()).getNextPosition());
                         header.setFlags(((EventHeaderV4) edde.getEventHeader()).getFlags());
@@ -589,7 +589,7 @@ public class BinlogReader extends AbstractReader {
             EventHeaderV4 eventHeader = (EventHeaderV4) data.getCause().getEventHeader(); // safe cast, instantiated that ourselves
 
             // logging some additional context but not the exception itself, this will happen in handleEvent()
-            if(eventDeserializationFailureHandlingMode == EventProcessingFailureHandlingMode.FAIL) {
+            if (eventDeserializationFailureHandlingMode == EventProcessingFailureHandlingMode.FAIL) {
                 logger.error(
                         "Error while deserializing binlog event at offset {}.{}" +
                         "Use the mysqlbinlog tool to view the problematic event: mysqlbinlog --start-position={} --stop-position={} --verbose {}",
@@ -602,7 +602,7 @@ public class BinlogReader extends AbstractReader {
 
                 throw new RuntimeException(data.getCause());
             }
-            else if(eventDeserializationFailureHandlingMode == EventProcessingFailureHandlingMode.WARN) {
+            else if (eventDeserializationFailureHandlingMode == EventProcessingFailureHandlingMode.WARN) {
                 logger.warn(
                         "Error while deserializing binlog event at offset {}.{}" +
                         "This exception will be ignored and the event be skipped.{}" +
@@ -1062,12 +1062,12 @@ public class BinlogReader extends AbstractReader {
 
         @Override
         public void onEventDeserializationFailure(BinaryLogClient client, Exception ex) {
-            if(eventDeserializationFailureHandlingMode == EventProcessingFailureHandlingMode.FAIL) {
+            if (eventDeserializationFailureHandlingMode == EventProcessingFailureHandlingMode.FAIL) {
                 logger.debug("A deserialization failure event arrived", ex);
                 logReaderState();
                 BinlogReader.this.failed(ex);
             }
-            else if(eventDeserializationFailureHandlingMode == EventProcessingFailureHandlingMode.WARN) {
+            else if (eventDeserializationFailureHandlingMode == EventProcessingFailureHandlingMode.WARN) {
                 logger.warn("A deserialization failure event arrived", ex);
                 logReaderState(Level.WARN);
             }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -425,7 +425,7 @@ public class BinlogReader extends AbstractReader {
      * @return a copy of the last offset of this reader, or null if this reader has not completed a poll.
      */
     public Map<String, ?> getLastOffset() {
-        return lastOffset == null? null : new HashMap<>(lastOffset);
+        return lastOffset == null ? null : new HashMap<>(lastOffset);
     }
 
     @Override

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -328,14 +328,14 @@ public final class MySqlConnectorTask extends BaseSourceTask {
     private Map<String, ?> getRestartOffset(Map<String, ?> storedOffset) {
         Map<String, Object> restartOffset = new HashMap<>();
         if (storedOffset != null) {
-            for (Entry<String, ?> entry : storedOffset.entrySet()){
+            for (Entry<String, ?> entry : storedOffset.entrySet()) {
                 if (entry.getKey().startsWith(SourceInfo.RESTART_PREFIX)) {
                     String newKey = entry.getKey().substring(SourceInfo.RESTART_PREFIX.length());
                     restartOffset.put(newKey, entry.getValue());
                 }
             }
         }
-        return restartOffset.isEmpty()? storedOffset : restartOffset;
+        return restartOffset.isEmpty() ? storedOffset : restartOffset;
     }
 
     private static MySqlTaskContext createAndStartTaskContext(Configuration config,

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlUnsignedIntegerConverter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlUnsignedIntegerConverter.java
@@ -34,7 +34,8 @@ public class MySqlUnsignedIntegerConverter {
     /**
      * Private constructor
      */
-    private MySqlUnsignedIntegerConverter(){}
+    private MySqlUnsignedIntegerConverter() {
+    }
 
     /**
      * Convert original value insertion of type 'TINYINT' into the correct TINYINT UNSIGNED representation
@@ -43,7 +44,7 @@ public class MySqlUnsignedIntegerConverter {
      * @param originalNumber {@link Short} the original insertion value
      * @return {@link Short} the correct representation of the original insertion value
      */
-    public static short convertUnsignedTinyint(short originalNumber){
+    public static short convertUnsignedTinyint(short originalNumber) {
         if (originalNumber < 0) {
             return (short) (originalNumber + TINYINT_CORRECTION);
         }
@@ -59,7 +60,7 @@ public class MySqlUnsignedIntegerConverter {
      * @param originalNumber {@link Integer} the original insertion value
      * @return {@link Integer} the correct representation of the original insertion value
      */
-    public static int convertUnsignedSmallint(int originalNumber){
+    public static int convertUnsignedSmallint(int originalNumber) {
         if (originalNumber < 0) {
             return originalNumber + SMALLINT_CORRECTION;
         }
@@ -75,7 +76,7 @@ public class MySqlUnsignedIntegerConverter {
      * @param originalNumber {@link Integer} the original insertion value
      * @return {@link Integer} the correct representation of the original insertion value
      */
-    public static int convertUnsignedMediumint(int originalNumber){
+    public static int convertUnsignedMediumint(int originalNumber) {
         if (originalNumber < 0) {
             return originalNumber + MEDIUMINT_CORRECTION;
         }
@@ -91,7 +92,7 @@ public class MySqlUnsignedIntegerConverter {
      * @param originalNumber {@link Long} the original insertion value
      * @return {@link Long} the correct representation of the original insertion value
      */
-    public static long convertUnsignedInteger(long originalNumber){
+    public static long convertUnsignedInteger(long originalNumber) {
         if (originalNumber < 0) {
             return originalNumber + INT_CORRECTION;
         }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
@@ -563,7 +563,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
      * @return the converted value, or null if the conversion could not be made and the column allows nulls
      * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
-    protected Object convertPoint(Column column, Field fieldDefn, Object data){
+    protected Object convertPoint(Column column, Field fieldDefn, Object data) {
         final MySqlGeometry empty = MySqlGeometry.createEmpty();
         return convertValue(column, fieldDefn, data, io.debezium.data.geometry.Geometry.createValue(fieldDefn.schema(), empty.getWkb(), empty.getSrid()), (r) -> {
             if (data instanceof byte[]) {
@@ -626,7 +626,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
      *
      * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
-    protected Object convertUnsignedTinyint(Column column, Field fieldDefn, Object data){
+    protected Object convertUnsignedTinyint(Column column, Field fieldDefn, Object data) {
         return convertValue(column, fieldDefn, data, (short) 0, (r) -> {
             if (data instanceof Short) {
                 r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedTinyint((short) data));
@@ -652,7 +652,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
      *
      * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
-    protected Object convertUnsignedSmallint(Column column, Field fieldDefn, Object data){
+    protected Object convertUnsignedSmallint(Column column, Field fieldDefn, Object data) {
         return convertValue(column, fieldDefn, data, 0, (r) -> {
             if (data instanceof Integer) {
                 r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedSmallint((int) data));
@@ -678,7 +678,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
      *
      * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
-    protected Object convertUnsignedMediumint(Column column, Field fieldDefn, Object data){
+    protected Object convertUnsignedMediumint(Column column, Field fieldDefn, Object data) {
         return convertValue(column, fieldDefn, data, 0, (r) -> {
             if (data instanceof Integer) {
                 r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedMediumint((int) data));
@@ -704,7 +704,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
      *
      * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
-    protected Object convertUnsignedInt(Column column, Field fieldDefn, Object data){
+    protected Object convertUnsignedInt(Column column, Field fieldDefn, Object data) {
         return convertValue(column, fieldDefn, data, 0L, (r) -> {
             if (data instanceof Long) {
                 r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedInteger((long) data));
@@ -730,7 +730,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
      *
      * @throws IllegalArgumentException if the value could not be converted but the column does not allow nulls
      */
-    protected Object convertUnsignedBigint(Column column, Field fieldDefn, Object data){
+    protected Object convertUnsignedBigint(Column column, Field fieldDefn, Object data) {
         return convertValue(column, fieldDefn, data, 0L, (r) -> {
             if (data instanceof BigDecimal) {
                 r.deliver(MySqlUnsignedIntegerConverter.convertUnsignedBigint((BigDecimal) data));

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/ParallelSnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/ParallelSnapshotReader.java
@@ -150,7 +150,7 @@ public class ParallelSnapshotReader implements Reader {
     @Override
     public List<SourceRecord> poll() throws InterruptedException {
         // the old tables reader is a raw BinlogReader and will throw an exception of poll is called when it is not running.
-        List<SourceRecord> allRecords = oldTablesReader.isRunning()? oldTablesReader.poll() : null;
+        List<SourceRecord> allRecords = oldTablesReader.isRunning() ? oldTablesReader.poll() : null;
         List<SourceRecord> newTablesRecords = newTablesReader.poll();
         if (newTablesRecords != null) {
             if (allRecords == null) {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/ReconcilingBinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/ReconcilingBinlogReader.java
@@ -104,7 +104,7 @@ public class ReconcilingBinlogReader implements Reader {
 
     @Override
     public void stop() {
-        if (running.compareAndSet(true, false)){
+        if (running.compareAndSet(true, false)) {
             try {
                 LOGGER.info("Stopping the {} reader", reconcilingReader.name());
                 reconcilingReader.stop();
@@ -126,7 +126,7 @@ public class ReconcilingBinlogReader implements Reader {
     }
 
     private void completeSuccessfully() {
-        if (completed.compareAndSet(false, true)){
+        if (completed.compareAndSet(false, true)) {
             stop();
             setupUnifiedReader();
             LOGGER.info("Completed reconciliation of parallel readers.");
@@ -192,12 +192,12 @@ public class ReconcilingBinlogReader implements Reader {
 
     /*package private*/ BinlogReader getLeadingReader() {
         checkLaggingLeadingInfo();
-        return aReaderLeading? binlogReaderA : binlogReaderB;
+        return aReaderLeading ? binlogReaderA : binlogReaderB;
     }
 
     /*package private*/ BinlogReader getLaggingReader() {
         checkLaggingLeadingInfo();
-        return aReaderLeading? binlogReaderB : binlogReaderA;
+        return aReaderLeading ? binlogReaderB : binlogReaderA;
     }
 
     private void checkLaggingLeadingInfo() {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RecordMakers.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RecordMakers.java
@@ -183,7 +183,7 @@ public class RecordMakers {
             return sourceOffset;
         }
         else {
-            for(Entry<String, ?> restartOffsetEntry : restartOffset.entrySet()){
+            for (Entry<String, ?> restartOffsetEntry : restartOffset.entrySet()){
                 sourceOffset.put(SourceInfo.RESTART_PREFIX + restartOffsetEntry.getKey(), restartOffsetEntry.getValue());
             }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RecordMakers.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RecordMakers.java
@@ -183,7 +183,7 @@ public class RecordMakers {
             return sourceOffset;
         }
         else {
-            for (Entry<String, ?> restartOffsetEntry : restartOffset.entrySet()){
+            for (Entry<String, ?> restartOffsetEntry : restartOffset.entrySet()) {
                 sourceOffset.put(SourceInfo.RESTART_PREFIX + restartOffsetEntry.getKey(), restartOffsetEntry.getValue());
             }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
@@ -274,7 +274,7 @@ final class SourceInfo extends AbstractSourceInfo {
         if (isSnapshotInEffect()) {
             map.put(SNAPSHOT_KEY, true);
         }
-        if(hasFilterInfo()) {
+        if (hasFilterInfo()) {
             map.put(DATABASE_WHITELIST_KEY, databaseWhitelist);
             map.put(DATABASE_BLACKLIST_KEY, databaseBlacklist);
             map.put(TABLE_WHITELIST_KEY, tableWhitelist);

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/AbstractMySqlConnectorOutputTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/AbstractMySqlConnectorOutputTest.java
@@ -147,7 +147,7 @@ public class AbstractMySqlConnectorOutputTest extends ConnectorOutputTest {
                         String masterUuid = uuids.iterator().next();
                         variables.put("master_uuid", masterUuid);
                     }
-                    else if(uuids.isEmpty()) {
+                    else if (uuids.isEmpty()) {
                         // do nothing ...
                     }
                     else {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlUnsignedIntegerConverterTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlUnsignedIntegerConverterTest.java
@@ -17,31 +17,31 @@ import org.junit.Test;
 public class MySqlUnsignedIntegerConverterTest {
 
     @Test
-    public void shouldConvertSignedBinlogTinyintToUnsigned(){
+    public void shouldConvertSignedBinlogTinyintToUnsigned() {
         assertEquals((short) 255, MySqlUnsignedIntegerConverter.convertUnsignedTinyint((short) -1));
         assertEquals((short) 255, MySqlUnsignedIntegerConverter.convertUnsignedTinyint((short) 255));
     }
 
     @Test
-    public void shouldConvertSignedBinlogSmallintToUnsigned(){
+    public void shouldConvertSignedBinlogSmallintToUnsigned() {
         assertEquals(65535, MySqlUnsignedIntegerConverter.convertUnsignedSmallint(-1));
         assertEquals(65535, MySqlUnsignedIntegerConverter.convertUnsignedSmallint(65535));
     }
 
     @Test
-    public void shouldConvertSignedBinlogMediumintToUnsigned(){
+    public void shouldConvertSignedBinlogMediumintToUnsigned() {
         assertEquals(16777215, MySqlUnsignedIntegerConverter.convertUnsignedMediumint(-1));
         assertEquals(16777215, MySqlUnsignedIntegerConverter.convertUnsignedMediumint(16777215));
     }
 
     @Test
-    public void shouldConvertSignedBinlogIntToUnsigned(){
+    public void shouldConvertSignedBinlogIntToUnsigned() {
         assertEquals(4294967295L, MySqlUnsignedIntegerConverter.convertUnsignedInteger(-1L));
         assertEquals(4294967295L, MySqlUnsignedIntegerConverter.convertUnsignedInteger(4294967295L));
     }
 
     @Test
-    public void shouldConvertSignedBinlogBigintToUnsigned(){
+    public void shouldConvertSignedBinlogBigintToUnsigned() {
         assertEquals(new BigDecimal("18446744073709551615"), MySqlUnsignedIntegerConverter.convertUnsignedBigint(new BigDecimal("-1")));
         assertEquals(new BigDecimal("18446744073709551615"), MySqlUnsignedIntegerConverter.convertUnsignedBigint(new BigDecimal("18446744073709551615")));
     }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotReaderIT.java
@@ -465,7 +465,7 @@ public class SnapshotReaderIT {
     }
 
     @Test
-    public void shouldSnapshotTablesInOrderSpecifiedInTablesWhitelist() throws Exception{
+    public void shouldSnapshotTablesInOrderSpecifiedInTablesWhitelist() throws Exception {
         config = simpleConfig()
                 .with(MySqlConnectorConfig.TABLE_WHITELIST, "connector_test_ro_(.*).orders,connector_test_ro_(.*).Products,connector_test_ro_(.*).products_on_hand,connector_test_ro_(.*).dbz_342_timetest")
                 .build();
@@ -492,7 +492,7 @@ public class SnapshotReaderIT {
     }
 
     @Test
-    public void shouldSnapshotTablesInLexicographicalOrder() throws Exception{
+    public void shouldSnapshotTablesInLexicographicalOrder() throws Exception {
         config = simpleConfig()
                 .build();
         context = new MySqlTaskContext(config, new Filters.Builder(config).build());
@@ -520,7 +520,7 @@ public class SnapshotReaderIT {
     }
 
     private Function<SourceRecord, String> getTableNameFromSourceRecord = sourceRecord -> ((Struct) sourceRecord.value()).getStruct("source").getString("table");
-    private LinkedHashSet<String> getTableNamesInSpecifiedOrder(String ... tables){
+    private LinkedHashSet<String> getTableNamesInSpecifiedOrder(String ... tables) {
         LinkedHashSet<String> tablesInOrderExpected = new LinkedHashSet<>();
         for (String table : tables) {
             tablesInOrderExpected.add(table);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -182,7 +182,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                 return null;
             }
             value = value.trim();
-            for(SnapshotMode option: SnapshotMode.values()) {
+            for (SnapshotMode option: SnapshotMode.values()) {
                 if (option.getValue().equalsIgnoreCase(value)) {
                     return option;
                 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -68,7 +68,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
 
         private final String value;
 
-        HStoreHandlingMode(String value){
+        HStoreHandlingMode(String value) {
             this.value=value;
         }
 
@@ -83,7 +83,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
          * @param value the configuration property value ; may not be null
          * @return the matching option, or null if the match is not found
          */
-        public static HStoreHandlingMode parse(String value){
+        public static HStoreHandlingMode parse(String value) {
             if (value == null) {
                 return null ;
             }
@@ -103,7 +103,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
          * @param defaultValue the default value ; may be null
          * @return the matching option or null if the match is not found and non-null default is invalid
          */
-        public static HStoreHandlingMode parse(String value, String defaultValue){
+        public static HStoreHandlingMode parse(String value, String defaultValue) {
             HStoreHandlingMode mode = parse(value);
             if (mode == null && defaultValue != null) {
                 mode = parse(defaultValue);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -185,13 +185,13 @@ public class PostgresConnectorTask extends BaseSourceTask {
         final Metronome metronome = Metronome.parker(retryDelay, Clock.SYSTEM);
         short retryCount = 0;
         ReplicationConnection replicationConnection = null;
-        while(retryCount <= maxRetries) {
+        while (retryCount <= maxRetries) {
             try {
                 return taskContext.createReplicationConnection(shouldExport);
             }
             catch (SQLException ex) {
                 retryCount++;
-                if (retryCount > maxRetries){
+                if (retryCount > maxRetries) {
                     LOGGER.error("Too many errors connecting to server. All {} retries failed.", maxRetries);
                     throw new ConnectException(ex);
                 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -227,7 +227,7 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
                     return rs.getString(columnIndex);
                 default:
                     Object x = rs.getObject(columnIndex);
-                    if(x != null) {
+                    if (x != null) {
                         LOGGER.trace("rs getobject returns class: {}; rs getObject value is: {}", x.getClass(), x);
                     }
                     return x;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -251,7 +251,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
                 else if (oidValue == typeRegistry.geometryArrayOid()) {
                     return SchemaBuilder.array(Geometry.builder().optional().build());
                 }
-                else if (oidValue == typeRegistry.hstoreOid()){
+                else if (oidValue == typeRegistry.hstoreOid()) {
                     return hstoreSchema();
                 }
                 else if (oidValue == typeRegistry.hstoreArrayOid()) {
@@ -280,7 +280,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
         return SpecialValueDecimal.builder(decimalMode, column.length(), column.scale().get());
     }
 
-    private SchemaBuilder hstoreSchema(){
+    private SchemaBuilder hstoreSchema() {
         if (hStoreMode == PostgresConnectorConfig.HStoreHandlingMode.JSON) {
             return Json.builder();
         }
@@ -479,14 +479,14 @@ public class PostgresValueConverter extends JdbcValueConverters {
         return SpecialValueDecimal.fromLogical(new SpecialValueDecimal(newDecimal), mode, column.name());
     }
 
-    protected Object convertHStore(Column column, Field fieldDefn, Object data, HStoreHandlingMode mode){
+    protected Object convertHStore(Column column, Field fieldDefn, Object data, HStoreHandlingMode mode) {
         if (mode == HStoreHandlingMode.JSON) {
             return convertHstoreToJsonString(column, fieldDefn, data);
         }
             return convertHstoreToMap(column, fieldDefn, data);
         }
 
-    private Object convertHstoreToMap(Column column, Field fieldDefn, Object data){
+    private Object convertHstoreToMap(Column column, Field fieldDefn, Object data) {
         return convertValue(column, fieldDefn, data, Collections.emptyMap(), (r) -> {
             if (data instanceof String) {
                 r.deliver(HStoreConverter.fromString((String) data));
@@ -509,7 +509,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
         return new String(data, databaseCharset);
     }
 
-    private Object convertHstoreToJsonString(Column column, Field fieldDefn, Object data){
+    private Object convertHstoreToJsonString(Column column, Field fieldDefn, Object data) {
         return convertValue(column, fieldDefn, data, "{}", (r) -> {
             logger.trace("in ANON: value from data object: *** {} ***", data);
             logger.trace("in ANON: object type is: *** {} ***", data.getClass());
@@ -528,7 +528,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
         });
     }
 
-    private String changePlainStringRepresentationToJsonStringRepresentation(String text){
+    private String changePlainStringRepresentationToJsonStringRepresentation(String text) {
         logger.trace("text value is: {}", text);
         try {
             Map<String, String> map = HStoreConverter.fromString(text);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -97,7 +97,7 @@ public class TypeRegistry {
             else if (TYPE_NAME_CITEXT.equals(type.getName())) {
                 citextOid = type.getOid();
             }
-            else if (TYPE_NAME_HSTORE.equals(type.getName())){
+            else if (TYPE_NAME_HSTORE.equals(type.getName())) {
                 hstoreOid = type.getOid();
             }
             else if (TYPE_NAME_HSTORE_ARRAY.equals(type.getName())) {
@@ -239,7 +239,7 @@ public class TypeRegistry {
      *
      * @return OID for {@code HSTORE} type of this PostgreSQL instance
      */
-    public int hstoreOid(){
+    public int hstoreOid() {
         return hstoreOid;
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -585,12 +585,12 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
         @Override
         public ReplicationConnectionBuilder streamParams(final String slotStreamParams) {
-            if(slotStreamParams != null && !slotStreamParams.isEmpty()) {
+            if (slotStreamParams != null && !slotStreamParams.isEmpty()) {
                 this.slotStreamParams = new Properties();
                 String[] paramsWithValues = slotStreamParams.split(";");
-                for(String paramsWithValue : paramsWithValues) {
+                for (String paramsWithValue : paramsWithValues) {
                     String[] paramAndValue = paramsWithValue.split("=");
-                    if(paramAndValue.length == 2) {
+                    if (paramAndValue.length == 2) {
                         this.slotStreamParams.setProperty(paramAndValue[0], paramAndValue[1]);
                     }
                     else {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -478,7 +478,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
     private static String readString(ByteBuffer buffer) {
         StringBuilder sb = new StringBuilder();
         byte b = 0;
-        while ((b = buffer.get()) != 0){
+        while ((b = buffer.get()) != 0) {
             sb.append((char) b);
         }
         return sb.toString();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
@@ -160,7 +160,7 @@ class PgProtoReplicationMessage implements ReplicationMessage {
             case PgOid.MONEY:
                 return datumMessage.hasDatumInt64() ? datumMessage.getDatumInt64() : null;
             case PgOid.FLOAT4:
-                return datumMessage.hasDatumFloat()? datumMessage.getDatumFloat() : null;
+                return datumMessage.hasDatumFloat() ? datumMessage.getDatumFloat() : null;
             case PgOid.FLOAT8:
                 return datumMessage.hasDatumDouble() ? datumMessage.getDatumDouble() : null;
             case PgOid.NUMERIC:
@@ -311,7 +311,7 @@ class PgProtoReplicationMessage implements ReplicationMessage {
         // 3. For larger arrays and especially 64-bit integers and the like it is less efficient sending string
         //    representations over the wire.
         try {
-            byte[] data = datumMessage.hasDatumBytes()? datumMessage.getDatumBytes().toByteArray() : null;
+            byte[] data = datumMessage.hasDatumBytes() ? datumMessage.getDatumBytes().toByteArray() : null;
             if (data == null) {
                 return null;
             }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
@@ -282,7 +282,7 @@ class PgProtoReplicationMessage implements ReplicationMessage {
                 if (type.getOid() == typeRegistry.geometryOid() || type.getOid() == typeRegistry.geographyOid() || type.getOid() == typeRegistry.citextOid() ) {
                     return datumMessage.getDatumBytes().toByteArray();
                 }
-                if(type.getOid() == typeRegistry.hstoreOid()) {
+                if (type.getOid() == typeRegistry.hstoreOid()) {
                     return datumMessage.getDatumBytes().toByteArray();
                 }
                 if (type.getOid() == typeRegistry.geometryArrayOid() ||

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -948,7 +948,7 @@ public abstract class AbstractRecordsProducerTest extends AbstractConnectorTest 
             Object actualValue = content.get(fieldName);
 
             // assert the value type; for List all implementation types (e.g. immutable ones) are acceptable
-            if(actualValue instanceof List) {
+            if (actualValue instanceof List) {
                 assertTrue("Incorrect value type for " + fieldName, value instanceof List);
                 final List<?> actualValueList = (List<?>) actualValue;
                 final List<?> valueList = (List<?>) value;

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -296,13 +296,13 @@ public abstract class AbstractRecordsProducerTest extends AbstractConnectorTest 
         return fields;
     }
 
-    protected List<SchemaAndValueField> schemaAndValueFieldForMapEncodedHStoreType(){
+    protected List<SchemaAndValueField> schemaAndValueFieldForMapEncodedHStoreType() {
          final Map<String, String> expected = new HashMap<>();
          expected.put("key", "val");
         return Arrays.asList(new SchemaAndValueField("hs", hstoreMapSchema(), expected));
     }
 
-    protected List<SchemaAndValueField> schemaAndValueFieldForMapEncodedHStoreTypeWithMultipleValues(){
+    protected List<SchemaAndValueField> schemaAndValueFieldForMapEncodedHStoreTypeWithMultipleValues() {
         final Map<String, String> expected = new HashMap<>();
         expected.put("key1", "val1");
         expected.put("key2", "val2");
@@ -321,14 +321,14 @@ public abstract class AbstractRecordsProducerTest extends AbstractConnectorTest 
         );
     }
 
-    protected List<SchemaAndValueField> schemaAndValueFieldForMapEncodedHStoreTypeWithNullValues(){
+    protected List<SchemaAndValueField> schemaAndValueFieldForMapEncodedHStoreTypeWithNullValues() {
         final Map<String, String> expected = new HashMap<>();
         expected.put("key1", "val1");
         expected.put("key2", null);
         return Arrays.asList(new SchemaAndValueField("hs", hstoreMapSchema(), expected));
     }
 
-    protected List<SchemaAndValueField> schemaAndValueFieldForMapEncodedHStoreTypeWithSpecialCharacters(){
+    protected List<SchemaAndValueField> schemaAndValueFieldForMapEncodedHStoreTypeWithSpecialCharacters() {
         final Map<String, String> expected = new HashMap<>();
         expected.put("key_#1", "val 1");
         expected.put("key 2", " ##123 78");
@@ -344,12 +344,12 @@ public abstract class AbstractRecordsProducerTest extends AbstractConnectorTest 
                 .build();
     }
 
-    protected List<SchemaAndValueField> schemaAndValueFieldForJsonEncodedHStoreType(){
+    protected List<SchemaAndValueField> schemaAndValueFieldForJsonEncodedHStoreType() {
         final String expected = "{\"key\":\"val\"}";
         return Arrays.asList(new SchemaAndValueField("hs", Json.builder().optional().build(), expected));
     }
 
-    protected List<SchemaAndValueField> schemaAndValueFieldForJsonEncodedHStoreTypeWithMultipleValues(){
+    protected List<SchemaAndValueField> schemaAndValueFieldForJsonEncodedHStoreTypeWithMultipleValues() {
         final String expected = "{\"key1\":\"val1\",\"key2\":\"val2\",\"key3\":\"val3\"}";
         final List<String> expectedArray = Arrays.asList(
                 "{\"key5\":null,\"key4\":\"val4\"}",
@@ -362,12 +362,12 @@ public abstract class AbstractRecordsProducerTest extends AbstractConnectorTest 
         );
     }
 
-    protected List<SchemaAndValueField> schemaAndValueFieldForJsonEncodedHStoreTypeWithNullValues(){
+    protected List<SchemaAndValueField> schemaAndValueFieldForJsonEncodedHStoreTypeWithNullValues() {
         final String expected = "{\"key1\":\"val1\",\"key2\":null}";
         return Arrays.asList(new SchemaAndValueField("hs", Json.builder().optional().build(), expected));
     }
 
-    protected List<SchemaAndValueField> schemaAndValueFieldForJsonEncodedHStoreTypeWithSpcialCharacters(){
+    protected List<SchemaAndValueField> schemaAndValueFieldForJsonEncodedHStoreTypeWithSpcialCharacters() {
         final String expected = "{\"key_#1\":\"val 1\",\"key 2\":\" ##123 78\"}";
         return Arrays.asList(new SchemaAndValueField("hs", Json.builder().optional().build(), expected));
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -1170,7 +1170,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
     @Test
     @FixFor("DBZ-1029")
-    public void shouldReceiveChangesForTableWithoutPrimaryKey() throws Exception{
+    public void shouldReceiveChangesForTableWithoutPrimaryKey() throws Exception {
         TestHelper.execute(
                 "DROP TABLE IF EXISTS test_table;",
                 "CREATE TABLE test_table (id SERIAL, text TEXT);",
@@ -1415,7 +1415,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         logger.info("Many tx duration = {} ms", stopwatch.durations().statistics().getTotal().toMillis());
     }
 
-    private void testReceiveChangesForReplicaIdentityFullTableWithToastedValue(PostgresConnectorConfig.SchemaRefreshMode mode, boolean tablesBeforeStart) throws Exception{
+    private void testReceiveChangesForReplicaIdentityFullTableWithToastedValue(PostgresConnectorConfig.SchemaRefreshMode mode, boolean tablesBeforeStart) throws Exception {
         if (tablesBeforeStart) {
             TestHelper.execute(
                     "DROP TABLE IF EXISTS test_table;",

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotWithOverridesProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotWithOverridesProducerIT.java
@@ -94,7 +94,9 @@ public class SnapshotWithOverridesProducerIT extends AbstractRecordsProducerTest
         for (int i = 0; i < expectedRecordsCount; i++) {
             final SourceRecord record = consumer.remove();
             recordsByTopic.putIfAbsent(record.topic(), new ArrayList<SourceRecord>());
-            recordsByTopic.compute(record.topic(), (k, v) -> { v.add(record); return v; });
+            recordsByTopic.compute(record.topic(), (k, v) -> {
+                v.add(record);
+                return v; });
         }
         return recordsByTopic;
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -280,7 +280,7 @@ public final class TestHelper {
     }
 
     protected static boolean publicationExists(String publicationName) {
-        if(decoderPlugin().equals(PostgresConnectorConfig.LogicalDecoder.PGOUTPUT)) {
+        if (decoderPlugin().equals(PostgresConnectorConfig.LogicalDecoder.PGOUTPUT)) {
             try(PostgresConnection connection = create()) {
                 String query = String.format("SELECT pubname FROM pg_catalog.pg_publication WHERE pubname = '%s'", publicationName);
                 try {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/ReplicationConnectionIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/ReplicationConnectionIT.java
@@ -344,7 +344,7 @@ public class ReplicationConnectionIT {
         Metronome metronome = Metronome.sleeper(Duration.ofMillis(50), Clock.SYSTEM);
         Future<?> result = executorService.submit(() -> {
             while (!Thread.interrupted()) {
-                for(;;) {
+                for (;;) {
                     List<ReplicationMessage> message = new ArrayList<>();
                     stream.read(x -> message.add(x));
                     if (message.isEmpty()) {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/Lsn.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/Lsn.java
@@ -108,7 +108,7 @@ public class Lsn implements Comparable<Lsn>, Nullable {
     }
 
     @Override
-    public boolean equals(Object obj){
+    public boolean equals(Object obj) {
         if (this == obj) {
             return true;
         }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/TxLogPosition.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/TxLogPosition.java
@@ -48,7 +48,7 @@ public class TxLogPosition implements Nullable, Comparable<TxLogPosition> {
     }
 
     @Override
-    public boolean equals(Object obj){
+    public boolean equals(Object obj) {
         if (this == obj) {
             return true;
         }

--- a/debezium-core/src/main/java/io/debezium/config/Configuration.java
+++ b/debezium-core/src/main/java/io/debezium/config/Configuration.java
@@ -1180,7 +1180,8 @@ public interface Configuration {
             try {
                 return Integer.valueOf(value);
             }
-            catch (NumberFormatException e) {}
+            catch (NumberFormatException e) {
+            }
         }
         return defaultValueSupplier != null ? defaultValueSupplier.getAsInt() : null;
     }
@@ -1201,7 +1202,8 @@ public interface Configuration {
             try {
                 return Long.valueOf(value);
             }
-            catch (NumberFormatException e) {}
+            catch (NumberFormatException e) {
+            }
         }
         return defaultValueSupplier != null ? defaultValueSupplier.getAsLong() : null;
     }

--- a/debezium-core/src/main/java/io/debezium/config/Field.java
+++ b/debezium-core/src/main/java/io/debezium/config/Field.java
@@ -572,7 +572,7 @@ public final class Field {
         }
 
         // Do the same for any dependents ...
-        dependents.forEach(name->{
+        dependents.forEach(name-> {
             Field dependentField = fieldSupplier.apply(name);
             if ( dependentField != null ) {
                 dependentField.validate(config, fieldSupplier, results);
@@ -1113,11 +1113,12 @@ public final class Field {
             return 0;
         }
         try {
-            if (Integer.parseInt(value) > 0){
+            if (Integer.parseInt(value) > 0) {
                 return 0;
             }
         }
-        catch (Throwable e) {}
+        catch (Throwable e) {
+        }
         problems.accept(field, value, "A positive integer is expected");
         return 1;
     }
@@ -1132,7 +1133,8 @@ public final class Field {
                 return 0;
             }
         }
-        catch (Throwable e) {}
+        catch (Throwable e) {
+        }
         problems.accept(field, value, "An non-negative integer is expected");
         return 1;
     }
@@ -1162,7 +1164,8 @@ public final class Field {
                 return 0;
             }
         }
-        catch (Throwable e) {}
+        catch (Throwable e) {
+        }
         problems.accept(field, value, "A positive long value is expected");
         return 1;
     }
@@ -1177,7 +1180,8 @@ public final class Field {
                 return 0;
             }
         }
-        catch (Throwable e) {}
+        catch (Throwable e) {
+        }
         problems.accept(field, value, "A non-negative long value is expected");
         return 1;
     }

--- a/debezium-core/src/main/java/io/debezium/data/SchemaUtil.java
+++ b/debezium-core/src/main/java/io/debezium/data/SchemaUtil.java
@@ -187,7 +187,7 @@ public class SchemaUtil {
             else if (obj instanceof ByteBuffer) {
                 append((ByteBuffer) obj);
             }
-            else if(obj instanceof byte[]) {
+            else if (obj instanceof byte[]) {
                     append((byte[]) obj);
             }
             else if (obj instanceof Map<?, ?>) {

--- a/debezium-core/src/main/java/io/debezium/data/SchemaUtil.java
+++ b/debezium-core/src/main/java/io/debezium/data/SchemaUtil.java
@@ -154,7 +154,7 @@ public class SchemaUtil {
                 if (schema.version() != null) {
                     appendAdditional("version", schema.version());
                 }
-                switch(schema.type()){
+                switch(schema.type()) {
                 case STRUCT:
                     appendAdditional("fields", schema.fields());
                     break;

--- a/debezium-core/src/main/java/io/debezium/data/geometry/Geometry.java
+++ b/debezium-core/src/main/java/io/debezium/data/geometry/Geometry.java
@@ -61,7 +61,7 @@ public class Geometry {
      * @param srid the coordinate reference system identifier; may be null if unset/unknown
      * @return a {@link Struct} which represents a Connect value for this schema; never null
      */
-    public static Struct createValue(Schema geomSchema, byte[] wkb, Integer srid){
+    public static Struct createValue(Schema geomSchema, byte[] wkb, Integer srid) {
         Struct result = new Struct(geomSchema);
         result.put(WKB_FIELD, wkb);
         if (srid != null) {

--- a/debezium-core/src/main/java/io/debezium/data/geometry/Point.java
+++ b/debezium-core/src/main/java/io/debezium/data/geometry/Point.java
@@ -101,7 +101,7 @@ public class Point extends Geometry {
      * @param y the Y coordinate of the point; may not be null
      * @return a {@link Struct} which represents a Connect value for this schema; never null
      */
-    public static Struct createValue(Schema geomSchema, double x, double y){
+    public static Struct createValue(Schema geomSchema, double x, double y) {
         // turn the specified points
         byte[] wkb = buildWKBPoint(x, y);
         Struct result = Geometry.createValue(geomSchema, wkb, null);

--- a/debezium-core/src/main/java/io/debezium/document/BasicDocument.java
+++ b/debezium-core/src/main/java/io/debezium/document/BasicDocument.java
@@ -146,7 +146,7 @@ final class BasicDocument implements Document {
      *         is less than, equal to, or greater than the specified object.
      */
     protected int compareNonNull(Value value1, Value value2) {
-        if (Value.isNull(value1) || Value.isNull(value2)){
+        if (Value.isNull(value1) || Value.isNull(value2)) {
             return 0;
         }
         return value1.comparable().compareTo(value2.comparable());

--- a/debezium-core/src/main/java/io/debezium/document/BasicField.java
+++ b/debezium-core/src/main/java/io/debezium/document/BasicField.java
@@ -64,7 +64,7 @@ final class BasicField implements Document.Field, Comparable<Document.Field> {
             return 0;
         }
         int diff = Strings.compareTo(this.getName(), that.getName());
-        if ( diff != 0 ){
+        if ( diff != 0 ) {
             return diff;
         }
         return Value.compareTo(this.getValue(), that.getValue());

--- a/debezium-core/src/main/java/io/debezium/document/ComparableValue.java
+++ b/debezium-core/src/main/java/io/debezium/document/ComparableValue.java
@@ -219,7 +219,7 @@ final class ComparableValue implements Value {
         }
         if (value instanceof Long) {
             long raw = ((Long) value).longValue();
-            if (isValidInteger(raw)){
+            if (isValidInteger(raw)) {
                 return Integer.valueOf((int) raw);
             }
         }

--- a/debezium-core/src/main/java/io/debezium/document/ConvertingValue.java
+++ b/debezium-core/src/main/java/io/debezium/document/ConvertingValue.java
@@ -67,7 +67,7 @@ final class ConvertingValue implements Value {
             return value.asBoolean();
         }
         if (value.isNumber()) {
-            return value.asNumber().intValue() == 0?Boolean.FALSE:Boolean.TRUE;
+            return value.asNumber().intValue() == 0 ? Boolean.FALSE : Boolean.TRUE;
         }
         if (value.isString()) {
             return Boolean.valueOf(asString());

--- a/debezium-core/src/main/java/io/debezium/document/Document.java
+++ b/debezium-core/src/main/java/io/debezium/document/Document.java
@@ -341,7 +341,7 @@ public interface Document extends Iterable<Document.Field>, Comparable<Document>
      */
     default Stream<Field> children(Path path) {
         Value parent = find(path).orElse(Value.create(Document.create()));
-        if (!parent.isDocument()){
+        if (!parent.isDocument()) {
             return Stream.empty();
         }
         return parent.asDocument().stream();
@@ -1122,7 +1122,7 @@ public interface Document extends Iterable<Document.Field>, Comparable<Document>
      */
     default Document setDocument(CharSequence name,
                                  Document document) {
-        if (document == null){
+        if (document == null) {
             document = Document.create();
         }
         setValue(name, Value.create(document));
@@ -1149,7 +1149,7 @@ public interface Document extends Iterable<Document.Field>, Comparable<Document>
      */
     default Array setArray(CharSequence name,
                            Array array) {
-        if (array == null){
+        if (array == null) {
             array = Array.create();
         }
         setValue(name, Value.create(array));

--- a/debezium-core/src/main/java/io/debezium/document/NullValue.java
+++ b/debezium-core/src/main/java/io/debezium/document/NullValue.java
@@ -40,7 +40,7 @@ final class NullValue implements Value {
 
     @Override
     public int compareTo(Value that) {
-        if (this == that){
+        if (this == that) {
             return 0;
         }
         return -1;

--- a/debezium-core/src/main/java/io/debezium/document/Paths.java
+++ b/debezium-core/src/main/java/io/debezium/document/Paths.java
@@ -38,7 +38,7 @@ final class Paths {
             return new SingleSegmentPath(parseSegment(segments[0], resolveJsonPointerEscapes));
         }
         if (resolveJsonPointerEscapes) {
-            for (int i = 0; i != segments.length; ++i){
+            for (int i = 0; i != segments.length; ++i) {
                 segments[i]=parseSegment(segments[i], true);
             }
         }
@@ -462,7 +462,7 @@ final class Paths {
             return ((InnerPath) path).copyInto(segments, start);
         }
         int i = start;
-        for (String segment : path){
+        for (String segment : path) {
             segments[i++]=segment;
         }
         return i;

--- a/debezium-core/src/main/java/io/debezium/function/Predicates.java
+++ b/debezium-core/src/main/java/io/debezium/function/Predicates.java
@@ -221,7 +221,7 @@ public class Predicates {
             String str = conversion.apply(t);
             if (str != null) {
                 for (Pattern p : patterns) {
-                    if (p.matcher(str).matches()){
+                    if (p.matcher(str).matches()) {
                         return Optional.of(p);
                     }
                 }

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConfiguration.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConfiguration.java
@@ -68,7 +68,7 @@ public interface JdbcConfiguration extends Configuration {
      * @return the ClientConfiguration; never null
      */
     public static JdbcConfiguration adapt(Configuration config) {
-        if (config instanceof JdbcConfiguration){
+        if (config instanceof JdbcConfiguration) {
             return (JdbcConfiguration) config;
         }
         return new JdbcConfiguration() {

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -578,7 +578,7 @@ public class JdbcConnection implements AutoCloseable {
         final PreparedStatement statement = createPreparedStatement(preparedQueryString);
         preparer.accept(statement);
         try (ResultSet resultSet = statement.executeQuery();) {
-            if (resultConsumer != null){
+            if (resultConsumer != null) {
                 resultConsumer.accept(resultSet);
             }
         }
@@ -600,7 +600,7 @@ public class JdbcConnection implements AutoCloseable {
         final PreparedStatement statement = createPreparedStatement(preparedQueryString);
         preparer.accept(statement);
         try (ResultSet resultSet = statement.executeQuery();) {
-            if (resultConsumer != null){
+            if (resultConsumer != null) {
                 resultConsumer.accept(resultSet);
             }
         }

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
@@ -210,7 +210,7 @@ public class JdbcValueConverters implements ValueConverterProvider {
                 }
                 return org.apache.kafka.connect.data.Date.builder();
             case Types.TIME:
-                if(adaptiveTimeMicrosecondsPrecisionMode) {
+                if (adaptiveTimeMicrosecondsPrecisionMode) {
                     return MicroTime.builder();
                 }
                 if (adaptiveTimePrecisionMode) {
@@ -413,7 +413,7 @@ public class JdbcValueConverters implements ValueConverterProvider {
     }
 
     protected Object convertTime(Column column, Field fieldDefn, Object data) {
-        if(adaptiveTimeMicrosecondsPrecisionMode) {
+        if (adaptiveTimeMicrosecondsPrecisionMode) {
             return convertTimeToMicrosPastMidnight(column, fieldDefn, data);
         }
         if (adaptiveTimePrecisionMode) {

--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -166,7 +166,7 @@ public class EventDispatcher<T extends DataCollectionId> {
     }
 
     public void dispatchSchemaChangeEvent(T dataCollectionId, SchemaChangeEventEmitter schemaChangeEventEmitter) throws InterruptedException {
-        if(!filter.isIncluded(dataCollectionId)) {
+        if (!filter.isIncluded(dataCollectionId)) {
             LOGGER.trace("Filtering schema change event for {}", dataCollectionId);
             return;
         }
@@ -245,7 +245,7 @@ public class EventDispatcher<T extends DataCollectionId> {
 
             LOGGER.trace( "Received change record for {} operation on key {}", operation, key);
 
-            if(bufferedEvent != null) {
+            if (bufferedEvent != null) {
                 queue.enqueue(bufferedEvent.get());
             }
 
@@ -262,7 +262,7 @@ public class EventDispatcher<T extends DataCollectionId> {
 
         @Override
         public void completeSnapshot() throws InterruptedException {
-            if(bufferedEvent != null) {
+            if (bufferedEvent != null) {
                 // It is possible that the last snapshotted table was empty
                 // this way we ensure that the last event is always marked as last
                 // even if it originates form non-last table

--- a/debezium-core/src/main/java/io/debezium/relational/ColumnId.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnId.java
@@ -77,11 +77,11 @@ public final class ColumnId implements Comparable<ColumnId> {
      */
     private static ColumnId parse(String str, boolean useCatalogBeforeSchema) {
         String[] parts = IDENTIFIER_SEPARATOR_PATTERN.split(str);
-        if ( parts.length < 2 ){
+        if ( parts.length < 2 ) {
             return null;
         }
         TableId tableId = TableId.parse(parts, parts.length - 1, useCatalogBeforeSchema);
-        if ( tableId == null ){
+        if ( tableId == null ) {
             return null;
         }
         return new ColumnId(tableId, parts[parts.length-1]);
@@ -166,14 +166,14 @@ public final class ColumnId implements Comparable<ColumnId> {
 
     @Override
     public int compareTo(ColumnId that) {
-        if (this == that){
+        if (this == that) {
             return 0;
         }
         return this.id.compareTo(that.id);
     }
 
     public int compareToIgnoreCase(ColumnId that) {
-        if (this == that){
+        if (this == that) {
             return 0;
         }
         return this.id.compareToIgnoreCase(that.id);

--- a/debezium-core/src/main/java/io/debezium/relational/ColumnImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnImpl.java
@@ -152,7 +152,7 @@ final class ColumnImpl implements Column, Comparable<Column> {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == this){
+        if (obj == this) {
             return true;
         }
         if (obj instanceof Column) {

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -205,7 +205,7 @@ public abstract class RelationalSnapshotChangeEventSource implements SnapshotCha
         Timer timer = Threads.timer(Clock.SYSTEM, snapshotDelay);
         Metronome metronome = Metronome.parker(ConfigurationDefaults.RETURN_CONTROL_INTERVAL, Clock.SYSTEM);
 
-        while(!timer.expired()) {
+        while (!timer.expired()) {
             if (!context.isRunning()) {
                 throw new InterruptedException("Interrupted while awaiting initial snapshot delay");
             }
@@ -446,7 +446,7 @@ public abstract class RelationalSnapshotChangeEventSource implements SnapshotCha
         ResultSetMetaData metaData = rs.getMetaData();
         Column[] columns = new Column[metaData.getColumnCount()];
 
-        for(int i = 0; i < columns.length; i++) {
+        for (int i = 0; i < columns.length; i++) {
             columns[i] = table.columnWithName(metaData.getColumnName(i + 1));
         }
 
@@ -471,7 +471,7 @@ public abstract class RelationalSnapshotChangeEventSource implements SnapshotCha
     protected abstract void complete(SnapshotContext snapshotContext);
 
     private void rollbackTransaction(Connection connection) {
-        if(connection != null) {
+        if (connection != null) {
             try {
                 connection.rollback();
             }

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -315,7 +315,7 @@ public abstract class RelationalSnapshotChangeEventSource implements SnapshotCha
      */
     protected abstract SchemaChangeEvent getCreateTableEvent(SnapshotContext snapshotContext, Table table) throws Exception;
 
-    private void createDataEvents(ChangeEventSourceContext sourceContext, SnapshotContext snapshotContext) throws InterruptedException{
+    private void createDataEvents(ChangeEventSourceContext sourceContext, SnapshotContext snapshotContext) throws InterruptedException {
         SnapshotReceiver snapshotReceiver = dispatcher.getSnapshotChangeEventReceiver();
         snapshotContext.offset.preSnapshotStart();
 

--- a/debezium-core/src/main/java/io/debezium/relational/TableEditorImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableEditorImpl.java
@@ -104,7 +104,7 @@ final class TableEditorImpl implements TableEditor {
         Iterator<String> nameIter = this.pkColumnNames.iterator();
         while (nameIter.hasNext()) {
             String pkColumnName = nameIter.next();
-            if (!hasColumnWithName(pkColumnName)){
+            if (!hasColumnWithName(pkColumnName)) {
                 nameIter.remove();
             }
         }
@@ -259,7 +259,7 @@ final class TableEditorImpl implements TableEditor {
             throw new IllegalStateException("Unable to create a table from an editor that has no table ID");
         }
         List<Column> columns = new ArrayList<>();
-        sortedColumns.values().forEach(column->{
+        sortedColumns.values().forEach(column-> {
             column = column.edit().charsetNameOfTable(defaultCharsetName).create();
             columns.add(column);
         });

--- a/debezium-core/src/main/java/io/debezium/relational/TableId.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableId.java
@@ -60,7 +60,7 @@ public final class TableId implements DataCollectionId, Comparable<TableId> {
             return new TableId(null, null, parts[0]); // table only
         }
         if (numParts == 2) {
-            if (useCatalogBeforeSchema){
+            if (useCatalogBeforeSchema) {
                 return new TableId(parts[0], null, parts[1]); // catalog & table only
             }
             return new TableId(null, parts[0], parts[1]); // schema & table only

--- a/debezium-core/src/main/java/io/debezium/relational/TableIdParser.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableIdParser.java
@@ -29,7 +29,7 @@ class TableIdParser {
 
         List<String> parts = new ArrayList<>();
 
-        while(stream.hasNext()) {
+        while (stream.hasNext()) {
             parts.add(stream.consume().replaceAll("''", "'").replaceAll("\"\"", "\"").replaceAll("``", "`"));
         }
 
@@ -52,7 +52,7 @@ class TableIdParser {
 
             currentState.onEntry(parsingContext);
 
-            while(input.hasNext()) {
+            while (input.hasNext()) {
                 previousState = currentState;
                 currentState = currentState.handleCharacter(input.next(), parsingContext);
 
@@ -64,7 +64,7 @@ class TableIdParser {
 
             currentState.onExit(parsingContext);
 
-            if(currentState != ParsingState.BEFORE_SEPARATOR && currentState != ParsingState.IN_IDENTIFIER) {
+            if (currentState != ParsingState.BEFORE_SEPARATOR && currentState != ParsingState.IN_IDENTIFIER) {
                 throw new IllegalArgumentException("Invalid identifier: " + identifier);
             }
         }

--- a/debezium-core/src/main/java/io/debezium/relational/Tables.java
+++ b/debezium-core/src/main/java/io/debezium/relational/Tables.java
@@ -401,7 +401,7 @@ public final class Tables {
         }
 
         public void putAll(TablesById tablesByTableId) {
-            if(tableIdCaseInsensitive) {
+            if (tableIdCaseInsensitive) {
                 tablesByTableId.values.entrySet()
                     .forEach(e -> put(e.getKey().toLowercase(), e.getValue()));
             }

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/AbstractDdlParser.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/AbstractDdlParser.java
@@ -390,7 +390,7 @@ public abstract class AbstractDdlParser implements DdlParser {
                     if (foundDecimalPoint) {
                         ++scale;
                     }
-                    else{
+                    else {
                         ++precision;
                     }
                 }

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/DataTypeGrammarParser.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/DataTypeGrammarParser.java
@@ -283,7 +283,7 @@ public class DataTypeGrammarParser {
 
         @Override
         public boolean determineFirstTokens(Consumer<String> tokens) {
-            if (!pattern1.determineFirstTokens(tokens)){
+            if (!pattern1.determineFirstTokens(tokens)) {
                 return false;
             }
             return pattern2.determineFirstTokens(tokens);
@@ -315,12 +315,13 @@ public class DataTypeGrammarParser {
             catch (ParsingException e) {
             }
             stream.rewind(marker);
-            try{
+            try {
                 if ( pattern2.match(stream, builder, error) ) {
                     return true;
                 }
             }
-            catch (ParsingException e) {}
+            catch (ParsingException e) {
+            }
             stream.rewind(marker);
             return false;
         }

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/DdlChanges.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/DdlChanges.java
@@ -68,7 +68,7 @@ public class DdlChanges implements DdlParserListener {
         groupEventsByDatabase((DatabaseEventConsumer) (dbName, eventList) -> {
             final StringBuilder statements = new StringBuilder();
             final Set<TableId> tables = new HashSet<>();
-            eventList.forEach(event->{
+            eventList.forEach(event-> {
                 statements.append(event.statement());
                 statements.append(terminator);
                 addTable(tables, event);

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/DdlParserSql2003.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/DdlParserSql2003.java
@@ -613,7 +613,7 @@ public class DdlParserSql2003 extends LegacyDdlParser {
 
         if ( columnNames != null ) {
             // We know nothing other than the names ...
-            columnNames.forEach(name->{
+            columnNames.forEach(name-> {
                 table.addColumn(Column.editor().name(name).create());
             });
         }

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/DdlTokenizer.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/DdlTokenizer.java
@@ -153,7 +153,7 @@ public class DdlTokenizer implements Tokenizer {
                     if (!foundLineTerminator) {
                         ++endIndex; // must point beyond last char
                     }
-                    if (c == '\r' && input.isNext('\n')){
+                    if (c == '\r' && input.isNext('\n')) {
                         input.next();
                     }
                     if (useComments) {
@@ -178,7 +178,7 @@ public class DdlTokenizer implements Tokenizer {
                             }
                         }
                         endIndex = input.index(); // the token won't include the '\n' or '\r' character(s)
-                        if (!foundLineTerminator){
+                        if (!foundLineTerminator) {
                             ++endIndex; // must point beyond last char
                         }
                         if (c == '\r' && input.isNext('\n')) {

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/LegacyDdlParser.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/LegacyDdlParser.java
@@ -47,7 +47,7 @@ public class LegacyDdlParser extends AbstractDdlParser implements DdlParser {
 
         default void add(String firstToken, String... additionalTokens){
             add(firstToken);
-            for(String token: additionalTokens) {
+            for (String token: additionalTokens) {
                 add(token);
             }
         }
@@ -188,7 +188,7 @@ public class LegacyDdlParser extends AbstractDdlParser implements DdlParser {
         if (id != null) {
             ids.add(id);
         }
-        while(tokens.canConsume(',')){
+        while (tokens.canConsume(',')){
             id = parseQualifiedTableName(start);
             if (id != null) {
                 ids.add(id);

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/LegacyDdlParser.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/LegacyDdlParser.java
@@ -45,7 +45,7 @@ public class LegacyDdlParser extends AbstractDdlParser implements DdlParser {
     protected static interface TokenSet {
         void add(String token);
 
-        default void add(String firstToken, String... additionalTokens){
+        default void add(String firstToken, String... additionalTokens) {
             add(firstToken);
             for (String token: additionalTokens) {
                 add(token);
@@ -188,7 +188,7 @@ public class LegacyDdlParser extends AbstractDdlParser implements DdlParser {
         if (id != null) {
             ids.add(id);
         }
-        while (tokens.canConsume(',')){
+        while (tokens.canConsume(',')) {
             id = parseQualifiedTableName(start);
             if (id != null) {
                 ids.add(id);
@@ -849,7 +849,8 @@ public class LegacyDdlParser extends AbstractDdlParser implements DdlParser {
         if (tokens.canConsume("ON")) {
             try {
                 parseSchemaQualifiedName(start);
-                while (tokens.canConsume(DdlTokenizer.SYMBOL)) {}
+                while (tokens.canConsume(DdlTokenizer.SYMBOL)) {
+                }
                 parseSchemaQualifiedName(start);
                 return true;
             }

--- a/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
@@ -283,7 +283,7 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
 
         // The end offset should never change during recovery; doing this check here just as - a rather weak - attempt
         // to spot other connectors that share the same history topic accidentally
-        if(previousEndOffset != null && !previousEndOffset.equals(endOffset)) {
+        if (previousEndOffset != null && !previousEndOffset.equals(endOffset)) {
             throw new IllegalStateException("Detected changed end offset of database history topic (previous: "
                     + previousEndOffset + ", current: " + endOffset
                     + "). Make sure that the same history topic isn't shared by multiple connector instances."

--- a/debezium-core/src/main/java/io/debezium/relational/mapping/TruncateStrings.java
+++ b/debezium-core/src/main/java/io/debezium/relational/mapping/TruncateStrings.java
@@ -27,7 +27,7 @@ public class TruncateStrings implements ColumnMapper {
      * @throws IllegalArgumentException if the {@code maxLength} is not positive
      */
     public TruncateStrings(int maxLength) {
-        if (maxLength <= 0){
+        if (maxLength <= 0) {
             throw new IllegalArgumentException("Maximum length must be positive");
         }
         this.converter = new TruncatingValueConverter(maxLength);

--- a/debezium-core/src/main/java/io/debezium/schema/FieldNameSelector.java
+++ b/debezium-core/src/main/java/io/debezium/schema/FieldNameSelector.java
@@ -64,7 +64,7 @@ public class FieldNameSelector {
         private String sanitizeColumnName(String columnName) {
             boolean changed = false;
             StringBuilder sanitizedNameBuilder = new StringBuilder(columnName.length() + 1);
-            for(int i = 0; i < columnName.length(); i++) {
+            for (int i = 0; i < columnName.length(); i++) {
                 char c = columnName.charAt(i);
                 if ( i == 0 && Character.isDigit(c)) {
                     sanitizedNameBuilder.append(NUMBER_PREFIX);

--- a/debezium-core/src/main/java/io/debezium/schema/TopicSelector.java
+++ b/debezium-core/src/main/java/io/debezium/schema/TopicSelector.java
@@ -111,7 +111,7 @@ public class TopicSelector<I extends DataCollectionId> {
             StringBuilder sanitizedNameBuilder = new StringBuilder(topicName.length());
             boolean changed = false;
 
-            for(int i = 0; i < topicName.length(); i++) {
+            for (int i = 0; i < topicName.length(); i++) {
                 char c = topicName.charAt(i);
                 if (isValidTopicNameCharacter(c)) {
                     sanitizedNameBuilder.append(c);

--- a/debezium-core/src/main/java/io/debezium/text/MultipleParsingExceptions.java
+++ b/debezium-core/src/main/java/io/debezium/text/MultipleParsingExceptions.java
@@ -59,7 +59,7 @@ public class MultipleParsingExceptions extends RuntimeException {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(getMessage());
-        forEachError(e->{
+        forEachError(e-> {
             sb.append(System.lineSeparator()).append(e.toString());
         });
         return sb.toString();

--- a/debezium-core/src/main/java/io/debezium/text/Position.java
+++ b/debezium-core/src/main/java/io/debezium/text/Position.java
@@ -66,6 +66,11 @@ public final class Position {
     }
 
     @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+
+    @Override
     public int hashCode() {
         return indexInContent;
     }

--- a/debezium-core/src/main/java/io/debezium/text/TokenStream.java
+++ b/debezium-core/src/main/java/io/debezium/text/TokenStream.java
@@ -843,7 +843,7 @@ public class TokenStream {
                     "No more content but was expecting one token of type " + Strings.join("|", typeOptions));
         }
         for (int typeOption : typeOptions) {
-            if (typeOption == ANY_TYPE || matches(typeOption)){
+            if (typeOption == ANY_TYPE || matches(typeOption)) {
                 return consume();
             }
         }
@@ -870,7 +870,7 @@ public class TokenStream {
                     "No more content but was expecting one token of " + String.join("|", options));
         }
         for (String option : options) {
-            if (option == ANY_VALUE || matches(option)){
+            if (option == ANY_VALUE || matches(option)) {
                 return consume();
             }
         }
@@ -1029,7 +1029,7 @@ public class TokenStream {
         Marker start = mark();
         int remaining = 0;
         while (hasNext()) {
-            if (skipMatchingTokens != null && matchesAnyOf(skipMatchingTokens)){
+            if (skipMatchingTokens != null && matchesAnyOf(skipMatchingTokens)) {
                 ++remaining;
             }
             if (matches(expected)) {
@@ -1310,7 +1310,7 @@ public class TokenStream {
             return false;
         }
         Token token = iter.next();
-        if (currentExpected != ANY_VALUE && !token.matches(type, currentExpected)){
+        if (currentExpected != ANY_VALUE && !token.matches(type, currentExpected)) {
             return false;
         }
         for (String nextExpected : expectedForNextTokens) {
@@ -1318,7 +1318,7 @@ public class TokenStream {
                 return false;
             }
             token = iter.next();
-            if (nextExpected == ANY_VALUE){
+            if (nextExpected == ANY_VALUE) {
                 continue;
             }
             if (!token.matches(type, nextExpected)) {
@@ -1820,7 +1820,7 @@ public class TokenStream {
      */
     public boolean matchesAnyOf(int type, String firstOption, String... additionalOptions)
             throws IllegalStateException {
-        if (completed){
+        if (completed) {
             return false;
         }
         Token current = currentToken();
@@ -1877,7 +1877,7 @@ public class TokenStream {
      * @throws IllegalStateException if this method was called before the stream was {@link #start() started}
      */
     public boolean matchesAnyOf(Iterable<String> options) throws IllegalStateException {
-        if (completed){
+        if (completed) {
             return false;
         }
         Token current = currentToken();
@@ -1900,7 +1900,7 @@ public class TokenStream {
     public boolean matchesAnyOf(int firstTypeOption,
                                 int... additionalTypeOptions)
             throws IllegalStateException {
-        if (completed){
+        if (completed) {
             return false;
         }
         Token current = currentToken();
@@ -2601,7 +2601,7 @@ public class TokenStream {
                 columnNumber = 0;
             }
             else if (result == '\n') {
-                if (!nextCharMayBeLineFeed){
+                if (!nextCharMayBeLineFeed) {
                     ++lineNumber;
                 }
                 columnNumber = 0;
@@ -2643,7 +2643,7 @@ public class TokenStream {
             if (nextIndex <= maxIndex) {
                 char nextChar = content[lastIndex + 1];
                 for (char c : characters) {
-                    if (c == nextChar){
+                    if (c == nextChar) {
                         return true;
                     }
                 }
@@ -2656,7 +2656,7 @@ public class TokenStream {
             int nextIndex = lastIndex + 1;
             if (nextIndex <= maxIndex) {
                 char nextChar = content[lastIndex + 1];
-                if (characters.indexOf(nextChar) != -1){
+                if (characters.indexOf(nextChar) != -1) {
                     return true;
                 }
             }
@@ -2857,7 +2857,7 @@ public class TokenStream {
                                 }
                             }
                             endIndex = input.index(); // the token won't include the '\n' or '\r' character(s)
-                            if (!foundLineTerminator){
+                            if (!foundLineTerminator) {
                                 ++endIndex; // must point beyond last char
                             }
                             if (c == '\r' && input.isNext('\n')) {

--- a/debezium-core/src/main/java/io/debezium/text/XmlCharacters.java
+++ b/debezium-core/src/main/java/io/debezium/text/XmlCharacters.java
@@ -46,10 +46,10 @@ public class XmlCharacters {
         MASKS[0x9] |= VALID_CHARACTER | CONTENT_CHARACTER;
         MASKS[0xA] |= VALID_CHARACTER | CONTENT_CHARACTER;
         MASKS[0xD] |= VALID_CHARACTER | CONTENT_CHARACTER;
-        for(int i=0x20 ; i <=0xD7FF ; ++i) {
+        for (int i=0x20 ; i <=0xD7FF ; ++i) {
             MASKS[i]|=VALID_CHARACTER|CONTENT_CHARACTER;
         }
-        for(int i=0xE000 ; i<=0xFFFD ; ++i){
+        for (int i=0xE000 ; i<=0xFFFD ; ++i){
             MASKS[i]|=VALID_CHARACTER|CONTENT_CHARACTER;
         }
         // Last range is bigger than our character array, so we'll handle in the 'isValid' method ...
@@ -86,43 +86,43 @@ public class XmlCharacters {
         int nameStartMask = NAME_START_CHARACTER | NCNAME_START_CHARACTER | NAME_CHARACTER | NCNAME_CHARACTER;
         MASKS[':'] |= nameStartMask;
         MASKS['_'] |= nameStartMask;
-        for(int i = 'A'; i <= 'Z'; ++ i) {
+        for (int i = 'A'; i <= 'Z'; ++ i) {
             MASKS[i] |= nameStartMask;
         }
-        for(int i = 'a'; i <= 'z'; ++ i) {
+        for (int i = 'a'; i <= 'z'; ++ i) {
             MASKS[i] |= nameStartMask;
         }
-        for(int i = 0xC0; i <= 0xD6; ++ i) {
+        for (int i = 0xC0; i <= 0xD6; ++ i) {
             MASKS[i] |= nameStartMask;
         }
-        for(int i = 0xD8; i <= 0xF6; ++ i) {
+        for (int i = 0xD8; i <= 0xF6; ++ i) {
             MASKS[i] |= nameStartMask;
         }
-        for(int i = 0xF8; i <= 0x2FF; ++ i) {
+        for (int i = 0xF8; i <= 0x2FF; ++ i) {
             MASKS[i] |= nameStartMask;
         }
-        for(int i = 0x370; i <= 0x37D; ++ i) {
+        for (int i = 0x370; i <= 0x37D; ++ i) {
             MASKS[i] |= nameStartMask;
         }
-        for(int i = 0x37F; i <= 0x1FFF;  ++ i) {
+        for (int i = 0x37F; i <= 0x1FFF;  ++ i) {
             MASKS[i] |= nameStartMask;
         }
-        for(int i = 0x200C; i <= 0x200D; ++ i) {
+        for (int i = 0x200C; i <= 0x200D; ++ i) {
             MASKS[i] |= nameStartMask;
         }
-        for(int i = 0x2070; i <= 0x218F; ++ i) {
+        for (int i = 0x2070; i <= 0x218F; ++ i) {
             MASKS[i] |= nameStartMask;
         }
-        for(int i = 0x2C00; i <= 0x2FEF; ++ i) {
+        for (int i = 0x2C00; i <= 0x2FEF; ++ i) {
             MASKS[i] |= nameStartMask;
         }
-        for(int i = 0x3001; i <= 0xD7FF; ++ i) {
+        for (int i = 0x3001; i <= 0xD7FF; ++ i) {
             MASKS[i] |= nameStartMask;
         }
-        for(int i = 0xF900; i <= 0xFDCF; ++ i) {
+        for (int i = 0xF900; i <= 0xFDCF; ++ i) {
             MASKS[i] |= nameStartMask;
         }
-        for(int i = 0xFDF0; i <= 0xFFFD; ++ i) {
+        for (int i = 0xFDF0; i <= 0xFFFD; ++ i) {
             MASKS[i] |= nameStartMask;
         }
         // Last range is bigger than our character array ...
@@ -139,13 +139,13 @@ public class XmlCharacters {
         MASKS['-'] |= nameMask;
         MASKS['.'] |= nameMask;
         MASKS[0xB7] |= nameMask;
-        for(int i = '0'; i <= '9'; ++ i) {
+        for (int i = '0'; i <= '9'; ++ i) {
             MASKS[i] |= nameMask;
         }
-        for(int i = 0x0300; i <= 0x036F; ++ i) {
+        for (int i = 0x0300; i <= 0x036F; ++ i) {
             MASKS[i] |= nameStartMask;
         }
-        for(int i = 0x203F; i <= 0x2040; ++ i) {
+        for (int i = 0x203F; i <= 0x2040; ++ i) {
             MASKS[i] |= nameStartMask;
         }
 
@@ -165,13 +165,13 @@ public class XmlCharacters {
         MASKS[0x20] |= PUBID_CHARACTER;
         MASKS[0xA] |= PUBID_CHARACTER;
         MASKS[0xD] |= PUBID_CHARACTER;
-        for(int i='A'; i<='Z'; ++i){
+        for (int i='A'; i<='Z'; ++i){
             MASKS[i]|=PUBID_CHARACTER;
         }
-        for(int i='a'; i<='z'; ++i){
+        for (int i='a'; i<='z'; ++i){
             MASKS[i]|=PUBID_CHARACTER;
         }
-        for(int i='0'; i<='9'; ++i){
+        for (int i='0'; i<='9'; ++i){
             MASKS[i]|=PUBID_CHARACTER;
         }
         MASKS['-'] |= PUBID_CHARACTER;

--- a/debezium-core/src/main/java/io/debezium/text/XmlCharacters.java
+++ b/debezium-core/src/main/java/io/debezium/text/XmlCharacters.java
@@ -49,7 +49,7 @@ public class XmlCharacters {
         for (int i=0x20 ; i <=0xD7FF ; ++i) {
             MASKS[i]|=VALID_CHARACTER|CONTENT_CHARACTER;
         }
-        for (int i=0xE000 ; i<=0xFFFD ; ++i){
+        for (int i=0xE000 ; i<=0xFFFD ; ++i) {
             MASKS[i]|=VALID_CHARACTER|CONTENT_CHARACTER;
         }
         // Last range is bigger than our character array, so we'll handle in the 'isValid' method ...
@@ -165,13 +165,13 @@ public class XmlCharacters {
         MASKS[0x20] |= PUBID_CHARACTER;
         MASKS[0xA] |= PUBID_CHARACTER;
         MASKS[0xD] |= PUBID_CHARACTER;
-        for (int i='A'; i<='Z'; ++i){
+        for (int i='A'; i<='Z'; ++i) {
             MASKS[i]|=PUBID_CHARACTER;
         }
-        for (int i='a'; i<='z'; ++i){
+        for (int i='a'; i<='z'; ++i) {
             MASKS[i]|=PUBID_CHARACTER;
         }
-        for (int i='0'; i<='9'; ++i){
+        for (int i='0'; i<='9'; ++i) {
             MASKS[i]|=PUBID_CHARACTER;
         }
         MASKS['-'] |= PUBID_CHARACTER;
@@ -314,7 +314,7 @@ public class XmlCharacters {
      * @return true if the supplied name is indeed a valid XML NCName, or false otherwise
      */
     public static boolean isValidNcName( String name ) {
-        if (name == null || name.length() == 0){
+        if (name == null || name.length() == 0) {
             return false;
         }
         CharacterIterator iter = new StringCharacterIterator(name);

--- a/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java
@@ -171,7 +171,7 @@ public class ExtractNewRecordState<R extends ConnectRecord<R>> implements Transf
 
     private R addSourceFields(String[] addSourceFields, R originalRecord, R unwrappedRecord) {
         // Return if no source fields to add
-        if(addSourceFields == null) {
+        if (addSourceFields == null) {
             return unwrappedRecord;
         }
         
@@ -186,7 +186,7 @@ public class ExtractNewRecordState<R extends ConnectRecord<R>> implements Transf
         for (org.apache.kafka.connect.data.Field field : value.schema().fields()) {
             updatedValue.put(field.name(), value.get(field));
         }
-        for(String sourceField : addSourceFields) {
+        for (String sourceField : addSourceFields) {
             updatedValue.put(ExtractNewRecordStateConfigDefinition.METADATA_FIELD_PREFIX + sourceField, source.get(sourceField));
         }
 
@@ -207,8 +207,8 @@ public class ExtractNewRecordState<R extends ConnectRecord<R>> implements Transf
             builder.field(field.name(), field.schema());
         }
         // Add the requested source fields, throw exception if a specified source field is not part of the source schema
-        for(String sourceField: addSourceFields) {
-            if(sourceSchema.field(sourceField) == null) {
+        for (String sourceField: addSourceFields) {
+            if (sourceSchema.field(sourceField) == null) {
                 throw new ConfigException("Source field specified in 'add.source.fields' does not exist: " + sourceField);
             }
             builder.field(

--- a/debezium-core/src/main/java/io/debezium/util/ElapsedTimeStrategy.java
+++ b/debezium-core/src/main/java/io/debezium/util/ElapsedTimeStrategy.java
@@ -101,7 +101,7 @@ public interface ElapsedTimeStrategy {
                 }
                 if (!elapsed) {
                     elapsed = stepFunction.getAsBoolean();
-                    if (elapsed){
+                    if (elapsed) {
                         delta = postStepDelayInMilliseconds;
                     }
                 }
@@ -127,7 +127,7 @@ public interface ElapsedTimeStrategy {
      * @return the strategy; never null
      */
     public static ElapsedTimeStrategy linear(Clock clock, long delayInMilliseconds) {
-        if (delayInMilliseconds <= 0){
+        if (delayInMilliseconds <= 0) {
             throw new IllegalArgumentException("Initial delay must be positive");
         }
         return new ElapsedTimeStrategy() {

--- a/debezium-core/src/main/java/io/debezium/util/IoUtil.java
+++ b/debezium-core/src/main/java/io/debezium/util/IoUtil.java
@@ -250,7 +250,7 @@ public class IoUtil {
         }
         InputStream result = null;
         if (result == null) {
-            try{
+            try {
                 // Try absolute path ...
                 Path filePath = FileSystems.getDefault().getPath(resourcePath).toAbsolutePath();
                 File f        = filePath.toFile();
@@ -325,7 +325,7 @@ public class IoUtil {
     public static File createDirectory(Path path) {
         File dir = path.toAbsolutePath().toFile();
         if (dir.exists() && dir.canRead() && dir.canWrite()) {
-            if (dir.isDirectory()){
+            if (dir.isDirectory()) {
                 return dir;
             }
             throw new IllegalStateException("Expecting '" + path + "' to be a directory but found a file");
@@ -387,7 +387,7 @@ public class IoUtil {
      * @throws IOException if there is a problem deleting the file at the given path
      */
     public static void delete(String path) throws IOException {
-        if (path != null){
+        if (path != null) {
             delete(Paths.get(path));
         }
     }

--- a/debezium-core/src/main/java/io/debezium/util/Iterators.java
+++ b/debezium-core/src/main/java/io/debezium/util/Iterators.java
@@ -353,7 +353,7 @@ public class Iterators {
      * @return the peeking iterator; may be null if {@code iter} is null
      */
     public static <T> PreviewIterator<T> preview(Iterator<T> iter) {
-        if (iter == null){
+        if (iter == null) {
             return null;
         }
         if (iter instanceof PreviewIterator) {

--- a/debezium-core/src/main/java/io/debezium/util/Joiner.java
+++ b/debezium-core/src/main/java/io/debezium/util/Joiner.java
@@ -50,7 +50,7 @@ public final class Joiner {
         if (firstValue != null) {
             joiner.add(firstValue);
         }
-        for(CharSequence value: additionalValues) {
+        for (CharSequence value: additionalValues) {
             if (value != null) {
                 joiner.add(value);
             }
@@ -76,7 +76,7 @@ public final class Joiner {
         if (nextValue != null) {
             joiner.add(nextValue);
         }
-        for(CharSequence value: additionalValues) {
+        for (CharSequence value: additionalValues) {
             if (value != null) {
                 joiner.add(value);
             }

--- a/debezium-core/src/main/java/io/debezium/util/MathOps.java
+++ b/debezium-core/src/main/java/io/debezium/util/MathOps.java
@@ -98,7 +98,7 @@ public final class MathOps {
 
     public static Number add(Short first, int second) {
         long sum = first.longValue() + second;
-        if (Short.MAX_VALUE >= sum && Short.MIN_VALUE <= sum){
+        if (Short.MAX_VALUE >= sum && Short.MIN_VALUE <= sum) {
             return Short.valueOf((short) sum);
         }
         if (Integer.MAX_VALUE >= sum && Integer.MIN_VALUE <= sum) {
@@ -109,7 +109,7 @@ public final class MathOps {
 
     public static Number add(Short first, long second) {
         long sum = first.longValue() + second;
-        if (Short.MAX_VALUE >= sum && Short.MIN_VALUE <= sum){
+        if (Short.MAX_VALUE >= sum && Short.MIN_VALUE <= sum) {
             return Short.valueOf((short) sum);
         }
         if (Integer.MAX_VALUE >= sum && Integer.MIN_VALUE <= sum) {

--- a/debezium-core/src/main/java/io/debezium/util/SchemaNameAdjuster.java
+++ b/debezium-core/src/main/java/io/debezium/util/SchemaNameAdjuster.java
@@ -111,7 +111,7 @@ public interface SchemaNameAdjuster {
          * @return the new function; never null
          */
         default ReplacementOccurred andThen(ReplacementOccurred next) {
-            if (next == null){
+            if (next == null) {
                 return this;
             }
             return (original, replacement, conflictsWith) -> {

--- a/debezium-core/src/main/java/io/debezium/util/Strings.java
+++ b/debezium-core/src/main/java/io/debezium/util/Strings.java
@@ -1060,7 +1060,7 @@ public final class Strings {
 
             List<String> parts = new ArrayList<>();
 
-            while(stream.hasNext()) {
+            while (stream.hasNext()) {
                 final String part = stream.consume();
                 if (part.length() == 0) {
                     continue;

--- a/debezium-core/src/main/java/io/debezium/util/Strings.java
+++ b/debezium-core/src/main/java/io/debezium/util/Strings.java
@@ -618,7 +618,8 @@ public final class Strings {
                                     try {
                                         return new BigDecimal(value);
                                     }
-                                    catch (NumberFormatException e7) {}
+                                    catch (NumberFormatException e7) {
+                                    }
                                 }
                             }
                         }
@@ -641,7 +642,8 @@ public final class Strings {
             try {
                 return Integer.parseInt(value);
             }
-            catch (NumberFormatException e) {}
+            catch (NumberFormatException e) {
+            }
         }
         return defaultValue;
     }
@@ -658,7 +660,8 @@ public final class Strings {
             try {
                 return Long.parseLong(value);
             }
-            catch (NumberFormatException e) {}
+            catch (NumberFormatException e) {
+            }
         }
         return defaultValue;
     }
@@ -675,7 +678,8 @@ public final class Strings {
             try {
                 return Double.parseDouble(value);
             }
-            catch (NumberFormatException e) {}
+            catch (NumberFormatException e) {
+            }
         }
         return defaultValue;
     }
@@ -692,7 +696,8 @@ public final class Strings {
             try {
                 return Boolean.parseBoolean(value);
             }
-            catch (NumberFormatException e) {}
+            catch (NumberFormatException e) {
+            }
         }
         return defaultValue;
     }

--- a/debezium-core/src/test/java/io/debezium/data/SchemaAndValueField.java
+++ b/debezium-core/src/test/java/io/debezium/data/SchemaAndValueField.java
@@ -48,7 +48,7 @@ public class SchemaAndValueField {
         Assertions.assertThat(actualValue).as(fieldName + " is not present in the actual content").isNotNull();
 
         // assert the value type; for List all implementation types (e.g. immutable ones) are acceptable
-        if(actualValue instanceof List) {
+        if (actualValue instanceof List) {
             Assertions.assertThat(value).as("Incorrect value type for " + fieldName).isInstanceOf(List.class);
             final List<?> actualValueList = (List<?>) actualValue;
             final List<?> valueList = (List<?>) value;

--- a/debezium-core/src/test/java/io/debezium/data/VerifyRecord.java
+++ b/debezium-core/src/test/java/io/debezium/data/VerifyRecord.java
@@ -357,7 +357,7 @@ public class VerifyRecord {
      * @param expected expected value stored on the source record
      */
     public static void assertSameValue(Object actual, Object expected) {
-        if(expected instanceof Double || expected instanceof Float || expected instanceof BigDecimal) {
+        if (expected instanceof Double || expected instanceof Float || expected instanceof BigDecimal) {
             // Value should be within 1%
             double expectedNumericValue = ((Number) expected).doubleValue();
             double actualNumericValue = ((Number) actual).doubleValue();
@@ -1014,21 +1014,21 @@ public class VerifyRecord {
             return false;
         }
 
-        for (int i = 0; i < length; i++){
+        for (int i = 0; i < length; i++) {
             Object e1=a1[i];
             Object e2=a2[i];
 
-            if(e1==e2){
+            if (e1==e2) {
                 continue;
             }
-            if(e1==null){
+            if (e1==null) {
                 return false;
             }
 
             // Figure out whether the two elements are equal
             boolean eq = deepEquals0(e1, e2);
 
-            if(!eq){
+            if (!eq) {
                 return false;
             }
         }
@@ -1038,34 +1038,34 @@ public class VerifyRecord {
     private static boolean deepEquals0(Object e1, Object e2){
         assert e1!=null;
         boolean eq;
-        if(e1 instanceof Object[]&&e2 instanceof Object[]){
+        if (e1 instanceof Object[]&&e2 instanceof Object[]) {
             eq = deepEquals((Object[]) e1, (Object[]) e2);
         }
-        else if(e1 instanceof byte[]&&e2 instanceof byte[]){
+        else if (e1 instanceof byte[]&&e2 instanceof byte[]) {
             eq = Arrays.equals((byte[]) e1, (byte[]) e2);
             }
-        else if(e1 instanceof short[]&&e2 instanceof short[]){
+        else if (e1 instanceof short[]&&e2 instanceof short[]) {
                 eq = Arrays.equals((short[]) e1, (short[]) e2);
                 }
-        else if(e1 instanceof int[]&&e2 instanceof int[]){
+        else if (e1 instanceof int[]&&e2 instanceof int[]) {
                     eq = Arrays.equals((int[]) e1, (int[]) e2);
                     }
-        else if (e1 instanceof long[] && e2 instanceof long[]){
+        else if (e1 instanceof long[] && e2 instanceof long[]) {
                         eq = Arrays.equals((long[]) e1, (long[]) e2);
                     }
-        else if (e1 instanceof char[] && e2 instanceof char[]){
+        else if (e1 instanceof char[] && e2 instanceof char[]) {
                             eq = Arrays.equals((char[]) e1, (char[]) e2);
                         }
-        else if (e1 instanceof float[] && e2 instanceof float[]){
+        else if (e1 instanceof float[] && e2 instanceof float[]) {
                                 eq = Arrays.equals((float[]) e1, (float[]) e2);
                             }
-        else if (e1 instanceof double[] && e2 instanceof double[]){
+        else if (e1 instanceof double[] && e2 instanceof double[]) {
                                     eq = Arrays.equals((double[]) e1, (double[]) e2);
                                 }
-        else if (e1 instanceof boolean[] && e2 instanceof boolean[]){
+        else if (e1 instanceof boolean[] && e2 instanceof boolean[]) {
                                         eq = Arrays.equals((boolean[]) e1, (boolean[]) e2);
                                     }
-        else{
+        else {
                                         eq = equals(e1, e2);
                                     }
         return eq;
@@ -1119,7 +1119,7 @@ public class VerifyRecord {
             return false;
         }
 
-        for(int i = 0; i < fields1.size(); i++) {
+        for (int i = 0; i < fields1.size(); i++) {
             Field field1 = fields1.get(i);
             Field field2 = fields2.get(i);
 

--- a/debezium-core/src/test/java/io/debezium/data/VerifyRecord.java
+++ b/debezium-core/src/test/java/io/debezium/data/VerifyRecord.java
@@ -519,11 +519,11 @@ public class VerifyRecord {
     }
 
     private static String schemaName(Schema schema) {
-        if (schema == null){
+        if (schema == null) {
             return null;
         }
         String name = schema.name();
-        if (name != null){
+        if (name != null) {
             name = name.trim();
         }
         return name == null || name.isEmpty() ? null : name;
@@ -534,11 +534,11 @@ public class VerifyRecord {
                                        Predicate<String> ignoreFields,
                                        Map<String, RecordValueComparator> comparatorsByName,
                                        Map<String, RecordValueComparator> comparatorsBySchemaName) {
-        if (o1 == o2){
+        if (o1 == o2) {
             return;
         }
         if (o1 == null) {
-            if (o2 == null){
+            if (o2 == null) {
                 return;
             }
             fail(nameOf(keyOrValue, field) + " was null but expected " + SchemaUtil.asString(o2));
@@ -812,7 +812,7 @@ public class VerifyRecord {
             if (avroValueWithSchema != null) {
                 Testing.print("  value to/from Avro: " + SchemaUtil.asString(avroValueWithSchema.value()));
             }
-            if (t instanceof AssertionError){
+            if (t instanceof AssertionError) {
                 throw t;
             }
             fail("error " + msg + ": " + t.getMessage());
@@ -820,7 +820,7 @@ public class VerifyRecord {
     }
 
     protected static void validateSchemaNames(Schema schema) {
-        if (schema == null){
+        if (schema == null) {
             return;
         }
         String schemaName = schema.name();
@@ -835,7 +835,7 @@ public class VerifyRecord {
     }
 
     protected static void validateSubSchemaNames(Schema parentSchema, Field field) {
-        if (field == null){
+        if (field == null) {
             return;
         }
         Schema subSchema = field.schema();
@@ -915,10 +915,10 @@ public class VerifyRecord {
 
     @SuppressWarnings("unchecked")
     protected static boolean equals(Object o1, Object o2) {
-        if (o1 == o2){
+        if (o1 == o2) {
             return true;
         }
-        if (o1 == null){
+        if (o1 == null) {
             return o2 == null ? true : false;
         }
         if (o2 == null) {
@@ -1003,14 +1003,14 @@ public class VerifyRecord {
     }
 
     private static boolean deepEquals(Object[] a1, Object[] a2) {
-        if (a1 == a2){
+        if (a1 == a2) {
             return true;
         }
-        if (a1 == null || a2 == null){
+        if (a1 == null || a2 == null) {
             return false;
         }
         int length = a1.length;
-        if (a2.length != length){
+        if (a2.length != length) {
             return false;
         }
 
@@ -1035,7 +1035,7 @@ public class VerifyRecord {
         return true;
     }
 
-    private static boolean deepEquals0(Object e1, Object e2){
+    private static boolean deepEquals0(Object e1, Object e2) {
         assert e1!=null;
         boolean eq;
         if (e1 instanceof Object[]&&e2 instanceof Object[]) {

--- a/debezium-core/src/test/java/io/debezium/document/DocumentSerdesTest.java
+++ b/debezium-core/src/test/java/io/debezium/document/DocumentSerdesTest.java
@@ -57,7 +57,7 @@ public class DocumentSerdesTest implements Testing {
 
     protected void roundTrip(Document doc, IntConsumer sizeAccumulator) {
         byte[] bytes = SERDES.serialize("topicA", doc);
-        if (sizeAccumulator != null){
+        if (sizeAccumulator != null) {
             sizeAccumulator.accept(bytes.length);
         }
         Document reconstituted = SERDES.deserialize("topicA", bytes);

--- a/debezium-core/src/test/java/io/debezium/kafka/KafkaCluster.java
+++ b/debezium-core/src/test/java/io/debezium/kafka/KafkaCluster.java
@@ -782,7 +782,8 @@ public class KafkaCluster {
                         producer.flush();
                         LOGGER.debug("Producer {}: sent message {}", producerName, record);
                     }
-                } finally {
+                }
+                finally {
                     if (completionCallback != null){
                         completionCallback.run();
                     }
@@ -932,7 +933,8 @@ public class KafkaCluster {
                             }
                         });
                     }
-                } finally {
+                }
+                finally {
                     if (completion != null){
                         completion.run();
                     }

--- a/debezium-core/src/test/java/io/debezium/kafka/KafkaCluster.java
+++ b/debezium-core/src/test/java/io/debezium/kafka/KafkaCluster.java
@@ -92,7 +92,7 @@ public class KafkaCluster {
      * @throws IllegalStateException if the cluster is running
      */
     public KafkaCluster deleteDataUponShutdown(boolean delete) {
-        if (running){
+        if (running) {
             throw new IllegalStateException("Unable to change cluster settings when running");
         }
         this.deleteDataUponShutdown = delete;
@@ -107,7 +107,7 @@ public class KafkaCluster {
      * @throws IllegalStateException if the cluster is running
      */
     public KafkaCluster deleteDataPriorToStartup(boolean delete) {
-        if (running){
+        if (running) {
             throw new IllegalStateException("Unable to change cluster settings when running");
         }
         this.deleteDataPriorToStartup = delete;
@@ -122,7 +122,7 @@ public class KafkaCluster {
      * @throws IllegalStateException if the cluster is running
      */
     public KafkaCluster addBrokers(int count) {
-        if (running){
+        if (running) {
             throw new IllegalStateException("Unable to add a broker when the cluster is already running");
         }
         AtomicLong added = new AtomicLong();
@@ -130,13 +130,13 @@ public class KafkaCluster {
             kafkaServers.computeIfAbsent(Integer.valueOf(added.intValue() + 1), id -> {
                 added.incrementAndGet();
                 KafkaServer server = new KafkaServer(zkServer::getConnection, id);
-                if (dataDir != null){
+                if (dataDir != null) {
                     server.setStateDirectory(dataDir);
                 }
-                if (kafkaConfig != null){
+                if (kafkaConfig != null) {
                     server.setProperties(kafkaConfig);
                 }
-                if (startingKafkaPort >= 0){
+                if (startingKafkaPort >= 0) {
                     server.setPort((int) this.nextKafkaPort.getAndIncrement());
                 }
                 return server;
@@ -154,7 +154,7 @@ public class KafkaCluster {
      * @throws IllegalArgumentException if the supplied file is not a directory or not writable
      */
     public KafkaCluster usingDirectory(File dataDir) {
-        if (running){
+        if (running) {
             throw new IllegalStateException("Unable to add a broker when the cluster is already running");
         }
         if (dataDir != null && dataDir.exists() && !dataDir.isDirectory() && !dataDir.canWrite() && !dataDir.canRead()) {
@@ -173,7 +173,7 @@ public class KafkaCluster {
      * @throws IllegalStateException if the cluster is running
      */
     public KafkaCluster withKafkaConfiguration(Properties properties) {
-        if (running){
+        if (running) {
             throw new IllegalStateException("Unable to add a broker when the cluster is already running");
         }
         if (properties != null && !properties.isEmpty()) {
@@ -194,7 +194,7 @@ public class KafkaCluster {
      * @throws IllegalStateException if the cluster is running
      */
     public KafkaCluster withPorts(int zkPort, int firstKafkaPort) {
-        if (running){
+        if (running) {
             throw new IllegalStateException("Unable to add a broker when the cluster is already running");
         }
         this.zkServer.setPort(zkPort);
@@ -302,7 +302,7 @@ public class KafkaCluster {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Creating topics: {}", Arrays.toString(topics));
         }
-        if (!running){
+        if (!running) {
             throw new IllegalStateException("The cluster must be running to create topics");
         }
         kafkaServers.values().stream().findFirst().ifPresent(server -> server.createTopics(topics));
@@ -330,7 +330,7 @@ public class KafkaCluster {
             LOGGER.debug("Creating topics with {} partitions and {} replicas each: {}", numPartitions, replicationFactor,
                          Arrays.toString(topics));
         }
-        if (!running){
+        if (!running) {
             throw new IllegalStateException("The cluster must be running to create topics");
         }
         kafkaServers.values().stream().findFirst().ifPresent(server -> server.createTopics(numPartitions, replicationFactor, topics));
@@ -356,7 +356,7 @@ public class KafkaCluster {
      */
     public void createTopic(String topic, int numPartitions, int replicationFactor) {
         LOGGER.debug("Creating topic '{}' with {} partitions and {} replicas", topic, numPartitions, replicationFactor);
-        if (!running){
+        if (!running) {
             throw new IllegalStateException("The cluster must be running to create topics");
         }
         kafkaServers.values().stream().findFirst().ifPresent(server -> server.createTopic(topic, numPartitions, replicationFactor));
@@ -411,7 +411,7 @@ public class KafkaCluster {
      * @throws IllegalStateException if the cluster is not running
      */
     public Usage useTo() {
-        if (!running){
+        if (!running) {
             throw new IllegalStateException("Unable to use the cluster it is not running");
         }
         return new Usage();
@@ -542,7 +542,7 @@ public class KafkaCluster {
          * @see #getProducerProperties(String)
          */
         public Properties getConsumerProperties(String groupId, String clientId, OffsetResetStrategy autoOffsetReset) {
-            if (groupId == null){
+            if (groupId == null) {
                 throw new IllegalArgumentException("The groupId is required");
             }
             Properties props = new Properties();
@@ -552,7 +552,7 @@ public class KafkaCluster {
             if (autoOffsetReset != null) {
                 props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset.toString().toLowerCase());
             }
-            if (clientId != null){
+            if (clientId != null) {
                 props.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
             }
             return props;
@@ -569,7 +569,7 @@ public class KafkaCluster {
             Properties props = new Properties();
             props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList());
             props.setProperty(ProducerConfig.ACKS_CONFIG, Integer.toString(1));
-            if (clientId != null){
+            if (clientId != null) {
                 props.setProperty(ProducerConfig.CLIENT_ID_CONFIG, clientId);
             }
             return props;
@@ -784,7 +784,7 @@ public class KafkaCluster {
                     }
                 }
                 finally {
-                    if (completionCallback != null){
+                    if (completionCallback != null) {
                         completionCallback.run();
                     }
                     LOGGER.debug("Stopping producer {}", producerName);
@@ -935,7 +935,7 @@ public class KafkaCluster {
                     }
                 }
                 finally {
-                    if (completion != null){
+                    if (completion != null) {
                         completion.run();
                     }
                     LOGGER.debug("Stopping consumer {}", clientId);
@@ -1016,7 +1016,7 @@ public class KafkaCluster {
                            completion,
                            Collections.singleton(topicName),
                            record -> {
-                               if (consumer.test(record.key(), record.value())){
+                               if (consumer.test(record.key(), record.value())) {
                                    readCounter.incrementAndGet();
                                }
                            });
@@ -1039,7 +1039,7 @@ public class KafkaCluster {
                              completion,
                              Collections.singleton(topicName),
                              record -> {
-                                 if (consumer.test(record.key(), record.value())){
+                                 if (consumer.test(record.key(), record.value())) {
                                      readCounter.incrementAndGet();
                                  }
                              });
@@ -1062,7 +1062,7 @@ public class KafkaCluster {
                             completion,
                             Collections.singleton(topicName),
                             record -> {
-                                if (consumer.test(record.key(), record.value())){
+                                if (consumer.test(record.key(), record.value())) {
                                     readCounter.incrementAndGet();
                                 }
                             });
@@ -1113,7 +1113,7 @@ public class KafkaCluster {
 
                 @Override
                 public boolean getAsBoolean() {
-                    if (stopTime == 0L){
+                    if (stopTime == 0L) {
                         stopTime = System.currentTimeMillis() + unit.toMillis(timeout);
                     }
                     return continuation.getAsBoolean() && System.currentTimeMillis() <= stopTime;

--- a/debezium-core/src/test/java/io/debezium/kafka/KafkaServer.java
+++ b/debezium-core/src/test/java/io/debezium/kafka/KafkaServer.java
@@ -71,7 +71,7 @@ public class KafkaServer {
      * @param port the desired port
      */
     public KafkaServer(Supplier<String> zookeeperConnection, int brokerId, int port) {
-        if (zookeeperConnection == null){
+        if (zookeeperConnection == null) {
             throw new IllegalArgumentException("The Zookeeper connection string supplier may not be null");
         }
         this.zkConnection = zookeeperConnection;
@@ -110,7 +110,7 @@ public class KafkaServer {
      * @throws IllegalStateException if the server is running when this method is called
      */
     public KafkaServer setProperty(String name, String value) {
-        if (server != null){
+        if (server != null) {
             throw new IllegalStateException("Unable to change the properties when already running");
         }
         if (!KafkaConfig.ZkConnectProp().equalsIgnoreCase(name)
@@ -130,7 +130,7 @@ public class KafkaServer {
      * @throws IllegalStateException if the server is running when this method is called
      */
     public KafkaServer setProperties( Properties properties ) {
-        if (server != null){
+        if (server != null) {
             throw new IllegalStateException("Unable to change the properties when already running");
         }
         properties.stringPropertyNames().forEach(propName -> {
@@ -189,7 +189,7 @@ public class KafkaServer {
      * @throws IllegalStateException if the server is already running
      */
     public synchronized KafkaServer startup() {
-        if (server != null){
+        if (server != null) {
             throw new IllegalStateException("" + this + " is already running");
         }
 
@@ -295,7 +295,7 @@ public class KafkaServer {
      */
     public void createTopics(int numPartitions, int replicationFactor, String... topics) {
         for (String topic : topics) {
-            if ( topic != null ){
+            if ( topic != null ) {
                 createTopic(topic, numPartitions, replicationFactor);
             }
         }

--- a/debezium-core/src/test/java/io/debezium/kafka/ZookeeperServer.java
+++ b/debezium-core/src/test/java/io/debezium/kafka/ZookeeperServer.java
@@ -57,11 +57,11 @@ public class ZookeeperServer {
      * @throws IllegalStateException if the server is already running
      */
     public synchronized ZookeeperServer startup() throws IOException {
-        if (factory != null){
+        if (factory != null) {
             throw new IllegalStateException("" + this + " is already running");
         }
 
-        if (this.port == -1){
+        if (this.port == -1) {
             this.port = IoUtil.getAvailablePort();
         }
         this.factory = ServerCnxnFactory.createFactory(new InetSocketAddress("localhost", port), 1024);

--- a/debezium-core/src/test/java/io/debezium/relational/history/KafkaDatabaseHistoryTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/history/KafkaDatabaseHistoryTest.java
@@ -69,14 +69,14 @@ public class KafkaDatabaseHistoryTest {
     @After
     public void afterEach() {
         try {
-            if (history != null){
+            if (history != null) {
                 history.stop();
             }
         }
         finally {
             history = null;
             try {
-                if (kafka != null){
+                if (kafka != null) {
                     kafka.shutdown();
                 }
             }

--- a/debezium-core/src/test/java/io/debezium/transforms/ByLogicalTableRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ByLogicalTableRouterTest.java
@@ -120,7 +120,7 @@ public class ByLogicalTableRouterTest {
     }
 
     @Test
-    public void testHeartbeatMessageTopicReplacementTopic(){
+    public void testHeartbeatMessageTopicReplacementTopic() {
         final ByLogicalTableRouter<SourceRecord> router = new ByLogicalTableRouter<>();
         final Map<String, String> props = new HashMap<>();
         final String keyFieldName = "serverName";

--- a/debezium-core/src/test/java/io/debezium/util/SchemaNameAdjusterTest.java
+++ b/debezium-core/src/test/java/io/debezium/util/SchemaNameAdjusterTest.java
@@ -51,7 +51,7 @@ public class SchemaNameAdjusterTest {
         AtomicInteger counter = new AtomicInteger();
         AtomicInteger conflicts = new AtomicInteger();
         ReplacementOccurred handler = (original, replacement, conflict) -> {
-            if (conflict != null){
+            if (conflict != null) {
                 conflicts.incrementAndGet();
             }
             counter.incrementAndGet();
@@ -69,7 +69,7 @@ public class SchemaNameAdjusterTest {
         AtomicInteger counter = new AtomicInteger();
         AtomicInteger conflicts = new AtomicInteger();
         ReplacementOccurred handler = (original, replacement, conflict) -> {
-            if (conflict != null){
+            if (conflict != null) {
                 conflicts.incrementAndGet();
             }
             counter.incrementAndGet();
@@ -87,7 +87,7 @@ public class SchemaNameAdjusterTest {
         AtomicInteger counter = new AtomicInteger();
         AtomicInteger conflicts = new AtomicInteger();
         ReplacementOccurred handler = (original, replacement, conflict) -> {
-            if (conflict != null){
+            if (conflict != null) {
                 conflicts.incrementAndGet();
             }
             counter.incrementAndGet();

--- a/debezium-core/src/test/java/io/debezium/util/Testing.java
+++ b/debezium-core/src/test/java/io/debezium/util/Testing.java
@@ -62,11 +62,11 @@ public interface Testing {
     }
 
     public static void print(int length, String leader, Object message){
-        if(message!=null&&Print.enabled){
+        if (message!=null&&Print.enabled){
             int len=leader.length();
             System.out.print(leader);
-            if(len<length){
-                for(int i=len; i!=length; ++i){
+            if (len<length){
+                for (int i=len; i!=length; ++i){
                     System.out.print(" ");
                 }
             }

--- a/debezium-core/src/test/java/io/debezium/util/Testing.java
+++ b/debezium-core/src/test/java/io/debezium/util/Testing.java
@@ -61,12 +61,12 @@ public interface Testing {
         }
     }
 
-    public static void print(int length, String leader, Object message){
-        if (message!=null&&Print.enabled){
+    public static void print(int length, String leader, Object message) {
+        if (message!=null&&Print.enabled) {
             int len=leader.length();
             System.out.print(leader);
-            if (len<length){
-                for (int i=len; i!=length; ++i){
+            if (len<length) {
+                for (int i=len; i!=length; ++i) {
                     System.out.print(" ");
                 }
             }
@@ -275,7 +275,7 @@ public interface Testing {
          * @param path the path to the file or folder in the target directory
          */
         public static void delete(String path) {
-            if (path != null){
+            if (path != null) {
                 delete(Paths.get(path));
             }
         }
@@ -287,7 +287,7 @@ public interface Testing {
          * @param fileOrFolder the file or folder in the target directory
          */
         public static void delete(File fileOrFolder) {
-            if (fileOrFolder != null){
+            if (fileOrFolder != null) {
                 delete(fileOrFolder.toPath());
             }
         }
@@ -375,7 +375,7 @@ public interface Testing {
             sw.start();
             try {
                 sws.time(repeat, runnable, result -> {
-                    if (cleanup != null){
+                    if (cleanup != null) {
                         cleanup.accept(result);
                     }
                 });

--- a/debezium-ddl-parser/src/main/java/io/debezium/antlr/AntlrDdlParser.java
+++ b/debezium-ddl-parser/src/main/java/io/debezium/antlr/AntlrDdlParser.java
@@ -344,7 +344,7 @@ public abstract class AntlrDdlParser<L extends Lexer, P extends Parser> extends 
     }
 
     private void throwParsingException(Collection<ParsingException> errors) {
-        if(errors.size() == 1) {
+        if (errors.size() == 1) {
             throw errors.iterator().next();
         }
         else {

--- a/debezium-embedded/src/test/java/io/debezium/connector/simple/SimpleSourceConnectorOutputTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/connector/simple/SimpleSourceConnectorOutputTest.java
@@ -89,7 +89,7 @@ public class SimpleSourceConnectorOutputTest extends ConnectorOutputTest {
      * Run the connector with connector configuration and expected results files, which are read in one step.
      */
     @Test
-    public void shouldRunConnectorFromFilesInOneStep(){
+    public void shouldRunConnectorFromFilesInOneStep() {
         runConnector("simple-test-a", "src/test/resources/simple/test/a");
     }
 
@@ -97,7 +97,7 @@ public class SimpleSourceConnectorOutputTest extends ConnectorOutputTest {
      * Run the connector with connector configuration and expected results files, which are read in two steps.
      */
     @Test
-    public void shouldRunConnectorFromFilesInTwoSteps(){
+    public void shouldRunConnectorFromFilesInTwoSteps() {
         runConnector("simple-test-b", "src/test/resources/simple/test/b");
     }
 
@@ -105,7 +105,7 @@ public class SimpleSourceConnectorOutputTest extends ConnectorOutputTest {
      * Run the connector with connector configuration and expected results files, but find a mismatch in the results.
      */
     @Test(expected = AssertionError.class)
-    public void shouldRunConnectorFromFilesAndFindMismatch(){
+    public void shouldRunConnectorFromFilesAndFindMismatch() {
         // Testing.Debug.enable();
         Testing.Print.disable();
         runConnector("simple-test-c", "src/test/resources/simple/test/c");
@@ -117,7 +117,7 @@ public class SimpleSourceConnectorOutputTest extends ConnectorOutputTest {
      * However, this test filters out the timestamps from the matching logic.
      */
     @Test
-    public void shouldRunConnectorFromFilesInOneStepWithTimestamps(){
+    public void shouldRunConnectorFromFilesInOneStepWithTimestamps() {
         // Testing.Debug.enable();
         runConnector("simple-test-d", "src/test/resources/simple/test/d");
     }

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -176,7 +176,7 @@ public abstract class AbstractConnectorTest implements Testing {
                     Thread.currentThread().interrupt();
                 }
             }
-            if (callback != null){
+            if (callback != null) {
                 callback.accept(engine != null ? engine.isRunning() : false);
             }
         }

--- a/debezium-embedded/src/test/java/io/debezium/embedded/ConnectorOutputTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/ConnectorOutputTest.java
@@ -824,7 +824,7 @@ public abstract class ConnectorOutputTest {
                     // And possibly hand it to the test's recorder ...
                     try {
                         Document jsonRecord = serializeSourceRecord(actualRecord, keyConverter, valueConverter);
-                        if (jsonRecord != null){
+                        if (jsonRecord != null) {
                             recorder.accept(jsonRecord);
                         }
                     }

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
             <snapshots>
                 <enabled>true</enabled>
                 <updatePolicy>never</updatePolicy>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jboss</groupId>
     <artifactId>jboss-parent</artifactId>
-    <version>19</version>
+    <version>35</version>
   </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/support/checkstyle/pom.xml
+++ b/support/checkstyle/pom.xml
@@ -3,7 +3,7 @@
    <parent>
       <groupId>org.jboss</groupId>
       <artifactId>jboss-parent</artifactId>
-      <version>19</version>
+      <version>35</version>
       <!-- same as parent POM -->
    </parent>
 
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>6.7</version>
+            <version>${version.checkstyle}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.sun</groupId>

--- a/support/checkstyle/src/main/java/io/debezium/checkstyle/ExcludeTestPackages.java
+++ b/support/checkstyle/src/main/java/io/debezium/checkstyle/ExcludeTestPackages.java
@@ -25,7 +25,7 @@ public class ExcludeTestPackages implements Filter {
     private static final String MESSAGE_DISABLE_KEYWORD = "[not required for tests]";
 
     @Override
-    public boolean accept( AuditEvent aEvent ) {
+    public boolean accept(AuditEvent aEvent) {
         final String fileName = aEvent.getFileName();
         if (fileName != null && fileName.contains(SUB_PATH)) {
             return acceptTestfileEvent(aEvent);
@@ -33,7 +33,7 @@ public class ExcludeTestPackages implements Filter {
         return true;
     }
 
-    private boolean acceptTestfileEvent( AuditEvent aEvent ) {
+    private boolean acceptTestfileEvent(AuditEvent aEvent) {
         final String message = aEvent.getMessage();
         if (message != null && message.contains(MESSAGE_DISABLE_KEYWORD)) {
             return false;

--- a/support/checkstyle/src/main/java/io/debezium/checkstyle/Header.java
+++ b/support/checkstyle/src/main/java/io/debezium/checkstyle/Header.java
@@ -11,9 +11,10 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
+
+import com.puppycrawl.tools.checkstyle.api.FileText;
 
 public class Header extends com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck {
 
@@ -26,12 +27,12 @@ public class Header extends com.puppycrawl.tools.checkstyle.checks.header.Header
     public Header() {
     }
 
-    public void setExcludedFilesRegex( String excludedFilePattern ) {
+    public void setExcludedFilesRegex(String excludedFilePattern) {
         this.excludedFilesRegex = excludedFilePattern;
         this.excludedFilesPattern = Pattern.compile(this.excludedFilesRegex);
     }
 
-    public void setExcludedClasses( String excludedClasses ) {
+    public void setExcludedClasses(String excludedClasses) {
         this.excludedFileSet = new HashSet<>();
         if (excludedClasses != null) {
             for (String classname : excludedClasses.split(",")) {
@@ -43,8 +44,7 @@ public class Header extends com.puppycrawl.tools.checkstyle.checks.header.Header
         }
     }
 
-    @Override
-    public void setHeaderFile( String aFileName ) {
+    public void setHeaderFile(String aFileName) {
         // Load the file from the file ...
         InputStream stream = this.getClass().getClassLoader().getResourceAsStream("debezium.header");
         if (stream == null) {
@@ -68,7 +68,7 @@ public class Header extends com.puppycrawl.tools.checkstyle.checks.header.Header
         }
     }
 
-    protected boolean isExcluded( File file ) {
+    protected boolean isExcluded(File file) {
         // See whether this file is excluded ...
         String filename = file.getAbsolutePath().replace(File.separator, "/");
         if (filename.startsWith(workingDirPath)) filename = filename.substring(workingDirPathLength);
@@ -87,9 +87,8 @@ public class Header extends com.puppycrawl.tools.checkstyle.checks.header.Header
     }
 
     @Override
-    protected void processFiltered( File aFile,
-                                    List<String> aLines ) {
+    protected void processFiltered(File aFile, FileText fileText) {
         if (isExcluded(aFile)) return;
-        super.processFiltered(aFile, aLines);
+        super.processFiltered(aFile, fileText);
     }
 }

--- a/support/checkstyle/src/main/java/io/debezium/checkstyle/IllegalImport.java
+++ b/support/checkstyle/src/main/java/io/debezium/checkstyle/IllegalImport.java
@@ -7,19 +7,20 @@ package io.debezium.checkstyle;
 
 import java.util.HashSet;
 
-import com.puppycrawl.tools.checkstyle.api.Check;
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
  * A simple CheckStyle checker to verify specific import statements are not being used.
  * 
  * @author Sanne Grinovero
  */
-public class IllegalImport extends Check {
+public class IllegalImport extends AbstractCheck {
 
-    private final HashSet<String> notAllowedImports = new HashSet<String>();
+    private final HashSet<String> notAllowedImports = new HashSet<>();
     private String message = "";
 
     /**
@@ -27,13 +28,13 @@ public class IllegalImport extends Check {
      * 
      * @param importStatements array of illegal packages
      */
-    public void setIllegalClassnames( String[] importStatements ) {
+    public void setIllegalClassnames(String[] importStatements) {
         for (String impo : importStatements) {
             notAllowedImports.add(impo);
         }
     }
 
-    public void setMessage( String message ) {
+    public void setMessage(String message) {
         if (message != null) {
             this.message = message;
         }
@@ -45,7 +46,20 @@ public class IllegalImport extends Check {
     }
 
     @Override
-    public void visitToken( DetailAST aAST ) {
+    public int[] getAcceptableTokens() {
+        final int[] defaultTokens = getDefaultTokens();
+        final int[] copy = new int[defaultTokens.length];
+        System.arraycopy(defaultTokens, 0, copy, 0, defaultTokens.length);
+        return copy;
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return CommonUtil.EMPTY_INT_ARRAY;
+    }
+
+    @Override
+    public void visitToken(DetailAST aAST) {
         final FullIdent imp;
         if (aAST.getType() == TokenTypes.IMPORT) {
             imp = FullIdent.createFullIdentBelow(aAST);
@@ -60,11 +74,11 @@ public class IllegalImport extends Check {
         }
     }
 
-    private String buildError( String importStatement ) {
+    private String buildError(String importStatement) {
         return "Import statement violating a checkstyle rule: " + importStatement + ". " + message;
     }
 
-    private boolean isIllegalImport( String importString ) {
+    private boolean isIllegalImport(String importString) {
         return notAllowedImports.contains(importString);
     }
 }

--- a/support/checkstyle/src/main/java/io/debezium/checkstyle/JavaDocUtil.java
+++ b/support/checkstyle/src/main/java/io/debezium/checkstyle/JavaDocUtil.java
@@ -10,13 +10,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.common.collect.Lists;
-import com.puppycrawl.tools.checkstyle.Utils;
-import com.puppycrawl.tools.checkstyle.api.JavadocTagInfo;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocTag;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTag;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagInfo;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTags;
-import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocUtils.JavadocTagType;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+import com.puppycrawl.tools.checkstyle.utils.JavadocUtil.JavadocTagType;
 
 public final class JavaDocUtil {
 
@@ -30,12 +30,11 @@ public final class JavaDocUtil {
      * @param aTagType the type of validTags we're interested in
      * @return all standalone validTags from the given javadoc.
      */
-    public static JavadocTags getJavadocTags( TextBlock aCmt,
-                                              JavadocTagType aTagType ) {
+    public static JavadocTags getJavadocTags(TextBlock aCmt, JavadocTagType aTagType) {
         final String[] text = aCmt.getText();
         final List<JavadocTag> tags = Lists.newArrayList();
         final List<InvalidJavadocTag> invalidTags = Lists.newArrayList();
-        Pattern blockTagPattern = Utils.createPattern("/\\*{2,}\\s*@(\\p{Alpha}+)\\s");
+        Pattern blockTagPattern = CommonUtil.createPattern("/\\*{2,}\\s*@(\\p{Alpha}+)\\s");
         for (int i = 0; i < text.length; i++) {
             final String s = text[i];
             final Matcher blockTagMatcher = blockTagPattern.matcher(s);
@@ -59,7 +58,7 @@ public final class JavaDocUtil {
             // No block tag, so look for inline validTags
             else if (aTagType.equals(JavadocTagType.ALL) || aTagType.equals(JavadocTagType.INLINE)) {
                 // Match JavaDoc text after comment characters
-                final Pattern commentPattern = Utils.createPattern("^\\s*(?:/\\*{2,}|\\*+)\\s*(.*)");
+                final Pattern commentPattern = CommonUtil.createPattern("^\\s*(?:/\\*{2,}|\\*+)\\s*(.*)");
                 final Matcher commentMatcher = commentPattern.matcher(s);
                 final String commentContents;
                 final int commentOffset; // offset including comment characters
@@ -70,7 +69,7 @@ public final class JavaDocUtil {
                     commentContents = commentMatcher.group(1);
                     commentOffset = commentMatcher.start(1) - 1;
                 }
-                final Pattern tagPattern = Utils.createPattern(".*?\\{@(\\p{Alpha}+)\\s+([^\\}]*)"); // The last '}' may
+                final Pattern tagPattern = CommonUtil.createPattern(".*?\\{@(\\p{Alpha}+)\\s+([^\\}]*)"); // The last '}' may
                                                                                                   // appear on the next
                                                                                                   // line ...
                 final Matcher tagMatcher = tagPattern.matcher(commentContents);
@@ -92,7 +91,7 @@ public final class JavaDocUtil {
                     // else Error: Unexpected match count for inline JavaDoc tag
                 }
             }
-            blockTagPattern = Utils.createPattern("^\\s*\\**\\s*@(\\p{Alpha}+)\\s");
+            blockTagPattern = CommonUtil.createPattern("^\\s*\\**\\s*@(\\p{Alpha}+)\\s");
         }
         return new JavadocTags(tags, invalidTags);
     }

--- a/support/checkstyle/src/main/resources/checkstyle.xml
+++ b/support/checkstyle/src/main/resources/checkstyle.xml
@@ -60,6 +60,11 @@
         <!-- Checks for whitespace after tokens -->
         <module name="WhitespaceAfter"/>
 
+        <module name="WhitespaceAround">
+            <property name="tokens" value="LCURLY,QUESTION,COLON,SLIST" />
+            <property name="allowEmptyLambdas" value="true" />
+        </module>
+
         <!-- Checks for blocks. You know, those {}'s -->
         <module name="LeftCurly">
             <property name="option" value="eol" />

--- a/support/checkstyle/src/main/resources/checkstyle.xml
+++ b/support/checkstyle/src/main/resources/checkstyle.xml
@@ -20,8 +20,6 @@
     </module>
 
     <module name="TreeWalker">
-        <property name="cacheFile" value="${checkstyle.cache.file}" />
-
         <!-- Checks for imports -->
         <module name="AvoidStarImport" />
         <module name="RedundantImport" />
@@ -109,8 +107,21 @@
             <property name="message" value="Use the new org.junit.Assert class instead" />
         </module>
 
-        <!-- Required to get SuppressionCommentFilter to work -->
-        <module name="FileContentsHolder" />
+        <!--
+        Allow for suppressing sections of code using a starting and ending comment:
+        // CHECKSTYLE\:OFF
+        // CHECKSTYLE\:ON
+        -->
+        <module name="SuppressionCommentFilter" />
+
+        <!-- Allow for suppressing sections of code using just a leading comment:
+        // CHECKSTYLE IGNORE check FOR NEXT 2 LINES
+        -->
+        <module name="SuppressWithNearbyCommentFilter">
+            <property name="commentFormat" value="CHECKSTYLE IGNORE (\w+) FOR NEXT (\d+) LINES"/>
+            <property name="checkFormat" value="$1"/>
+            <property name="influenceFormat" value="$2"/>
+        </module>
 
         <!-- Checks that Debezium is expressly NOT using -->
         <!--module name="ModifiedControlVariable" /-->
@@ -147,22 +158,6 @@
     <!--  
     END: ModeShape doesn't current require these, though it would be nice to do so
     -->
-
-    <!-- 
-    Allow for suppressing sections of code using a starting and ending comment:
-    // CHECKSTYLE\:OFF
-    // CHECKSTYLE\:ON
-    -->
-    <module name="SuppressionCommentFilter" />
-
-    <!-- Allow for suppressing sections of code using just a leading comment:
-    // CHECKSTYLE IGNORE check FOR NEXT 2 LINES
-    -->
-    <module name="SuppressWithNearbyCommentFilter">
-        <property name="commentFormat" value="CHECKSTYLE IGNORE (\w+) FOR NEXT (\d+) LINES"/>
-        <property name="checkFormat" value="$1"/>
-        <property name="influenceFormat" value="$2"/>
-    </module>
 
     <!-- Allow for some code sanity rules to be violated by test code -->
     <module name="io.debezium.checkstyle.ExcludeTestPackages" />


### PR DESCRIPTION
This PR addresses quite a number of changes that are tightly coupled.  

~~**[DBZ-1391](https://issues.jboss.org/browse/DBZ-1391)**stri
Added a checkstyle check not to allow code to appear after a closing '}' brace and updated code base where applicable to adhere to the new rule.~~
This was actually applied separately as a part of PR#1065

**[DBZ-1341](https://issues.jboss.org/browse/DBZ-1341)**
Update checkstyle rules to flag for missing space situations and updated code base where applicable to adhere to the rule.  This change mandated the following 2 changes.

**[DBZ-675](https://issues.jboss.org/browse/DBZ-675)**
This upgrades the JBoss parent pom from version 19 to 35.  This change also incorporates changes necessary for checkstyle which are below.

**[DBZ-1355](https://issues.jboss.org/browse/DBZ-1355)**
This upgrades the checkstyle rules and custom check classes to be compatible with the version of checkstyle provided by the JBoss parent pom, which is version 8.19.