### PR TITLE
DBZ-1723 Moved task logic of postgres and sqlserver (EventSourceBased…

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFacade.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFacade.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import java.nio.charset.Charset;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.postgresql.util.PSQLException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.connector.postgresql.connection.ReplicationConnection;
+import io.debezium.connector.postgresql.spi.SlotCreationResult;
+import io.debezium.connector.postgresql.spi.SlotState;
+import io.debezium.connector.postgresql.spi.Snapshotter;
+import io.debezium.pipeline.ChangeEventSourceCoordinator;
+import io.debezium.pipeline.ChangeEventSourceFacade;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.RetryableErrorRecognitionStrategy;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.relational.TableId;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.Clock;
+import io.debezium.util.ExceptionUtils;
+import io.debezium.util.LoggingContext;
+import io.debezium.util.Metronome;
+
+public class PostgresChangeEventSourceFacade implements ChangeEventSourceFacade<PostgresTaskContext> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresChangeEventSourceFacade.class);
+    private static final String CONTEXT_NAME = "postgres-connector-task";
+
+    private final Configuration config;
+    private final Function<OffsetContext.Loader, OffsetContext> offsetProvider;
+
+    private volatile PostgresTaskContext taskContext;
+    private volatile ChangeEventQueue<DataChangeEvent> queue;
+    private volatile PostgresConnection jdbcConnection;
+    private volatile ChangeEventSourceCoordinator coordinator;
+    private volatile ErrorHandler errorHandler;
+    private volatile PostgresSchema schema;
+
+    public PostgresChangeEventSourceFacade(Configuration config, Function<OffsetContext.Loader, OffsetContext> offsetProvider) {
+        this.config = config;
+        this.offsetProvider = offsetProvider;
+    }
+
+    @Override
+    public void start() {
+        final PostgresConnectorConfig connectorConfig = new PostgresConnectorConfig(config);
+        final TopicSelector<TableId> topicSelector = PostgresTopicSelector.create(connectorConfig);
+        final Snapshotter snapshotter = connectorConfig.getSnapshotter();
+
+        if (snapshotter == null) {
+            throw new ConnectException("Unable to load snapshotter, if using custom snapshot mode, double check your settings");
+        }
+
+        jdbcConnection = new PostgresConnection(connectorConfig.jdbcConfig());
+        final TypeRegistry typeRegistry = jdbcConnection.getTypeRegistry();
+        final Charset databaseCharset = jdbcConnection.getDatabaseCharset();
+
+        schema = new PostgresSchema(connectorConfig, typeRegistry, databaseCharset, topicSelector);
+        this.taskContext = new PostgresTaskContext(connectorConfig, schema, topicSelector);
+        final PostgresOffsetContext previousOffset = (PostgresOffsetContext) offsetProvider.apply(
+                new PostgresOffsetContext.Loader(connectorConfig));
+        final Clock clock = Clock.system();
+
+        final SourceInfo sourceInfo = new SourceInfo(connectorConfig);
+        LoggingContext.PreviousContext previousContext = taskContext.configureLoggingContext(CONTEXT_NAME);
+        try {
+            // Print out the server information
+            SlotState slotInfo = null;
+            try (PostgresConnection connection = taskContext.createConnection()) {
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info(connection.serverInfo().toString());
+                }
+                slotInfo = connection.getReplicationSlotState(connectorConfig.slotName(), connectorConfig.plugin().getPostgresPluginName());
+            }
+            catch (SQLException e) {
+                LOGGER.warn("unable to load info of replication slot, Debezium will try to create the slot");
+            }
+
+            if (previousOffset == null) {
+                LOGGER.info("No previous offset found");
+                // if we have no initial offset, indicate that to Snapshotter by passing null
+                snapshotter.init(connectorConfig, null, slotInfo);
+            }
+            else {
+                LOGGER.info("Found previous offset {}", sourceInfo);
+                snapshotter.init(connectorConfig, previousOffset.asOffsetState(), slotInfo);
+            }
+
+            ReplicationConnection replicationConnection = null;
+            SlotCreationResult slotCreatedInfo = null;
+            if (snapshotter.shouldStream()) {
+                boolean shouldExport = snapshotter.exportSnapshot();
+                replicationConnection = createReplicationConnection(this.taskContext, shouldExport,
+                        connectorConfig.maxRetries(), connectorConfig.retryDelay());
+
+                // we need to create the slot before we start streaming if it doesn't exist
+                // otherwise we can't stream back changes happening while the snapshot is taking place
+                if (slotInfo == null) {
+                    try {
+                        slotCreatedInfo = replicationConnection.createReplicationSlot().orElse(null);
+                    }
+                    catch (SQLException ex) {
+                        throw new ConnectException(ex);
+                    }
+                }
+                else {
+                    slotCreatedInfo = null;
+                }
+            }
+
+            queue = new ChangeEventQueue.Builder<DataChangeEvent>()
+                    .pollInterval(connectorConfig.getPollInterval())
+                    .maxBatchSize(connectorConfig.getMaxBatchSize())
+                    .maxQueueSize(connectorConfig.getMaxQueueSize())
+                    .loggingContextSupplier(() -> taskContext.configureLoggingContext(CONTEXT_NAME))
+                    .build();
+
+            RetryableErrorRecognitionStrategy retryableErrorRecognitionStrategy = error -> ExceptionUtils.testInExceptionHierarchy(error,
+                    possibleCause -> (possibleCause instanceof PSQLException)
+                            && possibleCause.getMessage().startsWith("Database connection failed"));
+            errorHandler = new ErrorHandler(PostgresConnector.class, connectorConfig.getLogicalName(), this,
+                    retryableErrorRecognitionStrategy);
+
+            final PostgresEventMetadataProvider metadataProvider = new PostgresEventMetadataProvider();
+
+            final EventDispatcher<TableId> dispatcher = new EventDispatcher<>(
+                    connectorConfig,
+                    topicSelector,
+                    schema,
+                    queue,
+                    connectorConfig.getTableFilters().dataCollectionFilter(),
+                    DataChangeEvent::new,
+                    PostgresChangeRecordEmitter::updateSchema,
+                    metadataProvider);
+
+            coordinator = new ChangeEventSourceCoordinator(
+                    previousOffset,
+                    errorHandler,
+                    PostgresConnector.class,
+                    connectorConfig,
+                    new PostgresChangeEventSourceFactory(
+                            connectorConfig,
+                            snapshotter,
+                            jdbcConnection,
+                            dispatcher,
+                            clock,
+                            schema,
+                            taskContext,
+                            replicationConnection,
+                            slotCreatedInfo),
+                    dispatcher,
+                    schema);
+
+            coordinator.start(taskContext, this.queue, metadataProvider);
+        }
+        finally {
+            previousContext.restore();
+        }
+    }
+
+    @Override
+    public void commitOffset(Map<String, ?> offset) {
+        if (coordinator != null) {
+            coordinator.commitOffset(offset);
+        }
+    }
+
+    public static ReplicationConnection createReplicationConnection(PostgresTaskContext taskContext,
+                                                                    boolean shouldExport,
+                                                                    int maxRetries, Duration retryDelay)
+            throws ConnectException {
+        final Metronome metronome = Metronome.parker(retryDelay, Clock.SYSTEM);
+        short retryCount = 0;
+        ReplicationConnection replicationConnection = null;
+        while (retryCount <= maxRetries) {
+            try {
+                return taskContext.createReplicationConnection(shouldExport);
+            }
+            catch (SQLException ex) {
+                retryCount++;
+                if (retryCount > maxRetries) {
+                    LOGGER.error("Too many errors connecting to server. All {} retries failed.", maxRetries);
+                    throw new ConnectException(ex);
+                }
+
+                LOGGER.warn("Error connecting to server; will attempt retry {} of {} after {} " +
+                        "seconds. Exception message: {}", retryCount, maxRetries, retryDelay.getSeconds(),
+                        ex.getMessage());
+                try {
+                    metronome.pause();
+                }
+                catch (InterruptedException e) {
+                    LOGGER.warn("Connection retry sleep interrupted by exception: " + e);
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+        return replicationConnection;
+    }
+
+    @Override
+    public void stop() {
+
+        try {
+            if (coordinator != null) {
+                coordinator.stop();
+            }
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.error("Interrupted while stopping coordinator", e);
+            throw new ConnectException("Interrupted while stopping coordinator, failing the task");
+        }
+
+        try {
+            if (errorHandler != null) {
+                errorHandler.stop();
+            }
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.error("Interrupted while stopping", e);
+        }
+
+        if (jdbcConnection != null) {
+            jdbcConnection.close();
+        }
+
+        if (schema != null) {
+            schema.close();
+        }
+    }
+
+    @Override
+    public ChangeEventQueue<DataChangeEvent> getQueue() {
+        return queue;
+    }
+
+    PostgresTaskContext getTaskContext() {
+        return taskContext;
+    }
+
+    @Override
+    public ChangeEventSourceCoordinator getCoordinator() {
+        return coordinator;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFactory.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFactory.java
@@ -9,7 +9,6 @@ import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.ReplicationConnection;
 import io.debezium.connector.postgresql.spi.SlotCreationResult;
 import io.debezium.connector.postgresql.spi.Snapshotter;
-import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
@@ -23,7 +22,6 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
 
     private final PostgresConnectorConfig configuration;
     private final PostgresConnection jdbcConnection;
-    private final ErrorHandler errorHandler;
     private final EventDispatcher<TableId> dispatcher;
     private final Clock clock;
     private final PostgresSchema schema;
@@ -33,12 +31,11 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
     private final SlotCreationResult slotCreatedInfo;
 
     public PostgresChangeEventSourceFactory(PostgresConnectorConfig configuration, Snapshotter snapshotter, PostgresConnection jdbcConnection,
-                                            ErrorHandler errorHandler, EventDispatcher<TableId> dispatcher, Clock clock, PostgresSchema schema,
+                                            EventDispatcher<TableId> dispatcher, Clock clock, PostgresSchema schema,
                                             PostgresTaskContext taskContext,
                                             ReplicationConnection replicationConnection, SlotCreationResult slotCreatedInfo) {
         this.configuration = configuration;
         this.jdbcConnection = jdbcConnection;
-        this.errorHandler = errorHandler;
         this.dispatcher = dispatcher;
         this.clock = clock;
         this.schema = schema;
@@ -70,7 +67,6 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
                 (PostgresOffsetContext) offsetContext,
                 jdbcConnection,
                 dispatcher,
-                errorHandler,
                 clock,
                 schema,
                 taskContext,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -21,12 +21,14 @@ import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.connector.common.BaseSourceTask;
+import io.debezium.connector.common.ChangeEventSourceBasedTask;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.ReplicationConnection;
 import io.debezium.connector.postgresql.spi.SlotCreationResult;
 import io.debezium.connector.postgresql.spi.SlotState;
 import io.debezium.connector.postgresql.spi.Snapshotter;
 import io.debezium.pipeline.ChangeEventSourceCoordinator;
+import io.debezium.pipeline.ChangeEventSourceFacade;
 import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
@@ -41,227 +43,31 @@ import io.debezium.util.Metronome;
  *
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
-public class PostgresConnectorTask extends BaseSourceTask {
+public class PostgresConnectorTask extends ChangeEventSourceBasedTask {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresConnectorTask.class);
-    private static final String CONTEXT_NAME = "postgres-connector-task";
+	private PostgresChangeEventSourceFacade postgresChangeEventSourceFacade;
 
-    private volatile PostgresTaskContext taskContext;
-    private volatile ChangeEventQueue<DataChangeEvent> queue;
-    private volatile PostgresConnection jdbcConnection;
-    private volatile ChangeEventSourceCoordinator coordinator;
-    private volatile ErrorHandler errorHandler;
-    private volatile PostgresSchema schema;
+	@Override
+	protected ChangeEventSourceFacade createEventSourceFacade(Configuration config) {
+		postgresChangeEventSourceFacade = new PostgresChangeEventSourceFacade(config, loader -> getPreviousOffset(loader));
+		return postgresChangeEventSourceFacade;
+	}
 
-    @Override
-    public ChangeEventSourceCoordinator start(Configuration config) {
-        final PostgresConnectorConfig connectorConfig = new PostgresConnectorConfig(config);
-        final TopicSelector<TableId> topicSelector = PostgresTopicSelector.create(connectorConfig);
-        final Snapshotter snapshotter = connectorConfig.getSnapshotter();
+	@Override
+	public String version() {
+		return Module.version();
+	}
 
-        if (snapshotter == null) {
-            throw new ConnectException("Unable to load snapshotter, if using custom snapshot mode, double check your settings");
-        }
+	@Override
+	protected Iterable<Field> getAllConfigurationFields() {
+		return PostgresConnectorConfig.ALL_FIELDS;
+	}
 
-        jdbcConnection = new PostgresConnection(connectorConfig.jdbcConfig());
-        final TypeRegistry typeRegistry = jdbcConnection.getTypeRegistry();
-        final Charset databaseCharset = jdbcConnection.getDatabaseCharset();
+	/**
+	 * TODO remove this used only in test
+	 */
+	PostgresTaskContext getTaskContext() {
+		return postgresChangeEventSourceFacade.getTaskContext();
+	}
 
-        schema = new PostgresSchema(connectorConfig, typeRegistry, databaseCharset, topicSelector);
-        this.taskContext = new PostgresTaskContext(connectorConfig, schema, topicSelector);
-        final PostgresOffsetContext previousOffset = (PostgresOffsetContext) getPreviousOffset(new PostgresOffsetContext.Loader(connectorConfig));
-        final Clock clock = Clock.system();
-
-        final SourceInfo sourceInfo = new SourceInfo(connectorConfig);
-        LoggingContext.PreviousContext previousContext = taskContext.configureLoggingContext(CONTEXT_NAME);
-        try {
-            // Print out the server information
-            SlotState slotInfo = null;
-            try (PostgresConnection connection = taskContext.createConnection()) {
-                if (LOGGER.isInfoEnabled()) {
-                    LOGGER.info(connection.serverInfo().toString());
-                }
-                slotInfo = connection.getReplicationSlotState(connectorConfig.slotName(), connectorConfig.plugin().getPostgresPluginName());
-            }
-            catch (SQLException e) {
-                LOGGER.warn("unable to load info of replication slot, Debezium will try to create the slot");
-            }
-
-            if (previousOffset == null) {
-                LOGGER.info("No previous offset found");
-                // if we have no initial offset, indicate that to Snapshotter by passing null
-                snapshotter.init(connectorConfig, null, slotInfo);
-            }
-            else {
-                LOGGER.info("Found previous offset {}", sourceInfo);
-                snapshotter.init(connectorConfig, previousOffset.asOffsetState(), slotInfo);
-            }
-
-            ReplicationConnection replicationConnection = null;
-            SlotCreationResult slotCreatedInfo = null;
-            if (snapshotter.shouldStream()) {
-                boolean shouldExport = snapshotter.exportSnapshot();
-                replicationConnection = createReplicationConnection(this.taskContext, shouldExport,
-                        connectorConfig.maxRetries(), connectorConfig.retryDelay());
-
-                // we need to create the slot before we start streaming if it doesn't exist
-                // otherwise we can't stream back changes happening while the snapshot is taking place
-                if (slotInfo == null) {
-                    try {
-                        slotCreatedInfo = replicationConnection.createReplicationSlot().orElse(null);
-                    }
-                    catch (SQLException ex) {
-                        throw new ConnectException(ex);
-                    }
-                }
-                else {
-                    slotCreatedInfo = null;
-                }
-            }
-
-            queue = new ChangeEventQueue.Builder<DataChangeEvent>()
-                    .pollInterval(connectorConfig.getPollInterval())
-                    .maxBatchSize(connectorConfig.getMaxBatchSize())
-                    .maxQueueSize(connectorConfig.getMaxQueueSize())
-                    .loggingContextSupplier(() -> taskContext.configureLoggingContext(CONTEXT_NAME))
-                    .build();
-
-            errorHandler = new ErrorHandler(PostgresConnector.class, connectorConfig.getLogicalName(), queue, this::cleanupResources);
-
-            final PostgresEventMetadataProvider metadataProvider = new PostgresEventMetadataProvider();
-
-            final EventDispatcher<TableId> dispatcher = new EventDispatcher<>(
-                    connectorConfig,
-                    topicSelector,
-                    schema,
-                    queue,
-                    connectorConfig.getTableFilters().dataCollectionFilter(),
-                    DataChangeEvent::new,
-                    PostgresChangeRecordEmitter::updateSchema,
-                    metadataProvider);
-
-            coordinator = new ChangeEventSourceCoordinator(
-                    previousOffset,
-                    errorHandler,
-                    PostgresConnector.class,
-                    connectorConfig,
-                    new PostgresChangeEventSourceFactory(
-                            connectorConfig,
-                            snapshotter,
-                            jdbcConnection,
-                            errorHandler,
-                            dispatcher,
-                            clock,
-                            schema,
-                            taskContext,
-                            replicationConnection,
-                            slotCreatedInfo),
-                    dispatcher,
-                    schema);
-
-            coordinator.start(taskContext, this.queue, metadataProvider);
-
-            return coordinator;
-        }
-        finally {
-            previousContext.restore();
-        }
-    }
-
-    public ReplicationConnection createReplicationConnection(PostgresTaskContext taskContext, boolean shouldExport,
-                                                             int maxRetries, Duration retryDelay)
-            throws ConnectException {
-        final Metronome metronome = Metronome.parker(retryDelay, Clock.SYSTEM);
-        short retryCount = 0;
-        ReplicationConnection replicationConnection = null;
-        while (retryCount <= maxRetries) {
-            try {
-                return taskContext.createReplicationConnection(shouldExport);
-            }
-            catch (SQLException ex) {
-                retryCount++;
-                if (retryCount > maxRetries) {
-                    LOGGER.error("Too many errors connecting to server. All {} retries failed.", maxRetries);
-                    throw new ConnectException(ex);
-                }
-
-                LOGGER.warn("Error connecting to server; will attempt retry {} of {} after {} " +
-                        "seconds. Exception message: {}", retryCount, maxRetries, retryDelay.getSeconds(), ex.getMessage());
-                try {
-                    metronome.pause();
-                }
-                catch (InterruptedException e) {
-                    LOGGER.warn("Connection retry sleep interrupted by exception: " + e);
-                    Thread.currentThread().interrupt();
-                }
-            }
-        }
-        return replicationConnection;
-    }
-
-    @Override
-    public List<SourceRecord> poll() throws InterruptedException {
-        final List<DataChangeEvent> records = queue.poll();
-
-        final List<SourceRecord> sourceRecords = records.stream()
-                .map(DataChangeEvent::getRecord)
-                .collect(Collectors.toList());
-
-        return sourceRecords;
-    }
-
-    @Override
-    public void stop() {
-        cleanupResources();
-    }
-
-    private void cleanupResources() {
-        if (!state.compareAndSet(State.RUNNING, State.STOPPED)) {
-            LOGGER.info("Connector has already been stopped");
-            return;
-        }
-
-        try {
-            if (coordinator != null) {
-                coordinator.stop();
-            }
-        }
-        catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            LOGGER.error("Interrupted while stopping coordinator", e);
-            throw new ConnectException("Interrupted while stopping coordinator, failing the task");
-        }
-
-        try {
-            if (errorHandler != null) {
-                errorHandler.stop();
-            }
-        }
-        catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            LOGGER.error("Interrupted while stopping", e);
-        }
-
-        if (jdbcConnection != null) {
-            jdbcConnection.close();
-        }
-
-        if (schema != null) {
-            schema.close();
-        }
-    }
-
-    @Override
-    public String version() {
-        return Module.version();
-    }
-
-    @Override
-    protected Iterable<Field> getAllConfigurationFields() {
-        return PostgresConnectorConfig.ALL_FIELDS;
-    }
-
-    public PostgresTaskContext getTaskContext() {
-        return taskContext;
-    }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -23,7 +23,6 @@ import io.debezium.connector.postgresql.connection.ReplicationMessage.Operation;
 import io.debezium.connector.postgresql.connection.ReplicationStream;
 import io.debezium.connector.postgresql.spi.Snapshotter;
 import io.debezium.heartbeat.Heartbeat;
-import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
 import io.debezium.relational.TableId;
@@ -50,7 +49,6 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
 
     private final PostgresConnection connection;
     private final EventDispatcher<TableId> dispatcher;
-    private final ErrorHandler errorHandler;
     private final Clock clock;
     private final PostgresSchema schema;
     private final PostgresOffsetContext offsetContext;
@@ -69,12 +67,11 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
     private Long lastCompletelyProcessedLsn;
 
     public PostgresStreamingChangeEventSource(PostgresConnectorConfig connectorConfig, Snapshotter snapshotter, PostgresOffsetContext offsetContext,
-                                              PostgresConnection connection, EventDispatcher<TableId> dispatcher, ErrorHandler errorHandler, Clock clock,
+                                              PostgresConnection connection, EventDispatcher<TableId> dispatcher, Clock clock,
                                               PostgresSchema schema, PostgresTaskContext taskContext, ReplicationConnection replicationConnection) {
         this.connectorConfig = connectorConfig;
         this.connection = connection;
         this.dispatcher = dispatcher;
-        this.errorHandler = errorHandler;
         this.clock = clock;
         this.schema = schema;
         this.offsetContext = (offsetContext != null) ? offsetContext : PostgresOffsetContext.initialContext(connectorConfig, connection, clock);
@@ -85,7 +82,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
     }
 
     @Override
-    public void execute(ChangeEventSourceContext context) throws InterruptedException {
+    public void execute(ChangeEventSourceContext context) throws InterruptedException, SQLException {
         if (!snapshotter.shouldStream()) {
             LOGGER.info("Streaming is not enabled in correct configuration");
             return;
@@ -178,9 +175,6 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                     noMessageIterations = 0;
                 }
             }
-        }
-        catch (Throwable e) {
-            errorHandler.setProducerThrowable(e);
         }
         finally {
             if (replicationConnection != null) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorTaskIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorTaskIT.java
@@ -43,10 +43,9 @@ public class PostgresConnectorTaskIT {
     @Test(expected = ConnectException.class)
     @FixFor("DBZ-1426")
     public void retryOnFailureToCreateConnection() throws Exception {
-        PostgresConnectorTask postgresConnectorTask = new PostgresConnectorTask();
         PostgresConnectorConfig config = new PostgresConnectorConfig(TestHelper.defaultConfig().build());
         long startTime = System.currentTimeMillis();
-        postgresConnectorTask.createReplicationConnection(new FakeContext(config, new PostgresSchema(
+        PostgresChangeEventSourceFacade.createReplicationConnection(new FakeContext(config, new PostgresSchema(
                 config,
                 null,
                 Charset.forName("UTF-8"),

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFacade.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFacade.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.pipeline.ChangeEventSourceCoordinator;
+import io.debezium.pipeline.ChangeEventSourceFacade;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.RetryableErrorRecognitionStrategy;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.DatabaseHistory;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.Clock;
+import io.debezium.util.SchemaNameAdjuster;
+
+public class SqlServerChangeEventSourceFacade implements ChangeEventSourceFacade<SqlServerTaskContext> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerChangeEventSourceFacade.class);
+    private static final String CONTEXT_NAME = "sql-server-connector-task";
+
+    private final Configuration config;
+    private final Function<OffsetContext.Loader, OffsetContext> offsetProvider;
+
+    private volatile SqlServerTaskContext taskContext;
+    private volatile ChangeEventQueue<DataChangeEvent> queue;
+    private volatile SqlServerConnection dataConnection;
+    private volatile SqlServerConnection metadataConnection;
+    private volatile ChangeEventSourceCoordinator coordinator;
+    private volatile ErrorHandler errorHandler;
+    private volatile SqlServerDatabaseSchema schema;
+
+    public SqlServerChangeEventSourceFacade(Configuration config,
+                                            Function<OffsetContext.Loader, OffsetContext> offsetProvider) {
+        this.config = config.edit()
+                .withDefault("database.responseBuffering", "adaptive")
+                .withDefault("database.fetchSize", 10_000)
+                .build();
+        this.offsetProvider = offsetProvider;
+    }
+
+    @Override
+    public void start() {
+        final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(config);
+        final TopicSelector<TableId> topicSelector = SqlServerTopicSelector.defaultSelector(connectorConfig);
+        final SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create(LOGGER);
+
+        final Configuration jdbcConfig = config.filter(
+                x -> !(x.startsWith(DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING) || x.equals(HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY.name())))
+                .subset("database.", true);
+        dataConnection = new SqlServerConnection(jdbcConfig);
+        metadataConnection = new SqlServerConnection(jdbcConfig);
+        try {
+            dataConnection.setAutoCommit(false);
+        }
+        catch (SQLException e) {
+            throw new ConnectException(e);
+        }
+        this.schema = new SqlServerDatabaseSchema(connectorConfig, schemaNameAdjuster, topicSelector, dataConnection);
+        this.schema.initializeStorage();
+
+        final OffsetContext previousOffset = offsetProvider.apply(new SqlServerOffsetContext.Loader(connectorConfig));
+        if (previousOffset != null) {
+            schema.recover(previousOffset);
+        }
+
+        taskContext = new SqlServerTaskContext(connectorConfig, schema);
+
+        final Clock clock = Clock.system();
+
+        // Set up the task record queue ...
+        this.queue = new ChangeEventQueue.Builder<DataChangeEvent>()
+                .pollInterval(connectorConfig.getPollInterval())
+                .maxBatchSize(connectorConfig.getMaxBatchSize())
+                .maxQueueSize(connectorConfig.getMaxQueueSize())
+                .loggingContextSupplier(() -> taskContext.configureLoggingContext(CONTEXT_NAME))
+                .build();
+
+        RetryableErrorRecognitionStrategy retryableErrorRecognitionStrategy = error -> false;
+        errorHandler = new ErrorHandler(SqlServerConnector.class, connectorConfig.getLogicalName(), this,
+                retryableErrorRecognitionStrategy);
+
+        final SqlServerEventMetadataProvider metadataProvider = new SqlServerEventMetadataProvider();
+
+        final EventDispatcher<TableId> dispatcher = new EventDispatcher<>(
+                connectorConfig,
+                topicSelector,
+                schema,
+                queue,
+                connectorConfig.getTableFilters().dataCollectionFilter(),
+                DataChangeEvent::new,
+                metadataProvider);
+
+        coordinator = new ChangeEventSourceCoordinator(
+                previousOffset,
+                errorHandler,
+                SqlServerConnector.class,
+                connectorConfig,
+                new SqlServerChangeEventSourceFactory(connectorConfig, dataConnection, metadataConnection, dispatcher, clock, schema),
+                dispatcher,
+                schema);
+
+        coordinator.start(taskContext, this.queue, metadataProvider);
+    }
+
+    @Override
+    public void commitOffset(Map<String, ?> offset) {
+        if (coordinator != null) {
+            coordinator.commitOffset(offset);
+        }
+    }
+
+    @Override
+    public void stop() {
+        try {
+            if (coordinator != null) {
+                coordinator.stop();
+            }
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.error("Interrupted while stopping coordinator", e);
+            throw new ConnectException("Interrupted while stopping coordinator, failing the task");
+        }
+
+        try {
+            if (errorHandler != null) {
+                errorHandler.stop();
+            }
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.error("Interrupted while stopping", e);
+        }
+
+        try {
+            if (dataConnection != null) {
+                dataConnection.close();
+            }
+        }
+        catch (SQLException e) {
+            LOGGER.error("Exception while closing JDBC connection", e);
+        }
+
+        try {
+            if (metadataConnection != null) {
+                metadataConnection.close();
+            }
+        }
+        catch (SQLException e) {
+            LOGGER.error("Exception while closing JDBC metadata connection", e);
+        }
+
+        if (schema != null) {
+            schema.close();
+        }
+    }
+
+    @Override
+    public ChangeEventQueue<DataChangeEvent> getQueue() {
+        return queue;
+    }
+
+    @Override
+    public ChangeEventSourceCoordinator getCoordinator() {
+        return coordinator;
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.sqlserver;
 
-import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
@@ -20,17 +19,15 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
     private final SqlServerConnectorConfig configuration;
     private final SqlServerConnection dataConnection;
     private final SqlServerConnection metadataConnection;
-    private final ErrorHandler errorHandler;
     private final EventDispatcher<TableId> dispatcher;
     private final Clock clock;
     private final SqlServerDatabaseSchema schema;
 
     public SqlServerChangeEventSourceFactory(SqlServerConnectorConfig configuration, SqlServerConnection dataConnection, SqlServerConnection metadataConnection,
-                                             ErrorHandler errorHandler, EventDispatcher<TableId> dispatcher, Clock clock, SqlServerDatabaseSchema schema) {
+                                             EventDispatcher<TableId> dispatcher, Clock clock, SqlServerDatabaseSchema schema) {
         this.configuration = configuration;
         this.dataConnection = dataConnection;
         this.metadataConnection = metadataConnection;
-        this.errorHandler = errorHandler;
         this.dispatcher = dispatcher;
         this.clock = clock;
         this.schema = schema;
@@ -50,7 +47,6 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
                 dataConnection,
                 metadataConnection,
                 dispatcher,
-                errorHandler,
                 clock,
                 schema);
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -5,30 +5,17 @@
  */
 package io.debezium.connector.sqlserver;
 
-import java.sql.SQLException;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Collections;
+import java.util.Map;
 
-import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
-import io.debezium.connector.base.ChangeEventQueue;
-import io.debezium.connector.common.BaseSourceTask;
-import io.debezium.pipeline.ChangeEventSourceCoordinator;
-import io.debezium.pipeline.DataChangeEvent;
-import io.debezium.pipeline.ErrorHandler;
-import io.debezium.pipeline.EventDispatcher;
+import io.debezium.connector.common.ChangeEventSourceBasedTask;
+import io.debezium.pipeline.ChangeEventSourceFacade;
 import io.debezium.pipeline.spi.OffsetContext;
-import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
-import io.debezium.relational.TableId;
-import io.debezium.relational.history.DatabaseHistory;
-import io.debezium.schema.TopicSelector;
-import io.debezium.util.Clock;
-import io.debezium.util.SchemaNameAdjuster;
 
 /**
  * The main task executing streaming from SQL Server.
@@ -37,18 +24,9 @@ import io.debezium.util.SchemaNameAdjuster;
  * @author Jiri Pechanec
  *
  */
-public class SqlServerConnectorTask extends BaseSourceTask {
+public class SqlServerConnectorTask extends ChangeEventSourceBasedTask {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerConnectorTask.class);
-    private static final String CONTEXT_NAME = "sql-server-connector-task";
-
-    private volatile SqlServerTaskContext taskContext;
-    private volatile ChangeEventQueue<DataChangeEvent> queue;
-    private volatile SqlServerConnection dataConnection;
-    private volatile SqlServerConnection metadataConnection;
-    private volatile ChangeEventSourceCoordinator coordinator;
-    private volatile ErrorHandler errorHandler;
-    private volatile SqlServerDatabaseSchema schema;
 
     @Override
     public String version() {
@@ -56,138 +34,28 @@ public class SqlServerConnectorTask extends BaseSourceTask {
     }
 
     @Override
-    public ChangeEventSourceCoordinator start(Configuration config) {
-        final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(config);
-        final TopicSelector<TableId> topicSelector = SqlServerTopicSelector.defaultSelector(connectorConfig);
-        final SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create(LOGGER);
+    protected ChangeEventSourceFacade createEventSourceFacade(Configuration config) {
+        return new SqlServerChangeEventSourceFacade(config, loader -> getPreviousOffset(loader));
+    }
 
-        // By default do not load whole result sets into memory
-        config = config.edit()
-                .withDefault("database.responseBuffering", "adaptive")
-                .withDefault("database.fetchSize", 10_000)
-                .build();
+    /**
+     * Loads the connector's persistent offset (if present) via the given loader.
+     */
+    @Override
+    protected OffsetContext getPreviousOffset(OffsetContext.Loader loader) {
+        Map<String, ?> partition = loader.getPartition();
 
-        final Configuration jdbcConfig = config.filter(
-                x -> !(x.startsWith(DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING) || x.equals(HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY.name())))
-                .subset("database.", true);
-        dataConnection = new SqlServerConnection(jdbcConfig);
-        metadataConnection = new SqlServerConnection(jdbcConfig);
-        try {
-            dataConnection.setAutoCommit(false);
-        }
-        catch (SQLException e) {
-            throw new ConnectException(e);
-        }
-        this.schema = new SqlServerDatabaseSchema(connectorConfig, schemaNameAdjuster, topicSelector, dataConnection);
-        this.schema.initializeStorage();
+        Map<String, Object> previousOffset = context.offsetStorageReader()
+                .offsets(Collections.singleton(partition))
+                .get(partition);
 
-        final OffsetContext previousOffset = getPreviousOffset(new SqlServerOffsetContext.Loader(connectorConfig));
         if (previousOffset != null) {
-            schema.recover(previousOffset);
+            OffsetContext offsetContext = loader.load(previousOffset);
+            LOGGER.info("Found previous offset {}", offsetContext);
+            return offsetContext;
         }
-
-        taskContext = new SqlServerTaskContext(connectorConfig, schema);
-
-        final Clock clock = Clock.system();
-
-        // Set up the task record queue ...
-        this.queue = new ChangeEventQueue.Builder<DataChangeEvent>()
-                .pollInterval(connectorConfig.getPollInterval())
-                .maxBatchSize(connectorConfig.getMaxBatchSize())
-                .maxQueueSize(connectorConfig.getMaxQueueSize())
-                .loggingContextSupplier(() -> taskContext.configureLoggingContext(CONTEXT_NAME))
-                .build();
-
-        errorHandler = new ErrorHandler(SqlServerConnector.class, connectorConfig.getLogicalName(), queue, this::cleanupResources);
-
-        final SqlServerEventMetadataProvider metadataProvider = new SqlServerEventMetadataProvider();
-
-        final EventDispatcher<TableId> dispatcher = new EventDispatcher<>(
-                connectorConfig,
-                topicSelector,
-                schema,
-                queue,
-                connectorConfig.getTableFilters().dataCollectionFilter(),
-                DataChangeEvent::new,
-                metadataProvider);
-
-        coordinator = new ChangeEventSourceCoordinator(
-                previousOffset,
-                errorHandler,
-                SqlServerConnector.class,
-                connectorConfig,
-                new SqlServerChangeEventSourceFactory(connectorConfig, dataConnection, metadataConnection, errorHandler, dispatcher, clock, schema),
-                dispatcher,
-                schema);
-
-        coordinator.start(taskContext, this.queue, metadataProvider);
-
-        return coordinator;
-    }
-
-    @Override
-    public List<SourceRecord> poll() throws InterruptedException {
-        final List<DataChangeEvent> records = queue.poll();
-
-        final List<SourceRecord> sourceRecords = records.stream()
-                .map(DataChangeEvent::getRecord)
-                .collect(Collectors.toList());
-
-        return sourceRecords;
-    }
-
-    @Override
-    public void stop() {
-        cleanupResources();
-    }
-
-    private void cleanupResources() {
-        if (!state.compareAndSet(State.RUNNING, State.STOPPED)) {
-            LOGGER.info("Connector has already been stopped");
-            return;
-        }
-
-        try {
-            if (coordinator != null) {
-                coordinator.stop();
-            }
-        }
-        catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            LOGGER.error("Interrupted while stopping coordinator", e);
-            throw new ConnectException("Interrupted while stopping coordinator, failing the task");
-        }
-
-        try {
-            if (errorHandler != null) {
-                errorHandler.stop();
-            }
-        }
-        catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            LOGGER.error("Interrupted while stopping", e);
-        }
-
-        try {
-            if (dataConnection != null) {
-                dataConnection.close();
-            }
-        }
-        catch (SQLException e) {
-            LOGGER.error("Exception while closing JDBC connection", e);
-        }
-
-        try {
-            if (metadataConnection != null) {
-                metadataConnection.close();
-            }
-        }
-        catch (SQLException e) {
-            LOGGER.error("Exception while closing JDBC metadata connection", e);
-        }
-
-        if (schema != null) {
-            schema.close();
+        else {
+            return null;
         }
     }
 
@@ -196,3 +64,4 @@ public class SqlServerConnectorTask extends BaseSourceTask {
         return SqlServerConnectorConfig.ALL_FIELDS;
     }
 }
+

--- a/debezium-core/src/main/java/io/debezium/connector/common/ChangeEventSourceBasedTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/ChangeEventSourceBasedTask.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.common;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.pipeline.ChangeEventSourceCoordinator;
+import io.debezium.pipeline.ChangeEventSourceFacade;
+import io.debezium.pipeline.DataChangeEvent;
+
+public abstract class ChangeEventSourceBasedTask extends BaseSourceTask {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChangeEventSourceBasedTask.class);
+
+    private enum State {
+        RUNNING,
+        STOPPED;
+    }
+
+    private final AtomicReference<State> state = new AtomicReference<State>(State.STOPPED);
+    private ChangeEventSourceFacade eventSourceFacade;
+    private volatile ChangeEventQueue<DataChangeEvent> queue;
+    private volatile Map<String, ?> lastOffset;
+
+    @Override
+    protected final ChangeEventSourceCoordinator start(Configuration config) {
+        if (!state.compareAndSet(State.STOPPED, State.RUNNING)) {
+            LOGGER.info("Connector has already been started");
+            return null;
+        }
+
+        eventSourceFacade = createEventSourceFacade(config);
+        eventSourceFacade.start();
+        queue = eventSourceFacade.getQueue();
+        return eventSourceFacade.getCoordinator();
+    }
+
+    protected abstract ChangeEventSourceFacade createEventSourceFacade(Configuration config);
+
+    @Override
+    public void commit() {
+        if (eventSourceFacade != null) {
+            eventSourceFacade.commitOffset(lastOffset);
+        }
+    }
+
+    @Override
+    public List<SourceRecord> poll() throws InterruptedException {
+        final List<DataChangeEvent> records = queue.poll();
+
+        final List<SourceRecord> sourceRecords = records.stream()
+                .map(DataChangeEvent::getRecord)
+                .collect(Collectors.toList());
+
+        if (!sourceRecords.isEmpty()) {
+            this.lastOffset = sourceRecords.get(sourceRecords.size() - 1).sourceOffset();
+        }
+
+        return sourceRecords;
+    }
+
+    @Override
+    public final void stop() {
+        if (!state.compareAndSet(State.RUNNING, State.STOPPED)) {
+            LOGGER.info("Connector has already been stopped");
+            return;
+        }
+
+        if (eventSourceFacade != null) {
+            eventSourceFacade.stop();
+        }
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -107,7 +107,7 @@ public class ChangeEventSourceCoordinator {
                 LOGGER.warn("Change event source executor was interrupted", e);
             }
             catch (Throwable e) {
-                errorHandler.setProducerThrowable(e);
+                errorHandler.handleThrowable(e);
             }
             finally {
                 streamingMetrics.connected(false);

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceFacade.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceFacade.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.pipeline;
+
+import java.util.Map;
+
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.common.CdcSourceTaskContext;
+
+public interface ChangeEventSourceFacade<T extends CdcSourceTaskContext> {
+
+    void start();
+
+    void commitOffset(Map<String, ?> offset);
+
+    void stop();
+
+    ChangeEventQueue<DataChangeEvent> getQueue();
+
+    ChangeEventSourceCoordinator getCoordinator();
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/ErrorHandler.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ErrorHandler.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.pipeline;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -14,37 +16,90 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.util.Clock;
+import io.debezium.util.Metronome;
 import io.debezium.util.Threads;
 
 public class ErrorHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ErrorHandler.class);
 
+    private static final Duration MAX_BACK_OFF = Duration.ofMinutes(1);
+
+    private final ChangeEventSourceFacade facade;
     private final ChangeEventQueue<?> queue;
-    private final Runnable onThrowable;
+    private final RetryableErrorRecognitionStrategy retryableErrorRecognitionStrategy;
     private final AtomicReference<Throwable> producerThrowable;
     private final ExecutorService executor;
 
-    public ErrorHandler(Class<? extends SourceConnector> connectorType, String logicalName, ChangeEventQueue<?> queue, Runnable onThrowable) {
-        this.queue = queue;
-        this.onThrowable = onThrowable;
+    private Duration currentBackOff = Duration.ofSeconds(3);
+    private Instant lastErrorOccuranceInstant;
+
+    public ErrorHandler(Class<? extends SourceConnector> connectorType, String logicalName,
+                        ChangeEventSourceFacade facade,
+                        RetryableErrorRecognitionStrategy retryableErrorRecognitionStrategy) {
+        this.facade = facade;
+        this.queue = facade.getQueue();
+        this.retryableErrorRecognitionStrategy = retryableErrorRecognitionStrategy;
         this.executor = Threads.newSingleThreadExecutor(connectorType, logicalName, "error-handler");
         this.producerThrowable = new AtomicReference<>();
     }
 
-    public void setProducerThrowable(Throwable producerThrowable) {
+    public void handleThrowable(Throwable producerThrowable) {
         LOGGER.error("Producer failure", producerThrowable);
 
-        boolean first = this.producerThrowable.compareAndSet(null, producerThrowable);
+        if (retryableErrorRecognitionStrategy.isRetryable(producerThrowable)) {
 
-        if (first) {
-            queue.producerFailure(producerThrowable);
-            executor.execute(() -> onThrowable.run());
+            multiplyOrResetBackOff();
+
+            facade.stop();
+
+            try {
+                LOGGER.info("Backing off for {}", currentBackOff);
+                Metronome.parker(currentBackOff, Clock.SYSTEM).pause();
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+
+            facade.start();
+        }
+        else {
+
+            boolean first = this.producerThrowable.compareAndSet(null, producerThrowable);
+
+            if (first) {
+                queue.producerFailure(producerThrowable);
+                executor.execute(facade::stop);
+            }
         }
     }
 
-    public Throwable getProducerThrowable() {
-        return producerThrowable.get();
+    private void multiplyOrResetBackOff() {
+        if (lastOccuranceWasMoreThan10MinutesAgo()) {
+            resetCurrentBackOff();
+        }
+        else {
+            multiplyCurrentBackOff();
+        }
+        lastErrorOccuranceInstant = Instant.now();
+    }
+
+    private boolean lastOccuranceWasMoreThan10MinutesAgo() {
+        return lastErrorOccuranceInstant != null &&
+                Instant.now().minus(Duration.ofMinutes(10)).isAfter(lastErrorOccuranceInstant);
+    }
+
+    private void resetCurrentBackOff() {
+        currentBackOff = Duration.ofSeconds(3);
+    }
+
+    private void multiplyCurrentBackOff() {
+        currentBackOff = currentBackOff.multipliedBy(2);
+        if (currentBackOff.toMillis() > MAX_BACK_OFF.toMillis()) {
+            currentBackOff = MAX_BACK_OFF;
+        }
     }
 
     public void stop() throws InterruptedException {

--- a/debezium-core/src/main/java/io/debezium/pipeline/RetryableErrorRecognitionStrategy.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/RetryableErrorRecognitionStrategy.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline;
+
+public interface RetryableErrorRecognitionStrategy {
+
+    boolean isRetryable(Throwable error);
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingChangeEventSource.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.pipeline.source.spi;
 
+import java.sql.SQLException;
 import java.util.Map;
 
 /**
@@ -25,7 +26,7 @@ public interface StreamingChangeEventSource extends ChangeEventSource {
      * @throws InterruptedException
      *             in case the snapshot was aborted before completion
      */
-    void execute(ChangeEventSourceContext context) throws InterruptedException;
+    void execute(ChangeEventSourceContext context) throws InterruptedException, SQLException;
 
     /**
      * Commits the given offset with the source database. Used by some connectors

--- a/debezium-core/src/main/java/io/debezium/util/ExceptionUtils.java
+++ b/debezium-core/src/main/java/io/debezium/util/ExceptionUtils.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import java.util.function.Predicate;
+
+public class ExceptionUtils {
+
+    private ExceptionUtils() {
+    }
+
+    public static boolean testInExceptionHierarchy(Throwable throwable, Predicate<Throwable> predicate) {
+        Throwable cause = throwable;
+        while (cause != null) {
+            if (predicate.test(cause)) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
+
+}

--- a/debezium-core/src/test/java/io/debezium/util/ExceptionUtilsTest.java
+++ b/debezium-core/src/test/java/io/debezium/util/ExceptionUtilsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import org.fest.assertions.Assertions;
+import org.junit.Test;
+
+public class ExceptionUtilsTest {
+
+    @Test
+    public void findsAtTheBeginningOfHierarchy() {
+        Throwable throwable = new Exception("1", new Exception("2", new Exception("3")));
+
+        boolean actual = ExceptionUtils.testInExceptionHierarchy(throwable, throwable1 -> "1".equals(throwable1.getMessage()));
+
+        Assertions.assertThat(actual).isTrue();
+    }
+
+    @Test
+    public void findsInTheMiddleOfHierarchy() {
+        Throwable throwable = new Exception("1", new Exception("2", new Exception("3")));
+
+        boolean actual = ExceptionUtils.testInExceptionHierarchy(throwable, throwable1 -> "2".equals(throwable1.getMessage()));
+
+        Assertions.assertThat(actual).isTrue();
+    }
+
+    @Test
+    public void findsAtTheEndOfHierarchy() {
+        Throwable throwable = new Exception("1", new Exception("2", new Exception("3")));
+
+        boolean actual = ExceptionUtils.testInExceptionHierarchy(throwable, throwable1 -> "3".equals(throwable1.getMessage()));
+
+        Assertions.assertThat(actual).isTrue();
+    }
+
+    @Test
+    public void returnsFalseWhenCantBeFound() {
+        Throwable throwable = new Exception("1", new Exception("2", new Exception("3")));
+
+        boolean actual = ExceptionUtils.testInExceptionHierarchy(throwable, throwable1 -> "4".equals(throwable1.getMessage()));
+
+        Assertions.assertThat(actual).isFalse();
+    }
+}


### PR DESCRIPTION
…) to facades objects to decouple and allow maintaining its state from outside of connect's object. This allows to retry in case of error with full state restart which is neccessary as db connections are spread accros multiple objects and needs to be reinitialized in case of db connection crash.