### PR TITLE
DBZ-1712 MySQL connector use default port when database.port option not specified

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -58,6 +58,9 @@ public class MySqlJdbcContext implements AutoCloseable {
         boolean useSSL = sslModeEnabled();
         Configuration jdbcConfig = this.config
                 .filter(x -> !(x.startsWith(DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING) || x.equals(MySqlConnectorConfig.DATABASE_HISTORY.name())))
+                .edit()
+                .withDefault(MySqlConnectorConfig.PORT, MySqlConnectorConfig.PORT.defaultValue())
+                .build()
                 .subset("database.", true);
 
         Builder jdbcConfigBuilder = jdbcConfig


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1712