### PR TITLE
DBZ-2021 Updates to allow downstream UG to build

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -27,6 +27,7 @@ asciidoc:
     link-sqlserver-connector: 'connectors/sqlserver.adoc'
     link-db2-connector: 'connectors/db2.adoc'
     link-cassandra-connector: 'connectors/cassandra.adoc'
+    link-debezium-monitoring: 'operations/monitoring.adoc'
     link-custom-converters: 'development/converters.adoc'
     link-mysql-plugin-snapshot: 'https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.debezium&a=debezium-connector-mysql&v=LATEST&c=plugin&e=tar.gz'
     link-postgres-plugin-snapshot: 'https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.debezium&a=debezium-connector-postgres&v=LATEST&c=plugin&e=tar.gz'

--- a/documentation/modules/ROOT/pages/configuration/avro.adoc
+++ b/documentation/modules/ROOT/pages/configuration/avro.adoc
@@ -120,7 +120,7 @@ docker run -it --rm --name avro-consumer \
       --topic db.myschema.mytable
 ----
 
-[[names]]
+[[avro-naming]]
 == Naming
 
 As stated in the Avro link:https://avro.apache.org/docs/current/spec.html#names[documentation], names must adhere to the following rules:

--- a/documentation/modules/ROOT/pages/configuration/mongodb-event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/configuration/mongodb-event-flattening.adoc
@@ -301,7 +301,7 @@ Please use a comma separated list without spaces.
 |[[configuration-option-sanitize-field-names]]<<configuration-option-sanitize-field-names, `sanitize.field.names`>>
 |`false`
 |Whether field names will be sanitized to adhere to Avro naming requirements.
-See xref:configuration/avro.adoc#names[Avro naming] for more details.
+See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 |===
 
 == Known limitations

--- a/documentation/modules/ROOT/pages/connectors/cassandra.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cassandra.adoc
@@ -1004,7 +1004,7 @@ refreshing the cached Cassandra table schemas.
 |[[connector-property-sanitize-field-names]]<<connector-property-sanitize-field-names, `sanitize.field.names`>>
 |`true` when connector configuration explicitly specifies the `key.converter` or `value.converter` parameters to use Avro, otherwise defaults to `false`.
 |Whether field names will be sanitized to adhere to Avro naming requirements.
-See xref:configuration/avro.adoc#names[Avro naming] for more details.
+See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 
 |=======================
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1548,7 +1548,7 @@ This property contains a comma-separated list of fully-qualified tables _(SCHEMA
 |[[connector-property-sanitize-field-names]]<<connector-property-sanitize-field-names, `sanitize.field.names`>>
 |`true` when connector configuration explicitly specifies the `key.converter` or `value.converter` parameters to use Avro, otherwise defaults to `false`.
 |Whether field names will be sanitized to adhere to Avro naming requirements.
-See xref:configuration/avro.adoc#names[Avro naming] for more details.
+See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 
 |[[connector-property-provide-transaction-metadata]]<<connector-property-provide-transaction-metadata, `provide.transaction.metadata` (Incubating)>>
 |`false`

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -734,7 +734,7 @@ The {prodname} MongoDB connector has two metric types in addition to the built-i
 * <<mongodb-snapshot-metrics, snapshot metrics>>; for monitoring the connector when performing snapshots
 * <<mongodb-streaming-metrics, streaming metrics>>; for monitoring the connector when processing oplog events
 
-Please refer to the xref:operations/monitoring.adoc[monitoring documentation] for details of how to expose these metrics via JMX.
+Please refer to the {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[monitoring documentation] for details of how to expose these metrics via JMX.
 
 [[monitoring-snapshots]]
 [[mongodb-snapshot-metrics]]

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -951,7 +951,7 @@ The topic is named according to the pattern `<heartbeat.topics.prefix>.<server.n
 |`true` when connector configuration explicitly specifies the `key.converter` or `value.converter` parameters to use Avro, otherwise defaults to `false`.
 |Whether field names are sanitized to adhere to Avro naming requirements.
 ifndef::cdc-product[]
-See xref:configuration/avro.adoc#names[Avro naming] for more details.
+See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 endif::cdc-product[]
 
 |[[connector-property-skipped-operations]]<<connector-property-skipped-operations, `skipped.operations`>>

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1267,7 +1267,7 @@ The connector will read the table contents in multiple batches of this size. Def
 |[[connector-property-sanitize-field-names]]<<connector-property-sanitize-field-names, `sanitize.field.names`>>
 |`true` when connector configuration explicitly specifies the `key.converter` or `value.converter` parameters to use Avro, otherwise defaults to `false`.
 |Whether field names will be sanitized to adhere to Avro naming requirements.
-See xref:configuration/avro.adoc#names[Avro naming] for more details.
+See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 
 |[[connector-property-provide-transaction-metadata]]<<connector-property-provide-transaction-metadata, `provide.transaction.metadata` (Incubating)>>
 |`false`

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1,4 +1,3 @@
-
 [id="debezium-connector-for-postgresql"]
 = {prodname} Connector for PostgreSQL
 
@@ -479,7 +478,7 @@ This is particularly valuable for environments where installation of plug-ins is
 
 See link:#setting-up-PostgreSQL[Setting up PostgreSQL] for more details.
 
-[[topic-names]]
+[[postgresql-topic-names]]
 ==== Topics Names
 
 The PostgreSQL connector writes events for all insert, update, and delete operations on a single table to a single Kafka topic. By default, the Kafka topic name is _serverName_._schemaName_._tableName_ where _serverName_ is the logical name of the connector as specified with the `database.server.name` configuration property, _schemaName_ is the name of the database schema where the operation occurred, and _tableName_ is the name of the database table on which the operation occurred.
@@ -527,7 +526,7 @@ The `sourceOffset` portion of the message contains information about the locatio
 [[events]]
 ==== Events
 
-All data change events produced by the PostgreSQL connector have a key and a value, although the structure of the key and value depend on the table from which the change events originated (see link:#topic-names[Topic names]).
+All data change events produced by the PostgreSQL connector have a key and a value, although the structure of the key and value depend on the table from which the change events originated (see link:#postgresql-topic-names[Topic names]).
 
 [NOTE]
 ====
@@ -2034,7 +2033,7 @@ For example, `add-tables=public.table,public.table2;include-lsn=true`.
 |[[connector-property-sanitize-field-names]]<<connector-property-sanitize-field-names, `sanitize.field.names`>>
 |`true` when connector configuration explicitly specifies the `key.converter` or `value.converter` parameters to use Avro, otherwise defaults to `false`.
 |Whether field names will be sanitized to adhere to Avro naming requirements.
-See xref:configuration/avro.adoc#names[Avro naming] for more details.
+See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 
 |[[connector-property-slot-max-retries]]<<connector-property-slot-max-retries, `slot.max.retries`>>
 |6

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1591,7 +1591,7 @@ endif::cdc-product[]
 |`true` when connector configuration explicitly specifies the `key.converter` or `value.converter` parameters to use Avro, otherwise defaults to `false`.
 |Whether field names are sanitized to adhere to Avro naming requirements.
 ifndef::cdc-product[]
-See xref:configuration/avro.adoc#names[Avro naming] for more details.
+See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 endif::cdc-product[]
 
 |[[connector-property-database-server-timezone]]<<connector-property-database-server-timezone, `database.server.timezone`>>

--- a/documentation/modules/ROOT/pages/operations/monitoring.adoc
+++ b/documentation/modules/ROOT/pages/operations/monitoring.adoc
@@ -1,5 +1,6 @@
-= Monitoring Debezium
-include::../_attributes.adoc[]
+[id="monitoring-debezium"]
+= Monitoring {prodname}
+
 :linkattrs:
 :icons: font
 :toc:

--- a/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/r_mysql-connector-monitoring-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/r_mysql-connector-monitoring-metrics.adoc
@@ -10,7 +10,7 @@ The {prodname} MySQL connector has three metric types in addition to the built-i
 * <<mysql-connector-binlog-metrics, binlog metrics>>; for monitoring the connector when reading CDC table data
 * <<mysql-connector-schema-history-metrics, schema history metrics>>; for monitoring the status of the connector's schema history
 
-Refer to the xref:operations/monitoring.adoc[monitoring documentation] for details of how to expose these metrics via JMX.
+Refer to the {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[monitoring documentation] for details of how to expose these metrics via JMX.
 
 == Snapshot metrics
 [[mysql-connector-snapshot-metrics]]


### PR DESCRIPTION
Added `link-debezium-monitoring` attribute to `antora.yml`.
Used that attribute to change the link format for some links so they will work upstream and downstream. 
Changed the `names` anchor ID to `avro-naming` to avoid duplicate anchor IDs. 
With these updates, fetching the 1.1 branch from downstream should enable the Debezium User Guide to build. 