### PR TITLE
DBZ-2152 EventRouter with bytes based keys

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouter.java
@@ -113,6 +113,7 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         Object eventId = eventStruct.get(fieldEventId);
         Object payload = eventStruct.get(fieldPayload);
         Object payloadId = eventStruct.get(fieldPayloadId);
+        final Field fallbackPayloadIdField = eventValueSchema.field(fieldPayloadId);
 
         final Field eventIdField = eventValueSchema.field(fieldEventId);
         if (eventIdField == null) {
@@ -166,7 +167,7 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
         R newRecord = r.newRecord(
                 eventStruct.getString(routeByField),
                 null,
-                Schema.STRING_SCHEMA,
+                defineRecordKeySchema(eventValueSchema, fallbackPayloadIdField),
                 defineRecordKey(eventStruct, payloadId),
                 updatedSchema,
                 updatedValue,
@@ -212,6 +213,19 @@ public class EventRouter<R extends ConnectRecord<R>> implements Transformation<R
             default:
                 throw new ConnectException(String.format("Unsupported field type %s for event timestamp", schemaName));
         }
+    }
+
+    private Schema defineRecordKeySchema(Schema eventStruct, Field fallbackKeyField) {
+        Field eventKeySchema = null;
+        if (fieldEventKey != null) {
+            eventKeySchema = eventStruct.field(fieldEventKey);
+        }
+
+        if (eventKeySchema != null) {
+            return eventKeySchema.schema();
+        }
+
+        return (fallbackKeyField != null) ? fallbackKeyField.schema() : Schema.STRING_SCHEMA;
     }
 
     private Object defineRecordKey(Struct eventStruct, Object fallbackKey) {

--- a/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -8,13 +8,16 @@ package io.debezium.transforms.outbox;
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
 import static org.fest.assertions.Assertions.assertThat;
 
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.data.Envelope;
+import io.debezium.data.VerifyRecord;
+import io.debezium.doc.FixFor;
+import io.debezium.time.Timestamp;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -25,12 +28,6 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import io.debezium.connector.AbstractSourceInfo;
-import io.debezium.data.Envelope;
-import io.debezium.data.VerifyRecord;
-import io.debezium.doc.FixFor;
-import io.debezium.time.Timestamp;
 
 /**
  * Unit tests for {@link EventRouter}
@@ -709,6 +706,34 @@ public class EventRouterTest {
     }
 
     @Test
+    public void canSetBinaryMessageKey() {
+        final byte[] eventType = "a UserCreated".getBytes(StandardCharsets.UTF_8);
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        // This is not a good example of message key, this is just for test
+        config.put(EventRouterConfigDefinition.FIELD_EVENT_KEY.name(), "type");
+        router.configure(config);
+
+        final SourceRecord eventRecord = createEventRecord(
+                "da8d6de6-3b77-45ff-8f44-57db55a7a06c",
+                SchemaBuilder.bytes(),
+                eventType,
+                SchemaBuilder.string(),
+                "Some other payload id",
+                "User",
+                SchemaBuilder.string(),
+                "{}",
+                new HashMap<>(),
+                new HashMap<>());
+
+        final SourceRecord eventRouted = router.apply(eventRecord);
+
+        assertThat(eventRouted).isNotNull();
+        assertThat(eventRouted.keySchema().type()).isEqualTo(Schema.Type.BYTES);
+        assertThat(eventRouted.key()).isEqualTo(eventType);
+    }
+
+    @Test
     public void canPassBinaryKey() {
         final byte[] key = "a binary key".getBytes(StandardCharsets.UTF_8);
         canPassKeyByType(SchemaBuilder.bytes(), key);
@@ -727,6 +752,7 @@ public class EventRouterTest {
 
         final SourceRecord eventRecord = createEventRecord(
                 "da8d6de6-3b77-45ff-8f44-57db55a7a06c",
+                SchemaBuilder.string(),
                 "UserCreated",
                 keyType,
                 key,
@@ -752,6 +778,7 @@ public class EventRouterTest {
 
         final SourceRecord eventRecord = createEventRecord(
                 "da8d6de6-3b77-45ff-8f44-57db55a7a06c",
+                SchemaBuilder.string(),
                 "UserCreated",
                 SchemaBuilder.string(),
                 key,
@@ -899,6 +926,7 @@ public class EventRouterTest {
                                            Map<String, Object> extraValues) {
         return createEventRecord(
                 eventId,
+                SchemaBuilder.string(),
                 eventType,
                 SchemaBuilder.string(),
                 payloadId,
@@ -911,7 +939,8 @@ public class EventRouterTest {
 
     private SourceRecord createEventRecord(
                                            String eventId,
-                                           String eventType,
+                                           SchemaBuilder eventTypeSchemaType,
+                                           Object eventType,
                                            SchemaBuilder payloadIdSchemaType,
                                            Object payloadId,
                                            String payloadType,
@@ -923,7 +952,7 @@ public class EventRouterTest {
                 .field("id", SchemaBuilder.string())
                 .field("aggregatetype", SchemaBuilder.string())
                 .field("aggregateid", payloadIdSchemaType)
-                .field("type", SchemaBuilder.string())
+                .field("type", eventTypeSchemaType)
                 .field("payload", payloadSchemaType)
                 .field("is_deleted", SchemaBuilder.bool().optional());
 

--- a/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -8,15 +8,11 @@ package io.debezium.transforms.outbox;
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
 import static org.fest.assertions.Assertions.assertThat;
 
-import io.debezium.connector.AbstractSourceInfo;
-import io.debezium.data.Envelope;
-import io.debezium.data.VerifyRecord;
-import io.debezium.doc.FixFor;
-import io.debezium.time.Timestamp;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -28,6 +24,12 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.data.Envelope;
+import io.debezium.data.VerifyRecord;
+import io.debezium.doc.FixFor;
+import io.debezium.time.Timestamp;
 
 /**
  * Unit tests for {@link EventRouter}
@@ -692,6 +694,7 @@ public class EventRouterTest {
     }
 
     @Test
+    @FixFor("DBZ-2152")
     public void canPassStringKey() {
         // canSetDefaultMessageKey() duplicates this logic, as the current test assumes the key will be a String
         final EventRouter<SourceRecord> router = new EventRouter<>();
@@ -706,6 +709,7 @@ public class EventRouterTest {
     }
 
     @Test
+    @FixFor("DBZ-2152")
     public void canSetBinaryMessageKey() {
         final byte[] eventType = "a UserCreated".getBytes(StandardCharsets.UTF_8);
         final EventRouter<SourceRecord> router = new EventRouter<>();
@@ -734,12 +738,14 @@ public class EventRouterTest {
     }
 
     @Test
+    @FixFor("DBZ-2152")
     public void canPassBinaryKey() {
         final byte[] key = "a binary key".getBytes(StandardCharsets.UTF_8);
         canPassKeyByType(SchemaBuilder.bytes(), key);
     }
 
     @Test
+    @FixFor("DBZ-2152")
     public void canPassIntKey() {
         final int key = 54321;
         canPassKeyByType(SchemaBuilder.int32(), key);
@@ -769,6 +775,7 @@ public class EventRouterTest {
     }
 
     @Test
+    @FixFor("DBZ-2152")
     public void canPassBinaryMessage() {
         final byte[] value = "a binary message".getBytes(StandardCharsets.UTF_8);
         final String key = "a key";

--- a/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/outbox/EventRouterTest.java
@@ -8,11 +8,13 @@ package io.debezium.transforms.outbox;
 import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
 import static org.fest.assertions.Assertions.assertThat;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -693,6 +695,82 @@ public class EventRouterTest {
     }
 
     @Test
+    public void canPassStringKey() {
+        // canSetDefaultMessageKey() duplicates this logic, as the current test assumes the key will be a String
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        router.configure(config);
+
+        final SourceRecord eventRecord = createEventRecord();
+        final SourceRecord eventRouted = router.apply(eventRecord);
+
+        assertThat(eventRouted).isNotNull();
+        assertThat(eventRouted.keySchema().type()).isEqualTo(Schema.Type.STRING);
+    }
+
+    @Test
+    public void canPassBinaryKey() {
+        final byte[] key = "a binary key".getBytes(StandardCharsets.UTF_8);
+        canPassKeyByType(SchemaBuilder.bytes(), key);
+    }
+
+    @Test
+    public void canPassIntKey() {
+        final int key = 54321;
+        canPassKeyByType(SchemaBuilder.int32(), key);
+    }
+
+    private void canPassKeyByType(SchemaBuilder keyType, Object key) {
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        router.configure(config);
+
+        final SourceRecord eventRecord = createEventRecord(
+                "da8d6de6-3b77-45ff-8f44-57db55a7a06c",
+                "UserCreated",
+                keyType,
+                key,
+                "User",
+                SchemaBuilder.string(),
+                "{}",
+                new HashMap<>(),
+                new HashMap<>());
+        final SourceRecord eventRouted = router.apply(eventRecord);
+
+        assertThat(eventRouted).isNotNull();
+        assertThat(eventRouted.keySchema().type()).isEqualTo(keyType.type());
+        assertThat(eventRouted.key()).isEqualTo(key);
+    }
+
+    @Test
+    public void canPassBinaryMessage() {
+        final byte[] value = "a binary message".getBytes(StandardCharsets.UTF_8);
+        final String key = "a key";
+        final EventRouter<SourceRecord> router = new EventRouter<>();
+        final Map<String, String> config = new HashMap<>();
+        router.configure(config);
+
+        final SourceRecord eventRecord = createEventRecord(
+                "da8d6de6-3b77-45ff-8f44-57db55a7a06c",
+                "UserCreated",
+                SchemaBuilder.string(),
+                key,
+                "User",
+                SchemaBuilder.bytes(),
+                value,
+                new HashMap<>(),
+                new HashMap<>());
+        final SourceRecord eventRouted = router.apply(eventRecord);
+
+        assertThat(eventRouted).isNotNull();
+        assertThat(eventRouted.keySchema().type()).isEqualTo(Schema.Type.STRING);
+        assertThat(eventRouted.key()).isEqualTo(key);
+        assertThat(eventRouted.valueSchema().type()).isEqualTo(Schema.Type.STRUCT);
+        Struct valuePassed = (Struct) eventRouted.value();
+        assertThat(valuePassed.get("payload")).isEqualTo(value);
+    }
+
+    @Test
     public void canMarkAnEventAsDeleted() {
         final EventRouter<SourceRecord> router = new EventRouter<>();
         final Map<String, String> config = new HashMap<>();
@@ -819,12 +897,34 @@ public class EventRouterTest {
                                            String payload,
                                            Map<String, Schema> extraFields,
                                            Map<String, Object> extraValues) {
+        return createEventRecord(
+                eventId,
+                eventType,
+                SchemaBuilder.string(),
+                payloadId,
+                payloadType,
+                SchemaBuilder.string(),
+                payload,
+                extraFields,
+                extraValues);
+    }
+
+    private SourceRecord createEventRecord(
+                                           String eventId,
+                                           String eventType,
+                                           SchemaBuilder payloadIdSchemaType,
+                                           Object payloadId,
+                                           String payloadType,
+                                           SchemaBuilder payloadSchemaType,
+                                           Object payload,
+                                           Map<String, Schema> extraFields,
+                                           Map<String, Object> extraValues) {
         SchemaBuilder schemaBuilder = SchemaBuilder.struct()
                 .field("id", SchemaBuilder.string())
                 .field("aggregatetype", SchemaBuilder.string())
-                .field("aggregateid", SchemaBuilder.string())
+                .field("aggregateid", payloadIdSchemaType)
                 .field("type", SchemaBuilder.string())
-                .field("payload", SchemaBuilder.string())
+                .field("payload", payloadSchemaType)
                 .field("is_deleted", SchemaBuilder.bool().optional());
 
         extraFields.forEach(schemaBuilder::field);


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2152

Enhances the EventRouter to pass along keys that are not Strings

Based off of https://github.com/debezium/debezium/pull/1568 and rebases to master.