### PR TITLE
Handle error conditions better for the Pg MONEY datatype

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -209,7 +209,16 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
             switch (type.getOid()) {
                 case PgOid.MONEY:
                     // TODO author=Horia Chiorean date=14/11/2016 description=workaround for https://github.com/pgjdbc/pgjdbc/issues/100
-                    return new PGmoney(rs.getString(columnIndex)).val;
+                    final String sMoney = rs.getString(columnIndex);
+                    if (sMoney == null) {
+                        return sMoney;
+                    }
+                    try {
+                        return new PGmoney(sMoney).val;
+                    }
+                    catch (SQLException e) {
+                        return sMoney;
+                    }
                 case PgOid.BIT:
                     return rs.getString(columnIndex);
                 case PgOid.NUMERIC:


### PR DESCRIPTION
I ran into the situation where the pgmoney field is null or a negative and that would crash the snapshot process. The changes in this pull request solved this.