### PR TITLE
DBZ-1831 Support MongoDB Oplog operations as config

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -332,7 +332,8 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
             CommonConnectorConfig.SNAPSHOT_DELAY_MS,
             CommonConnectorConfig.SNAPSHOT_FETCH_SIZE,
             SNAPSHOT_MODE, CommonConnectorConfig.SOURCE_STRUCT_MAKER_VERSION,
-            Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX);
+            Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX,
+            CommonConnectorConfig.SKIPPED_OPERATIONS);
 
     protected static Field.Set EXPOSED_FIELDS = ALL_FIELDS;
 
@@ -349,7 +350,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
         ConfigDef config = new ConfigDef();
         Field.group(config, "MongoDB", HOSTS, USER, PASSWORD, LOGICAL_NAME, CONNECT_BACKOFF_INITIAL_DELAY_MS,
                 CONNECT_BACKOFF_MAX_DELAY_MS, MAX_FAILED_CONNECTIONS, AUTO_DISCOVER_MEMBERS,
-                SSL_ENABLED, SSL_ALLOW_INVALID_HOSTNAMES);
+                SSL_ENABLED, SSL_ALLOW_INVALID_HOSTNAMES, CommonConnectorConfig.SKIPPED_OPERATIONS);
         Field.group(config, "Events", DATABASE_WHITELIST, DATABASE_BLACKLIST, COLLECTION_WHITELIST, COLLECTION_BLACKLIST, FIELD_BLACKLIST, FIELD_RENAMES,
                 CommonConnectorConfig.TOMBSTONES_ON_DELETE,
                 CommonConnectorConfig.SOURCE_STRUCT_MAKER_VERSION, Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX);

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -317,6 +317,69 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
     }
 
     @Test
+    public void shouldConsumeAllEventsFromDatabaseWithSkippedOperations() throws InterruptedException, IOException {
+        // Use the DB configuration to define the connector's configuration ...
+        config = TestHelper.getConfiguration().edit()
+                .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
+                .with(MongoDbConnectorConfig.COLLECTION_WHITELIST, "dbit.*")
+                .with(MongoDbConnectorConfig.LOGICAL_NAME, "mongo")
+                .with(MongoDbConnectorConfig.SKIPPED_OPERATIONS, "u")
+                .build();
+
+        // Set up the replication context for connections ...
+        context = new MongoDbTaskContext(config);
+
+        // Cleanup database
+        TestHelper.cleanDatabase(primary(), "dbit");
+
+        // Start the connector ...
+        start(MongoDbConnector.class, config);
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Create and then update a document
+        // ---------------------------------------------------------------------------------------------------------------
+        // Testing.Debug.enable();
+        AtomicReference<String> id = new AtomicReference<>();
+        primary().execute("create", mongo -> {
+            MongoDatabase db1 = mongo.getDatabase("dbit");
+            MongoCollection<Document> coll = db1.getCollection("arbitrary");
+            coll.drop();
+
+            // Insert the document with a generated ID ...
+            Document doc = Document.parse("{\"a\": 1, \"b\": 2}");
+            InsertOneOptions insertOptions = new InsertOneOptions().bypassDocumentValidation(true);
+            coll.insertOne(doc, insertOptions);
+
+            // Find the document to get the generated ID ...
+            doc = coll.find().first();
+            Testing.debug("Document: " + doc);
+            id.set(doc.getObjectId("_id").toString());
+            Testing.debug("Document ID: " + id.get());
+        });
+
+        primary().execute("update", mongo -> {
+            MongoDatabase db1 = mongo.getDatabase("dbit");
+            MongoCollection<Document> coll = db1.getCollection("arbitrary");
+
+            // Find the document ...
+            Document doc = coll.find().first();
+            Testing.debug("Document: " + doc);
+            Document filter = Document.parse("{\"a\": 1}");
+            Document operation = Document.parse("{ \"$set\": { \"b\": 10 } }");
+            coll.updateOne(filter, operation);
+
+            doc = coll.find().first();
+            Testing.debug("Document: " + doc);
+        });
+
+        // Wait until we can consume the only 1 insert
+        SourceRecords insertAndUpdate = consumeRecordsByTopic(1);
+        assertThat(insertAndUpdate.recordsForTopic("mongo.dbit.arbitrary").size()).isEqualTo(1);
+        assertThat(insertAndUpdate.topics().size()).isEqualTo(1);
+
+    }
+
+    @Test
     @FixFor("DBZ-1168")
     public void shouldConsumeAllEventsFromDatabaseWithCustomAuthSource() throws InterruptedException, IOException {
 
@@ -869,7 +932,7 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
 
     protected List<Document> loadTestDocuments(String pathOnClasspath) {
         List<Document> results = new ArrayList<>();
-        try (InputStream stream = Testing.Files.readResourceAsStream(pathOnClasspath);) {
+        try (InputStream stream = Testing.Files.readResourceAsStream(pathOnClasspath)) {
             assertThat(stream).isNotNull();
             IoUtil.readLines(stream, line -> {
                 Document doc = Document.parse(line);

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -258,6 +258,20 @@ public abstract class CommonConnectorConfig {
             .withDescription("Optional list of custom converters that would be used instead of default ones. "
                     + "The converters are defined using '<converter.prefix>.type' config option and configured using options '<converter.prefix>.<option>'");
 
+    /** The comma-separated list of operations that  reader will skip reading them
+    valid operations list:
+        1. i: insert
+        2. u: update
+        3. d: delete
+     *  */
+    public static final Field SKIPPED_OPERATIONS = Field.create("skipped.operations")
+            .withDisplayName("skipped Operations")
+            .withType(Type.LIST)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withValidation(CommonConnectorConfig::validateSkippedOperation)
+            .withDescription("The comma-separated list of operations  to skip it");
+
     private final Configuration config;
     private final boolean emitTombstoneOnDelete;
     private final int maxQueueSize;
@@ -380,6 +394,28 @@ public abstract class CommonConnectorConfig {
             ++count;
         }
         return count;
+    }
+
+    private static int validateSkippedOperation(Configuration config, Field field, ValidationOutput problems) {
+        String operations = config.getString(field);
+
+        if (operations == null) {
+            return 0;
+        }
+
+        for (String operation : operations.trim().split(",")) {
+            switch (operation.trim()) {
+                case "i":
+                case "u":
+                case "d":
+                    continue;
+                default:
+                    problems.accept(field, operation, "Invalid operation");
+                    return 1;
+            }
+        }
+
+        return 0;
     }
 
     private static boolean isUsingAvroConverter(Configuration config) {

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -778,6 +778,10 @@ The topic is named according to the pattern `<heartbeat.topics.prefix>.<server.n
 ifndef::cdc-product[]
 See xref:configuration/avro.adoc#names[Avro naming] for more details.
 endif::cdc-product[]
+
+|`skipped.operations`
+|
+| comma-separated list of operations  that reader will skip reading them i.e "i,u,d"
 |=======================
 
 [[fault-tolerance]]


### PR DESCRIPTION
In some cases, user not interested to listen to every event that happens on Oplog.
For example, the users only interested listen to only insert event or update event or both of them. It's a good idea to have a config like oplog.events that let the user select the events that he/she wants.
Whit this feature we can decrease the load on the Kafka cluster with large scale MongoDB cluster to filter the events that they are interested in.