### PR TITLE
DBZ-1585 Set the ConnectRecord timestamp for the ExtractNewRecordState SMT

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordStateConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordStateConfigDefinition.java
@@ -104,4 +104,14 @@ public class ExtractNewRecordStateConfigDefinition {
             .withDefault("")
             .withDescription("Adds each field listed from the 'source' element of the payload, prefixed with __ "
                     + "Example: 'version,connector' would add __version and __connector fields");
+
+    public static final Field SET_CONNECT_RECORD_TIMESTAMP = Field.create("set.connect.record.timestamp")
+            .withDisplayName("Set the timestamp in ConnectRecord by using the 'ts_ms' which is from the 'source' field.")
+            .withType(ConfigDef.Type.BOOLEAN)
+            .withWidth(ConfigDef.Width.SHORT)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDefault(false)
+            .withDescription("The 'ts_ms' which is from the 'source' field is the original timestamp when the event happened"
+                    + " in the database, and we can set the timestamp in ConnectRecord with it. We can get the timestamp from "
+                    + " SinkRecord on sink connector side, and easily estimate the end-to-end latency.");
 }


### PR DESCRIPTION
Related issue : https://issues.redhat.com/browse/DBZ-1585

Hi, I want to estimate the end-to-end latency between data extracting  and loading, so I should know the exact time when the event(insert,update,delete...) happened in the source database.

In my case , I use  the ExtractNewRecordState SMT to  transform the received ConnectRecord , and my solution is adding an option(false by default) to determine if  the SMT should set the timestamp with the 'ts_ms" field value which is  from  'source' field.

Thanks a lot.