### PR TITLE
DBZ-2324 Fix test failure - TablesWithoutPrimaryKeyIT#shouldProcessFromStreaming

### DIFF
--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TablesWithoutPrimaryKeyIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TablesWithoutPrimaryKeyIT.java
@@ -112,6 +112,10 @@ public class TablesWithoutPrimaryKeyIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO t2 VALUES (2,20);");
         connection.execute("INSERT INTO t3 VALUES (3,30);");
 
+        TestHelper.waitForCdcRecord(connection, "t1", rs -> rs.getInt("pk") == 1);
+        TestHelper.waitForCdcRecord(connection, "t2", rs -> rs.getInt("pk") == 2);
+        TestHelper.waitForCdcRecord(connection, "t3", rs -> rs.getInt("pk") == 3);
+
         final int expectedRecordsCount = 1 + 1 + 1;
 
         final SourceRecords records = consumeRecordsByTopic(expectedRecordsCount, 24);

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -8,10 +8,13 @@ package io.debezium.connector.sqlserver.util;
 
 import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
@@ -24,7 +27,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.sqlserver.Lsn;
 import io.debezium.connector.sqlserver.SourceTimestampMode;
+import io.debezium.connector.sqlserver.SqlServerChangeTable;
 import io.debezium.connector.sqlserver.SqlServerConnection;
 import io.debezium.connector.sqlserver.SqlServerConnectorConfig;
 import io.debezium.jdbc.JdbcConfiguration;
@@ -344,5 +349,67 @@ public class TestHelper {
 
     public static int waitTimeForRecords() {
         return Integer.parseInt(System.getProperty(TEST_PROPERTY_PREFIX + "records.waittime", "5"));
+    }
+
+    /**
+     * Utility method that will poll the CDC change tables and provide the record handler with the changes detected.
+     * The record handler can then make a determination as to whether to return {@code true} if the expected outcome
+     * exists or {@code false} to indicate it did not find what it expected.  This method will block until either
+     * the handler returns {@code true} or if the polling fails to complete within the allocated poll window.
+     *
+     * @param connection the SQL Server connection to be used
+     * @param tableName the main table name to be checked
+     * @param handler the handler method to be called if changes are found in the capture table instance
+     */
+    public static void waitForCdcRecord(SqlServerConnection connection, String tableName, CdcRecordHandler handler) {
+        try {
+            Awaitility.await("Checking for expected record in CDC table for " + tableName)
+                    .atMost(30, TimeUnit.SECONDS)
+                    .pollDelay(Duration.ofSeconds(0))
+                    .pollInterval(Duration.ofSeconds(1)).until(() -> {
+                        if (!connection.getMaxLsn().isAvailable()) {
+                            return false;
+                        }
+
+                        for (SqlServerChangeTable ct : connection.listOfChangeTables()) {
+                            final String ctTableName = ct.getChangeTableId().table();
+                            if (ctTableName.endsWith("dbo_" + connection.getNameOfChangeTable(tableName))) {
+                                try {
+                                    final Lsn minLsn = connection.getMinLsn(ctTableName);
+                                    final Lsn maxLsn = connection.getMaxLsn();
+                                    final AtomicReference<Boolean> found = new AtomicReference(false);
+                                    SqlServerChangeTable[] tables = Collections.singletonList(ct).toArray(new SqlServerChangeTable[]{});
+                                    connection.getChangesForTables(tables, minLsn, maxLsn, resultsets -> {
+                                        final ResultSet rs = resultsets[0];
+                                        while (rs.next()) {
+                                            if (handler.apply(rs)) {
+                                                found.set(true);
+                                                break;
+                                            }
+                                        }
+                                    });
+                                    return found.get();
+                                }
+                                catch (Exception e) {
+                                    if (e.getMessage().contains("An insufficient number of arguments were supplied")) {
+                                        // This can happen if the request to get changes for tables happens too quickly.
+                                        // In this case, we're going to ignore it.
+                                        return false;
+                                    }
+                                    org.junit.Assert.fail("Failed to fetch changes for " + tableName + ": " + e.getMessage());
+                                }
+                            }
+                        }
+                        return false;
+                    });
+        }
+        catch (ConditionTimeoutException e) {
+            throw new IllegalStateException("Expected record never appeared in the CDC table", e);
+        }
+    }
+
+    @FunctionalInterface
+    public interface CdcRecordHandler {
+        boolean apply(ResultSet rs) throws SQLException;
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2324

I went ahead in this PR and created a utility method in `TestHelper` to allow us to validate the existence of the CDC records prior to allowing the test to proceed and validate the expected connector observations as I think this is going to become a more prominent problem in our SQL Server tests are we uncover more timing-related issues.  If there are better ways to structure that check, I'm welcome to any suggestions.