### PR TITLE
DBZ-2326 Fixed a typo that was causing bold font for metric table description columns

### DIFF
--- a/documentation/modules/ROOT/partials/modules/cdc-all-connectors/r_connector-monitoring-schema-history-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-all-connectors/r_connector-monitoring-schema-history-metrics.adoc
@@ -1,4 +1,4 @@
-[cols="45%a,25%a,30%s"]
+[cols="45%a,25%a,30%a"]
 |===
 |Attributes |Type |Description
 

--- a/documentation/modules/ROOT/partials/modules/cdc-all-connectors/r_connector-monitoring-snapshot-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-all-connectors/r_connector-monitoring-snapshot-metrics.adoc
@@ -1,4 +1,4 @@
-[cols="45%a,25%a,30%s"]
+[cols="45%a,25%a,30%a"]
 |===
 |Attributes |Type |Description
 

--- a/documentation/modules/ROOT/partials/modules/cdc-all-connectors/r_connector-monitoring-streaming-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-all-connectors/r_connector-monitoring-streaming-metrics.adoc
@@ -1,4 +1,4 @@
-[cols="45%a,25%a,30%s"]
+[cols="45%a,25%a,30%a"]
 |===
 |Attributes |Type |Description
 


### PR DESCRIPTION
The table column specification had a %s at the end where it should have been %a.
I rant Antora and this update enables rendering the text without bold. 