### PR TITLE
DBZ-1531 added headers for primary key update events

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeRecordEmitter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeRecordEmitter.java
@@ -64,7 +64,7 @@ public class MongoDbChangeRecordEmitter extends AbstractChangeRecordEmitter<Mong
         value.put(FieldName.OPERATION, getOperation().code());
         value.put(FieldName.TIMESTAMP, getClock().currentTimeAsInstant().toEpochMilli());
 
-        receiver.changeRecord(schema, getOperation(), newKey, value, getOffset());
+        receiver.changeRecord(schema, getOperation(), newKey, value, getOffset(), null);
     }
 
     @Override
@@ -97,7 +97,7 @@ public class MongoDbChangeRecordEmitter extends AbstractChangeRecordEmitter<Mong
         value.put(FieldName.OPERATION, getOperation().code());
         value.put(FieldName.TIMESTAMP, getClock().currentTimeAsInstant().toEpochMilli());
 
-        receiver.changeRecord(schema, getOperation(), newKey, value, getOffset());
+        receiver.changeRecord(schema, getOperation(), newKey, value, getOffset(), null);
     }
 
     public static boolean isValidOperation(String operation) {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -456,7 +456,6 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         SourceRecord deleteRecord = updates.get(0);
         assertDelete(deleteRecord, "id", 1001);
 
-        assertEquals(1, deleteRecord.headers().size()); // to be removed/updated once we set additional headers
         Header keyPKUpdateHeader = getPKUpdateNewKeyHeader(deleteRecord);
         assertEquals(Integer.valueOf(2001), ((Struct) keyPKUpdateHeader.value()).getInt32("id"));
 
@@ -465,7 +464,6 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         SourceRecord insertRecord = updates.get(2);
         assertInsert(insertRecord, "id", 2001);
 
-        assertEquals(1, insertRecord.headers().size()); // to be removed/updated once we set additional headers
         keyPKUpdateHeader = getPKUpdateOldKeyHeader(insertRecord);
         assertEquals(Integer.valueOf(1001), ((Struct) keyPKUpdateHeader.value()).getInt32("id"));
 
@@ -2017,7 +2015,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
 
     @Test
     @FixFor("DBZ-1531")
-    public void shouldEmitOldKeyHeaderOnPrimaryKeyUpdate() throws Exception {
+    public void shouldEmitHeadersOnPrimaryKeyUpdate() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.NEVER)
                 .build();
@@ -2043,12 +2041,10 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         assertThat(updates.size()).isEqualTo(3);
 
         SourceRecord deleteRecord = updates.get(0);
-        assertEquals(1, deleteRecord.headers().size()); // to be removed/updated once we set additional headers
         Header keyPKUpdateHeader = getPKUpdateNewKeyHeader(deleteRecord);
         assertEquals(Integer.valueOf(10303), ((Struct) keyPKUpdateHeader.value()).getInt32("order_number"));
 
         SourceRecord insertRecord = updates.get(2);
-        assertEquals(1, insertRecord.headers().size()); // to be removed/updated once we set additional headers
         keyPKUpdateHeader = getPKUpdateOldKeyHeader(insertRecord);
         assertEquals(Integer.valueOf(10003), ((Struct) keyPKUpdateHeader.value()).getInt32("order_number"));
 
@@ -2062,7 +2058,6 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         assertThat(updates.size()).isEqualTo(1);
 
         SourceRecord updateRecord = updates.get(0);
-        assertEquals(0, updateRecord.headers().size()); // to be removed/updated once we set additional headers
 
         stopConnector();
     }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -2017,7 +2017,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
 
     @Test
     @FixFor("DBZ-1531")
-    public void shouldEmitOldkeyHeaderOnPrimaryKeyUpdate() throws Exception {
+    public void shouldEmitOldKeyHeaderOnPrimaryKeyUpdate() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.NEVER)
                 .build();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -32,12 +32,14 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.storage.MemoryOffsetBackingStore;
 import org.awaitility.Awaitility;
@@ -73,6 +75,7 @@ import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.junit.ConditionalFail;
 import io.debezium.junit.ShouldFailWhen;
 import io.debezium.junit.logging.LogInterceptor;
+import io.debezium.relational.RelationalChangeRecordEmitter;
 import io.debezium.relational.RelationalDatabaseConnectorConfig.DecimalHandlingMode;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
@@ -680,6 +683,12 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
                 Collections.singletonList(new SchemaAndValueField("modtype", SchemaBuilder.OPTIONAL_INT16_SCHEMA, (short) 2)), updatedRecord, Envelope.FieldName.AFTER);
     }
 
+    private Header getPKUpdateOldKeyHeader(SourceRecord record) {
+        return StreamSupport.stream(record.headers().spliterator(), false)
+                .filter(header -> RelationalChangeRecordEmitter.PK_UPDATE_OLDKEY_FIELD.equals(header.key()))
+                .collect(Collectors.toList()).get(0);
+    }
+
     @Test
     public void shouldReceiveChangesForUpdatesWithPKChanges() throws Exception {
         startConnector();
@@ -693,6 +702,11 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         assertEquals(topicName, deleteRecord.topic());
         VerifyRecord.isValidDelete(deleteRecord, PK_FIELD, 1);
 
+        assertEquals(1, deleteRecord.headers().size()); // to be removed/updated once we set additional headers
+
+        Header oldkeyPKUpdateHeader = getPKUpdateOldKeyHeader(deleteRecord);
+        assertEquals(Integer.valueOf(1), ((Struct) oldkeyPKUpdateHeader.value()).getInt32("pk"));
+
         // followed by a tombstone of the old pk
         SourceRecord tombstoneRecord = consumer.remove();
         assertEquals(topicName, tombstoneRecord.topic());
@@ -702,6 +716,10 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         SourceRecord insertRecord = consumer.remove();
         assertEquals(topicName, insertRecord.topic());
         VerifyRecord.isValidInsert(insertRecord, PK_FIELD, 2);
+
+        assertEquals(1, insertRecord.headers().size()); // to be removed/updated once we set additional headers
+        oldkeyPKUpdateHeader = getPKUpdateOldKeyHeader(insertRecord);
+        assertEquals(Integer.valueOf(1), ((Struct) oldkeyPKUpdateHeader.value()).getInt32("pk"));
     }
 
     @Test
@@ -721,10 +739,18 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         assertEquals(topicName, deleteRecord.topic());
         VerifyRecord.isValidDelete(deleteRecord, PK_FIELD, 1);
 
+        assertEquals(1, deleteRecord.headers().size()); // to be removed/updated once we set additional headers
+        Header oldkeyPKUpdateHeader = getPKUpdateOldKeyHeader(deleteRecord);
+        assertEquals(Integer.valueOf(1), ((Struct) oldkeyPKUpdateHeader.value()).getInt32("pk"));
+
         // followed by insert of the new value
         SourceRecord insertRecord = consumer.remove();
         assertEquals(topicName, insertRecord.topic());
         VerifyRecord.isValidInsert(insertRecord, PK_FIELD, 2);
+
+        assertEquals(1, insertRecord.headers().size()); // to be removed/updated once we set additional headers
+        oldkeyPKUpdateHeader = getPKUpdateOldKeyHeader(insertRecord);
+        assertEquals(Integer.valueOf(1), ((Struct) oldkeyPKUpdateHeader.value()).getInt32("pk"));
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -710,8 +710,6 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         assertEquals(topicName, deleteRecord.topic());
         VerifyRecord.isValidDelete(deleteRecord, PK_FIELD, 1);
 
-        assertEquals(1, deleteRecord.headers().size()); // to be removed/updated once we set additional headers
-
         Header keyPKUpdateHeader = getPKUpdateNewKeyHeader(deleteRecord);
         assertEquals(Integer.valueOf(2), ((Struct) keyPKUpdateHeader.value()).getInt32("pk"));
 
@@ -725,7 +723,6 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         assertEquals(topicName, insertRecord.topic());
         VerifyRecord.isValidInsert(insertRecord, PK_FIELD, 2);
 
-        assertEquals(1, insertRecord.headers().size()); // to be removed/updated once we set additional headers
         keyPKUpdateHeader = getPKUpdateOldKeyHeader(insertRecord);
         assertEquals(Integer.valueOf(1), ((Struct) keyPKUpdateHeader.value()).getInt32("pk"));
     }
@@ -747,7 +744,6 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         assertEquals(topicName, deleteRecord.topic());
         VerifyRecord.isValidDelete(deleteRecord, PK_FIELD, 1);
 
-        assertEquals(1, deleteRecord.headers().size()); // to be removed/updated once we set additional headers
         Header keyPKUpdateHeader = getPKUpdateNewKeyHeader(deleteRecord);
         assertEquals(Integer.valueOf(2), ((Struct) keyPKUpdateHeader.value()).getInt32("pk"));
 
@@ -756,7 +752,6 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         assertEquals(topicName, insertRecord.topic());
         VerifyRecord.isValidInsert(insertRecord, PK_FIELD, 2);
 
-        assertEquals(1, insertRecord.headers().size()); // to be removed/updated once we set additional headers
         keyPKUpdateHeader = getPKUpdateOldKeyHeader(insertRecord);
         assertEquals(Integer.valueOf(1), ((Struct) keyPKUpdateHeader.value()).getInt32("pk"));
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -683,9 +683,17 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
                 Collections.singletonList(new SchemaAndValueField("modtype", SchemaBuilder.OPTIONAL_INT16_SCHEMA, (short) 2)), updatedRecord, Envelope.FieldName.AFTER);
     }
 
+    private Header getPKUpdateNewKeyHeader(SourceRecord record) {
+        return this.getHeaderField(record, RelationalChangeRecordEmitter.PK_UPDATE_NEWKEY_FIELD);
+    }
+
     private Header getPKUpdateOldKeyHeader(SourceRecord record) {
+        return this.getHeaderField(record, RelationalChangeRecordEmitter.PK_UPDATE_OLDKEY_FIELD);
+    }
+
+    private Header getHeaderField(SourceRecord record, String fieldName) {
         return StreamSupport.stream(record.headers().spliterator(), false)
-                .filter(header -> RelationalChangeRecordEmitter.PK_UPDATE_OLDKEY_FIELD.equals(header.key()))
+                .filter(header -> fieldName.equals(header.key()))
                 .collect(Collectors.toList()).get(0);
     }
 
@@ -704,8 +712,8 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
         assertEquals(1, deleteRecord.headers().size()); // to be removed/updated once we set additional headers
 
-        Header oldkeyPKUpdateHeader = getPKUpdateOldKeyHeader(deleteRecord);
-        assertEquals(Integer.valueOf(1), ((Struct) oldkeyPKUpdateHeader.value()).getInt32("pk"));
+        Header keyPKUpdateHeader = getPKUpdateNewKeyHeader(deleteRecord);
+        assertEquals(Integer.valueOf(2), ((Struct) keyPKUpdateHeader.value()).getInt32("pk"));
 
         // followed by a tombstone of the old pk
         SourceRecord tombstoneRecord = consumer.remove();
@@ -718,8 +726,8 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         VerifyRecord.isValidInsert(insertRecord, PK_FIELD, 2);
 
         assertEquals(1, insertRecord.headers().size()); // to be removed/updated once we set additional headers
-        oldkeyPKUpdateHeader = getPKUpdateOldKeyHeader(insertRecord);
-        assertEquals(Integer.valueOf(1), ((Struct) oldkeyPKUpdateHeader.value()).getInt32("pk"));
+        keyPKUpdateHeader = getPKUpdateOldKeyHeader(insertRecord);
+        assertEquals(Integer.valueOf(1), ((Struct) keyPKUpdateHeader.value()).getInt32("pk"));
     }
 
     @Test
@@ -740,8 +748,8 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         VerifyRecord.isValidDelete(deleteRecord, PK_FIELD, 1);
 
         assertEquals(1, deleteRecord.headers().size()); // to be removed/updated once we set additional headers
-        Header oldkeyPKUpdateHeader = getPKUpdateOldKeyHeader(deleteRecord);
-        assertEquals(Integer.valueOf(1), ((Struct) oldkeyPKUpdateHeader.value()).getInt32("pk"));
+        Header keyPKUpdateHeader = getPKUpdateNewKeyHeader(deleteRecord);
+        assertEquals(Integer.valueOf(2), ((Struct) keyPKUpdateHeader.value()).getInt32("pk"));
 
         // followed by insert of the new value
         SourceRecord insertRecord = consumer.remove();
@@ -749,8 +757,8 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
         VerifyRecord.isValidInsert(insertRecord, PK_FIELD, 2);
 
         assertEquals(1, insertRecord.headers().size()); // to be removed/updated once we set additional headers
-        oldkeyPKUpdateHeader = getPKUpdateOldKeyHeader(insertRecord);
-        assertEquals(Integer.valueOf(1), ((Struct) oldkeyPKUpdateHeader.value()).getInt32("pk"));
+        keyPKUpdateHeader = getPKUpdateOldKeyHeader(insertRecord);
+        assertEquals(Integer.valueOf(1), ((Struct) keyPKUpdateHeader.value()).getInt32("pk"));
     }
 
     @Test

--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -12,6 +12,7 @@ import java.util.function.Supplier;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -154,12 +155,24 @@ public class EventDispatcher<T extends DataCollectionId> {
                 changeRecordEmitter.emitChangeRecords(dataCollectionSchema, new Receiver() {
 
                     @Override
-                    public void changeRecord(DataCollectionSchema schema, Operation operation, Object key, Struct value,
+                    public void changeRecord(DataCollectionSchema schema,
+                                             Operation operation,
+                                             Object key, Struct value,
                                              OffsetContext offset)
+                            throws InterruptedException {
+                        this.changeRecord(schema, operation, key, value, offset, null);
+                    }
+
+                    @Override
+                    public void changeRecord(DataCollectionSchema schema,
+                                             Operation operation,
+                                             Object key, Struct value,
+                                             OffsetContext offset,
+                                             ConnectHeaders headers)
                             throws InterruptedException {
                         transactionMonitor.dataEvent(dataCollectionId, offset, key, value);
                         eventListener.onEvent(dataCollectionId, offset, key, value);
-                        streamingReceiver.changeRecord(schema, operation, key, value, offset);
+                        streamingReceiver.changeRecord(schema, operation, key, value, offset, headers);
                     }
                 });
                 handled = true;
@@ -255,8 +268,22 @@ public class EventDispatcher<T extends DataCollectionId> {
     private final class StreamingChangeRecordReceiver implements ChangeRecordEmitter.Receiver {
 
         @Override
-        public void changeRecord(DataCollectionSchema dataCollectionSchema, Operation operation, Object key, Struct value, OffsetContext offsetContext)
+        public void changeRecord(DataCollectionSchema dataCollectionSchema,
+                                 Operation operation,
+                                 Object key, Struct value,
+                                 OffsetContext offsetContext)
                 throws InterruptedException {
+            this.changeRecord(dataCollectionSchema, operation, key, value, offsetContext, null);
+        }
+
+        @Override
+        public void changeRecord(DataCollectionSchema dataCollectionSchema,
+                                 Operation operation,
+                                 Object key, Struct value,
+                                 OffsetContext offsetContext,
+                                 ConnectHeaders headers)
+                throws InterruptedException {
+
             Objects.requireNonNull(value, "value must not be null");
 
             LOGGER.trace("Received change record for {} operation on key {}", operation, key);
@@ -264,8 +291,13 @@ public class EventDispatcher<T extends DataCollectionId> {
             Schema keySchema = dataCollectionSchema.keySchema();
             String topicName = topicSelector.topicNameFor((T) dataCollectionSchema.id());
 
-            SourceRecord record = new SourceRecord(offsetContext.getPartition(), offsetContext.getOffset(),
-                    topicName, null, keySchema, key, dataCollectionSchema.getEnvelopeSchema().schema(), value);
+            SourceRecord record = new SourceRecord(offsetContext.getPartition(),
+                    offsetContext.getOffset(), topicName, null,
+                    keySchema, key,
+                    dataCollectionSchema.getEnvelopeSchema().schema(),
+                    value,
+                    null,
+                    headers);
 
             queue.enqueue(changeEventCreator.createDataChangeEvent(record));
 
@@ -277,7 +309,8 @@ public class EventDispatcher<T extends DataCollectionId> {
                         record.key(),
                         null, // value schema
                         null, // value
-                        record.timestamp());
+                        record.timestamp(),
+                        record.headers());
 
                 queue.enqueue(changeEventCreator.createDataChangeEvent(tombStone));
             }

--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -111,11 +111,14 @@ public class EventDispatcher<T extends DataCollectionId> {
         changeRecordEmitter.emitChangeRecords(dataCollectionSchema, new Receiver() {
 
             @Override
-            public void changeRecord(DataCollectionSchema schema, Operation operation, Object key, Struct value,
-                                     OffsetContext offset)
+            public void changeRecord(DataCollectionSchema schema,
+                                     Operation operation,
+                                     Object key, Struct value,
+                                     OffsetContext offset,
+                                     ConnectHeaders headers)
                     throws InterruptedException {
                 eventListener.onEvent(dataCollectionSchema.id(), offset, key, value);
-                receiver.changeRecord(dataCollectionSchema, operation, key, value, offset);
+                receiver.changeRecord(dataCollectionSchema, operation, key, value, offset, headers);
             }
         });
     }
@@ -153,15 +156,6 @@ public class EventDispatcher<T extends DataCollectionId> {
                 }
 
                 changeRecordEmitter.emitChangeRecords(dataCollectionSchema, new Receiver() {
-
-                    @Override
-                    public void changeRecord(DataCollectionSchema schema,
-                                             Operation operation,
-                                             Object key, Struct value,
-                                             OffsetContext offset)
-                            throws InterruptedException {
-                        this.changeRecord(schema, operation, key, value, offset, null);
-                    }
 
                     @Override
                     public void changeRecord(DataCollectionSchema schema,
@@ -271,15 +265,6 @@ public class EventDispatcher<T extends DataCollectionId> {
         public void changeRecord(DataCollectionSchema dataCollectionSchema,
                                  Operation operation,
                                  Object key, Struct value,
-                                 OffsetContext offsetContext)
-                throws InterruptedException {
-            this.changeRecord(dataCollectionSchema, operation, key, value, offsetContext, null);
-        }
-
-        @Override
-        public void changeRecord(DataCollectionSchema dataCollectionSchema,
-                                 Operation operation,
-                                 Object key, Struct value,
                                  OffsetContext offsetContext,
                                  ConnectHeaders headers)
                 throws InterruptedException {
@@ -322,7 +307,11 @@ public class EventDispatcher<T extends DataCollectionId> {
         private Supplier<DataChangeEvent> bufferedEvent;
 
         @Override
-        public void changeRecord(DataCollectionSchema dataCollectionSchema, Operation operation, Object key, Struct value, OffsetContext offsetContext)
+        public void changeRecord(DataCollectionSchema dataCollectionSchema,
+                                 Operation operation,
+                                 Object key, Struct value,
+                                 OffsetContext offsetContext,
+                                 ConnectHeaders headers)
                 throws InterruptedException {
             Objects.requireNonNull(value, "value must not be null");
 
@@ -337,8 +326,13 @@ public class EventDispatcher<T extends DataCollectionId> {
 
             // the record is produced lazily, so to have the correct offset as per the pre/post completion callbacks
             bufferedEvent = () -> {
-                SourceRecord record = new SourceRecord(offsetContext.getPartition(), offsetContext.getOffset(),
-                        topicName, null, keySchema, key, dataCollectionSchema.getEnvelopeSchema().schema(), value);
+                SourceRecord record = new SourceRecord(
+                        offsetContext.getPartition(),
+                        offsetContext.getOffset(),
+                        topicName, null,
+                        keySchema, key,
+                        dataCollectionSchema.getEnvelopeSchema().schema(), value,
+                        null, headers);
                 return changeEventCreator.createDataChangeEvent(record);
             };
         }

--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/ChangeRecordEmitter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/ChangeRecordEmitter.java
@@ -30,16 +30,14 @@ public interface ChangeRecordEmitter {
      */
     OffsetContext getOffset();
 
+    /**
+     * Callback passed to {@link ChangeRecordEmitter}s, allowing them to produce one
+     * or more change records.
+     */
     public interface Receiver {
 
-        default void changeRecord(DataCollectionSchema schema,
-                                  Operation operation,
-                                  Object key, Struct value,
-                                  OffsetContext offset,
-                                  ConnectHeaders headers)
-                throws InterruptedException {
-            throw new RuntimeException("Not implemented yet in " + this.getClass().getName());
-        }
-
+        void changeRecord(DataCollectionSchema schema, Operation operation, Object key, Struct value,
+                          OffsetContext offset, ConnectHeaders headers)
+                throws InterruptedException;
     }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/ChangeRecordEmitter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/ChangeRecordEmitter.java
@@ -31,11 +31,6 @@ public interface ChangeRecordEmitter {
     OffsetContext getOffset();
 
     public interface Receiver {
-        void changeRecord(DataCollectionSchema schema,
-                          Operation operation,
-                          Object key, Struct value,
-                          OffsetContext offset)
-                throws InterruptedException;
 
         default void changeRecord(DataCollectionSchema schema,
                                   Operation operation,

--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/ChangeRecordEmitter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/ChangeRecordEmitter.java
@@ -6,6 +6,7 @@
 package io.debezium.pipeline.spi;
 
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.ConnectHeaders;
 
 import io.debezium.data.Envelope.Operation;
 import io.debezium.schema.DataCollectionSchema;
@@ -30,6 +31,20 @@ public interface ChangeRecordEmitter {
     OffsetContext getOffset();
 
     public interface Receiver {
-        void changeRecord(DataCollectionSchema schema, Operation operation, Object key, Struct value, OffsetContext offset) throws InterruptedException;
+        void changeRecord(DataCollectionSchema schema,
+                          Operation operation,
+                          Object key, Struct value,
+                          OffsetContext offset)
+                throws InterruptedException;
+
+        default void changeRecord(DataCollectionSchema schema,
+                                  Operation operation,
+                                  Object key, Struct value,
+                                  OffsetContext offset,
+                                  ConnectHeaders headers)
+                throws InterruptedException {
+            throw new RuntimeException("Not implemented yet in " + this.getClass().getName());
+        }
+
     }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalChangeRecordEmitter.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalChangeRecordEmitter.java
@@ -26,8 +26,8 @@ import io.debezium.util.Clock;
  */
 public abstract class RelationalChangeRecordEmitter extends AbstractChangeRecordEmitter<TableSchema> {
 
-    public static final String PK_UPDATE_OLDKEY_FIELD = "oldkey";
-    public static final String PK_UPDATE_NEWKEY_FIELD = "newkey";
+    public static final String PK_UPDATE_OLDKEY_FIELD = "__debezium.oldkey";
+    public static final String PK_UPDATE_NEWKEY_FIELD = "__debezium.newkey";
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -70,7 +70,7 @@ public abstract class RelationalChangeRecordEmitter extends AbstractChangeRecord
             logger.warn("no new values found for table '{}' from create message at '{}'; skipping record", tableSchema, getOffset().getSourceInfo());
             return;
         }
-        receiver.changeRecord(tableSchema, Operation.CREATE, newKey, envelope, getOffset());
+        receiver.changeRecord(tableSchema, Operation.CREATE, newKey, envelope, getOffset(), null);
     }
 
     @Override
@@ -81,7 +81,7 @@ public abstract class RelationalChangeRecordEmitter extends AbstractChangeRecord
         Struct newValue = tableSchema.valueFromColumnData(newColumnValues);
         Struct envelope = tableSchema.getEnvelopeSchema().read(newValue, getOffset().getSourceInfo(), getClock().currentTimeAsInstant());
 
-        receiver.changeRecord(tableSchema, Operation.READ, newKey, envelope, getOffset());
+        receiver.changeRecord(tableSchema, Operation.READ, newKey, envelope, getOffset(), null);
     }
 
     @Override
@@ -104,7 +104,7 @@ public abstract class RelationalChangeRecordEmitter extends AbstractChangeRecord
         // in this case we handle all updates as regular ones
         if (oldKey == null || Objects.equals(oldKey, newKey)) {
             Struct envelope = tableSchema.getEnvelopeSchema().update(oldValue, newValue, getOffset().getSourceInfo(), getClock().currentTimeAsInstant());
-            receiver.changeRecord(tableSchema, Operation.UPDATE, newKey, envelope, getOffset());
+            receiver.changeRecord(tableSchema, Operation.UPDATE, newKey, envelope, getOffset(), null);
         }
         // PK update -> emit as delete and re-insert with new key
         else {
@@ -134,7 +134,7 @@ public abstract class RelationalChangeRecordEmitter extends AbstractChangeRecord
         }
 
         Struct envelope = tableSchema.getEnvelopeSchema().delete(oldValue, getOffset().getSourceInfo(), getClock().currentTimeAsInstant());
-        receiver.changeRecord(tableSchema, Operation.DELETE, oldKey, envelope, getOffset());
+        receiver.changeRecord(tableSchema, Operation.DELETE, oldKey, envelope, getOffset(), null);
     }
 
     /**

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -360,7 +360,7 @@ The full API of the interface can be seen here:
 
 [source,java,indent=0,subs="+attributes"]
 ----
-**
+/**
  * This interface is used to determine details about the snapshot process:
  *
  * Namely:
@@ -882,7 +882,7 @@ When the columns for a row's primary/unique key are updated, the value of the ro
 
 ===== Primary Key Update Header
 
-When there is an update event that's changing the rows primary key field/s, also known
+When there is an update event that's changing the row's primary key field/s, also known
 as a primary key change, Debezium will in that case send a DELETE event for the old key
 and an INSERT event for the new (updated) key.
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -880,6 +880,19 @@ There are several things we can learn by just looking at this `payload` section.
 When the columns for a row's primary/unique key are updated, the value of the row's key has changed so {prodname} will output _three_ events: a `DELETE` event and link:#tombstone-events[tombstone event] with the old key for the row, followed by an `INSERT` event with the new key for the row.
 ====
 
+===== Primary Key Update Header
+
+When there is an update event that's changing the rows primary key field/s, also known
+as a primary key change, Debezium will in that case send a DELETE event for the old key
+and an INSERT event for the new (updated) key.
+
+The DELETE event produces a Kafka message which has a message header `__debezium.newkey`
+and the value is the new primary key.
+
+The INSERT event produces a Kafka message which has a message header `__debezium.oldkey`
+and the value is the previous (old) primary key of the updated row.
+
+
 [[delete-events]]
 ===== Delete Events
 So far we've seen samples of _create_ and _update_ events. Now, let's look at the value of a _delete_ event for the same table. Once again, the `schema` portion of the value will be exactly the same as with the _create_ and _update_ events:

--- a/documentation/modules/ROOT/pages/modules/cdc-mysql-connector/c_mysql-connector-events.adoc
+++ b/documentation/modules/ROOT/pages/modules/cdc-mysql-connector/c_mysql-connector-events.adoc
@@ -396,7 +396,7 @@ CREATE TABLE customers (
 
 == Primary Key Update Header
 
-When there is an update event that's changing the rows primary key field/s, also known
+When there is an update event that's changing the row's primary key field/s, also known
 as a primary key change, Debezium will in that case send a DELETE event for the old key
 and an INSERT event for the new (updated) key.
 
@@ -405,4 +405,3 @@ and the value is the new primary key.
 
 The INSERT event produces a Kafka message which has a message header `__debezium.oldkey`
 and the value is the previous (old) primary key of the updated row.
-

--- a/documentation/modules/ROOT/pages/modules/cdc-mysql-connector/c_mysql-connector-events.adoc
+++ b/documentation/modules/ROOT/pages/modules/cdc-mysql-connector/c_mysql-connector-events.adoc
@@ -394,3 +394,15 @@ CREATE TABLE customers (
 }
 ----
 
+== Primary Key Update Header
+
+When there is an update event that's changing the rows primary key field/s, also known
+as a primary key change, Debezium will in that case send a DELETE event for the old key
+and an INSERT event for the new (updated) key.
+
+The DELETE event produces a Kafka message which has a message header `__debezium.newkey`
+and the value is the new primary key.
+
+The INSERT event produces a Kafka message which has a message header `__debezium.oldkey`
+and the value is the previous (old) primary key of the updated row.
+


### PR DESCRIPTION
DBZ-1531 added headers for primary key update events to reference the original key

Current state:
- implementation for the "new" relational* architecture (postgres and sqlserver) is done and unit tests added, but sqlserver is not capable
- MySQL server is done and tested
- MongoDB uses the default new Relational* architecture imlpementation, if it sends an UPDATE event that DBZ can recognize as PK update, then it should send the header. but I doubt that (based on the code) and also had no time to test this, so I expect it doesn't set the header.
- unit tests updated
- unit tests for postgres are green
- sqlserver doesn't support primary key upate recognition by debezium (it sends separate DELETE and INSERT events for a PK update and it looks like it doesn't carry the previous key in any field, correct me when I'm wrong)

