### PR TITLE
DBZ-2016 Remove Tech Preview note for MongoDB connector doc

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -12,14 +12,6 @@ ifdef::community[]
 toc::[]
 endif::community[]
 
-ifdef::product[]
-[IMPORTANT]
-====
-Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete; therefore, Red Hat does not recommend implementing any Technology Preview features in production environments. This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
-For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope^].
-====
-endif::product[]
-
 {prodname}'s MongoDB connector tracks a MongoDB replica set or a MongoDB sharded cluster for document changes in databases and collections, recording those changes as events in Kafka topics.
 The connector automatically handles the addition or removal of shards in a sharded cluster, changes in membership of each replica set, elections within each replica set, and awaiting the resolution of communications problems.
 

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -318,7 +318,7 @@ When the alternative implementations are not available then the default ones are
 |Custom implementation maps the planned destination (topic) name into a physical Kinesis stream name.
 By default the same name is used.
 
-|=======================
+|===
 
 
 ==== Google Cloud Pub/Sub
@@ -326,8 +326,8 @@ By default the same name is used.
 Google Cloud Pub/Sub is an implementation of messaging/eventing system designed for scalable batch and stream processing applications.
 Pub/Sub exposes a set of REST APIs and provides a (not-only) Java SDK that is used to implement the sink.
 
-[cols="35%a,10%a,55%a",options="header"]
-|=======================
+[cols="35%a,10%a,55%a"]
+|===
 |Property
 |Default
 |Description
@@ -350,7 +350,7 @@ This feature can be disabled.
 |Tables without primary key sends messages with `null` key.
 This is not supported by Pub/Sub so a surrogate key must be used.
 
-|=======================
+|===
 
 
 ==== Injection points
@@ -358,8 +358,8 @@ This is not supported by Pub/Sub so a surrogate key must be used.
 The Pub/Sub sink behaviour can be modified by a custom logic providing alternative implementations for specific functionalities.
 When the alternative implementations are not available then the default ones are used.
 
-[cols="35%a,10%a,55%a",options="header"]
-|=======================
+[cols="35%a,10%a,55%a"]
+|===
 |Interface
 |CDI classifier
 |Description


### PR DESCRIPTION
This removed the Tech Preview note from the MongoDB connector doc. The note was conditionalized to be downstream only. When I ran antora to confirm that the doc still built, there were some errors in the debezium-server.adoc file. Some table formatting was causing the errors so I fixed that and ran antora again - no errors. 
Please backport this to 1.1. 