### PR TITLE
Improve getting started experience

### DIFF
--- a/documentation/modules/ROOT/pages/tutorial.adoc
+++ b/documentation/modules/ROOT/pages/tutorial.adoc
@@ -1257,7 +1257,7 @@ What happened? We only deleted one row, but we now have two events. To understan
   {
     "schema": {
       "type": "struct",
-      "name": "dbserver1.inventory.customers.Key"
+      "name": "dbserver1.inventory.customers.Key",
       "optional": false,
       "fields": [
         {

--- a/documentation/modules/ROOT/pages/tutorial.adoc
+++ b/documentation/modules/ROOT/pages/tutorial.adoc
@@ -23,6 +23,12 @@ Debezium is a distributed platform that turns your existing databases into event
 
 Debezium {debezium-version} includes support for monitoring MySQL database servers with its xref:connectors/mysql.adoc[MySQL connector], and this is what we'll use in this demonstration. Support for other DBMSes will be added in future releases.
 
+== Running Debezium Sample Application
+
+The fastest way to get started with Debezium is to checkout and try our tutorial application: 
+
+https://github.com/debezium/debezium-examples/tree/master/tutorial
+
 == Running Debezium with Docker
 
 Running Debezium involves three major services: http://zookeeper.apache.org[ZooKeeper], Kafka, and Debezium's connector service. This tutorial walks you through starting a single instance of these services using http://docker.com[Docker] and https://hub.docker.com/u/debezium/[Debezium's Docker images]. Production environments, on the other hand, require running multiple instances of each service to provide the performance, reliability, replication, and fault tolerance. This can be done with a platform like https://www.openshift.com[OpenShift] and http://kubernetes.io[Kubernetes] that manages multiple Docker containers running on multiple hosts and machines, but often you'll want to xref:install.adoc[install on dedicated hardware].

--- a/documentation/modules/ROOT/pages/tutorial.adoc
+++ b/documentation/modules/ROOT/pages/tutorial.adoc
@@ -1323,7 +1323,7 @@ Remember that we saw two events when we deleted the row? Let's look at that seco
   {
     "schema": {
       "type": "struct",
-      "name": "dbserver1.inventory.customers.Key"
+      "name": "dbserver1.inventory.customers.Key",
       "optional": false,
       "fields": [
         {


### PR DESCRIPTION
Tutorial for debezium is really long and it can be very error prone. 
On the other hand, debezium has top-quality tutorials that can be used for better getting started.
For example tutorial tells developers to manually setup containers, copy paste code etc.
I could not get that to work and got various different errors probably related to my machine setup. 

Debezium has very nice tutorial repo that works out of the box and gives developers not only the fastest getting started but also allows to pick different databases etc. It is also not easy to pick what tutorial should be used if someone will miss the context.

Tutorial example:
https://github.com/debezium/debezium-examples/tree/master/tutorial

Tutorial repo should be mentioned in the docs IMHO as it really lowers the high entry barrier for debezium