### PR TITLE
DBZ-2176 Open transaction tests are more reliable

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -283,7 +283,7 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
 
         waitForStreamingToStart();
 
-        TestHelper.noTransactionActive();
+        TestHelper.assertNoOpenTransactions();
 
         stopConnector();
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -66,7 +66,6 @@ import io.debezium.connector.postgresql.spi.SlotState;
 import io.debezium.data.Bits;
 import io.debezium.data.Enum;
 import io.debezium.data.Envelope;
-import io.debezium.data.SchemaAndValueField;
 import io.debezium.data.SpecialValueDecimal;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.data.VerifyRecord;
@@ -1318,7 +1317,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
             assertEquals(Arrays.asList("pk", "text", "not_toast"), tbl.retrieveColumnNames());
         });
 
-        TestHelper.noTransactionActive();
+        TestHelper.assertNoOpenTransactions();
     }
 
     @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2176

Checking pg_stat_activity for transactions with a state of "idle in transaction"
should be more reliable to find open abandoned transaction than looking for
a non-null backend_xmin. For example, an autovaccum process will have a
backend_xmin but will not have a state of "idle in transaction"