### PR TITLE
DBZ-1738 replaced casts to PgConnection with interface BaseConnection

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
@@ -18,7 +18,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.errors.ConnectException;
-import org.postgresql.jdbc.PgConnection;
+import org.postgresql.core.BaseConnection;
 
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.ReplicationMessage;
@@ -167,7 +167,7 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
 
             int position = getPosition(columnName, table, values);
             if (position != -1) {
-                Object value = column.getValue(() -> (PgConnection) connection.connection(), connectorConfig.includeUnknownDatatypes());
+                Object value = column.getValue(() -> (BaseConnection) connection.connection(), connectorConfig.includeUnknownDatatypes());
                 if (sourceOfToasted) {
                     cachedOldToastedValues.put(columnName, value);
                 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -12,7 +12,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.connect.errors.ConnectException;
-import org.postgresql.jdbc.PgConnection;
+import org.postgresql.core.BaseConnection;
 import org.postgresql.replication.LogSequenceNumber;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -246,6 +246,6 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
 
     @FunctionalInterface
     public static interface PgConnectionSupplier {
-        PgConnection get() throws SQLException;
+        BaseConnection get() throws SQLException;
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.kafka.connect.errors.ConnectException;
-import org.postgresql.jdbc.PgConnection;
+import org.postgresql.core.BaseConnection;
 import org.postgresql.replication.LogSequenceNumber;
 import org.postgresql.util.PSQLState;
 import org.slf4j.Logger;
@@ -400,7 +400,7 @@ public class PostgresConnection extends JdbcConnection {
 
     private Charset determineDatabaseCharset() {
         try {
-            return Charset.forName(((PgConnection) connection()).getEncoding().name());
+            return Charset.forName(((BaseConnection) connection()).getEncoding().name());
         }
         catch (SQLException e) {
             throw new RuntimeException("Couldn't obtain encoding for database " + database(), e);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -23,8 +23,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
 import org.apache.kafka.connect.errors.ConnectException;
+import org.postgresql.core.BaseConnection;
 import org.postgresql.core.ServerVersion;
-import org.postgresql.jdbc.PgConnection;
 import org.postgresql.replication.LogSequenceNumber;
 import org.postgresql.replication.PGReplicationStream;
 import org.postgresql.replication.fluent.logical.ChainedLogicalStreamBuilder;
@@ -302,8 +302,8 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         }
     }
 
-    protected PgConnection pgConnection() throws SQLException {
-        return (PgConnection) connection(false);
+    protected BaseConnection pgConnection() throws SQLException {
+        return (BaseConnection) connection(false);
     }
 
     private SlotCreationResult parseSlotCreation(ResultSet rs) {


### PR DESCRIPTION
This change allows proxied postgres connections to be used by the connector. 

[io.debezium.connector.postgresql.TypeRegistry](https://github.com/debezium/debezium/blob/c32b771e1b6a545208d1df3c5615bf754d5c3140/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java#L312) already casts connections to BaseConnection but in these other files it is being cast to PgConnection. Java Proxies can be cast to interfaces but not to concrete classes so those break if the connection is being proxied.

See https://issues.redhat.com/browse/DBZ-1738 for more information. 

I couldn't see any clear way to add a test for this based on the existing test, but I'm open to suggestions.