### PR TITLE
DBZ-1680 Fix enum value resolution across all PostgreSQL decoders

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessageColumnValueResolver.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessageColumnValueResolver.java
@@ -48,6 +48,10 @@ public class ReplicationMessageColumnValueResolver {
             return value.asArray(columnName, type, fullType, connection);
         }
 
+        if (type.isEnumType()) {
+            return value.asString();
+        }
+
         switch (type.getName()) {
             // include all types from https://www.postgresql.org/docs/current/static/datatype.html#DATATYPE-TABLE
             // plus aliases from the shorter names produced by older wal2json

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoColumnValue.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoColumnValue.java
@@ -325,9 +325,6 @@ public class PgProtoColumnValue extends AbstractColumnValue<PgProto.DatumMessage
                 type.getOid() == typeRegistry.hstoreArrayOid()) {
             return asArray(columnName, type, fullType, connection);
         }
-        if (type.isEnumType()) {
-            return asString();
-        }
         // unknown data type is sent by decoder as binary value
         if (includeUnknownDatatypes) {
             return asByteArray();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -1795,6 +1795,40 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         assertThat(consumer.isEmpty()).isTrue();
     }
 
+    @Test
+    @FixFor("DBZ-1680")
+    public void shouldStreamEnumsWhenIncludeUnknownDataTypesDisabled() throws Exception {
+        // Specifically enable `column.propagate.source.type` here to validate later that the actual
+        // type, length, and scale values are resolved correctly when paired with Enum types.
+        TestHelper.execute("CREATE TYPE test_type AS ENUM ('V1','V2');");
+        TestHelper.execute("CREATE TABLE enum_table (pk SERIAL, data varchar(25) NOT NULL, value test_type NOT NULL DEFAULT 'V1', PRIMARY KEY (pk));");
+        startConnector(config -> config
+                .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, false)
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER)
+                .with("column.propagate.source.type", "public.enum_table.value")
+                .with(PostgresConnectorConfig.TABLE_WHITELIST, "public.enum_table"), false);
+
+        waitForStreamingToStart();
+
+        consumer = testConsumer(1);
+        executeAndWait("INSERT INTO enum_table (data) VALUES ('hello');");
+
+        SourceRecord rec = assertRecordInserted("public.enum_table", PK_FIELD, 1);
+        assertSourceInfo(rec, "postgres", "public", "enum_table");
+
+        List<SchemaAndValueField> expected = Arrays.asList(
+                new SchemaAndValueField(PK_FIELD, Schema.INT32_SCHEMA, 1),
+                new SchemaAndValueField("data", Schema.STRING_SCHEMA, "hello"),
+                new SchemaAndValueField("value", Enum.builder("V1,V2")
+                        .parameter(TestHelper.TYPE_NAME_PARAMETER_KEY, "TEST_TYPE")
+                        .parameter(TestHelper.TYPE_LENGTH_PARAMETER_KEY, String.valueOf(Integer.MAX_VALUE))
+                        .parameter(TestHelper.TYPE_SCALE_PARAMETER_KEY, "0")
+                        .build(), "V1"));
+
+        assertRecordSchemaAndValues(expected, rec, Envelope.FieldName.AFTER);
+        assertThat(consumer.isEmpty()).isTrue();
+    }
+
     private long asEpochMicros(String timestamp) {
         Instant instant = LocalDateTime.parse(timestamp).atOffset(ZoneOffset.UTC).toInstant();
         return instant.getEpochSecond() * 1_000_000 + instant.getNano() / 1_000;


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1680

This fix applies to the scenario where include.unknown.datatypes is disabled and
the decoder is pgoutput or wal2json as decoderbufs was unaffected.