### PR TITLE
DBZ-2047: Add 'flush table' alias to MySQL grammar

### DIFF
--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -1799,6 +1799,7 @@ flushOption
        )                                                            #simpleFlushOption
     | RELAY LOGS channelOption?                                     #channelFlushOption
     | TABLES tables flushTableOption?                               #tableFlushOption
+    | TABLE tables flushTableOption?                                #tableFlushOption
     ;
 
 flushTableOption

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_flush.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_flush.sql
@@ -1,0 +1,19 @@
+-- With our without binlog
+flush no_write_to_binlog hosts;
+flush local hosts;
+flush hosts, status;
+
+-- Table flushing
+flush local tables Foo;
+flush tables Foo, Bar;
+flush tables Foo, Bar for export;
+flush tables Foo, Bar with read lock;
+
+-- 'FLUSH TABLE' is an alias for 'FLUSH TABLES' (https://dev.mysql.com/doc/refman/8.0/en/flush.html)
+flush local table Foo;
+flush TABLE Foo, Bar;
+flush table Foo, Bar for export;
+flush table Foo, Bar with read lock;
+
+
+


### PR DESCRIPTION
According to MySQL docs - `FLUSH TABLE` is an alias for `FLUSH TABLES`. This patch adds that alias together with some test-cases.