### PR TITLE
DBZ-1995 Removed unneeded attribute definition. 

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -29,7 +29,6 @@ asciidoc:
     link-mongodb-connector: 'connectors/mongodb.adoc'
     link-mongodb-event-flattening: 'configuration/mongodb-event-flattening.adoc' 
     link-mysql-connector: 'connectors/mysql.adoc'
-    link-mysql-connector-properties: 'connectors/mysql.adoc'
     link-oracle-connector: 'connectors/oracle.adoc'
     link-outbox-event-router: 'configuration/outbox-event-router.adoc'
     link-prefix: 'xref'

--- a/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/r_mysql-connector-configuration-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-mysql-connector/r_mysql-connector-configuration-properties.adoc
@@ -1,12 +1,9 @@
-{link-prefix}:{link-mysql-connector}#// Metadata created by nebel
-//
-
 [id="mysql-connector-configuration-properties_{context}"]
 = MySQL connector configuration properties
 
 The configuration properties listed here are *required* to run the {prodname} MySQL connector. There are also <<advanced-mysql-connector-properties, advanced MySQL connector properties>> whose default value rarely needs to be changed and therefore, they do not need to be specified in the connector configuration.
 
-TIP: The {prodname} MySQL connector supports _pass-through_ configuration when creating the Kafka producer and consumer. See {link-prefix}:{link-mysql-connector-properties}#mysql-connector-pass-through-properties[information about pass-through properties] at the end of this section, and also see link:{link-kafka-docs}.html[the Kafka documentation] for more details about _pass-through_ properties.
+TIP: The {prodname} MySQL connector supports _pass-through_ configuration when creating the Kafka producer and consumer. See {link-prefix}:{link-mysql-connector}#mysql-connector-pass-through-properties[information about pass-through properties] at the end of this section, and also see link:{link-kafka-docs}.html[the Kafka documentation] for more details about _pass-through_ properties.
 
 [cols="3,2,5"]
 |===
@@ -210,7 +207,7 @@ Fully-qualified tables could be defined as _databaseName_._tableName_.
 [[advanced-mysql-connector-properties]]
 == Advanced MySQL connector properties
 
-The following table describes {link-prefix}:{link-mysql-connector-properties}#advanced-mysql-connector-properties[advanced MySQL connector properties].
+The following table describes {link-prefix}:{link-mysql-connector}#advanced-mysql-connector-properties[advanced MySQL connector properties].
 
 [cols="3,2,5"]
 |===
@@ -358,7 +355,7 @@ By default, no operations are skipped.
 [id="mysql-connector-pass-through-properties"]
 == Pass-through configuration properties
 
-The MySQL connector also supports {link-prefix}:{link-mysql-connector-properties}#mysql-connector-pass-through-properties[pass-through configuration properties] that are used when creating the Kafka producer and consumer. Specifically, all connector configuration properties that begin with the `database.history.producer.` prefix are used (without the prefix) when creating the Kafka producer that writes to the database history. All properties that begin with the prefix `database.history.consumer.` are used (without the prefix) when creating the Kafka consumer that reads the database history upon connector start-up.
+The MySQL connector also supports {link-prefix}:{link-mysql-connector}#mysql-connector-pass-through-properties[pass-through configuration properties] that are used when creating the Kafka producer and consumer. Specifically, all connector configuration properties that begin with the `database.history.producer.` prefix are used (without the prefix) when creating the Kafka producer that writes to the database history. All properties that begin with the prefix `database.history.consumer.` are used (without the prefix) when creating the Kafka consumer that reads the database history upon connector start-up.
 
 For example, the following connector configuration properties can be used to secure connections to the Kafka broker:
 
@@ -380,4 +377,4 @@ database.history.consumer.ssl.key.password=test1234
 [id="mysql-connector-pass-through-properties-for-database-drivers"]
 == Pass-through properties for database drivers
 
-In addition to the pass-through properties for the Kafka producer and consumer, there are {link-prefix}:{link-mysql-connector-properties}#mysql-connector-pass-through-properties-for-database-drivers[pass-through properties for database drivers]. These properties have the `database.` prefix. For example, `database.tinyInt1isBit=false` is passed to the JDBC URL.
+In addition to the pass-through properties for the Kafka producer and consumer, there are {link-prefix}:{link-mysql-connector}#mysql-connector-pass-through-properties-for-database-drivers[pass-through properties for database drivers]. These properties have the `database.` prefix. For example, `database.tinyInt1isBit=false` is passed to the JDBC URL.


### PR DESCRIPTION
I removed that attribute that was not needed: 
link-mysql-connector-properties

I updated the references to that attribute to instead use link-mysql-connector.

And I deleted an extraneous xref and comment from the top of the file. Not sure when that crept in but it is not needed.
I rant antora to confirm that the doc builds successfully. 