### PR TITLE
DBZ-1840 Re-instantiating pausing between readPending() calls without event

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -403,10 +403,13 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                 ByteBuffer read = stream.readPending();
                 final long lastReceiveLsn = stream.getLastReceiveLSN().asLong();
                 LOGGER.trace("Streaming requested from LSN {}, received LSN {}", startingLsn, lastReceiveLsn);
-                if (read != null && messageDecoder.shouldMessageBeSkipped(read, lastReceiveLsn, startingLsn, skipFirstFlushRecord)) {
+
+                if (read == null || messageDecoder.shouldMessageBeSkipped(read, lastReceiveLsn, startingLsn, skipFirstFlushRecord)) {
                     return false;
                 }
+
                 deserializeMessages(read, processor);
+
                 return true;
             }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationStream.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationStream.java
@@ -20,6 +20,11 @@ public interface ReplicationStream extends AutoCloseable {
 
     @FunctionalInterface
     public interface ReplicationMessageProcessor {
+
+        /**
+         * Processes the given replication message.
+         * @param message The replication message, never {@code null}.
+         */
         void process(ReplicationMessage message) throws SQLException, InterruptedException;
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1840

Note this means to that WAL offsets cannot be acknowledged in cases
where a null message is received from the server (e.g. wal2json for
DDL events). But as we cannot tell apart null events from the server
from readPending() simply having no events to read, the current
logic renders the pausing between two read calls without events
obsolete, so that's the lesser evil

@jpechane, @Naros, still doing some more testing, but pushing it here for feedback. Best review ignoring whitespace changes. Thx!