### PR TITLE
DBZ-2062 allowing compression keyword to contain backticks in create table for MariaDB

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -942,14 +942,20 @@ public class MySqlAntlrDdlParserTest {
                 + " c1 INTEGER NOT NULL, " + System.lineSeparator()
                 + " c2 VARCHAR(22) " + System.lineSeparator()
                 + ") engine=Aria;";
-        parser.parse(ddl1 + ddl2 + ddl3, tables);
-        assertThat(tables.size()).isEqualTo(3);
+        String ddl4 = "CREATE TABLE escaped_foo ( " + System.lineSeparator()
+                + " c1 INTEGER NOT NULL, " + System.lineSeparator()
+                + " c2 VARCHAR(22) " + System.lineSeparator()
+                + ") engine=TokuDB `compression`=tokudb_zlib;";
+        parser.parse(ddl1 + ddl2 + ddl3 + ddl4, tables);
+        assertThat(tables.size()).isEqualTo(4);
         listener.assertNext().createTableNamed("foo").ddlStartsWith("CREATE TABLE foo (");
         listener.assertNext().createTableNamed("bar").ddlStartsWith("CREATE TABLE bar (");
         listener.assertNext().createTableNamed("baz").ddlStartsWith("CREATE TABLE baz (");
+        listener.assertNext().createTableNamed("escaped_foo").ddlStartsWith("CREATE TABLE escaped_foo (");
         parser.parse("DROP TABLE foo", tables);
         parser.parse("DROP TABLE bar", tables);
         parser.parse("DROP TABLE baz", tables);
+        parser.parse("DROP TABLE escaped_foo", tables);
         assertThat(tables.size()).isEqualTo(0);
     }
 

--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlLexer.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlLexer.g4
@@ -363,7 +363,7 @@ COMMIT:                              'COMMIT';
 COMPACT:                             'COMPACT';
 COMPLETION:                          'COMPLETION';
 COMPRESSED:                          'COMPRESSED';
-COMPRESSION:                         'COMPRESSION';
+COMPRESSION:                         QUOTE_SYMB? 'COMPRESSION' QUOTE_SYMB?;
 CONCURRENT:                          'CONCURRENT';
 CONNECTION:                          'CONNECTION';
 CONSISTENT:                          'CONSISTENT';


### PR DESCRIPTION
Debezium will currently throw an error if a table is created with the syntax below which is completely valid:

```CREATE TABLE foo ( c1 INTEGER NOT NULL ) engine=TokuDB `compression`=tokudb_zlib;```

This would **not** throw an error however

```CREATE TABLE foo ( c1 INTEGER NOT NULL ) engine=TokuDB compression=tokudb_zlib;```

This PR addresses the issue described above, however I'm not extremely familiar with ANTLR so if there's a better way to accomplish this, please let me know and I will make updates. Thanks!