### PR TITLE
DBZ-1863 Centralizing coordinator shutdown

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
@@ -52,7 +52,6 @@ public final class MongoDbConnectorTask extends BaseSourceTask {
     private volatile ChangeEventQueue<DataChangeEvent> queue;
     private volatile String taskName;
     private volatile MongoDbTaskContext taskContext;
-    private volatile ChangeEventSourceCoordinator coordinator;
     private volatile ErrorHandler errorHandler;
     private volatile MongoDbSchema schema;
 
@@ -99,7 +98,7 @@ public final class MongoDbConnectorTask extends BaseSourceTask {
                     DataChangeEvent::new,
                     metadataProvider);
 
-            coordinator = new ChangeEventSourceCoordinator(
+            ChangeEventSourceCoordinator coordinator = new ChangeEventSourceCoordinator(
                     previousOffsets,
                     errorHandler,
                     MongoDbConnector.class,
@@ -133,17 +132,6 @@ public final class MongoDbConnectorTask extends BaseSourceTask {
     public void doStop() {
         PreviousContext previousLogContext = this.taskContext.configureLoggingContext(taskName);
         try {
-            try {
-                if (coordinator != null) {
-                    coordinator.stop();
-                }
-            }
-            catch (InterruptedException e) {
-                Thread.interrupted();
-                logger.error("Interrupted while stopping coordinator", e);
-                throw new ConnectException("Interrupted while stopping coordinator, failing the task");
-            }
-
             if (schema != null) {
                 schema.close();
             }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -49,7 +49,6 @@ public class PostgresConnectorTask extends BaseSourceTask {
     private volatile PostgresTaskContext taskContext;
     private volatile ChangeEventQueue<DataChangeEvent> queue;
     private volatile PostgresConnection jdbcConnection;
-    private volatile ChangeEventSourceCoordinator coordinator;
     private volatile ErrorHandler errorHandler;
     private volatile PostgresSchema schema;
 
@@ -140,7 +139,7 @@ public class PostgresConnectorTask extends BaseSourceTask {
                     PostgresChangeRecordEmitter::updateSchema,
                     metadataProvider);
 
-            coordinator = new ChangeEventSourceCoordinator(
+            ChangeEventSourceCoordinator coordinator = new ChangeEventSourceCoordinator(
                     previousOffset,
                     errorHandler,
                     PostgresConnector.class,
@@ -212,17 +211,6 @@ public class PostgresConnectorTask extends BaseSourceTask {
 
     @Override
     protected void doStop() {
-        try {
-            if (coordinator != null) {
-                coordinator.stop();
-            }
-        }
-        catch (InterruptedException e) {
-            Thread.interrupted();
-            LOGGER.error("Interrupted while stopping coordinator", e);
-            throw new ConnectException("Interrupted while stopping coordinator, failing the task");
-        }
-
         if (jdbcConnection != null) {
             jdbcConnection.close();
         }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -46,7 +46,6 @@ public class SqlServerConnectorTask extends BaseSourceTask {
     private volatile ChangeEventQueue<DataChangeEvent> queue;
     private volatile SqlServerConnection dataConnection;
     private volatile SqlServerConnection metadataConnection;
-    private volatile ChangeEventSourceCoordinator coordinator;
     private volatile ErrorHandler errorHandler;
     private volatile SqlServerDatabaseSchema schema;
 
@@ -111,7 +110,7 @@ public class SqlServerConnectorTask extends BaseSourceTask {
                 DataChangeEvent::new,
                 metadataProvider);
 
-        coordinator = new ChangeEventSourceCoordinator(
+        ChangeEventSourceCoordinator coordinator = new ChangeEventSourceCoordinator(
                 previousOffset,
                 errorHandler,
                 SqlServerConnector.class,
@@ -138,17 +137,6 @@ public class SqlServerConnectorTask extends BaseSourceTask {
 
     @Override
     protected void doStop() {
-        try {
-            if (coordinator != null) {
-                coordinator.stop();
-            }
-        }
-        catch (InterruptedException e) {
-            Thread.interrupted();
-            LOGGER.error("Interrupted while stopping coordinator", e);
-            throw new ConnectException("Interrupted while stopping coordinator, failing the task");
-        }
-
         try {
             if (dataConnection != null) {
                 dataConnection.close();

--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -180,6 +180,17 @@ public abstract class BaseSourceTask extends SourceTask {
                 LOGGER.info("Stopping down connector");
             }
 
+            try {
+                if (coordinator != null) {
+                    coordinator.stop();
+                }
+            }
+            catch (InterruptedException e) {
+                Thread.interrupted();
+                LOGGER.error("Interrupted while stopping coordinator", e);
+                throw new ConnectException("Interrupted while stopping coordinator, failing the task");
+            }
+
             doStop();
 
             if (restart && restartDelay == null) {


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1863

Small follow-up based on the changes to `BaseSourceTask` to handle the coordinator lifecycle in one place.