### PR TITLE
DBZ-2133 attempt shutdown on interrupt

### DIFF
--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -195,6 +195,7 @@ public abstract class BaseSourceTask extends SourceTask {
             catch (InterruptedException e) {
                 Thread.interrupted();
                 LOGGER.error("Interrupted while stopping coordinator", e);
+                doStop();
                 throw new ConnectException("Interrupted while stopping coordinator, failing the task");
             }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2133

It appears that connectors can get into a weird state where the task has failed but connection are still open. I believe this bug was introduced with a recent refactor. Attempting to shutdown the connections even during the caught exception should help this issue.