### PR TITLE
DBZ-1947 Remove obsolete MySQL metrics

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReaderMetrics.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReaderMetrics.java
@@ -71,18 +71,8 @@ class BinlogReaderMetrics extends PipelineMetrics implements BinlogReaderMetrics
     }
 
     @Override
-    public long getSecondsSinceLastEvent() {
-        return this.stats.getSecondsSinceLastEvent();
-    }
-
-    @Override
     public long getMilliSecondsSinceLastEvent() {
         return this.stats.getSecondsSinceLastEvent() * 1000;
-    }
-
-    @Override
-    public long getSecondsBehindMaster() {
-        return this.stats.getSecondsBehindMaster();
     }
 
     @Override
@@ -162,7 +152,7 @@ class BinlogReaderMetrics extends PipelineMetrics implements BinlogReaderMetrics
 
     @Override
     public long getMilliSecondsBehindSource() {
-        return getSecondsBehindMaster() * 1000;
+        return this.stats.getSecondsBehindMaster() * 1000;
     }
 
     @Override

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReaderMetricsMXBean.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReaderMetricsMXBean.java
@@ -29,17 +29,6 @@ public interface BinlogReaderMetricsMXBean extends StreamingChangeEventSourceMet
     String getGtidSet();
 
     /**
-     * Tracks the number of seconds since last MySQL binlog event was processed by underlying mysql-binlog-client.
-     */
-    long getSecondsSinceLastEvent();
-
-    /**
-     * Tracks the number of seconds between "now" and when the last processed MySQL binlog event was originally written
-     * to the MySQL server.
-     */
-    long getSecondsBehindMaster();
-
-    /**
      * Tracks the number of events skipped by underlying mysql-binlog-client, generally due to the client
      * being unable to properly deserialize the event.
      */

--- a/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/r_mysql-connector-monitoring-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/r_mysql-connector-monitoring-metrics.adoc
@@ -63,14 +63,6 @@ The {prodname} MySQL connector also provides the following custom binlog metrics
 |`string`
 |The string representation of the most recent GTID set seen by the connector when reading the binlog.
 
-|`SecondsSinceLastEvent` (obsolete)
-|`long`
-|The number of seconds since the connector has read and processed the most recent event.
-
-|`SecondsBehindMaster` (obsolete)
-|`long`
-|The number of seconds between the last event's MySQL timestamp and the connector processing it. The values will incorporate any differences between the clocks on the machines where the MySQL server and the MySQL connector are running.
-
 |`NumberOfSkippedEvents`
 |`long`
 |The number of events that have been skipped by the MySQL connector.  Typically events are skipped due to a malformed or unparseable event from MySQL's binlog.


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1947

This removes the obsolete metrics `SecondsSinceLastEvent` and `SecondsBehindMaster` from both the exposed JMX metrics as well as the MySQL connector documentation.