### PR TITLE
DBZ-1939 graceful handling of non-existent tables

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
@@ -88,6 +88,10 @@ public class Filters {
         return columnFilter;
     }
 
+    public Predicate<TableId> ignoredTableFilter() {
+        return isIgnoredTable;
+    }
+
     public static class Builder {
 
         private Predicate<String> dbFilter;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
@@ -31,8 +31,9 @@ public class Filters {
     protected static final Set<String> BUILT_IN_DB_NAMES = Collect.unmodifiableSet("mysql", "performance_schema", "sys", "information_schema");
 
     /**
-     * A list of tables that always ignored. Useful for ignoring "phantom" tables 
-     * occasionally exposed by services such as Amazon RDS Aurora. See DBZ-1939.
+     * A list of tables that are always ignored. Useful for ignoring "phantom"
+     * tables occasionally exposed by services such as Amazon RDS Aurora. See
+     * DBZ-1939.
      */
     protected static final Set<String> IGNORED_TABLE_NAMES = Collect.unmodifiableSet(
             "mysql.rds_configuration",
@@ -61,7 +62,7 @@ public class Filters {
         return !isBuiltInTable(id);
     }
 
-    protected static boolean isIgnoredTable(TableId id) {
+    private static boolean isIgnoredTable(TableId id) {
         return IGNORED_TABLE_NAMES.contains(id.catalog() + "." + id.table());
     }
 
@@ -104,10 +105,6 @@ public class Filters {
 
     public Predicate<TableId> builtInTableFilter() {
         return isBuiltInTable;
-    }
-
-    public Predicate<TableId> ignoredTableFilter() {
-        return isIgnoredTable;
     }
 
     public Predicate<String> builtInDatabaseFilter() {
@@ -182,6 +179,8 @@ public class Filters {
                 this.tableFilter = tableFilter;
                 this.dbFilter = dbFilter;
             }
+
+            this.tableFilter = this.tableFilter.and(isIgnoredTable.negate());
         }
 
         /**

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/Filters.java
@@ -5,12 +5,9 @@
  */
 package io.debezium.connector.mysql;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import io.debezium.annotation.Immutable;
 import io.debezium.config.Configuration;
@@ -35,7 +32,7 @@ public class Filters {
      * tables occasionally exposed by services such as Amazon RDS Aurora. See
      * DBZ-1939.
      */
-    protected static final Set<String> IGNORED_TABLE_NAMES = Collect.unmodifiableSet(
+    private static final Set<String> IGNORED_TABLE_NAMES = Collect.unmodifiableSet(
             "mysql.rds_configuration",
             "mysql.rds_global_status_history",
             "mysql.rds_global_status_history_old",
@@ -50,28 +47,12 @@ public class Filters {
         return BUILT_IN_DB_NAMES.contains(databaseName.toLowerCase());
     }
 
-    protected static boolean isBuiltInTable(TableId id) {
+    private static boolean isBuiltInTable(TableId id) {
         return isBuiltInDatabase(id.catalog());
-    }
-
-    protected static boolean isNotBuiltInDatabase(String databaseName) {
-        return !isBuiltInDatabase(databaseName);
-    }
-
-    protected static boolean isNotBuiltInTable(TableId id) {
-        return !isBuiltInTable(id);
     }
 
     private static boolean isIgnoredTable(TableId id) {
         return IGNORED_TABLE_NAMES.contains(id.catalog() + "." + id.table());
-    }
-
-    protected static List<TableId> withoutBuiltIns(Collection<TableId> tableIds) {
-        return tableIds.stream().filter(Filters::isNotBuiltInTable).collect(Collectors.toList());
-    }
-
-    protected static List<String> withoutBuiltInDatabases(Collection<String> dbNames) {
-        return dbNames.stream().filter(Filters::isNotBuiltInDatabase).collect(Collectors.toList());
     }
 
     private final Predicate<String> dbFilter;
@@ -101,14 +82,6 @@ public class Filters {
 
     public Predicate<TableId> tableFilter() {
         return tableFilter;
-    }
-
-    public Predicate<TableId> builtInTableFilter() {
-        return isBuiltInTable;
-    }
-
-    public Predicate<String> builtInDatabaseFilter() {
-        return isBuiltInDb;
     }
 
     public ColumnNameFilter columnFilter() {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -866,8 +866,9 @@ public class SnapshotReader extends AbstractReader {
         });
     }
 
-    private boolean shouldRecordTableSchema(final MySqlSchema schema, final Filters filters, TableId id) {
-        return !schema.isStoreOnlyMonitoredTablesDdl() || filters.tableFilter().test(id);
+    private boolean shouldRecordTableSchema(final MySqlSchema schema, final Filters filters, TableId id) throws SQLException {
+        return (!schema.isStoreOnlyMonitoredTablesDdl() || filters.tableFilter().test(id)) &&
+                !filters.ignoredTableFilter().test(id);
     }
 
     protected void readBinlogPosition(int step, SourceInfo source, JdbcConnection mysql, AtomicReference<String> sql) throws SQLException {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -872,7 +872,8 @@ public class SnapshotReader extends AbstractReader {
      * {@code false} otherwise.
      */
     private boolean shouldRecordTableSchema(MySqlSchema schema, Filters filters, TableId id) {
-        return (filters.tableFilter().test(id) || !schema.isStoreOnlyMonitoredTablesDdl());
+        return (filters.tableFilter().test(id) || !schema.isStoreOnlyMonitoredTablesDdl())
+                && !filters.ignoredTableFilter().test(id);
     }
 
     protected void readBinlogPosition(int step, SourceInfo source, JdbcConnection mysql, AtomicReference<String> sql) throws SQLException {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -866,9 +866,13 @@ public class SnapshotReader extends AbstractReader {
         });
     }
 
-    private boolean shouldRecordTableSchema(final MySqlSchema schema, final Filters filters, TableId id) throws SQLException {
-        return (!schema.isStoreOnlyMonitoredTablesDdl() || filters.tableFilter().test(id)) &&
-                !filters.ignoredTableFilter().test(id);
+    /**
+     * Whether DDL for the given table should be recorded; {@code true} when the
+     * table matches the filter configuration or we capture _any_ table's DDL,
+     * {@code false} otherwise.
+     */
+    private boolean shouldRecordTableSchema(MySqlSchema schema, Filters filters, TableId id) {
+        return (filters.tableFilter().test(id) || !schema.isStoreOnlyMonitoredTablesDdl());
     }
 
     protected void readBinlogPosition(int step, SourceInfo source, JdbcConnection mysql, AtomicReference<String> sql) throws SQLException {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/FiltersTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/FiltersTest.java
@@ -301,6 +301,13 @@ public class FiltersTest {
         assertSystemDatabasesExcluded();
     }
 
+    @Test
+    public void shouldNotAllowIgnoreTable() {
+        filters = build.includeBuiltInTables().createFilters();
+        assertIgnoredTableExcluded("mysql.rds_configuration");
+        assertNonIgnoredTableIncluded("mysql.table1");
+    }
+
     protected void assertDatabaseIncluded(String databaseName) {
         assertThat(filters.databaseFilter().test(databaseName)).isTrue();
     }
@@ -337,6 +344,16 @@ public class FiltersTest {
     protected void assertTableExcluded(String fullyQualifiedTableName) {
         TableId id = TableId.parse(fullyQualifiedTableName);
         assertThat(filters.tableFilter().test(id)).isFalse();
+    }
+
+    protected void assertIgnoredTableExcluded(String fullyQualifiedTableName) {
+        TableId id = TableId.parse(fullyQualifiedTableName);
+        assertThat(filters.ignoredTableFilter().test(id)).isTrue();
+    }
+
+    protected void assertNonIgnoredTableIncluded(String fullyQualifiedTableName) {
+        TableId id = TableId.parse(fullyQualifiedTableName);
+        assertThat(filters.ignoredTableFilter().test(id)).isFalse();
     }
 
 }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/FiltersTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/FiltersTest.java
@@ -302,7 +302,8 @@ public class FiltersTest {
     }
 
     @Test
-    public void shouldNotAllowIgnoreTable() {
+    @FixFor("DBZ-1939")
+    public void shouldNotAllowIgnoredTable() {
         filters = build.includeBuiltInTables().createFilters();
         assertIgnoredTableExcluded("mysql.rds_configuration");
         assertNonIgnoredTableIncluded("mysql.table1");
@@ -348,12 +349,11 @@ public class FiltersTest {
 
     protected void assertIgnoredTableExcluded(String fullyQualifiedTableName) {
         TableId id = TableId.parse(fullyQualifiedTableName);
-        assertThat(filters.ignoredTableFilter().test(id)).isTrue();
+        assertThat(filters.tableFilter().test(id)).isFalse();
     }
 
     protected void assertNonIgnoredTableIncluded(String fullyQualifiedTableName) {
         TableId id = TableId.parse(fullyQualifiedTableName);
-        assertThat(filters.ignoredTableFilter().test(id)).isFalse();
+        assertThat(filters.tableFilter().test(id)).isTrue();
     }
-
 }


### PR DESCRIPTION
This PR adds a check that verifies that a table actually exists (as opposed to what's reported by `SHOW TABLES`) before it is further processed so as to handle https://issues.redhat.com/browse/DBZ-1939.