### PR TITLE
DBZ-1831 Support MongoDB Oplog operations as config

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -140,6 +140,7 @@ Sanjay Kr Singh
 Sanne Grinovero
 Satyajit Vegesna
 Saulius Valatka
+Sayed Mohammad Hossein Torabi
 Scofield Xu
 Sean Rooney
 Sherafudheen PM

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -332,7 +332,8 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
             CommonConnectorConfig.SNAPSHOT_DELAY_MS,
             CommonConnectorConfig.SNAPSHOT_FETCH_SIZE,
             SNAPSHOT_MODE, CommonConnectorConfig.SOURCE_STRUCT_MAKER_VERSION,
-            Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX);
+            Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX,
+            CommonConnectorConfig.SKIPPED_OPERATIONS);
 
     protected static Field.Set EXPOSED_FIELDS = ALL_FIELDS;
 
@@ -349,7 +350,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
         ConfigDef config = new ConfigDef();
         Field.group(config, "MongoDB", HOSTS, USER, PASSWORD, LOGICAL_NAME, CONNECT_BACKOFF_INITIAL_DELAY_MS,
                 CONNECT_BACKOFF_MAX_DELAY_MS, MAX_FAILED_CONNECTIONS, AUTO_DISCOVER_MEMBERS,
-                SSL_ENABLED, SSL_ALLOW_INVALID_HOSTNAMES);
+                SSL_ENABLED, SSL_ALLOW_INVALID_HOSTNAMES, CommonConnectorConfig.SKIPPED_OPERATIONS);
         Field.group(config, "Events", DATABASE_WHITELIST, DATABASE_BLACKLIST, COLLECTION_WHITELIST, COLLECTION_BLACKLIST, FIELD_BLACKLIST, FIELD_RENAMES,
                 CommonConnectorConfig.TOMBSTONES_ON_DELETE,
                 CommonConnectorConfig.SOURCE_STRUCT_MAKER_VERSION, Heartbeat.HEARTBEAT_INTERVAL, Heartbeat.HEARTBEAT_TOPICS_PREFIX);

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -919,6 +919,12 @@ The topic is named according to the pattern `<heartbeat.topics.prefix>.<server.n
 ifndef::cdc-product[]
 See xref:configuration/avro.adoc#names[Avro naming] for more details.
 endif::cdc-product[]
+
+|`skipped.operations`
+|
+| comma-separated list of oplog operations that will be skipped during streaming.
+The operations include: `i` for inserts, `u` for updates, and `d` for deletes.
+By default, no operations are skipped.
 |=======================
 
 [[fault-tolerance]]


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1831

This PR supersedes https://github.com/debezium/debezium/pull/1294 and is based on the work that is in PR https://github.com/debezium/debezium/pull/1316.  

@gunnarmorling Would it make more sense for me to cherry-pick the final commit into PR #1294 or is it sufficient that we merely rebase this once PR #1294 has been merged to master?