### PR TITLE
DBZ-2376 Remove remaining references to column.whitelist

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -592,7 +592,7 @@ Therefore, we interpret this key as describing the row in the `public.customers`
 
 [NOTE]
 ====
-Although the `column.blacklist` configuration property allow you to capture only a subset of table columns, all columns in a primary or unique key are always included in the event's key.
+Although the `column.blacklist` configuration property allows you to capture only a subset of table columns, all columns in a primary or unique key are always included in the event's key.
 ====
 
 [WARNING]

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -592,7 +592,7 @@ Therefore, we interpret this key as describing the row in the `public.customers`
 
 [NOTE]
 ====
-Although the `column.blacklist` and `column.whitelist` configuration properties allow you to capture only a subset of table columns, all columns in a primary or unique key are always included in the event's key.
+Although the `column.blacklist` configuration property allow you to capture only a subset of table columns, all columns in a primary or unique key are always included in the event's key.
 ====
 
 [WARNING]


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2376

This should address the remaining reference to `column.whitelist` identified by @TovaCohen.