### PR TITLE
[DBZ-1555] Enable configuration of table parse mode to support DB2

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
@@ -131,7 +131,7 @@ public class MySqlSchema extends RelationalDatabaseSchema {
                 return SourceInfo.isPositionAtOrBefore(recorded, desired, gtidFilter);
             }
         };
-        this.dbHistory.configure(dbHistoryConfig, historyComparator, new DatabaseHistoryMetrics(configuration)); // validates
+        this.dbHistory.configure(dbHistoryConfig, historyComparator, new DatabaseHistoryMetrics(configuration), true); // validates
 
     }
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -280,7 +280,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
     private final ColumnNameFilter columnFilter;
 
     public SqlServerConnectorConfig(Configuration config) {
-        super(config, config.getString(SERVER_NAME), new SystemTablesPredicate(), x -> x.schema() + "." + x.table());
+        super(config, config.getString(SERVER_NAME), new SystemTablesPredicate(), x -> x.schema() + "." + x.table(), true);
 
         this.databaseName = config.getString(DATABASE_NAME);
         this.snapshotMode = SnapshotMode.parse(config.getString(SNAPSHOT_MODE), SNAPSHOT_MODE.defaultValueAsString());

--- a/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
@@ -27,6 +27,7 @@ import io.debezium.relational.history.KafkaDatabaseHistory;
 public abstract class HistorizedRelationalDatabaseConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     protected static final int DEFAULT_SNAPSHOT_FETCH_SIZE = 2_000;
+    private boolean useCatalogBeforeSchema;
 
     /**
      * The database history class is hidden in the {@link #configDef()} since that is designed to work with a user interface,
@@ -43,12 +44,14 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
                     + DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING + "' string.")
             .withDefault(KafkaDatabaseHistory.class.getName());
 
-    protected HistorizedRelationalDatabaseConnectorConfig(Configuration config, String logicalName, TableFilter systemTablesFilter) {
+    protected HistorizedRelationalDatabaseConnectorConfig(Configuration config, String logicalName, TableFilter systemTablesFilter, boolean useCatalogBeforeSchema) {
         super(config, logicalName, systemTablesFilter, TableId::toString, DEFAULT_SNAPSHOT_FETCH_SIZE);
+        this.useCatalogBeforeSchema = useCatalogBeforeSchema;
     }
 
-    protected HistorizedRelationalDatabaseConnectorConfig(Configuration config, String logicalName, TableFilter systemTablesFilter, TableIdToStringMapper tableIdMapper) {
+    protected HistorizedRelationalDatabaseConnectorConfig(Configuration config, String logicalName, TableFilter systemTablesFilter, TableIdToStringMapper tableIdMapper, boolean useCatalogBeforeSchema) {
         super(config, logicalName, systemTablesFilter, tableIdMapper, DEFAULT_SNAPSHOT_FETCH_SIZE);
+        this.useCatalogBeforeSchema = useCatalogBeforeSchema;
     }
 
     /**
@@ -70,7 +73,7 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
                                               .build();
 
         HistoryRecordComparator historyComparator = getHistoryRecordComparator();
-        databaseHistory.configure(dbHistoryConfig, historyComparator, new DatabaseHistoryMetrics(this)); // validates
+        databaseHistory.configure(dbHistoryConfig, historyComparator, new DatabaseHistoryMetrics(this), useCatalogBeforeSchema); // validates
 
         return databaseHistory;
     }

--- a/debezium-core/src/main/java/io/debezium/relational/history/AbstractDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/AbstractDatabaseHistory.java
@@ -42,7 +42,7 @@ public abstract class AbstractDatabaseHistory implements DatabaseHistory {
     }
 
     @Override
-    public void configure(Configuration config, HistoryRecordComparator comparator, DatabaseHistoryListener listener) {
+    public void configure(Configuration config, HistoryRecordComparator comparator, DatabaseHistoryListener listener, boolean useCatalogBeforeSchema) {
         this.config = config;
         this.comparator = comparator != null ? comparator : HistoryRecordComparator.INSTANCE;
         this.skipUnparseableDDL = config.getBoolean(DatabaseHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS);
@@ -50,7 +50,7 @@ public abstract class AbstractDatabaseHistory implements DatabaseHistory {
         final String ddlFilter = config.getString(DatabaseHistory.DDL_FILTER);
         this.ddlFilter = (ddlFilter != null) ? Predicates.matchedBy(ddlFilter) : this.ddlFilter;
         this.listener = listener;
-        this.useCatalogBeforeSchema = config.getBoolean(DatabaseHistory.USE_CATALOG_BEFORE_SCHEMA, true);
+        this.useCatalogBeforeSchema = useCatalogBeforeSchema;
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/relational/history/AbstractDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/AbstractDatabaseHistory.java
@@ -36,6 +36,7 @@ public abstract class AbstractDatabaseHistory implements DatabaseHistory {
     private boolean skipUnparseableDDL;
     private Function<String, Optional<Pattern>> ddlFilter = (x -> Optional.empty());
     private DatabaseHistoryListener listener = DatabaseHistoryListener.NOOP;
+    private boolean useCatalogBeforeSchema;
 
     protected AbstractDatabaseHistory() {
     }
@@ -49,6 +50,7 @@ public abstract class AbstractDatabaseHistory implements DatabaseHistory {
         final String ddlFilter = config.getString(DatabaseHistory.DDL_FILTER);
         this.ddlFilter = (ddlFilter != null) ? Predicates.matchedBy(ddlFilter) : this.ddlFilter;
         this.listener = listener;
+        this.useCatalogBeforeSchema = config.getBoolean(DatabaseHistory.USE_CATALOG_BEFORE_SCHEMA, true);
     }
 
     @Override
@@ -83,7 +85,7 @@ public abstract class AbstractDatabaseHistory implements DatabaseHistory {
                 String ddl = recovered.ddl();
 
                 if (tableChanges != null) {
-                    TableChanges changes = TableChanges.fromArray(tableChanges);
+                    TableChanges changes = TableChanges.fromArray(tableChanges, useCatalogBeforeSchema);
                     for (TableChange entry : changes) {
                         if (entry.getType() == TableChangeType.CREATE || entry.getType() == TableChangeType.ALTER) {
                             schema.overwriteTable(entry.getTable());

--- a/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
@@ -74,15 +74,6 @@ public interface DatabaseHistory {
                                                         + "from processing and storing into schema history evolution.")
                                                 .withValidation(Field::isListOfRegex);
 
-    public static final Field USE_CATALOG_BEFORE_SCHEMA = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "use.catalog.before.schema")
-            .withDisplayName("Parse tables as catalog.table or schema.table")
-            .withType(Type.BOOLEAN)
-            .withWidth(Width.SHORT)
-            .withImportance(Importance.LOW)
-            .withDescription("true if the parsed string for a table contains only 2 items and the first should be used as " + 
-                             "the catalog and the second as the table name, or false if the first should be used as the schema and the " + 
-                             "second as the table name")
-            .withDefault(true);
     
     /**
      * Configure this instance.
@@ -92,8 +83,11 @@ public interface DatabaseHistory {
      *            {@link #recover(Map, Map, Tables, DdlParser) recovery}; may be null if the
      *            {@link HistoryRecordComparator#INSTANCE default comparator} is to be used
      * @param listener TODO
+     * @param useCatalogBeforeSchema true if the parsed string for a table contains only 2 items and the first should be used as 
+                             the catalog and the second as the table name, or false if the first should be used as the schema and the 
+                             second as the table name
      */
-    void configure(Configuration config, HistoryRecordComparator comparator, DatabaseHistoryListener listener);
+    void configure(Configuration config, HistoryRecordComparator comparator, DatabaseHistoryListener listener, boolean useCatalogBeforeSchema);
 
     /**
      * Start the history.

--- a/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
@@ -74,6 +74,16 @@ public interface DatabaseHistory {
                                                         + "from processing and storing into schema history evolution.")
                                                 .withValidation(Field::isListOfRegex);
 
+    public static final Field USE_CATALOG_BEFORE_SCHEMA = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "use.catalog.before.schema")
+            .withDisplayName("Parse tables as catalog.table or schema.table")
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDescription("true if the parsed string for a table contains only 2 items and the first should be used as " + 
+                             "the catalog and the second as the table name, or false if the first should be used as the schema and the " + 
+                             "second as the table name")
+            .withDefault(true);
+    
     /**
      * Configure this instance.
      *

--- a/debezium-core/src/main/java/io/debezium/relational/history/FileDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/FileDatabaseHistory.java
@@ -50,7 +50,7 @@ public final class FileDatabaseHistory extends AbstractDatabaseHistory {
     private Path path;
 
     @Override
-    public void configure(Configuration config, HistoryRecordComparator comparator, DatabaseHistoryListener listener) {
+    public void configure(Configuration config, HistoryRecordComparator comparator, DatabaseHistoryListener listener, boolean useCatalogBeforeSchema) {
         if (!config.validateAndRecord(ALL_FIELDS, logger::error)) {
             throw new ConnectException(
                     "Error configuring an instance of " + getClass().getSimpleName() + "; check the logs for details");
@@ -59,7 +59,7 @@ public final class FileDatabaseHistory extends AbstractDatabaseHistory {
         if (running.get()) {
             throw new IllegalStateException("Database history file already initialized to " + path);
         }
-        super.configure(config, comparator, listener);
+        super.configure(config, comparator, listener, useCatalogBeforeSchema);
         path = Paths.get(config.getString(FILE_PATH));
     }
 

--- a/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
@@ -130,8 +130,8 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
     private Duration pollInterval;
 
     @Override
-    public void configure(Configuration config, HistoryRecordComparator comparator, DatabaseHistoryListener listener) {
-        super.configure(config, comparator, listener);
+    public void configure(Configuration config, HistoryRecordComparator comparator, DatabaseHistoryListener listener, boolean useCatalogBeforeSchema) {
+        super.configure(config, comparator, listener, useCatalogBeforeSchema);
         if (!config.validateAndRecord(ALL_FIELDS, logger::error)) {
             throw new ConnectException("Error configuring an instance of " + getClass().getSimpleName() + "; check the logs for details");
         }

--- a/debezium-core/src/main/java/io/debezium/relational/history/TableChanges.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/TableChanges.java
@@ -36,11 +36,16 @@ public class TableChanges implements Iterable<TableChange> {
         this.changes = new ArrayList<>();
     }
 
-    public static TableChanges fromArray(Array array) {
+    /*
+     * useCatalogBeforeSchema is true if the parsed string contains only 2 items and the first should be used as
+     * the catalog and the second as the table name, or false if the first should be used as the schema and the
+     * second as the table name
+     */
+    public static TableChanges fromArray(Array array, boolean useCatalogBeforeSchema) {
         TableChanges tableChanges = new TableChanges();
 
         for (Entry entry : array) {
-            TableChange change = TableChange.fromDocument(entry.getValue().asDocument());
+            TableChange change = TableChange.fromDocument(entry.getValue().asDocument(), useCatalogBeforeSchema);
 
             if (change.getType() == TableChangeType.CREATE) {
                 tableChanges.create(change.table);
@@ -118,9 +123,9 @@ public class TableChanges implements Iterable<TableChange> {
             this.id = table.id();
         }
 
-        public static TableChange fromDocument(Document document) {
+        public static TableChange fromDocument(Document document, boolean useCatalogBeforeSchema) {
             TableChangeType type = TableChangeType.valueOf(document.getString("type"));
-            TableId id = TableId.parse(document.getString("id"));
+            TableId id = TableId.parse(document.getString("id"), useCatalogBeforeSchema);
             Table table = null;
 
             if (type == TableChangeType.CREATE || type == TableChangeType.ALTER) {

--- a/debezium-core/src/main/java/io/debezium/relational/history/TableChanges.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/TableChanges.java
@@ -36,7 +36,7 @@ public class TableChanges implements Iterable<TableChange> {
         this.changes = new ArrayList<>();
     }
 
-    /*
+    /**
      * useCatalogBeforeSchema is true if the parsed string contains only 2 items and the first should be used as
      * the catalog and the second as the table name, or false if the first should be used as the schema and the
      * second as the table name

--- a/debezium-core/src/test/java/io/debezium/relational/history/FileDatabaseHistoryTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/history/FileDatabaseHistoryTest.java
@@ -32,7 +32,7 @@ public class FileDatabaseHistoryTest extends AbstractDatabaseHistoryTest {
         DatabaseHistory history = new FileDatabaseHistory();
         history.configure(Configuration.create()
                                        .with(FileDatabaseHistory.FILE_PATH, TEST_FILE_PATH.toAbsolutePath().toString())
-                                       .build(), null, DatabaseHistoryMetrics.NOOP);
+                                       .build(), null, DatabaseHistoryMetrics.NOOP, true);
         history.start();
         return history;
     }

--- a/debezium-core/src/test/java/io/debezium/relational/history/HistoryRecordTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/history/HistoryRecordTest.java
@@ -66,7 +66,7 @@ public class HistoryRecordTest {
         assertThat(deserialized.ddl()).isEqualTo(ddl);
 
         System.out.println(record);
-        assertThat((Object) TableChanges.fromArray(deserialized.tableChanges())).isEqualTo(tableChanges);
+        assertThat((Object) TableChanges.fromArray(deserialized.tableChanges(), true)).isEqualTo(tableChanges);
 
     }
 }

--- a/debezium-core/src/test/java/io/debezium/relational/history/KafkaDatabaseHistoryTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/history/KafkaDatabaseHistoryTest.java
@@ -111,7 +111,7 @@ public class KafkaDatabaseHistoryTest {
                                                   50000)
                                             .with(KafkaDatabaseHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, skipUnparseableDDL)
                                             .build();
-        history.configure(config, null, DatabaseHistoryMetrics.NOOP);
+        history.configure(config, null, DatabaseHistoryMetrics.NOOP, true);
         history.start();
 
         // Should be able to call start more than once ...
@@ -170,7 +170,7 @@ public class KafkaDatabaseHistoryTest {
         // Stop the history (which should stop the producer) ...
         history.stop();
         history = new KafkaDatabaseHistory();
-        history.configure(config, null, DatabaseHistoryListener.NOOP);
+        history.configure(config, null, DatabaseHistoryListener.NOOP, true);
         // no need to start
 
         // Recover from the very beginning to just past the first change ...
@@ -287,7 +287,7 @@ public class KafkaDatabaseHistoryTest {
                 .with(KafkaDatabaseHistory.SKIP_UNPARSEABLE_DDL_STATEMENTS, true)
                 .build();
 
-        history.configure(config, null, DatabaseHistoryMetrics.NOOP);
+        history.configure(config, null, DatabaseHistoryMetrics.NOOP, true);
         history.start();
 
         // dummytopic should not exist yet


### PR DESCRIPTION
This is to make the [DB2 connector|https://github.com/debezium/debezium-incubator/pull/115] work.

The DB2 connector parses the table names using a SCHEMA.TABLE convention instead of CATALOG.TABLE, which is different from the default parsing in `io.debezium.relation.TableId`

We introduce a parameter `use.catalog.before.schema`, which by default is set to `true`, following the default parsing in  `io.debezium.relation.TableId`. In the case of the DB2 connector, it must be set to `false`. All the other connectors need not specify this parameter, as they are fine with the default parsing.

FYI: @SeanRooooney @zrlurb