### PR TITLE
DBZ-2306 Set connection.autoCommit to true

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -186,6 +186,13 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
 
     @Override
     protected void complete(SnapshotContext snapshotContext) {
+        try {
+            jdbcConnection.setAutoCommit(true);
+        }
+        catch (java.sql.SQLException e) {
+            LOGGER.error("Failed to turn on AutoCommit");
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsSnapshotProducerIT.java
@@ -12,6 +12,7 @@ import static io.debezium.junit.EqualityCheck.LESS_THAN;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -199,6 +200,8 @@ public class RecordsSnapshotProducerIT extends AbstractRecordsProducerTest {
 
         // then insert some more data and check that we get it back
         waitForStreamingToStart();
+        // ensure AutoCommit gets turned back on
+        assertTrue(TestHelper.getAutoCommit());
         TestHelper.execute(insertStmt);
         consumer.expects(2);
         consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -249,6 +249,16 @@ public final class TestHelper {
         return TestHelper.TEST_SERVER + "." + suffix;
     }
 
+    protected static boolean getAutoCommit() {
+        try {
+            return create().connection().getAutoCommit();
+        }
+        catch (SQLException e) {
+            // ignored
+        }
+        return false;
+    }
+
     protected static boolean shouldSSLConnectionFail() {
         return Boolean.parseBoolean(System.getProperty(TEST_PROPERTY_PREFIX + "ssl.failonconnect", "true"));
     }


### PR DESCRIPTION
For postgres when no snapshot is taken connection.autoCommit is set to false. When a
snapshot is taken it sets connection.autoCommit to false and never
changes it back.

This commit ensures that connection.autoCommit is changes to true after
a snapshot completes

The long running query we have seen is: `select * from pg_replication_slots where slot_name = $1 and database = $2 and plugin = $3`.

So not entirely sure that this will fix the issue for DBZ-2306, but it solved the long running transaction for us.