### PR TITLE
DBZ-1956 Updates to CloudEvents content, and fix for a table format

### DIFF
--- a/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
+++ b/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
@@ -34,23 +34,33 @@ The CloudEvents specification defines:
 
 * A set of standardized event attributes
 * Rules for defining custom attributes
+ifdef::community[]
 * Encoding rules for mapping event formats to serialized representations such as JSON or Avro
+endif::community[]
+ifdef::product[]
+* Encoding rules for mapping event formats to serialized representations such as JSON
+endif::product[]
 * Protocol bindings for transport layers such as Apache Kafka, HTTP or AMQP
 
 To configure a {prodname} connector to emit change event records that conform to the CloudEvents specification, {prodname} provides the `io.debezium.converters.CloudEventsConverter`, which is a Kafka Connect message converter. 
 
+ifdef::community[]
 Currently, only structured mapping mode is supported. The CloudEvents change event envelope can be JSON or Avro and each envelope type supports JSON or Avro as the `data` format. It is expected that a future {prodname} release will support binary mapping mode. 
+endif::community[]
+ifdef::product[]
+Currently, only structured mapping mode is supported. The CloudEvents change event envelope must be JSON and  the `data` format must be JSON. It is expected that a future {prodname} release will support binary mapping mode. 
+endif::product[]
 
+ifdef::community[]
 For information about using Avro, see: 
 
 * {link-prefix}:{link-avro-serialization}#avro-serialization[Avro serialization] 
 
-ifdef::community[]
 * link:https://github.com/Apicurio/apicurio-registry[Apicurio Registry]
 endif::community[]
-ifdef::product[]
-* link:{LinkServiceRegistryGetStart}[{NameServiceRegistryGetStart}]
-endif::product[]
+// ifdef::product[]
+// * link:{LinkServiceRegistryGetStart}[{NameServiceRegistryGetStart}]
+// endif::product[]
 
 // Type: concept
 // ModuleID: example-change-event-records-in-cloudevents-format
@@ -97,12 +107,19 @@ The following example shows what a CloudEvents change event record emitted by a 
 <3> The CloudEvents specification version. 
 <4> Connector type that generated the change event. The format of this field is `io.debezium._CONNECTOR_TYPE_.datachangeevent`. The value of `_CONNECTOR_TYPE_` is `mongodb`, `mysql`, `postgresql`, or `sqlserver`.
 <5> Time of the change in the source database.
-<6> Describes the content type of the `data` attribute, which is JSON in this example. The only alternative is Avro. 
+ifdef::community[]
+<6> Describes the content type of the `data` attribute, which is JSON in this example. 
+The only alternative is Avro. 
+endif::community[]
+ifdef::product[]
+<6> Describes the content type of the `data` attribute, which is JSON. 
+endif::product[]
 <7> An operation identifier. Possible values are `r` for read, `c` for create, `u` for update, or `d` for delete. 
 <8> All `source` attributes that are known from {prodname} change events are mapped to CloudEvents extension attributes by using the `iodebezium` prefix for the attribute name.
 <9> When enabled in the connector, each `transaction` attribute that is known from {prodname} change events is mapped to a CloudEvents extension attribute by using the `iodebeziumtx` prefix for the attribute name.
 <10> The actual data change itself. Depending on the operation and the connector, the data might contain `before`, `after` and/or `patch` fields.
 
+ifdef::community[]
 The following example also shows what a CloudEvents change event record emitted by a PostgreSQL connector looks like. In this example, the PostgreSQL connector is again configured to use JSON as the CloudEvents format envelope, but this time the connector is configured to use Avro for the `data` format. 
 
 [source,json,indent=0,subs="attributes"]
@@ -138,16 +155,18 @@ The following example also shows what a CloudEvents change event record emitted 
 <3> The `data` attribute contains base64-encoded Avro binary data.
 
 It is also possible to use Avro for the envelope as well as the `data` attribute.
+endif::community[]
 
 // Type: concept
 // ModuleID: example-of-configuring-cloudevents-converter
 // Title: Example of configuring `CloudEventsConverter`
 == Example configuration
 
+ifdef::community[]
 Configure `io.debezium.converters.CloudEventsConverter` in your {prodname} connector configuration. Following is an example of configuring `CloudEventsConverter` to emit change event records that:
 
 * Use JSON as the envelope
-* Use the schema registry at \http://schema-registry:8081 to serialize the `data` attribute as binary Avro data
+* Use the schema registry at `\http://my-registry/schemas/ids/1` to serialize the `data` attribute as binary Avro data
 
 In this example, you could omit the specification of `serializer.type` because `json` is the default. 
 
@@ -157,11 +176,25 @@ In this example, you could omit the specification of `serializer.type` because `
 "value.converter": "io.debezium.converters.CloudEventsConverter",
 "value.converter.serializer.type" : "json",
 "value.converter.data.serializer.type" : "avro",
-"value.converter.avro.schema.registry.url": "http://schema-registry:8081"
+"value.converter.avro.schema.registry.url": "http://my-registry/schemas/ids/1"
 ...
 ----
 
 `CloudEventsConverter` converts Kafka record values. In the same connector configuration, you can specify `key.converter` if you want to operate on record keys, for example you might specify `StringConverter`, `LongConverter`, `JsonConverter`, or `AvroConverter`.
+endif::community[]
+ifdef::product[]
+Configure `io.debezium.converters.CloudEventsConverter` in your {prodname} connector configuration. Following is an example of configuring `CloudEventsConverter`. In this example, you could omit the specification of `serializer.type` because `json` is the default. 
+
+[source,json,indent=0]
+----
+...
+"value.converter": "io.debezium.converters.CloudEventsConverter",
+"value.converter.serializer.type" : "json",
+...
+----
+
+`CloudEventsConverter` converts Kafka record values. In the same connector configuration, you can specify `key.converter` if you want to operate on record keys, for example you might specify `StringConverter`, `LongConverter`, or `JsonConverter`.
+endif::product[]
 
 // Type: reference
 // ModuleID: cloudeventsconverter-configuration-properties
@@ -181,21 +214,34 @@ When you configure a {prodname} connector to use the CloudEvent converter you ca
 [id="cloud-events-converter-serializer-type"]
 |{link-prefix}:{link-cloud-events}#cloud-events-converter-serializer-type[`serializer.type`]
 |`json`
-|The encoding type to use for the CloudEvents envelope structure. The value can be `json` or `avro`.
+|The encoding type to use for the CloudEvents envelope structure. 
+ifdef::community[]
+The value can be `json` or `avro`.
+endif::community[]
+ifdef::product[]
+`json` is the only supported value.
+endif::product[]
 
 [id="cloud-events-converter-data-serializer-type"]
 |{link-prefix}:{link-cloud-events}#cloud-events-converter-data-serializer-type[`data.serializer.type`]
 |`json`
-|The encoding type to use for the `data` attribute. The value can be `json` or `avro`.
+|The encoding type to use for the `data` attribute. 
+ifdef::community[]
+The value can be `json` or `avro`.
+endif::community[]
+ifdef::product[]
+`json` is the only supported value.
+endif::product[]
 
 [id="cloud-events-converter-json"]
 |{link-prefix}:{link-cloud-events}#cloud-events-converter-json[`json. \...`]
 |N/A
 |Any configuration properties to be passed through to the underlying converter when using JSON. The `json.` prefix is removed. 
 
+ifdef::community[]
 [id="cloud-events-converter-avro"]
 |{link-prefix}:{link-cloud-events}#cloud-events-converter-avro[`avro. \...`]
 |N/A
 |Any configuration properties to be passed through to the underlying converter when using Avro. The `avro.` prefix is removed. For example, for Avro `data`, you would specify the `avro.schema.registry.url` property. 
-
+endif::community[]
 |===

--- a/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
+++ b/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
@@ -41,6 +41,17 @@ To configure a {prodname} connector to emit change event records that conform to
 
 Currently, only structured mapping mode is supported. The CloudEvents change event envelope can be JSON or Avro and each envelope type supports JSON or Avro as the `data` format. It is expected that a future {prodname} release will support binary mapping mode. 
 
+For information about using Avro, see: 
+
+* {link-prefix}:{link-avro-serialization}#avro-serialization[Avro serialization] 
+
+ifdef::community[]
+* link:https://github.com/Apicurio/apicurio-registry[Apicurio Registry]
+endif::community[]
+ifdef::product[]
+* link:{LinkServiceRegistryGetStart}[{NameServiceRegistryGetStart}]
+endif::product[]
+
 // Type: concept
 // ModuleID: example-change-event-records-in-cloudevents-format
 // Title: Example change event records in CloudEvents format
@@ -48,7 +59,7 @@ Currently, only structured mapping mode is supported. The CloudEvents change eve
 
 The following example shows what a CloudEvents change event record emitted by a PostgreSQL connector looks like. In this example, the PostgreSQL connector is configured to use JSON as the CloudEvents format envelope and also as the `data` format.  
 
-[source,json,indent=0]
+[source,json,indent=0,subs="attributes"]
 ----
 {
   "id" : "name:test_server;lsn:29274832;txId:565",   <1>
@@ -58,7 +69,7 @@ The following example shows what a CloudEvents change event record emitted by a 
   "time" : "2020-01-13T13:55:39.738Z",               <5>
   "datacontenttype" : "application/json",            <6>
   "iodebeziumop" : "r",                              <7>
-  "iodebeziumversion" : "1.1.0-SNAPSHOT",            <8>
+  "iodebeziumversion" : "{debezium-version}",        <8>
   "iodebeziumconnector" : "postgresql",
   "iodebeziumname" : "test_server",
   "iodebeziumtsms" : "1578923739738",
@@ -94,7 +105,7 @@ The following example shows what a CloudEvents change event record emitted by a 
 
 The following example also shows what a CloudEvents change event record emitted by a PostgreSQL connector looks like. In this example, the PostgreSQL connector is again configured to use JSON as the CloudEvents format envelope, but this time the connector is configured to use Avro for the `data` format. 
 
-[source,json,indent=0]
+[source,json,indent=0,subs="attributes"]
 ----
 {
   "id" : "name:test_server;lsn:33227720;txId:578",
@@ -105,7 +116,7 @@ The following example also shows what a CloudEvents change event record emitted 
   "datacontenttype" : "application/avro",            <1>
   "dataschema" : "http://my-registry/schemas/ids/1", <2>
   "iodebeziumop" : "r",
-  "iodebeziumversion" : "1.1.0-SNAPSHOT",
+  "iodebeziumversion" : "{debezium-version}",
   "iodebeziumconnector" : "postgresql",
   "iodebeziumname" : "test_server",
   "iodebeziumtsms" : "1578924258597",
@@ -133,10 +144,10 @@ It is also possible to use Avro for the envelope as well as the `data` attribute
 // Title: Example of configuring `CloudEventsConverter`
 == Example configuration
 
-Configure `io.debezium.converters.CloudEventsConverter` in your {prodname} connector configuration. Following is an example of configuring `CloudEventConverter` to emit change event records that:
+Configure `io.debezium.converters.CloudEventsConverter` in your {prodname} connector configuration. Following is an example of configuring `CloudEventsConverter` to emit change event records that:
 
 * Use JSON as the envelope
-* Contain Avro data that adheres to the schema at http://schema-registry:8081 
+* Use the schema registry at \http://schema-registry:8081 to serialize the `data` attribute as binary Avro data
 
 In this example, you could omit the specification of `serializer.type` because `json` is the default. 
 


### PR DESCRIPTION
This updates the content about exportiing CloudEvents format, based on Chris's comments in this Google document: 
https://docs.google.com/document/d/1lKSq4WUU7I3Ndz1CYgPuQRf5B10A4Y7wWIMZflkWrck/edit?usp=sharing

I also adjusted the column widths for a table that is reused for the doc for multiple connectors. 