### PR TITLE
DBZ-2238 Fix test failure - MySqlSourceTypeInSchemaIT#shouldPropagateSourceTypeAsSchemaParameter

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSourceTypeInSchemaIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSourceTypeInSchemaIT.java
@@ -66,7 +66,7 @@ public class MySqlSourceTypeInSchemaIT extends AbstractConnectorTest {
         // Use the DB configuration to define the connector's configuration ...
         config = DATABASE.defaultConfig()
                 .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.NEVER)
-                .with("column.propagate.source.type", ".*c1,.*c2,.*c3.*,.*f.")
+                .with("column.propagate.source.type", ".*\\.c1,.*\\.c2,.*\\.c3.*,.*\\.f.")
                 .build();
 
         // Start the connector ...


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2238

