### PR TITLE
DBZ-1730 Resume Postgres steams from last_flushed_lsn when offset storage not available.

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -103,7 +103,7 @@ public class PostgresConnectorTask extends BaseSourceTask {
             }
 
             if (previousOffset == null && slotInfo != null) {
-                LOGGER.info("No previous offset found");
+                LOGGER.warn("Replication slot present, but no previous offset found. Recovering from slot");
                 previousOffset = PostgresOffsetContext.slotResumeOffsetContext(connectorConfig, slotInfo, clock);
             }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -84,7 +84,7 @@ public class PostgresConnectorTask extends BaseSourceTask {
 
         schema = new PostgresSchema(connectorConfig, typeRegistry, databaseCharset, topicSelector);
         this.taskContext = new PostgresTaskContext(connectorConfig, schema, topicSelector);
-        final PostgresOffsetContext previousOffset = (PostgresOffsetContext) getPreviousOffset(new PostgresOffsetContext.Loader(connectorConfig));
+        PostgresOffsetContext previousOffset = (PostgresOffsetContext) getPreviousOffset(new PostgresOffsetContext.Loader(connectorConfig));
         final Clock clock = Clock.system();
 
         final SourceInfo sourceInfo = new SourceInfo(connectorConfig);
@@ -100,6 +100,11 @@ public class PostgresConnectorTask extends BaseSourceTask {
             }
             catch (SQLException e) {
                 LOGGER.warn("unable to load info of replication slot, Debezium will try to create the slot");
+            }
+
+            if (previousOffset == null && slotInfo != null) {
+                LOGGER.info("No previous offset found");
+                previousOffset = PostgresOffsetContext.slotResumeOffsetContext(connectorConfig, slotInfo, clock);
             }
 
             if (previousOffset == null) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
@@ -21,6 +21,7 @@ import io.debezium.connector.SnapshotRecord;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.ReplicationConnection;
 import io.debezium.connector.postgresql.spi.OffsetState;
+import io.debezium.connector.postgresql.spi.SlotState;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.relational.TableId;
 import io.debezium.schema.DataCollectionId;
@@ -204,6 +205,18 @@ public class PostgresOffsetContext implements OffsetContext {
         catch (SQLException e) {
             throw new ConnectException("Database processing error", e);
         }
+    }
+
+    public static PostgresOffsetContext slotResumeOffsetContext(PostgresConnectorConfig connectorConfig, SlotState slotInfo, Clock clock) {
+        LOGGER.info("Resuming offset context from Replication Slot's confirmed_flushed_lsn '{}'", slotInfo.slotLastFlushedLsn());
+        return new PostgresOffsetContext(
+                connectorConfig,
+                slotInfo.slotLastFlushedLsn(),
+                null,
+                slotInfo.slotCatalogXmin(),
+                clock.currentTimeAsInstant(),
+                false,
+                false);
     }
 
     public OffsetState asOffsetState() {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -252,36 +252,6 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     }
 
     @Test
-    public void shouldResumeFromConfirmedFlushLsnWhenLastOffsetNotPresent() throws Exception {
-        TestHelper.execute(SETUP_TABLES_STMT);
-        Configuration.Builder configBuilder = TestHelper.defaultConfig()
-                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.getValue())
-                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE);
-        start(PostgresConnector.class, configBuilder.build());
-        assertConnectorIsRunning();
-        waitForStreamingRunning();
-
-        // insert 2 new records
-        TestHelper.execute(INSERT_STMT);
-        assertRecordsAfterInsert(2, 2, 2);
-
-        // now stop the connector and delete the offset storage
-        stopConnector();
-        assertNoRecordsToConsume();
-        Files.delete(OFFSET_STORE_PATH);
-
-        // insert some more records
-        TestHelper.execute(INSERT_STMT);
-
-        // start the connector back up and check that a new snapshot has not been performed (we're running initial only mode)
-        // but the 2 records that we were inserted while we were down will be retrieved
-        start(PostgresConnector.class, configBuilder.with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE).build());
-        assertConnectorIsRunning();
-
-        assertRecordsAfterInsert(2, 3, 3);
-    }
-
-    @Test
     @FixFor("DBZ-1174")
     public void shouldUseMicrosecondsForTransactionCommitTime() throws InterruptedException {
         TestHelper.execute(SETUP_TABLES_STMT);
@@ -349,7 +319,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
             TestHelper.execute(INSERT_STMT);
         }
         Configuration.Builder configBuilder = TestHelper.defaultConfig()
-                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL.getValue())
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_ONLY.getValue())
                 .with(PostgresConnectorConfig.MAX_QUEUE_SIZE, recordCount / 2)
                 .with(PostgresConnectorConfig.MAX_BATCH_SIZE, 10)
                 .with(PostgresConnectorConfig.SCHEMA_WHITELIST, "s1");
@@ -361,6 +331,76 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         Assertions.assertThat(records.recordsForTopic("test_server.s1.a")).hasSize(recordCount);
 
         stopConnector();
+    }
+
+    @Test
+    public void shouldSnapshotWhenOffsetMissingAndReplicationSlotInactive() throws Exception {
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.createDefaultReplicationSlot();
+        Files.delete(OFFSET_STORE_PATH);
+
+        shouldConsumeMessagesFromSnapshot();
+    }
+
+    private static class NoSnapShotDetectedException extends AssertionError {
+    }
+
+    @Test(expected = NoSnapShotDetectedException.class)
+    public void shouldNotSnapshotWhenOffsetMissingButReplicationSlotActive() throws Exception {
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.createDefaultReplicationSlot();
+
+        // Activate the Replication slot by streaming changes from it
+        TestHelper.execute(SETUP_TABLES_STMT);
+        Configuration.Builder configBuilder = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.getValue())
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE);
+        start(PostgresConnector.class, configBuilder.build());
+        assertConnectorIsRunning();
+        waitForStreamingRunning();
+
+        // Stop the connector and delete the offset storage
+        stopConnector();
+        assertNoRecordsToConsume();
+        Files.delete(OFFSET_STORE_PATH);
+
+        // Assert that no snapshot occurs
+        try {
+            shouldConsumeMessagesFromSnapshot();
+        }
+        catch (AssertionError e) {
+            throw new NoSnapShotDetectedException();
+        }
+    }
+
+    @Test
+    public void shouldResumeStreamFromActiveReplicationSlotWhenOffsetNotAvailable() throws Exception {
+        TestHelper.execute(SETUP_TABLES_STMT);
+        Configuration.Builder configBuilder = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.getValue())
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE);
+        start(PostgresConnector.class, configBuilder.build());
+        assertConnectorIsRunning();
+        waitForStreamingRunning();
+
+        // insert 2 new records
+        TestHelper.execute(INSERT_STMT);
+        assertRecordsAfterInsert(2, 2, 2);
+
+        // now stop the connector and delete the offset storage
+        stopConnector();
+        assertNoRecordsToConsume();
+        Files.delete(OFFSET_STORE_PATH);
+
+        // insert some more records
+        TestHelper.execute(INSERT_STMT);
+
+        // start the connector back up and check that a new snapshot has not been performed (we're running initial only mode)
+        // but the 2 records that we were inserted while we were down will be retrieved
+        start(PostgresConnector.class, configBuilder.with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE).build());
+        assertConnectorIsRunning();
+
+        assertRecordsAfterInsert(2, 3, 3);
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -261,6 +261,16 @@ public final class TestHelper {
         }
     }
 
+    protected static void createDefaultReplicationSlot() {
+        try {
+            execute("CREATE_REPLICATION_SLOT " + ReplicationConnection.Builder.DEFAULT_SLOT_NAME +
+                    " LOGICAL " + decoderPlugin().getPostgresPluginName());
+        }
+        catch (Exception e) {
+            LOGGER.debug("Error creating replication slot", e);
+        }
+    }
+
     protected static void dropPublication() {
         dropPublication(ReplicationConnection.Builder.DEFAULT_PUBLICATION_NAME);
     }


### PR DESCRIPTION
Changes the behaviour of the PostgresConnector to resume from the last flushed LSN when the previous offset information is not available, but the replication slot is.

Previously the connector resumed from the LSN of the latest committed transaction, which is a potentially data loss scenario for resuming the change stream.

https://issues.redhat.com/browse/DBZ-1730