### PR TITLE
DBZ-2266 Adjust column widths

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -720,7 +720,7 @@ Please refer to the {link-prefix}:{link-debezium-monitoring}#monitoring-debezium
 
 The *MBean* is `debezium.mongodb:type=connector-metrics,context=snapshot,server=_<mongodb.name>_`.
 
-[cols="30%a,10%a,60%a",options="header"]
+[cols="45%a,25%a,30%s"]
 |===
 |Attribute Name
 |Type
@@ -800,7 +800,7 @@ The {prodname} MongoDB connector also provides the following custom snapshot met
 
 The *MBean* is `debezium.sql_server:type=connector-metrics,context=streaming,server=_<mongodb.name>_`.
 
-[cols="30%a,10%a,60%a",options="header"]
+[cols="45%a,25%a,30%s"]
 |===
 |Attribute Name
 |Type

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1675,7 +1675,7 @@ Please refer to the {link-prefix}:{link-debezium-monitoring}#monitoring-debezium
 
 The *MBean* is `debezium.postgres:type=connector-metrics,context=snapshot,server=_<database.server.name>_`.
 
-[cols="30%a,10%a,60%a",options="header"]
+[cols="45%a,25%a,30%s"]
 |===
 |Attribute Name
 |Type
@@ -1744,7 +1744,7 @@ The *MBean* is `debezium.postgres:type=connector-metrics,context=snapshot,server
 
 The *MBean* is `debezium.postgres:type=connector-metrics,context=streaming,server=_<database.server.name>_`.
 
-[cols="30%a,10%a,60%a",options="header"]
+[cols="45%a,25%a,30%s"]
 |===
 |Attribute Name
 |Type

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1179,7 +1179,7 @@ Please refer to the {link-prefix}:{link-debezium-monitoring}[monitoring document
 
 The *MBean* is `debezium.sql_server:type=connector-metrics,context=snapshot,server=_<database.server.name>_`.
 
-[cols="30%a,10%a,60%a",options="header"]
+[cols="45%a,25%a,30%s"]
 |===
 |Attribute Name
 |Type
@@ -1248,7 +1248,7 @@ The *MBean* is `debezium.sql_server:type=connector-metrics,context=snapshot,serv
 
 The *MBean* is `debezium.sql_server:type=connector-metrics,context=streaming,server=_<database.server.name>_`.
 
-[cols="30%a,10%a,60%a",options="header"]
+[cols="45%a,25%a,30%s"]
 |===
 |Attribute Name
 |Type
@@ -1309,7 +1309,7 @@ The *MBean* is `debezium.sql_server:type=connector-metrics,context=streaming,ser
 
 The *MBean* is `debezium.sql_server:type=connector-metrics,context=schema-history,server=_<database.server.name>_`.
 
-[cols="30%a,10%a,60%a",options="header"]
+[cols="45%a,25%a,30%s"]
 |===
 |Attribute Name
 |Type


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2266

This introduces a branch 1.1 specific change to align column widths used by several connector tables that were rendering incorrectly downstream.  