### PR TITLE
DBZ-2021 Updated doc for 1.1 SMTs for topic routing and event flattening

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -15,6 +15,7 @@ asciidoc:
     modules: '../../modules'
     mysql-version: '8.0'
     strimzi-version: '0.13.0'
+    community: 
     link-prefix: 'xref'
     link-avro-serialization: 'configuration/avro.adoc'
     link-mysql-connector: 'connectors/mysql.adoc'

--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -15,9 +15,11 @@ asciidoc:
     modules: '../../modules'
     mysql-version: '8.0'
     strimzi-version: '0.13.0'
-    community: 
+    community: true
     link-prefix: 'xref'
     link-avro-serialization: 'configuration/avro.adoc'
+    link-event-flattening: 'configuration/event-flattening.adoc'
+    link-topic-routing: 'configuration/topic-routing.adoc'
     link-mysql-connector: 'connectors/mysql.adoc'
     link-mongodb-connector: 'connectors/mongodb.adoc'
     link-postgresql-connector: 'connectors/postgresql.adoc'

--- a/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
@@ -1,3 +1,10 @@
+// Category: cdc-using
+// Type: assembly
+// :community:
+:product:
+
+ifdef::community[]
+[id="new-record-state-extraction"]
 = New Record State Extraction
 include::../_attributes.adoc[]
 :toc:
@@ -10,18 +17,56 @@ toc::[]
 
 [NOTE]
 ====
-This SMT is supported only for the SQL database connectors, it does not work with the MongoDB connector.
-See xref:configuration/mongodb-event-flattening.adoc[here] for the MongoDB equivalent to this SMT.
+This single message transformation (SMT) is supported for only the SQL database connectors. For the MongoDB connector, see the xref:configuration/mongodb-event-flattening.adoc[documentation for the MongoDB equivalent to this SMT].
 ====
+endif::community[]
 
-Debezium generates data change events in a form of a complex message structure.
+ifdef::product[]
+[id="extracting-source-record-after-state-from-debezium-change-events"]
+= Extracting source record `after` state from Debezium change events
+endif::product[]
+
+A Debezium database change event has a complex structure that provides a wealth of information. Kafka records that convey Debezium change events contain all of this information. 
+However, parts of a Kafka ecosystem expect Kafka records that provide a flat structure of field names and values. 
+To provide this kind of record, Debezium provides the `ExtractNewRecordState` single message transformation (SMT). Configure this transformation when consumers need Kafka records that have a format that is simpler than Kafka records that contain Debezium change events. 
+
+The `ExtractNewRecordState` transformation is a 
+link:https://kafka.apache.org/documentation/#connect_transforms[Kafka Connect SMT].
+
+ifdef::product[]
+The transformation is available to only SQL database connectors. 
+
+The following topics provide details: 
+
+* xref:description-of-debezium-change-event-structure[]
+* xref:behavior-of-debezium-extractnewrecordstate-transformation[]
+* xref:configuration-of-extractnewrecordstate-transformation[]
+* xref:example-of-adding-metadata-to-the-kafka-record-or-its-header[]
+* xref:options-for-configuring-extractnewrecordstate-transformation[]
+
+// Type: concept
+[id="description-of-debezium-change-event-structure"]
+== Description of Debezium change event structure
+endif::product[]
+
+ifdef::community[]
+== Change event structure
+endif::community[]
+
+Debezium generates database change events that have a complex structure.
 Each event consists of three parts:
 
-* metadata, comprising the type of operation, information on the event source, a timestamp, and optionally transaction information
-* the row data before change
-* the row data after change
+* Metadata, which includes but is not limited to:
 
-E.g. the general message structure for an `update` change looks like this:
+** The operation that made the change 
+** Source information such as the names of the database and table where the change was made
+** Time stamp for when the change was made
+** Optional transaction information
+
+* Row data before the change
+* Row data after the change
+
+For example, the structure of an `UPDATE` change event looks like this:
 
 [source,json,indent=0]
 ----
@@ -42,10 +87,13 @@ E.g. the general message structure for an `update` change looks like this:
 }
 ----
 
-More details about the message structure are provided in xref:connectors/index.adoc[the documentation for each connector].
+ifdef::community[]
+More details about change event structure are provided in 
+xref:connectors/index.adoc[the documentation for each connector].
+endif::community[]
 
-This format allows the user to get most information about changes happening in the system.
-The downside of using the complex format is that other connectors or other parts of the Kafka ecosystem usually expect the data in a simple message format that can generally be described like so:
+This complex format provides the most information about changes happening in the system.
+However, other connectors or other parts of the Kafka ecosystem usually expect the data in a simple format like this: 
 
 [source,json,indent=0]
 ----
@@ -55,22 +103,62 @@ The downside of using the complex format is that other connectors or other parts
 }
 ----
 
-Debezium provides {link-kafka-docs}/#connect_transforms[a single message transformation] that crosses the bridge between the complex and simple formats, the https://github.com/debezium/debezium/blob/master/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java[ExtractNewRecordState] SMT.
+To provide the needed Kafka record format for consumers, configure the `ExtractNewRecordState` SMT.
 
-The SMT provides three main functions.
-It
+ifdef::community[]
+== Behavior
+endif::community[]
 
-* extracts the `after` field from change events and replaces the original event just with this part
-* optionally filters delete and tombstone records, as per the capabilities and requirements of downstream consumers
-* optionally adds metadata fields from the change event to the outgoing flattened record
-* optionally add metadata fields to the header
+ifdef::product[]
+// Type: concept
+[id="behavior-of-debezium-extractnewrecordstate-transformation"]
+== Behavior of Debezium `ExtractNewRecordState` transformation
+endif::product[]
 
-The SMT can be applied either to a source connector (Debezium) or a sink connector.
-We generally recommend to apply the transformation on the sink side as it means that the messages stored in Apache Kafka will contain the whole context.
-The final decision depends on use case for each user.
+link:https://github.com/debezium/debezium/blob/master/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java[The `ExtractNewRecordState` SMT] extracts the `after` field from a Debezium change event in a Kafka record. The SMT replaces the original change event with only its `after` field to create a simple Kafka record. 
 
+You can configure the `ExtractNewRecordState` SMT for a Debezium connector, that is, for a source connector, or for a sink connector. The advantage of configuring `ExtractNewRecordState` for a sink connector is that records stored in Apache Kafka contain whole Debezium change events. The decision to apply the SMT to a source or sink connector depends on your particular use case. 
+
+You can configure the transformation to do either or both of the following: 
+
+* Add metadata from the change event to the simplified Kafka record or header.
+
+* Pass Kafka records that contain change events for `DELETE` operations to consumers. 
+
+The default behavior is that the transformation drops Kafka records for `DELETE` operation change events because most consumers cannot yet handle them. A database `DELETE` operation causes Debezium to generate two Kafka records: 
+
+* A record that contains `"op": "d",` and the `before` row data.
+* A tombstone record that has the same key as the deleted row and a value of `null`. This record is a marker for Apache Kafka. It indicates that 
+link:https://kafka.apache.org/documentation/#compaction[log compaction] can remove all records that have this key. 
+
+Instead of dropping the record that contains the `before` row data, you can configure the `ExtractNewRecordData` SMT to do one of the following: 
+
+* Pass the record as is.
+* Convert the record into another tombstone record and pass it on. 
+
+Similary, instead of dropping the tombstone record, you can configure the `ExtractNewRecordData` SMT to pass the tombstone record along. 
+
+ifdef::community[]
 == Configuration
-The configuration is a part of source/sink task connector and is expressed in a set of properties:
+endif::community[]
+
+ifdef::product[]
+// Type: concept
+[id="configuration-of-extractnewrecordstate-transformation"]
+== Configuration of `ExtractNewRecordState` transformation
+endif::product[]
+
+Configure the Debezium `ExtractNewRecordState` SMT in a Kafka Connect source or sink connector `.properties` file. To obtain the default behavior, specify something like the following: 
+
+[source]
+----
+transforms=unwrap,...
+transforms.unwrap.type=io.debezium.transforms.ExtractNewRecordState
+----
+
+As in any Kafka Connect connector `.properties` file, you can set `transforms=` to multiple, comma-separated, SMT aliases in the order in which you want Kafka Connect  to apply the SMTs. 
+
+To pass tombstone records for `DELETE` operations and also add metadata to the simplified Kafka record, specify something like this: 
 
 [source]
 ----
@@ -78,91 +166,165 @@ transforms=unwrap,...
 transforms.unwrap.type=io.debezium.transforms.ExtractNewRecordState
 transforms.unwrap.drop.tombstones=false
 transforms.unwrap.delete.handling.mode=rewrite
-transforms.unwrap.add.source.fields=table,lsn
+transforms.unwrap.add.fields=table,lsn
 ----
 
-=== Record filtering for delete records
+`drop-tombstones=false`:: Keeps tombstone records for `DELETE` operations in the event stream. 
 
-The SMT provides a special handling for events that signal a `delete` operation.
-When a `DELETE` is executed on a datasource then Debezium generates two events:
+`delete-handling-mode=rewrite`:: Adds metadata for `DELETE` operations to the simplified Kafka record. 
 
-* a record with `d` operation that contains only old row data
-* (optionally) a record with `null` value and the same key (a "tombstone" message). This record serves as a marker for Apache Kafka that all messages with this key can be removed from the topic during {link-kafka-docs}/#compaction[log compaction].
+`add.fields=table,lsn`:: Adds change event metadata for the `table` and `lsn` fields to the simplified Kafka record. 
 
-Upon processing these two records, the SMT can pass on the `d` record as is,
-convert it into another tombstone record or drop it.
-The original tombstone message can be passed on as is or also be dropped.
+ifdef::community[]
+== Adding metadata
+endif::community[]
+ 
+ifdef::product[]
+// Type: concept
+[id="example-of-adding-metadata-to-the-kafka-record-or-its-header"]
+== Example of adding metadata to the Kafka record or its header
+endif::product[]
 
-[NOTE]
-====
-The SMT by default filters out *both* delete records as widely used sink connectors do not support handling of tombstone messages at this point.
-====
+The `ExtractNewRecordState` SMT can add original, change event metadata to the simplified Kafka record or its header. For example, you might want the simplified record or its header to contain any of the following: 
 
-=== Adding metadata fields to the message
+* The type of operation that made the change
+* The name of the database or table that was changed
+* Connector-specific fields such as the Postgres LSN field
 
-The SMT can optionally add metadata fields from the original change event to the final flattened record. This functionality can be used to add things like the operation or the table from the change event, or connector-specific fields like the Postgres LSN field. For more information on what's available see xref:connectors/index.adoc[the documentation for each connector].
+ifdef::community[]
+For more information on what is available see xref:connectors/index.adoc[the documentation for each connector].
+endif::community[]
 
-In case of duplicate field names (e.g. "ts_ms" exists twice), the struct should be specified to get the correct field (e.g. "source.ts_ms"). The fields will be prefixed with "\\__" or "__<struct>_", depending on the specification of the struct. Please use a comma separated list without spaces.
-
-For example, the configuration
+To add metadata to the simplified Kafka record, specify the `add.fields` option. 
+To add metadata to the header of the simplified Kafka record, specify the `add.header` option. Each of these options takes a comma separated list of change event field names. Do not specify spaces. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field. For example:
 
 ----
 transforms=unwrap,...
 transforms.unwrap.type=io.debezium.transforms.ExtractNewRecordState
 transforms.unwrap.add.fields=op,table,lsn,source.ts_ms
+transforms.unwrap.add.headers=db
+transforms.unwrap.delete.handling.mode=rewrite
 ----
 
-will add
+With that configuration, a simplified Kafka record would contain something like the following: 
 
 ----
 { "__op" : "c", __table": "MY_TABLE", "__lsn": "123456789", "__source_ts_ms" : "123456789", ...}
 ----
 
-to the final flattened record.
+Also, simplified Kafka records would have a `__db` header. 
 
-For `DELETE` events, this option is only supported when the <<configuration-option-delete-handling-mode, `delete.handling.mode`>> option is set to "rewrite".
+In the simplified Kafka record, the SMT prefixes the metadata field names with a double underscore. When you specify a struct, the SMT also inserts an underscore between the struct name and the field name. 
 
-=== Adding metadata fields to the header
+To add metadata from a `DELETE` change event, you must also configure the `delete.handling.mode` option with a setting of `rewrite`.
 
-The SMT can optionally add metadata fields from the original change event to the header of the final flattened record. This functionality can be used to add things like the operation or the table from the change event, or connector-specific fields like the Postgres LSN field. For more information on what's available see xref:connectors/index.adoc[the documentation for each connector].
+ifdef::community[]
+// Do not include deprecated content in downstream doc
+== Determine original operation  [DEPRECATED]
 
-In case of duplicate field names (e.g. "ts_ms" exists twice), the struct should be specified to get the correct field (e.g. "source.ts_ms"). The fields will be prefixed with "\\__" or "__<struct>_", depending on the specification of the struct. Please use a comma separated list without spaces.
+_The `operation.header` option is deprecated and scheduled for removal. Please use add.headers instead. If both add.headers and operation.header are specified, the latter will be ignored._
+
+When a Kafka record is flattened the final result won't show whether it was an insert, update or first read
+(deletions can be detected via tombstones or rewrites, see link:#options-for-configuring-extractnewrecordstate-transformation[Configuration options]).
+
+To solve this problem Debezium offers an option to propagate the original operation via a header added to the Kafka record.
+To enable this feature the option `operation.header` must be set to `true`.
+
+[source]
+----
+transforms=unwrap,...
+transforms.unwrap.type=io.debezium.transforms.ExtractNewRecordState
+transforms.unwrap.operation.header=true
+----
+
+The possible values are the ones from the `op` field of the original change event.
+endif::community[]
+
+ifdef::community[]
+// Do not include deprecated content in downstream doc
+== Adding source metadata fields [DEPRECATED]
+
+_The `add.source.fields` option is deprecated and scheduled for removal. Please use add.fields instead. If both add.fields and add.source.fields are specified, the latter will be ignored._
+
+The SMT can optionally add metadata fields from the original change event's `source` structure to the final flattened record (prefixed with "__"). This functionality can be used to add things like the table from the change event, or connector-specific fields like the Postgres LSN field. For more information on what's available in the source structure see xref:connectors/index.adoc[the documentation for each connector].
 
 For example, the configuration
 
 ----
 transforms=unwrap,...
 transforms.unwrap.type=io.debezium.transforms.ExtractNewRecordState
-transforms.unwrap.add.headers=op,table,lsn,source.ts_ms
+transforms.unwrap.add.source.fields=table,lsn
 ----
 
-will add headers `__op`, `__table`, `__lsn` and `__source_ts_ms` to the outgoing record.
+will add
 
-[[configuration_options]]
+----
+{ "__table": "MY_TABLE", "__lsn": "123456789", ...}
+----
+
+to the final flattened record.
+
+For `DELETE` events, this option is only supported when the `delete.handling.mode` option is set to "rewrite".
+
 == Configuration options
-[cols="35%a,10%a,55%a"]
+
+endif::community[]
+
+ifdef::product[]
+// Type: reference
+[id="options-for-configuring-extractnewrecordstate-transformation"]
+== Options for configuring `ExtractNewRecordState` transformation
+endif::product[]
+
+The following table describes the options that you can specify for the `ExtractNewRecordState` SMT. 
+
+[cols="35%a,10%a,55%a",options="header"]
 |===
-|Property |Default |Description
+|Property
+|Default
+|Description
 
 |[[configuration-option-drop-tombstones]]<<configuration-option-drop-tombstones, `drop.tombstones`>>
 |`true`
-|The SMT removes the tombstone generated by Debezium from the stream.
+|Debezium generates a tombstone record for each `DELETE` operation. The default behavior is that `ExtractNewRecordState` removes tombstone records from the stream. To keep tombstone records in the stream, specify `drop.tombstones=false`.  
 
 |[[configuration-option-delete-handling-mode]]<<configuration-option-delete-handling-mode, `delete.handling.mode`>>
 |`drop`
-|The SMT can `drop` (the default), `rewrite` or pass delete events (`none`). The rewrite mode will add a `__deleted` column with true/false values based on record operation.
-
+|Debezium generates a change event record for each `DELETE` operation. The default behavior is that `ExtractNewRecordState` removes these records from the stream. To keep Kafka records for `DELETE` operations in the stream, set `delete.handling.mode` to `none` or `rewrite`. +
+ +
+Specify `none` to keep this change event record in the stream as it is. + 
+ +
+Specify `rewrite` to keep this change event record in the stream and also add a `__deleted` field set to `true` to the change event record. 
 
 |[[configuration-option-route-by-field]]<<configuration-option-route-by-field, `route.by.field`>>
 |
-|The column which determines how the events will be routed, the value will the topic name; obtained from the old record state for delete events, and from the new record state otherwise
+|The column that determines how the events will be routed. The value is a topic name obtained from the `after` state. For `DELETE` operations, the value is obtained from the `before` record state.
 
 |[[configuration-option-add-fields]]<<configuration-option-add-fields, `add.fields`>>
 |
-|Specify a list of metadata fields to add to the flattened message. In case of duplicate field names (e.g. "ts_ms" exists twice), the struct should be specified to get the correct field (e.g. "source.ts_ms"). The fields will be prefixed with "\\__" or "__<struct>__", depending on the specification of the struct. Please use a comma separated list without spaces.
+|Set this option to a comma-separated list, with no spaces, of metadata fields to add to the simplified Kafka record. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
+ +
+ When the SMT adds metadata fields to the simplified record, it prefixes each metadata field name with a double underscore. For a struct specification, the SMT also inserts an underscore between the struct name and the field name. 
 
 |[[configuration-option-add-headers]]<<configuration-option-add-headers, `add.headers`>>
 |
-|Specify a list of metadata fields to add to the header of the flattened message. In case of duplicate field names (e.g. "ts_ms" exists twice), the struct should be specified to get the correct field (e.g. "source.ts_ms"). The fields will be prefixed with "\\__" or "__<struct>__", depending on the specification of the struct. Please use a comma separated list without spaces.
+|Set this option to a comma-separated list, with no spaces, of metadata fields to add to the header of the simplified Kafka record. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
+ +
+ When the SMT adds metadata fields to the simplified record's header, it prefixes each metadata field name with a double underscore. For a struct specification, the SMT also inserts an underscore between the struct name and the field name. 
 
+ifdef::community[]
+// Do not include deprecated content in downstream doc
+|`operation.header` DEPRECATED
+|`false`
+|_This option is deprecated and scheduled for removal. Please use add.headers instead. If both add.headers and operation.header are specified, the latter will be ignored._
+
+The SMT adds the event operation (as obtained from the `op` field of the original record) as a Kafka record header.
+
+// Do not include deprecated content in downstream doc
+|`add.source.fields` DEPRECATED
+|
+|_This option is deprecated and scheduled for removal. Please use add.fields instead. If both add.fields and add.source.fields are specified, the latter will be ignored._
+
+Fields from the change event's `source` structure to add as metadata (prefixed with "__") to the flattened record.
+endif::community[]
 |===

--- a/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
@@ -4,7 +4,6 @@
 ifdef::community[]
 [id="new-record-state-extraction"]
 = New Record State Extraction
-include::../_attributes.adoc[]
 :toc:
 :toc-placement: macro
 :linkattrs:
@@ -21,12 +20,12 @@ endif::community[]
 
 ifdef::product[]
 [id="extracting-source-record-after-state-from-debezium-change-events"]
-= Extracting source record `after` state from Debezium change events
+= Extracting source record `after` state from {prodname} change events
 endif::product[]
 
-A Debezium database change event has a complex structure that provides a wealth of information. Kafka records that convey Debezium change events contain all of this information. 
+A {prodname} database change event has a complex structure that provides a wealth of information. Kafka records that convey {prodname} change events contain all of this information. 
 However, parts of a Kafka ecosystem expect Kafka records that provide a flat structure of field names and values. 
-To provide this kind of record, Debezium provides the `ExtractNewRecordState` single message transformation (SMT). Configure this transformation when consumers need Kafka records that have a format that is simpler than Kafka records that contain Debezium change events. 
+To provide this kind of record, {prodname} provides the `ExtractNewRecordState` single message transformation (SMT). Configure this transformation when consumers need Kafka records that have a format that is simpler than Kafka records that contain {prodname} change events. 
 
 The `ExtractNewRecordState` transformation is a 
 link:https://kafka.apache.org/documentation/#connect_transforms[Kafka Connect SMT].
@@ -44,14 +43,14 @@ The following topics provide details:
 
 // Type: concept
 [id="description-of-debezium-change-event-structure"]
-== Description of Debezium change event structure
+== Description of {prodname} change event structure
 endif::product[]
 
 ifdef::community[]
 == Change event structure
 endif::community[]
 
-Debezium generates database change events that have a complex structure.
+{prodname} generates database change events that have a complex structure.
 Each event consists of three parts:
 
 * Metadata, which includes but is not limited to:
@@ -110,12 +109,12 @@ endif::community[]
 ifdef::product[]
 // Type: concept
 [id="behavior-of-debezium-extractnewrecordstate-transformation"]
-== Behavior of Debezium `ExtractNewRecordState` transformation
+== Behavior of {prodname} `ExtractNewRecordState` transformation
 endif::product[]
 
-link:https://github.com/debezium/debezium/blob/master/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java[The `ExtractNewRecordState` SMT] extracts the `after` field from a Debezium change event in a Kafka record. The SMT replaces the original change event with only its `after` field to create a simple Kafka record. 
+link:https://github.com/debezium/debezium/blob/master/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java[The `ExtractNewRecordState` SMT] extracts the `after` field from a {prodname} change event in a Kafka record. The SMT replaces the original change event with only its `after` field to create a simple Kafka record. 
 
-You can configure the `ExtractNewRecordState` SMT for a Debezium connector, that is, for a source connector, or for a sink connector. The advantage of configuring `ExtractNewRecordState` for a sink connector is that records stored in Apache Kafka contain whole Debezium change events. The decision to apply the SMT to a source or sink connector depends on your particular use case. 
+You can configure the `ExtractNewRecordState` SMT for a {prodname} connector or for a sink connector that consumes messages emitted by a {prodname} connector. The advantage of configuring `ExtractNewRecordState` for a sink connector is that records stored in Apache Kafka contain whole {prodname} change events. The decision to apply the SMT to a source or sink connector depends on your particular use case. 
 
 You can configure the transformation to do any of the following: 
 
@@ -123,7 +122,7 @@ You can configure the transformation to do any of the following:
 
 * Keep Kafka records that contain change events for `DELETE` operations in the stream. The default behavior is that the SMT drops Kafka records for `DELETE` operation change events because most consumers cannot yet handle them. 
 
-A database `DELETE` operation causes Debezium to generate two Kafka records: 
+A database `DELETE` operation causes {prodname} to generate two Kafka records: 
 
 * A record that contains `"op": "d",` the `before` row data, and some other fields.
 * A tombstone record that has the same key as the deleted row and a value of `null`. This record is a marker for Apache Kafka. It indicates that 
@@ -147,7 +146,7 @@ ifdef::product[]
 == Configuration of `ExtractNewRecordState` transformation
 endif::product[]
 
-Configure the Debezium `ExtractNewRecordState` SMT in a Kafka Connect source or sink connector `.properties` file. To obtain the default behavior, specify something like the following: 
+Configure the {prodname} `ExtractNewRecordState` SMT in a Kafka Connect source or sink connector `.properties` file. To obtain the default behavior, specify something like the following: 
 
 [source]
 ----
@@ -223,7 +222,7 @@ Also, simplified Kafka records would have a `__db` header.
 
 In the simplified Kafka record, the SMT prefixes the metadata field names with a double underscore. When you specify a struct, the SMT also inserts an underscore between the struct name and the field name. 
 
-To add metadat to a simplified Kafka record that is for a `DELETE` operation, you must also configure `delete.handling.mode=rewrite`.
+To add metadata to a simplified Kafka record that is for a `DELETE` operation, you must also configure `delete.handling.mode=rewrite`.
 
 ifdef::community[]
 // Do not include deprecated content in downstream doc
@@ -234,7 +233,7 @@ _The `operation.header` option is deprecated and scheduled for removal. Please u
 When a Kafka record is flattened the final result won't show whether it was an insert, update or first read
 (deletions can be detected via tombstones or rewrites, see link:#options-for-configuring-extractnewrecordstate-transformation[Configuration options]).
 
-To solve this problem Debezium offers an option to propagate the original operation via a header added to the Kafka record.
+To solve this problem {prodname} offers an option to propagate the original operation via a header added to the Kafka record.
 To enable this feature the option `operation.header` must be set to `true`.
 
 [source]
@@ -285,35 +284,39 @@ endif::product[]
 
 The following table describes the options that you can specify for the `ExtractNewRecordState` SMT. 
 
-[cols="35%a,10%a,55%a",options="header"]
+[cols="35%a,10%a,55%a"]
 |===
 |Property
 |Default
 |Description
 
-|[[configuration-option-drop-tombstones]]<<configuration-option-drop-tombstones, `drop.tombstones`>>
+[id="configuration-option-drop-tombstones"]
+|{link-prefix}:{link-event-flattening}#configuration-option-drop-tombstones[`drop.tombstones`]
 |`true`
-|Debezium generates a tombstone record for each `DELETE` operation. The default behavior is that `ExtractNewRecordState` removes tombstone records from the stream. To keep tombstone records in the stream, specify `drop.tombstones=false`.  
+|{prodname} generates a tombstone record for each `DELETE` operation. The default behavior is that `ExtractNewRecordState` removes tombstone records from the stream. To keep tombstone records in the stream, specify `drop.tombstones=false`.  
 
-|[[configuration-option-delete-handling-mode]]<<configuration-option-delete-handling-mode, `delete.handling.mode`>>
+[id="configuration-option-delete-handling-mode"]
+|{link-prefix}:{link-event-flattening}#configuration-option-delete-handling-mode[`delete.handling.mode`]
 |`drop`
-|Debezium generates a change event record for each `DELETE` operation. The default behavior is that `ExtractNewRecordState` removes these records from the stream. To keep Kafka records for `DELETE` operations in the stream, set `delete.handling.mode` to `none` or `rewrite`. +
+|{prodname} generates a change event record for each `DELETE` operation. The default behavior is that `ExtractNewRecordState` removes these records from the stream. To keep Kafka records for `DELETE` operations in the stream, set `delete.handling.mode` to `none` or `rewrite`. +
  +
 Specify `none` to keep the change event record in the stream. The record contains only `"value": "null"`.  + 
  +
 Specify `rewrite` to keep the change event record in the stream and edit the record to have a `value` field that contains the key/value pairs that were in the `before` field and also add `+__deleted: true+` to the `value`. This is another way to indicate that the record has been deleted. +
  +
-When you  specify `rewrite`, the updated simplified records for `DELETE` operations might be all you need to track deleted records. You can consider accepting the default behavior of dropping the tombstone records that the Debezium connector creates.
+When you  specify `rewrite`, the updated simplified records for `DELETE` operations might be all you need to track deleted records. You can consider accepting the default behavior of dropping the tombstone records that the {prodname} connector creates.
 
-|[[configuration-option-route-by-field]]<<configuration-option-route-by-field, `route.by.field`>>
+[id="configuration-option-route-by-field"]
+|{link-prefix}:{link-event-flattening}#configuration-option-route-by-field[`route.by.field`]
 |
 |To use row data to determine the topic to route the record to, set this option to an `after` field attribute. The SMT routes the record to the topic whose name matches the value of the specified `after` field attribute. For a `DELETE` operation, set this option to a `before` field attribute. +
  +
-For example, configuration of `route.by.field=destination` routes records to the topic whose name is the value of `after.destination`. The default behavior is that a Debezium connector sends each change event record to a topic whose name is formed from the name of the database and the name of the table in which the change was made. + 
+For example, configuration of `route.by.field=destination` routes records to the topic whose name is the value of `after.destination`. The default behavior is that a {prodname} connector sends each change event record to a topic whose name is formed from the name of the database and the name of the table in which the change was made. + 
  +
 If you are configuring the `ExtractNewRecordState` SMT on a sink connector, setting this option might be useful when the destination topic name dictates the name of the database table that will be updated with the simplified change event record. If the topic name is not correct for your use case, you can configure `route.by.field` to re-route the event.
 
-|[[configuration-option-add-fields]]<<configuration-option-add-fields, `add.fields`>>
+[id="configuration-option-add-fields"]
+|{link-prefix}:{link-event-flattening}#configuration-option-add-fields[`add.fields`]
 |
 |Set this option to a comma-separated list, with no spaces, of metadata fields to add to the simplified Kafka record. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
  +
@@ -321,7 +324,8 @@ When the SMT adds metadata fields to the simplified record, it prefixes each met
  +
 If you specify a field that is not in the change event record, the SMT adds the field.  
 
-|[[configuration-option-add-headers]]<<configuration-option-add-headers, `add.headers`>>
+[id="configuration-option-add-headers"]
+|{link-prefix}:{link-event-flattening}#configuration-option-add-headers[`add.headers`]
 |
 |Set this option to a comma-separated list, with no spaces, of metadata fields to add to the header of the simplified Kafka record. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
  +
@@ -331,14 +335,20 @@ If you specify a field that is not in the change event record, the SMT does not 
 
 ifdef::community[]
 // Do not include deprecated content in downstream doc
-|`operation.header` DEPRECATED
+
+[id="configuration-option-operation.header"]
+|{link-prefix}:{link-event-flattening}#configuration-option-operation-header[`operation.header`] +
+DEPRECATED
 |`false`
 |_This option is deprecated and scheduled for removal. Please use add.headers instead. If both add.headers and operation.header are specified, the latter will be ignored._
 
 The SMT adds the event operation (as obtained from the `op` field of the original record) as a Kafka record header.
 
 // Do not include deprecated content in downstream doc
-|`add.source.fields` DEPRECATED
+
+[id="configuration-option-add-source-fields"]
+|{link-prefix}:{link-event-flattening}#configuration-option-add-source-fields[`add.source.fields`] +
+DEPRECATED
 |
 |_This option is deprecated and scheduled for removal. Please use add.fields instead. If both add.fields and add.source.fields are specified, the latter will be ignored._
 

--- a/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
@@ -1,7 +1,5 @@
 // Category: cdc-using
 // Type: assembly
-// :community:
-:product:
 
 ifdef::community[]
 [id="new-record-state-extraction"]
@@ -119,24 +117,25 @@ link:https://github.com/debezium/debezium/blob/master/debezium-core/src/main/jav
 
 You can configure the `ExtractNewRecordState` SMT for a Debezium connector, that is, for a source connector, or for a sink connector. The advantage of configuring `ExtractNewRecordState` for a sink connector is that records stored in Apache Kafka contain whole Debezium change events. The decision to apply the SMT to a source or sink connector depends on your particular use case. 
 
-You can configure the transformation to do either or both of the following: 
+You can configure the transformation to do any of the following: 
 
-* Add metadata from the change event to the simplified Kafka record or header.
+* Add metadata from the change event to the simplified Kafka record or record header. The default behavior is that the SMT does not add metadata to the simplified Kafka record.
 
-* Pass Kafka records that contain change events for `DELETE` operations to consumers. 
+* Keep Kafka records that contain change events for `DELETE` operations in the stream. The default behavior is that the SMT drops Kafka records for `DELETE` operation change events because most consumers cannot yet handle them. 
 
-The default behavior is that the transformation drops Kafka records for `DELETE` operation change events because most consumers cannot yet handle them. A database `DELETE` operation causes Debezium to generate two Kafka records: 
+A database `DELETE` operation causes Debezium to generate two Kafka records: 
 
-* A record that contains `"op": "d",` and the `before` row data.
+* A record that contains `"op": "d",` the `before` row data, and some other fields.
 * A tombstone record that has the same key as the deleted row and a value of `null`. This record is a marker for Apache Kafka. It indicates that 
 link:https://kafka.apache.org/documentation/#compaction[log compaction] can remove all records that have this key. 
 
 Instead of dropping the record that contains the `before` row data, you can configure the `ExtractNewRecordData` SMT to do one of the following: 
 
-* Pass the record as is.
-* Convert the record into another tombstone record and pass it on. 
+* Keep the record in the stream and edit it to have only the `"value": "null"` field.
+ 
+* Keep the record in the stream and edit it to have a `value` field that contains the key/value pairs that were in the `before` field with an added `"__deleted": "true"` entry.
 
-Similary, instead of dropping the tombstone record, you can configure the `ExtractNewRecordData` SMT to pass the tombstone record along. 
+Similary, instead of dropping the tombstone record, you can configure the `ExtractNewRecordData` SMT to keep the tombstone record in the stream. 
 
 ifdef::community[]
 == Configuration
@@ -158,7 +157,7 @@ transforms.unwrap.type=io.debezium.transforms.ExtractNewRecordState
 
 As in any Kafka Connect connector `.properties` file, you can set `transforms=` to multiple, comma-separated, SMT aliases in the order in which you want Kafka Connect  to apply the SMTs. 
 
-To pass tombstone records for `DELETE` operations and also add metadata to the simplified Kafka record, specify something like this: 
+The following example sets several `ExtractNewRecordState` options: 
 
 [source]
 ----
@@ -171,7 +170,15 @@ transforms.unwrap.add.fields=table,lsn
 
 `drop-tombstones=false`:: Keeps tombstone records for `DELETE` operations in the event stream. 
 
-`delete-handling-mode=rewrite`:: Adds metadata for `DELETE` operations to the simplified Kafka record. 
+`delete-handling-mode=rewrite`:: For `DELETE` operations, edits the Kafka record by flattening the `value` field that was in the change event. The `value` field directly contains the key/value pairs that were in the `before` field. The SMT adds `__deleted` and sets it to `true`, for example:   
++
+----
+"value": {
+  "pk": 2,
+  "cola": null,
+  "__deleted": "true"
+}
+----
 
 `add.fields=table,lsn`:: Adds change event metadata for the `table` and `lsn` fields to the simplified Kafka record. 
 
@@ -216,7 +223,7 @@ Also, simplified Kafka records would have a `__db` header.
 
 In the simplified Kafka record, the SMT prefixes the metadata field names with a double underscore. When you specify a struct, the SMT also inserts an underscore between the struct name and the field name. 
 
-To add metadata from a `DELETE` change event, you must also configure the `delete.handling.mode` option with a setting of `rewrite`.
+To add metadat to a simplified Kafka record that is for a `DELETE` operation, you must also configure `delete.handling.mode=rewrite`.
 
 ifdef::community[]
 // Do not include deprecated content in downstream doc
@@ -292,25 +299,35 @@ The following table describes the options that you can specify for the `ExtractN
 |`drop`
 |Debezium generates a change event record for each `DELETE` operation. The default behavior is that `ExtractNewRecordState` removes these records from the stream. To keep Kafka records for `DELETE` operations in the stream, set `delete.handling.mode` to `none` or `rewrite`. +
  +
-Specify `none` to keep this change event record in the stream as it is. + 
+Specify `none` to keep the change event record in the stream. The record contains only `"value": "null"`.  + 
  +
-Specify `rewrite` to keep this change event record in the stream and also add a `__deleted` field set to `true` to the change event record. 
+Specify `rewrite` to keep the change event record in the stream and edit the record to have a `value` field that contains the key/value pairs that were in the `before` field and also add `+__deleted: true+` to the `value`. This is another way to indicate that the record has been deleted. +
+ +
+When you  specify `rewrite`, the updated simplified records for `DELETE` operations might be all you need to track deleted records. You can consider accepting the default behavior of dropping the tombstone records that the Debezium connector creates.
 
 |[[configuration-option-route-by-field]]<<configuration-option-route-by-field, `route.by.field`>>
 |
-|The column that determines how the events will be routed. The value is a topic name obtained from the `after` state. For `DELETE` operations, the value is obtained from the `before` record state.
+|To use row data to determine the topic to route the record to, set this option to an `after` field attribute. The SMT routes the record to the topic whose name matches the value of the specified `after` field attribute. For a `DELETE` operation, set this option to a `before` field attribute. +
+ +
+For example, configuration of `route.by.field=destination` routes records to the topic whose name is the value of `after.destination`. The default behavior is that a Debezium connector sends each change event record to a topic whose name is formed from the name of the database and the name of the table in which the change was made. + 
+ +
+If you are configuring the `ExtractNewRecordState` SMT on a sink connector, setting this option might be useful when the destination topic name dictates the name of the database table that will be updated with the simplified change event record. If the topic name is not correct for your use case, you can configure `route.by.field` to re-route the event.
 
 |[[configuration-option-add-fields]]<<configuration-option-add-fields, `add.fields`>>
 |
 |Set this option to a comma-separated list, with no spaces, of metadata fields to add to the simplified Kafka record. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
  +
- When the SMT adds metadata fields to the simplified record, it prefixes each metadata field name with a double underscore. For a struct specification, the SMT also inserts an underscore between the struct name and the field name. 
+When the SMT adds metadata fields to the simplified record, it prefixes each metadata field name with a double underscore. For a struct specification, the SMT also inserts an underscore between the struct name and the field name. +
+ +
+If you specify a field that is not in the change event record, the SMT adds the field.  
 
 |[[configuration-option-add-headers]]<<configuration-option-add-headers, `add.headers`>>
 |
 |Set this option to a comma-separated list, with no spaces, of metadata fields to add to the header of the simplified Kafka record. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
  +
- When the SMT adds metadata fields to the simplified record's header, it prefixes each metadata field name with a double underscore. For a struct specification, the SMT also inserts an underscore between the struct name and the field name. 
+When the SMT adds metadata fields to the simplified record's header, it prefixes each metadata field name with a double underscore. For a struct specification, the SMT also inserts an underscore between the struct name and the field name. +
+ +
+If you specify a field that is not in the change event record, the SMT does not add the field to the header.
 
 ifdef::community[]
 // Do not include deprecated content in downstream doc

--- a/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
@@ -23,7 +23,7 @@ ifdef::product[]
 = Extracting source record `after` state from {prodname} change events
 endif::product[]
 
-A {prodname} database change event has a complex structure that provides a wealth of information. Kafka records that convey {prodname} change events contain all of this information. 
+A {prodname} data change event has a complex structure that provides a wealth of information. Kafka records that convey {prodname} change events contain all of this information. 
 However, parts of a Kafka ecosystem expect Kafka records that provide a flat structure of field names and values. 
 To provide this kind of record, {prodname} provides the `ExtractNewRecordState` single message transformation (SMT). Configure this transformation when consumers need Kafka records that have a format that is simpler than Kafka records that contain {prodname} change events. 
 
@@ -38,7 +38,7 @@ The following topics provide details:
 * xref:description-of-debezium-change-event-structure[]
 * xref:behavior-of-debezium-extractnewrecordstate-transformation[]
 * xref:configuration-of-extractnewrecordstate-transformation[]
-* xref:example-of-adding-metadata-to-the-kafka-record-or-its-header[]
+* xref:example-of-adding-metadata-to-the-kafka-record[]
 * xref:options-for-configuring-extractnewrecordstate-transformation[]
 
 // Type: concept
@@ -50,7 +50,7 @@ ifdef::community[]
 == Change event structure
 endif::community[]
 
-{prodname} generates database change events that have a complex structure.
+{prodname} generates data change events that have a complex structure.
 Each event consists of three parts:
 
 * Metadata, which includes but is not limited to:
@@ -118,7 +118,7 @@ You can configure the `ExtractNewRecordState` SMT for a {prodname} connector or 
 
 You can configure the transformation to do any of the following: 
 
-* Add metadata from the change event to the simplified Kafka record or record header. The default behavior is that the SMT does not add metadata to the simplified Kafka record.
+* Add metadata from the change event to the simplified Kafka record. The default behavior is that the SMT does not add metadata.
 
 * Keep Kafka records that contain change events for `DELETE` operations in the stream. The default behavior is that the SMT drops Kafka records for `DELETE` operation change events because most consumers cannot yet handle them. 
 
@@ -146,7 +146,7 @@ ifdef::product[]
 == Configuration of `ExtractNewRecordState` transformation
 endif::product[]
 
-Configure the {prodname} `ExtractNewRecordState` SMT in a Kafka Connect source or sink connector `.properties` file. To obtain the default behavior, specify something like the following: 
+Configure the {prodname} `ExtractNewRecordState` SMT in a Kafka Connect source or sink connector. Add the SMT configuration details to your connector's configuration. To obtain the default behavior, in a `.properties` file, you would specify something like the following: 
 
 [source]
 ----
@@ -154,9 +154,9 @@ transforms=unwrap,...
 transforms.unwrap.type=io.debezium.transforms.ExtractNewRecordState
 ----
 
-As in any Kafka Connect connector `.properties` file, you can set `transforms=` to multiple, comma-separated, SMT aliases in the order in which you want Kafka Connect  to apply the SMTs. 
+As for any Kafka Connect connector configuration, you can set `transforms=` to multiple, comma-separated, SMT aliases in the order in which you want Kafka Connect to apply the SMTs. 
 
-The following example sets several `ExtractNewRecordState` options: 
+The following `.properties` example sets several `ExtractNewRecordState` options: 
 
 [source]
 ----
@@ -187,11 +187,11 @@ endif::community[]
  
 ifdef::product[]
 // Type: concept
-[id="example-of-adding-metadata-to-the-kafka-record-or-its-header"]
-== Example of adding metadata to the Kafka record or its header
+[id="example-of-adding-metadata-to-the-kafka-record"]
+== Example of adding metadata to the Kafka record
 endif::product[]
 
-The `ExtractNewRecordState` SMT can add original, change event metadata to the simplified Kafka record or its header. For example, you might want the simplified record or its header to contain any of the following: 
+The `ExtractNewRecordState` SMT can add original, change event metadata to the simplified Kafka record. For example, you might want the simplified record's header or value to contain any of the following: 
 
 * The type of operation that made the change
 * The name of the database or table that was changed
@@ -201,8 +201,9 @@ ifdef::community[]
 For more information on what is available see xref:connectors/index.adoc[the documentation for each connector].
 endif::community[]
 
-To add metadata to the simplified Kafka record, specify the `add.fields` option. 
-To add metadata to the header of the simplified Kafka record, specify the `add.header` option. Each of these options takes a comma separated list of change event field names. Do not specify spaces. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field. For example:
+To add metadata to the simplified Kafka record's header, specify the `add.header` option. 
+To add metadata to the simplified Kafka record's value, specify the `add.fields` option. 
+Each of these options takes a comma separated list of change event field names. Do not specify spaces. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field. For example:
 
 ----
 transforms=unwrap,...
@@ -272,6 +273,7 @@ to the final flattened record.
 
 For `DELETE` events, this option is only supported when the `delete.handling.mode` option is set to "rewrite".
 
+[id="configuration-options"]
 == Configuration options
 
 endif::community[]
@@ -290,13 +292,13 @@ The following table describes the options that you can specify for the `ExtractN
 |Default
 |Description
 
-[id="configuration-option-drop-tombstones"]
-|{link-prefix}:{link-event-flattening}#configuration-option-drop-tombstones[`drop.tombstones`]
+[id="extract-new-record-state-drop-tombstones"]
+|{link-prefix}:{link-event-flattening}#extract-new-record-state-drop-tombstones[`drop.tombstones`]
 |`true`
 |{prodname} generates a tombstone record for each `DELETE` operation. The default behavior is that `ExtractNewRecordState` removes tombstone records from the stream. To keep tombstone records in the stream, specify `drop.tombstones=false`.  
 
-[id="configuration-option-delete-handling-mode"]
-|{link-prefix}:{link-event-flattening}#configuration-option-delete-handling-mode[`delete.handling.mode`]
+[id="extract-new-record-state-delete-handling-mode"]
+|{link-prefix}:{link-event-flattening}#extract-new-record-state-delete-handling-mode[`delete.handling.mode`]
 |`drop`
 |{prodname} generates a change event record for each `DELETE` operation. The default behavior is that `ExtractNewRecordState` removes these records from the stream. To keep Kafka records for `DELETE` operations in the stream, set `delete.handling.mode` to `none` or `rewrite`. +
  +
@@ -306,8 +308,8 @@ Specify `rewrite` to keep the change event record in the stream and edit the rec
  +
 When you  specify `rewrite`, the updated simplified records for `DELETE` operations might be all you need to track deleted records. You can consider accepting the default behavior of dropping the tombstone records that the {prodname} connector creates.
 
-[id="configuration-option-route-by-field"]
-|{link-prefix}:{link-event-flattening}#configuration-option-route-by-field[`route.by.field`]
+[id="extract-new-record-state-route-by-field"]
+|{link-prefix}:{link-event-flattening}#extract-new-record-state-route-by-field[`route.by.field`]
 |
 |To use row data to determine the topic to route the record to, set this option to an `after` field attribute. The SMT routes the record to the topic whose name matches the value of the specified `after` field attribute. For a `DELETE` operation, set this option to a `before` field attribute. +
  +
@@ -315,17 +317,17 @@ For example, configuration of `route.by.field=destination` routes records to the
  +
 If you are configuring the `ExtractNewRecordState` SMT on a sink connector, setting this option might be useful when the destination topic name dictates the name of the database table that will be updated with the simplified change event record. If the topic name is not correct for your use case, you can configure `route.by.field` to re-route the event.
 
-[id="configuration-option-add-fields"]
-|{link-prefix}:{link-event-flattening}#configuration-option-add-fields[`add.fields`]
+[id="extract-new-record-state-add-fields"]
+|{link-prefix}:{link-event-flattening}#extract-new-record-state-add-fields[`add.fields`]
 |
-|Set this option to a comma-separated list, with no spaces, of metadata fields to add to the simplified Kafka record. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
+|Set this option to a comma-separated list, with no spaces, of metadata fields to add to the simplified Kafka record's value. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
  +
-When the SMT adds metadata fields to the simplified record, it prefixes each metadata field name with a double underscore. For a struct specification, the SMT also inserts an underscore between the struct name and the field name. +
+When the SMT adds metadata fields to the simplified record's value, it prefixes each metadata field name with a double underscore. For a struct specification, the SMT also inserts an underscore between the struct name and the field name. +
  +
-If you specify a field that is not in the change event record, the SMT adds the field.  
+If you specify a field that is not in the change event record, the SMT still adds the field to the record's value.  
 
-[id="configuration-option-add-headers"]
-|{link-prefix}:{link-event-flattening}#configuration-option-add-headers[`add.headers`]
+[id="extract-new-record-state-add-headers"]
+|{link-prefix}:{link-event-flattening}#extract-new-record-state-add-headers[`add.headers`]
 |
 |Set this option to a comma-separated list, with no spaces, of metadata fields to add to the header of the simplified Kafka record. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
  +
@@ -336,8 +338,8 @@ If you specify a field that is not in the change event record, the SMT does not 
 ifdef::community[]
 // Do not include deprecated content in downstream doc
 
-[id="configuration-option-operation.header"]
-|{link-prefix}:{link-event-flattening}#configuration-option-operation-header[`operation.header`] +
+[id="extract-new-record-state-operation.header"]
+|{link-prefix}:{link-event-flattening}#extract-new-record-state-operation-header[`operation.header`] +
 DEPRECATED
 |`false`
 |_This option is deprecated and scheduled for removal. Please use add.headers instead. If both add.headers and operation.header are specified, the latter will be ignored._
@@ -346,8 +348,8 @@ The SMT adds the event operation (as obtained from the `op` field of the origina
 
 // Do not include deprecated content in downstream doc
 
-[id="configuration-option-add-source-fields"]
-|{link-prefix}:{link-event-flattening}#configuration-option-add-source-fields[`add.source.fields`] +
+[id="extract-new-record-state-add-source-fields"]
+|{link-prefix}:{link-event-flattening}#extract-new-record-state-add-source-fields[`add.source.fields`] +
 DEPRECATED
 |
 |_This option is deprecated and scheduled for removal. Please use add.fields instead. If both add.fields and add.source.fields are specified, the latter will be ignored._

--- a/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
+++ b/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
@@ -101,7 +101,7 @@ endif::product[]
 
 A Debezium change event key uses the table columns that make up the table's primary key. To route records for multiple physical tables to one topic, the event key must be unique across all of those tables. However, it is possible for each physical table to have a primary key that is unique within only that table. For example, a row in the `myserver.mydb.customers_shard1` table might have the same key value as a row in the `myserver.mydb.customers_shard2` table. 
 
-To ensure that each event key is unique across the tables whose change event records go to the same topic, the `ByLogicalTableRouter` transformation inserts a field into change event keys. By default, the name of the inserted field is `+__dbz__+` followed by the default destination topic name.
+To ensure that each event key is unique across the tables whose change event records go to the same topic, the `ByLogicalTableRouter` transformation inserts a field into change event keys. By default, the name of the inserted field is `+__dbz__+` followed by the physical table identifier. The value of the inserted field is the default destination topic name.
 
 If you want to, you can configure the `ByLogicalTableRouter` transformation to insert a different field into the key. To do this, specify the `key.field.name` option and set it to a field name that does not clash with existing primary key field names. For example: 
 

--- a/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
+++ b/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
@@ -50,8 +50,14 @@ endif::product[]
 
 The default behavior is that a {prodname} connector sends each change event record to a topic whose name is formed from the name of the database and the name of the table in which the change was made. In other words, a topic receives records for one physical table. When you want a topic to receive records for more than one physical table, you must configure the {prodname} connector to re-route the records to that topic. 
 
+.Logical tables
+
 A logical table is a common use case for routing records for multiple physical tables to one topic. In a logical table, there are multiple physical tables that all have the same schema. For example, sharded tables have the same schema. A logical table might consist of two or more sharded tables: `db_shard1.my_table` and `db_shard2.my_table`. The tables are in different shards and are physically distinct but together they form a logical table. 
 You can re-route change event records for tables in any of the shards to the same topic.
+
+.Partitioned PostgreSQL tables
+
+When the {prodname} PostgreSQL connector captures changes in a partitioned table, the default behavior is that change event records are routed to a different topic for each partition. To emit records from all partitions to one topic, configure the `ByLogicalTableRouter` SMT. Because each key in a partitioned table is guaranteed to be unique, configure {link-prefix}:{link-topic-routing}#by-logical-table-router-key-enforce-uniqueness[`key.enforce.uniqueness=false`] so that the SMT does not add a key field to ensure unique keys. The addition of a key field is default behavior. 
 
 ifdef::community[]
 == Example
@@ -167,7 +173,9 @@ endif::product[]
 [id="by-logical-table-router-key-enforce-uniqueness"]
 |{link-prefix}:{link-topic-routing}#by-logical-table-router-key-enforce-uniqueness[`key.enforce.uniqueness`]
 |`true`
-|Indicates whether to add a field to the record's change event key. Adding a key field ensures that each event key is unique across the tables whose change event records go to the same topic. This helps to prevent collisions of change events for records that have the same key but that originate from different source tables. Specify `false` if you do not want the transformation to add a key field.
+|Indicates whether to add a field to the record's change event key. Adding a key field ensures that each event key is unique across the tables whose change event records go to the same topic. This helps to prevent collisions of change events for records that have the same key but that originate from different source tables. +
+ +
+Specify `false` if you do not want the transformation to add a key field.  For example, if you are routing records from a partitioned PostgreSQL table to one topic, you can configure `key.enforce.uniqueness=false` because unique keys are guaranteed in partitioned PostgreSQL tables. 
 
 [id="by-logical-table-router-key-field-name"]
 |{link-prefix}:{link-topic-routing}#by-logical-table-router-key-field-name[`key.field.name`]

--- a/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
+++ b/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
@@ -101,7 +101,7 @@ endif::product[]
 
 A Debezium change event key uses the table columns that make up the table's primary key. To route records for multiple physical tables to one topic, the event key must be unique across all of those tables. However, it is possible for each physical table to have a primary key that is unique within only that table. For example, a row in the `myserver.mydb.customers_shard1` table might have the same key value as a row in the `myserver.mydb.customers_shard2` table. 
 
-To ensure that each event key is unique across the tables whose change event records go to the same topic, the `ByLogicalTableRouter` transformation inserts a field into change event keys. By default, the name of the inserted field is `+__dbz__+` followed by the physical table identifier. The value of the inserted field is the default destination topic name.
+To ensure that each event key is unique across the tables whose change event records go to the same topic, the `ByLogicalTableRouter` transformation inserts a field into change event keys. By default, the name of the inserted field is `+__dbz__physicalTableIdentifier+`. The value of the inserted field is the default destination topic name.
 
 If you want to, you can configure the `ByLogicalTableRouter` transformation to insert a different field into the key. To do this, specify the `key.field.name` option and set it to a field name that does not clash with existing primary key field names. For example: 
 

--- a/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
+++ b/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
@@ -18,8 +18,8 @@ ifdef::product[]
 = Routing change event records to topics that you specify
 endif::product[]
 
-Each Kafka record that contains a database change event has a default destination topic. If you need to, you can re-route records to topics that you specify before the records reach the Kafka Connect converter. 
-To do this, {prodname} provides the `ByLogicalTableRouter` single message transformation (SMT). Configure this transformation in the {prodname} connector's Kafka Connect `.properties` file. Configuration options enable you to specify the following: 
+Each Kafka record that contains a data change event has a default destination topic. If you need to, you can re-route records to topics that you specify before the records reach the Kafka Connect converter. 
+To do this, {prodname} provides the `ByLogicalTableRouter` single message transformation (SMT). Configure this transformation in the {prodname} connector's Kafka Connect configuration. Configuration options enable you to specify the following: 
 
 * An expression for identifying the records to re-route
 * An expression that resolves to the destination topic
@@ -63,12 +63,12 @@ ifdef::product[]
 == Example of routing records for multiple tables to one topic
 endif::product[]
 
-To route change event records for multiple physical tables to the same topic, configure the `ByLogicalTableRouter` transformation in the Kafka Connect `.properties` file for the {prodname} connector. Configuration of the `ByLogicalTableRouter` SMT requires you to specify regular expressions that determine: 
+To route change event records for multiple physical tables to the same topic, configure the `ByLogicalTableRouter` transformation in the Kafka Connect configuration for the {prodname} connector. Configuration of the `ByLogicalTableRouter` SMT requires you to specify regular expressions that determine: 
 
 * The tables for which to route records. These tables must all have the same schema. 
 * The destination topic name.
 
-For example: 
+For example, configuration in a `.properties` file looks like this: 
 
 [source]
 ----
@@ -154,33 +154,33 @@ endif::product[]
 |Default
 |Description
 
-[id="configuration-option-topic-regex"]
-|{link-prefix}:{link-topic-routing}#configuration-option-topic-regex[`topic.regex`]
+[id="by-logical-table-router-topic-regex"]
+|{link-prefix}:{link-topic-routing}#by-logical-table-router-topic-regex[`topic.regex`]
 |
 |Specifies a regular expression that the transformation applies to each change event record to determine if it should be routed to a particular topic.
 
-[id="configuration-option-topic-replacement"]
-|{link-prefix}:{link-topic-routing}configuration-option-topic-replacement#[`topic.replacement`]
+[id="by-logical-table-router-topic-replacement"]
+|{link-prefix}:{link-topic-routing}by-logical-table-router-topic-replacement#[`topic.replacement`]
 |
 |Specifies a regular expression that represents the destination topic name. The transformation routes each matching record to the topic identified by this expression. This expression can refer to groups captured by the regular expression that you specify for `topic.regex`. To refer to a group, specify `$1`, `$2`, and so on. 
 
-[id="configuration-option-key-enforce-uniqueness"]
-|{link-prefix}:{link-topic-routing}#configuration-option-key-enforce-uniqueness[`key.enforce.uniqueness`]
+[id="by-logical-table-router-key-enforce-uniqueness"]
+|{link-prefix}:{link-topic-routing}#by-logical-table-router-key-enforce-uniqueness[`key.enforce.uniqueness`]
 |`true`
 |Indicates whether to add a field to the record's change event key. Adding a key field ensures that each event key is unique across the tables whose change event records go to the same topic. This helps to prevent collisions of change events for records that have the same key but that originate from different source tables. Specify `false` if you do not want the transformation to add a key field.
 
-[id="configuration-option-key-field-name"]
-|{link-prefix}:{link-topic-routing}#configuration-option-key-field-name[`key.field.name`]
+[id="by-logical-table-router-key-field-name"]
+|{link-prefix}:{link-topic-routing}#by-logical-table-router-key-field-name[`key.field.name`]
 |`+__dbz__physicalTableIdentifier+`
 |Name of a field to be added to the change event key. The value of this field identifies the original table name. For the SMT to add this field, `key.enforce.uniqueness` must be `true`, which is the default. 
 
-[id="configuration-option-key-field-regex"]
-|{link-prefix}:{link-topic-routing}#configuration-option-key-field-regex[`key.field.regex`]
+[id="by-logical-table-router-key-field-regex"]
+|{link-prefix}:{link-topic-routing}#by-logical-table-router-key-field-regex[`key.field.regex`]
 |
 |Specifies a regular expression that the transformation applies to the default destination topic name to capture one or more groups of characters. For the SMT to apply this expression, `key.enforce.uniqueness` must be `true`, which is the default. 
 
-[id="configuration-option-key-field-replacement"]
-|{link-prefix}:{link-topic-routing}#configuration-option-key-field-replacement[`key.field.replacement`]
+[id="by-logical-table-router-key-field-replacement"]
+|{link-prefix}:{link-topic-routing}#by-logical-table-router-key-field-replacement[`key.field.replacement`]
 |
 |Specifies a regular expression for determining the value of the inserted key field in terms of the groups captured by the expression specified for `key.field.regex`. For the SMT to apply this expression, `key.enforce.uniqueness` must be `true`, which is the default. 
 

--- a/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
+++ b/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
@@ -1,3 +1,10 @@
+// Category: cdc-using
+// Type: assembly
+// :community:
+:product: 
+
+ifdef::community[]
+[id="topic-routing"]
 = Topic Routing
 include::../_attributes.adoc[]
 :toc:
@@ -7,46 +14,64 @@ include::../_attributes.adoc[]
 :source-highlighter: highlight.js
 
 toc::[]
+endif::community[]
 
-Debezium enables you to re-route the emitted change before the message reaches the converter using a single message transformation,
-or {link-kafka-docs}/#connect_transforms[SMT].
-The SMT provided by Debezium enables you to rewrite the topic and the key according to a regular expression and a replacement pattern,
-configurable per instance of Debezium.
+ifdef::product[]
+[id="routing-change-event-records-to-topics-that-you-specify"]
+= Routing change event records to topics that you specify
+endif::product[]
 
-The implementation does not care about the sanity of the change, this is in the responsibility of the user.
+Before Kafka records that contain database change events reach the Kafka Connect converter, you can re-route them to topics that you choose. 
+To do this, Debezium provides the `ByLogicalTableRouter` single message transformation (SMT). Configure this transformation in the Debezium connector's Kafka Connect `.properties` file. Configuration options enable you to specify the following: 
 
-== Use-Cases
+* An expression for identifying the records to route
+* The destination topic
+* How to ensure a unique key among the records being routed to the topic
 
-=== Logical Tables
+It is up to you to ensure that the transformation configuration provides the behavior that you want. Debezium does not validate the behavior that results from the way that you configure the transformation. 
 
-A logical table consists of one or more physical tables with the same table structure.
-A common use case is sharding, where for example two physical tables `db_shard1.my_table` and `db_shard2.my_table` together form one logical table.
+The `ByLogicalTableRouter` transformation is a 
+link:https://kafka.apache.org/documentation/#connect_transforms[Kafka Connect SMT].
 
-Typically the physical tables share the same schema.
+ifdef::product[]
+The following topics provide details: 
 
-Normally, Debezium connectors send each change event to a topic that is named by the database and table.
-But since the sharded tables have the same schema, we'd instead like to re-route each change event to a topic named by the _logical_ table name.
-This way, all changes events for any of the shards all go to the same topic.
+* xref:use-case-for-routing-records-to-topics-that-you-specify[]
+* xref:example-of-routing-records-for-multiple-tables-to-one-topic[]
+* xref:ensuring-unique-keys-across-records-routed-to-the-same-topic[]
+endif::product[]
 
-What happens if each physical table has a primary key that is only unique within that table?
-In this case, a row in shard 1 can have the same primary key as a row in shard 2.
-Since Debezium events are keyed by the columns that make up the primary key, the events for that row in shard 1 would have the same key as the row in shard 2,
-even though globally they are different rows.
-So, in addition to changing the topic name, we may also want to _modify the event key_ to add a field that makes the key globally unique.
+ifdef::community[]
+= Use case
+endif::community[]
 
-This SMT lets you specify how you want to choose the new topic name and then specify how to modify the change event key to ensure it is globally unique.
+ifdef::product[]
+// Type: concept
+[id="use-case-for-routing-records-to-topics-that-you-specify"]
+== Use case for routing records to topics that you specify
+endif::product[]
 
-=== Partitioned Postgres Tables
+The default behavior is that a Debezium connector sends each change event record to a topic whose name is formed from the name of the database and the name of the table in which the change was made. In other words, a topic receives records for one physical table. When you want a topic to receive records for more than one physical table, you must configure the Debezium connector to re-route the records to that topic. 
 
-when capturing changes from a partioned Postgres table,
-there will be one topic per partition table.
-Using this routing SMT allows you to emit all change events to a single topic for the entire partioned table.
-As key uniqueness across the different partition topics already is guaranteed in this case,
-the `key.enforce.uniqueness` option can be set to `false` (see below).
+A logical table is a common use case for routing records for multiple physical tables to one topic. In a logical table, there are multiple physical tables that all have the same schema. For example, sharded tables have the same schema. A logical table might consist of two or more sharded tables: `db_shard1.my_table` and `db_shard2.my_table`. The tables are in different shards and are physically distinct but together they form a logical table. 
+You can re-route change event records for tables in any of the shards to the same topic.
 
-== Topic Names
+ifdef::community[]
+= Example
+endif::community[]
 
-Below is an example for a configuration which replaces a part of the table in the topic with another string, allowing two tables to emit changes to the same topic:
+ifdef::product[]
+// Type: concept
+[id="example-of-routing-records-for-multiple-tables-to-one-topic"]
+== Example of routing records for multiple tables to one topic
+endif::product[]
+
+To route change event records for multiple physical tables to the same topic, configure the `ByLogicalTableRouter` transformation in the Kafka Connect `.properties` file for the Debezium connector. Configuration of the `ByLogicalTableRouter` SMT requires you to specify regular expressions that identify: 
+
+* The tables for which to route records. These tables must all have the same schema. 
+* The destination topic name.
+
+For example: 
 
 [source]
 ----
@@ -56,79 +81,61 @@ transforms.Reroute.topic.regex=(.*)customers_shard(.*)
 transforms.Reroute.topic.replacement=$1customers_all_shards
 ----
 
-The configuration above will match topics such as `myserver.mydb.customers_shard1`, `myserver.mydb.customers_shard2` etc. and replace it with `myserver.mydb.customers_all_shards.`
+`topic.regex`:: Specifies a regular expression that the transformation applies to each change event record to determine if it should be routed to a particular topic.  
++
+In the example, the regular expression, `(.*)customers_shard(.*)` matches records for changes to tables whose names include the `customers_shard` string. This would re-route records for tables with the following names:
++
+`myserver.mydb.customers_shard1` +
+`myserver.mydb.customers_shard2` +
+`myserver.mydb.customers_shard3`
 
-== Key Fields
+`topic.replacement`:: Specifies a regular expression that represents the destination topic name. The transformation routes each matching record to the topic identified by this expression. In this example, records for the three sharded tables listed above would be routed to the `myserver.mydb.customers_all_shards` topic. 
 
-To address the concern of uniqueness across all the original tables discussed above,
-one more field for identifying the original (physical) table may be inserted into the key structure of the change events.
-By default, this field is named `\__dbz__physicalTableIdentifier` and has the original topic name as its value.
+ifdef::community[]
+= Ensure unique key
+endif::community[]
 
-If your tables already contain globally unique keys and you do not need to change the key structure, you can set the `key.enforce.uniqueness` property to `false`:
+ifdef::product[]
+// Type: procedure
+[id="ensuring-unique-keys-across-records-routed-to-the-same-topic"]
+== Ensuring unique keys across records routed to the same topic
+endif::product[]
+
+A Debezium change event key uses the table columns that make up the table's primary key. To route records for multiple physical tables to one topic, the event key must be unique across all of those tables. However, it is possible for each physical table to have a primary key that is unique within only that table. For example, a row in the `myserver.mydb.customers_shard1` table might have the same key value as a row in the `myserver.mydb.customers_shard2` table. 
+
+To ensure that each event key is unique across the tables whose change event records go to the same topic, the `ByLogicalTableRouter` transformation inserts a field into change event keys. By default, the name of the inserted field is `+__dbz__+` followed by the default destination topic name.
+
+If you want to, you can configure the `ByLogicalTableRouter` transformation to insert a different field into the key. To do this, specify the `key.field.name` option and set it to a field name that does not clash with existing primary key field names. For example: 
 
 [source]
 ----
-...
-transforms.Reroute.key.enforce.uniqueness=false
-...
-----
-
-If needed, another _field name_ can be chosen by means of the `key.field.name` property
-(obviously you'll want to choose a field name that doesn't clash with existing primary key fields).
-For example the following configuration will use the name `shard_id` for the key field:
-
-[source]
-----
-...
+transforms=Reroute
+transforms.Reroute.type=io.debezium.transforms.ByLogicalTableRouter
+transforms.Reroute.topic.regex=(.*)customers_shard(.*)
+transforms.Reroute.topic.replacement=$1customers_all_shards
 transforms.Reroute.key.field.name=shard_id
-...
 ----
 
-The _value_ of the field can be adjusted via the `key.field.regex` and `key.field.replacement` properties.
-The former allows you to define a regular expression that will be applied to the original topic name to capture one or more groups of characters.
-The latter lets you specify an expression that defines the value for the field in terms of those captured groups.
-For example:
+This example adds the `shard_id` field to the key structure in routed records.
+
+If you want to adjust the value of key's new field, configure both of these options:
+
+`key.field.regex`:: Specifies a regular expression that the transformation applies to the default destination topic name to capture one or more groups of characters. 
+
+`key.field.replacement`:: Specifies a regular expression for the value of the inserted key field in terms of those captured groups. 
+
+For example: 
 
 [source]
 ----
-...
 transforms.Reroute.key.field.regex=(.*)customers_shard(.*)
 transforms.Reroute.key.field.replacement=$2
 ----
 
-This will apply the given regular expression to original topic names and use the second capturing group as value for the key field.
-Assuming the source topics are named `myserver.mydb.customers_shard1`, `myserver.mydb.customers_shard2` etc., the key field's values would be `1`, `2` etc.
+With this configuration, suppose that the default destination topic names are: 
 
-[[configuration-options]]
-== Configuration Options
-[cols="35%a,10%a,55%a",options="header"]
-|=======================
-|Property
-|Default
-|Description
+`myserver.mydb.customers_shard1` +
+`myserver.mydb.customers_shard2` +
+`myserver.mydb.customers_shard3`
 
-|`topic.regex`
-|
-|A regular expression for matching the topic(s) which should be re-routed.
-
-|`topic.replacement`
-|
-|The name of the topic to which re-routed events will be sent. May refer to capturing groups from the regular expression given via `topic.regex` via `$1`, `$2` etc.
-
-|`key.enforce.uniqueness`
-|`true`
-|Whether to add a field to the change event key that identifies the original table/topic name and thus helps to prevent collisions of change events for records with the same key originating from multiple source tables; either `true` or `false`
-
-|`key.field.name`
-|`__dbz__physicalTableIdentifier`
-|Name of a field to be added to the change event key for  identifying the original table/topic name; only takes affect if `key.enforce.uniqueness` is `true`
-
-|`key.field.regex`
-|
-|A regular expression applied to the original topic name to capture one or more groups of characters; only takes affect if `key.enforce.uniqueness` is `true`
-
-|`key.field.replacement`
-|
-|Expression that specifies the value for the added key field in terms of captured groups defined using `key.field.regex`; only takes affect if `key.enforce.uniqueness` is `true`
-
-|=======================
+The transformation uses the values in the second captured group, the shard numbers, as the value of the key's new field. In this example, the inserted key field's values would be `1`, `2`, or `3`.

--- a/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
+++ b/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
@@ -1,7 +1,5 @@
 // Category: cdc-using
 // Type: assembly
-// :community:
-:product: 
 
 ifdef::community[]
 [id="topic-routing"]
@@ -21,14 +19,14 @@ ifdef::product[]
 = Routing change event records to topics that you specify
 endif::product[]
 
-Before Kafka records that contain database change events reach the Kafka Connect converter, you can re-route them to topics that you choose. 
+Each Kafka record that contains a database change event has a default destination topic. If you need to, you can re-route records to topics that you specify before the records reach the Kafka Connect converter. 
 To do this, Debezium provides the `ByLogicalTableRouter` single message transformation (SMT). Configure this transformation in the Debezium connector's Kafka Connect `.properties` file. Configuration options enable you to specify the following: 
 
-* An expression for identifying the records to route
-* The destination topic
-* How to ensure a unique key among the records being routed to the topic
+* An expression for identifying the records to re-route
+* An expression that resolves to the destination topic
+* How to ensure a unique key among the records being re-routed to the destination topic
 
-It is up to you to ensure that the transformation configuration provides the behavior that you want. Debezium does not validate the behavior that results from the way that you configure the transformation. 
+It is up to you to ensure that the transformation configuration provides the behavior that you want. Debezium does not validate the behavior that results from your configuration of the transformation. 
 
 The `ByLogicalTableRouter` transformation is a 
 link:https://kafka.apache.org/documentation/#connect_transforms[Kafka Connect SMT].
@@ -42,7 +40,7 @@ The following topics provide details:
 endif::product[]
 
 ifdef::community[]
-= Use case
+== Use case
 endif::community[]
 
 ifdef::product[]
@@ -57,7 +55,7 @@ A logical table is a common use case for routing records for multiple physical t
 You can re-route change event records for tables in any of the shards to the same topic.
 
 ifdef::community[]
-= Example
+== Example
 endif::community[]
 
 ifdef::product[]
@@ -66,7 +64,7 @@ ifdef::product[]
 == Example of routing records for multiple tables to one topic
 endif::product[]
 
-To route change event records for multiple physical tables to the same topic, configure the `ByLogicalTableRouter` transformation in the Kafka Connect `.properties` file for the Debezium connector. Configuration of the `ByLogicalTableRouter` SMT requires you to specify regular expressions that identify: 
+To route change event records for multiple physical tables to the same topic, configure the `ByLogicalTableRouter` transformation in the Kafka Connect `.properties` file for the Debezium connector. Configuration of the `ByLogicalTableRouter` SMT requires you to specify regular expressions that determine: 
 
 * The tables for which to route records. These tables must all have the same schema. 
 * The destination topic name.
@@ -92,7 +90,7 @@ In the example, the regular expression, `(.*)customers_shard(.*)` matches record
 `topic.replacement`:: Specifies a regular expression that represents the destination topic name. The transformation routes each matching record to the topic identified by this expression. In this example, records for the three sharded tables listed above would be routed to the `myserver.mydb.customers_all_shards` topic. 
 
 ifdef::community[]
-= Ensure unique key
+== Ensure unique key
 endif::community[]
 
 ifdef::product[]
@@ -118,11 +116,11 @@ transforms.Reroute.key.field.name=shard_id
 
 This example adds the `shard_id` field to the key structure in routed records.
 
-If you want to adjust the value of key's new field, configure both of these options:
+If you want to adjust the value of the key's new field, configure both of these options:
 
 `key.field.regex`:: Specifies a regular expression that the transformation applies to the default destination topic name to capture one or more groups of characters. 
 
-`key.field.replacement`:: Specifies a regular expression for the value of the inserted key field in terms of those captured groups. 
+`key.field.replacement`:: Specifies a regular expression for determining the value of the inserted key field in terms of those captured groups. 
 
 For example: 
 

--- a/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
+++ b/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
@@ -4,7 +4,6 @@
 ifdef::community[]
 [id="topic-routing"]
 = Topic Routing
-include::../_attributes.adoc[]
 :toc:
 :toc-placement: macro
 :linkattrs:
@@ -20,13 +19,13 @@ ifdef::product[]
 endif::product[]
 
 Each Kafka record that contains a database change event has a default destination topic. If you need to, you can re-route records to topics that you specify before the records reach the Kafka Connect converter. 
-To do this, Debezium provides the `ByLogicalTableRouter` single message transformation (SMT). Configure this transformation in the Debezium connector's Kafka Connect `.properties` file. Configuration options enable you to specify the following: 
+To do this, {prodname} provides the `ByLogicalTableRouter` single message transformation (SMT). Configure this transformation in the {prodname} connector's Kafka Connect `.properties` file. Configuration options enable you to specify the following: 
 
 * An expression for identifying the records to re-route
 * An expression that resolves to the destination topic
 * How to ensure a unique key among the records being re-routed to the destination topic
 
-It is up to you to ensure that the transformation configuration provides the behavior that you want. Debezium does not validate the behavior that results from your configuration of the transformation. 
+It is up to you to ensure that the transformation configuration provides the behavior that you want. {prodname} does not validate the behavior that results from your configuration of the transformation. 
 
 The `ByLogicalTableRouter` transformation is a 
 link:https://kafka.apache.org/documentation/#connect_transforms[Kafka Connect SMT].
@@ -49,7 +48,7 @@ ifdef::product[]
 == Use case for routing records to topics that you specify
 endif::product[]
 
-The default behavior is that a Debezium connector sends each change event record to a topic whose name is formed from the name of the database and the name of the table in which the change was made. In other words, a topic receives records for one physical table. When you want a topic to receive records for more than one physical table, you must configure the Debezium connector to re-route the records to that topic. 
+The default behavior is that a {prodname} connector sends each change event record to a topic whose name is formed from the name of the database and the name of the table in which the change was made. In other words, a topic receives records for one physical table. When you want a topic to receive records for more than one physical table, you must configure the {prodname} connector to re-route the records to that topic. 
 
 A logical table is a common use case for routing records for multiple physical tables to one topic. In a logical table, there are multiple physical tables that all have the same schema. For example, sharded tables have the same schema. A logical table might consist of two or more sharded tables: `db_shard1.my_table` and `db_shard2.my_table`. The tables are in different shards and are physically distinct but together they form a logical table. 
 You can re-route change event records for tables in any of the shards to the same topic.
@@ -64,7 +63,7 @@ ifdef::product[]
 == Example of routing records for multiple tables to one topic
 endif::product[]
 
-To route change event records for multiple physical tables to the same topic, configure the `ByLogicalTableRouter` transformation in the Kafka Connect `.properties` file for the Debezium connector. Configuration of the `ByLogicalTableRouter` SMT requires you to specify regular expressions that determine: 
+To route change event records for multiple physical tables to the same topic, configure the `ByLogicalTableRouter` transformation in the Kafka Connect `.properties` file for the {prodname} connector. Configuration of the `ByLogicalTableRouter` SMT requires you to specify regular expressions that determine: 
 
 * The tables for which to route records. These tables must all have the same schema. 
 * The destination topic name.
@@ -99,7 +98,7 @@ ifdef::product[]
 == Ensuring unique keys across records routed to the same topic
 endif::product[]
 
-A Debezium change event key uses the table columns that make up the table's primary key. To route records for multiple physical tables to one topic, the event key must be unique across all of those tables. However, it is possible for each physical table to have a primary key that is unique within only that table. For example, a row in the `myserver.mydb.customers_shard1` table might have the same key value as a row in the `myserver.mydb.customers_shard2` table. 
+A {prodname} change event key uses the table columns that make up the table's primary key. To route records for multiple physical tables to one topic, the event key must be unique across all of those tables. However, it is possible for each physical table to have a primary key that is unique within only that table. For example, a row in the `myserver.mydb.customers_shard1` table might have the same key value as a row in the `myserver.mydb.customers_shard2` table. 
 
 To ensure that each event key is unique across the tables whose change event records go to the same topic, the `ByLogicalTableRouter` transformation inserts a field into change event keys. By default, the name of the inserted field is `+__dbz__physicalTableIdentifier+`. The value of the inserted field is the default destination topic name.
 
@@ -137,3 +136,52 @@ With this configuration, suppose that the default destination topic names are:
 `myserver.mydb.customers_shard3`
 
 The transformation uses the values in the second captured group, the shard numbers, as the value of the key's new field. In this example, the inserted key field's values would be `1`, `2`, or `3`.
+
+ifdef::community[]
+[[configuration-options]]
+== Configuration options
+endif::community[]
+
+ifdef::product[]
+// Type: reference
+[id="options-for-configuring-bylogicaltablerouter-transformation"]
+== Options for configuring `ByLogicalTableRouter` transformation
+endif::product[]
+
+[cols="35%a,10%a,55%a"]
+|===
+|Property
+|Default
+|Description
+
+[id="configuration-option-topic-regex"]
+|{link-prefix}:{link-topic-routing}#configuration-option-topic-regex[`topic.regex`]
+|
+|Specifies a regular expression that the transformation applies to each change event record to determine if it should be routed to a particular topic.
+
+[id="configuration-option-topic-replacement"]
+|{link-prefix}:{link-topic-routing}configuration-option-topic-replacement#[`topic.replacement`]
+|
+|Specifies a regular expression that represents the destination topic name. The transformation routes each matching record to the topic identified by this expression. This expression can refer to groups captured by the regular expression that you specify for `topic.regex`. To refer to a group, specify `$1`, `$2`, and so on. 
+
+[id="configuration-option-key-enforce-uniqueness"]
+|{link-prefix}:{link-topic-routing}#configuration-option-key-enforce-uniqueness[`key.enforce.uniqueness`]
+|`true`
+|Indicates whether to add a field to the record's change event key. Adding a key field ensures that each event key is unique across the tables whose change event records go to the same topic. This helps to prevent collisions of change events for records that have the same key but that originate from different source tables. Specify `false` if you do not want the transformation to add a key field.
+
+[id="configuration-option-key-field-name"]
+|{link-prefix}:{link-topic-routing}#configuration-option-key-field-name[`key.field.name`]
+|`+__dbz__physicalTableIdentifier+`
+|Name of a field to be added to the change event key. The value of this field identifies the original table name. For the SMT to add this field, `key.enforce.uniqueness` must be `true`, which is the default. 
+
+[id="configuration-option-key-field-regex"]
+|{link-prefix}:{link-topic-routing}#configuration-option-key-field-regex[`key.field.regex`]
+|
+|Specifies a regular expression that the transformation applies to the default destination topic name to capture one or more groups of characters. For the SMT to apply this expression, `key.enforce.uniqueness` must be `true`, which is the default. 
+
+[id="configuration-option-key-field-replacement"]
+|{link-prefix}:{link-topic-routing}#configuration-option-key-field-replacement[`key.field.replacement`]
+|
+|Specifies a regular expression for determining the value of the inserted key field in terms of the groups captured by the expression specified for `key.field.regex`. For the SMT to apply this expression, `key.enforce.uniqueness` must be `true`, which is the default. 
+
+|===

--- a/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
+++ b/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
@@ -143,6 +143,15 @@ With this configuration, suppose that the default destination topic names are:
 
 The transformation uses the values in the second captured group, the shard numbers, as the value of the key's new field. In this example, the inserted key field's values would be `1`, `2`, or `3`.
 
+If your tables contain globally unique keys and you do not need to change the key structure, you can set the `key.enforce.uniqueness` property to `false`:
+
+[source]
+----
+...
+transforms.Reroute.key.enforce.uniqueness=false
+...
+----
+
 ifdef::community[]
 [[configuration-options]]
 == Configuration options
@@ -166,7 +175,7 @@ endif::product[]
 |Specifies a regular expression that the transformation applies to each change event record to determine if it should be routed to a particular topic.
 
 [id="by-logical-table-router-topic-replacement"]
-|{link-prefix}:{link-topic-routing}by-logical-table-router-topic-replacement#[`topic.replacement`]
+|{link-prefix}:{link-topic-routing}#by-logical-table-router-topic-replacement[`topic.replacement`]
 |
 |Specifies a regular expression that represents the destination topic name. The transformation routes each matching record to the topic identified by this expression. This expression can refer to groups captured by the regular expression that you specify for `topic.regex`. To refer to a group, specify `$1`, `$2`, and so on. 
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -731,13 +731,13 @@ This configuration can be sent via POST to a running Kafka Connect service, whic
 
 The {prodname} MongoDB connector has two metric types in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect have.
 
-* <<snapshot-metrics, snapshot metrics>>; for monitoring the connector when performing snapshots
-* <<streaming-metrics, streaming metrics>>; for monitoring the connector when processing oplog events
+* <<mongodb-snapshot-metrics, snapshot metrics>>; for monitoring the connector when performing snapshots
+* <<mongodb-streaming-metrics, streaming metrics>>; for monitoring the connector when processing oplog events
 
 Please refer to the xref:operations/monitoring.adoc[monitoring documentation] for details of how to expose these metrics via JMX.
 
 [[monitoring-snapshots]]
-[[snapshot-metrics]]
+[[mongodb-snapshot-metrics]]
 ==== Snapshot Metrics
 
 The *MBean* is `debezium.mongodb:type=connector-metrics,context=snapshot,server=_<mongodb.name>_`.
@@ -757,7 +757,7 @@ The {prodname} MongoDB connector also provides the following custom snapshot met
 |===
 
 [[monitoring-streaming]]
-[[streaming-metrics]]
+[[mongodb-streaming-metrics]]
 ==== Streaming Metrics
 
 The *MBean* is `debezium.sql_server:type=connector-metrics,context=streaming,server=_<mongodb.name>_`.

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -669,7 +669,7 @@ The `source` structure tells us information about SQL Server's record of this ch
 
 [NOTE]
 ====
-When the columns for a row's primary/unique key are updated, the value of the row's key has changed so {prodname} will output _three_ events: a `DELETE` event and a link:#tombstone-events[tombstone event] with the old key for the row, followed by an `INSERT` event with the new key for the row.
+When the columns for a row's primary/unique key are updated, the value of the row's key has changed so {prodname} will output _three_ events: a `DELETE` event and a link:#sqlserver-tombstone-events[tombstone event] with the old key for the row, followed by an `INSERT` event with the new key for the row.
 ====
 
 [[sqlserver-delete-events]]
@@ -724,12 +724,12 @@ The SQL Server connector's events are designed to work with https://cwiki.apache
 which allows for the removal of some older messages as long as at least the most recent message for every key is kept.
 This allows Kafka to reclaim storage space while ensuring the topic contains a complete dataset and can be used for reloading key-based state.
 
-[[tombstone-events]]
+[[sqlserver-tombstone-events]]
 When a row is deleted, the _delete_ event value listed above still works with log compaction, since Kafka can still remove all earlier messages with that same key.
 But only if the message value is `null` will Kafka know that it can remove _all messages_ with that same key.
 To make this possible, the SQL Server connector always follows the _delete_ event with a special _tombstone_ event that has the same key but `null` value.
 
-[[transaction-metadata]]
+[[sqlserver-transaction-metadata]]
 === Transaction Metadata
 
 [NOTE]
@@ -1606,7 +1606,7 @@ Possible values include "Z", "UTC", offset values like "+02:00", short zone ids 
 |`false`
 |When set to `true` Debezium generates events with transaction boundaries and enriches data events envelope with transaction metadata.
 
-See link:#transaction-metadata[Transaction Metadata] for additional details.
+See link:#sqlserver-transaction-metadata[Transaction Metadata] for additional details.
 
 |=======================
 


### PR DESCRIPTION
@Naros   cc: @gunnarmorling 
This PR provides revised doc for topic routing and event flattening. My revision of the content needs to be reviewed. Please let me know what needs to change. 

I used a new conditionalization approach. I added `:community:` to the list of AsciiDoc attributes in `antora.yml`. I enclosed upstream only content like this: 

```
ifdef::community[]
upstream only content here
endif::community[]
```
I enclosed downstream only content like this: 
```
ifdef::product[]
upstream only content here
endif::product[]
```
Upstream, the `:product:` attribute is not defined. 

I used conditionalization to have short headings upstream, which are easy for scanning on the individual page minitocs on the right. While downstream, there are the longer, descriptive headings required by modularization, which are not so easy to scan. 

I modularized the content within the original source files. I did not break the original source files up into smaller files. Instead, I added comments that serve as annotations for the Nebel utility, which is a utility that Fintan created to operate on modular doc. For example, just before each heading, you will see comments like these:

```
// Category: cdc-using
// Type: assembly

// Type: concept

// Type: procedure

// Type: reference
```
Nebel can use these annotations to break the larger file into smaller module files. 

I did NOT edit the deprecated content in the event flattening section. 

Finally, there are some additional updates to other files that are required for the downstream build. Specifically, content that is fetched from upstream and reused downstream cannot contain duplicate anchor IDs, so I had to change some IDs and any references to those IDs. 

After this is merged, it will need to be backported to 1.1 so that I can fetch these updates from downstream add them to the downstream Debezium User Guide. 