### PR TITLE
DBZ-2038 Refactor Postgres TypeRegistry

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresType.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresType.java
@@ -279,6 +279,10 @@ public class PostgresType {
             return this;
         }
 
+        public boolean hasParentType() {
+            return this.parentTypeOid != 0;
+        }
+
         public Builder elementType(int elementTypeOid) {
             this.elementTypeOid = elementTypeOid;
             return this;
@@ -291,7 +295,7 @@ public class PostgresType {
 
         public PostgresType build() {
             PostgresType parentType = null;
-            if (parentTypeOid != 0) {
+            if (this.hasParentType()) {
                 parentType = typeRegistry.get(parentTypeOid);
             }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -63,13 +63,9 @@ public class TypeRegistry {
             + "FROM pg_catalog.pg_type t JOIN pg_catalog.pg_namespace n ON (t.typnamespace = n.oid) "
             + "WHERE n.nspname != 'pg_toast'";
 
-    private static final String SQL_NAME_LOOKUP = "SELECT t.oid as oid, t.typname AS name, t.typelem AS element, t.typbasetype AS parentoid, t.typtypmod AS modifiers, t.typcategory as category "
-            + "FROM pg_catalog.pg_type t JOIN pg_catalog.pg_namespace n ON (t.typnamespace = n.oid) "
-            + "WHERE n.nspname != 'pg_toast' AND t.typname = ?";
+    private static final String SQL_NAME_LOOKUP = SQL_TYPES + " AND t.typname = ?";
 
-    private static final String SQL_OID_LOOKUP = "SELECT t.oid as oid, t.typname AS name, t.typelem AS element, t.typbasetype AS parentoid, t.typtypmod AS modifiers, t.typcategory as category "
-            + "FROM pg_catalog.pg_type t JOIN pg_catalog.pg_namespace n ON (t.typnamespace = n.oid) "
-            + "WHERE n.nspname != 'pg_toast' AND t.oid = ?";
+    private static final String SQL_OID_LOOKUP = SQL_TYPES + " AND t.oid = ?";
 
     private static final String SQL_ENUM_VALUES_LOOKUP = "select t.enumlabel as enum_value "
             + "FROM pg_catalog.pg_enum t "


### PR DESCRIPTION
This attempts to factor out a lot of duplicated logic that I noticed when working on my last PR. There is currently a lot of logic duplicated when querying for array vs non-array types. There's also a lot of duplicated logic when priming the initial type registry vs resolving an unknown type later. These changes try to consolidate all of that and have the added benefit of producing fewer queries to Postgres.

https://issues.redhat.com/browse/DBZ-2038