### PR TITLE
DBZ-2367 Fix dependency groupId on Outbox Quarkus Extension documentation

### DIFF
--- a/documentation/modules/ROOT/pages/integrations/outbox.adoc
+++ b/documentation/modules/ROOT/pages/integrations/outbox.adoc
@@ -31,7 +31,7 @@ In order to start using the {prodname} Outbox Quarkus extension, the extension n
 [source,xml,subs="verbatim,attributes"]
 ----
 <dependency>
-  <groupId>io.debezium.quarkus</groupId>
+  <groupId>io.debezium</groupId>
   <artfiactId>debezium-quarkus-outbox</artfiactId>
   <version>{debezium-version}</version>
 </dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2367

Fix the dependency group id from `io.debezium.quarkus` to `io.debezium`.

Reference:
https://mvnrepository.com/artifact/io.debezium/debezium-quarkus-outbox/