### PR TITLE
DBZ-1648 outbox EventRouter remove topic toLowerCase 

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -129,7 +129,7 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         SourceRecord routedEvent = outboxEventRouter.apply(newEventRecord);
 
         assertThat(routedEvent).isNotNull();
-        assertThat(routedEvent.topic()).isEqualTo("outbox.event.user");
+        assertThat(routedEvent.topic()).isEqualTo("outbox.event.User");
 
         Struct valueStruct = requireStruct(routedEvent.value(), "test payload");
         assertThat(valueStruct.getString("eventType")).isEqualTo("UserCreated");
@@ -163,7 +163,7 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         SourceRecord routedEvent = outboxEventRouter.apply(newEventRecord);
 
         assertThat(routedEvent).isNotNull();
-        assertThat(routedEvent.topic()).isEqualTo("outbox.event.user");
+        assertThat(routedEvent.topic()).isEqualTo("outbox.event.User");
 
         Object value = routedEvent.value();
         assertThat(routedEvent.headers().lastWithName("eventType").value()).isEqualTo("UserCreated");
@@ -246,7 +246,7 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         assertConnectSchemasAreEqual(null, eventRouted.valueSchema(), expectedSchema);
 
         assertThat(eventRouted.timestamp()).isEqualTo(1553460779000000L);
-        assertThat(eventRouted.topic()).isEqualTo("outbox.event.useremail");
+        assertThat(eventRouted.topic()).isEqualTo("outbox.event.UserEmail");
 
         // Validate headers
         Headers headers = eventRouted.headers();
@@ -311,7 +311,7 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         // Validate metadata
         assertThat(eventRouted.valueSchema()).isNotNull();
         assertThat(eventRouted.timestamp()).isEqualTo(1553460779000000L);
-        assertThat(eventRouted.topic()).isEqualTo("outbox.event.useremail");
+        assertThat(eventRouted.topic()).isEqualTo("outbox.event.UserEmail");
 
         // Validate headers
         Headers headers = eventRouted.headers();
@@ -374,7 +374,7 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
         // Validate metadata
         assertThat(eventRouted.valueSchema()).isNull();
         assertThat(eventRouted.timestamp()).isEqualTo(1553460779000000L);
-        assertThat(eventRouted.topic()).isEqualTo("outbox.event.useremail");
+        assertThat(eventRouted.topic()).isEqualTo("outbox.event.UserEmail");
 
         // Validate headers
         Headers headers = eventRouted.headers();
@@ -422,7 +422,7 @@ public class OutboxEventRouterIT extends AbstractConnectorTest {
 
         // Validate metadata
         assertThat(eventRouted.valueSchema()).isNull();
-        assertThat(eventRouted.topic()).isEqualTo("outbox.event.useremail");
+        assertThat(eventRouted.topic()).isEqualTo("outbox.event.UserEmail");
 
         // Validate headers
         Headers headers = eventRouted.headers();

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -165,7 +165,7 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         }
 
         R newRecord = r.newRecord(
-                eventStruct.getString(routeByField).toLowerCase(),
+                eventStruct.getString(routeByField),
                 null,
                 Schema.STRING_SCHEMA,
                 defineRecordKey(eventStruct, payloadId),

--- a/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -376,7 +376,7 @@ public class EventRouterTest {
         final SourceRecord userEventRouted = router.apply(userEventRecord);
 
         assertThat(userEventRouted).isNotNull();
-        assertThat(userEventRouted.topic()).isEqualTo("outbox.event.user");
+        assertThat(userEventRouted.topic()).isEqualTo("outbox.event.User");
 
         final SourceRecord userUpdatedEventRecord = createEventRecord(
                 "ab720dd3-176d-40a6-96f3-6cf961d7df6a",
@@ -387,7 +387,7 @@ public class EventRouterTest {
         final SourceRecord userUpdatedEventRouted = router.apply(userUpdatedEventRecord);
 
         assertThat(userUpdatedEventRouted).isNotNull();
-        assertThat(userUpdatedEventRouted.topic()).isEqualTo("outbox.event.user");
+        assertThat(userUpdatedEventRouted.topic()).isEqualTo("outbox.event.User");
 
         final SourceRecord addressCreatedEventRecord = createEventRecord(
                 "ab720dd3-176d-40a6-96f3-6cf961d7df6a",
@@ -398,7 +398,7 @@ public class EventRouterTest {
         final SourceRecord addressCreatedEventRouted = router.apply(addressCreatedEventRecord);
 
         assertThat(addressCreatedEventRouted).isNotNull();
-        assertThat(addressCreatedEventRouted.topic()).isEqualTo("outbox.event.address");
+        assertThat(addressCreatedEventRouted.topic()).isEqualTo("outbox.event.Address");
     }
 
     @Test


### PR DESCRIPTION
- kafka topics names are case sensitive. We should not perform
  a toLowerCase on the topic name. It can cause some issue if
  topic name have a upper case