### PR TITLE
DBZ-2229 Fix test failure - MySqlConnectorRegressionIT#shouldConsumeAllEventsFromDecimalTableInDatabaseUsingBinlogAndNoSnapshot

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
@@ -933,6 +933,7 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 .build();
         // Start the connector ...
         start(MySqlConnector.class, config);
+        waitForStreamingRunning("mysql", DATABASE.getServerName(), "binlog");
 
         // ---------------------------------------------------------------------------------------------------------------
         // Consume all of the events due to startup and initialization of the database


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2229