### PR TITLE
DBZ-1663 Resume tests after Connect crash in OpenShift for MySQL and PostgreSQL

### DIFF
--- a/debezium-testing/debezium-testing-openshift/src/main/java/io/debezium/testing/openshift/tools/WaitConditions.java
+++ b/debezium-testing/debezium-testing-openshift/src/main/java/io/debezium/testing/openshift/tools/WaitConditions.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.testing.openshift.tools;
+
+import java.util.stream.Stream;
+
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentCondition;
+import io.fabric8.kubernetes.api.model.apps.DeploymentStatus;
+import io.strimzi.api.kafka.model.status.HasStatus;
+import io.strimzi.api.kafka.model.status.Status;
+
+/**
+ *
+ * @author Jakub Cechacek
+ */
+public class WaitConditions {
+
+    /**
+     * Wait condition for readiness of Strimzi resources
+     * @param resource resource instance
+     * @param <T> resource type
+     * @return true if resource is ready
+     */
+    public static <T extends Status> boolean kafkaReadyCondition(HasStatus<T> resource) {
+        T status = resource.getStatus();
+        if (status == null) {
+            return false;
+        }
+        return status.getConditions().stream().anyMatch(c -> c.getType().equalsIgnoreCase("Ready") && c.getStatus().equalsIgnoreCase("True"));
+    }
+
+    /**
+     * Wait condition for deployments
+     * @param resource deployment resource
+     * @return true when deployment becomes available
+     */
+    public static boolean deploymentAvailableCondition(Deployment resource) {
+        DeploymentStatus status = resource.getStatus();
+        if (status == null) {
+            return false;
+        }
+        Stream<DeploymentCondition> conditions = status.getConditions().stream();
+        return conditions.anyMatch(c -> c.getType().equalsIgnoreCase("Available") && c.getStatus().equalsIgnoreCase("True"));
+    }
+}

--- a/debezium-testing/debezium-testing-openshift/src/main/java/io/debezium/testing/openshift/tools/kafka/KafkaDeployer.java
+++ b/debezium-testing/debezium-testing-openshift/src/main/java/io/debezium/testing/openshift/tools/kafka/KafkaDeployer.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.testing.openshift.tools.OpenShiftUtils;
+import io.debezium.testing.openshift.tools.WaitConditions;
 import io.debezium.testing.openshift.tools.YAML;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -26,8 +27,6 @@ import io.strimzi.api.kafka.model.DoneableKafkaConnect;
 import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.KafkaConnect;
 import io.strimzi.api.kafka.model.KafkaConnectBuilder;
-import io.strimzi.api.kafka.model.status.HasStatus;
-import io.strimzi.api.kafka.model.status.Status;
 
 import okhttp3.OkHttpClient;
 
@@ -103,16 +102,11 @@ public class KafkaDeployer {
     }
 
     public Kafka waitForKafkaCluster(String name) throws InterruptedException {
-        return kafkaOperation().withName(name).waitUntilCondition(this::waitForReadyStatus, 5, MINUTES);
+        return kafkaOperation().withName(name).waitUntilCondition(WaitConditions::kafkaReadyCondition, 5, MINUTES);
     }
 
     public KafkaConnect waitForConnectCluster(String name) throws InterruptedException {
-        return kafkaConnectOperation().withName(name).waitUntilCondition(this::waitForReadyStatus, 5, MINUTES);
-    }
-
-    private <T extends Status> boolean waitForReadyStatus(HasStatus<T> kc) {
-        return kc.getStatus() != null &&
-                kc.getStatus().getConditions().stream().anyMatch(c -> c.getType().equalsIgnoreCase("Ready") && c.getStatus().equalsIgnoreCase("True"));
+        return kafkaConnectOperation().withName(name).waitUntilCondition(WaitConditions::kafkaReadyCondition, 5, MINUTES);
     }
 
     /**


### PR DESCRIPTION
The Connect crash is currently simulated by

- Disabling Kafka Operator by scaling it to ZERO
- Connect pods are then force deleted (grace period ZERO)
- Immediately after Connect deployment is scaled to ZERO -- this prevents new pod to fully start 

After that, we make a database insert and verify that the connector is indeed down.
In the last step, Operator is enabled again, given time to reconcile deployed Connect cluster and then we check for number of messages as well as "grep" for the inserted record by used email.