### PR TITLE
For avro, the spec says that we wanna use 'application/avro'

### DIFF
--- a/debezium-core/src/main/java/io/debezium/converters/CloudEventsMaker.java
+++ b/debezium-core/src/main/java/io/debezium/converters/CloudEventsMaker.java
@@ -70,7 +70,7 @@ public abstract class CloudEventsMaker {
 
     static final Map<SerializerType, String> CONTENT_TYPE_NAME_MAP = Collect.hashMapOf(
             SerializerType.JSON, "application/json",
-            SerializerType.AVRO, "avro/binary");
+            SerializerType.AVRO, "application/avro");
 
     /**
      * Create a concrete CloudEvents maker using the outputs of a record parser. Also need to specify the data content

--- a/debezium-core/src/test/java/io/debezium/converters/CloudEventsConverterTest.java
+++ b/debezium-core/src/test/java/io/debezium/converters/CloudEventsConverterTest.java
@@ -175,7 +175,7 @@ public class CloudEventsConverterTest {
             assertThat(valueJson.get(CloudEventsMaker.FieldName.ID)).isNotNull();
             assertThat(valueJson.get(CloudEventsMaker.FieldName.SOURCE)).isNotNull();
             assertThat(valueJson.get(CloudEventsMaker.FieldName.SPECVERSION)).isNotNull();
-            assertThat(valueJson.get(CloudEventsMaker.FieldName.DATACONTENTTYPE).asText()).isEqualTo("avro/binary");
+            assertThat(valueJson.get(CloudEventsMaker.FieldName.DATACONTENTTYPE).asText()).isEqualTo("application/avro");
             assertThat(valueJson.get(CloudEventsMaker.FieldName.DATASCHEMA).asText()).startsWith("http://fake-url/schemas/ids/");
             assertThat(valueJson.get(CloudEventsMaker.FieldName.TYPE)).isNotNull();
             assertThat(valueJson.get(CloudEventsMaker.FieldName.TIME)).isNotNull();
@@ -265,7 +265,7 @@ public class CloudEventsConverterTest {
             assertThat(avroValue.getString(CloudEventsMaker.FieldName.SOURCE)).isEqualTo("/debezium/" + connectorName + "/" + serverName);
             assertThat(avroValue.get(CloudEventsMaker.FieldName.SPECVERSION)).isEqualTo("1.0");
             assertThat(avroValue.get(CloudEventsMaker.FieldName.TYPE)).isEqualTo("io.debezium." + connectorName + ".datachangeevent");
-            assertThat(avroValue.get(CloudEventsMaker.FieldName.DATACONTENTTYPE)).isEqualTo("avro/binary");
+            assertThat(avroValue.get(CloudEventsMaker.FieldName.DATACONTENTTYPE)).isEqualTo("application/avro");
             assertThat(avroValue.getString(CloudEventsMaker.FieldName.DATASCHEMA)).startsWith("http://fake-url/schemas/ids/");
             assertThat(avroValue.get(CloudEventsMaker.FieldName.TIME)).isNotNull();
             assertThat(avroValue.get(CloudEventsMaker.FieldName.DATA)).isNotNull();

--- a/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
+++ b/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
@@ -87,7 +87,7 @@ Alternatively, Avro can be used as content type for the `data` attribute:
   "specversion" : "1.0",
   "type" : "io.debezium.postgresql.datachangeevent",
   "time" : "2020-01-13T14:04:18.597Z",
-  "datacontenttype" : "avro/binary",                 <1>
+  "datacontenttype" : "application/avro",            <1>
   "dataschema" : "http://my-registry/schemas/ids/1", <2>
   "iodebeziumop" : "r",
   "iodebeziumversion" : "1.1.0-SNAPSHOT",


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1784

see spec: https://github.com/cloudevents/spec/blob/85e5df9f35faeb2913766343ec878bdfb07b39aa/kafka-protocol-binding.md#325-example

/assign @slinkydeveloper

Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>