### PR TITLE
DBZ-1980 Only top-level menu items shown for MySQL connector

### DIFF
--- a/documentation/modules/ROOT/partials/assemblies/cdc-mysql-connector/as_connector-common-issues.adoc
+++ b/documentation/modules/ROOT/partials/assemblies/cdc-mysql-connector/as_connector-common-issues.adoc
@@ -1,6 +1,3 @@
-:toc:
-:toclevels: 1
-:toc-placement: macro
 
 // Metadata created by nebel
 //

--- a/documentation/modules/ROOT/partials/assemblies/cdc-mysql-connector/as_deploy-the-mysql-connector.adoc
+++ b/documentation/modules/ROOT/partials/assemblies/cdc-mysql-connector/as_deploy-the-mysql-connector.adoc
@@ -1,6 +1,3 @@
-:toc:
-:toclevels: 1
-:toc-placement: macro
 
 // Metadata created by nebel
 //

--- a/documentation/modules/ROOT/partials/assemblies/cdc-mysql-connector/as_overview-of-how-the-mysql-connector-works.adoc
+++ b/documentation/modules/ROOT/partials/assemblies/cdc-mysql-connector/as_overview-of-how-the-mysql-connector-works.adoc
@@ -1,6 +1,3 @@
-:toc:
-:toclevels: 1
-:toc-placement: macro
 
 // Metadata created by nebel
 //

--- a/documentation/modules/ROOT/partials/assemblies/cdc-mysql-connector/as_setup-the-mysql-server.adoc
+++ b/documentation/modules/ROOT/partials/assemblies/cdc-mysql-connector/as_setup-the-mysql-server.adoc
@@ -1,6 +1,3 @@
-:toc:
-:toclevels: 1
-:toc-placement: macro
 
 // Metadata created by nebel
 //


### PR DESCRIPTION
This removes some attributes from the partials that interfered with generating the ToC properly.  This commit should likely also be cherry-picked back to the 1.0 branch as it exhibits the same behavior problems.