### PR TITLE
DBZ-2011 re-do: add examples of .yaml connector configurations

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -556,7 +556,7 @@ Installing the MongoDB connector is a simple process whereby you only need to do
 
 .Procedure
 
-. Visit link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=jboss.amq.streams[Product Downloads^] on the Red Hat Customer Portal and download the MongoDB connector.
+. Download the {prodname} link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions[MongoDB connector].
 . Extract the files into your Kafka Connect environment.
 . Add the plugin's parent directory to your Kafka Connect plugin path:
 +

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -591,7 +591,10 @@ To use the connector to produce change events for a particular MongoDB replica s
 When the connector starts, it will perform a snapshot of the collections in your MongoDB replica sets and start reading the replica sets' oplogs, producing events for every inserted, updated, and deleted row.
 Optionally filter out collections that are not needed.
 
-Here is an example of the configuration for a MongoDB connector that monitors a MongoDB replica set `rs0` at port 27017 on 192.168.99.100, which we logically name `fullfillment`:
+ifndef::cdc-product[]
+
+Following is an example of the configuration for a MongoDB connector that monitors a MongoDB replica set `rs0` at port 27017 on 192.168.99.100, which we logically name `fullfillment`.
+Typically, you configure the {prodname} MongoDB connector in a `.json` file using the configuration properties available for the connector.
 
 [source,json]
 ----
@@ -607,9 +610,37 @@ Here is an example of the configuration for a MongoDB connector that monitors a 
 ----
 <1> The name of our connector when we register it with a Kafka Connect service.
 <2> The name of the MongoDB connector class.
-<3> The host addresses to use to connect to the MongoDB replica set
+<3> The host addresses to use to connect to the MongoDB replica set.
 <4> The _logical name_ of the MongoDB replica set, which forms a namespace for generated events and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro Connector is used.
-<5> A list of regular expressions that match the collection namespaces (e.g., <dbName>.<collectionName>) of all collections to be monitored. This is optional.
+<5> A list of regular expressions that match the collection namespaces (for example, <dbName>.<collectionName>) of all collections to be monitored. This is optional.
+
+endif::[]
+
+ifdef::cdc-product[]
+Following is an example of the configuration for a MongoDB connector that monitors a MongoDB replica set `rs0` at port 27017 on 192.168.99.100, which we logically name `fullfillment`.
+Typically, you configure the {prodname} MongoDB connector in a `.yaml` file using the configuration properties available for the connector.
+
+[source,yaml,options="nowrap"]
+----
+apiVersion: 
+  kind: MongoDbConnector
+  metadata:
+    name: inventory-connector  // <1>
+    labels:  
+  spec:
+    class: io.debezium.connector.mongodb.MongoDbConnector // <2>
+    config:  
+     mongodb.hosts: rs0/192.168.99.100:27017 // <3>
+     mongodb.name: fulfillment // <4>
+     collection.whitelist: inventory[.]* // <5>
+----
+<1> The name of our connector when we register it with a Kafka Connect service.
+<2> The name of the MongoDB connector class.
+<3> The host addresses to use to connect to the MongoDB replica set.
+<4> The _logical name_ of the MongoDB replica set, which forms a namespace for generated events and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro Connector is used.
+<5> A list of regular expressions that match the collection namespaces (for example, <dbName>.<collectionName>) of all collections to be monitored. This is optional.
+
+endif::[]
 
 See the link:#mongodb-connector-properties[complete list of connector properties] that can be specified in these configurations.
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -622,11 +622,11 @@ Typically, you configure the {prodname} MongoDB connector in a `.yaml` file usin
 
 [source,yaml,options="nowrap"]
 ----
-apiVersion: 
-  kind: MongoDbConnector
+apiVersion: kafka.strimzi.io/v1beta1
+  kind: KafkaConnector
   metadata:
     name: inventory-connector  // <1>
-    labels:  
+    labels: strimzi.io/cluster: my-connect-cluster
   spec:
     class: io.debezium.connector.mongodb.MongoDbConnector // <2>
     config:  

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -205,7 +205,7 @@ configure the server to load the plugin at startup:
 [source,properties]
 ----
 # MODULES
-shared_preload_libraries = 'decoderbufs,wal2json' //<1>
+shared_preload_libraries = 'decoderbufs,wal2json' // <1>
 ----
 <1> tells the server that it should load at startup the `decoderbufs` and `wal2json` logical decoding plugins (the names of the plugins are set in https://github.com/debezium/postgres-decoderbufs/blob/v0.3.0/Makefile[_Protobuf_] and https://github.com/eulerto/wal2json/blob/master/Makefile[_wal2json_] Makefiles)
 
@@ -215,9 +215,9 @@ Next is to configure the replication slot regardless of the decoder being used:
 [source,properties]
 ----
 # REPLICATION
-wal_level = logical             //<1>
-max_wal_senders = 1             //<2>
-max_replication_slots = 1       //<3>
+wal_level = logical             // <1>
+max_wal_senders = 1             // <2>
+max_replication_slots = 1       // <3>
 ----
 <1> tells the server that it should use logical decoding with the write-ahead log
 <2> tells the server that it should use a maximum of `1` separate processes for processing WAL changes
@@ -262,9 +262,9 @@ Finally, configure the PostgreSQL server to allow replication to take place betw
 .pg_hba.conf
 [source]
 ----
-local   replication     <youruser>                          trust   //<1>
-host    replication     <youruser>  127.0.0.1/32            trust   //<2>
-host    replication     <youruser>  ::1/128                 trust   //<3>
+local   replication     <youruser>                          trust   // <1>
+host    replication     <youruser>  127.0.0.1/32            trust   // <2>
+host    replication     <youruser>  ::1/128                 trust   // <3>
 ----
 <1> Tells the server to allow replication for `<youruser>` locally (i.e. on the server machine)
 <2> Tells the server to allow `<youruser>` on `localhost` to receive replication changes using `IPV4`

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1595,12 +1595,15 @@ To use the connector to produce change events for a particular PostgreSQL server
 
 . Install the link:#output-plugin[logical decoding plugin]
 . Configure the link:#server-configuration[PostgreSQL server] to support logical replication
-. Create a configuration file for the PostgreSQL connector in JSON.
+. Create a configuration file for the PostgreSQL connector.
 
 When the connector starts, it will grab a consistent snapshot of the databases in your PostgreSQL server and start streaming changes, producing events for every inserted, updated, and deleted row. You can also choose to produce events for a subset of the schemas and tables.
 Optionally ignore, mask, or truncate columns that are sensitive, too large, or not needed.
 
-Here is an example of the configuration for a PostgreSQL connector that monitors a PostgreSQL server at port 5432 on 192.168.99.100, which we logically name `fullfillment`:
+ifndef::cdc-product[]
+
+Following is an example of the configuration for a PostgreSQL connector that monitors a PostgreSQL server at port 5432 on 192.168.99.100, which we logically name `fullfillment`.
+Typically, you configure the {prodname} PostgreSQL connector in a `.json` file using the configuration properties available for the connector.
 
 [source,json]
 ----
@@ -1628,6 +1631,49 @@ Here is an example of the configuration for a PostgreSQL connector that monitors
 <7> The name of the PostgreSQL database to connect to
 <8> The logical name of the PostgreSQL server/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro Connector is used.
 <9> A list of all tables hosted by this server that this connector will monitor. This is optional, and there are other properties for listing the schemas and tables to include or exclude from monitoring.
+
+endif::[]
+
+ifdef::cdc-product[]
+
+Following is an example of the configuration for a PostgreSQL connector that monitors a PostgreSQL server at port 5432 on 192.168.99.100, which we logically name `fullfillment`.
+Typically, you configure the {prodname} PostgreSQL connector in a `.yaml` file using the configuration properties available for the connector.
+
+[source,yaml,options="nowrap"]
+----
+apiVersion: 
+  kind: PostgresConnector
+  metadata:
+    name: inventory-connector  // <1>
+    labels:  
+  spec:
+    class: io.debezium.connector.postgresql.PostgresConnector
+    tasksMax: 1  // <2>
+    config:  // <3>
+      database.hostname: postgresqldb   // <4>
+      database.port: 5432
+      database.user: debezium
+      database.password: dbz
+      database.dbname: postgres  
+      database.server.name: fullfillment   // <5>
+      database.whitelist: public.inventory   // <6>
+----
+<1> The name of the connector.
+<2> Only one task should operate at any one time.
+Because the PostgreSQL connector reads the PostgreSQL server’s `binlog`,
+using a single connector task ensures proper order and event handling.
+The Kafka Connect service uses connectors to start one or more tasks that do the work,
+and it automatically distributes the running tasks across the cluster of Kafka Connect services.
+If any of the services stop or crash,
+those tasks will be redistributed to running services.
+<3> The connector’s configuration.
+<4> The database host, which is the name of the container running the PostgreSQL server (`postgresqldb`).
+<5> A unique server name.
+The server name is the logical identifier for the PostgreSQL server or cluster of servers.
+This name will be used as the prefix for all Kafka topics.
+<6> Only changes in the `public.inventory` database will be detected.
+
+endif::[]
 
 See the link:#connector-properties[complete list of connector properties] that can be specified in these configurations.
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1641,11 +1641,11 @@ Typically, you configure the {prodname} PostgreSQL connector in a `.yaml` file u
 
 [source,yaml,options="nowrap"]
 ----
-apiVersion: 
-  kind: PostgresConnector
+apiVersion: kafka.strimzi.io/v1beta1
+  kind: KafkaConnector
   metadata:
     name: inventory-connector  // <1>
-    labels:  
+    labels: strimzi.io/cluster: my-connect-cluster
   spec:
     class: io.debezium.connector.postgresql.PostgresConnector
     tasksMax: 1  // <2>

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1562,7 +1562,7 @@ Installing the PostgreSQL connector is a simple process whereby you only need to
 
 .Procedure
 
-. Visit link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=jboss.amq.streams[Product Downloads^] on the Red Hat Customer Portal and download the PostgreSQL connector.
+. Download the {prodname} link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions[PostgreSQL connector].
 . Extract the files into your Kafka Connect environment.
 . Add the plugin's parent directory to your Kafka Connect plugin path:
 +

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1053,7 +1053,7 @@ Installing the SQL Server connector is a simple process whereby you only need to
 
 .Procedure
 
-. Visit link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?downloadType=distributions&product=jboss.amq.streams[Product Downloads^] on the Red Hat Customer Portal and download the SQL Server connector.
+. Download the {prodname} link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions[SQL Server connector].
 . Extract the files into your Kafka Connect environment.
 . Add the plugin's parent directory to your Kafka Connect plugin path:
 +

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1086,14 +1086,16 @@ endif::cdc-product[]
 
 To use the connector to produce change events for a particular SQL Server database or cluster:
 
-. Enable the link:#setting-up-sqlserver[CDC on SQL Server] to publish the _CDC_ events in the database
-. Create a configuration file for the SQL Server connector in JSON.
+. Enable the link:#setting-up-sqlserver[CDC on SQL Server] to publish the _CDC_ events in the database.
+. Create a configuration file for the SQL Server connector.
 
 When the connector starts, it will grab a consistent snapshot of the schemas in your SQL Server database and start streaming changes, producing events for every inserted, updated, and deleted row.
 You can also choose to produce events for a subset of the schemas and tables.
 Optionally ignore, mask, or truncate columns that are sensitive, too large, or not needed.
 
-Here is an example of the configuration for a connector instance that monitors a SQL Server server at port 3306 on 192.168.99.100, which we logically name `fullfillment`:
+ifndef::cdc-product[]
+Following is an example of the configuration for a connector instance that monitors a SQL Server server at port 3306 on 192.168.99.100, which we logically name `fullfillment`.
+Typically, you configure the {prodname} SQL Server connector in a `.json` file using the configuration properties available for the connector.
 
 [source,json]
 ----
@@ -1102,7 +1104,7 @@ Here is an example of the configuration for a connector instance that monitors a
   "config": {
     "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector", // <2>
     "database.hostname": "192.168.99.100", // <3>
-    "database.port": "1433", // <4>
+    "database.port": "3306", // <4>
     "database.user": "sa", // <5>
     "database.password": "Password!", // <6>
     "database.dbname": "testDB", // <7>
@@ -1119,11 +1121,52 @@ Here is an example of the configuration for a connector instance that monitors a
 <4> The port number of the SQL Server instance.
 <5> The name of the SQL Server user
 <6> The password for the SQL Server user
-<7> The name of the database to capture changes from
+<7> The name of the database to capture changes from.
 <8> The logical name of the SQL Server instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro Connector is used.
-<9> A list of all tables whose changes {prodname} should capture
+<9> A list of all tables whose changes {prodname} should capture.
 <10> The list of Kafka brokers that this connector will use to write and recover DDL statements to the database history topic.
 <11> The name of the database history topic where the connector will write and recover DDL statements. This topic is for internal use only and should not be used by consumers.
+
+endif::[]
+
+ifdef::cdc-product[]
+Following is an example of the configuration for a connector instance that monitors a SQL Server server at port 3306 on 192.168.99.100, which we logically name `fullfillment`.
+Typically, you configure the {prodname} SQL Server connector in a `.yaml` file using the configuration properties available for the connector.
+
+[source,yaml,options="nowrap"]
+----
+apiVersion: 
+  kind: SqlServerConnector
+  metadata:
+    name: inventory-connector  // <1>
+    labels:
+  spec:
+    class: io.debezium.connector.sqlserver.SqlServerConnector // <2>
+    config:  
+      database.hostname: 192.168.99.100  // <3>
+      database.port: 3306 //<4>
+      database.user: debezium  //<5>
+      database.password: dbz  //<6>
+      database.dbname: testDB  //<7>
+      database.server.name: fullfullment //<8>
+      database.whitelist: dbo.customers   //<9>
+      database.history.kafka.bootstrap.servers: my-cluster-kafka-bootstrap:9092  //<10> 
+      database.history.kafka.topic: dbhistory.fullfillment  //<11>
+
+----
+<1> The name of our connector when we register it with a Kafka Connect service.
+<2> The name of this SQL Server connector class.
+<3> The address of the SQL Server instance.
+<4> The port number of the SQL Server instance.
+<5> The name of the SQL Server user
+<6> The password for the SQL Server user
+<7> The name of the database to capture changes from.
+<8> The logical name of the SQL Server instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro Connector is used.
+<9> A list of all tables whose changes {prodname} should capture.
+<10> The list of Kafka brokers that this connector will use to write and recover DDL statements to the database history topic.
+<11> The name of the database history topic where the connector will write and recover DDL statements. This topic is for internal use only and should not be used by consumers.
+
+endif::[]
 
 See the link:#sqlserver-connector-properties[complete list of connector properties] that can be specified in these configurations.
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -124,7 +124,7 @@ endif::cdc-product[]
 [[how-the-connector-works]]
 == How the SQL Server connector works
 
-[[snapshots]]
+[[snapshots-sqlserver]]
 === Snapshots
 
 SQL Server CDC is not designed to store the complete history of database changes.
@@ -161,7 +161,7 @@ After a restart, the connector will resume from the offset (commit and change LS
 
 The connector is able to detect whether the CDC is enabled or disabled for whitelisted source table during the runtime and modify its behaviour.
 
-[[topic-names]]
+[[topic-names-sqlserver]]
 === Topic names
 
 The SQL Server connector writes events for all insert, update, and delete operations on a single table to a single Kafka topic. The name of the Kafka topics always takes the form _serverName_._schemaName_._tableName_, where _serverName_ is the logical name of the connector as specified with the `database.server.name` configuration property, _schemaName_ is the name of the schema where the operation occurred, and _tableName_ is the name of the database table on which the operation occurred.
@@ -179,7 +179,7 @@ The user-facing schema change topic is not implemented yet (see {jira-url}/brows
 
 === Events
 
-All data change events produced by the SQL Server connector have a key and a value, although the structure of the key and value depend on the table from which the change events originated (see link:#topic-names[Topic names]).
+All data change events produced by the SQL Server connector have a key and a value, although the structure of the key and value depend on the table from which the change events originated (see link:#topic-names-sqlserver[Topic names]).
 
 [WARNING]
 ====
@@ -1135,11 +1135,11 @@ Typically, you configure the {prodname} SQL Server connector in a `.yaml` file u
 
 [source,yaml,options="nowrap"]
 ----
-apiVersion: 
-  kind: SqlServerConnector
+apiVersion: kafka.strimzi.io/v1beta1 
+  kind: KafkaConnector
   metadata:
     name: inventory-connector  // <1>
-    labels:
+    labels: strimzi.io/cluster: my-connect-cluster
   spec:
     class: io.debezium.connector.sqlserver.SqlServerConnector // <2>
     config:  
@@ -1173,7 +1173,7 @@ See the link:#sqlserver-connector-properties[complete list of connector properti
 This configuration can be sent via POST to a running Kafka Connect service, which will then record the configuration and start up the one connector task that will connect to the SQL Server database, read the transaction log, and record events to Kafka topics.
 
 
-[[monitoring]]
+[[monitoring-sqlserver]]
 === Monitoring
 
 The {prodname} SQL Server connector has three metric types in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect have.
@@ -1185,7 +1185,7 @@ The {prodname} SQL Server connector has three metric types in addition to the bu
 Please refer to the xref:operations/monitoring.adoc[monitoring documentation] for details of how to expose these metrics via JMX.
 
 [[monitoring-snapshots]]
-[[snapshot-metrics]]
+[[snapshot-metrics-sqlserver]]
 ==== Snapshot Metrics
 
 The *MBean* is `debezium.sql_server:type=connector-metrics,context=snapshot,server=_<database.server.name>_`.
@@ -1193,7 +1193,7 @@ The *MBean* is `debezium.sql_server:type=connector-metrics,context=snapshot,serv
 include::{partialsdir}/modules/cdc-all-connectors/r_connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
 [[monitoring-streaming]]
-[[streaming-metrics]]
+[[streaming-metrics-sqlserver]]
 ==== Streaming Metrics
 
 The *MBean* is `debezium.sql_server:type=connector-metrics,context=streaming,server=_<database.server.name>_`.
@@ -1418,7 +1418,7 @@ The connector will read the table contents in multiple batches of this size. Def
 
 |`snapshot.lock.timeout.ms`
 |`10000`
-|An integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If table locks cannot be acquired in this time interval, the snapshot will fail (also see link:#snapshots[snapshots]). +
+|An integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If table locks cannot be acquired in this time interval, the snapshot will fail (also see link:#snapshots-sqlserver[snapshots]). +
 When set to `0` the connector will fail immediately when it cannot obtain the lock. Value `-1` indicates infinite waiting.
 
 |`snapshot.select.statement.overrides`

--- a/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/p_configure-the-mysql-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/p_configure-the-mysql-connector.adoc
@@ -3,17 +3,16 @@
 
 [id="configure-the-mysql-connector_{context}"]
 = Configuring the MySQL connector
-// Start the title of a procedure module with a verb, such as Creating or Create. See also _Wording of headings_ in _The IBM Style Guide_.
 
-Typically, you configure the {prodname} MySQL connector in a `JSON` file using the configuration properties available for the connector.
+ifndef::cdc-product[]
+Typically, you configure the {prodname} MySQL connector in a `.json` file using the configuration properties available for the connector.
 
 .Prerequisites
 * You should have completed the xref:install-the-mysql-connector_{context}[installation process] for the connector.
 
-
 .Procedure
 
-. Set the `"name"` of the connector in the JSON file.
+. Set the `"name"` of the connector in the `.json` file.
 . Set the configuration properties that you require for your {prodname} MySQL connector.
 
 TIP: For a complete list of configuration properties, see xref:mysql-connector-configuration-properties_{context}[MySQL connector configuration properties].
@@ -28,8 +27,8 @@ TIP: For a complete list of configuration properties, see xref:mysql-connector-c
     "connector.class": "io.debezium.connector.mysql.MySqlConnector", <2>
     "database.hostname": "192.168.99.100", <3>
     "database.port": "3306", <4>
-    "database.user": "{prodname}-user", <5>
-    "database.password": "thePassword", <6>
+    "database.user": "debezium-user", <5>
+    "database.password": "debezium-user-pw", <6>
     "database.server.id": "184054", <7>
     "database.server.name": "fullfillment", <8>
     "database.whitelist": "inventory", <9>
@@ -55,3 +54,64 @@ TIP: For a complete list of configuration properties, see xref:mysql-connector-c
 . A list of Kafka brokers that the connector uses to write and recover DDL statements to the database history topic.
 . The name of the database history topic.
 . The flag that specifies if the connector should generate on the schema change topic named `fulfillment` events with DDL changes that can be used by consumers.
+
+endif::[]
+ifdef::cdc-product[]
+
+Typically, you configure the {prodname} MySQL connector in a `.yaml` file using the configuration properties available for the connector.
+
+.Prerequisites
+* You should have completed the xref:install-the-mysql-connector_{context}[installation process] for the connector.
+
+.Procedure
+
+. Set the `"name"` of the connector in the `.yaml` file.
+
+. Set the configuration properties that you require for your {prodname} MySQL connector.
+
+TIP: For a complete list of configuration properties, see xref:mysql-connector-configuration-properties_{context}[MySQL connector configuration properties].
+
+.MySQL connector example configuration
+=========
+[source,yaml,options="nowrap"]
+----
+  apiVersion: kafka.strimzi.io/v1alpha1
+  kind: KafkaConnector
+  metadata:
+    name: inventory-connector  // <1>
+    labels:
+      strimzi.io/cluster: my-connect-cluster
+  spec:
+    class: io.debezium.connector.mysql.MySqlConnector
+    tasksMax: 1  // <2>
+    config:  // <3>
+      database.hostname: mysql  // <4>
+      database.port: 3306
+      database.user: debezium
+      database.password: dbz
+      database.server.id: 184054  // <5>
+      database.server.name: dbserver1  // <5>
+      database.whitelist: inventory  // <6>
+      database.history.kafka.bootstrap.servers: my-cluster-kafka-bootstrap:9092  // <7>
+      database.history.kafka.topic: schema-changes.inventory  // <7>
+----
+<1> The name of the connector.
+<2> Only one task should operate at any one time.
+Because the MySQL connector reads the MySQL server’s `binlog`,
+using a single connector task ensures proper order and event handling.
+The Kafka Connect service uses connectors to start one or more tasks that do the work,
+and it automatically distributes the running tasks across the cluster of Kafka Connect services.
+If any of the services stop or crash,
+those tasks will be redistributed to running services.
+<3> The connector’s configuration.
+<4> The database host, which is the name of the container running the MySQL server (`mysql`).
+<5> A unique server ID and name.
+The server name is the logical identifier for the MySQL server or cluster of servers.
+This name will be used as the prefix for all Kafka topics.
+<6> Only changes in the `inventory` database will be detected.
+<7> The connector will store the history of the database schemas in Kafka using this broker (the same broker to which you are sending events) and topic name.
+Upon restart, the connector will recover the schemas of the database that existed at the point in time in the `binlog` when the connector should begin reading.
+----
+=========
+
+endif::[]

--- a/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/p_install-the-mysql-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/p_install-the-mysql-connector.adoc
@@ -14,7 +14,7 @@ Installing the {prodname} MySQL connector is a simple process whereby you only n
 .Procedure
 
 ifdef::cdc-product[]
-. Download the {prodname} link:{mysql-connector-plugin-download}[MySQL connector plugin].
+. Download the {prodname} link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions[MySQL connector].
 endif::cdc-product[]
 ifndef::cdc-product[]
 ifeval::['{page-version}' == 'master']

--- a/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/r_mysql-connector-configuration-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/r_mysql-connector-configuration-properties.adoc
@@ -4,7 +4,7 @@
 [id="mysql-connector-configuration-properties_{context}"]
 = MySQL connector configuration properties
 
-The configuration properties listed here are *required* to run the {prodname} MySQL connector. There are also <<advanced-mysql-connector-properties, advanced MySQL connector properties>> whose default value rarely need changed and therefore, specified in the connector configuration.
+The configuration properties listed here are *required* to run the {prodname} MySQL connector. There are also <<advanced-mysql-connector-properties, advanced MySQL connector properties>> whose default value rarely needs to be changed and therefore, they do not need to be specified in the connector configuration.
 
 TIP: The {prodname} MySQL connector supports _pass-through_ configuration when creating the Kafka producer and consumer. See link:{link-kafka-docs}.html[the Kafka documentation] for more details on _pass-through_ properties.
 

--- a/documentation/modules/ROOT/partials/modules/monitoring/c_metrics-monitoring-connectors.adoc
+++ b/documentation/modules/ROOT/partials/modules/monitoring/c_metrics-monitoring-connectors.adoc
@@ -8,7 +8,7 @@ each connector provides additional metrics that you can use to monitor their act
 * {link-prefix}:{link-mysql-connector}#mysql-connector-monitoring-metrics_{context}[MySQL connector metrics]
 * {link-prefix}:{link-mongodb-connector}#mongodb-connector-monitoring[MongoDB connector metrics]
 * {link-prefix}:{link-postgresql-connector}#monitoring[PosgreSQL connector metrics]
-* {link-prefix}:{link-sqlserver-connector}#monitoring[SQL Server connector metrics]
+* {link-prefix}:{link-sqlserver-connector}#monitoring-sqlserver[SQL Server connector metrics]
 ifndef::cdc-product[]
 * {link-prefix}:{link-oracle-connector}#monitoring[Oracle connector metrics]
 * {link-prefix}:{link-db2-connector}#monitoring[Db2 connector metrics]

--- a/documentation/modules/ROOT/partials/modules/monitoring/c_metrics-monitoring-connectors.adoc
+++ b/documentation/modules/ROOT/partials/modules/monitoring/c_metrics-monitoring-connectors.adoc
@@ -2,8 +2,10 @@
 [id="metrics-monitoring-connectors"]
 = Metrics for monitoring {prodname} connectors
 
-In addition to the built-in support for JMX metrics in Kafka, Zookeeper, and Kafka Connect,
-each connector provides additional metrics that you can use to monitor their activities.
+In addition to the built-in support for JMX metrics in Kafka, 
+Zookeeper, and Kafka Connect,
+each connector provides additional metrics that you can 
+use to monitor their activities.
 
 * {link-prefix}:{link-mysql-connector}#mysql-connector-monitoring-metrics_{context}[MySQL connector metrics]
 * {link-prefix}:{link-mongodb-connector}#mongodb-connector-monitoring[MongoDB connector metrics]

--- a/documentation/modules/ROOT/partials/modules/monitoring/c_metrics-monitoring-connectors.adoc
+++ b/documentation/modules/ROOT/partials/modules/monitoring/c_metrics-monitoring-connectors.adoc
@@ -2,10 +2,8 @@
 [id="metrics-monitoring-connectors"]
 = Metrics for monitoring {prodname} connectors
 
-In addition to the built-in support for JMX metrics in Kafka, 
-Zookeeper, and Kafka Connect,
-each connector provides additional metrics that you can 
-use to monitor their activities.
+In addition to the built-in support for JMX metrics in Kafka, Zookeeper, and Kafka Connect,
+each connector provides additional metrics that you can use to monitor their activities.
 
 * {link-prefix}:{link-mysql-connector}#mysql-connector-monitoring-metrics_{context}[MySQL connector metrics]
 * {link-prefix}:{link-mongodb-connector}#mongodb-connector-monitoring[MongoDB connector metrics]


### PR DESCRIPTION
@Naros  -  This is a re-do of the PR that was merged. 
In this PR, please fill in the missing information in the .yaml configuration examples for the MongoDB, PostgreSQL, and SQL Server connectors. Those examples are missing the apiVersion specification in their first lines. They might also be missing other data. I used the MySQL .yaml config sample to create the .yaml examples for the other connectors.  I copied the .yaml config example for MySQL from the tutorial so that one should be complete and correct. 

For the AsciiDoc files that contain the connector information, when the .yaml configurations are complete, those files are ready to merge. 

In the r_mysql-connector-configuration-properties.adoc file, please review my update to the sentence that was broken. I was guessing. It be right or wrong now, but what was previously there did not make sense. 

The unnecessary commit so Antora would work is still present. Sorry, I don't know how to revert that. 

After updates are in place and this is merged, I would really appreciate it if you would backport it to 1.0 and 1.1. Thanks!