### PR TITLE
NO-JIRA: Typos in deployment.yaml and code readability

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -845,7 +845,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
 
                 // Wait max 2 seconds for LSN change
                 try {
-                    Awaitility.await().atMost(2, TimeUnit.MINUTES.SECONDS).ignoreExceptions().until(() -> flushLsn.add(getConfirmedFlushLsn(connection)));
+                    Awaitility.await().atMost(2, TimeUnit.SECONDS).ignoreExceptions().until(() -> flushLsn.add(getConfirmedFlushLsn(connection)));
                 }
                 catch (ConditionTimeoutException e) {
                     // We do not require all flushes to succeed in time

--- a/debezium-testing/debezium-testing-openshift/src/test/resources/database-resources/mysql/deployment.yaml
+++ b/debezium-testing/debezium-testing-openshift/src/test/resources/database-resources/mysql/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           tcpSocket:
             port: 3306
           timeoutSeconds: 1
-          readinessProbe:
+        readinessProbe:
             exec:
               command:
               - "/bin/sh"
@@ -51,7 +51,7 @@ spec:
               - "-c"
               - "MYSQL_PWD=\"$MYSQL_PASSWORD\" mysql -h 127.0.0.1 -u $MYSQL_USER -D inventory -e 'SELECT 1'"
             initialDelaySeconds: 5
-            timeoutSeconds": 1
+            timeoutSeconds: 1
         terminationMessagePolicy: File
         terminationMessagePath: /dev/termination-log
         image: 'debezium/example-mysql:latest'

--- a/debezium-testing/debezium-testing-openshift/src/test/resources/database-resources/postgresql/deployment.yaml
+++ b/debezium-testing/debezium-testing-openshift/src/test/resources/database-resources/postgresql/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - "-c"
             - "PGPASSWORD=${POSTGRESQL_PASSWORD} /usr/bin/psql -w -U ${POSTGRESQL_USER} -d ${POSTGRESQL_DATABASE} -c 'SELECT 1'"
           initialDelaySeconds: 5
-          timeoutSeconds": 1
+          timeoutSeconds: 1
         terminationMessagePolicy: File
         terminationMessagePath: /dev/termination-log
         image: 'quay.io/debezium/example-postgres-ocp:latest'


### PR DESCRIPTION
Fixed typos in the YAML. An unnecessary call to TimeUnit has also been removed.