### PR TITLE
DBZ-2094 Allow Postgres snapshotter to set streaming start on resume

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceCoordinator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceCoordinator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import java.sql.SQLException;
+
+import org.apache.kafka.connect.source.SourceConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.postgresql.spi.SlotState;
+import io.debezium.connector.postgresql.spi.Snapshotter;
+import io.debezium.pipeline.ChangeEventSourceCoordinator;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.metrics.spi.ChangeEventSourceMetricsFactory;
+import io.debezium.pipeline.source.spi.ChangeEventSource;
+import io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContext;
+import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
+import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.schema.DatabaseSchema;
+
+/**
+ * Coordinates one or more {@link ChangeEventSource}s and executes them in order. Extends the base
+ * {@link ChangeEventSourceCoordinator} to support a pre-snapshot catch up streaming phase.
+ */
+public class PostgresChangeEventSourceCoordinator extends ChangeEventSourceCoordinator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresChangeEventSourceCoordinator.class);
+
+    private final Snapshotter snapshotter;
+    private final SlotState slotInfo;
+
+    public PostgresChangeEventSourceCoordinator(OffsetContext previousOffset, ErrorHandler errorHandler,
+                                                Class<? extends SourceConnector> connectorType,
+                                                CommonConnectorConfig connectorConfig,
+                                                ChangeEventSourceFactory changeEventSourceFactory,
+                                                ChangeEventSourceMetricsFactory changeEventSourceMetricsFactory,
+                                                EventDispatcher<?> eventDispatcher, DatabaseSchema<?> schema,
+                                                Snapshotter snapshotter, SlotState slotInfo) {
+        super(previousOffset, errorHandler, connectorType, connectorConfig, changeEventSourceFactory, changeEventSourceMetricsFactory, eventDispatcher, schema);
+        this.snapshotter = snapshotter;
+        this.slotInfo = slotInfo;
+    }
+
+    @Override
+    protected CatchUpStreamingResult executeCatchUpStreaming(OffsetContext previousOffset, ChangeEventSourceContext context,
+                                                             SnapshotChangeEventSource snapshotSource)
+            throws InterruptedException {
+        if (previousOffset != null && !snapshotter.shouldStreamEventsStartingFromSnapshot() && slotInfo != null) {
+            try {
+                setSnapshotStartLsn((PostgresSnapshotChangeEventSource) snapshotSource,
+                        (PostgresOffsetContext) previousOffset);
+            }
+            catch (SQLException e) {
+                throw new DebeziumException("Failed to determine catch-up streaming stopping LSN");
+            }
+            LOGGER.info("Previous connector state exists and will stream events until {} then perform snapshot",
+                    ((PostgresOffsetContext) previousOffset).getStreamingStoppingLsn());
+            streamEvents(previousOffset, context);
+            return new CatchUpStreamingResult(true);
+        }
+
+        return new CatchUpStreamingResult(false);
+    }
+
+    private void setSnapshotStartLsn(PostgresSnapshotChangeEventSource snapshotSource,
+                                     PostgresOffsetContext offsetContext)
+            throws SQLException {
+        snapshotSource.createSnapshotConnection();
+        snapshotSource.setSnapshotTransactionIsolationLevel();
+        snapshotSource.updateOffsetForPreSnapshotCatchUpStreaming(offsetContext);
+    }
+
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFactory.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFactory.java
@@ -8,6 +8,7 @@ package io.debezium.connector.postgresql;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.ReplicationConnection;
 import io.debezium.connector.postgresql.spi.SlotCreationResult;
+import io.debezium.connector.postgresql.spi.SlotState;
 import io.debezium.connector.postgresql.spi.Snapshotter;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
@@ -31,11 +32,12 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
     private final Snapshotter snapshotter;
     private final ReplicationConnection replicationConnection;
     private final SlotCreationResult slotCreatedInfo;
+    private final SlotState startingSlotInfo;
 
     public PostgresChangeEventSourceFactory(PostgresConnectorConfig configuration, Snapshotter snapshotter, PostgresConnection jdbcConnection,
                                             ErrorHandler errorHandler, EventDispatcher<TableId> dispatcher, Clock clock, PostgresSchema schema,
                                             PostgresTaskContext taskContext,
-                                            ReplicationConnection replicationConnection, SlotCreationResult slotCreatedInfo) {
+                                            ReplicationConnection replicationConnection, SlotCreationResult slotCreatedInfo, SlotState startingSlotInfo) {
         this.configuration = configuration;
         this.jdbcConnection = jdbcConnection;
         this.errorHandler = errorHandler;
@@ -46,6 +48,7 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
         this.snapshotter = snapshotter;
         this.replicationConnection = replicationConnection;
         this.slotCreatedInfo = slotCreatedInfo;
+        this.startingSlotInfo = startingSlotInfo;
     }
 
     @Override
@@ -59,7 +62,8 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
                 dispatcher,
                 clock,
                 snapshotProgressListener,
-                slotCreatedInfo);
+                slotCreatedInfo,
+                startingSlotInfo);
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -170,7 +170,7 @@ public class PostgresConnectorTask extends BaseSourceTask {
                     heartbeat,
                     schemaNameAdjuster);
 
-            ChangeEventSourceCoordinator coordinator = new ChangeEventSourceCoordinator(
+            ChangeEventSourceCoordinator coordinator = new PostgresChangeEventSourceCoordinator(
                     previousOffset,
                     errorHandler,
                     PostgresConnector.class,
@@ -185,10 +185,13 @@ public class PostgresConnectorTask extends BaseSourceTask {
                             schema,
                             taskContext,
                             replicationConnection,
-                            slotCreatedInfo),
+                            slotCreatedInfo,
+                            slotInfo),
                     new DefaultChangeEventSourceMetricsFactory(),
                     dispatcher,
-                    schema);
+                    schema,
+                    snapshotter,
+                    slotInfo);
 
             coordinator.start(taskContext, this.queue, metadataProvider);
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
@@ -41,6 +41,7 @@ public class PostgresOffsetContext implements OffsetContext {
     private boolean lastSnapshotRecord;
     private Lsn lastCompletelyProcessedLsn;
     private Lsn lastCommitLsn;
+    private Lsn streamingStoppingLsn = null;
     private final TransactionContext transactionContext;
 
     private PostgresOffsetContext(PostgresConnectorConfig connectorConfig, Lsn lsn, Lsn lastCompletelyProcessedLsn, Lsn lastCommitLsn, Long txId, Instant time,
@@ -161,6 +162,21 @@ public class PostgresOffsetContext implements OffsetContext {
 
     Lsn lastCommitLsn() {
         return lastCommitLsn;
+    }
+
+    /**
+     * Returns the LSN that the streaming phase should stream events up to or null if
+     * a stopping point is not set. If set during the streaming phase, any event with
+     * an LSN less than the stopping LSN will be processed and once the stopping LSN
+     * is reached, the streaming phase will end. Useful for a pre-snapshot catch up
+     * streaming phase.
+     */
+    Lsn getStreamingStoppingLsn() {
+        return streamingStoppingLsn;
+    }
+
+    public void setStreamingStoppingLsn(Lsn streamingStoppingLsn) {
+        this.streamingStoppingLsn = streamingStoppingLsn;
     }
 
     Long xmin() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.connector.postgresql.connection.Lsn;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.spi.SlotCreationResult;
+import io.debezium.connector.postgresql.spi.SlotState;
 import io.debezium.connector.postgresql.spi.Snapshotter;
 import io.debezium.data.SpecialValueDecimal;
 import io.debezium.pipeline.EventDispatcher;
@@ -42,16 +43,18 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
     private final PostgresSchema schema;
     private final Snapshotter snapshotter;
     private final SlotCreationResult slotCreatedInfo;
+    private final SlotState startingSlotInfo;
 
     public PostgresSnapshotChangeEventSource(PostgresConnectorConfig connectorConfig, Snapshotter snapshotter, PostgresOffsetContext previousOffset,
                                              PostgresConnection jdbcConnection, PostgresSchema schema, EventDispatcher<TableId> dispatcher, Clock clock,
-                                             SnapshotProgressListener snapshotProgressListener, SlotCreationResult slotCreatedInfo) {
+                                             SnapshotProgressListener snapshotProgressListener, SlotCreationResult slotCreatedInfo, SlotState startingSlotInfo) {
         super(connectorConfig, previousOffset, jdbcConnection, dispatcher, clock, snapshotProgressListener);
         this.connectorConfig = connectorConfig;
         this.jdbcConnection = jdbcConnection;
         this.schema = schema;
         this.snapshotter = snapshotter;
         this.slotCreatedInfo = slotCreatedInfo;
+        this.startingSlotInfo = startingSlotInfo;
     }
 
     @Override
@@ -78,10 +81,15 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
 
     @Override
     protected void connectionCreated(RelationalSnapshotContext snapshotContext) throws Exception {
-        LOGGER.info("Setting isolation level");
-        String transactionStatement = snapshotter.snapshotTransactionIsolationLevelStatement(slotCreatedInfo);
-        LOGGER.info("Opening transaction with statement {}", transactionStatement);
-        jdbcConnection.executeWithoutCommitting(transactionStatement);
+        // If using catch up streaming, the connector opens the transaction that the snapshot will eventually use
+        // before the catch up streaming starts. By looking at the current wal location, the transaction can determine
+        // where the catch up streaming should stop. The transaction is held open throughout the catch up
+        // streaming phase so that the snapshot is performed from a consistent view of the data. Since the isolation
+        // level on the transaction used in catch up streaming has already set the isolation level and executed
+        // statements, the transaction does not need to get set the level again here.
+        if (snapshotter.shouldStreamEventsStartingFromSnapshot() && startingSlotInfo == null) {
+            setSnapshotTransactionIsolationLevel();
+        }
         schema.refresh(jdbcConnection, false);
     }
 
@@ -121,16 +129,26 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
     @Override
     protected void determineSnapshotOffset(RelationalSnapshotContext ctx) throws Exception {
         PostgresOffsetContext offset = (PostgresOffsetContext) ctx.offset;
-        final Lsn xlogStart = getTransactionStartLsn();
-        final long txId = jdbcConnection.currentTransactionId().longValue();
-        LOGGER.info("Read xlogStart at '{}' from transaction '{}'", xlogStart, txId);
         if (offset == null) {
             offset = PostgresOffsetContext.initialContext(connectorConfig, jdbcConnection, getClock());
             ctx.offset = offset;
         }
 
+        updateOffsetForSnapshot(offset);
+    }
+
+    private void updateOffsetForSnapshot(PostgresOffsetContext offset) throws SQLException {
+        final Lsn xlogStart = getTransactionStartLsn();
+        final long txId = jdbcConnection.currentTransactionId().longValue();
+        LOGGER.info("Read xlogStart at '{}' from transaction '{}'", xlogStart, txId);
+
         // use the old xmin, as we don't want to update it if in xmin recovery
-        offset.updateWalPosition(xlogStart, null, clock.currentTime(), txId, null, offset.xmin());
+        offset.updateWalPosition(xlogStart, offset.lastCompletelyProcessedLsn(), clock.currentTime(), txId, null, offset.xmin());
+    }
+
+    protected void updateOffsetForPreSnapshotCatchUpStreaming(PostgresOffsetContext offset) throws SQLException {
+        updateOffsetForSnapshot(offset);
+        offset.setStreamingStoppingLsn(Lsn.valueOf(jdbcConnection.currentXLogLocation()));
     }
 
     private Lsn getTransactionStartLsn() throws SQLException {
@@ -141,6 +159,13 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
             // they'll be lost.
             return slotCreatedInfo.startLsn();
         }
+        else if (!snapshotter.shouldStreamEventsStartingFromSnapshot() && startingSlotInfo != null) {
+            // Allow streaming to resume from where streaming stopped last rather than where the current snapshot starts.
+            SlotState currentSlotState = jdbcConnection.getReplicationSlotState(connectorConfig.slotName(),
+                    connectorConfig.plugin().getPostgresPluginName());
+            return currentSlotState.slotLastFlushedLsn();
+        }
+
         return Lsn.valueOf(jdbcConnection.currentXLogLocation());
     }
 
@@ -249,6 +274,13 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
             // not a known type
             return super.getColumnValue(rs, columnIndex, column);
         }
+    }
+
+    protected void setSnapshotTransactionIsolationLevel() throws SQLException {
+        LOGGER.info("Setting isolation level");
+        String transactionStatement = snapshotter.snapshotTransactionIsolationLevelStatement(slotCreatedInfo);
+        LOGGER.info("Opening transaction with statement {}", transactionStatement);
+        jdbcConnection.executeWithoutCommitting(transactionStatement);
     }
 
     /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTaskContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresTaskContext.java
@@ -66,10 +66,6 @@ public class PostgresTaskContext extends CdcSourceTaskContext {
 
     protected void refreshSchema(PostgresConnection connection, boolean printReplicaIdentityInfo) throws SQLException {
         schema.refresh(connection, printReplicaIdentityInfo);
-        // Open transaction unnecessary during task execution
-        if (!connection.connection().getAutoCommit()) {
-            connection.connection().commit();
-        }
     }
 
     Long getSlotXmin(PostgresConnection connection) throws SQLException {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/Snapshotter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/Snapshotter.java
@@ -45,6 +45,16 @@ public interface Snapshotter {
     boolean shouldStream();
 
     /**
+     *
+     * @return true if streaming should resume from the start of the snapshot
+     * transaction, or false for when a connector resumes and takes a snapshot,
+     * streaming should resume from where streaming previously left off.
+     */
+    default boolean shouldStreamEventsStartingFromSnapshot() {
+        return true;
+    }
+
+    /**
      * @return true if when creating a slot, a snapshot should be exported, which
      * can be used as an alternative to taking a lock
      */

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomPartialTableTestSnapshot.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomPartialTableTestSnapshot.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.postgresql;
+
+import java.util.Optional;
+
+import io.debezium.relational.TableId;
+
+public class CustomPartialTableTestSnapshot extends CustomStartFromStreamingTestSnapshot {
+    @Override
+    public Optional<String> buildSnapshotQuery(TableId tableId) {
+        if (tableId.schema().equals("s1") && tableId.table().equals("a")) {
+            return super.buildSnapshotQuery(tableId);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomStartFromStreamingTestSnapshot.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomStartFromStreamingTestSnapshot.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.postgresql;
+
+import io.debezium.connector.postgresql.snapshot.AlwaysSnapshotter;
+
+public class CustomStartFromStreamingTestSnapshot extends AlwaysSnapshotter {
+    @Override
+    public boolean shouldStreamEventsStartingFromSnapshot() {
+        return false;
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
@@ -31,7 +31,7 @@ public abstract class AbstractSnapshotChangeEventSource implements SnapshotChang
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSnapshotChangeEventSource.class);
 
     private final CommonConnectorConfig connectorConfig;
-    private final OffsetContext previousOffset;
+    protected final OffsetContext previousOffset;
     private final SnapshotProgressListener snapshotProgressListener;
 
     public AbstractSnapshotChangeEventSource(CommonConnectorConfig connectorConfig, OffsetContext previousOffset, SnapshotProgressListener snapshotProgressListener) {

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -99,8 +99,7 @@ public abstract class RelationalSnapshotChangeEventSource extends AbstractSnapsh
                 LOGGER.info("Previous snapshot was cancelled before completion; a new snapshot will be taken.");
             }
 
-            connection = jdbcConnection.connection();
-            connection.setAutoCommit(false);
+            connection = createSnapshotConnection();
             connectionCreated(ctx);
 
             LOGGER.info("Snapshot step 2 - Determining captured tables");
@@ -151,6 +150,12 @@ public abstract class RelationalSnapshotChangeEventSource extends AbstractSnapsh
         finally {
             rollbackTransaction(connection);
         }
+    }
+
+    public Connection createSnapshotConnection() throws SQLException {
+        Connection connection = jdbcConnection.connection();
+        connection.setAutoCommit(false);
+        return connection;
     }
 
     /**


### PR DESCRIPTION
When a connector resumes after previously streaming and takes a
snapshot, through a new method on the snapshotter interface,
shouldStreamEventsStartingFromSnapshot, can choose whether
to resume streaming from the last known streaming position or the
beginning of the snapshot. This is helpful for snapshotters that
may not want to resnapshot every table in the whitelist/blacklist
but not miss event on the tables that are skipped.

This PR was created to address changes requested in #1596 