### PR TITLE
DBZ-1585 Add operation timestamp header

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordStateConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordStateConfigDefinition.java
@@ -13,6 +13,7 @@ import io.debezium.config.Field;
 public class ExtractNewRecordStateConfigDefinition {
 
     public static final String DEBEZIUM_OPERATION_HEADER_KEY = "__debezium-operation";
+    public static final String DEBEZIUM_OPERATION_TIMESTAMP_HEADER_KEY = "__debezium-operation-timestamp";
     public static final String DELETED_FIELD = "__deleted";
     public static final String METADATA_FIELD_PREFIX = "__";
 


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1585?_sscc=t

I want to do  some end-to-end latency estimation on JDBC sink side, so I make the ExtractNewRecordState SMT add the exact time when the event happened in the source database to SourceRecord headers.