### PR TITLE
DBZ-1962 Introduce column.whitelist for the Postgres connector

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
@@ -16,8 +16,8 @@ import io.debezium.annotation.Immutable;
 import io.debezium.config.Configuration;
 import io.debezium.relational.Selectors;
 import io.debezium.relational.TableId;
-import io.debezium.relational.Tables.ColumnNameFilterFactory;
 import io.debezium.relational.Tables.ColumnNameFilter;
+import io.debezium.relational.Tables.ColumnNameFilterFactory;
 import io.debezium.util.Collect;
 
 /**

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
@@ -16,6 +16,7 @@ import io.debezium.annotation.Immutable;
 import io.debezium.config.Configuration;
 import io.debezium.relational.Selectors;
 import io.debezium.relational.TableId;
+import io.debezium.relational.Tables.ColumnNameFilterFactory;
 import io.debezium.relational.Tables.ColumnNameFilter;
 import io.debezium.util.Collect;
 
@@ -116,7 +117,7 @@ public class Filters {
                     config.getString(MySqlConnectorConfig.TABLE_BLACKLIST));
 
             // Define the filter that excludes blacklisted columns, truncated columns, and masked columns ...
-            this.columnFilter = ColumnNameFilter.getInstance(config.getString(MySqlConnectorConfig.COLUMN_BLACKLIST));
+            this.columnFilter = ColumnNameFilterFactory.createBlacklistFilter(config.getString(MySqlConnectorConfig.COLUMN_BLACKLIST));
         }
 
         /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/Filters.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/Filters.java
@@ -63,13 +63,13 @@ public class Filters {
                 .excludeSchemas(schemaBlacklist)
                 .build());
 
-        String columnBlacklist = config.columnBlacklist();
-        if (columnBlacklist != null) {
-            // Define the filter that excludes blacklisted columns, truncated columns, and masked columns ...
-            this.columnFilter = ColumnNameFilterFactory.createBlacklistFilter(config.columnBlacklist());
+        String columnWhitelist = config.columnWhitelist();
+        if (columnWhitelist != null) {
+            this.columnFilter = ColumnNameFilterFactory.createWhitelistFilter(config.columnWhitelist());
         }
         else {
-            this.columnFilter = ColumnNameFilterFactory.createWhitelistFilter(config.columnWhitelist());
+            // Define the filter that excludes blacklisted columns, truncated columns, and masked columns ...
+            this.columnFilter = ColumnNameFilterFactory.createBlacklistFilter(config.columnBlacklist());
         }
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -899,7 +899,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             DatabaseHeartbeatImpl.HEARTBEAT_ACTION_QUERY,
             SCHEMA_WHITELIST,
             SCHEMA_BLACKLIST, TABLE_WHITELIST, TABLE_BLACKLIST, MSG_KEY_COLUMNS, RelationalDatabaseConnectorConfig.MASK_COLUMN_WITH_HASH,
-            COLUMN_BLACKLIST, SNAPSHOT_MODE, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE, HSTORE_HANDLING_MODE,
+            COLUMN_BLACKLIST, COLUMN_WHITELIST, SNAPSHOT_MODE, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE, HSTORE_HANDLING_MODE,
             INTERVAL_HANDLING_MODE, SSL_MODE, SSL_CLIENT_CERT, SSL_CLIENT_KEY_PASSWORD,
             SSL_ROOT_CERT, SSL_CLIENT_KEY, RelationalDatabaseConnectorConfig.SNAPSHOT_LOCK_TIMEOUT_MS, SSL_SOCKET_FACTORY,
             STATUS_UPDATE_INTERVAL_MS, TCP_KEEPALIVE, INCLUDE_UNKNOWN_DATATYPES,
@@ -1017,6 +1017,10 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         return getConfig().getString(COLUMN_BLACKLIST);
     }
 
+    protected String columnWhitelist() {
+        return getConfig().getString(COLUMN_WHITELIST);
+    }
+
     protected Snapshotter getSnapshotter() {
         return this.snapshotMode.getSnapshotter(getConfig());
     }
@@ -1053,7 +1057,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                 USER, PASSWORD, ON_CONNECT_STATEMENTS, SSL_MODE, SSL_CLIENT_CERT, SSL_CLIENT_KEY_PASSWORD, SSL_ROOT_CERT, SSL_CLIENT_KEY,
                 DROP_SLOT_ON_STOP, STREAM_PARAMS, MAX_RETRIES, RETRY_DELAY_MS, SSL_SOCKET_FACTORY, STATUS_UPDATE_INTERVAL_MS, TCP_KEEPALIVE, XMIN_FETCH_INTERVAL);
         Field.group(config, "Events", SCHEMA_WHITELIST, SCHEMA_BLACKLIST, TABLE_WHITELIST, TABLE_BLACKLIST,
-                COLUMN_BLACKLIST, MSG_KEY_COLUMNS, RelationalDatabaseConnectorConfig.MASK_COLUMN_WITH_HASH,
+                COLUMN_BLACKLIST, COLUMN_WHITELIST, MSG_KEY_COLUMNS, RelationalDatabaseConnectorConfig.MASK_COLUMN_WITH_HASH,
                 INCLUDE_UNKNOWN_DATATYPES, SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
                 CommonConnectorConfig.TOMBSTONES_ON_DELETE, CommonConnectorConfig.PROVIDE_TRANSACTION_METADATA, Heartbeat.HEARTBEAT_INTERVAL,
                 Heartbeat.HEARTBEAT_TOPICS_PREFIX, DatabaseHeartbeatImpl.HEARTBEAT_ACTION_QUERY,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -556,8 +556,6 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     protected static final int DEFAULT_MAX_RETRIES = 6;
     protected static final Duration DEFAULT_RETRY_DELAY = Duration.ofSeconds(10);
 
-    private static final String TABLE_WHITELIST_NAME = "table.whitelist";
-
     public static final Field PLUGIN_NAME = Field.create("plugin.name")
             .withDisplayName("Plugin")
             .withEnum(LogicalDecoder.class, LogicalDecoder.DECODERBUFS)
@@ -716,33 +714,6 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withImportance(Importance.MEDIUM)
             .withDescription(
                     "A name of class to that creates SSL Sockets. Use org.postgresql.ssl.NonValidatingFactory to disable SSL validation in development environments");
-
-    /**
-     * A comma-separated list of regular expressions that match the fully-qualified names of tables to be monitored.
-     * Fully-qualified names for tables are of the form {@code <schemaName>.<tableName>} or
-     * {@code <databaseName>.<schemaName>.<tableName>}. May not be used with {@link #TABLE_BLACKLIST}, and superseded by schema
-     * inclusions/exclusions.
-     */
-    public static final Field TABLE_WHITELIST = Field.create(TABLE_WHITELIST_NAME)
-            .withDisplayName("Tables")
-            .withType(Type.LIST)
-            .withWidth(Width.LONG)
-            .withImportance(Importance.HIGH)
-            .withValidation(Field::isListOfRegex)
-            .withDescription("The tables for which changes are to be captured");
-
-    /**
-     * A comma-separated list of regular expressions that match the fully-qualified names of tables to be excluded from
-     * monitoring. Fully-qualified names for tables are of the form {@code <schemaName>.<tableName>} or
-     * {@code <databaseName>.<schemaName>.<tableName>}. May not be used with {@link #TABLE_WHITELIST}.
-     */
-    public static final Field TABLE_BLACKLIST = Field.create("table.blacklist")
-            .withDisplayName("Exclude Tables")
-            .withType(Type.STRING)
-            .withWidth(Width.LONG)
-            .withImportance(Importance.MEDIUM)
-            .withValidation(Field::isListOfRegex, PostgresConnectorConfig::validateTableBlacklist)
-            .withInvisibleRecommender();
 
     // TODO author=Horia Chiorean date=25/10/2016 description=PG 9.x logical decoding does not support schema changes
     public static final Field INCLUDE_SCHEMA_CHANGES = Field.create("include.schema.changes")

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
@@ -233,7 +233,16 @@ public class PostgresSchemaIT {
             assertTablesIncluded("s1.b");
             assertTablesExcluded("s1.a", "s2.a", "s2.b");
         }
+
         config = new PostgresConnectorConfig(TestHelper.defaultConfig().with(PostgresConnectorConfig.COLUMN_BLACKLIST, ".*aa")
+                .build());
+        schema = TestHelper.getSchema(config, typeRegistry);
+        try (PostgresConnection connection = TestHelper.create()) {
+            schema.refresh(connection, false);
+            assertColumnsExcluded("s1.a.aa", "s2.a.aa");
+        }
+
+        config = new PostgresConnectorConfig(TestHelper.defaultConfig().with(PostgresConnectorConfig.COLUMN_WHITELIST, ".*bb")
                 .build());
         schema = TestHelper.getSchema(config, typeRegistry);
         try (PostgresConnection connection = TestHelper.create()) {

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -179,6 +179,7 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
             .withType(Type.STRING)
             .withWidth(Width.LONG)
             .withImportance(Importance.MEDIUM)
+            .withValidation(RelationalDatabaseConnectorConfig::validateColumnBlacklist)
             .withDescription("");
 
     /**
@@ -192,7 +193,6 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
             .withType(Type.STRING)
             .withWidth(Width.LONG)
             .withImportance(Importance.MEDIUM)
-            .withValidation(RelationalDatabaseConnectorConfig::validateColumnBlacklist)
             .withDescription("");
 
     public static final Field MSG_KEY_COLUMNS = Field.create("message.key.columns")

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -181,6 +181,20 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
             .withImportance(Importance.MEDIUM)
             .withDescription("");
 
+    /**
+     * A comma-separated list of regular expressions that match fully-qualified names of columns to be excluded from monitoring
+     * and change messages. The exact form of fully qualified names for columns might vary between connector types.
+     * For instance, they could be of the form {@code <databaseName>.<tableName>.<columnName>} or
+     * {@code <schemaName>.<tableName>.<columnName>} or {@code <databaseName>.<schemaName>.<tableName>.<columnName>}.
+     */
+    public static final Field COLUMN_WHITELIST = Field.create("column.whitelist")
+            .withDisplayName("Include Columns")
+            .withType(Type.STRING)
+            .withWidth(Width.LONG)
+            .withImportance(Importance.MEDIUM)
+            .withValidation(RelationalDatabaseConnectorConfig::validateColumnBlacklist)
+            .withDescription("");
+
     public static final Field MSG_KEY_COLUMNS = Field.create("message.key.columns")
             .withDisplayName("Columns PK mapping")
             .withType(Type.STRING)
@@ -317,6 +331,16 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
 
     public Duration snapshotLockTimeout() {
         return Duration.ofMillis(getConfig().getLong(SNAPSHOT_LOCK_TIMEOUT_MS));
+    }
+
+    private static int validateColumnBlacklist(Configuration config, Field field, Field.ValidationOutput problems) {
+        String whitelist = config.getString(COLUMN_WHITELIST);
+        String blacklist = config.getString(COLUMN_BLACKLIST);
+        if (whitelist != null && blacklist != null) {
+            problems.accept(COLUMN_BLACKLIST, blacklist, "Column whitelist is already specified");
+            return 1;
+        }
+        return 0;
     }
 
     private static int validateTableBlacklist(Configuration config, Field field, ValidationOutput problems) {

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -180,7 +180,7 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
             .withWidth(Width.LONG)
             .withImportance(Importance.MEDIUM)
             .withValidation(RelationalDatabaseConnectorConfig::validateColumnBlacklist)
-            .withDescription("");
+            .withDescription("Regular expressions matching columns to exclude from change events");
 
     /**
      * A comma-separated list of regular expressions that match fully-qualified names of columns to be excluded from monitoring
@@ -193,7 +193,7 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
             .withType(Type.STRING)
             .withWidth(Width.LONG)
             .withImportance(Importance.MEDIUM)
-            .withDescription("");
+            .withDescription("Regular expressions matching columns to include in change events");
 
     public static final Field MSG_KEY_COLUMNS = Field.create("message.key.columns")
             .withDisplayName("Columns PK mapping")

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -593,7 +593,7 @@ Therefore, we interpret this key as describing the row in the `public.customers`
 
 [NOTE]
 ====
-Although the `column.blacklist` and `column.whitelist` configuration properties allow you to remove columns from the event values, all columns in a primary or unique key are always included in the event's key.
+Although the `column.blacklist` and `column.whitelist` configuration properties allow you to capture only a subset of table columns, all columns in a primary or unique key are always included in the event's key.
 ====
 
 [WARNING]
@@ -1757,12 +1757,12 @@ Only alphanumeric characters and underscores should be used.
 
 |`column.whitelist`
 |
-|An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in change event message values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_
+|An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in change event message values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. May not be used with column.blacklist.
 
 
 |`column.blacklist`
 |
-|An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event message values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_
+|An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event message values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. May not be used with column.whitelist.
 
 |`time.precision.mode`
 |`adaptive`

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -593,7 +593,7 @@ Therefore, we interpret this key as describing the row in the `public.customers`
 
 [NOTE]
 ====
-Although the `column.blacklist` configuration property allows you to remove columns from the event values, all columns in a primary or unique key are always included in the event's key.
+Although the `column.blacklist` and `column.whitelist` configuration properties allow you to remove columns from the event values, all columns in a primary or unique key are always included in the event's key.
 ====
 
 [WARNING]
@@ -1754,6 +1754,11 @@ Only alphanumeric characters and underscores should be used.
 |`table.blacklist`
 |
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be excluded from monitoring; any table not included in the blacklist will be monitored. Each identifier is of the form _schemaName_._tableName_. May not be used with `table.whitelist`.
+
+|`column.whitelist`
+|
+|An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in change event message values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_
+
 
 |`column.blacklist`
 |


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1962

Right now the Debezium Postgres connector just supports `column.blacklist`. Added `column.whitelist` as well which might be convenient in some cases.