### PR TITLE
DBZ-1730 Stream from replica slot position not end of tx log

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -121,10 +121,10 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
     protected void determineSnapshotOffset(SnapshotContext ctx) throws Exception {
         PostgresOffsetContext offset = (PostgresOffsetContext) ctx.offset;
         final long xlogStart = getTransactionStartLsn();
-        final long txId = jdbcConnection.currentTransactionId().longValue();
+        final long txId = jdbcConnection.currentTransactionId();
         LOGGER.info("Read xlogStart at '{}' from transaction '{}'", ReplicationConnection.format(xlogStart), txId);
         if (offset == null) {
-            offset = PostgresOffsetContext.initialContext(connectorConfig, jdbcConnection, getClock());
+            offset = PostgresOffsetContext.snapshotInitialOffsetContext(connectorConfig, xlogStart, txId, getClock());
             ctx.offset = offset;
         }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -152,7 +152,6 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     }
 
     protected void initReplicationSlot() throws SQLException, InterruptedException {
-        final String postgresPluginName = plugin.getPostgresPluginName();
         ServerInfo.ReplicationSlot slotInfo = getSlotInfo();
 
         boolean shouldCreateSlot = ServerInfo.ReplicationSlot.INVALID == slotInfo;
@@ -479,6 +478,11 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                                 w.getMessage(), w.getSQLState(), w.getErrorCode());
                     }
                 }
+            }
+
+            @Override
+            public Long startLsn() {
+                return startingLsn;
             }
         };
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -261,6 +261,11 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     }
 
     @Override
+    public long getDefaultStartingPosition() {
+        return defaultStartingPos;
+    }
+
+    @Override
     public Optional<SlotCreationResult> createReplicationSlot() throws SQLException {
         // note that some of these options are only supported in pg94+, additionally
         // the options are not yet exported by the jdbc api wrapper, therefore, we just do this ourselves

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationConnection.java
@@ -83,6 +83,13 @@ public interface ReplicationConnection extends AutoCloseable {
     boolean isConnected() throws SQLException;
 
     /**
+     * The default starting position is either the latest flushed LSN or xlogpos.
+     *
+     * @return the LSN to resume from when no previous LSN is found in Kafka
+     */
+    long getDefaultStartingPosition();
+
+    /**
      * Creates a new {@link Builder} instance which can be used for creating replication connections.
      *
      * @param jdbcConfig a {@link Configuration} instance that contains JDBC settings; may not be null

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationStream.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationStream.java
@@ -75,6 +75,13 @@ public interface ReplicationStream extends AutoCloseable {
     Long lastReceivedLsn();
 
     /**
+     * Returns the value for the LSN form which the streaming is executed.
+     *
+     * @return a {@link Long} value, possibly null if starting LSN is undefined
+     */
+    Long startLsn();
+
+    /**
      * Starts a background thread to ensure the slot is kept alive, useful for when temporarily
      * stopping reads from the stream such as querying metadata, etc
      */


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1730

Addresses the bug introduced in DBZ-777 where the logic for resuming the stream from the replication slot was bypassed when OffsetStore information is absent. Ensures that the stream starts from one of the following locations in order of precedence:
1.  The txn and lsn at which a Snapshot took place
1. The confirmed_flush_lsn in the replication slot
1. The current XLog location 

