### PR TITLE
DBZ-1591 Add parallel snapshot

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbOffsetContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbOffsetContext.java
@@ -72,6 +72,12 @@ public class MongoDbOffsetContext implements OffsetContext {
     }
 
     @Override
+    public OffsetContext getDataCollectionOffsetContext(DataCollectionId collectionId) {
+        // Concurrent snapshot not support so mutable copy not used
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean isSnapshotRunning() {
         return sourceInfo.isSnapshot() && sourceInfo.isSnapshotRunning();
     }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSetOffsetContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSetOffsetContext.java
@@ -64,6 +64,12 @@ public class ReplicaSetOffsetContext implements OffsetContext {
     }
 
     @Override
+    public OffsetContext getDataCollectionOffsetContext(DataCollectionId collectionId) {
+        // Concurrent snapshot not support so mutable copy not used
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean isSnapshotRunning() {
         return offsetContext.isSnapshotRunning();
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
@@ -40,9 +40,11 @@ public class PostgresOffsetContext implements OffsetContext {
     private boolean lastSnapshotRecord;
     private Long lastCompletelyProcessedLsn;
     private final TransactionContext transactionContext;
+    private PostgresConnectorConfig connectorConfig;
 
     private PostgresOffsetContext(PostgresConnectorConfig connectorConfig, Long lsn, Long lastCompletelyProcessedLsn, Long txId, Instant time, boolean snapshot,
                                   boolean lastSnapshotRecord, TransactionContext transactionContext) {
+        this.connectorConfig = connectorConfig;
         partition = Collections.singletonMap(SERVER_PARTITION_KEY, connectorConfig.getLogicalName());
         sourceInfo = new SourceInfo(connectorConfig);
 
@@ -58,6 +60,20 @@ public class PostgresOffsetContext implements OffsetContext {
             sourceInfo.setSnapshot(snapshot ? SnapshotRecord.TRUE : SnapshotRecord.FALSE);
         }
         this.transactionContext = transactionContext;
+    }
+
+    public PostgresOffsetContext(PostgresOffsetContext postgresOffsetContext) {
+        SourceInfo sourceInfoCopy = new SourceInfo(postgresOffsetContext.connectorConfig);
+        sourceInfoCopy.update(postgresOffsetContext.sourceInfo.lsn(), null, postgresOffsetContext.sourceInfo.txId(), null, postgresOffsetContext.sourceInfo.xmin());
+        sourceInfoCopy.setSnapshot(postgresOffsetContext.sourceInfo.snapshot());
+
+        this.sourceInfoSchema = postgresOffsetContext.sourceInfoSchema;
+        this.sourceInfo = sourceInfoCopy;
+        this.partition = postgresOffsetContext.partition;
+        this.lastSnapshotRecord = postgresOffsetContext.lastSnapshotRecord;
+        this.lastCompletelyProcessedLsn = postgresOffsetContext.lastCompletelyProcessedLsn;
+        this.transactionContext = postgresOffsetContext.transactionContext;
+        this.connectorConfig = postgresOffsetContext.connectorConfig;
     }
 
     @Override
@@ -98,6 +114,11 @@ public class PostgresOffsetContext implements OffsetContext {
     @Override
     public Struct getSourceInfo() {
         return sourceInfo.struct();
+    }
+
+    @Override
+    public OffsetContext getDataCollectionOffsetContext(DataCollectionId tableId) {
+        return new PostgresOffsetContext(this);
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -7,6 +7,7 @@
 package io.debezium.connector.postgresql;
 
 import static io.debezium.connector.postgresql.TestHelper.PK_FIELD;
+import static io.debezium.connector.postgresql.TestHelper.topicName;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -1019,6 +1020,11 @@ public abstract class AbstractRecordsProducerTest extends AbstractConnectorTest 
         assertNotNull(source.getString("db"));
         assertNotNull(source.getString("schema"));
         assertNotNull(source.getString("table"));
+    }
+
+    protected String topicNameFromSourceRecord(SourceRecord record) {
+        Struct source = ((Struct) record.value()).getStruct("source");
+        return topicName(source.getString("schema") + "." + source.getString("table"));
     }
 
     protected static String topicNameFromInsertStmt(String statement) {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
@@ -193,4 +193,10 @@ public class SqlServerOffsetContext implements OffsetContext {
     public TransactionContext getTransactionContext() {
         return transactionContext;
     }
+
+    @Override
+    public OffsetContext getDataCollectionOffsetContext(DataCollectionId collectionId) {
+        // Concurrent snapshot not support so mutable copy not used
+        throw new UnsupportedOperationException();
+    }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
@@ -223,6 +223,11 @@ public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChange
     }
 
     @Override
+    protected boolean supportsConcurrentSnapshot() {
+        return false;
+    }
+
+    @Override
     protected Object getColumnValue(ResultSet rs, int columnIndex, Column column) throws SQLException {
         final ResultSetMetaData metaData = rs.getMetaData();
         final int columnType = metaData.getColumnType(columnIndex);

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -221,6 +221,15 @@ public abstract class CommonConnectorConfig {
             .withDescription("The maximum number of records that should be loaded into memory while performing a snapshot")
             .withValidation(Field::isNonNegativeInteger);
 
+    public static final Field SNAPSHOT_MAX_THREADS = Field.create("snapshot.max.threads")
+            .withDisplayName("Snapshot max threads")
+            .withType(Type.INT)
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.LOW)
+            .withDescription("The maximum number of worker threads used to perform a snapshot")
+            .withDefault(1)
+            .withValidation(Field::isNonNegativeInteger);
+
     public static final Field SOURCE_STRUCT_MAKER_VERSION = Field.create("source.struct.version")
             .withDisplayName("Source struct maker version")
             .withEnum(Version.class, Version.V2)

--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -318,6 +318,10 @@ public class EventDispatcher<T extends DataCollectionId> {
      */
     public interface SnapshotReceiver extends ChangeRecordEmitter.Receiver {
         void completeSnapshot() throws InterruptedException;
+
+        boolean hasEventStaged();
+
+        void flushStagedEvent() throws InterruptedException;
     }
 
     private final class StreamingChangeRecordReceiver implements ChangeRecordEmitter.Receiver {
@@ -378,9 +382,7 @@ public class EventDispatcher<T extends DataCollectionId> {
 
             LOGGER.trace("Received change record for {} operation on key {}", operation, key);
 
-            if (bufferedEvent != null) {
-                queue.enqueue(bufferedEvent.get());
-            }
+            flushStagedEvent();
 
             Schema keySchema = dataCollectionSchema.keySchema();
             String topicName = topicSelector.topicNameFor((T) dataCollectionSchema.id());
@@ -414,6 +416,19 @@ public class EventDispatcher<T extends DataCollectionId> {
                     }
                 }
                 queue.enqueue(event);
+                bufferedEvent = null;
+            }
+        }
+
+        @Override
+        public boolean hasEventStaged() {
+            return bufferedEvent != null;
+        }
+
+        @Override
+        public void flushStagedEvent() throws InterruptedException {
+            if (bufferedEvent != null) {
+                queue.enqueue(bufferedEvent.get());
                 bufferedEvent = null;
             }
         }

--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
@@ -40,6 +40,8 @@ public interface OffsetContext {
 
     Struct getSourceInfo();
 
+    OffsetContext getDataCollectionOffsetContext(DataCollectionId collectionId);
+
     /**
      * Whether this offset indicates that an (uncompleted) snapshot is currently running or not.
      * @return


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1591

Adds support for performing snapshots concurrently to the postgres and oracle
connectors. The snapshot process is now performed using a fixed worker thread
pool whose size is controlled by the "snapshot.max.threads" property.
Worker threads open a new connection to the datasource to snapshot a single
datasource object(ex. table) and close when finished. Connectors that do
support concurrent snapshots is a special case where the existing connection
is reused, performed on a fixed single thread pool, and all snapshotted objects
are published in order.