### PR TITLE
DBZ-2315 fix BIT VARYING handling in Postgres connector

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -113,9 +113,9 @@ public abstract class AbstractRecordsProducerTest extends AbstractConnectorTest 
             "'P1Y2M3DT4H5M6.78S'::INTERVAL," +
             "'21016-11-04T13:51:30.123456'::TIMESTAMP, '21016-11-04T13:51:30.123457'::TIMESTAMP, '21016-11-04T13:51:30.124'::TIMESTAMP," +
             "'21016-11-04T13:51:30.123456+07:00'::TIMESTAMPTZ)";
-    protected static final String INSERT_BIN_TYPES_STMT = "INSERT INTO bitbin_table (ba, bol, bs, bv, bv2, bvl) " +
-            "VALUES (E'\\\\001\\\\002\\\\003'::bytea, '0'::bit(1), '11'::bit(2), '00'::bit(2), '000000110000001000000001'::bit(24)," +
-            "'1000000000000000000000000000000000000000000000000000000000000000'::bit(64))";
+    protected static final String INSERT_BIN_TYPES_STMT = "INSERT INTO bitbin_table (ba, bol, bol2, bs, bs7, bv, bv2, bvl, bvunlimited1, bvunlimited2) " +
+            "VALUES (E'\\\\001\\\\002\\\\003'::bytea, '0'::bit(1), '1'::bit(1), '11'::bit(2), '1'::bit(7), '00'::bit(2), '000000110000001000000001'::bit(24)," +
+            "'1000000000000000000000000000000000000000000000000000000000000000'::bit(64), '101', '111011010001000110000001000000001')";
     protected static final String INSERT_BYTEA_BINMODE_STMT = "INSERT INTO bytea_binmode_table (ba) VALUES (E'\\\\001\\\\002\\\\003'::bytea)";
     protected static final String INSERT_CIRCLE_STMT = "INSERT INTO circle_table (ccircle) VALUES ('((10, 20),10)'::circle)";
     protected static final String INSERT_GEOM_TYPES_STMT = "INSERT INTO geom_table(p) VALUES ('(1,1)'::point)";
@@ -555,10 +555,14 @@ public abstract class AbstractRecordsProducerTest extends AbstractConnectorTest 
     protected List<SchemaAndValueField> schemaAndValuesForBinTypes() {
         return Arrays.asList(new SchemaAndValueField("ba", Schema.OPTIONAL_BYTES_SCHEMA, ByteBuffer.wrap(new byte[]{ 1, 2, 3 })),
                 new SchemaAndValueField("bol", Schema.OPTIONAL_BOOLEAN_SCHEMA, false),
+                new SchemaAndValueField("bol2", Schema.OPTIONAL_BOOLEAN_SCHEMA, true),
                 new SchemaAndValueField("bs", Bits.builder(2).optional().build(), new byte[]{ 3 }),
-                new SchemaAndValueField("bv", Bits.builder(2).optional().build(), new byte[]{ 0 }),
+                new SchemaAndValueField("bs7", Bits.builder(7).optional().build(), new byte[]{ 64 }),
+                new SchemaAndValueField("bv", Bits.builder(2).optional().build(), new byte[]{}),
                 new SchemaAndValueField("bv2", Bits.builder(24).optional().build(), new byte[]{ 1, 2, 3 }),
-                new SchemaAndValueField("bvl", Bits.builder(64).optional().build(), new byte[]{ 0, 0, 0, 0, 0, 0, 0, -128 })); // Long.MAX_VALUE + 1
+                new SchemaAndValueField("bvl", Bits.builder(64).optional().build(), new byte[]{ 0, 0, 0, 0, 0, 0, 0, -128 }), // Long.MAX_VALUE + 1
+                new SchemaAndValueField("bvunlimited1", Bits.builder(Integer.MAX_VALUE).optional().build(), new byte[]{ 5 }),
+                new SchemaAndValueField("bvunlimited2", Bits.builder(Integer.MAX_VALUE).optional().build(), new byte[]{ 1, 2, 35, -38, 1 }));
     }
 
     private long asEpochMillis(String timestamp) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSchemaIT.java
@@ -105,9 +105,11 @@ public class PostgresSchemaIT {
             assertTableSchema("public.cidr_network_address_table", "i", Schema.OPTIONAL_STRING_SCHEMA);
             assertTableSchema("public.macaddr_table", "m", Schema.OPTIONAL_STRING_SCHEMA);
             assertTableSchema("public.cash_table", "csh", Decimal.builder(2).optional().build());
-            assertTableSchema("public.bitbin_table", "ba, bol, bs, bv",
-                    Schema.OPTIONAL_BYTES_SCHEMA, Schema.OPTIONAL_BOOLEAN_SCHEMA, Bits.builder(2).optional().build(),
-                    Bits.builder(2).optional().build());
+            assertTableSchema("public.bitbin_table", "ba, bol, bol2, bs, bs7, bv, bvl, bvunlimited1, bvunlimited2",
+                    Schema.OPTIONAL_BYTES_SCHEMA, Schema.OPTIONAL_BOOLEAN_SCHEMA, Schema.OPTIONAL_BOOLEAN_SCHEMA,
+                    Bits.builder(2).optional().build(), Bits.builder(7).optional().build(),
+                    Bits.builder(2).optional().build(), Bits.builder(64).optional().build(),
+                    Bits.builder(Integer.MAX_VALUE).optional().build(), Bits.builder(Integer.MAX_VALUE).optional().build());
             assertTableSchema("public.time_table", "ts, tz, date, ti, ttz, it",
                     MicroTimestamp.builder().optional().build(), ZonedTimestamp.builder().optional().build(),
                     Date.builder().optional().build(), MicroTime.builder().optional().build(), ZonedTime.builder().optional().build(),

--- a/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
+++ b/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
@@ -20,7 +20,7 @@ CREATE TABLE network_address_table (pk SERIAL, i INET, PRIMARY KEY(pk));
 CREATE TABLE cidr_network_address_table (pk SERIAL, i CIDR, PRIMARY KEY(pk));
 CREATE TABLE macaddr_table(pk SERIAL, m MACADDR, PRIMARY KEY(pk));
 CREATE TABLE cash_table (pk SERIAL, csh MONEY, PRIMARY KEY(pk));
-CREATE TABLE bitbin_table (pk SERIAL, ba BYTEA, bol BIT(1), bs BIT(2), bv BIT VARYING(2), bv2 BIT VARYING(24), bvl BIT VARYING(64), PRIMARY KEY(pk));
+CREATE TABLE bitbin_table (pk SERIAL, ba BYTEA, bol BIT(1), bol2 BIT, bs BIT(2), bs7 BIT(7), bv BIT VARYING(2), bv2 BIT VARYING(24), bvl BIT VARYING(64), bvunlimited1 BIT VARYING, bvunlimited2 BIT VARYING, PRIMARY KEY(pk));
 CREATE TABLE bytea_binmode_table (pk SERIAL, ba BYTEA, PRIMARY KEY(pk));
 
 CREATE TABLE time_table (pk SERIAL, ts TIMESTAMP, tsneg TIMESTAMP(6) WITHOUT TIME ZONE, ts_ms TIMESTAMP(3), ts_us TIMESTAMP(6), tz TIMESTAMPTZ, date DATE,

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
@@ -1149,27 +1149,6 @@ public class JdbcValueConverters implements ValueConverterProvider {
                 Boolean value = (Boolean) data;
                 r.deliver(new byte[]{ value.booleanValue() ? (byte) 1 : (byte) 0 });
             }
-            else if (data instanceof Short) {
-                Short value = (Short) data;
-                ByteBuffer buffer = ByteBuffer.allocate(Short.BYTES);
-                buffer.order(ByteOrder.LITTLE_ENDIAN);
-                buffer.putShort(value.shortValue());
-                r.deliver(buffer.array());
-            }
-            else if (data instanceof Integer) {
-                Integer value = (Integer) data;
-                ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES);
-                buffer.order(ByteOrder.LITTLE_ENDIAN);
-                buffer.putInt(value.intValue());
-                r.deliver(buffer.array());
-            }
-            else if (data instanceof Long) {
-                Long value = (Long) data;
-                ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
-                buffer.order(ByteOrder.LITTLE_ENDIAN);
-                buffer.putLong(value.longValue());
-                r.deliver(buffer.array());
-            }
             else if (data instanceof byte[]) {
                 byte[] bytes = (byte[]) data;
                 if (bytes.length == 1) {
@@ -1201,9 +1180,6 @@ public class JdbcValueConverters implements ValueConverterProvider {
         if (data.length < numBytes) {
             byte[] padded = new byte[numBytes];
             System.arraycopy(data, 0, padded, 0, data.length);
-            for (int i = data.length; i != numBytes; ++i) {
-                padded[i] = 0;
-            }
             return padded;
         }
         return data;

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1054,10 +1054,15 @@ The _semantic type_ describes how the Kafka Connect schema captures the _meaning
 |n/a
 |
 
-|`BIT( > 1)`, `BIT VARYING[(M)]`
+|`BIT( > 1)`
 |`BYTES`
 |`io.debezium.data.Bits`
-|The `length` schema parameter contains an integer representing the number of bits. The resulting `byte[]` will contain the bits in little-endian form and will be sized to contain at least the specified number of bits (e.g., `numBytes = n/8 + (n%8== 0 ? 0 : 1)` where `n` is the number of bits).
+|The `length` schema parameter contains an integer representing the number of bits. The resulting `byte[]` will contain the bits in little-endian form and will be sized to contain the specified number of bits (e.g., `numBytes = n/8 + (n % 8 == 0 ? 0 : 1)` where `n` is the number of bits).
+
+|`BIT VARYING[(M)]`
+|`BYTES`
+|`io.debezium.data.Bits`
+|The `length` schema parameter contains an integer representing the number of bits. The resulting `byte[]` will contain the bits in little-endian form and will be sized based on the content. The specified size (M) is stored in the length parameter of the io.debezium.data.Bits type.
 
 |`SMALLINT`, `SMALLSERIAL`
 |`INT16`


### PR DESCRIPTION
* removed little endian padding for BIT VARYING types in PostgresValueConverter
* removed legacy format handling fot BIT related types in JdbcValueConverters#convertBits which were maybe leftovers from PR #1408?
* removed unnecessary zero-ing of a newly created byte array to improve performance for huge byte arrays

fixes https://issues.redhat.com/browse/DBZ-2315