### PR TITLE
DBZ-2159 Add API checks using Revapi

### DIFF
--- a/debezium-api/pom.xml
+++ b/debezium-api/pom.xml
@@ -65,6 +65,10 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <properties>
+        <!-- Enable API checks in this module -->
+        <revapi.skip>false</revapi.skip>
+    </properties>
     <build>
         <resources>
             <!-- Apply the properties set in the POM to the resource files -->

--- a/debezium-api/src/chore/intentional-api-changes.xml
+++ b/debezium-api/src/chore/intentional-api-changes.xml
@@ -1,0 +1,10 @@
+<revapi-configuration>
+    <!-- No changes as of yet. This is just an example of how to tell Revapi to ignore intentional changes.
+    <version-1.2.0>
+        <revapi.ignore>
+            You can copy the ignore suggestions printed by Revapi during the build here, if you think
+            the API change is necessary.
+        </revapi.ignore>
+    </version-1.2.0>
+    -->
+</revapi-configuration>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -241,7 +241,7 @@
                             <filter>
                                 <packages>
                                     <include>
-                                        <item>io.debezium.connector.posgresql.spi</item>
+                                        <item>io.debezium.connector.postgresql.spi</item>
                                     </include>
                                 </packages>
                             </filter>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -31,6 +31,9 @@
         <docker.initimage>ln -fs /usr/share/zoneinfo/US/Samoa /etc/localtime &amp;&amp; echo timezone=US/Samoa &gt;&gt; ${postgres.config.file}</docker.initimage>
 
         <protobuf.output.directory>${project.basedir}/generated-sources</protobuf.output.directory>
+
+        <!-- We're tracking the API changes of the SPI. -->
+        <revapi.skip>false</revapi.skip>
     </properties>
 
     <dependencies>
@@ -227,6 +230,23 @@
                         <plugin.name>${decoder.plugin.name}</plugin.name>
                         <skipLongRunningTests>${skipLongRunningTests}</skipLongRunningTests>
                     </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.revapi</groupId>
+                <artifactId>revapi-maven-plugin</artifactId>
+                <configuration>
+                    <analysisConfiguration combine.children="append">
+                        <revapi.java>
+                            <filter>
+                                <packages>
+                                    <include>
+                                        <item>io.debezium.connector.posgresql.spi</item>
+                                    </include>
+                                </packages>
+                            </filter>
+                        </revapi.java>
+                    </analysisConfiguration>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,7 @@
     <modules>
         <module>support/checkstyle</module>
         <module>support/ide-configs</module>
+        <module>support/revapi</module>
         <module>debezium-api</module>
         <module>debezium-ddl-parser</module>
         <module>debezium-assembly-descriptors</module>
@@ -658,6 +659,18 @@
                     <groupId>org.revapi</groupId>
                     <artifactId>revapi-maven-plugin</artifactId>
                     <version>${version.revapi.plugin}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>io.debezium</groupId>
+                            <artifactId>debezium-revapi</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.revapi</groupId>
+                            <artifactId>revapi-java</artifactId>
+                            <version>${version.revapi-java.plugin}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -866,44 +879,26 @@
             <plugin>
                 <groupId>org.revapi</groupId>
                 <artifactId>revapi-maven-plugin</artifactId>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.revapi</groupId>
-                        <artifactId>revapi-java</artifactId>
-                        <version>${version.revapi-java.plugin}</version>
-                    </dependency>
-                </dependencies>
                 <configuration>
                     <failOnMissingConfigurationFiles>false</failOnMissingConfigurationFiles>
                     <!-- Consider changes from the latest .Final version, not from the latest non-snapshot. -->
                     <versionFormat>\d+\.\d+\.\d+\.Final</versionFormat>
                     <ignoreSuggestionsFormat>xml</ignoreSuggestionsFormat>
-                    <analysisConfiguration>
-                        <revapi.semver.ignore>
-                            <!-- Automatically ignore changes that are OK according to the semver rules. -->
-                            <enabled>true</enabled>
-                        </revapi.semver.ignore>
-                        <revapi.java.filter.annotated>
-                            <exclude>
-                                <!-- Don't break on changes in the incubating API. -->
-                                <item>@io.debezium.common.annotation.Incubating</item>
-                            </exclude>
-                        </revapi.java.filter.annotated>
-                    </analysisConfiguration>
                     <analysisConfigurationFiles>
                         <configurationFile>
-                            <!--
-                                Each API checked module can have a file detailing the intentional API changes
-                                in the form of a configuration for Revapi.
-                            -->
-                            <path>${basedir}/src/chore/intentional-api-changes.xml</path>
+                            <!-- common API checking configuration -->
+                            <resource>revapi/revapi-configuration.xml</resource>
+                        </configurationFile>
+                        <configurationFile>
+                            <!-- API changes recorded in the support/revapi module -->
+                            <resource>revapi/debezium-api-changes.xml</resource>
                             <roots>
                                 <!--
-                                    The XML file has "<revapi-configuration>" root node, underneath which
+                                    The XML file has "<analysisConfiguration>" root node, underneath which
                                     there are nodes named after each version.
                                     This way we only need a single file for all releases of Debezium.
                                 -->
-                                <root>revapi-configuration/version-${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</root>
+                                <root>analysisConfiguration/version-${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</root>
                             </roots>
                         </configurationFile>
                     </analysisConfigurationFiles>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,9 @@
         <version.surefire.plugin>2.22.2</version.surefire.plugin>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.checkstyle>8.32</version.checkstyle>
+        <version.revapi.plugin>0.11.5</version.revapi.plugin>
+        <version.revapi-java.plugin>0.21.0</version.revapi-java.plugin>
+        <version.build-helper.plugin>1.9.1</version.build-helper.plugin>
 
         <!-- Dockerfiles -->
         <docker.maintainer>Debezium community</docker.maintainer>
@@ -156,6 +159,9 @@
 
         <!-- Needed for pre jdk 9 -->
         <useSystemClassLoader>true</useSystemClassLoader>
+
+        <!-- Skip the API checks by default. Let the modules opt in. -->
+        <revapi.skip>true</revapi.skip>
     </properties>
 
     <modules>
@@ -648,6 +654,16 @@
                         <removeUnused>true</removeUnused>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.revapi</groupId>
+                    <artifactId>revapi-maven-plugin</artifactId>
+                    <version>${version.revapi.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>${version.build-helper.plugin}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -828,6 +844,74 @@
                         <phase>verify</phase>
                         <goals>
                             <goal>checkstyle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!-- Serves as support for configuring Revapi -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>parse-version</id>
+                        <goals>
+                            <!-- This defines the ${parsedVersion.*} properties used in the Revapi config. -->
+                            <goal>parse-version</goal>
+                        </goals>
+                        <phase>validate</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.revapi</groupId>
+                <artifactId>revapi-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.revapi</groupId>
+                        <artifactId>revapi-java</artifactId>
+                        <version>${version.revapi-java.plugin}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <failOnMissingConfigurationFiles>false</failOnMissingConfigurationFiles>
+                    <!-- Consider changes from the latest .Final version, not from the latest non-snapshot. -->
+                    <versionFormat>\d+\.\d+\.\d+\.Final</versionFormat>
+                    <ignoreSuggestionsFormat>xml</ignoreSuggestionsFormat>
+                    <analysisConfiguration>
+                        <revapi.semver.ignore>
+                            <!-- Automatically ignore changes that are OK according to the semver rules. -->
+                            <enabled>true</enabled>
+                        </revapi.semver.ignore>
+                        <revapi.java.filter.annotated>
+                            <exclude>
+                                <!-- Don't break on changes in the incubating API. -->
+                                <item>@io.debezium.common.annotation.Incubating</item>
+                            </exclude>
+                        </revapi.java.filter.annotated>
+                    </analysisConfiguration>
+                    <analysisConfigurationFiles>
+                        <configurationFile>
+                            <!--
+                                Each API checked module can have a file detailing the intentional API changes
+                                in the form of a configuration for Revapi.
+                            -->
+                            <path>${basedir}/src/chore/intentional-api-changes.xml</path>
+                            <roots>
+                                <!--
+                                    The XML file has "<revapi-configuration>" root node, underneath which
+                                    there are nodes named after each version.
+                                    This way we only need a single file for all releases of Debezium.
+                                -->
+                                <root>revapi-configuration/version-${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</root>
+                            </roots>
+                        </configurationFile>
+                    </analysisConfigurationFiles>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/support/revapi/pom.xml
+++ b/support/revapi/pom.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <parent>
+      <groupId>org.jboss</groupId>
+      <artifactId>jboss-parent</artifactId>
+      <version>35</version>
+      <!-- same as parent POM -->
+   </parent>
+
+   <modelVersion>4.0.0</modelVersion>
+   <groupId>io.debezium</groupId>
+   <artifactId>debezium-revapi</artifactId>
+   <version>1.2.0-SNAPSHOT</version>
+   <name>Debezium Revapi Rules</name>
+   <description>Contains the configuration of the Revapi API checker and the list of the API changes in the Debezium APIs.</description>
+
+    <properties>
+        <!-- Instruct the build to use only UTF-8 encoding for source code -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <version.jar.plugin>3.0.2</version.jar.plugin>
+        <version.compiler.plugin>3.8.1</version.compiler.plugin>
+    </properties>
+ 
+    <build>
+        <plugins>
+            <!-- 
+            This is not deployed into a Maven repository. It is merely installed into the local Maven repository
+            during a local build.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/support/revapi/src/main/resources/revapi/debezium-api-changes.xml
+++ b/support/revapi/src/main/resources/revapi/debezium-api-changes.xml
@@ -1,4 +1,5 @@
-<revapi-configuration>
+<?xml version='1.0' encoding='UTF-8'?>
+<analysisConfiguration>
     <!-- No changes as of yet. This is just an example of how to tell Revapi to ignore intentional changes.
     <version-1.2.0>
         <revapi.ignore>
@@ -7,4 +8,4 @@
         </revapi.ignore>
     </version-1.2.0>
     -->
-</revapi-configuration>
+</analysisConfiguration>

--- a/support/revapi/src/main/resources/revapi/revapi-configuration.xml
+++ b/support/revapi/src/main/resources/revapi/revapi-configuration.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- The basic configuration for Revapi API checks in all modules that have API checks enabled. -->
+<analysisConfiguration>
+    <revapi.semver.ignore>
+        <!-- Automatically ignore changes that are OK according to the semver rules. -->
+        <enabled>true</enabled>
+    </revapi.semver.ignore>
+    <revapi.java.filter.annotated>
+        <exclude>
+            <!-- Don't break on changes in the incubating API. -->
+            <item>@io.debezium.common.annotation.Incubating</item>
+        </exclude>
+    </revapi.java.filter.annotated>
+</analysisConfiguration>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2159

I've set it up in the following way:
* you can have a per-module file where you can detail intentional API changes,
* I've set up automatic ignoring of changes that are OK according to semver (based on the difference between currently built version and the last released version).
* All changes in the `@Incubating` API are ignored, too.

I've only enabled the API checks in the `debezium-api` though they are configured in the parent so that additional modules can opt in. It is possible to apply filtering so that you can for example consider only part of the classes in a module as API, etc.

