### PR TITLE
DBZ-1807 Converters in Debezium engine

### DIFF
--- a/debezium-api/src/main/java/io/debezium/engine/DebeziumEngine.java
+++ b/debezium-api/src/main/java/io/debezium/engine/DebeziumEngine.java
@@ -210,6 +210,14 @@ public interface DebeziumEngine<R> extends Runnable, Closeable {
         Builder<R> using(OffsetCommitPolicy policy);
 
         /**
+         * Prescribe the output format used by the {@link DebeziumEngine}.
+         * Usually called by {@link DebeziumEngine#create}.
+         * @param format
+         * @return this builder object so methods can be chained together; never null
+         */
+        Builder<R> asType(Class<? extends ChangeEventFormat<R>> format);
+
+        /**
          * Build a new connector with the information previously supplied to this builder.
          *
          * @return the embedded connector; never null
@@ -235,6 +243,6 @@ public interface DebeziumEngine<R> extends Runnable, Closeable {
         if (iterator.hasNext()) {
             LoggerFactory.getLogger(Builder.class).warn("More than one Debezium engine builder implementation was found, using {}", builder.getClass());
         }
-        return builder;
+        return builder.asType(eventFormat);
     }
 }

--- a/debezium-api/src/main/java/io/debezium/engine/format/Avro.java
+++ b/debezium-api/src/main/java/io/debezium/engine/format/Avro.java
@@ -10,5 +10,5 @@ import io.debezium.engine.ChangeEventFormat;
 /**
  * A {@link ChangeEventFormat} defining the Avro format serialized as byte[].
  */
-public class Avro implements ChangeEventFormat<Change<byte[]>> {
+public class Avro implements ChangeEventFormat<ChangeEvent<byte[]>> {
 }

--- a/debezium-api/src/main/java/io/debezium/engine/format/Avro.java
+++ b/debezium-api/src/main/java/io/debezium/engine/format/Avro.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.engine.format;
+
+import io.debezium.engine.ChangeEventFormat;
+
+/**
+ * A {@link ChangeEventFormat} defining the Avro format serialized as byte[].
+ */
+public class Avro implements ChangeEventFormat<Change<byte[]>> {
+}

--- a/debezium-api/src/main/java/io/debezium/engine/format/Change.java
+++ b/debezium-api/src/main/java/io/debezium/engine/format/Change.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.engine.format;
+
+public class Change<T> {
+    public final T key;
+    public final T value;
+    private final Object backReference;
+
+    public Change(T key, T value, Object backReference) {
+        this.key = key;
+        this.value = value;
+        this.backReference = backReference;
+    }
+
+    public Object reference() {
+        return backReference;
+    }
+
+    @Override
+    public String toString() {
+        return "Change [key=" + key + ", value=" + value + "]";
+    }
+}

--- a/debezium-api/src/main/java/io/debezium/engine/format/ChangeEvent.java
+++ b/debezium-api/src/main/java/io/debezium/engine/format/ChangeEvent.java
@@ -5,15 +5,24 @@
  */
 package io.debezium.engine.format;
 
-public class Change<T> {
-    public final T key;
-    public final T value;
+public class ChangeEvent<T> {
+
+    private final T key;
+    private final T value;
     private final Object backReference;
 
-    public Change(T key, T value, Object backReference) {
+    public ChangeEvent(T key, T value, Object backReference) {
         this.key = key;
         this.value = value;
         this.backReference = backReference;
+    }
+
+    public T key() {
+        return key;
+    }
+
+    public T value() {
+        return value;
     }
 
     public Object reference() {
@@ -22,6 +31,6 @@ public class Change<T> {
 
     @Override
     public String toString() {
-        return "Change [key=" + key + ", value=" + value + "]";
+        return "ChangeEvent [key=" + key + ", value=" + value + "]";
     }
 }

--- a/debezium-api/src/main/java/io/debezium/engine/format/CloudEvents.java
+++ b/debezium-api/src/main/java/io/debezium/engine/format/CloudEvents.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.engine.format;
+
+import io.debezium.engine.ChangeEventFormat;
+
+/**
+ * A {@link ChangeEventFormat} defining the JSON format serialized as String.
+ */
+public class CloudEvents implements ChangeEventFormat<Change<String>> {
+}

--- a/debezium-api/src/main/java/io/debezium/engine/format/CloudEvents.java
+++ b/debezium-api/src/main/java/io/debezium/engine/format/CloudEvents.java
@@ -10,5 +10,5 @@ import io.debezium.engine.ChangeEventFormat;
 /**
  * A {@link ChangeEventFormat} defining the JSON format serialized as String.
  */
-public class CloudEvents implements ChangeEventFormat<Change<String>> {
+public class CloudEvents implements ChangeEventFormat<ChangeEvent<String>> {
 }

--- a/debezium-api/src/main/java/io/debezium/engine/format/Json.java
+++ b/debezium-api/src/main/java/io/debezium/engine/format/Json.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.engine.format;
+
+import io.debezium.engine.ChangeEventFormat;
+
+/**
+ * A {@link ChangeEventFormat} defining the JSON format serialized as String.
+ */
+public class Json implements ChangeEventFormat<Change<String>> {
+}

--- a/debezium-api/src/main/java/io/debezium/engine/format/Json.java
+++ b/debezium-api/src/main/java/io/debezium/engine/format/Json.java
@@ -10,5 +10,5 @@ import io.debezium.engine.ChangeEventFormat;
 /**
  * A {@link ChangeEventFormat} defining the JSON format serialized as String.
  */
-public class Json implements ChangeEventFormat<Change<String>> {
+public class Json implements ChangeEventFormat<ChangeEvent<String>> {
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DebeziumEngineIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DebeziumEngineIT.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.postgresql;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
+import org.fest.assertions.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.document.Document;
+import io.debezium.document.DocumentReader;
+import io.debezium.engine.DebeziumEngine;
+import io.debezium.engine.format.Change;
+import io.debezium.engine.format.Json;
+import io.debezium.util.LoggingContext;
+import io.debezium.util.Testing;
+
+/**
+ * Integration tests for Debezium Engine API
+ *
+ * @author Jiri Pechanec
+ */
+public class DebeziumEngineIT {
+
+    protected static final Path OFFSET_STORE_PATH = Testing.Files.createTestingPath("connector-offsets.txt").toAbsolutePath();
+
+    @Before
+    public void before() throws SQLException {
+        OFFSET_STORE_PATH.getParent().toFile().mkdirs();
+        OFFSET_STORE_PATH.toFile().delete();
+        TestHelper.dropAllSchemas();
+        TestHelper.execute(
+                "CREATE SCHEMA engine;",
+                "CREATE TABLE engine.test (id INT PRIMARY KEY, val VARCHAR(32));",
+                "INSERT INTO engine.test VALUES(1, 'value1');");
+    }
+
+    @Test
+    public void shouldSerializeToJson() throws Exception {
+        final Properties props = new Properties();
+        props.putAll(TestHelper.defaultConfig().build().asMap());
+        props.setProperty("name", "debezium-engine");
+        props.setProperty("connector.class", "io.debezium.connector.postgresql.PostgresConnector");
+        props.setProperty(StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG,
+                OFFSET_STORE_PATH.toAbsolutePath().toString());
+        props.setProperty("offset.flush.interval.ms", "0");
+        props.setProperty("converter.schemas.enable", "false");
+
+        CountDownLatch allLatch = new CountDownLatch(1);
+
+        final ExecutorService executor = Executors.newFixedThreadPool(1);
+        try (final DebeziumEngine<Change<String>> engine = DebeziumEngine.create(Json.class).using(props)
+                .notifying((records, committer) -> {
+
+                    for (Change<String> r : records) {
+                        Assertions.assertThat(r.key).isNotNull();
+                        Assertions.assertThat(r.value).isNotNull();
+                        try {
+                            final Document key = DocumentReader.defaultReader().read(r.key);
+                            final Document value = DocumentReader.defaultReader().read(r.value);
+                            Assertions.assertThat(key.getInteger("id")).isEqualTo(1);
+                            Assertions.assertThat(value.getDocument("after").getInteger("id")).isEqualTo(1);
+                            Assertions.assertThat(value.getDocument("after").getString("val")).isEqualTo("value1");
+                        }
+                        catch (IOException e) {
+                            throw new IllegalStateException(e);
+                        }
+                        allLatch.countDown();
+                        committer.markProcessed(r);
+                    }
+                    committer.markBatchFinished();
+                }).using(this.getClass().getClassLoader()).build()) {
+
+            executor.execute(() -> {
+                LoggingContext.forConnector(getClass().getSimpleName(), "debezium-engine", "engine");
+                engine.run();
+            });
+            allLatch.await(5000, TimeUnit.MILLISECONDS);
+            assertThat(allLatch.getCount()).isEqualTo(0);
+        }
+    }
+}

--- a/debezium-embedded/src/main/java/io/debezium/embedded/ConvertingEngineBuilder.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/ConvertingEngineBuilder.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.embedded;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.util.List;
+import java.util.Properties;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.storage.Converter;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.Configuration;
+import io.debezium.engine.ChangeEventFormat;
+import io.debezium.engine.DebeziumEngine;
+import io.debezium.engine.DebeziumEngine.Builder;
+import io.debezium.engine.DebeziumEngine.ChangeConsumer;
+import io.debezium.engine.DebeziumEngine.CompletionCallback;
+import io.debezium.engine.DebeziumEngine.ConnectorCallback;
+import io.debezium.engine.DebeziumEngine.RecordCommitter;
+import io.debezium.engine.format.Change;
+import io.debezium.engine.format.Json;
+import io.debezium.engine.spi.OffsetCommitPolicy;
+
+/**
+ * A builder that creates a decorator around {@link EmbbeddedEngine} that is responsible for the conversion
+ * to the final format.
+ * 
+ * @author Jiri Pechanec
+ */
+public class ConvertingEngineBuilder<R> implements Builder<R> {
+
+    private static final String CONVERTER_PREFIX = "converter";
+    private static final String FIELD_CLASS = "class";
+    private static final String TOPIC_NAME = "debezium";
+
+    private final Builder<SourceRecord> delegate;
+    private Class<? extends ChangeEventFormat<R>> format;
+    private Configuration config;
+
+    @SuppressWarnings("unchecked")
+    private Function<SourceRecord, R> toFormat = (record) -> (R) record;
+
+    private Function<R, SourceRecord> fromFormat = (record) -> (SourceRecord) record;
+
+    public ConvertingEngineBuilder() {
+        this.delegate = EmbeddedEngine.create();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Builder<R> notifying(Consumer<R> consumer) {
+        if (isFormat(Connect.class)) {
+            delegate.notifying((record) -> consumer.accept((R) record));
+        }
+        else {
+            delegate.notifying((record) -> consumer.accept(toFormat.apply(record)));
+        }
+        return this;
+    }
+
+    private boolean isFormat(Class<? extends ChangeEventFormat<?>> format) {
+        return (Class<?>) this.format == (Class<?>) format;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Builder<R> notifying(ChangeConsumer<R> handler) {
+        if (isFormat(Connect.class)) {
+            delegate.notifying((records, committer) -> handler.handleBatch((List<R>) records, (RecordCommitter<R>) committer));
+        }
+        else {
+            delegate.notifying(
+                    (records, committer) -> handler.handleBatch(records.stream().map(x -> toFormat.apply(x)).collect(Collectors.toList()),
+                            new RecordCommitter<R>() {
+
+                                @Override
+                                public void markProcessed(R record) throws InterruptedException {
+                                    committer.markProcessed(fromFormat.apply(record));
+                                }
+
+                                @Override
+                                public void markBatchFinished() {
+                                    committer.markBatchFinished();
+                                }
+                            }));
+        }
+        return this;
+    }
+
+    @Override
+    public Builder<R> using(Properties config) {
+        this.config = Configuration.from(config);
+        delegate.using(config);
+        return this;
+    }
+
+    @Override
+    public Builder<R> using(ClassLoader classLoader) {
+        delegate.using(classLoader);
+        return this;
+    }
+
+    @Override
+    public Builder<R> using(Clock clock) {
+        delegate.using(clock);
+        return this;
+    }
+
+    @Override
+    public Builder<R> using(CompletionCallback completionCallback) {
+        delegate.using(completionCallback);
+        return this;
+    }
+
+    @Override
+    public Builder<R> using(ConnectorCallback connectorCallback) {
+        delegate.using(connectorCallback);
+        return this;
+    }
+
+    @Override
+    public Builder<R> using(OffsetCommitPolicy policy) {
+        delegate.using(policy);
+        return this;
+    }
+
+    @Override
+    public Builder<R> asType(Class<? extends ChangeEventFormat<R>> format) {
+        this.format = format;
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public DebeziumEngine<R> build() {
+        final DebeziumEngine<SourceRecord> engine = delegate.build();
+        Configuration converterConfig = config.subset(CONVERTER_PREFIX, true);
+        Converter keyConverter;
+        Converter valueConverter;
+
+        if (!isFormat(Connect.class)) {
+            if (isFormat(Json.class)) {
+                converterConfig = converterConfig.edit().withDefault(FIELD_CLASS, "org.apache.kafka.connect.json.JsonConverter").build();
+            }
+            else {
+                throw new DebeziumException("Converter '" + format.getSimpleName() + "' is not supported");
+            }
+            keyConverter = converterConfig.getInstance(FIELD_CLASS, Converter.class);
+            valueConverter = converterConfig.getInstance(FIELD_CLASS, Converter.class);
+            keyConverter.configure(converterConfig.asMap(), true);
+            valueConverter.configure(converterConfig.asMap(), false);
+            toFormat = (record) -> {
+                final byte[] key = keyConverter.fromConnectData(TOPIC_NAME, record.keySchema(), record.key());
+                final byte[] value = valueConverter.fromConnectData(TOPIC_NAME, record.valueSchema(), record.value());
+                return (R) new Change<String>(
+                        key != null ? new String(key) : null,
+                        value != null ? new String(value) : null,
+                        record);
+            };
+            fromFormat = (record) -> (SourceRecord) ((Change<String>) record).reference();
+        }
+
+        return new DebeziumEngine<R>() {
+
+            @Override
+            public void run() {
+                engine.run();
+            }
+
+            @Override
+            public void close() throws IOException {
+                engine.close();
+            }
+        };
+    }
+
+}

--- a/debezium-embedded/src/main/java/io/debezium/embedded/ConvertingEngineBuilder.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/ConvertingEngineBuilder.java
@@ -26,7 +26,7 @@ import io.debezium.engine.DebeziumEngine.CompletionCallback;
 import io.debezium.engine.DebeziumEngine.ConnectorCallback;
 import io.debezium.engine.DebeziumEngine.RecordCommitter;
 import io.debezium.engine.format.Avro;
-import io.debezium.engine.format.Change;
+import io.debezium.engine.format.ChangeEvent;
 import io.debezium.engine.format.CloudEvents;
 import io.debezium.engine.format.Json;
 import io.debezium.engine.spi.OffsetCommitPolicy;
@@ -168,12 +168,12 @@ public class ConvertingEngineBuilder<R> implements Builder<R> {
             toFormat = (record) -> {
                 final byte[] key = keyConverter.fromConnectData(TOPIC_NAME, record.keySchema(), record.key());
                 final byte[] value = valueConverter.fromConnectData(TOPIC_NAME, record.valueSchema(), record.value());
-                return (R) new Change<String>(
+                return (R) new ChangeEvent<String>(
                         key != null ? new String(key) : null,
                         value != null ? new String(value) : null,
                         record);
             };
-            fromFormat = (record) -> (SourceRecord) ((Change<String>) record).reference();
+            fromFormat = (record) -> (SourceRecord) ((ChangeEvent<String>) record).reference();
         }
 
         return new DebeziumEngine<R>() {

--- a/debezium-embedded/src/main/java/io/debezium/embedded/ConvertingEngineBuilder.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/ConvertingEngineBuilder.java
@@ -25,6 +25,7 @@ import io.debezium.engine.DebeziumEngine.ChangeConsumer;
 import io.debezium.engine.DebeziumEngine.CompletionCallback;
 import io.debezium.engine.DebeziumEngine.ConnectorCallback;
 import io.debezium.engine.DebeziumEngine.RecordCommitter;
+import io.debezium.engine.format.Avro;
 import io.debezium.engine.format.Change;
 import io.debezium.engine.format.Json;
 import io.debezium.engine.spi.OffsetCommitPolicy;
@@ -149,6 +150,9 @@ public class ConvertingEngineBuilder<R> implements Builder<R> {
         if (!isFormat(Connect.class)) {
             if (isFormat(Json.class)) {
                 converterConfig = converterConfig.edit().withDefault(FIELD_CLASS, "org.apache.kafka.connect.json.JsonConverter").build();
+            }
+            else if (isFormat(Avro.class)) {
+                converterConfig = converterConfig.edit().withDefault(FIELD_CLASS, "io.confluent.connect.avro.AvroConverter").build();
             }
             else {
                 throw new DebeziumException("Converter '" + format.getSimpleName() + "' is not supported");

--- a/debezium-embedded/src/main/java/io/debezium/embedded/ConvertingEngineBuilder.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/ConvertingEngineBuilder.java
@@ -27,6 +27,7 @@ import io.debezium.engine.DebeziumEngine.ConnectorCallback;
 import io.debezium.engine.DebeziumEngine.RecordCommitter;
 import io.debezium.engine.format.Avro;
 import io.debezium.engine.format.Change;
+import io.debezium.engine.format.CloudEvents;
 import io.debezium.engine.format.Json;
 import io.debezium.engine.spi.OffsetCommitPolicy;
 
@@ -150,6 +151,9 @@ public class ConvertingEngineBuilder<R> implements Builder<R> {
         if (!isFormat(Connect.class)) {
             if (isFormat(Json.class)) {
                 converterConfig = converterConfig.edit().withDefault(FIELD_CLASS, "org.apache.kafka.connect.json.JsonConverter").build();
+            }
+            else if (isFormat(CloudEvents.class)) {
+                converterConfig = converterConfig.edit().withDefault(FIELD_CLASS, "io.debezium.converters.CloudEventsConverter").build();
             }
             else if (isFormat(Avro.class)) {
                 converterConfig = converterConfig.edit().withDefault(FIELD_CLASS, "io.confluent.connect.avro.AvroConverter").build();

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -51,6 +51,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
+import io.debezium.engine.ChangeEventFormat;
 import io.debezium.engine.DebeziumEngine;
 import io.debezium.engine.StopEngineException;
 import io.debezium.engine.spi.OffsetCommitPolicy;
@@ -519,6 +520,12 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord> {
 
         @Override
         Builder using(OffsetCommitPolicy policy);
+
+        @Override
+        default Builder asType(Class<? extends ChangeEventFormat<SourceRecord>> eventFormat) {
+            // The legacy EmbeddedEngine always returns SourceRecord
+            return this;
+        };
 
         @Override
         EmbeddedEngine build();

--- a/debezium-embedded/src/main/resources/META-INF/services/io.debezium.engine.DebeziumEngine$Builder
+++ b/debezium-embedded/src/main/resources/META-INF/services/io.debezium.engine.DebeziumEngine$Builder
@@ -1,1 +1,1 @@
-io.debezium.embedded.EmbeddedEngine$BuilderImpl
+io.debezium.embedded.ConvertingEngineBuilder


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1807

Documentation will be added when the code is approved

Open question - we need to provide offsets to the callback function `Committer.markProcessed()`
Current implementation intoruces opaque `Change.reference()` theat is used for this purpose so the user should not make any assumptions on offsets. The other option is to expose it as method `offset` with type `Map` so the users can assess the offsets.

To complement `Connect` format the latter is prefered, to tighten isolation the former is preferred.