### PR TITLE
DBZ-1671 Adding configurable lock_wait_timeout for mysql connector 

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -269,6 +269,8 @@ public class SnapshotReader extends AbstractReader {
             mysql.setAutoCommit(false);
             sql.set("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ");
             mysql.executeWithoutCommitting(sql.get());
+            sql.set("SET SESSION lock_wait_timeout=" + context.getConnectorConfig().snapshotLockTimeout().getSeconds());
+            mysql.executeWithoutCommitting(sql.get());
 
             // Generate the DDL statements that set the charset-related system variables ...
             Map<String, String> systemVariables = connectionContext.readMySqlCharsetSystemVariables();

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -1908,6 +1908,11 @@ Can be used to avoid snapshot interruptions when starting multiple connectors in
 |Specifies the maximum number of rows that should be read in one go from each table while taking a snapshot.
 The connector will read the table contents in multiple batches of this size.
 
+|`snapshot.lock.timeout.ms`
+|`10000`
+|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot.
+If table locks cannot be acquired in this time interval, the snapshot will fail. See link:#snapshots[snapshots]
+
 |`enable.time.adjuster`
 |
 |MySQL allows user to insert year value as either 2-digit or 4-digit.

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1655,7 +1655,7 @@ The following _advanced_ configuration properties have good defaults that will w
 
 |`snapshot.lock.timeout.ms`
 |`10000`
-|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If table locks cannot be acquired in this time interval, the snapshot will fail See link:#snapshots[snapshots]
+|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If table locks cannot be acquired in this time interval, the snapshot will fail. See link:#snapshots[snapshots]
 
 |`snapshot.select.statement.overrides`
 |


### PR DESCRIPTION
Ref: https://issues.redhat.com/projects/DBZ/issues/DBZ-1671

Adds `lock_wait_timeout` to Mysql Connector Snapshot Reader. Enables the use of Debezium on tables with a large number of additional clients competing for table locks. 

Some more context on this issue; we're currently testing running Debezium in a high concurrency environment, where our LWTO is set very low (to avoid outages if someone attempts to lock a busy table), we'd like to be able to tune the setting back up for the single case of snapshotting. 