### PR TITLE
NO-JIRA: Move mysql connector assemblies to partials

### DIFF
--- a/documentation/modules/ROOT/nav.adoc
+++ b/documentation/modules/ROOT/nav.adoc
@@ -14,10 +14,6 @@
 * Connectors
 ** xref:connectors/index.adoc[Overview]
 ** xref:connectors/mysql.adoc[MySQL]
-*** xref:assemblies/cdc-mysql-connector/as_overview-of-how-the-mysql-connector-works.adoc[How It Works]
-*** xref:assemblies/cdc-mysql-connector/as_setup-the-mysql-server.adoc[Setup]
-*** xref:assemblies/cdc-mysql-connector/as_deploy-the-mysql-connector.adoc[Deployment]
-*** xref:assemblies/cdc-mysql-connector/as_connector-common-issues.adoc[Common Issues]
 ** xref:connectors/mongodb.adoc[MongoDB]
 ** xref:connectors/postgresql.adoc[PostgreSQL]
 ** xref:connectors/oracle.adoc[Oracle]

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -1,5 +1,9 @@
 include::../_attributes.adoc[]
-
+:toc:
+:toc-placement: macro
+:linkattrs:
+:icons: font
+:source-highlighter: highlight.js
 :context: cdc
 
 = {prodname} Connector for MySQL
@@ -12,8 +16,10 @@ As MySQL is typically set up to purge binlogs after a specified period of time, 
 
 The following sections provide more detailed information on how the {prodname} MySQL connector functions, instructs you on how to set it up, as well as deploy and troubleshoot the connector.
 
-* xref:assemblies/cdc-mysql-connector/as_overview-of-how-the-mysql-connector-works.adoc[Overview of how the MySQL connector works]
-* xref:assemblies/cdc-mysql-connector/as_setup-the-mysql-server.adoc[Set up MySQL Server]
-* xref:assemblies/cdc-mysql-connector/as_deploy-the-mysql-connector.adoc[Deploy the MySQL connector]
-* xref:assemblies/cdc-mysql-connector/as_connector-common-issues.adoc[Common issues]
+include::{partialsdir}/assemblies/cdc-mysql-connector/as_overview-of-how-the-mysql-connector-works.adoc[leveloffset=+1]
 
+include::{partialsdir}/assemblies/cdc-mysql-connector/as_setup-the-mysql-server.adoc[leveloffset=+1]
+
+include::{partialsdir}/assemblies/cdc-mysql-connector/as_deploy-the-mysql-connector.adoc[leveloffset=+1]
+
+include::{partialsdir}/assemblies/cdc-mysql-connector/as_connector-common-issues.adoc[leveloffset=+1]

--- a/documentation/modules/ROOT/partials/assemblies/cdc-mysql-connector/as_connector-common-issues.adoc
+++ b/documentation/modules/ROOT/partials/assemblies/cdc-mysql-connector/as_connector-common-issues.adoc
@@ -1,6 +1,3 @@
-:toc:
-:toclevels: 1
-:toc-placement: macro
 
 // Metadata created by nebel
 //

--- a/documentation/modules/ROOT/partials/assemblies/cdc-mysql-connector/as_deploy-the-mysql-connector.adoc
+++ b/documentation/modules/ROOT/partials/assemblies/cdc-mysql-connector/as_deploy-the-mysql-connector.adoc
@@ -1,6 +1,3 @@
-:toc:
-:toclevels: 1
-:toc-placement: macro
 
 // Metadata created by nebel
 //

--- a/documentation/modules/ROOT/partials/assemblies/cdc-mysql-connector/as_overview-of-how-the-mysql-connector-works.adoc
+++ b/documentation/modules/ROOT/partials/assemblies/cdc-mysql-connector/as_overview-of-how-the-mysql-connector-works.adoc
@@ -1,6 +1,3 @@
-:toc:
-:toclevels: 1
-:toc-placement: macro
 
 // Metadata created by nebel
 //

--- a/documentation/modules/ROOT/partials/assemblies/cdc-mysql-connector/as_setup-the-mysql-server.adoc
+++ b/documentation/modules/ROOT/partials/assemblies/cdc-mysql-connector/as_setup-the-mysql-server.adoc
@@ -1,6 +1,3 @@
-:toc:
-:toclevels: 1
-:toc-placement: macro
 
 // Metadata created by nebel
 //


### PR DESCRIPTION
This is a follow-up to #1405. I moved the last remaining assembly files to {partialsdir}/assemblies. I also changed the nav so that mysql.adoc includes each of the assemblies instead of xref-ing them. The result is that the MySQL connector doc is now presented on a single page, which is consistent with all of the other connectors.