### PR TITLE
ignoring built-in table schemas on capture

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -867,7 +867,8 @@ public class SnapshotReader extends AbstractReader {
     }
 
     private boolean shouldRecordTableSchema(final MySqlSchema schema, final Filters filters, TableId id) {
-        return !schema.isStoreOnlyMonitoredTablesDdl() || filters.tableFilter().test(id);
+        return (!schema.isStoreOnlyMonitoredTablesDdl() || filters.tableFilter().test(id)) &&
+                (!filters.builtInTableFilter().test(id));
     }
 
     protected void readBinlogPosition(int step, SourceInfo source, JdbcConnection mysql, AtomicReference<String> sql) throws SQLException {


### PR DESCRIPTION
From https://issues.redhat.com/browse/DBZ-1939:

When `table.ignore.builtin` is set to `true` (default), one might expect the tables under the `mysql` schema to be completely ignored from both data capture and schema capture.

Nevertheless those tables get registered in the `createTablesMap` map because the condition `createTableFilters == filters && shouldRecordTableSchema` is `true` whenever `isStoreOnlyMonitoredTablesDdl` is set since `!schema.isStoreOnlyMonitoredTablesDdl()` will be true by default and therefore `shouldRecordTableSchema(schema, filters, id)` will return true, even for builtin table.

It's not really clear if these is any added value of capturing builtin tables schema, if not, probably this behavior needs to be changed to fully and completely ignore built-in tables.