### PR TITLE
DBZ-1401 Document REPLICA IDENTITY for unique key on postgres

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -437,7 +437,7 @@ Debezium and Kafka Connect are designed around _continuous streams of event mess
 [[change-events-key]]
 ==== Change Event's Key
 
-For a given table, the change event's key will have a structure that contains a field for each column in the primary key (or unique key constraint) of the table at the time the event was created.
+For a given table, the change event's key will have a structure that contains a field for each column in the primary key (or unique key constraint with `REPLICA IDENTITY` set to `FULL` or `USING INDEX` on the table) of the table at the time the event was created.
 
 Consider a `customers` table defined in the `public` database schema:
 


### PR DESCRIPTION
@gunnarmorling ok, it seems that as a by-product of copy/paste the documentation of all connectors already mentioned unique key constraint to be source of key fields. I've added to the postgres only note about necessity to use REPLICA IDENTITY USING INDEX on the table.
Also the other parts of the text you've refered to in postgres documentation ar still valid as they speak of limitations of decoder plugins ntot connector itself.