### PR TITLE
DBZ-2224 Using Log4j 2 as logging backend during tests;

### DIFF
--- a/debezium-api/pom.xml
+++ b/debezium-api/pom.xml
@@ -23,8 +23,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -64,6 +64,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -59,8 +59,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldRenamesIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldRenamesIT.java
@@ -16,6 +16,7 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.bson.Document;
 import org.bson.types.ObjectId;
+import org.junit.Rule;
 import org.junit.Test;
 
 import io.debezium.config.Configuration;
@@ -31,6 +32,9 @@ public class FieldRenamesIT extends AbstractMongoConnectorIT {
     private static final String SERVER_NAME = "serverX";
     private static final String PATCH = "patch";
     private static final String ID = "_id";
+
+    @Rule
+    public LogInterceptor logInterceptor = new LogInterceptor();
 
     @Test
     public void shouldNotRenameMissingFieldsForReadEvent() throws Exception {
@@ -1436,7 +1440,6 @@ public class FieldRenamesIT extends AbstractMongoConnectorIT {
 
         dropAndInsertDocuments(database, collection, document);
 
-        logInterceptor = new LogInterceptor();
         start(MongoDbConnector.class, config);
 
         SourceRecords sourceRecords = consumeRecordsByTopic(1);
@@ -1457,7 +1460,6 @@ public class FieldRenamesIT extends AbstractMongoConnectorIT {
 
         insertDocuments(database, collection, document);
 
-        logInterceptor = new LogInterceptor();
         start(MongoDbConnector.class, config);
 
         SourceRecords sourceRecords = consumeRecordsByTopic(1);
@@ -1486,7 +1488,7 @@ public class FieldRenamesIT extends AbstractMongoConnectorIT {
 
     private void assertDocumentContainsFieldError(String fieldName) {
         stopConnector(value -> {
-            final String message = "IllegalArgumentException: Document already contains field : " + fieldName;
+            final String message = "Document already contains field : " + fieldName;
             assertThat(logInterceptor.containsStacktraceElement(message)).isTrue();
         });
     }
@@ -1499,7 +1501,6 @@ public class FieldRenamesIT extends AbstractMongoConnectorIT {
 
         dropAndInsertDocuments(DATABASE_NAME, COLLECTION_NAME, snapshot);
 
-        logInterceptor = new LogInterceptor();
         start(MongoDbConnector.class, config);
 
         SourceRecords sourceRecords = consumeRecordsByTopic(1);
@@ -1515,7 +1516,6 @@ public class FieldRenamesIT extends AbstractMongoConnectorIT {
 
         TestHelper.cleanDatabase(primary(), DATABASE_NAME);
 
-        logInterceptor = new LogInterceptor();
         start(MongoDbConnector.class, config);
 
         insertDocuments(DATABASE_NAME, COLLECTION_NAME, document);
@@ -1540,7 +1540,6 @@ public class FieldRenamesIT extends AbstractMongoConnectorIT {
         config = getConfiguration(renamesList, DATABASE_NAME, COLLECTION_NAME);
         context = new MongoDbTaskContext(config);
 
-        logInterceptor = new LogInterceptor();
         start(MongoDbConnector.class, config);
         waitForStreamingRunning("mongodb", SERVER_NAME);
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -36,6 +36,7 @@ import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.mongodb.DBRef;
@@ -68,6 +69,9 @@ import io.debezium.util.Testing;
  *
  */
 public class MongoDbConnectorIT extends AbstractConnectorTest {
+
+    @Rule
+    public LogInterceptor logInterceptor = new LogInterceptor();
 
     private Configuration config;
     private MongoDbTaskContext context;
@@ -608,9 +612,6 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
     @Test
     @FixFor("DBZ-865 and DBZ-1242")
     public void shouldConsumeEventsFromCollectionWithReplacedTopicName() throws InterruptedException, IOException {
-        // This captures all logged messages, allowing us to verify log message was written.
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
         // Use the DB configuration to define the connector's configuration ...
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
@@ -662,9 +663,6 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
     @Test
     @FixFor("DBZ-1242")
     public void testEmptySchemaWarningAfterApplyingCollectionFilters() throws Exception {
-        // This captures all logged messages, allowing us to verify log message was written.
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
         // Use the DB configuration to define the connector's configuration...
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -74,8 +74,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -79,6 +79,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -31,6 +31,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.fest.assertions.Assertions;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import io.debezium.config.CommonConnectorConfig;
@@ -70,6 +71,9 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
     private static final int PRODUCTS_TABLE_EVENT_COUNT = 9;
     private static final int ORDERS_TABLE_EVENT_COUNT = 5;
     private static final int INITIAL_EVENT_COUNT = PRODUCTS_TABLE_EVENT_COUNT + 9 + 4 + ORDERS_TABLE_EVENT_COUNT + 6;
+
+    @Rule
+    public LogInterceptor logInterceptor = new LogInterceptor();
 
     private Configuration config;
 
@@ -1990,8 +1994,6 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
     @Test
     @FixFor("DBZ-1242")
     public void testEmptySchemaLogWarningWithDatabaseWhitelist() throws Exception {
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
         config = DATABASE.defaultConfig()
                 .with(MySqlConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
                 .with(MySqlConnectorConfig.DATABASE_WHITELIST, "my_database")
@@ -2008,8 +2010,6 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
     @Test
     @FixFor("DBZ-1242")
     public void testNoEmptySchemaLogWarningWithDatabaseWhitelist() throws Exception {
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
         config = DATABASE.defaultConfig()
                 .with(MySqlConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
                 .build();
@@ -2025,9 +2025,6 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
     @Test
     @FixFor("DBZ-1242")
     public void testEmptySchemaWarningWithTableWhitelist() throws Exception {
-        // This captures all logged messages, allowing us to verify log message was written.
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
         config = DATABASE.defaultConfig()
                 .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.INITIAL)
                 .with(MySqlConnectorConfig.TABLE_WHITELIST, DATABASE.qualifiedTableName("my_products"))
@@ -2046,9 +2043,6 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
     @Test
     @FixFor("DBZ-1242")
     public void testNoEmptySchemaWarningWithTableWhitelist() throws Exception {
-        // This captures all logged messages, allowing us to verify log message was written.
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
         config = DATABASE.defaultConfig()
                 .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.INITIAL)
                 .build();

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSchemaMigrationIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSchemaMigrationIT.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import io.debezium.config.Configuration;
@@ -31,6 +32,9 @@ public class MySqlSchemaMigrationIT extends AbstractConnectorTest {
             .withDbHistoryPath(DB_HISTORY_PATH);
 
     private Configuration config;
+
+    @Rule
+    public LogInterceptor logInterceptor = new LogInterceptor();
 
     @Before
     public void beforeEach() {
@@ -143,9 +147,6 @@ public class MySqlSchemaMigrationIT extends AbstractConnectorTest {
 
     @Test
     public void shouldWarnOnInvalidMigrateTable() throws SQLException, InterruptedException {
-        // Use the DB configuration to define the connector's configuration ...
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
         config = DATABASE.defaultConfig()
                 .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.INITIAL)
                 .with(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -89,6 +89,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -84,8 +84,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -102,6 +102,9 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     @Rule
     public final TestRule skipName = new SkipTestDependingOnDecoderPluginNameRule();
 
+    @Rule
+    public LogInterceptor logInterceptor = new LogInterceptor();
+
     @BeforeClass
     public static void beforeClass() throws SQLException {
         TestHelper.dropAllSchemas();
@@ -1121,9 +1124,6 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     @Test
     @FixFor("DBZ-1437")
     public void shouldPeformSnapshotOnceForInitialOnlySnapshotMode() throws Exception {
-        // This captures all logged messages, allowing us to verify log message was written.
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
         TestHelper.dropDefaultReplicationSlot();
 
         TestHelper.execute(SETUP_TABLES_STMT);
@@ -1259,9 +1259,6 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     @Test
     @FixFor("DBZ-1242")
     public void testEmptySchemaWarningAfterApplyingFilters() throws Exception {
-        // This captures all logged messages, allowing us to verify log message was written.
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
         TestHelper.dropAllSchemas();
         TestHelper.executeDDL("postgres_create_tables.ddl");
 
@@ -1279,9 +1276,6 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     @Test
     @FixFor("DBZ-1242")
     public void testNoEmptySchemaWarningAfterApplyingFilters() throws Exception {
-        // This captures all logged messages, allowing us to verify log message was written.
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
         TestHelper.dropAllSchemas();
         TestHelper.executeDDL("postgres_create_tables.ddl");
 
@@ -1299,9 +1293,6 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     @FixFor("DBZ-1436")
     @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Publication configuration only valid for PGOUTPUT decoder")
     public void testCustomPublicationNameUsed() throws Exception {
-        // This captures all logged messages, allowing us to verify log message was written.
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
         TestHelper.dropAllSchemas();
         TestHelper.dropPublication("cdc");
         TestHelper.executeDDL("postgres_create_tables.ddl");
@@ -1349,8 +1340,6 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     @Test
     @FixFor("DBZ-1519")
     public void shouldNotIssueWarningForNoMonitoredTablesAfterApplyingFilters() throws Exception {
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
         TestHelper.execute(SETUP_TABLES_STMT);
         TestHelper.execute(INSERT_STMT);
         Configuration config = TestHelper.defaultConfig().with(PostgresConnectorConfig.SCHEMA_WHITELIST, "s2").build();
@@ -1397,8 +1386,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         stopConnector();
         TestHelper.dropPublication();
 
-        // Create log interceptor and restart the connector, should observe publication gets re-created
-        final LogInterceptor interceptor = new LogInterceptor();
+        // restart the connector, should observe publication gets re-created
         start(PostgresConnector.class, config);
         waitForStreamingRunning();
 
@@ -1407,7 +1395,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
 
         // Stop Connector and check log messages
         stopConnector(value -> {
-            assertThat(interceptor.containsMessage("Creating new publication 'dbz_publication' for plugin 'PGOUTPUT'")).isTrue();
+            assertThat(logInterceptor.containsMessage("Creating new publication 'dbz_publication' for plugin 'PGOUTPUT'")).isTrue();
         });
     }
 
@@ -1669,9 +1657,6 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     @FixFor("DBZ-1813")
     @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Publication configuration only valid for PGOUTPUT decoder")
     public void shouldConfigureSubscriptionsForAllTablesByDefault() throws Exception {
-        // This captures all logged messages, allowing us to verify log message was written.
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
         TestHelper.dropAllSchemas();
         TestHelper.dropPublication("cdc");
         TestHelper.executeDDL("postgres_create_tables.ddl");
@@ -1693,9 +1678,6 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     @FixFor("DBZ-1813")
     @SkipWhenDecoderPluginNameIsNot(value = SkipWhenDecoderPluginNameIsNot.DecoderPluginName.PGOUTPUT, reason = "Publication configuration only valid for PGOUTPUT decoder")
     public void shouldConfigureSubscriptionsFromTableFilters() throws Exception {
-        // This captures all logged messages, allowing us to verify log message was written.
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
         TestHelper.dropAllSchemas();
         TestHelper.dropPublication("cdc");
         TestHelper.executeDDL("postgres_create_tables.ddl");

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -110,6 +110,9 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     public final TestRule skip = new SkipTestDependingOnDecoderPluginNameRule();
 
     @Rule
+    public LogInterceptor logInterceptor = new LogInterceptor();
+
+    @Rule
     public TestRule conditionalFail = new ConditionalFail();
 
     @Before
@@ -1262,7 +1265,6 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     @Test
     @FixFor("DBZ-1565")
     public void shouldWarnOnMissingHeartbeatForFilteredEvents() throws Exception {
-        final LogInterceptor logInterceptor = new LogInterceptor();
         startConnector(config -> config
                 .with(PostgresConnectorConfig.POLL_INTERVAL_MS, "50")
                 .with(PostgresConnectorConfig.TABLE_WHITELIST, "s1\\.b")

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -69,8 +69,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -74,6 +74,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/EventProcessingFailureHandlingIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/EventProcessingFailureHandlingIT.java
@@ -12,6 +12,7 @@ import org.awaitility.Awaitility;
 import org.fest.assertions.Assertions;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import io.debezium.config.CommonConnectorConfig.EventProcessingFailureHandlingMode;
@@ -30,6 +31,9 @@ import io.debezium.util.Testing;
  * @author Jiri Pechanec
  */
 public class EventProcessingFailureHandlingIT extends AbstractConnectorTest {
+
+    @Rule
+    public LogInterceptor logInterceptor = new LogInterceptor();
 
     private SqlServerConnection connection;
 
@@ -64,7 +68,6 @@ public class EventProcessingFailureHandlingIT extends AbstractConnectorTest {
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
                 .with(SqlServerConnectorConfig.EVENT_PROCESSING_FAILURE_HANDLING_MODE, EventProcessingFailureHandlingMode.WARN)
                 .build();
-        final LogInterceptor logInterceptor = new LogInterceptor();
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
@@ -122,7 +125,6 @@ public class EventProcessingFailureHandlingIT extends AbstractConnectorTest {
         final Configuration config = TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
                 .build();
-        final LogInterceptor logInterceptor = new LogInterceptor();
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
@@ -24,6 +24,7 @@ import org.fest.assertions.MapAssert;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import io.debezium.config.CommonConnectorConfig.Version;
@@ -51,6 +52,9 @@ public class SnapshotIT extends AbstractConnectorTest {
 
     private static final int INITIAL_RECORDS_PER_TABLE = 500;
     private static final int STREAMING_RECORDS_PER_TABLE = 500;
+
+    @Rule
+    public LogInterceptor logInterceptor = new LogInterceptor();
 
     private SqlServerConnection connection;
 
@@ -161,7 +165,6 @@ public class SnapshotIT extends AbstractConnectorTest {
     @Test
     @FixFor("DBZ-1280")
     public void testDeadlockDetection() throws Exception {
-        final LogInterceptor logInterceptor = new LogInterceptor();
         final Configuration config = TestHelper.defaultConfig()
                 .with(RelationalDatabaseConnectorConfig.SNAPSHOT_LOCK_TIMEOUT_MS, 1_000)
                 .build();

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -34,6 +34,7 @@ import org.awaitility.Awaitility;
 import org.fest.assertions.Assertions;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import io.debezium.config.Configuration;
@@ -64,6 +65,9 @@ import io.debezium.util.Testing;
 public class SqlServerConnectorIT extends AbstractConnectorTest {
 
     private SqlServerConnection connection;
+
+    @Rule
+    public LogInterceptor logInterceptor = new LogInterceptor();
 
     @Before
     public void before() throws SQLException {
@@ -1203,9 +1207,6 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
     @Test
     @FixFor("DBZ-1242")
     public void testEmptySchemaWarningAfterApplyingFilters() throws Exception {
-        // This captures all logged messages, allowing us to verify log message was written.
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
         Configuration config = TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
                 .with(SqlServerConnectorConfig.TABLE_WHITELIST, "my_products")
@@ -1221,9 +1222,6 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
     @Test
     @FixFor("DBZ-1242")
     public void testNoEmptySchemaWarningAfterApplyingFilters() throws Exception {
-        // This captures all logged messages, allowing us to verify log message was written.
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
         Configuration config = TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
                 .build();
@@ -1367,7 +1365,6 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         Testing.Files.delete(TestHelper.DB_HISTORY_PATH);
 
-        final LogInterceptor logInterceptor = new LogInterceptor();
         start(SqlServerConnector.class, config);
         assertConnectorNotRunning();
         assertThat(logInterceptor.containsStacktraceElement(

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -80,6 +80,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -75,8 +75,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/debezium-core/src/test/java/io/debezium/junit/logging/AssertingAppender.java
+++ b/debezium-core/src/test/java/io/debezium/junit/logging/AssertingAppender.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.junit.logging;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+
+/**
+ * @author Chris Cranford
+ */
+class AssertingAppender extends AbstractAppender {
+
+    private final List<LogEvent> events = new CopyOnWriteArrayList<>();
+    private final Logger rootLogger;
+
+    private AssertingAppender(Logger rootLogger) {
+        super("LogInterceptor", null, null, false, null);
+        this.rootLogger = rootLogger;
+    }
+
+    public static AssertingAppender register() {
+        Logger rootLogger = (Logger) LogManager.getRootLogger();
+
+        AssertingAppender interceptor = new AssertingAppender(rootLogger);
+        interceptor.start();
+
+        rootLogger.addAppender(interceptor);
+
+        return interceptor;
+    }
+
+    public void unregister() {
+        rootLogger.removeAppender(this);
+    }
+
+    public boolean containsMessage(String text) {
+        for (LogEvent event : events) {
+            if (event.getMessage().toString().contains(text)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean containsWarnMessage(String text) {
+        return containsMessage(Level.WARN, text);
+    }
+
+    public boolean containsErrorMessage(String text) {
+        return containsMessage(Level.ERROR, text);
+    }
+
+    public boolean containsStacktraceElement(String text) {
+        for (LogEvent event : events) {
+            Throwable thrown = event.getThrown();
+
+            if (thrown == null) {
+                continue;
+            }
+
+            if (containsMessage(thrown, text)) {
+                return true;
+            }
+
+            StackTraceElement[] stackTrace = thrown.getStackTrace();
+            if (stackTrace == null) {
+                continue;
+            }
+
+            for (StackTraceElement element : stackTrace) {
+                if (element.toString().contains(text)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean containsMessage(Throwable throwable, String text) {
+        while (throwable != null) {
+            if (throwable.getMessage() != null && throwable.getMessage().contains(text)) {
+                return true;
+            }
+
+            throwable = throwable.getCause();
+        }
+
+        return false;
+    }
+
+    private boolean containsMessage(Level level, String text) {
+        for (LogEvent event : events) {
+            if (event.getLevel().equals(level) && event.getMessage().toString().contains(text)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        events.add(event);
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/junit/logging/LogInterceptor.java
+++ b/debezium-core/src/test/java/io/debezium/junit/logging/LogInterceptor.java
@@ -5,91 +5,45 @@
  */
 package io.debezium.junit.logging;
 
-import static org.slf4j.Logger.ROOT_LOGGER_NAME;
-
-import java.lang.reflect.Field;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-
-import org.apache.log4j.AppenderSkeleton;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.apache.log4j.spi.LoggingEvent;
-import org.slf4j.LoggerFactory;
-import org.slf4j.impl.Log4jLoggerAdapter;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 /**
- * @author Chris Cranford
+ * Captures all logged messages, allowing us to verify log message was written.
+ *
+ * @author Gunnar Morling
  */
-public class LogInterceptor extends AppenderSkeleton {
-    private List<LoggingEvent> events = new CopyOnWriteArrayList<>();
+public final class LogInterceptor implements TestRule {
 
-    public LogInterceptor() {
-        try {
-            final Field field = Log4jLoggerAdapter.class.getDeclaredField("logger");
-            field.setAccessible(true);
-
-            Logger logger = (Logger) field.get(LoggerFactory.getLogger(ROOT_LOGGER_NAME));
-            logger.addAppender(this);
-        }
-        catch (Exception e) {
-            throw new RuntimeException("Failed to obtain Log4j logger for log interceptor.");
-        }
-    }
+    private AssertingAppender interceptor;
 
     @Override
-    protected void append(LoggingEvent loggingEvent) {
-        this.events.add(loggingEvent);
-    }
+    public Statement apply(Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                interceptor = AssertingAppender.register();
 
-    @Override
-    public void close() {
-        // do nothing
-    }
-
-    @Override
-    public boolean requiresLayout() {
-        return false;
-    }
-
-    public boolean containsMessage(String text) {
-        for (LoggingEvent event : events) {
-            if (event.getMessage().toString().contains(text)) {
-                return true;
+                try {
+                    base.evaluate();
+                }
+                finally {
+                    interceptor.unregister();
+                }
             }
-        }
-        return false;
+        };
     }
 
-    public boolean containsWarnMessage(String text) {
-        return containsMessage(Level.WARN, text);
+    public boolean containsMessage(String message) {
+        return interceptor.containsMessage(message);
     }
 
-    public boolean containsErrorMessage(String text) {
-        return containsMessage(Level.ERROR, text);
+    public boolean containsWarnMessage(String message) {
+        return interceptor.containsWarnMessage(message);
     }
 
     public boolean containsStacktraceElement(String text) {
-        for (LoggingEvent event : events) {
-            final String[] stackTrace = event.getThrowableStrRep();
-            if (stackTrace == null) {
-                continue;
-            }
-            for (String element : stackTrace) {
-                if (element.contains(text)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private boolean containsMessage(Level level, String text) {
-        for (LoggingEvent event : events) {
-            if (event.getLevel().equals(level) && event.getMessage().toString().contains(text)) {
-                return true;
-            }
-        }
-        return false;
+        return interceptor.containsStacktraceElement(text);
     }
 }

--- a/debezium-embedded/pom.xml
+++ b/debezium-embedded/pom.xml
@@ -49,8 +49,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/debezium-microbenchmark/pom.xml
+++ b/debezium-microbenchmark/pom.xml
@@ -28,8 +28,8 @@
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>

--- a/debezium-testing/debezium-testing-openshift/pom.xml
+++ b/debezium-testing/debezium-testing-openshift/pom.xml
@@ -180,8 +180,8 @@
     </dependency>
 
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
     </dependency>
 
     <dependency>

--- a/debezium-testing/debezium-testing-testcontainers/pom.xml
+++ b/debezium-testing/debezium-testing-testcontainers/pom.xml
@@ -68,8 +68,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <version.zookeeper>3.5.7</version.zookeeper>
         <version.jackson>2.10.0</version.jackson>
         <version.org.slf4j>1.7.28</version.org.slf4j>
-        <version.log4j>1.2.17</version.log4j>
+        <version.log4j>2.13.3</version.log4j>
         <!-- check new release version at https://github.com/confluentinc/schema-registry/releases -->
         <version.confluent.platform>5.5.0</version.confluent.platform>
 
@@ -295,6 +295,12 @@
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>${version.zookeeper}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
@@ -375,10 +381,16 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>${version.org.slf4j}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-1.2-api</artifactId>
                 <version>${version.log4j}</version>
             </dependency>
 
@@ -793,7 +805,13 @@
                                 <requireMavenVersion>
                                     <version>3.0.5</version>
                                 </requireMavenVersion>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>log4j:log4j</exclude>
+                                    </excludes>
+                                </bannedDependencies>
                             </rules>
+                            <fail>true</fail>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -393,6 +393,11 @@
                 <artifactId>log4j-1.2-api</artifactId>
                 <version>${version.log4j}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${version.log4j}</version>
+            </dependency>
 
             <!-- Scripting -->
             <dependency>


### PR DESCRIPTION
By using the Log4j 1 to 2 bridge, this should be a drop-in replacement.
As this is a test-only dependency, we can upgrade it independently from the version used in Kafka itself.

https://issues.redhat.com/browse/DBZ-2224

Also see https://github.com/debezium/debezium-incubator/pull/178 in the incubator repo.