### PR TITLE
DBZ-2270 Fix test failure - MySqlConnectorIT#shouldNotParseQueryIfServerOptionDisabled

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -1489,6 +1489,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
 
         // Start the connector ...
         start(MySqlConnector.class, config);
+        waitForStreamingRunning(DATABASE.getServerName());
 
         // Flush all existing records not related to the test.
         consumeRecords(PRODUCTS_TABLE_EVENT_COUNT, null);


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2270