### PR TITLE
DBZ-1766 Update lastOffset to commit only after a record is committed

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -214,8 +214,16 @@ public class PostgresConnectorTask extends BaseSourceTask {
 
     @Override
     public void commit() throws InterruptedException {
-        if (coordinator != null) {
+        if (coordinator != null && lastOffset != null) {
             coordinator.commitOffset(lastOffset);
+        }
+    }
+
+    @Override
+    public void commitRecord(SourceRecord record) throws InterruptedException {
+        Map<String, ?> currentOffset = record.sourceOffset();
+        if (currentOffset != null) {
+            this.lastOffset = currentOffset;
         }
     }
 
@@ -226,10 +234,6 @@ public class PostgresConnectorTask extends BaseSourceTask {
         final List<SourceRecord> sourceRecords = records.stream()
                 .map(DataChangeEvent::getRecord)
                 .collect(Collectors.toList());
-
-        if (!sourceRecords.isEmpty()) {
-            this.lastOffset = sourceRecords.get(sourceRecords.size() - 1).sourceOffset();
-        }
 
         return sourceRecords;
     }


### PR DESCRIPTION
Kafka Connect has an inconsistency between the API and the implementation of commit() (see https://issues.apache.org/jira/browse/KAFKA-5716). Although the comment on commit() says that it represents a commit of anything that has been returned from poll(), that is NOT actually the case - not all poll() records may have been processed yet. In order to avoid data loss in this situation when Kafka Connect goes down, commit should only flush offsets that it knows for sure have been committed. Luckily, the pre-existing commitRecord method does exactly this - it is called for every committed record. Instead of updating the lastOffset on poll, we'll update it in commitRecord().

While this change is only for postgres, the issue probably affects all connectors.

https://issues.redhat.com/browse/DBZ-1766

While the unit and integration tests are not suited to testing this subtle issue (as far as I can tell), we validated the change by following our repro steps with a similar change (although not identical, as our project is based on a prior version of debezium and manually handled LSNs) - see the bug report and its associated repro directions.