### PR TITLE
DBZ-2302: Allow OffsetCommitPolicy to be initiated with Properties object

### DIFF
--- a/debezium-core/src/main/java/io/debezium/config/Instantiator.java
+++ b/debezium-core/src/main/java/io/debezium/config/Instantiator.java
@@ -6,6 +6,7 @@
 package io.debezium.config;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.Properties;
 import java.util.function.Supplier;
 
 /**
@@ -22,16 +23,33 @@ public class Instantiator {
      *
      * @return The newly created instance or {@code null} if no class name was given
      */
-    @SuppressWarnings("unchecked")
     public static <T> T getInstance(String className, Supplier<ClassLoader> classloaderSupplier,
                                     Configuration configuration) {
+        return getInstanceWithProvidedConstructorType(className, classloaderSupplier, Configuration.class, configuration);
+    }
+
+    /**
+     * Instantiates the specified class either using the no-args constructor or the
+     * constructor with a single parameter of type {@link Properties}, if a
+     * properties object is passed.
+     *
+     * @return The newly created instance or {@code null} if no class name was given
+     */
+    public static <T> T getInstanceWithProperties(String className, Supplier<ClassLoader> classloaderSupplier,
+                                                  Properties prop) {
+        return getInstanceWithProvidedConstructorType(className, classloaderSupplier, Properties.class, prop);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T, C> T getInstanceWithProvidedConstructorType(String className, Supplier<ClassLoader> classloaderSupplier, Class<C> constructorType,
+                                                                   C constructorValue) {
         if (className != null) {
             ClassLoader classloader = classloaderSupplier != null ? classloaderSupplier.get()
                     : Configuration.class.getClassLoader();
             try {
                 Class<? extends T> clazz = (Class<? extends T>) classloader.loadClass(className);
-                return configuration == null ? clazz.getDeclaredConstructor().newInstance()
-                        : clazz.getConstructor(Configuration.class).newInstance(configuration);
+                return constructorValue == null ? clazz.getDeclaredConstructor().newInstance()
+                        : clazz.getConstructor(constructorType).newInstance(constructorValue);
             }
             catch (ClassNotFoundException e) {
                 throw new IllegalArgumentException("Unable to find class " + className, e);

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -51,6 +51,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
+import io.debezium.config.Instantiator;
 import io.debezium.engine.DebeziumEngine;
 import io.debezium.engine.StopEngineException;
 import io.debezium.engine.spi.OffsetCommitPolicy;
@@ -695,7 +696,8 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord> {
 
                 // Set up the offset commit policy ...
                 if (offsetCommitPolicy == null) {
-                    offsetCommitPolicy = config.getInstance(EmbeddedEngine.OFFSET_COMMIT_POLICY, OffsetCommitPolicy.class, config);
+                    offsetCommitPolicy = Instantiator.getInstanceWithProperties(config.getString(EmbeddedEngine.OFFSET_COMMIT_POLICY),
+                            () -> getClass().getClassLoader(), config.asProperties());
                 }
 
                 // Initialize the connector using a context that does NOT respond to requests to reconfigure tasks ...

--- a/debezium-embedded/src/main/java/io/debezium/embedded/spi/OffsetCommitPolicy.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/spi/OffsetCommitPolicy.java
@@ -6,6 +6,7 @@
 package io.debezium.embedded.spi;
 
 import java.time.Duration;
+import java.util.Properties;
 
 import org.apache.kafka.connect.storage.OffsetBackingStore;
 
@@ -44,6 +45,10 @@ public interface OffsetCommitPolicy extends io.debezium.engine.spi.OffsetCommitP
 
         public PeriodicCommitOffsetPolicy(Configuration config) {
             minimumTime = Duration.ofMillis(config.getLong(EmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS));
+        }
+
+        public PeriodicCommitOffsetPolicy(Properties properties) {
+            this(Configuration.from(properties));
         }
 
         @Override

--- a/debezium-embedded/src/test/java/io/debezium/embedded/OffsetCommitPolicyTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/OffsetCommitPolicyTest.java
@@ -8,6 +8,7 @@ package io.debezium.embedded;
 import static org.fest.assertions.Assertions.assertThat;
 
 import java.time.Duration;
+import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
@@ -31,6 +32,16 @@ public class OffsetCommitPolicyTest {
     public void shouldCommitPeriodically() {
         // 10 hours
         OffsetCommitPolicy policy = OffsetCommitPolicy.periodic(Configuration.create().with(EmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS, 10 * 60 * 60 * 1000).build());
+        assertThat(policy.performCommit(0, Duration.ofNanos(0))).isFalse();
+        assertThat(policy.performCommit(10000, Duration.ofHours(9))).isFalse();
+        assertThat(policy.performCommit(0, Duration.ofHours(10))).isTrue();
+    }
+
+    @Test
+    public void shouldCommitPeriodicallyWithProperties() {
+        // 10 hours
+        final Properties props = Configuration.create().with(EmbeddedEngine.OFFSET_FLUSH_INTERVAL_MS, 10 * 60 * 60 * 1000).build().asProperties();
+        OffsetCommitPolicy policy = new OffsetCommitPolicy.PeriodicCommitOffsetPolicy(props);
         assertThat(policy.performCommit(0, Duration.ofNanos(0))).isFalse();
         assertThat(policy.performCommit(10000, Duration.ofHours(9))).isFalse();
         assertThat(policy.performCommit(0, Duration.ofHours(10))).isTrue();


### PR DESCRIPTION
In order to fix the issue that is reported in [DBZ-2302](https://issues.redhat.com/browse/DBZ-2302), the `EmbeddedEngine` should initiate the `OffsetCommitPolicy` with `Properties` type being provided instead of `Configuration` type in order to keep the `debezium-api` light without depending on `debezium-core` (if I understood it correctly) for `Configuration` type.

Sorry in advance @gunnarmorling @jpechane if I have missed something, is been sometime since I contributed to Debezium :). 

P/S: Also I have tested with camel-debezium-* integration tests that we have there