### PR TITLE
DBZ-1650 Changing sorting into a HashSet to a LinkedHashSet

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -244,7 +244,7 @@ public abstract class RelationalSnapshotChangeEventSource implements SnapshotCha
         return capturedTables
                 .stream()
                 .sorted()
-                .collect(Collectors.toCollection(HashSet::new));
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private void determineCapturedTables(SnapshotContext ctx) throws Exception {


### PR DESCRIPTION
Doesn't seem like sorting the set and then storing it in a HashSet makes much sense here (ordering gets lost once again). The IDE also showing a warning at this line. Changing it to a LinkedHashSet in order to preserve the order. 