### PR TITLE
DBZ-2136 Update ChangeEventQueue Javadoc by fixing typo

### DIFF
--- a/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
+++ b/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
@@ -37,7 +37,7 @@ import io.debezium.util.Threads.Timer;
  * the queue.
  * <p>
  * If an exception occurs on the producer side, the producer should make that
- * exception known by calling {@link #producerFailure} before stopping its
+ * exception known by calling {@link #producerException(RuntimeException)} before stopping its
  * operation. Upon the next call to {@link #poll()}, that exception will be
  * raised, causing Kafka Connect to stop the connector and mark it as
  * {@code FAILED}.


### PR DESCRIPTION
ChangeEventQueue's javadoc refers to a function `producerFailure`, which has been renamed to `producerException`.