### PR TITLE
DBZ-1829 (Don't merge)

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
@@ -138,49 +138,6 @@ transforms.unwrap.add.headers=op,table,lsn,source.ts_ms
 
 will add headers `__op`, `__table`, `__lsn` and `__source_ts_ms` to the outgoing record.
 
-=== Determine original operation  [DEPRECATED]
-
-_The `operation.header` option is deprecated and scheduled for removal. Please use add.headers instead. If both add.headers and operation.header are specified, the latter will be ignored._
-
-When a message is flattened the final result won't show whether it was an insert, update or first read
-(deletions can be detected via tombstones or rewrites, see link:#configuration_options[Configuration options]).
-
-To solve this problem Debezium offers an option to propagate the original operation via a header added to the message.
-To enable this feature the option `operation.header` must be set to `true`.
-
-[source]
-----
-transforms=unwrap,...
-transforms.unwrap.type=io.debezium.transforms.ExtractNewRecordState
-transforms.unwrap.operation.header=true
-----
-
-The possible values are the ones from the `op` field of the original change event.
-
-=== Adding source metadata fields [DEPRECATED]
-
-_The `add.source.fields` option is deprecated and scheduled for removal. Please use add.fields instead. If both add.fields and add.source.fields are specified, the latter will be ignored._
-
-The SMT can optionally add metadata fields from the original change event's `source` structure to the final flattened record (prefixed with "__"). This functionality can be used to add things like the table from the change event, or connector-specific fields like the Postgres LSN field. For more information on what's available in the source structure see xref:connectors/index.adoc[the documentation for each connector].
-
-For example, the configuration
-
-----
-transforms=unwrap,...
-transforms.unwrap.type=io.debezium.transforms.ExtractNewRecordState
-transforms.unwrap.add.source.fields=table,lsn
-----
-
-will add
-
-----
-{ "__table": "MY_TABLE", "__lsn": "123456789", ...}
-----
-
-to the final flattened record.
-
-For `DELETE` events, this option is only supported when the `delete.handling.mode` option is set to "rewrite".
-
 [[configuration_options]]
 == Configuration options
 [cols="35%a,10%a,55%a",options="header"]
@@ -204,16 +161,4 @@ For `DELETE` events, this option is only supported when the `delete.handling.mod
 |`add.headers`
 |
 |Specify a list of metadata fields to add to the header of the flattened message. In case of duplicate field names (e.g. "ts_ms" exists twice), the struct should be specified to get the correct field (e.g. "source.ts_ms"). The fields will be prefixed with "\\__" or "__<struct>__", depending on the specification of the struct. Please use a comma separated list without spaces.
-
-|`operation.header` DEPRECATED
-|`false`
-|_This option is deprecated and scheduled for removal. Please use add.headers instead. If both add.headers and operation.header are specified, the latter will be ignored._ 
-
-The SMT adds the event operation (as obtained from the `op` field of the original record) as a message header.
-
-|`add.source.fields` DEPRECATED
-|
-|_This option is deprecated and scheduled for removal. Please use add.fields instead. If both add.fields and add.source.fields are specified, the latter will be ignored._
-
-Fields from the change event's `source` structure to add as metadata (prefixed with "__") to the flattened record. Please no
 |=======================

--- a/documentation/modules/ROOT/pages/modules/cdc-mysql-connector/r_mysql-connector-configuration-properties.adoc
+++ b/documentation/modules/ROOT/pages/modules/cdc-mysql-connector/r_mysql-connector-configuration-properties.adoc
@@ -94,7 +94,7 @@ Fully-qualified names for columns are of the form _databaseName_._tableName_._co
 
 |`time.precision.mode`
 |`adaptive_time{zwsp}_microseconds`
-| Time, date, and timestamps can be represented with different kinds of precision, including: `adaptive_time_microseconds` (the default) captures the date, datetime and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type, with the exception of TIME type fields, which are always captured as microseconds; `adaptive` (deprecated) captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type; or `connect` always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which uses millisecond precision regardless of the database columns' precision.
+| Time, date, and timestamps can be represented with different kinds of precision, including: `adaptive_time_microseconds` (the default) captures the date, datetime and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type, with the exception of TIME type fields, which are always captured as microseconds; `connect` always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which uses millisecond precision regardless of the database columns' precision.
 
 |`decimal.handling.mode`
 |`precise`
@@ -151,11 +151,6 @@ WARNING: Enabling this option may expose tables or fields explicitly blacklisted
 |`gtid.source.excludes`
 |
 |A comma-separated list of regular expressions that match source UUIDs in the GTID set used to find the binlog position in the MySQL server. Only the GTID ranges that have sources matching none of these exclude patterns will be used. May not be used with `gtid.source.includes`.
-
-|`gtid.new.channel.position` +
-_deprecated and scheduled for removal_
-|`earliest`
-| When set to `latest`, when the connector sees a new GTID channel, it will start consuming from the last executed transaction in that GTID channel. If set to `earliest` (default), the connector starts reading that channel from the first available (not purged) GTID position. `earliest` is useful when you have a active-passive MySQL setup where {prodname} is connected to master, in this case during failover the slave with new UUID (and GTID channel) starts receiving writes before {prodname} is connected. These writes would be lost when using `latest`.
 
 |`tombstones.on.delete`
 |`true`


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1829

Hey @bhardesty, this removes the deprecated options discussed in DBZ-1829. I'd prefer to not actually apply this upstream, as we should list options there, also if deprecated. But you should apply this change downstream. Let me know if it's possible and I can close this PR. Thanks!