### PR TITLE
DBZ-1707 Ensuring correct Kafka record timestamp for outbox events;

### DIFF
--- a/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -28,6 +28,7 @@ import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.data.Envelope;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
+import io.debezium.time.Timestamp;
 
 /**
  * Unit tests for {@link EventRouter}
@@ -344,7 +345,7 @@ public class EventRouterTest {
         Long expectedTimestamp = 14222264625338L;
 
         Map<String, Schema> extraFields = new HashMap<>();
-        extraFields.put("event_timestamp", Schema.INT64_SCHEMA);
+        extraFields.put("event_timestamp", Timestamp.schema());
 
         Map<String, Object> extraValues = new HashMap<>();
         extraValues.put("event_timestamp", expectedTimestamp);


### PR DESCRIPTION
Depending on the width of the configured TIMESTAMP column, a microsecond or nanosecond timestamp could have been returned before, whereas this should always be milliseconds.

https://issues.redhat.com/browse/DBZ-1707