### PR TITLE
DBZ-1829 Conditionalize deprecated options for downstream doc

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
@@ -138,6 +138,8 @@ transforms.unwrap.add.headers=op,table,lsn,source.ts_ms
 
 will add headers `__op`, `__table`, `__lsn` and `__source_ts_ms` to the outgoing record.
 
+ifndef::cdc-product[]
+// Do not include deprecated content in downstream doc
 === Determine original operation  [DEPRECATED]
 
 _The `operation.header` option is deprecated and scheduled for removal. Please use add.headers instead. If both add.headers and operation.header are specified, the latter will be ignored._
@@ -156,7 +158,10 @@ transforms.unwrap.operation.header=true
 ----
 
 The possible values are the ones from the `op` field of the original change event.
+endif::cdc-product[]
 
+ifndef::cdc-product[]
+// Do not include deprecated content in downstream doc
 === Adding source metadata fields [DEPRECATED]
 
 _The `add.source.fields` option is deprecated and scheduled for removal. Please use add.fields instead. If both add.fields and add.source.fields are specified, the latter will be ignored._
@@ -180,6 +185,7 @@ will add
 to the final flattened record.
 
 For `DELETE` events, this option is only supported when the `delete.handling.mode` option is set to "rewrite".
+endif::cdc-product[]
 
 [[configuration_options]]
 == Configuration options
@@ -210,15 +216,21 @@ For `DELETE` events, this option is only supported when the `delete.handling.mod
 |
 |Specify a list of metadata fields to add to the header of the flattened message. In case of duplicate field names (e.g. "ts_ms" exists twice), the struct should be specified to get the correct field (e.g. "source.ts_ms"). The fields will be prefixed with "\\__" or "__<struct>__", depending on the specification of the struct. Please use a comma separated list without spaces.
 
+ifndef::cdc-product[]
+// Do not include deprecated content in downstream doc
 |`operation.header` DEPRECATED
 |`false`
-|_This option is deprecated and scheduled for removal. Please use add.headers instead. If both add.headers and operation.header are specified, the latter will be ignored._ 
+|_This option is deprecated and scheduled for removal. Please use add.headers instead. If both add.headers and operation.header are specified, the latter will be ignored._
 
 The SMT adds the event operation (as obtained from the `op` field of the original record) as a message header.
+endif::cdc-product[]
 
+ifndef::cdc-product[]
+// Do not include deprecated content in downstream doc
 |`add.source.fields` DEPRECATED
 |
 |_This option is deprecated and scheduled for removal. Please use add.fields instead. If both add.fields and add.source.fields are specified, the latter will be ignored._
 
 Fields from the change event's `source` structure to add as metadata (prefixed with "__") to the flattened record.
+endif::cdc-product[]
 |=======================

--- a/documentation/modules/ROOT/pages/modules/cdc-mysql-connector/r_mysql-connector-configuration-properties.adoc
+++ b/documentation/modules/ROOT/pages/modules/cdc-mysql-connector/r_mysql-connector-configuration-properties.adoc
@@ -102,7 +102,12 @@ See xref:data-types[] for the list of MySQL-specific data type names.
 
 |`time.precision.mode`
 |`adaptive_time{zwsp}_microseconds`
-| Time, date, and timestamps can be represented with different kinds of precision, including: `adaptive_time_microseconds` (the default) captures the date, datetime and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type, with the exception of TIME type fields, which are always captured as microseconds; `adaptive` (deprecated) captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type; or `connect` always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which uses millisecond precision regardless of the database columns' precision.
+| Time, date, and timestamps can be represented with different kinds of precision, including: `adaptive_time_microseconds` (the default) captures the date, datetime and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type, with the exception of TIME type fields, which are always captured as microseconds;
+ifndef::cdc-product[]
+// Do not include deprecated content in downstream doc
+`adaptive` (deprecated) captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type;
+endif::cdc-product[]
+or `connect` always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which uses millisecond precision regardless of the database columns' precision.
 
 |`decimal.handling.mode`
 |`precise`
@@ -160,10 +165,13 @@ WARNING: Enabling this option may expose tables or fields explicitly blacklisted
 |
 |A comma-separated list of regular expressions that match source UUIDs in the GTID set used to find the binlog position in the MySQL server. Only the GTID ranges that have sources matching none of these exclude patterns will be used. May not be used with `gtid.source.includes`.
 
+ifndef::cdc-product[]
+// Do not include deprecated content in downstream doc
 |`gtid.new.channel.position` +
 _deprecated and scheduled for removal_
 |`earliest`
 | When set to `latest`, when the connector sees a new GTID channel, it will start consuming from the last executed transaction in that GTID channel. If set to `earliest` (default), the connector starts reading that channel from the first available (not purged) GTID position. `earliest` is useful when you have a active-passive MySQL setup where {prodname} is connected to master, in this case during failover the slave with new UUID (and GTID channel) starts receiving writes before {prodname} is connected. These writes would be lost when using `latest`.
+endif::cdc-product[]
 
 |`tombstones.on.delete`
 |`true`


### PR DESCRIPTION
With this change, if the "cdc-product" attribute it set (as in the downstream), the deprecated content will not appear in the output. If "cdc-product" is not set (as in the upstream), the deprecated content will appear in the content.