### PR TITLE
Fix for misuse of ConfigurationDefaults.RETURN_CONTROL_INTERVAL 

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractReader.java
@@ -267,7 +267,7 @@ public abstract class AbstractReader implements Reader {
 
         logger.trace("Polling for next batch of records");
         List<SourceRecord> batch = new ArrayList<>(maxBatchSize);
-        final Timer timeout = Threads.timer(Clock.SYSTEM, Temporals.max(pollInterval, ConfigurationDefaults.RETURN_CONTROL_INTERVAL));
+        final Timer timeout = Threads.timer(Clock.SYSTEM, Temporals.min(pollInterval, ConfigurationDefaults.RETURN_CONTROL_INTERVAL));
         while (running.get() && (records.drainTo(batch, maxBatchSize) == 0) && !success.get()) {
             // No records are available even though the snapshot has not yet completed, so sleep for a bit ...
             metronome.pause();

--- a/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
+++ b/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
@@ -145,7 +145,7 @@ public class ChangeEventQueue<T> implements ChangeEventQueueMetrics {
         try {
             LOGGER.debug("polling records...");
             List<T> records = new ArrayList<>();
-            final Timer timeout = Threads.timer(Clock.SYSTEM, Temporals.max(pollInterval, ConfigurationDefaults.RETURN_CONTROL_INTERVAL));
+            final Timer timeout = Threads.timer(Clock.SYSTEM, Temporals.min(pollInterval, ConfigurationDefaults.RETURN_CONTROL_INTERVAL));
             while (!timeout.expired() && queue.drainTo(records, maxBatchSize) == 0) {
                 throwProducerExceptionIfPresent();
 

--- a/debezium-core/src/main/java/io/debezium/time/Temporals.java
+++ b/debezium-core/src/main/java/io/debezium/time/Temporals.java
@@ -22,4 +22,13 @@ public class Temporals {
     public static Duration max(Duration d1, Duration d2) {
         return d1.compareTo(d2) == 1 ? d1 : d2;
     }
+
+    /**
+     * Returns that duration from the given ones which represents the smaller amount
+     * of time ("is shorted"). If both durations are equal, that same value will be
+     * returned.
+     */
+    public static Duration min(Duration d1, Duration d2) {
+        return d1.compareTo(d2) == 1 ? d2 : d1;
+    }
 }


### PR DESCRIPTION
Javadoc for `ConfigurationDefaults.RETURN_CONTROL_INTERVAL` says: *"The **maximum** wait time before `poll()` return control back to Connect when no events are available."*

That requires a `min()` call not a `max()`.