### PR TITLE
DBZ-2067 Add support for ALGORITHM=INSTANT on alter table statements

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -211,6 +211,16 @@ public class MySqlAntlrDdlParserTest {
     }
 
     @Test
+    @FixFor("DBZ-2067")
+    public void shouldSupportInstantAlgoOnAlterStatements() {
+        final String ddl = "CREATE TABLE foo (id SERIAL, c1 INT);" +
+                "ALTER TABLE foo ADD COLUMN c2 INT, ALGORITHM=INSTANT;";
+        parser.parse(ddl, tables);
+
+        assertThat(((MySqlAntlrDdlParser) parser).getParsingExceptionsFromWalker().size()).isEqualTo(0);
+    }
+
+    @Test
     @FixFor("DBZ-1220")
     public void shouldParseFloatVariants() {
         final String ddl = "CREATE TABLE mytable (id SERIAL, f1 FLOAT, f2 FLOAT(4), f3 FLOAT(7,4));";

--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlLexer.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlLexer.g4
@@ -439,6 +439,7 @@ INPLACE:                             'INPLACE';
 INSERT_METHOD:                       'INSERT_METHOD';
 INSTALL:                             'INSTALL';
 INSTANCE:                            'INSTANCE';
+INSTANT:                             'INSTANT';
 INVISIBLE:                           'INVISIBLE';
 INVOKER:                             'INVOKER';
 IO:                                  'IO';

--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -609,7 +609,7 @@ alterSpecification
     | ADD (CONSTRAINT name=uid?)? FOREIGN KEY
       indexName=uid? indexColumnNames referenceDefinition           #alterByAddForeignKey
     | ADD (CONSTRAINT name=uid?)? CHECK '(' expression ')'          #alterByAddCheckTableConstraint
-    | ALGORITHM '='? algType=(DEFAULT | INPLACE | COPY)             #alterBySetAlgorithm
+    | ALGORITHM '='? algType=(DEFAULT | INSTANT | INPLACE | COPY)   #alterBySetAlgorithm
     | ALTER COLUMN? uid
       (SET DEFAULT defaultValue | DROP DEFAULT)                     #alterByChangeDefault
     | CHANGE COLUMN? oldColumn=uid

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_alter.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_alter.sql
@@ -1,6 +1,6 @@
 #begin
 -- Alter Table
-alter table ship_class add column ship_spec varchar(150) first, add somecol int after start_build;
+alter table ship_class add column ship_spec varchar(150) first, add somecol int after start_build, algorithm=instant;
 alter table t3 add column (c2 decimal(10, 2) comment 'comment`' null, c3 enum('abc', 'cba', 'aaa')), add index t3_i1 using btree (c2) comment 'some index';
 alter table t2 add constraint t2_pk_constraint primary key (1c), alter column `_` set default 1;
 alter table ship_class change column somecol col_for_del tinyint first;


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2067

Updated Antlr grammar to support `ALGORITHM=INSTANT` on alter table statements.