### PR TITLE
DBZ-1956 Corrected property names by replacing dots with hyphens

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
@@ -167,9 +167,9 @@ transforms.unwrap.delete.handling.mode=rewrite
 transforms.unwrap.add.fields=table,lsn
 ----
 
-`drop-tombstones=false`:: Keeps tombstone records for `DELETE` operations in the event stream. 
+`drop.tombstones=false`:: Keeps tombstone records for `DELETE` operations in the event stream. 
 
-`delete-handling-mode=rewrite`:: For `DELETE` operations, edits the Kafka record by flattening the `value` field that was in the change event. The `value` field directly contains the key/value pairs that were in the `before` field. The SMT adds `__deleted` and sets it to `true`, for example:   
+`delete.handling.mode=rewrite`:: For `DELETE` operations, edits the Kafka record by flattening the `value` field that was in the change event. The `value` field directly contains the key/value pairs that were in the `before` field. The SMT adds `__deleted` and sets it to `true`, for example:   
 +
 ----
 "value": {


### PR DESCRIPTION
Good catch Gunnar! Sorry about the typos. 
This correct two instances of property names that had hyphens where they should have had dots. 
Please backport this to 1.1. 