### PR TITLE
DBZ-1531 added headers for primary key update events

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/ChangeRecordEmitter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/ChangeRecordEmitter.java
@@ -6,6 +6,7 @@
 package io.debezium.pipeline.spi;
 
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.ConnectHeaders;
 
 import io.debezium.data.Envelope.Operation;
 import io.debezium.schema.DataCollectionSchema;
@@ -31,5 +32,10 @@ public interface ChangeRecordEmitter {
 
     public interface Receiver {
         void changeRecord(DataCollectionSchema schema, Operation operation, Object key, Struct value, OffsetContext offset) throws InterruptedException;
+
+        default void changeRecord(DataCollectionSchema schema, Operation operation, Object key, Struct value, OffsetContext offset, ConnectHeaders headers)
+                throws InterruptedException {
+            throw new RuntimeException("Not implemented yet in " + this.getClass().getName());
+        }
     }
 }


### PR DESCRIPTION
DBZ-1531 added headers for primary key update events to reference the orginal key

:warning: WIP!!!! Unit Tests missing.

Current state:
- change applied
- unit tests with the new Relational* architecture are green (Postgres, MS SQL server)

Open:
- add unit tests
- add functionality to MySQL Connector
