### PR TITLE
DBZ-2310: Return true when messages are skipped

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -464,8 +464,12 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                 final long lastReceiveLsn = stream.getLastReceiveLSN().asLong();
                 LOGGER.trace("Streaming requested from LSN {}, received LSN {}", startingLsn, lastReceiveLsn);
 
-                if (read == null || messageDecoder.shouldMessageBeSkipped(read, lastReceiveLsn, startingLsn, skipFirstFlushRecord)) {
+                if (read == null) {
                     return false;
+                }
+
+                if (messageDecoder.shouldMessageBeSkipped(read, lastReceiveLsn, startingLsn, skipFirstFlushRecord)) {
+                    return true;
                 }
 
                 deserializeMessages(read, processor);


### PR DESCRIPTION
See https://issues.redhat.com/browse/DBZ-2310 for more explanation.

Short summary: Whenever LSNs are skipped return back that messages have
been processed, which will cause two things:

* The replication can be advanced properly
* The connector does not fallback to the poll timeout waiting interval

I also think its more correct to say, "yes I have read messages, but
still skipped all of them".