### PR TITLE
DBZ-2094 Allow Postgres snapshotter to set streaming start on resume

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceCoordinator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceCoordinator.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import java.sql.SQLException;
+
+import org.apache.kafka.connect.source.SourceConnector;
+import org.postgresql.replication.LogSequenceNumber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.postgresql.spi.SlotState;
+import io.debezium.connector.postgresql.spi.Snapshotter;
+import io.debezium.pipeline.ChangeEventSourceCoordinator;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.metrics.spi.ChangeEventSourceMetricsFactory;
+import io.debezium.pipeline.source.spi.ChangeEventSource;
+import io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContext;
+import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
+import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.schema.DatabaseSchema;
+
+/**
+ * Coordinates one or more {@link ChangeEventSource}s and executes them in order. Extends the base
+ * {@link ChangeEventSourceCoordinator} to support a pre-snapshot catch up streaming phase.
+ */
+public class PostgresChangeEventSourceCoordinator extends ChangeEventSourceCoordinator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresChangeEventSourceCoordinator.class);
+
+    private final Snapshotter snapshotter;
+    private final SlotState slotInfo;
+
+    public PostgresChangeEventSourceCoordinator(OffsetContext previousOffset, ErrorHandler errorHandler,
+                                                Class<? extends SourceConnector> connectorType,
+                                                CommonConnectorConfig connectorConfig,
+                                                ChangeEventSourceFactory changeEventSourceFactory,
+                                                ChangeEventSourceMetricsFactory changeEventSourceMetricsFactory,
+                                                EventDispatcher<?> eventDispatcher, DatabaseSchema<?> schema,
+                                                Snapshotter snapshotter, SlotState slotInfo) {
+        super(previousOffset, errorHandler, connectorType, connectorConfig, changeEventSourceFactory, changeEventSourceMetricsFactory, eventDispatcher, schema);
+        this.snapshotter = snapshotter;
+        this.slotInfo = slotInfo;
+    }
+
+    @Override
+    protected CatchUpStreamingResult executeCatchUpStreaming(OffsetContext previousOffset, ChangeEventSourceContext context,
+                                                             SnapshotChangeEventSource snapshotSource)
+            throws InterruptedException {
+        if (previousOffset != null && !snapshotter.shouldStreamEventsStartingFromSnapshot() && slotInfo != null) {
+            try {
+                setSnapshotStartLsn((PostgresSnapshotChangeEventSource) snapshotSource,
+                        (PostgresOffsetContext) previousOffset);
+            }
+            catch (SQLException e) {
+                throw new DebeziumException("Failed to determine catch-up streaming stopping LSN");
+            }
+            LOGGER.info("Previous connector state exists and will stream events until {} then perform snapshot",
+                    LogSequenceNumber.valueOf(((PostgresOffsetContext) previousOffset).getStreamingStoppingLsn()));
+            streamEvents(previousOffset, context);
+            return new CatchUpStreamingResult(true);
+        }
+
+        return new CatchUpStreamingResult(false);
+    }
+
+    private void setSnapshotStartLsn(PostgresSnapshotChangeEventSource snapshotSource,
+                                     PostgresOffsetContext offsetContext)
+            throws SQLException {
+        snapshotSource.createSnapshotConnection();
+        snapshotSource.setSnapshotTransactionIsolationLevel();
+        snapshotSource.updateOffsetForPreSnapshotCatchUpStreaming(offsetContext);
+    }
+
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFactory.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFactory.java
@@ -8,6 +8,7 @@ package io.debezium.connector.postgresql;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.ReplicationConnection;
 import io.debezium.connector.postgresql.spi.SlotCreationResult;
+import io.debezium.connector.postgresql.spi.SlotState;
 import io.debezium.connector.postgresql.spi.Snapshotter;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
@@ -31,11 +32,12 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
     private final Snapshotter snapshotter;
     private final ReplicationConnection replicationConnection;
     private final SlotCreationResult slotCreatedInfo;
+    private final SlotState startingSlotInfo;
 
     public PostgresChangeEventSourceFactory(PostgresConnectorConfig configuration, Snapshotter snapshotter, PostgresConnection jdbcConnection,
                                             ErrorHandler errorHandler, EventDispatcher<TableId> dispatcher, Clock clock, PostgresSchema schema,
                                             PostgresTaskContext taskContext,
-                                            ReplicationConnection replicationConnection, SlotCreationResult slotCreatedInfo) {
+                                            ReplicationConnection replicationConnection, SlotCreationResult slotCreatedInfo, SlotState startingSlotInfo) {
         this.configuration = configuration;
         this.jdbcConnection = jdbcConnection;
         this.errorHandler = errorHandler;
@@ -46,6 +48,7 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
         this.snapshotter = snapshotter;
         this.replicationConnection = replicationConnection;
         this.slotCreatedInfo = slotCreatedInfo;
+        this.startingSlotInfo = startingSlotInfo;
     }
 
     @Override
@@ -59,7 +62,8 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
                 dispatcher,
                 clock,
                 snapshotProgressListener,
-                slotCreatedInfo);
+                slotCreatedInfo,
+                startingSlotInfo);
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -169,7 +169,7 @@ public class PostgresConnectorTask extends BaseSourceTask {
                     heartbeat,
                     schemaNameAdjuster);
 
-            ChangeEventSourceCoordinator coordinator = new ChangeEventSourceCoordinator(
+            ChangeEventSourceCoordinator coordinator = new PostgresChangeEventSourceCoordinator(
                     previousOffset,
                     errorHandler,
                     PostgresConnector.class,
@@ -184,10 +184,13 @@ public class PostgresConnectorTask extends BaseSourceTask {
                             schema,
                             taskContext,
                             replicationConnection,
-                            slotCreatedInfo),
+                            slotCreatedInfo,
+                            slotInfo),
                     new DefaultChangeEventSourceMetricsFactory(),
                     dispatcher,
-                    schema);
+                    schema,
+                    snapshotter,
+                    slotInfo);
 
             coordinator.start(taskContext, this.queue, metadataProvider);
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
@@ -39,6 +39,7 @@ public class PostgresOffsetContext implements OffsetContext {
     private final Map<String, String> partition;
     private boolean lastSnapshotRecord;
     private Long lastCompletelyProcessedLsn;
+    private Long streamingStoppingLsn = null;
     private final TransactionContext transactionContext;
 
     private PostgresOffsetContext(PostgresConnectorConfig connectorConfig, Long lsn, Long lastCompletelyProcessedLsn, Long txId, Instant time, boolean snapshot,
@@ -144,6 +145,21 @@ public class PostgresOffsetContext implements OffsetContext {
 
     Long lastCompletelyProcessedLsn() {
         return lastCompletelyProcessedLsn;
+    }
+
+    /**
+     * Returns the LSN that the streaming phase should stream events up to or null if
+     * a stopping point is not set. If set during the streaming phase, any event with
+     * an LSN less than the stopping LSN will be processed and once the stopping LSN
+     * is reached, the streaming phase will end. Useful for a pre-snapshot catch up
+     * streaming phase.
+     */
+    Long getStreamingStoppingLsn() {
+        return streamingStoppingLsn;
+    }
+
+    public void setStreamingStoppingLsn(Long streamingStoppingLsn) {
+        this.streamingStoppingLsn = streamingStoppingLsn;
     }
 
     Long xmin() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.ReplicationConnection;
 import io.debezium.connector.postgresql.spi.SlotCreationResult;
+import io.debezium.connector.postgresql.spi.SlotState;
 import io.debezium.connector.postgresql.spi.Snapshotter;
 import io.debezium.data.SpecialValueDecimal;
 import io.debezium.pipeline.EventDispatcher;
@@ -42,16 +43,18 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
     private final PostgresSchema schema;
     private final Snapshotter snapshotter;
     private final SlotCreationResult slotCreatedInfo;
+    private final SlotState startingSlotInfo;
 
     public PostgresSnapshotChangeEventSource(PostgresConnectorConfig connectorConfig, Snapshotter snapshotter, PostgresOffsetContext previousOffset,
                                              PostgresConnection jdbcConnection, PostgresSchema schema, EventDispatcher<TableId> dispatcher, Clock clock,
-                                             SnapshotProgressListener snapshotProgressListener, SlotCreationResult slotCreatedInfo) {
+                                             SnapshotProgressListener snapshotProgressListener, SlotCreationResult slotCreatedInfo, SlotState startingSlotInfo) {
         super(connectorConfig, previousOffset, jdbcConnection, dispatcher, clock, snapshotProgressListener);
         this.connectorConfig = connectorConfig;
         this.jdbcConnection = jdbcConnection;
         this.schema = schema;
         this.snapshotter = snapshotter;
         this.slotCreatedInfo = slotCreatedInfo;
+        this.startingSlotInfo = startingSlotInfo;
     }
 
     @Override
@@ -78,10 +81,9 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
 
     @Override
     protected void connectionCreated(RelationalSnapshotContext snapshotContext) throws Exception {
-        LOGGER.info("Setting isolation level");
-        String transactionStatement = snapshotter.snapshotTransactionIsolationLevelStatement(slotCreatedInfo);
-        LOGGER.info("Opening transaction with statement {}", transactionStatement);
-        jdbcConnection.executeWithoutCommitting(transactionStatement);
+        if (snapshotter.shouldStreamEventsStartingFromSnapshot() && startingSlotInfo == null) {
+            setSnapshotTransactionIsolationLevel();
+        }
         schema.refresh(jdbcConnection, false);
     }
 
@@ -121,16 +123,26 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
     @Override
     protected void determineSnapshotOffset(RelationalSnapshotContext ctx) throws Exception {
         PostgresOffsetContext offset = (PostgresOffsetContext) ctx.offset;
-        final long xlogStart = getTransactionStartLsn();
-        final long txId = jdbcConnection.currentTransactionId().longValue();
-        LOGGER.info("Read xlogStart at '{}' from transaction '{}'", ReplicationConnection.format(xlogStart), txId);
         if (offset == null) {
             offset = PostgresOffsetContext.initialContext(connectorConfig, jdbcConnection, getClock());
             ctx.offset = offset;
         }
 
+        updateOffsetForSnapshot(offset);
+    }
+
+    private void updateOffsetForSnapshot(PostgresOffsetContext offset) throws SQLException {
+        final long xlogStart = getTransactionStartLsn();
+        final long txId = jdbcConnection.currentTransactionId();
+        LOGGER.info("Read xlogStart at '{}' from transaction '{}'", ReplicationConnection.format(xlogStart), txId);
+
         // use the old xmin, as we don't want to update it if in xmin recovery
-        offset.updateWalPosition(xlogStart, null, clock.currentTime(), txId, null, offset.xmin());
+        offset.updateWalPosition(xlogStart, offset.lastCompletelyProcessedLsn(), clock.currentTime(), txId, null, offset.xmin());
+    }
+
+    protected void updateOffsetForPreSnapshotCatchUpStreaming(PostgresOffsetContext offset) throws SQLException {
+        updateOffsetForSnapshot(offset);
+        offset.setStreamingStoppingLsn(jdbcConnection.currentXLogLocation());
     }
 
     private long getTransactionStartLsn() throws SQLException {
@@ -141,6 +153,13 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
             // they'll be lost.
             return slotCreatedInfo.startLsn();
         }
+        else if (!snapshotter.shouldStreamEventsStartingFromSnapshot() && startingSlotInfo != null) {
+            // Allow streaming to resume from where streaming stopped last rather than where the current snapshot starts.
+            SlotState currentSlotState = jdbcConnection.getReplicationSlotState(connectorConfig.slotName(),
+                    connectorConfig.plugin().getPostgresPluginName());
+            return currentSlotState.slotLastFlushedLsn();
+        }
+
         return jdbcConnection.currentXLogLocation();
     }
 
@@ -249,6 +268,13 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
             // not a known type
             return super.getColumnValue(rs, columnIndex, column);
         }
+    }
+
+    protected void setSnapshotTransactionIsolationLevel() throws SQLException {
+        LOGGER.info("Setting isolation level");
+        String transactionStatement = snapshotter.snapshotTransactionIsolationLevelStatement(slotCreatedInfo);
+        LOGGER.info("Opening transaction with statement {}", transactionStatement);
+        jdbcConnection.executeWithoutCommitting(transactionStatement);
     }
 
     /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTaskContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTaskContext.java
@@ -66,10 +66,6 @@ public class PostgresTaskContext extends CdcSourceTaskContext {
 
     protected void refreshSchema(PostgresConnection connection, boolean printReplicaIdentityInfo) throws SQLException {
         schema.refresh(connection, printReplicaIdentityInfo);
-        // Open transaction unnecessary during task execution
-        if (!connection.connection().getAutoCommit()) {
-            connection.connection().commit();
-        }
     }
 
     Long getSlotXmin(PostgresConnection connection) throws SQLException {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/Snapshotter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/Snapshotter.java
@@ -45,6 +45,16 @@ public interface Snapshotter {
     boolean shouldStream();
 
     /**
+     *
+     * @return true if streaming should resume from the start of the snapshot
+     * transaction, or false for when a connector resumes and takes a snapshot,
+     * streaming should resume from where streaming previously left off.
+     */
+    default boolean shouldStreamEventsStartingFromSnapshot() {
+        return true;
+    }
+
+    /**
      * @return true if when creating a slot, a snapshot should be exported, which
      * can be used as an alternative to taking a lock
      */

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomStartFromStreamingTestSnapshot.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomStartFromStreamingTestSnapshot.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.postgresql;
+
+import io.debezium.connector.postgresql.snapshot.AlwaysSnapshotter;
+
+public class CustomStartFromStreamingTestSnapshot extends AlwaysSnapshotter {
+    @Override
+    public boolean shouldStreamEventsStartingFromSnapshot() {
+        return false;
+    }
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -90,13 +90,13 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
      */
     private static final String INSERT_STMT = "INSERT INTO s1.a (aa) VALUES (1);" +
             "INSERT INTO s2.a (aa) VALUES (1);";
-    private static final String SETUP_TABLES_STMT = "DROP SCHEMA IF EXISTS s1 CASCADE;" +
+    private static final String CREATE_TABLES_STMT = "DROP SCHEMA IF EXISTS s1 CASCADE;" +
             "DROP SCHEMA IF EXISTS s2 CASCADE;" +
             "CREATE SCHEMA s1; " +
             "CREATE SCHEMA s2; " +
             "CREATE TABLE s1.a (pk SERIAL, aa integer, PRIMARY KEY(pk));" +
-            "CREATE TABLE s2.a (pk SERIAL, aa integer, bb varchar(20), PRIMARY KEY(pk));" +
-            INSERT_STMT;
+            "CREATE TABLE s2.a (pk SERIAL, aa integer, bb varchar(20), PRIMARY KEY(pk));";
+    private static final String SETUP_TABLES_STMT = CREATE_TABLES_STMT + INSERT_STMT;
     private PostgresConnector connector;
 
     @Rule
@@ -1167,6 +1167,55 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
 
         // Stop the connector, verify that no snapshot was performed
         stopConnector(value -> assertThat(logInterceptor.containsMessage("Previous initial snapshot completed, no snapshot will be performed")).isTrue());
+    }
+
+    @Test
+    @FixFor("DBZ-2094")
+    public void shouldResumeStreamingFromSlotPositionForCustomSnapshot() throws Exception {
+        TestHelper.execute(SETUP_TABLES_STMT);
+        // Perform an empty snapshot
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.CUSTOM.getValue())
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE_CLASS, CustomStartFromStreamingTestSnapshot.class.getName())
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
+                .build();
+        start(PostgresConnector.class, config);
+        assertConnectorIsRunning();
+        waitForStreamingRunning();
+
+        SourceRecords actualRecords = consumeRecordsByTopic(2);
+        List<SourceRecord> s1recs = actualRecords.recordsForTopic(topicName("s1.a"));
+        List<SourceRecord> s2recs = actualRecords.recordsForTopic(topicName("s2.a"));
+        assertThat(s1recs.size()).isEqualTo(1);
+        assertThat(s2recs.size()).isEqualTo(1);
+        VerifyRecord.isValidRead(s1recs.get(0), PK_FIELD, 1);
+        VerifyRecord.isValidRead(s2recs.get(0), PK_FIELD, 1);
+
+        stopConnector();
+
+        // Insert records while connector is stopped
+        TestHelper.execute(INSERT_STMT);
+        config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.CUSTOM.getValue())
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE_CLASS, CustomStartFromStreamingTestSnapshot.class.getName())
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
+                .build();
+        start(PostgresConnector.class, config);
+        assertConnectorIsRunning();
+
+        waitForSnapshotToBeCompleted();
+
+        // Expect duplicate records from the snapshot and while streaming is running
+        actualRecords = consumeRecordsByTopic(2);
+
+        s1recs = actualRecords.recordsForTopic(topicName("s1.a"));
+        s2recs = actualRecords.recordsForTopic(topicName("s2.a"));
+        assertThat(s1recs.size()).isEqualTo(1);
+        assertThat(s2recs.size()).isEqualTo(1);
+        VerifyRecord.isValidInsert(s1recs.get(0), PK_FIELD, 2);
+        VerifyRecord.isValidInsert(s2recs.get(0), PK_FIELD, 2);
+
+        TestHelper.assertNoOpenTransactions();
     }
 
     private String getConfirmedFlushLsn(PostgresConnection connection) throws SQLException {

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
@@ -31,7 +31,7 @@ public abstract class AbstractSnapshotChangeEventSource implements SnapshotChang
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSnapshotChangeEventSource.class);
 
     private final CommonConnectorConfig connectorConfig;
-    private final OffsetContext previousOffset;
+    protected final OffsetContext previousOffset;
     private final SnapshotProgressListener snapshotProgressListener;
 
     public AbstractSnapshotChangeEventSource(CommonConnectorConfig connectorConfig, OffsetContext previousOffset, SnapshotProgressListener snapshotProgressListener) {

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -99,8 +99,7 @@ public abstract class RelationalSnapshotChangeEventSource extends AbstractSnapsh
                 LOGGER.info("Previous snapshot was cancelled before completion; a new snapshot will be taken.");
             }
 
-            connection = jdbcConnection.connection();
-            connection.setAutoCommit(false);
+            connection = createSnapshotConnection();
             connectionCreated(ctx);
 
             LOGGER.info("Snapshot step 2 - Determining captured tables");
@@ -151,6 +150,12 @@ public abstract class RelationalSnapshotChangeEventSource extends AbstractSnapsh
         finally {
             rollbackTransaction(connection);
         }
+    }
+
+    public Connection createSnapshotConnection() throws SQLException {
+        Connection connection = jdbcConnection.connection();
+        connection.setAutoCommit(false);
+        return connection;
     }
 
     /**


### PR DESCRIPTION
When a connector resumes after previously streaming and takes a
snapshot, through a new method on the snapshotter interface,
shouldStreamEventsStartingFromSnapshot, can choose whether
to resume streaming from the last known streaming position or the
beginning of the snapshot. This is helpful for snapshotters that
may not want to resnapshot every table in the whitelist/blacklist
but not miss event on the tables that are skipped.

Supersedes https://github.com/debezium/debezium/pull/1519 after rebasing.

https://issues.jboss.org/browse/DBZ-2094