### PR TITLE
[DBZ-1715] Add route by field option for ExtractRecordState transformation

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordStateConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordStateConfigDefinition.java
@@ -96,6 +96,13 @@ public class ExtractNewRecordStateConfigDefinition {
             .withDescription("Adds the operation {@link FieldName#OPERATION operation} as a header." +
                     "Its key is '" + ExtractNewRecordStateConfigDefinition.DEBEZIUM_OPERATION_HEADER_KEY + "'");
 
+    public static final Field ROUTE_BY_FIELD = Field.create("route.by.field")
+            .withDisplayName("The column which determines how the events will be routed, the value will replace the topic name.")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDefault("");
+
     public static final Field ADD_SOURCE_FIELDS = Field.create("add.source.fields")
             .withDisplayName("Adds the specified fields from the 'source' field from the payload if they exist.")
             .withType(ConfigDef.Type.LIST)

--- a/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
@@ -160,4 +160,8 @@ For `DELETE` events, this option is only supported when the `delete.handling.mod
 |`add.source.fields`
 |
 |Fields from the change event's `source` structure to add as metadata (prefixed with "__") to the flattened record
+
+|`route.by.field`
+|
+|The column which determines how the events will be routed, the value will the topic name
 |=======================


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1715

As explained in DBZ-1715 this SMT adds the ability to set a topic based on the field in the table this SMT is consuming. 

I've checked on the Gitter dev channel if this is potentially interesting for core and @Naros replied that it might be. I've added some basic tests, would like to know how much more testing coverage is required for this piece of code.

 