### PR TITLE
DBZ-2052 Added support for SSH tunneling using JSch

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlJdbcContext.java
@@ -47,6 +47,7 @@ public class MySqlJdbcContext implements AutoCloseable {
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
     protected final Configuration config;
+    protected final Configuration tunneledConfig;
     protected final JdbcConnection jdbc;
     private final Map<String, String> originalSystemProperties = new HashMap<>();
 
@@ -81,6 +82,8 @@ public class MySqlJdbcContext implements AutoCloseable {
         String driverClassName = jdbcConfig.getString(MySqlConnectorConfig.JDBC_DRIVER);
         this.jdbc = new JdbcConnection(jdbcConfig,
                 JdbcConnection.patternBasedFactory(MYSQL_CONNECTION_URL, driverClassName, getClass().getClassLoader()));
+
+        this.tunneledConfig = this.config().edit().with("database.hostname", this.jdbc.hostname()).with("database.port", this.jdbc.port()).build();
     }
 
     public Configuration config() {
@@ -104,11 +107,11 @@ public class MySqlJdbcContext implements AutoCloseable {
     }
 
     public String hostname() {
-        return config.getString(MySqlConnectorConfig.HOSTNAME);
+        return tunneledConfig.getString(MySqlConnectorConfig.HOSTNAME);
     }
 
     public int port() {
-        return config.getInteger(MySqlConnectorConfig.PORT);
+        return tunneledConfig.getInteger(MySqlConnectorConfig.PORT);
     }
 
     public SecureConnectionMode sslMode() {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -59,9 +59,11 @@ public final class MySqlTaskContext extends CdcSourceTaskContext {
     public MySqlTaskContext(Configuration config, Filters filters, Boolean tableIdCaseInsensitive, Map<String, ?> restartOffset) {
         super(Module.contextName(), config.getString(MySqlConnectorConfig.SERVER_NAME), Collections::emptyList);
 
-        this.config = config;
-        this.connectorConfig = new MySqlConnectorConfig(config);
-        this.connectionContext = new MySqlJdbcContext(connectorConfig);
+        MySqlConnectorConfig tmpConnectorConfig = new MySqlConnectorConfig(config);
+        this.connectionContext = new MySqlJdbcContext(tmpConnectorConfig);
+        this.connectorConfig = new MySqlConnectorConfig(this.connectionContext.config);
+
+        this.config = this.connectionContext.config;
 
         // Set up the topic selector ...
         this.topicSelector = MySqlTopicSelector.defaultSelector(connectorConfig.getLogicalName(), connectorConfig.getHeartbeatTopicsPrefix());

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -321,13 +321,23 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         // which may be the same as the "master" ...
         config = Configuration.create()
                 .with(MySqlConnectorConfig.HOSTNAME, System.getProperty("database.replica.hostname", "localhost"))
+                // .with(MySqlConnectorConfig.HOSTNAME,
+                // System.getProperty("database.hostname", "oryan-debezium-mysql-source.cqvgyp3n1jvu.us-east-2.rds.amazonaws.com"))
                 .with(MySqlConnectorConfig.PORT, System.getProperty("database.replica.port", "3306"))
                 .with(MySqlConnectorConfig.USER, "snapper")
+                // .with(MySqlConnectorConfig.USER, System.getProperty("database.user", "admin"))
                 .with(MySqlConnectorConfig.PASSWORD, "snapperpass")
+                // .with(MySqlConnectorConfig.PASSWORD, System.getProperty("database.password", "oror13254"))
                 .with(MySqlConnectorConfig.SERVER_ID, 18765)
                 .with(MySqlConnectorConfig.SERVER_NAME, DATABASE.getServerName())
                 .with(MySqlConnectorConfig.SSL_MODE, SecureConnectionMode.DISABLED)
                 .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
+
+                // .with(MySqlConnectorConfig.SSH_HOSTNAME, System.getProperty("database.ssh.host", "52.15.128.12"))
+                // .with(MySqlConnectorConfig.SSH_USER, System.getProperty("database.ssh.user", "ec2-user"))
+                // .with(MySqlConnectorConfig.SSH_PRIVATE_KEY, System.getProperty("database.ssh.pem", ""))
+                // .with(MySqlConnectorConfig.SSH_KEY_FILE, "~/.ssh/RiveryKeyPairDev.pem")
+
                 .with(MySqlConnectorConfig.DATABASE_WHITELIST, DATABASE.getDatabaseName())
                 .with(MySqlConnectorConfig.DATABASE_HISTORY, FileDatabaseHistory.class)
                 .with(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -67,6 +67,11 @@
             <artifactId>js-scriptengine</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch</artifactId>
+        </dependency>
+
 
         <!-- Testing -->
         <dependency>

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConfiguration.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConfiguration.java
@@ -50,6 +50,41 @@ public interface JdbcConfiguration extends Configuration {
     public static final Field PORT = Field.create("port", "Port of the database");
 
     /**
+     * A field for the hostname of the ssh jumpserver. There is no default value.
+     */
+    public static final Field SSH_HOSTNAME = Field.create("ssh.host", "Hostname of the ssh jumpserver");
+
+    /**
+     * A field for the username of the ssh jumpserver. There is no default value.
+     */
+    public static final Field SSH_USER = Field.create("ssh.user", "Username of the ssh jumpserver");
+
+    /**
+     * A field for the private key of the ssh jumpserver. There is no default value.
+     */
+    public static final Field SSH_PRIVATE_KEY = Field.create("ssh.pem", "Private key of the ssh jumpserver");
+
+    /**
+     * A field for the public key of the ssh jumpserver. There is no default value.
+     */
+    public static final Field SSH_PUBLIC_KEY = Field.create("ssh.pub", "Public key of the ssh jumpserver");
+
+    /**
+     * A field for the path to the private key of the ssh jumpserver. There is no default value.
+     */
+    public static final Field SSH_KEY_FILE = Field.create("ssh.keyfile", "Path to the private key of the ssh jumpserver");
+
+    /**
+     * A field for the key passphrase of the ssh jumpserver. There is no default value.
+     */
+    public static final Field SSH_PASSPHRASE = Field.create("ssh.pass", "Passphrase for the private key of the ssh jumpserver");
+
+    /**
+     * A field for the port of the ssh jumpserver. There is no default value.
+     */
+    public static final Field SSH_PORT = Field.create("ssh.port", "Port of the ssh jumpserver");
+
+    /**
      * A semicolon separated list of SQL statements to be executed when the connection to database is established.
      * Typical use-case is setting of session parameters. There is no default value.
      */
@@ -59,7 +94,8 @@ public interface JdbcConfiguration extends Configuration {
      * The set of names of the pre-defined JDBC configuration fields, including {@link #DATABASE}, {@link #USER},
      * {@link #PASSWORD}, {@link #HOSTNAME}, and {@link #PORT}.
      */
-    public static Set<String> ALL_KNOWN_FIELDS = Collect.unmodifiableSet(Field::name, DATABASE, USER, PASSWORD, HOSTNAME, PORT, ON_CONNECT_STATEMENTS);
+    public static Set<String> ALL_KNOWN_FIELDS = Collect.unmodifiableSet(Field::name, DATABASE, USER, PASSWORD, HOSTNAME, PORT, ON_CONNECT_STATEMENTS, SSH_HOSTNAME,
+            SSH_USER, SSH_PRIVATE_KEY, SSH_PUBLIC_KEY, SSH_KEY_FILE, SSH_PORT, SSH_PASSPHRASE);
 
     /**
      * Obtain a {@link JdbcConfiguration} adapter for the given {@link Configuration}.
@@ -144,6 +180,66 @@ public interface JdbcConfiguration extends Configuration {
          */
         default Builder withPort(int port) {
             return with(PORT, port);
+        }
+
+        /**
+         * Use the given ssh hostname in the resulting configuration.
+         *
+         * @param sshHostname the hostname for the ssh connection
+         * @return this builder object so methods can be chained together; never null
+         */
+        default Builder withSshHostname(String sshHostname) {
+            return with(SSH_HOSTNAME, sshHostname);
+        }
+
+        /**
+         * Use the given ssh user in the resulting configuration.
+         *
+         * @param sshUsername the username for the ssh connection
+         * @return this builder object so methods can be chained together; never null
+         */
+        default Builder withSshUsername(String sshUsername) {
+            return with(SSH_USER, sshUsername);
+        }
+
+        /**
+         * Use the given ssh private key in the resulting configuration.
+         *
+         * @param sshPkey the private key for the ssh connection
+         * @return this builder object so methods can be chained together; never null
+         */
+        default Builder withSshPkey(String sshPkey) {
+            return with(SSH_PRIVATE_KEY, sshPkey);
+        }
+
+        /**
+         * Use the given ssh private key file path in the resulting configuration.
+         *
+         * @param sshKeyFile the path to the private key for the ssh connection
+         * @return this builder object so methods can be chained together; never null
+         */
+        default Builder withSsshKeyFile(String sshKeyFile) {
+            return with(SSH_KEY_FILE, sshKeyFile);
+        }
+
+        /**
+         * Use the given ssh passphrase in the resulting configuration.
+         *
+         * @param sshPassphrase the passphrase to the private key for the ssh connection
+         * @return this builder object so methods can be chained together; never null
+         */
+        default Builder withSshPassphrase(String sshPassphrase) {
+            return with(SSH_PASSPHRASE, sshPassphrase);
+        }
+
+        /**
+         * Use the given ssh port in the resulting configuration.
+         *
+         * @param sshPort the port for the ssh connection
+         * @return this builder object so methods can be chained together; never null
+         */
+        default Builder withPort(String sshPort) {
+            return with(SSH_PORT, sshPort);
         }
     }
 
@@ -320,5 +416,68 @@ public interface JdbcConfiguration extends Configuration {
      */
     default String getPassword() {
         return getString(PASSWORD);
+    }
+
+    /**
+     * Get the sshhost property from the configuration.
+     *
+     * @return the specified or default sshhost value, or null if there is none.
+     */
+    default String getSshHost() {
+        return getString(SSH_HOSTNAME);
+    }
+
+    /**
+     * Get the sshuser property from the configuration.
+     *
+     * @return the specified or default sshuser value, or null if there is none.
+     */
+    default String getSshUser() {
+        return getString(SSH_USER);
+    }
+
+    /**
+     * Get the ssh.pem property from the configuration.
+     *
+     * @return the specified or default ssh.pub value, or null if there is none.
+     */
+    default String getSshPem() {
+        return getString(SSH_PRIVATE_KEY);
+    }
+
+    /**
+     * Get the ssh.pub property from the configuration.
+     *
+     * @return the specified or default ssh.pem value, or null if there is none.
+     */
+    default String getSshPub() {
+        return getString(SSH_PUBLIC_KEY);
+    }
+
+    /**
+     * Get the sshkeyfile property from the configuration.
+     *
+     * @return the specified or default sshkeyfile value, or null if there is none.
+     */
+    default String getSshKeyFile() {
+        return getString(SSH_KEY_FILE);
+    }
+
+    /**
+     * Get the sshpass property from the configuration.
+     *
+     * @return the specified or default sshpass value, or null if there is none.
+     */
+    default String getSshPassphrase() {
+        return getString(SSH_PASSPHRASE);
+    }
+
+    /**
+     * Get the sshport property from the configuration.
+     *
+     * @return the specified or default sshport value, or null if there is none.
+     */
+    default String getSshPort() {
+        return getString(SSH_PORT);
     }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -122,6 +122,14 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
         }
     }
 
+    public static final Field SSH_HOSTNAME = Field.create("database.ssh.host", "Hostname of the ssh jumpserver");
+    public static final Field SSH_PASSPHRASE = Field.create("database.ssh.pass", "Passphrase of the ssh jumpserver");
+    public static final Field SSH_USER = Field.create("database.ssh.user", "Username of the ssh jumpserver");
+    public static final Field SSH_PORT = Field.create("database.ssh.port", "Port of the ssh jumpserver");
+    public static final Field SSH_PRIVATE_KEY = Field.create("database.ssh.pem", "Private key of the ssh jumpserver");
+    public static final Field SSH_PUBLIC_KEY = Field.create("database.ssh.pub", "Public key of the ssh jumpserver");
+    public static final Field SSH_KEY_FILE = Field.create("database.ssh.keyfile", "Private key file path of the ssh jumpserver");
+
     public static final Field SERVER_NAME = Field.create(DATABASE_CONFIG_PREFIX + "server.name")
             .withDisplayName("Namespace")
             .withType(Type.STRING)

--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,13 @@
                 <version>1.0.2</version>
             </dependency>
 
+
+            <dependency>
+                <groupId>com.jcraft</groupId>
+                <artifactId>jsch</artifactId>
+                <version>0.1.55</version>
+            </dependency>
+
             <!-- MongoDB Java driver -->
             <dependency>
                 <groupId>org.mongodb</groupId>


### PR DESCRIPTION
I added support for SSH tunneling using JSch, in order to connect to a database through a jumpserver, configured dynamically per connection.

The configuration options are:
```json
{
  "database.ssh.host": "JUMP_SERVER_HOST",
  "database.ssh.user": "JUMP_SERVER_USERNAME",
  "database.ssh.port": "JUMP_SERVER_PORT",
  "database.ssh.pem": "JUMP_SERVER_PRIVATE_KEY",
  "database.ssh.pass": "JUMP_SERVER_PRIVATE_KEY_PASSPHRASE",
  "database.ssh.keyfile": "PATH_TO_JUMP_SERVER_PRIVATE_KEY_FILE"
}
```

The changes are mainly in the JdbcConnection part, intercepting in this part allowed me to make minimal changes in the other connectors.