### PR TITLE
DBZ-2264 Fix test failure - MongoDbConnectorIT#shouldConsumeTransaction

### DIFF
--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -90,8 +90,9 @@
 
         <!-- The command line args passed to each mongod service -->
         <mongo.data.replicaset.name>rs0</mongo.data.replicaset.name>
+        <mongo.data.transaction.lock.request.timeout.ms>1000</mongo.data.transaction.lock.request.timeout.ms>
         <mongo.cfg.replicaset.name>cfg</mongo.cfg.replicaset.name>
-        <mongo.data.runOptions>--replSet ${mongo.data.replicaset.name} --oplogSize=2 --enableMajorityReadConcern</mongo.data.runOptions>
+        <mongo.data.runOptions>--replSet ${mongo.data.replicaset.name} --oplogSize=2 --enableMajorityReadConcern --setParameter maxTransactionLockRequestTimeoutMillis=${mongo.data.transaction.lock.request.timeout.ms}</mongo.data.runOptions>
         <mongo.cfg.runOptions>--configsvr --replSet ${mongo.cfg.replicaset.name} --oplogSize=2 --enableMajorityReadConcern</mongo.cfg.runOptions>
         <mongo.router.runOptions>mongos --configdb ${mongo.cfg.replicaset.name}/config:27019</mongo.router.runOptions>
         <!-- 

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -90,9 +90,8 @@
 
         <!-- The command line args passed to each mongod service -->
         <mongo.data.replicaset.name>rs0</mongo.data.replicaset.name>
-        <mongo.data.transaction.lock.request.timeout.ms>1000</mongo.data.transaction.lock.request.timeout.ms>
         <mongo.cfg.replicaset.name>cfg</mongo.cfg.replicaset.name>
-        <mongo.data.runOptions>--replSet ${mongo.data.replicaset.name} --oplogSize=2 --enableMajorityReadConcern --setParameter maxTransactionLockRequestTimeoutMillis=${mongo.data.transaction.lock.request.timeout.ms}</mongo.data.runOptions>
+        <mongo.data.runOptions>--replSet ${mongo.data.replicaset.name} --oplogSize=2 --enableMajorityReadConcern</mongo.data.runOptions>
         <mongo.cfg.runOptions>--configsvr --replSet ${mongo.cfg.replicaset.name} --oplogSize=2 --enableMajorityReadConcern</mongo.cfg.runOptions>
         <mongo.router.runOptions>mongos --configdb ${mongo.cfg.replicaset.name}/config:27019</mongo.router.runOptions>
         <!-- 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -1025,6 +1025,14 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
             coll.drop();
             db1.createCollection(collectionName);
             final ClientSession session = mongo.startSession();
+
+            MongoDatabase admin = mongo.getDatabase("admin");
+            if (admin != null) {
+                int timeout = Integer.parseInt(System.getProperty("mongo.transaction.lock.request.timeout.ms", "1000"));
+                Testing.debug("Setting MongoDB transaction lock request timeout as '" + timeout + "ms'");
+                admin.runCommand(session, new Document().append("setParameter", 1).append("maxTransactionLockRequestTimeoutMillis", timeout));
+            }
+
             session.startTransaction();
             storeDocuments(session, coll, pathOnClasspath);
             session.commitTransaction();


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2264

The default lock timeout in MongoDB is `5ms` and apparently this was too short for the environment where this error occurred.  The POM now introduces a new configurable property, `mongo.data.transaction.lock.timeout.ms` which by default I have increased to `1000ms`.  This should likely be sufficient for the Jenkins environment; however if we find it is not we can increase this in the Jenkins job rather than making code changes now.