### PR TITLE
DBZ-1950 Make validation of binlog_row_image compatible with MySQL 5.5

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -611,6 +611,11 @@ public final class MySqlConnectorTask extends BaseSourceTask {
                 if (rs.next()) {
                     rowImage.set(rs.getString(2));
                 }
+                else {
+                    // This setting was introduced in MySQL 5.6+ with default of 'FULL'.
+                    // For older versions, assume 'FULL'.
+                    rowImage.set("FULL");
+                }
             });
         }
         catch (SQLException e) {


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1950

This is the fix for bootstrapping Debezium with MySQL 5.5.