### PR TITLE
DBZ-1546 Remove whitespaces between table.whitelist regexes

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/FiltersTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/FiltersTest.java
@@ -189,6 +189,15 @@ public class FiltersTest {
     }
 
     @Test
+    @FixFor("DBZ-1546")
+    public void shouldAllowTableListedWithWhitespaceCharactersInWhitelistAndNoTableBlacklistWhenDatabaseIncluded() {
+        filters = build.includeTables("connector_test.table1, connector_test.table2").createFilters();
+        assertTableIncluded("connector_test.table1");
+        assertTableIncluded("connector_test.table2");
+        assertTableExcluded("connector_test.table3");
+    }
+
+    @Test
     public void shouldAllowTableListedWithMultipleRegexInWhitelistAndNoTableBlacklistWhenDatabaseIncluded() {
         filters = build.includeTables("connector_test.table[x]?1,connector_test[.](.*)2").createFilters();
         assertTableIncluded("connector_test.table1");

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -994,7 +994,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
     }
 
     @Test
-    @FixFor("DBZ-683")
+    @FixFor("DBZ-1546")
     public void shouldHandleWhitelistedTables() throws SQLException, InterruptedException {
         Testing.Files.delete(DB_HISTORY_PATH);
 

--- a/debezium-core/src/main/java/io/debezium/util/Strings.java
+++ b/debezium-core/src/main/java/io/debezium/util/Strings.java
@@ -1070,7 +1070,7 @@ public final class Strings {
                 if (part.length() == 0) {
                     continue;
                 }
-                parts.add(part.replace("\\,", ","));
+                parts.add(part.trim().replace("\\,", ","));
             }
 
             return parts.toArray(new String[parts.size()]);


### PR DESCRIPTION
The table whitespace parameter should remove whitespace between regular expressions
since tables cannot start with whitespace characters.

https://issues.jboss.org/browse/DBZ-1546