### PR TITLE
DBZ-1830 new connector property datatype.propagate.source.type

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSourceTypeInSchemaIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSourceTypeInSchemaIT.java
@@ -163,7 +163,7 @@ public class MySqlSourceTypeInSchemaIT extends AbstractConnectorTest {
         // Use the DB configuration to define the connector's configuration ...
         config = DATABASE.defaultConfig()
                 .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.NEVER)
-                .with("datatype.propagate.source.type", "FLOAT,VARCHAR")
+                .with("datatype.propagate.source.type", ".+\\.FLOAT,.+\\.VARCHAR")
                 .build();
 
         // Start the connector ...

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSourceTypeInSchemaIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSourceTypeInSchemaIT.java
@@ -156,4 +156,100 @@ public class MySqlSourceTypeInSchemaIT extends AbstractConnectorTest {
         assertThat(f2SchemaParameters).includes(
                 entry(TYPE_NAME_PARAMETER_KEY, "FLOAT"), entry(TYPE_LENGTH_PARAMETER_KEY, "8"), entry(TYPE_SCALE_PARAMETER_KEY, "4"));
     }
+
+    @Test
+    @FixFor("DBZ-1830")
+    public void shouldPropagateSourceTypeByDatatype() throws SQLException, InterruptedException {
+        // Use the DB configuration to define the connector's configuration ...
+        config = DATABASE.defaultConfig()
+                .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.NEVER)
+                .with("datatype.propagate.source.type", "FLOAT,VARCHAR")
+                .build();
+
+        // Start the connector ...
+        start(MySqlConnector.class, config);
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Consume all of the events due to startup and initialization of the database
+        // ---------------------------------------------------------------------------------------------------------------
+        // Testing.Debug.enable();
+        int numCreateDatabase = 1;
+        int numCreateTables = 1;
+        int numInserts = 1;
+        SourceRecords records = consumeRecordsByTopic(numCreateDatabase + numCreateTables + numInserts);
+        stopConnector();
+        assertThat(records).isNotNull();
+        records.forEach(this::validate);
+
+        List<SourceRecord> dmls = records.recordsForTopic(DATABASE.topicForTable("dbz_644_source_type_mapped_as_schema_parameter_test"));
+        assertThat(dmls).hasSize(1);
+
+        SourceRecord insert = dmls.get(0);
+        Field before = insert.valueSchema().field("before");
+
+        // no type info requested as per given datatypes
+        Map<String, String> idSchemaParameters = before
+                .schema()
+                .field("id")
+                .schema()
+                .parameters();
+
+        assertThat(idSchemaParameters).isNull();
+
+        // no type info requested as per given datatypes
+        Map<String, String> c1SchemaParameters = before
+                .schema()
+                .field("c1")
+                .schema()
+                .parameters();
+
+        assertThat(c1SchemaParameters).isNull();
+
+        // no type info requested as per given datatypes
+        Map<String, String> c2SchemaParameters = before
+                .schema()
+                .field("c2")
+                .schema()
+                .parameters();
+
+        assertThat(c2SchemaParameters).isNull();
+
+        // no type info requested as per given datatypes
+        Map<String, String> c3aSchemaParameters = before
+                .schema()
+                .field("c3a")
+                .schema()
+                .parameters();
+
+        assertThat(c3aSchemaParameters).excludes(entry(TYPE_NAME_PARAMETER_KEY, "NUMERIC"));
+
+        // variable width, name and length info
+        Map<String, String> c3bSchemaParameters = before
+                .schema()
+                .field("c3b")
+                .schema()
+                .parameters();
+
+        assertThat(c3bSchemaParameters).includes(
+                entry(TYPE_NAME_PARAMETER_KEY, "VARCHAR"), entry(TYPE_LENGTH_PARAMETER_KEY, "128"));
+
+        // float info
+        Map<String, String> f1SchemaParameters = before
+                .schema()
+                .field("f1")
+                .schema()
+                .parameters();
+
+        assertThat(f1SchemaParameters).includes(
+                entry(TYPE_NAME_PARAMETER_KEY, "FLOAT"), entry(TYPE_LENGTH_PARAMETER_KEY, "10"));
+
+        Map<String, String> f2SchemaParameters = before
+                .schema()
+                .field("f2")
+                .schema()
+                .parameters();
+
+        assertThat(f2SchemaParameters).includes(
+                entry(TYPE_NAME_PARAMETER_KEY, "FLOAT"), entry(TYPE_LENGTH_PARAMETER_KEY, "8"), entry(TYPE_SCALE_PARAMETER_KEY, "4"));
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/mapping/ColumnMappers.java
+++ b/debezium-core/src/main/java/io/debezium/relational/mapping/ColumnMappers.java
@@ -86,9 +86,13 @@ public class ColumnMappers {
         }
 
         public Builder mapByDatatype(String columnDatatypes, ColumnMapper mapper) {
-            BiPredicate<TableId, Column> columnMatcher = Predicates.includes(columnDatatypes, (tableId, column) -> column.typeName());
+            BiPredicate<TableId, Column> columnMatcher = Predicates.includes(columnDatatypes, (tableId, column) -> fullyQualifiedColumnDatatype(tableId, column));
             rules.add(new MapperRule(columnMatcher, mapper));
             return this;
+        }
+
+        public static String fullyQualifiedColumnDatatype(TableId tableId, Column column) {
+            return tableId.toString() + "." + column.typeName();
         }
 
         /**

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1419,6 +1419,7 @@ Fully-qualified names for columns are of the form _schemaName_._tableName_._colu
 |An optional comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
 The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
 Useful to properly size corresponding columns in sink databases.
+Fully-qualified data type names are of the form _schemaName_._tableName_._typeName_.
 See xref:data-types[] for the list of Db2-specific data type names.
 
 |`message.key.columns`

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1414,6 +1414,13 @@ The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pa
 Useful to properly size corresponding columns in sink databases.
 Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 
+|`datatype.propagate.source.type`
+|_n/a_
+|An optional comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
+The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
+Useful to properly size corresponding columns in sink databases.
+See xref:data-types[] for the list of Db2-specific data type names.
+
 |`message.key.columns`
 |_empty string_
 | A semi-colon list of regular expressions that match fully-qualified tables and columns to map a primary key. +

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1210,6 +1210,13 @@ The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pa
 Useful to properly size corresponding columns in sink databases.
 Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_.
 
+|`datatype.propagate.source.type`
+|_n/a_
+|An optional comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
+The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
+Useful to properly size corresponding columns in sink databases.
+See xref:data-types[] for the list of Oracle-specific data type names.
+
 |`heartbeat.interval.ms`
 |`0`
 |Controls how frequently heartbeat messages are sent. +

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1215,6 +1215,7 @@ Fully-qualified names for columns are of the form _databaseName_._tableName_._co
 |An optional comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
 The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
 Useful to properly size corresponding columns in sink databases.
+Fully-qualified data type names are of the form _databaseName_._tableName_._typeName_, or _databaseName_._schemaName_._tableName_._typeName_.
 See xref:data-types[] for the list of Oracle-specific data type names.
 
 |`heartbeat.interval.ms`

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1782,6 +1782,7 @@ Fully-qualified names for columns are of the form _databaseName_._tableName_._co
 |An optional comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
 The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
 Useful to properly size corresponding columns in sink databases.
+Fully-qualified data type names are of the form _databaseName_._tableName_._typeName_, or _databaseName_._schemaName_._tableName_._typeName_.
 See xref:data-types[] for the list of PostgreSQL-specific data type names.
 
 |`message.key.columns`

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1777,6 +1777,13 @@ The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pa
 Useful to properly size corresponding columns in sink databases.
 Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_.
 
+|`datatype.propagate.source.type`
+|_n/a_
+|An optional comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
+The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
+Useful to properly size corresponding columns in sink databases.
+See xref:data-types[] for the list of PostgreSQL-specific data type names.
+
 |`message.key.columns`
 |_empty string_
 | A semi-colon list of regular expressions that match fully-qualified tables and columns to map a primary key. +

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1408,6 +1408,7 @@ Fully-qualified names for columns are of the form _schemaName_._tableName_._colu
 |An optional comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
 The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
 Useful to properly size corresponding columns in sink databases.
+Fully-qualified data type names are of the form _schemaName_._tableName_._typeName_.
 See xref:data-types[] for the list of SQL Server-specific data type names.
 
 |`message.key.columns`

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1403,6 +1403,12 @@ The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pa
 Useful to properly size corresponding columns in sink databases.
 Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 
+|`datatype.propagate.source.type`
+|_n/a_
+|An optional comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
+The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
+Useful to properly size corresponding columns in sink databases.
+See xref:data-types[] for the list of SQL Server-specific data type names.
 
 |`message.key.columns`
 |_empty string_

--- a/documentation/modules/ROOT/pages/modules/cdc-mysql-connector/r_mysql-connector-configuration-properties.adoc
+++ b/documentation/modules/ROOT/pages/modules/cdc-mysql-connector/r_mysql-connector-configuration-properties.adoc
@@ -97,6 +97,7 @@ Fully-qualified names for columns are of the form _databaseName_._tableName_._co
 |An optional comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
 The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
 Useful to properly size corresponding columns in sink databases.
+Fully-qualified data type names are of the form _databaseName_._tableName_._typeName_, or _databaseName_._schemaName_._tableName_._typeName_.
 See xref:data-types[] for the list of MySQL-specific data type names.
 
 |`time.precision.mode`

--- a/documentation/modules/ROOT/pages/modules/cdc-mysql-connector/r_mysql-connector-configuration-properties.adoc
+++ b/documentation/modules/ROOT/pages/modules/cdc-mysql-connector/r_mysql-connector-configuration-properties.adoc
@@ -92,6 +92,13 @@ The schema parameters `pass:[_]pass:[_]{prodname}.source.column.type`, `pass:[_]
 Useful to properly size corresponding columns in sink databases.
 Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_.
 
+|`datatype.propagate.source.type`
+|_n/a_
+|An optional comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
+The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
+Useful to properly size corresponding columns in sink databases.
+See xref:data-types[] for the list of MySQL-specific data type names.
+
 |`time.precision.mode`
 |`adaptive_time{zwsp}_microseconds`
 | Time, date, and timestamps can be represented with different kinds of precision, including: `adaptive_time_microseconds` (the default) captures the date, datetime and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type, with the exception of TIME type fields, which are always captured as microseconds; `adaptive` (deprecated) captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type; or `connect` always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which uses millisecond precision regardless of the database columns' precision.


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1830

This change provides support for the new connector property
```
datatype.propagate.source.type
```
to propagate the column data type as a parameter to the corresponding field schemas in the emitted change messages. The expected value is a comma-separated list of database-specific type names,  fully qualified with DB schema and table names, in example:
```
db1.table1.VARCHAR,db1,table1.INT,db1.table2.TIMESTAMP
```
regular expressions are allowed, in example:
```
db1\..*\.VARCHAR,.*\.INT
``` 