### PR TITLE
DBZ-1861 Modularize the logging doc

### DIFF
--- a/documentation/modules/ROOT/pages/assemblies/logging/as_configuring-logging.adoc
+++ b/documentation/modules/ROOT/pages/assemblies/logging/as_configuring-logging.adoc
@@ -1,0 +1,19 @@
+[id="configuring-logging"]
+= Configuring logging
+
+By default, {prodname} connectors write all `INFO`, `WARN`, and `ERROR` messages to the console.
+However, you can change this configuration in the following ways:
+
+* xref:changing-logging-level[Change the logging level]
+* xref:adding-mapped-diagnostic-contexts[Add mapped diagnostic contexts]
+
+[NOTE]
+====
+This section only covers a couple methods you can use to configure {prodname} logging with Log4j.
+For more information about using Log4j,
+search for tutorials to set up and use appenders to send log messages to specific destinations.
+====
+
+include::../../modules/logging/p_changing-logging-level.adoc[leveloffset=+1]
+
+include::../../modules/logging/p_adding-mapped-diagnostic-contexts.adoc[leveloffset=+1]

--- a/documentation/modules/ROOT/pages/modules/logging/c_logging-concepts.adoc
+++ b/documentation/modules/ROOT/pages/modules/logging/c_logging-concepts.adoc
@@ -1,0 +1,35 @@
+[id="logging-concepts"]
+= Logging concepts
+
+Before configuring logging, you should understand what Log4J _loggers_, _log levels_, and _appenders_ are.
+
+[discrete]
+== Loggers
+
+Each log message produced by the application is sent to a specific _logger_
+(for example, `io.debezium.connector.mysql`).
+Loggers are arranged in hierarchies.
+For example, the `io.debezium.connector.mysql` logger is the child of the `io.debezium.connector` logger,
+which is the child of the `io.debezium` logger.
+At the top of the hierarchy,
+the _root logger_ defines the default logger configuration for all of the loggers beneath it.
+
+[discrete]
+== Log levels
+
+Every log message produced by the application will also have a specific _log level_:
+
+1. `ERROR` - errors, exceptions, and other significant problems
+2. `WARN` - _potential_ problems and issues
+3. `INFO` - status and general activity (usually low-volume)
+4. `DEBUG` - more detailed activity that would be useful in diagnosing unexpected behavior
+5. `TRACE` - very verbose and detailed activity (usually very high-volume)
+
+[discrete]
+== Appenders
+
+An _appender_ is essentially a destination where log messages will be written.
+Each appender controls the format of its log messages,
+giving you even more control over what the log messages look like.
+
+To configure logging, you specify the desired level for each logger and the appender(s) where those log messages should be written. Since loggers are hierarchical, the configuration for the root logger serves as a default for all of the loggers below it, although you can override any child (or descendant) logger.

--- a/documentation/modules/ROOT/pages/modules/logging/c_understanding-default-logging-configuration.adoc
+++ b/documentation/modules/ROOT/pages/modules/logging/c_understanding-default-logging-configuration.adoc
@@ -1,0 +1,26 @@
+[id="understanding-default-logging-configuration"]
+= Understanding the default logging configuration
+
+If you are running {prodname} connectors in a Kafka Connect process,
+then Kafka Connect will use the Log4j configuration file (for example, `/opt/kafka/config/connect-log4j.properties`) in the Kafka installation.
+By default, this file contains the following configuration:
+
+.connect-log4j.properties
+[source,properties,options="nowrap"]
+----
+log4j.rootLogger=INFO, stdout  // <1>
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender  // <2>
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout  // <3>
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n  // <4>
+...
+----
+<1> The root logger, which defines the default logger configuration.
+By default, loggers will include `INFO`, `WARN`, and `ERROR` messages.
+These log messages will be written to the `stdout` appender.
+<2> The `stdout` appender will write log messages to the console (as opposed to a file).
+<3> The `stdout` appender will use a pattern matching algorithm to format the log messages.
+<4> The pattern for the `stdout` appender (see the https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html[Log4j documentation] for details).
+
+Unless you configure other loggers,
+all of the loggers used by {prodname} will inherit the `rootLogger` configuration.

--- a/documentation/modules/ROOT/pages/modules/logging/p_adding-mapped-diagnostic-contexts.adoc
+++ b/documentation/modules/ROOT/pages/modules/logging/p_adding-mapped-diagnostic-contexts.adoc
@@ -1,0 +1,63 @@
+[id="adding-mapped-diagnostic-contexts"]
+= Adding mapped diagnostic contexts
+
+Most {prodname} connectors (and the Kafka Connect workers) use multiple threads to perform different activities.
+This can make it difficult to look at a log file and find only those log messages for a particular logical activity.
+To make the log messages easier to find,
+{prodname} provides several _mapped diagnostic contexts_ (MDC) that provide additional information for each thread.
+
+{prodname} provides the following MDC properties:
+
+`dbz.connectorType`::
+A short alias for the type of connector.
+For example, `MySql`, `Mongo`, `Postgres`, and so on.
+All threads associated with the same _type_ of connector use the same value,
+so you can use this to find all log messages produced by a given type of connector.
+
+`dbz.connectorName`::
+The name of the connector or database server as defined in the connector's configuration.
+For example `products`, `serverA`, and so on.
+All threads associated with a specific _connector instance_ use the same value,
+so you can find all of the log messages produced by a specific connector instance.
+
+`dbz.connectorContext`::
+A short name for an activity running as a separate thread running within the connector's task.
+For example, `main`, `binlog`, `snapshot`, and so on.
+In some cases, when a connector assigns threads to specific resources (such as a table or collection),
+the name of that resource could be used instead.
+Each thread associated with a connector would use a distinct value,
+so you can find all of the log messages associated with this particular activity.
+
+To enable MDC for a connector,
+you configure an appender in the `log4j.properties` file.
+
+.Procedure
+
+. Open the `log4j.properties` file.
+
+. Configure an appender to use any of the supported {prodname} MDC properties.
++
+--
+In this example, the `stdout` appender is configured to use these MDC properties:
+
+.log4j.properties
+[source,properties,options="nowrap"]
+----
+...
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p  %X{dbz.connectorType}|%X{dbz.connectorName}|%X{dbz.connectorContext}  %m   [%c]%n
+...
+----
+
+This will produce log messages similar to these:
+
+[source,shell,options="nowrap"]
+----
+...
+2017-02-07 20:49:37,692 INFO   MySQL|dbserver1|snapshot  Starting snapshot for jdbc:mysql://mysql:3306/?useInformationSchema=true&nullCatalogMeansCurrent=false&useSSL=false&useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8&zeroDateTimeBehavior=convertToNull with user 'debezium'   [io.debezium.connector.mysql.SnapshotReader]
+2017-02-07 20:49:37,696 INFO   MySQL|dbserver1|snapshot  Snapshot is using user 'debezium' with these MySQL grants:   [io.debezium.connector.mysql.SnapshotReader]
+2017-02-07 20:49:37,697 INFO   MySQL|dbserver1|snapshot  	GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'debezium'@'%'   [io.debezium.connector.mysql.SnapshotReader]
+...
+----
+
+Each line in the log includes the connector type (for example, `MySQL`), the name of the connector (for example, `dbserver1`), and the activity of the thread (for example, `snapshot`).
+--

--- a/documentation/modules/ROOT/pages/modules/logging/p_changing-logging-level.adoc
+++ b/documentation/modules/ROOT/pages/modules/logging/p_changing-logging-level.adoc
@@ -1,0 +1,79 @@
+[id="changing-logging-level"]
+= Changing the logging level
+
+The default {prodname} logging level provides sufficient information to show whether a connector is healthy or not.
+However, if a connector is not healthy,
+you can change its logging level to troubleshoot the issue.
+
+In general, {prodname} connectors send their log messages to loggers with names that match the fully-qualified name of the Java class that is generating the log message.
+{prodname} uses packages to organize code with similar or related functions.
+This means that you can control all of the log messages for a specific class or for all of the classes within or under a specific package.
+
+.Procedure
+
+. Open the `log4j.properties` file.
+
+. Configure a logger for the connector.
++
+--
+This example configures loggers for the MySQL connector and the database history implementation used by the connector,
+and sets them to log `DEBUG` level messages:
+
+.log4j.properties
+[source,properties,options="nowrap"]
+----
+...
+log4j.logger.io.debezium.connector.mysql=DEBUG, stdout  // <1>
+log4j.logger.io.debezium.relational.history=DEBUG, stdout  // <2>
+
+log4j.additivity.io.debezium.connector.mysql=false  // <3>
+log4j.additivity.io.debezium.relational.history=false  // <3>
+...
+----
+<1> Configures the logger named `io.debezium.connector.mysql` to send `DEBUG`, `INFO`, `WARN`, and `ERROR` messages to the `stdout` appender.
+<2> Configures the logger named `io.debezium.relational.history` to send `DEBUG`, `INFO`, `WARN`, and `ERROR` messages to the `stdout` appender.
+<3> Turns off _additivity_,
+which means that the log messages will not be sent to appenders of parent loggers (this can prevent seeing duplicate log messages when using multiple appenders).
+--
+
+. If necessary, change the logging level for a specific subset of the classes within the connector.
++
+--
+Increasing the logging level for the entire connector increases the log verbosity,
+which can make it difficult to understand what is happening.
+In these cases,
+you can change the logging level just for the subset of classes that are related to the issue that you are troubleshooting.
+--
+
+.. Set the connector's logging level to either `DEBUG` or `TRACE`.
+
+.. Review the connector's log messages.
++
+--
+Find the log messages that are related to the issue that you are troubleshooting.
+The end of each log message shows the name of the Java class that produced the message.
+--
+
+.. Set the connector's logging level back to `INFO`.
+
+.. Configure a logger for each Java class that you identified.
++
+--
+For example, consider a scenario in which you are unsure why the MySQL connector is skipping some events when it is processing the binlog.
+Rather than turn on `DEBUG` or `TRACE` logging for the entire connector,
+you can keep the connector's logging level at `INFO` and then configure `DEBUG` or `TRACE` on just the class that is reading the binlog:
+
+.log4j.properties
+[source,properties,options="nowrap"]
+----
+...
+log4j.logger.io.debezium.connector.mysql=INFO, stdout
+log4j.logger.io.debezium.connector.mysql.BinlogReader=DEBUG, stdout
+log4j.logger.io.debezium.relational.history=INFO, stdout
+
+log4j.additivity.io.debezium.connector.mysql=false
+log4j.additivity.io.debezium.relational.history=false
+log4j.additivity.io.debezium.connector.mysql.BinlogReader=false
+...
+----
+--

--- a/documentation/modules/ROOT/pages/modules/logging/p_configuring-log-level-docker.adoc
+++ b/documentation/modules/ROOT/pages/modules/logging/p_configuring-log-level-docker.adoc
@@ -1,0 +1,25 @@
+[id="configuring-log-level-docker"]
+= Configuring the log level in the {prodname} container images
+
+The {prodname} container images for Zookeeper, Kafka, and Kafka Connect all set up their `log4j.properties` file to configure the Debezium-related loggers.
+All log messages are sent to the Docker container's console (and thus the Docker logs).
+The log messages are also written to files under the `/kafka/logs` directory.
+
+The containers use a `LOG_LEVEL` environment variable to set the log level for the root logger.
+You can use this environment variable to set the log level for the service running in the container.
+When you start the container,
+set this environment variable to one of the log levels (for example, `-e LOG_LEVEL=DEBUG`),
+and all of the code within the container will use that log level.
+
+If you need more control over the logging configuration,
+create a new container image that is based on ours,
+except that in your `Dockerfile`, copy your own `log4j.properties` file into the image.
+For example:
+
+.Dockerfile
+[source,dockerfile,options="nowrap"]
+----
+...
+COPY log4j.properties $KAFKA_HOME/config/log4j.properties
+...
+----

--- a/documentation/modules/ROOT/pages/operations/logging.adoc
+++ b/documentation/modules/ROOT/pages/operations/logging.adoc
@@ -1,4 +1,4 @@
-= Debezium Logging
+= {prodname} logging
 include::../_attributes.adoc[]
 :linkattrs:
 :icons: font
@@ -8,134 +8,21 @@ include::../_attributes.adoc[]
 
 toc::[]
 
-Debezium has extensive logging built into its connectors, and you can easily change the logging configuration to control which of these log statements appear in the logs and where those logs are sent. Debezium (and Kafka, Kafka Connect, and Zookeeper) use the ubiquitous https://logging.apache.org/log4j/1.2/[Log4J] logging framework for Java.
+{prodname} has extensive logging built into its connectors,
+and you can change the logging configuration to control which of these log statements appear in the logs
+and where those logs are sent.
+{prodname} (as well as Kafka, Kafka Connect, and Zookeeper) use the https://logging.apache.org/log4j/1.2/[Log4j] logging framework for Java.
 
-By default the connectors produce a fair amount of useful information on startup, but then produce very few logs when the connector is simply keeping up with the source databases. This is often sufficient when the connector is operating normally, but likely is not be enough when the connector is behaving unexpectedly. In such cases, you can "turn on debug or trace logging" so that the connector generates much more verbose log messages describing what the connector is doing and what it is not doing.
+By default, the connectors produce a fair amount of useful information when they start up,
+but then produce very few logs when the connector is keeping up with the source databases.
+This is often sufficient when the connector is operating normally,
+but may not be enough when the connector is behaving unexpectedly.
+In such cases, you can change the logging level so that the connector generates much more verbose log messages describing what the connector is doing and what it is not doing.
 
-== Logging concepts
+include::../modules/logging/c_logging-concepts.adoc[leveloffset=+1]
 
-Each log message produced by the application will be sent to a specific _logger_. Every logger has a name such as `io.debezium.connector.mysql`, and the names form a _hierarchy_ of loggers. For example, the logger named `io.debezium.connector.mysql` has a parent logger named `io.debezium.connector`, which has a parent logger named `io.debezium`, all the way to the _root logger_ at the very top of this hierarchy.
+include::../modules/logging/c_understanding-default-logging-configuration.adoc[leveloffset=+1]
 
-Every log message produced by the application will also have a specific log _level_:
+include::../assemblies/logging/as_configuring-logging.adoc[leveloffset=+1]
 
-1. `ERROR` for errors, exceptions, and other significant problems
-2. `WARN` for _potential_ problems and issues
-3. `INFO` - for status and general activity (usually low-volume)
-4. `DEBUG` - more detailed activity that would be useful in diagnosing unexpected behavior
-5. `TRACE` - very verbose and detailed activity (usually very high volume)
-
-Log4J also allows you to define one or more _appenders_, which are essentially destinations where log messages will be written. Each appender controls the format of its log messages, giving you even more control over what the log messages look like.
-
-To configure logging, you specify the desired level for each logger and the appender(s) where those log messages should be written. Since loggers are hierarchical, the configuration for the root logger serves as a default for all of the loggers below it, although you can override any child (or descendant) logger.
-
-== Example logging configuration
-
-If you're running Debezium connectors in a Kafka Connect process, then Kafka Connect will use the Log4J configuration file (e.g., `config/connect-log4j.properties`) in the Kafka installation. The following are snippets from this file:
-
-.log4j.properties
-[source,properties]
-----
-log4j.rootLogger=INFO, stdout <1>
-
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender <2>
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout <3>
-log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n <4>
-...
-----
-<1> Define the root logger should include `INFO`, `WARN`, and `ERROR` messages that should be written to the `stdout` appender.
-<2> Defines the `stdout` appender as writing to the console (as opposed to a file).
-<3> The `stdout` appender uses a pattern matching algorithm for the formatter
-<4> The pattern for the `stdout` appender (see the https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html[Log4J documentation] for details)
-
-Unless you configure other loggers, all of the loggers used by Debezium will inherit the `rootLogger` configuration.
-
-== Debezium loggers
-
-For the most part, the Debezium code sends its log messages to loggers with names that match the fully-qualified name of the Java class that is generating the log message. This normally works well, since we use packages to organize code with similar or related functions.
-
-This means that you can easily control all of the log messages for a specific class or for all of the classes within or under a specific package. For example, to turn on debug logging for the _entire_ MySQL connector (and the database history implementation used by the connector) might be as simple as adding the following line(s) to your `log4j.properties` file:
-
-.log4j.properties
-[listing,properties,indent=0,options="nowrap"]
-----
-...
-log4j.logger.io.debezium.connector.mysql=DEBUG, stdout <1>
-log4j.logger.io.debezium.relational.history=DEBUG, stdout <2>
-
-log4j.additivity.io.debezium.connector.mysql=false <3>
-log4j.additivity.io.debezium.relational.history=false <3>
-...
-----
-<1> Configures the logger named `io.debezium.connector.mysql` to send `DEBUG`, `INFO`, `WARN`, and `ERROR` messages to the `stdout` appender
-<2> Configures the logger named `io.debezium.relational.history` to send `DEBUG`, `INFO`, `WARN`, and `ERROR` messages to the `stdout` appender
-<3> Turns off _additivity_, meaning the messages will not be sent also to appenders of parent loggers (this can prevent seeing duplicate log messages when using multiple appenders)
-
-Configuring logging is a tradeoff: provide too little and it's not clear what is going on; provide too much and it's too difficult to understand what's going on. Our goal is that `INFO` provides enough to see that the connector is healthy (though logging is not a substitute for xref:operations/monitoring.adoc[monitoring]), and that `DEBUG` is provides more detailed information to help you figure out what is going on. But sometimes `DEBUG` is not enough, and that's where `TRACE` comes in. The `TRACE` level is literally every log message produced by or under that named logger, and it can be voluminous.
-
-You can also configure logging for a specific subset of the classes within the connector, simply by adding more lines like those above except for more specific logger names. For example, maybe you're not sure why the MySQL connector is skipping some events when it is processing the binlog. Rather than turn on `DEBUG` or `TRACE` logging for whole connector, you can set the connector's logging to `INFO` and then configure `DEBUG` or `TRACE` on just the class that's reading the binlog. For example:
-
-.log4j.properties
-[listing,properties,indent=0,options="nowrap"]
-----
-...
-log4j.logger.io.debezium.connector.mysql=INFO, stdout <1>
-log4j.logger.io.debezium.connector.mysql.BinlogReader=DEBUG, stdout <1>
-log4j.logger.io.debezium.relational.history=INFO, stdout <2>
-
-log4j.additivity.io.debezium.connector.mysql=false <3>
-log4j.additivity.io.debezium.relational.history=false <3>
-log4j.additivity.io.debezium.connector.mysql.BinlogReader=false <3>
-...
-----
-
-This requires a bit more knowledge about the code, but here's a useful tip. First turn on `DEBUG` or `TRACE` logging for the whole connector (or even the `io.debezium` package), find the messages that are most useful, and look at the end of the log message to see the name of the Java class that produced the message. Then, turn the connector's logging back to `INFO` and _add_ a logger configuration for each of those "interesting" classes or packages. If there are a few classes you don't want to see as detailed log messages, add another logger configuration for those classes and set them to `INFO`.
-
-We've only just touched on the power of Log4J, so if you want even more control look for some tutorials about how to set up and use other appenders to send different log messages to specific destinations.
-
-== Mapped Diagnostic Contexts
-
-Most Debezium connectors use multiple threads to perform different activities, and the Kafka Connect workers also use multiple threads. This can make it challenging to look at a log file and find only those log messages for one of these logical activities. To make this easier, Debezium uses _mapped diagnostic contexts_, or _MDC_ to provide additional information for each thread via several properties that you can embed in your appender patterns:
-
-* `dbz.connectorType` - A short alias for the type of connector. For example, `MySql`, `Mongo`, `Postgres`, etc. All threads associated with the same _type_ of connector use the same value, so you can use this to find all log messages produced by a given type of connector.
-* `dbz.connectorName` - The name of the connector or database server as defined in the connector's configuration. For example `products`, `serverA`, etc. All threads associated with a specific _connector instance_ use the same value, so you can find all the log messages produced by a specific connector instance.
-* `dbz.connectorContext` - A short name for an activity running as a separate thread running within the connector's task. For example, `main`, `binlog`, `snapshot`, etc. In some cases when a connector assigns threads to specific resources (e.g., table or collection), the name of that resource could be used instead. Each thread associated with a connector would use a distinct value, so you can find all the log messages associated with this particular activity.
-
-You can use these properties within the appender's pattern defined in the `log4j.properties` file. For example, the following is a modification of the `stdout` appender's layout to use these MDC properties:
-
-.log4j.properties
-[listing,properties,indent=0,options="nowrap"]
-----
-...
-log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p  %X{dbz.connectorType}|%X{dbz.connectorName}|%X{dbz.connectorContext}  %m   [%c]%n
-...
-----
-
-This will produce messages in the log similar to these:
-
-[listing,shell,indent=0,options="nowrap"]
-----
-...
-2017-02-07 20:49:37,692 INFO   MySQL|dbserver1|snapshot  Starting snapshot for jdbc:mysql://mysql:3306/?useInformationSchema=true&nullCatalogMeansCurrent=false&useSSL=false&useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8&zeroDateTimeBehavior=convertToNull with user 'debezium'   [io.debezium.connector.mysql.SnapshotReader]
-2017-02-07 20:49:37,696 INFO   MySQL|dbserver1|snapshot  Snapshot is using user 'debezium' with these MySQL grants:   [io.debezium.connector.mysql.SnapshotReader]
-2017-02-07 20:49:37,697 INFO   MySQL|dbserver1|snapshot  	GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'debezium'@'%'   [io.debezium.connector.mysql.SnapshotReader]
-...
-----
-
-Notice how each line includes the connector type (e.g., `MySQL`), the name of the connector (e.g., `dbserver1`), and the activity of the thread (e.g., `snapshot`). And here you can see at the end of the line the name of the class that generated the message.
-
-
-== Debezium Container Images
-
-The Debezium Container images for Zookeeper, Kafka, and Kafka Connect all set up their `log4j.properties` file to configure the Debezium-related loggers and to ensure all log messages go to the Docker containers console (and thus the Docker logs) and are written to files under the `/kafka/logs` directory, which you can mount to easily get access to those files.
-
-The containers use a `LOG_LEVEL` environment variable to set the log level for the root logger. So, when starting a container simply set this environment variable to one of the log levels (e.g., `-e LOG_LEVEL=DEBUG`), and all of the code within the container will start using that log level.
-
-If you need more control, create a new image that is based on ours, except in your `Dockerfile` copy your own `log4j.properties` file into the image:
-
-.Dockerfile
-[listing,dockerfile,indent=0,options="nowrap"]
-----
-...
-COPY log4j.properties $KAFKA_HOME/config/log4j.properties
-...
-----
+include::../modules/logging/p_configuring-log-level-docker.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR modularizes the logging doc so that it can be reused in the downstream doc. 

To be clear, the Docker-related procedure (p_configuring-log-level-docker.adoc) is upstream-specific, so it will not be included in the downstream doc.

I will create a separate PR to cherry-pick this to 1.0.