### PR TITLE
DBZ-2269 Fix test failure - MySqlSourceTypeInSchemaIT#shouldPropagateSourceTypeByDatatype

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSourceTypeInSchemaIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSourceTypeInSchemaIT.java
@@ -168,6 +168,7 @@ public class MySqlSourceTypeInSchemaIT extends AbstractConnectorTest {
 
         // Start the connector ...
         start(MySqlConnector.class, config);
+        waitForStreamingRunning("mysql", DATABASE.getServerName(), "binlog");
 
         // ---------------------------------------------------------------------------------------------------------------
         // Consume all of the events due to startup and initialization of the database


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2269