### PR TITLE
[tutorial] Added missing step when deleting customers

### DIFF
--- a/documentation/modules/ROOT/pages/tutorial.adoc
+++ b/documentation/modules/ROOT/pages/tutorial.adoc
@@ -1232,6 +1232,16 @@ So far we've seen samples of _create_ and _update_ events. Now, let's look at _d
     mysql> DELETE FROM customers WHERE id=1004;
 ----
 
+[NOTE]
+====
+If the above command fails with a foreign key constraint violation, then you will have to remove the reference of the customer address from the _addresses_ table using the following statement:
+
+[source,sql,indent=0]
+----
+    mysql> DELETE FROM addresses WHERE customer_id=1004;
+----
+====
+
 In our terminal running `watch-topic`, we see _two_ new events:
 
 [source,json,indent=0,subs="attributes"]


### PR DESCRIPTION
I've followed the tutorial and I got to the step when we had to delete a customer.

When running:
```
DELETE FROM customers WHERE id=1004;
```
I got back:
```
ERROR 1451 (23000): Cannot delete or update a parent row: a foreign key constraint fails (`inventory`.`addresses`, CONSTRAINT `addresses_ibfk_1` FOREIGN KEY (`customer_id`) REFERENCES `customers` (`id`))
```
So I added some instructions on deleting this entry first before continuing.