### PR TITLE
DBZ-2017 Remove Tech Preview note from SQL Server connector doc

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -17,14 +17,6 @@ Want to help us further hone and improve it? link:/docs/contribute/[Learn how].
 toc::[]
 endif::community[]
 
-ifdef::product[]
-[IMPORTANT]
-====
-Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete; therefore, Red Hat does not recommend implementing any Technology Preview features in production environments. This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
-For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope^].
-====
-endif::product[]
-
 {prodname}'s SQL Server Connector can monitor and record the row-level changes in the schemas of a SQL Server database.
 
 The first time it connects to a SQL Server database/cluster, it reads a consistent snapshot of all of the schemas.


### PR DESCRIPTION
The title says it all. Please backport to 1.1. Thanks!