### PR TITLE
NO-JIRA: update doc xrefs to work downstream

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -24,6 +24,7 @@ asciidoc:
     link-sqlserver-connector: 'connectors/sqlserver.adoc'
     link-db2-connector: 'connectors/db2.adoc'
     link-cassandra-connector: 'connectors/cassandra.adoc'
+    link-custom-converters: 'development/converters.adoc'
     link-mysql-plugin-snapshot: 'https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.debezium&a=debezium-connector-mysql&v=LATEST&c=plugin&e=tar.gz'
     link-postgres-plugin-snapshot: 'https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.debezium&a=debezium-connector-postgres&v=LATEST&c=plugin&e=tar.gz'
     link-mongodb-plugin-snapshot: 'https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.debezium&a=debezium-connector-mongodb&v=LATEST&c=plugin&e=tar.gz'

--- a/documentation/modules/ROOT/partials/assemblies/tutorial/as_viewing-change-events.adoc
+++ b/documentation/modules/ROOT/partials/assemblies/tutorial/as_viewing-change-events.adoc
@@ -1,7 +1,6 @@
 // Metadata created by nebel
 //
 // UserStory: As an evaluator, I want to use Debezium to view create, update, and delete events in my database.
-
 :context: debezium
 
 [id="viewing-change-events"]
@@ -14,7 +13,7 @@ When you watched the connector start up,
 you saw that events were written to the following topics with the `dbserver1` prefix (the name of the connector):
 
 `dbserver1`::
-The xref:connectors/mysql.adoc#how-the-mysql-connector-handles-schema-change-topics_{context}[schema change topic] to which all of the DDL statements are written.
+The {link-prefix}:{link-mysql-connector}#how-the-mysql-connector-handles-schema-change-topics_{context}[schema change topic] to which all of the DDL statements are written.
 
 `dbserver1.inventory.products`::
 Captures change events for the `products` table in the `inventory` database.

--- a/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/c_how-the-mysql-connector-maps-data-types.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/c_how-the-mysql-connector-maps-data-types.adoc
@@ -148,7 +148,7 @@ NOTE: In link:https://www.iso.org/iso-8601-date-and-time-format.html[ISO 8601] f
 
 Excluding the `TIMESTAMP` data type, MySQL temporal types depend on the value of the `time.precision.mode` configuration property.
 
-TIP: See xref:connectors/mysql.adoc#mysql-connector-configuration-properties_{context}[MySQL connector configuration properties] for more details.
+TIP: See xref:mysql-connector-configuration-properties_{context}[MySQL connector configuration properties] for more details.
 
 Temporal values without timezones are converted from UTC to milliseconds or microseconds (`DATETIME`) or to the configured database timezone (`TIMESTAMP`).
 
@@ -224,7 +224,7 @@ NOTE: Represents the number of milliseconds since epoch, and does not include ti
 
 Decimals are handled via the `decimal.handling.mode` property.
 
-TIP: See xref:connectors/mysql.adoc#mysql-connector-configuration-properties_{context}[MySQL connector configuration properties] for more details.
+TIP: See xref:mysql-connector-configuration-properties_{context}[MySQL connector configuration properties] for more details.
 
 decimal.handling.mode=precise::
 +
@@ -288,11 +288,13 @@ a| _n/a_
 
 MySQL handles the `BOOLEAN` value internally in a specific way.
 The `BOOLEAN` column is internally mapped to `TINYINT(1)` datatype.
-When the table is created during streaming then it uses proper `BOOLEAN` mapping as Debezium receives the original DDL.
-During snapshot Debezium executes `SHOW CREATE TABLE` to obtain table definition which returns `TINYINT(1)` for both `BOOLEAN` and `TINYINT(1)` columns.
+When the table is created during streaming then it uses proper `BOOLEAN` mapping as {prodname} receives the original DDL.
+During snapshot {prodname} executes `SHOW CREATE TABLE` to obtain table definition which returns `TINYINT(1)` for both `BOOLEAN` and `TINYINT(1)` columns.
 
-Debezium then has no way how to obtain the original type mapping and will map to `TINYINT(1)`.
-The operator can configure the out-of-the-box xref:development/converters.adoc[custom converter] `TinyIntOneToBooleanConverter` that would either map all `TINYINT(1)` columns to `BOOLEAN` or if `selector` parameter is set then a subset of columns could be enumerated using comma-separated regular expressions.
+{prodname} then has no way how to obtain the original type mapping and will map to `TINYINT(1)`.
+ifndef::cdc-product[]
+The operator can configure the out-of-the-box {link-prefix}:{link-custom-converters}[custom converter] `TinyIntOneToBooleanConverter` that would either map all `TINYINT(1)` columns to `BOOLEAN` or if `selector` parameter is set then a subset of columns could be enumerated using comma-separated regular expressions.
+endif::cdc-product[]
 
 An example configuration is
 

--- a/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/c_how-the-mysql-connector-performs-database-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/c_how-the-mysql-connector-performs-database-snapshots.adoc
@@ -7,7 +7,7 @@
 
 When your {prodname} MySQL connector is first started, it performs an initial _consistent snapshot_ of your database. The following flow describes how this snapshot is completed.
 
-NOTE: This is the default snapshot mode which is set as `initial` in the `snapshot.mode` property. For other snapshots modes, please check out the xref:connectors/mysql.adoc#mysql-connector-configuration-properties_{context}[MySQL connector configuration properties].
+NOTE: This is the default snapshot mode which is set as `initial` in the `snapshot.mode` property. For other snapshots modes, please check out the xref:mysql-connector-configuration-properties_{context}[MySQL connector configuration properties].
 
 ifeval::["{isImageReady}" == "true"]
 image:debezium-architecture.png[Debezium Architecture]
@@ -57,7 +57,7 @@ a| Records the completed snapshot in the connector offsets.
 
 If the connector fails, stops, or is rebalanced while making the _initial snapshot_, the connector creates a new snapshot once restarted. Once that _intial snapshot_ is completed, the {prodname} MySQL connector restarts from the same position in the binlog so it does not miss any updates.
 
-NOTE: If the connector stops for long enough, MySQL could purge old binlog files and the connector's position would be lost. If the position is lost, the connector reverts to the _initial snapshot_ for its starting position. For more tips on troubleshooting the {prodname} MySQL connector, see xref:connectors/mysql.adoc#connector-common-issues[MySQL connector common issues].
+NOTE: If the connector stops for long enough, MySQL could purge old binlog files and the connector's position would be lost. If the position is lost, the connector reverts to the _initial snapshot_ for its starting position. For more tips on troubleshooting the {prodname} MySQL connector, see xref:connector-common-issues[MySQL connector common issues].
 
 == What if Global Read Locks are not allowed?
 [[no-global-read-lock-mysql-connect_{context}]]

--- a/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/c_mysql-connector-events.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/c_mysql-connector-events.adoc
@@ -102,7 +102,7 @@ a| A *mandatory* field that describes the source metadata for the event includin
 * the MySQL server ID (if available)
 * timestamp
 
-NOTE: If the xref:connectors/mysql.adoc#enable-query-log-events-for-cdc_{context}[binlog_rows_query_log_events] option is enabled and the connector has the `include.query` option enabled, a `query` field is displayed which contains the original SQL statement that generated the event.
+NOTE: If the xref:enable-query-log-events-for-cdc_{context}[binlog_rows_query_log_events] option is enabled and the connector has the `include.query` option enabled, a `query` field is displayed which contains the original SQL statement that generated the event.
 
 |6
 |`ts_ms`

--- a/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/p_configure-the-mysql-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/p_configure-the-mysql-connector.adoc
@@ -8,7 +8,7 @@
 Typically, you configure the {prodname} MySQL connector in a `JSON` file using the configuration properties available for the connector.
 
 .Prerequisites
-* You should have completed the xref:connectors/mysql.adoc#install-the-mysql-connector_{context}[installation process] for the connector.
+* You should have completed the xref:install-the-mysql-connector_{context}[installation process] for the connector.
 
 
 .Procedure
@@ -16,7 +16,7 @@ Typically, you configure the {prodname} MySQL connector in a `JSON` file using t
 . Set the `"name"` of the connector in the JSON file.
 . Set the configuration properties that you require for your {prodname} MySQL connector.
 
-TIP: For a complete list of configuration properties, see xref:connectors/mysql.adoc#mysql-connector-configuration-properties_{context}[MySQL connector configuration properties].
+TIP: For a complete list of configuration properties, see xref:mysql-connector-configuration-properties_{context}[MySQL connector configuration properties].
 
 .MySQL connector example configuration
 =========
@@ -28,12 +28,12 @@ TIP: For a complete list of configuration properties, see xref:connectors/mysql.
     "connector.class": "io.debezium.connector.mysql.MySqlConnector", <2>
     "database.hostname": "192.168.99.100", <3>
     "database.port": "3306", <4>
-    "database.user": "{prodname}-user", <5> 
+    "database.user": "{prodname}-user", <5>
     "database.password": "thePassword", <6>
     "database.server.id": "184054", <7>
-    "database.server.name": "fullfillment", <8> 
+    "database.server.name": "fullfillment", <8>
     "database.whitelist": "inventory", <9>
-    "database.history.kafka.bootstrap.servers": "kafka:9092", <10> 
+    "database.history.kafka.bootstrap.servers": "kafka:9092", <10>
     "database.history.kafka.topic": "dbhistory.fullfillment", <11>
     "include.schema.changes": "true" <12>
   }

--- a/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/p_create-a-mysql-user-for-cdc.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/p_create-a-mysql-user-for-cdc.adoc
@@ -29,7 +29,7 @@ mysql> GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIE
 
 TIP: See xref:permissions-explained-mysql-connector[permissions explained] for notes on each permission.
 
-IMPORTANT: If using a hosted option such as Amazon RDS or Amazon Aurora that do not allow a *global read lock*, table-level locks are used to create the _consistent snapshot_. In this case, you need to also grant `LOCK_TABLES` permissions to the user that you create. See xref:connectors/mysql.adoc[Overview of how the MySQL connector works] for more details.
+IMPORTANT: If using a hosted option such as Amazon RDS or Amazon Aurora that do not allow a *global read lock*, table-level locks are used to create the _consistent snapshot_. In this case, you need to also grant `LOCK_TABLES` permissions to the user that you create. See xref:overview-of-how-the-mysql-connector-works[Overview of how the MySQL connector works] for more details.
 
 [start=3]
 . Finalize the user's permissions:
@@ -73,7 +73,7 @@ a| enables the connector the use of following statements:
 IMPORTANT: This is always required for the connector.
 
 |`ON`
-a| Identifies the *database* to which the permission apply. 
+a| Identifies the *database* to which the permission apply.
 
 |`TO 'user'`
 | Specifies the *user* to which the permissions are granted.

--- a/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/r_mysql-connector-configuration-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/r_mysql-connector-configuration-properties.adoc
@@ -114,7 +114,7 @@ Fully-qualified names for columns are of the form _databaseName_._tableName_._co
 The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
 Useful to properly size corresponding columns in sink databases.
 Fully-qualified data type names are of the form _databaseName_._tableName_._typeName_, or _databaseName_._schemaName_._tableName_._typeName_.
-See xref:connectors/mysql.adoc#how-the-mysql-connector-maps-data-types_{context}[] for the list of MySQL-specific data type names.
+See xref:how-the-mysql-connector-maps-data-types_{context}[] for the list of MySQL-specific data type names.
 
 |`time.precision.mode`
 |`adaptive_time{zwsp}_microseconds`
@@ -318,7 +318,7 @@ The connector will read the table contents in multiple batches of this size.
 |`snapshot.lock.timeout.ms`
 |`10000`
 |Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot.
-If table locks cannot be acquired in this time interval, the snapshot will fail. See xref:connectors/mysql.adoc#how-the-mysql-connector-performs-database-snapshots_{context}[How the MySQL connector performs database snapshots].
+If table locks cannot be acquired in this time interval, the snapshot will fail. See xref:how-the-mysql-connector-performs-database-snapshots_{context}[How the MySQL connector performs database snapshots].
 
 |`enable.time.adjuster`
 |

--- a/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/r_mysql-connector-monitoring-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/r_mysql-connector-monitoring-metrics.adoc
@@ -10,7 +10,7 @@ The {prodname} MySQL connector has three metric types in addition to the built-i
 * <<mysql-connector-binlog-metrics, binlog metrics>>; for monitoring the connector when reading CDC table data
 * <<mysql-connector-schema-history-metrics, schema history metrics>>; for monitoring the status of the connector's schema history
 
-Please refer to the xref:operations/monitoring.adoc[monitoring documentation] for details of how to expose these metrics via JMX.
+Refer to the xref:operations/monitoring.adoc[monitoring documentation] for details of how to expose these metrics via JMX.
 
 == Snapshot metrics
 [[mysql-connector-snapshot-metrics]]
@@ -37,7 +37,7 @@ The {prodname} MySQL connector also provides the following custom snapshot metri
 
 The *MBean* is `debezium.mysql:type=connector-metrics,context=binlog,server=<database.server.name>`.
 
-NOTE: The transaction-related attributes are only available if binlog event buffering is enabled. See xref:connectors/mysql.adoc#mysql-connector-configuration-properties_{context}[binlog.buffer.size] in the advanced connector configuration properties for more details.
+NOTE: The transaction-related attributes are only available if binlog event buffering is enabled. See xref:mysql-connector-configuration-properties_{context}[binlog.buffer.size] in the advanced connector configuration properties for more details.
 
 include::{partialsdir}/modules/cdc-all-connectors/r_connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 

--- a/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/r_mysql-purges-binlog-files.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/r_mysql-purges-binlog-files.adoc
@@ -6,4 +6,4 @@
 
 If the {prodname} MySQL connector stops for too long, the MySQL server purges older binlog files and the connector's last position may be lost. When the connector is restarted, the MySQL server no longer has the starting point and the connector performs another initial snapshot. If the snapshot is disabled, the connector fails with an error.
 
-TIP: See xref:connectors/mysql.adoc#how-the-mysql-connector-performs-database-snapshots_{context}[How the MySQL connector performs database snapshots] for more information on initial snapshots.
+TIP: See xref:how-the-mysql-connector-performs-database-snapshots_{context}[How the MySQL connector performs database snapshots] for more information on initial snapshots.

--- a/documentation/modules/ROOT/partials/modules/tutorial/r_watching-connector-start-up.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/r_watching-connector-start-up.adoc
@@ -204,10 +204,6 @@ Step 7 releases the global write lock just 0.3 seconds after acquiring it,
 and Step 8 reads all of the rows in each of the tables and reports the time taken and number of rows found.
 In this case, the connector completed its consistent snapshot in just 0.38 seconds.
 
-:link-prefix: xref
-:link-avro-serialization: configuration/avro.adoc
-:link-mysql-connector: connectors/mysql.adoc
-
 [NOTE]
 ====
 The snapshot process will take longer with your databases,

--- a/documentation/modules/ROOT/partials/modules/tutorial/r_watching-connector-start-up.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/r_watching-connector-start-up.adoc
@@ -204,6 +204,10 @@ Step 7 releases the global write lock just 0.3 seconds after acquiring it,
 and Step 8 reads all of the rows in each of the tables and reports the time taken and number of rows found.
 In this case, the connector completed its consistent snapshot in just 0.38 seconds.
 
+:link-prefix: xref
+:link-avro-serialization: configuration/avro.adoc
+:link-mysql-connector: connectors/mysql.adoc
+
 [NOTE]
 ====
 The snapshot process will take longer with your databases,
@@ -212,7 +216,7 @@ even when the tables have a large number of rows.
 And although an exclusive write lock is used at the beginning of the snapshot process,
 it should not last very long even for large databases.
 This is because the lock is released before any data is copied.
-For more information, see the xref:connectors/mysql.adoc[MySQL connector documentation].
+For more information, see the {link-prefix}:{link-mysql-connector}#debezium-connector-for-mysql[MySQL connector documentation].
 ====
 
 Next, Kafka Connect reports some "errors".


### PR DESCRIPTION
Updated several xrefs so that the links will not break in the downstream doc. In addition, I cleaned up some of the MySQL connector doc xrefs; now that all of the MySQL connector doc is presented on a single page on the Antora site, the xrefs do not need to point to the full path of the target.