### PR TITLE
DBZ-2333 Modularize and edit content for PostgreSQL connector

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1,5 +1,7 @@
+// Category: debezium-using
+// Type: assembly
 [id="debezium-connector-for-postgresql"]
-= {prodname} Connector for PostgreSQL
+= {prodname} connector for PostgreSQL
 
 ifdef::community[]
 
@@ -12,11 +14,26 @@ ifdef::community[]
 toc::[]
 endif::community[]
 
-{prodname}'s PostgreSQL Connector can monitor and record row-level changes in the schemas of a PostgreSQL database.
+{prodname}'s PostgreSQL connector captures row-level changes in the schemas of a PostgreSQL database. PostgreSQL versions 10, 11, and 12 are supported. 
 
-The first time it connects to a PostgreSQL server/cluster, it reads a consistent snapshot of all of the schemas. When that snapshot is complete, the connector continuously streams the changes that were committed to PostgreSQL 9.6 or later and generates corresponding insert, update and delete events. All of the events for each table are recorded in a separate Kafka topic, where they can be easily consumed by applications and services.
+The first time it connects to a PostgreSQL server or cluster, the connector takes a consistent snapshot of all schemas. After that snapshot is complete, the connector continuously streams changes that were committed to a PostgreSQL database and generates corresponding data change events for insert, update and delete operations. For each table, the default behavior is that all generated events are streamed to a separate Kafka topic for that table. Applications and services consume data change events from that topic. 
 
+ifdef::product[]
+Information and procedures for using a {prodname} PostgreSQL connector is organized as follows: 
 
+* xref:overview-of-debezium-postgresql-connector[]
+* xref:how-debezium-postgresql-connectors-work[]
+* xref:descriptions-of-debezium-postgresql-connector-data-change-events[]
+* xref:how-debezium-postgresql-connectors-map-data-types[]
+* xref:setting-up-postgresql-to-run-a-debezium-connector[]
+* xref:deploying-debezium-postgresql-connectors[]
+* xref:how-debezium-postgresql-connectors-handle-faults-and-problems[]
+
+endif::product[]
+
+// Type: assembly
+// Title: Overview of {prodname} PostgreSQL connector 
+// ModuleID: overview-of-debezium-postgresql-connector
 [[postgresql-overview]]
 == Overview
 
@@ -30,13 +47,11 @@ ifdef::product[]
 endif::product[]
 
 ifdef::community[]
-* a logical decoding output plug-in which has to be installed and configured in the PostgreSQL server, one of
-** https://github.com/debezium/postgres-decoderbufs[decoderbufs] (maintained by the {prodname} community, based on ProtoBuf)
-** https://github.com/eulerto/wal2json[wal2json] (maintained by the wal2json community, based on JSON)
-** pgoutput, the standard logical decoding plug-in in PostgreSQL 10+ (maintained by the Postgres community, used by Postgres itself for https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication]);
-this plug-in is always present, meaning that no additional libraries must be installed,
-and the {prodname} connector will interpret the raw replication event stream into change events directly.
-* Java code (the actual Kafka Connect connector) which reads the changes produced by the chosen plug-in, using PostgreSQL's https://www.postgresql.org/docs/current/static/logicaldecoding-walsender.html[_streaming replication protocol_], via the PostgreSQL https://github.com/pgjdbc/pgjdbc[_JDBC driver_]
+* A logical decoding output plug-in, which has to be installed and configured in the PostgreSQL server. The plug-in is one of these: 
+** https://github.com/debezium/postgres-decoderbufs[`decoderbufs`] (maintained by the {prodname} community, based on ProtoBuf)
+** https://github.com/eulerto/wal2json[`wal2json`] (maintained by the wal2json community, based on JSON)
+** `pgoutput`, which is the standard logical decoding plug-in in PostgreSQL 10+ (maintained by the PostgreSQL community, used by PostgreSQL itself for https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication]). This plug-in is always present so no additional libraries need to be installed. The {prodname} connector interprets the raw replication event stream directly into change events.
+* Java code (the actual Kafka Connect connector) that reads the changes produced by the chosen plug-in, using PostgreSQL's link:https://www.postgresql.org/docs/current/static/logicaldecoding-walsender.html[_streaming replication protocol_], by means of the PostgreSQL link:https://github.com/pgjdbc/pgjdbc[_JDBC driver_]
 endif::community[]
 
 The connector then produces a _change event_ for every row-level insert, update, and delete operation that was received, recording all the change events for each table in a separate Kafka topic. Your client applications read the Kafka topics that correspond to the database tables they're interested in following, and react to every row-level event it sees in those topics.
@@ -47,10 +62,10 @@ The connector is also tolerant of failures. As the connector reads changes and p
 
 ifdef::product[]
 [[postgresql-output-plugin]]
-=== Logical decoding output plug-in
+.Logical decoding output plug-in
 The `pgoutput` logical decoder is the only supported logical decoder in the Tecnhology Preview release of {prodname}.
 
-`pgoutput`, the standard logical decoding plug-in in PostgreSQL 10+, is maintained by the Postgres community, and is also used by Postgres for https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication].
+`pgoutput`, the standard logical decoding plug-in in PostgreSQL 10+, is maintained by the PostgreSQL community, and is also used by PostgreSQL for https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication].
 The `pgoutput` plug-in is always present, meaning that no additional libraries must be installed,
 and the connector will interpret the raw replication event stream into change events directly.
 endif::product[]
@@ -58,298 +73,43 @@ endif::product[]
 [[postgresql-limitations]]
 [IMPORTANT]
 ====
-The connector's functionality relies on PostgreSQL's logical decoding feature.
-Please be aware of the following limitations which are also reflected by the connector:
+The connector relies on and reflects the PostgreSQL logical decoding feature, which has the following limitations:
 
-. Logical Decoding does not support DDL changes: this means that the connector is unable to report DDL change events back to consumers.
-. Logical Decoding replication slots are only supported on `primary` servers: this means that when there is a cluster of PostgreSQL servers, the connector can only run on the active `primary` server. It cannot run on `hot` or `warm` standby replicas. If the `primary` server fails or is demoted, the connector will stop. Once the `primary` has recovered the connector can simply be restarted. If a different PostgreSQL server has been promoted to `primary`, the connector configuration must be adjusted before the connector is restarted. Make sure you read more about how the connector behaves {link-prefix}:{link-postgresql-connector}#postgresql-when-things-go-wrong[when things go wrong].
+* Logical decoding does not support DDL changes. This means that the connector is unable to report DDL change events back to consumers.
+* Logical decoding replication slots are supported on only `primary` servers. When there is a cluster of PostgreSQL servers, the connector can run on only the active `primary` server. It cannot run on `hot` or `warm` standby replicas. If the `primary` server fails or is demoted, the connector stops. After the `primary` server has recovered, you can restart the connector. If a different PostgreSQL server has been promoted to `primary`, adjust the connector configuration before the connector is restarted. Make sure you read more about how the connector behaves {link-prefix}:{link-postgresql-connector}#postgresql-when-things-go-wrong[when things go wrong].
 ====
 
 [IMPORTANT]
 ====
 {prodname} currently supports only databases with UTF-8 character encoding.
-With a single byte character encoding it is not possible to correctly process strings containing extended ASCII code characters.
+With a single byte character encoding it is not possible to correctly process strings that contain extended ASCII code characters.
 ====
 
-[[setting-up-postgresql]]
-== Setting up PostgreSQL
+// Type: assembly
+// ModuleID: how-debezium-postgresql-connectors-work
+// Title: How {prodname} PostgreSQL connectors work
+[[how-the-postgresql-connector-works]]
+== How the connector works
+
+To optimally configure and run a {prodname} PostgreSQL connector, it is helpful to understand how the connector performs snapshots, streams change events, determines Kafka topic names, and uses metadata. 
 
 ifdef::product[]
-This release of {prodname} only supports the native pgoutput logical replication stream.
-To set up PostgreSQL using pgoutput, you will need to enable a replication slot, and configure a user with sufficient privileges to perform the replication.
+Details are in the following topics: 
 
-=== Configuring the replication slot
+* xref:how-debezium-postgresql-connectors-perform-database-snapshots[]
+* xref:how-debezium-postgresql-connectors-stream-change-event-records[]
+* xref:postgresql-10-logical-decoding-support-pgoutput[]
+* xref:default-names-of-kafka-topics-that-receive-debezium-change-event-records[]
+* xref:metadata-in-debezium-change-event-records[]
+* xref:debezium-connector-generated-events-that-represent-transaction-boundaries[]
 
-PostgreSQL's logical decoding uses replication slots.
-
-First, you configure the replication slot:
-
-.postgresql.conf
-
-[source]
-----
-wal_level=logical
-max_wal_senders=1
-max_replication_slots=1
-----
-
-* `wal_level` tells the server to use logical decoding with the write-ahead log
-* `max_wal_senders` tells the server to use a maximum of 1 separate processes for processing WAL changes
-* `max_replication_slots` tells the server to allow a maximum of 1 replication slots to be created for streaming WAL changes
-
-Replication slots are guaranteed to retain all WAL required for {prodname} even during {prodname} outages.
-It is important for this reason to closely monitor replication slots to avoid too much disk consumption and other conditions that can happen such as catalog bloat if a replication slot stays unused for too long.
-For more information, refer to the https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION-SLOTS[the Postgres documentation].
-
-[NOTE]
-====
-We recommend reading and understanding the https://www.postgresql.org/docs/current/static/wal-configuration.html[WAL configuration documentation] regarding the mechanics and configuration of the PostgreSQL write-ahead log.
-====
 endif::product[]
 
-ifdef::community[]
-Before using the PostgreSQL connector to monitor the changes committed on a PostgreSQL server,
-first decide which logical decoder method you intend to use.
-If you plan *not* to use the native pgoutput logical replication stream support,
-then you will need to install the logical decoding plug-in into the PostgreSQL server.
-Afterward enable a replication slot, and configure a user with sufficient privileges to perform the replication.
-
-Note that if your database is hosted by a service such as https://www.heroku.com/postgres[Heroku Postgres] you may be unable to install the plug-in.
-If so, and if you're using PostgreSQL 10+, you can use the pgoutput decoder support to monitor your database.
-If that is not an option, you'll be unable to monitor your database with {prodname}.
-
-[[postgresql-in-the-cloud]]
-=== PostgreSQL in the Cloud
-
-[[postgresql-on-amazon-rds]]
-==== PostgreSQL on Amazon RDS
-
-It is possible to monitor PostgreSQL database running in https://aws.amazon.com/rds/[Amazon RDS]. To get it running you must fulfill the following conditions
-
-* The instance parameter `rds.logical_replication` is set to `1`.
-* Verify that `wal_level` parameter is set to `logical` by running the query `SHOW wal_level` as DB master user; this might not be the case in multi-zone replication setups.
-You cannot set this option manually, it is (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html[automatically changed]) when the `rds.logical_replication` is set to `1`.
-If the `wal_level` is not `logical` after the change above, it is probably because the instance has to be restarted due to the parameter group change. This happens accordingly to your maintenance window or can be done manually.
-* Set `plugin.name` {prodname} parameter to `wal2json`.  You can skip this on PostgreSQL 10+ if you wish to use pgoutput logical replication stream support.
-* Use database master account for replication as RDS currently does not support setting of `REPLICATION` privilege for another account.
-
-[IMPORTANT]
-====
-You should make sure to use the latest versions of Postgres 9.6, 10 or 11 on Amazon RDS.
-Otherwise, older versions of the wal2json plug-in may be installed
-(see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html[the official documentation] for the exact wal2json versions installed on Amazon RDS).
-In that case, replication messages received from the database may not carry complete information about type constraints like length or scale or `NULL`/`NOT NULL`,
-which in turn might cause creation of messages with an inconsistent schema for a short period of time in case of changes to a column's definition.
-
-As of January 2019, the following Postgres versions on RDS come with an up-to-date version of wal2json and thus should be used:
-
-* Postgres 9.6: 9.6.10 and newer
-* Postgres 10: 10.5 and newer
-* Postgres 11: any version
-====
-
-[[postgresql-on-azure]]
-==== PostgreSQL on Azure
-
-It is possible to use Debezium with (https://docs.microsoft.com/azure/postgresql/)[Azure Database for PostgreSQL] that has support for `wal2json` and `pgoutput` plugins, both of which are supported by Debezium as well.
-
-Set the Azure replication support to `logical`. You can use the (https://docs.microsoft.com/en-us/azure/postgresql/concepts-logical#using-azure-cli)[Azure CLI] or the (https://docs.microsoft.com/en-us/azure/postgresql/concepts-logical#using-azure-portal)[Azure Portal] to configure this.
-
-For example, if you were to choose the Azure CLI, here are the (https://docs.microsoft.com/cli/azure/postgres/server?view=azure-cli-latest)[`az postgres server`] commands which you will need to execute:
-
-```
-az postgres server configuration set --resource-group mygroup --server-name myserver --name azure.replication_support --value logical
-
-az postgres server restart --resource-group mygroup --name myserver
-```
-
-[IMPORTANT]
-====
-While using the `pgoutput` plugin, it is recommended that you configure `filtered` as the (https://debezium.io/documentation/reference/1.2/connectors/postgresql.html#postgresql-publication-autocreate-mode)[`publication.autocreate.mode`]. If you use `all_tables` (which is the default value for `publication.autocreate.mode`) and the publication is not found, the connector will try to create one using `CREATE PUBLICATION <publication_name> FOR ALL TABLES;` which will fail due to lack of permissions.
-====
-
-===
-
-[[postgresql-output-plugin]]
-=== Installing the Logical Decoding Output Plug-in
-
-[TIP]
-====
-Also see {link-prefix}:{link-postgresql-plugins}[Logical Decoding Output Plug-in Installation for PostgreSQL] for more detailed instructions of setting up and testing logical decoding plug-ins.
-====
-
-[NOTE]
-====
-As of {prodname} 0.10, the connector supports PostgreSQL 10+ logical replication streaming using _pgoutput_.
-This means that a logical decoding output plug-in is no longer necessary and changes can be emitted directly from the replication stream by the connector.
-====
-
-As of PostgreSQL 9.4, the only way to read changes to the write-ahead-log is to first install a logical decoding output plug-in. Plugins are written in C, compiled, and installed on the machine which runs the PostgreSQL server. Plugins use  a number of PostgreSQL specific APIs, as described by the https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[_PostgreSQL documentation_].
-
-The PostgreSQL connector works with one of {prodname}'s supported logical decoding plug-ins to encode the changes in either https://github.com/google/protobuf[_Protobuf format_] or http://www.json.org/[_JSON_] format.
-See the documentation of your chosen plug-in (https://github.com/debezium/postgres-decoderbufs/blob/master/README.md[_protobuf_], https://github.com/eulerto/wal2json/blob/master/README.md[_wal2json_]) to learn more about the plug-in's requirements, limitations, and how to compile it.
-
-For simplicity, {prodname} also provides a Docker image based on a vanilla PostgreSQL server image on top of which it compiles and installs the plug-ins. We recommend https://github.com/debezium/docker-images/tree/master/postgres/9.6[_using this image_] as an example of the detailed steps required for the installation.
-
-[WARNING]
-====
-The {prodname} logical decoding plug-ins have only been installed and tested on _Linux_ machines.
-For Windows and other operating systems it may require different installation steps.
-====
-
-[[postgresql-differences-between-plugins]]
-==== Differences Between Plug-ins
-
-The plug-ins' behavior is not completely same for all cases.
-So far these differences have been identified:
-
-* wal2json plug-in is not able to process quoted identifiers (https://github.com/eulerto/wal2json/issues/35[issue])
-* wal2json and decoderbufs plug-ins emit events for tables without primary keys
-* wal2json plug-in does not support special values (`NaN` or `infinity`) for floating point types
-* wal2json should be used with setting the `schema.refresh.mode` connector option to `columns_diff_exclude_unchanged_toast`;
-otherwise, when receiving a change event for a row containing an unchanged TOAST column, no field for that column is contained in the emitted change event's `after` structure.
-This is because wal2json's messages do not contain a field for such a column.
-
-The requirement for adding this is tracked under the wal2json https://github.com/eulerto/wal2json/issues/98[issue 98].
-See the documentation of `columns_diff_exclude_unchanged_toast` further below for implications of using it.
-
-* pgoutput plug-in does not emit all the events for tables without primary keys, it only emits inserts
-
-All up-to-date differences are tracked in a test suite https://github.com/debezium/debezium/blob/master/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DecoderDifferences.java[Java class].
-
-
-[[postgresql-server-configuration]]
-=== Configuring the PostgreSQL Server
-
-If you are using one of the supported {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-ins] (i.e. not pgoutput) and it has been installed,
-configure the server to load the plug-in at startup:
-
-.postgresql.conf
-[source,properties]
-----
-# MODULES
-shared_preload_libraries = 'decoderbufs,wal2json' // <1>
-----
-<1> tells the server that it should load at startup the `decoderbufs` and `wal2json` logical decoding plug-ins (the names of the plug-ins are set in https://github.com/debezium/postgres-decoderbufs/blob/v0.3.0/Makefile[_Protobuf_] and https://github.com/eulerto/wal2json/blob/master/Makefile[_wal2json_] Makefiles)
-
-Next is to configure the replication slot regardless of the decoder being used:
-
-.postgresql.conf
-[source,properties]
-----
-# REPLICATION
-wal_level = logical             // <1>
-max_wal_senders = 1             // <2>
-max_replication_slots = 1       // <3>
-----
-<1> tells the server that it should use logical decoding with the write-ahead log
-<2> tells the server that it should use a maximum of `1` separate processes for processing WAL changes
-<3> tells the server that it should allow a maximum of `1` replication slots to be created for streaming WAL changes
-
-{prodname} uses PostgreSQL's logical decoding, which uses replication slots.
-Replication slots are guaranteed to retain all WAL required for {prodname} even during {prodname} outages.
-It is important for this reason to closely monitor replication slots to avoid too much disk consumption and other conditions that can happen such as catalog bloat if a replication slot stays unused for too long.
-For more information please see the official Postgres docs on https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION-SLOTS[this subject].
-
-If you are working with a `synchronous_commit` setting other than `on`,
-the recommendation is to set `wal_writer_delay` to a value such as 10 ms to achieve a low latency of change events.
-Otherwise, its default value is applied, which adds a latency of about 200 ms.
-
-[TIP]
-====
-We strongly recommend reading and understanding https://www.postgresql.org/docs/current/static/wal-configuration.html[the official documentation] regarding the mechanics and configuration of the PostgreSQL write-ahead log.
-====
-endif::community[]
-
-[[postgresql-permissions]]
-=== Setting up Permissions
-
-Next, configure a database user who can perform replications.
-
-Replication can only be performed by a database user that has appropriate permissions and only for a configured number of hosts.
-
-In order to give a user replication permissions, define a PostgreSQL role that has _at least_ the `REPLICATION` and `LOGIN` permissions. For example:
-
-[source,sql]
-----
-CREATE ROLE name REPLICATION LOGIN;
-----
-
-[NOTE]
-====
-Superusers have by default both of the above roles.
-====
-
-Finally, configure the PostgreSQL server to allow replication to take place between the server machine and the host on which the PostgreSQL connector is running:
-
-.pg_hba.conf
-[source]
-----
-local   replication     <youruser>                          trust   // <1>
-host    replication     <youruser>  127.0.0.1/32            trust   // <2>
-host    replication     <youruser>  ::1/128                 trust   // <3>
-----
-<1> Tells the server to allow replication for `<youruser>` locally (i.e. on the server machine)
-<2> Tells the server to allow `<youruser>` on `localhost` to receive replication changes using `IPV4`
-<3> Tells the server to allow `<youruser>` on `localhost` to receive replication changes using `IPV6`
-
-[NOTE]
-====
-See https://www.postgresql.org/docs/current/static/datatype-net-types.html[_the PostgreSQL documentation_] for more information on network masks.
-====
-
-ifdef::community[]
-[[supported-postgresql-topologies]]
-== Supported PostgreSQL Topologies
-
-The PostgreSQL connector can be used with a standalone PostgreSQL server or with a cluster of PostgreSQL servers.
-
-As mentioned {link-prefix}:{link-postgresql-connector}#postgresql-limitations[in the beginning], PostgreSQL (for all versions <= 12) only supports logical replication slots on `primary` servers. This means that a replica in a PostgreSQL cluster cannot be configured for logical replication, and consequently that the {prodname} PostgreSQL Connector can only connect and communicate with the primary server. Should this server fail, the connector will stop. When the cluster is repaired, if the original primary server is once again promoted to `primary`, the connector can simply be restarted. However, if a different PostgreSQL server _with the plug-in and proper configuration_ is promoted to `primary`, the connector configuration must be changed to point to the new `primary` server and then can be restarted.
-endif::community[]
-
-[[postgresql-wal-disk-space]]
-=== WAL Disk Space Consumption
-In certain cases, it is possible that PostgreSQL disk space consumed by WAL files either experiences spikes or increases out of usual proportions.
-There are three potential reasons that explain the situation:
-
- * {prodname} regularly confirms LSN of processed events to the database.
-This is visible as `confirmed_flush_lsn` in the `pg_replication_slots` slots table.
-The database is responsible for reclaiming the disk space and the WAL size can be calculated from `restart_lsn` of the same table.
-So if the `confirmed_flush_lsn` is regularly increasing and `restart_lsn` lags then the database does need to reclaim the space.
-Disk space is usually reclaimed in batch blocks so this is expected behavior and no action on a user's side is necessary.
- * There are many updates in a monitored database but only a minuscule amount relates to the monitored table(s) and/or schema(s).
-This situation can be easily solved by enabling periodic heartbeat events using `heartbeat.interval.ms` configuration option.
- * The PostgreSQL instance contains multiple databases where one of them is a high-traffic database.
- {prodname} monitors another database that is low-traffic in comparison to the other one.
- {prodname} then cannot confirm the LSN as replication slots work per-database and {prodname} is not invoked.
- As WAL is shared by all databases it tends to grow until an event is emitted by the database monitored by {prodname}.
-
-To overcome the third cause it is necessary to
-
- * enable periodic heartbeat record generation using the `heartbeat.interval.ms` configuration option
- * regularly emit change events from the database tracked by {prodname}
-ifdef::community[]
- ** In the case of `wal2json` decoder plug-in, it is sufficient to generate empty events.
- This can be achieved for example by truncating an empty temporary table.
- ** For other decoder plug-ins, it is recommended to create a supplementary table that is not monitored by {prodname}.
-endif::community[]
-
-A separate process would then periodically update the table (either inserting a new event or updating the same row all over).
-PostgreSQL then will invoke {prodname} which will confirm the latest LSN and allow the database to reclaim the WAL space.
-This task can be automated by means of the `heartbeat.action.query` connector option (see below).
-
-[TIP]
-====
-For users on AWS RDS with Postgres, a similar situation to the third cause may occur on an idle environment,
-since AWS RDS makes writes to its own system tables not visible to the useres on a frequent basis (5 minutes).
-Again regularly emitting events will solve the problem.
-====
-
-[[how-the-postgresql-connector-works]]
-=== How the PostgreSQL connector works
-
+// Type: concept
+// ModuleID: how-debezium-postgresql-connectors-perform-database-snapshots
+// Title: How {prodname} PostgreSQL connectors perform database snapshots
 [[postgresql-snapshots]]
-==== Snapshots
+=== Snapshots
 
 Most PostgreSQL servers are configured to not retain the complete history of the database in the WAL segments, so the PostgreSQL connector would be unable to see the entire history of the database by simply reading the WAL. So, by default the connector will upon first startup perform an initial _consistent snapshot_ of the database. Each snapshot consists of the following steps (when using the builtin snapshot modes, *custom* snapshot modes may override this):
 
@@ -372,18 +132,17 @@ The fifth snapshot mode, *exported*, will perform a database snapshot based on t
 
 [WARNING]
 ====
-It is strongly recommended to use *exported* mode as the *initial (only)* and *always* modes can lose few events while switching from snapshot to streaming mode when database is under heavy load.
+It is strongly recommended to use *exported* mode. The *initial (only)* and *always* modes can lose few events while switching from snapshot to streaming mode when a database is under heavy load.
 This is a known issue and the affected modes will be reworked to use *exported* mode under the hood (https://issues.redhat.com/browse/DBZ-2337[DBZ-2337]).
 ====
 
 ifdef::community[]
 The final snapshot mode, *custom*, allows the user to inject their own implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface via the `snapshot.custom.class` configuration property, with the class on the classpath of your Kafka Connect cluster (or included in the JAR if using the `EmbeddedEngine`). For more details, see the {link-prefix}:{link-postgresql-connector}#postgresql-custom-snapshot[Custom Snapshot] section.
 
-
 [[postgresql-custom-snapshot]]
 === Custom Snapshotter SPI
 
-For more advanced usages, the user can provide an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. This interfaces allows control of most of the aspects of how snapshots operate, such as whether to take a snapshot or not and the way the options used to open the snapshot transaction or take locks.
+For more advanced usages, you can provide an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. This interfaces allows control of most of the aspects of how snapshots operate, such as whether to take a snapshot or not and the way the options used to open the snapshot transaction or take locks.
 
 The full API of the interface can be seen here:
 
@@ -397,11 +156,11 @@ The full API of the interface can be seen here:
  * - Should streaming occur
  * - What queries should be used to snapshot
  *
- * While many default snapshot modes are provided with {prodname}
- * a custom implementation of this interface can be provided by the implementor which
- * can provide more advanced functionality, such as partial snapshots
+ * While many default snapshot modes are provided with {prodname},
+ * a custom implementation of this interface can be provided by the implementor, which
+ * can provide more advanced functionality, such as partial snapshots.
  *
- * Implementor's must return true for either {@link #shouldSnapshot()} or {@link #shouldStream()}
+ * Implementations must return true for either {@link #shouldSnapshot()} or {@link #shouldStream()}
  * or true for both.
  */
 @Incubating
@@ -467,13 +226,16 @@ public interface Snapshotter {
 }
 ----
 
-All of the builtin snapshot modes are implemented in terms of this interface as well.
+All built-in snapshot modes are implemented in terms of this interface as well.
 endif::community[]
 
+// Type: concept
+// ModuleID: how-debezium-postgresql-connectors-stream-change-event-records
+// Title: How {prodname} PostgreSQL connectors stream change event records
 [[postgresql-streaming-changes]]
-==== Streaming Changes
+=== Streaming changes
 
-The PostgreSQL connector will typically spend the vast majority of its time streaming changes from the PostgreSQL server to which it is connected. This mechanism relies on https://www.postgresql.org/docs/current/static/protocol-replication.html[_PostgreSQL's replication protocol_] where the client can receive changes from the server as they are committed in the server's transaction log at certain positions (also known as `Log Sequence Numbers` or in short LSNs).
+The PostgreSQL connector typically spends the vast majority of its time streaming changes from the PostgreSQL server to which it is connected. This mechanism relies on https://www.postgresql.org/docs/current/static/protocol-replication.html[_PostgreSQL's replication protocol_] where the client can receive changes from the server as they are committed in the server's transaction log at certain positions (also known as Log Sequence Numbers or LSNs).
 
 Whenever the server commits a transaction, a separate server process invokes a callback function from the {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in]. This function processes the changes from the transaction, converts them to a specific format (Protobuf or JSON in the case of {prodname} plug-in) and writes them on an output stream which can then be consumed by clients.
 
@@ -498,18 +260,23 @@ To prevent the issue completely it is recommended to synchronize updates to the 
 * Put the database or the application into read/write state and start {prodname} again
 ====
 
+// Type: concept
+// ModuleID: postgresql-10-logical-decoding-support-pgoutput
 [[postgresql-pgoutput]]
-==== PostgreSQL 10+ Logical Decoding Support (pgoutput)
+=== PostgreSQL 10+ logical decoding support (`pgoutput`)
 
-As of PostgreSQL 10+, a new logical replication stream mode was introduced, called _pgoutput_.  This logical replication stream mode is natively supported by PostgreSQL,
+As of PostgreSQL 10+, a new logical replication stream mode was introduced, called `pgoutput_`.  This logical replication stream mode is natively supported by PostgreSQL,
 which means that this connector can consume that replication stream
 without the need for additional plug-ins being installed.
 This is particularly valuable for environments where installation of plug-ins is not supported or allowed.
 
 See {link-prefix}:{link-postgresql-connector}#setting-up-postgresql[Setting up PostgreSQL] for more details.
 
+// Type: concept
+// ModuleID: default-names-of-kafka-topics-that-receive-debezium-change-event-records
+// Title: Default names of Kafka topics that receive {prodname} change event records
 [[postgresql-topic-names]]
-==== Topics Names
+=== Topics names
 
 The PostgreSQL connector writes events for all insert, update, and delete operations on a single table to a single Kafka topic. By default, the Kafka topic name is _serverName_._schemaName_._tableName_ where _serverName_ is the logical name of the connector as specified with the `database.server.name` configuration property, _schemaName_ is the name of the database schema where the operation occurred, and _tableName_ is the name of the database table on which the operation occurred.
 
@@ -527,10 +294,13 @@ If on the other hand the tables were not part of a specific schema but rather cr
 * `fulfillment.public.customers`
 * `fulfillment.public.orders`
 
+// Type: concept
+// ModuleID: metadata-in-debezium-change-event-records
+// Title: Metadata in {prodname} change event records
 [[postgresql-meta-information]]
-==== Meta Information
+=== Meta information
 
-Each `record` produced by the PostgreSQL connector has, in addition to the {link-prefix}:{link-postgresql-connector}#postgresql-events[_database event_], some meta-information about where the event occurred on the server, the name of the source partition and the name of the Kafka topic and partition where the event should be placed:
+Each `record` produced by the PostgreSQL connector has, in addition to the {link-prefix}:{link-postgresql-connector}#postgresql-events[_database event_], some metadata about where the event occurred on the server, the name of the source partition and the name of the Kafka topic and partition where the event should be placed:
 
 [source,json,indent=0]
 ----
@@ -549,31 +319,128 @@ The PostgreSQL connector uses only 1 Kafka Connect _partition_ and it places the
 
 The `sourceOffset` portion of the message contains information about the location of the server where the event occurred:
 
-* `lsn` represents the PostgreSQL https://www.postgresql.org/docs/current/static/datatype-pg-lsn.html[_log sequence number_] or `offset` in the transaction log
+* `lsn` represents the PostgreSQL https://www.postgresql.org/docs/current/static/datatype-pg-lsn.html[_Log Sequence Number_] or `offset` in the transaction log
 * `txId` represents the identifier of the server transaction which caused the event
 * `ts_ms` represents the number of microseconds since Unix Epoch as the server time at which the transaction was committed
 
-[[postgresql-events]]
-==== Events
+// Type: concept
+// ModuleID: debezium-connector-generated-events-that-represent-transaction-boundaries
+// Title: {prodname} connector generated events that represent transaction boundaries
+[[postgresql-transaction-metadata]]
+=== Transaction metadata
 
-All data change events produced by the PostgreSQL connector have a key and a value, although the structure of the key and value depend on the table from which the change events originated (see {link-prefix}:{link-postgresql-connector}#postgresql-topic-names[Topic names]).
+{prodname} can generate events that represent transaction boundaries and that enrich change data event messages.
+
+{prodname} generates events for every transaction `BEGIN` and `END`.
+Every event contains
+
+* `status` - `BEGIN` or `END`
+* `id` - string representation of unique transaction identifier
+* `event_count` (for `END` events) - total number of events emmitted by the transaction
+* `data_collections` (for `END` events) - an array of pairs of `data_collection` and `event_count` that provides number of events emitted by changes originating from given data collection
+
+Following is an example message:
+
+[source,json,indent=0,subs="attributes"]
+----
+{
+  "status": "BEGIN",
+  "id": "571",
+  "event_count": null,
+  "data_collections": null
+}
+
+{
+  "status": "END",
+  "id": "571",
+  "event_count": 2,
+  "data_collections": [
+    {
+      "data_collection": "s1.a",
+      "event_count": 1
+    },
+    {
+      "data_collection": "s2.a",
+      "event_count": 1
+    }
+  ]
+}
+----
+
+Transaction events are written to the topic named `<database.server.name>.transaction`.
+
+.Change data event enrichment
+
+When transaction metadata is enabled the data message `Envelope` is enriched with a new `transaction` field.
+This field provides information about every event in the form of a composite of fields:
+
+* `id` - string representation of unique transaction identifier
+* `total_order` - the absolute position of the event among all events generated by the transaction
+* `data_collection_order` - the per-data collection position of the event among all events that were emitted by the transaction
+
+Following is an example of a message:
+
+[source,json,indent=0,subs="attributes"]
+----
+{
+  "before": null,
+  "after": {
+    "pk": "2",
+    "aa": "1"
+  },
+  "source": {
+...
+  },
+  "op": "c",
+  "ts_ms": "1580390884335",
+  "transaction": {
+    "id": "571",
+    "total_order": "1",
+    "data_collection_order": "1"
+  }
+}
+----
+
+// Type: assembly
+// ModuleID: descriptions-of-debezium-postgresql-connector-data-change-events
+// Title: Descriptions of {prodname} PostgreSQL connector data change events
+[[postgresql-events]]
+== Data change events
+
+All data change events produced by the PostgreSQL connector have a key and a value. The structure of the key and value depend on the table from which the change events originated. The default behavior is that the connector stream change event records to {link-prefix}:{link-postgresql-connector}#postgresql-topic-names[topic names] that are the same as the event's originating table.
 
 [NOTE]
 ====
-Starting with Kafka 0.10, Kafka can optionally record with the message key and value the {link-kafka-docs}.html#upgrade_10_performance_impact[_timestamp_] at which the message was created (recorded by the producer) or written to the log by Kafka.
+Starting with Kafka 0.10, Kafka can optionally record the event key and value with the {link-kafka-docs}.html#upgrade_10_performance_impact[_timestamp_] at which the message was created (recorded by the producer) or written to the log by Kafka.
 ====
 
 [WARNING]
 ====
-The PostgreSQL connector ensures that all Kafka Connect _schema names_ are http://avro.apache.org/docs/current/spec.html#names[valid Avro schema names]. This means that the logical server name must start with Latin letters or an underscore (e.g., [a-z,A-Z,\_]), and the remaining characters in the logical server name and all characters in the schema and table names must be Latin letters, digits, or an underscore (e.g., [a-z,A-Z,0-9,\_]). If not, then all invalid characters will automatically be replaced with an underscore character.
+The PostgreSQL connector ensures that all Kafka Connect _schema names_ are http://avro.apache.org/docs/current/spec.html#names[valid Avro schema names]. This means that the logical server name must start with a Latin letter or an underscore, that is, a-z, A-Z, or \_. Each remaining character in the logical server name and each character in the schema and table names must be a Latin letter, a digit, or an underscore, that is, a-z, A-Z, 0-9, or \_. If there is an invalid character it is replaced with an underscore character.
 
-This can lead to unexpected conflicts when the logical server name, schema names, and table names contain other characters, and the only distinguishing characters between table full names are invalid and thus replaced with underscores.
+This can lead to unexpected conflicts if the logical server name, a schema name, or a table name contain invalid characters, and the only characters that  distinguish names from one another are invalid and thus replaced with underscores.
 ====
 
-{prodname} and Kafka Connect are designed around _continuous streams of event messages_, and the structure of these events may change over time. This could be difficult for consumers to deal with, so to make it easy Kafka Connect makes each event self-contained. Every message key and value has two parts: a _schema_ and _payload_. The schema describes the structure of the payload, while the payload contains the actual data.
+{prodname} and Kafka Connect are designed around _continuous streams of event messages_, and the structure of these events may change over time. This could be difficult for consumers to handle, so to make it easier, Kafka Connect makes each event self-contained. Each message key and each message value has two parts: a _schema_ and a _payload_. The schema describes the structure of the payload, while the payload contains the actual data.
 
+ifdef::product[]
+Details are in the following topics:
+
+* xref:about-keys-in-debezium-change-events[]
+* xref:about-values-in-debezium-change-events[]
+* xref:how-replica-identity-controls-data-that can-be-in-debezium-change-events[]
+* xref:about-debezium-change-events-for-create-operations[]
+* xref:about-debezium-change-events-for-update-operations[]
+* xref:about-debezium-change-events-for-primary-key-update[]
+* xref:about-debezium-change-events-for-delete-operations[]
+
+endif::product[]
+
+// Type: concept
+// ModuleID: about-keys-in-debezium-change-events
+// Title: About keys in {prodname} change events
 [[postgresql-change-events-key]]
-===== Change Event's Key
+=== Change event key
 
 For a given table, the change event's key will have a structure that contains a field for each column in the primary key (or unique key constraint with `REPLICA IDENTITY` set to `FULL` or `USING INDEX` on the table) of the table at the time the event was created.
 
@@ -630,6 +497,9 @@ Although the `column.blacklist` and `column.whitelist` configuration properties 
 If the table does not have a primary or unique key, then the change event's key will be null. This makes sense since the rows in a table without a primary or unique key constraint cannot be uniquely identified.
 ====
 
+// Type: concept
+// ModuleID: about-values-in-debezium-change-events
+// Title: About values in {prodname} change events
 [[postgresql-change-events-value]]
 ===== Change Event's Value
 
@@ -649,10 +519,13 @@ Whether or not this field is available is highly dependent on the {link-prefix}:
 
 And of course, the _schema_ portion of the event message's value contains a schema that describes this envelope structure and the nested fields within it.
 
+// Type: concept
+// ModuleID: how-replica-identity-controls-data-that can-be-in-debezium-change-events
+// Title: How `REPLICA IDENTITY` controls data that can be in {prodname}change events
 [[postgresql-replica-identity]]
-===== Replica Identity
+=== Replica identity
 
-https://www.postgresql.org/docs/current/static/sql-altertable.html#SQL-CREATETABLE-REPLICA-IDENTITY[REPLICA IDENTITY] is a PostgreSQL specific table-level setting which determines the amount of information that is available to `logical decoding` in case of `UPDATE` and `DELETE` events. More specifically, this controls what (if any) information is available regarding the previous values of the table columns involved, whenever one of the aforementioned events occur.
+link:https://www.postgresql.org/docs/current/static/sql-altertable.html#SQL-CREATETABLE-REPLICA-IDENTITY[REPLICA IDENTITY] is a PostgreSQL specific table-level setting that determines the amount of information that is available to `logical decoding` in case of `UPDATE` and `DELETE` events. More specifically, this controls what (if any) information is available regarding the previous values of the table columns involved, whenever one of the aforementioned events occur.
 
 There are 4 possible values for `REPLICA IDENTITY`:
 
@@ -661,8 +534,11 @@ There are 4 possible values for `REPLICA IDENTITY`:
 * FULL - `UPDATE` and `DELETE` events will contain the previous values of all the table's columns
 * INDEX `index name` - `UPDATE` and `DELETE` events will contain the previous values of the columns contained in the index definition named `index name`, in case of `UPDATE` only the indexed columns with changed values are present
 
+// Type: concept
+// ModuleID: about-debezium-change-events-for-create-operations
+// Title: About {prodname} change events for `CREATE` operations
 [[postgresql-create-events]]
-===== Create Events
+=== `CREATE` events
 
 Let's look at what a _create_ event value might look like for our `customers` table:
 
@@ -851,8 +727,11 @@ It may appear that the JSON representations of the events are much larger than t
 It is possible and even recommended to use the Avro Converter to dramatically decrease the size of the actual messages written to the Kafka topics.
 ====
 
+// Type: concept
+// ModuleID: about-debezium-change-events-for-update-operations
+// Title: About {prodname} change events for `UPDATE` operations
 [[postgresql-update-events]]
-===== Update Events
+=== `UPDATE` events
 The value of an _update_ change event on this table will actually have the exact same _schema_, and its payload will be structured the same but will hold different values. Here's an example:
 
 [source,json,indent=0,subs="attributes"]
@@ -909,21 +788,23 @@ There are several things we can learn by just looking at this `payload` section.
 When the columns for a row's primary/unique key are updated, the value of the row's key has changed so {prodname} will output _three_ events: a `DELETE` event and {link-prefix}:{link-postgresql-connector}#postgresql-tombstone-events[tombstone event] with the old key for the row, followed by an `INSERT` event with the new key for the row.
 ====
 
-===== Primary Key Update Header
+// Type: concept
+// ModuleID: about-debezium-change-events-for-primary-key-update
+// Title: About {prodname} change events for primary key updates
+=== Primary key updates
 
-When there is an update event that's changing the row's primary key field/s, also known
-as a primary key change, {prodname} will in that case send a DELETE event for the old key
-and an INSERT event for the new (updated) key.
+An update event that changes a row's primary key field(s) is known
+as a primary key change. For a primary key change, {prodname} sends a `DELETE` event for the old key and an `INSERT` event for the new (updated) key.
 
-The DELETE event produces a Kafka message which has a message header `__debezium.newkey`
-and the value is the new primary key.
+* The `DELETE` event produces a Kafka message that has `__debezium.oldkey` as a message header. The value of the message is the previous (old) primary key of the updated row.
 
-The INSERT event produces a Kafka message which has a message header `__debezium.oldkey`
-and the value is the previous (old) primary key of the updated row.
+* The `INSERT` event produces a Kafka message that has `__debezium.newkey` as a message header. The value of the message is the new primary key for the updated row.
 
-
+// Type: concept
+// ModuleID: about-debezium-change-events-for-delete-operations
+// Title: About {prodname} change events for `DELETE` operations
 [[postgresql-delete-events]]
-===== Delete Events
+=== `DELETE` events
 So far we've seen samples of _create_ and _update_ events. Now, let's look at the value of a _delete_ event for the same table. Once again, the `schema` portion of the value will be exactly the same as with the _create_ and _update_ events:
 
 [source,json,indent=0,subs="attributes"]
@@ -967,94 +848,42 @@ This event gives a consumer all kinds of information that it can use to process 
 [WARNING]
 ====
 Please pay attention to the tables without PK, any delete messages from such table with REPLICA IDENTITY DEFAULT will have no `before` part (because they have no PK which is the only field for the default identity level) and therefore will be skipped as totally empty.
-To be able to process messages from tables without PK set REPLICA IDENTITY to FULL level.
+To be able to process messages from tables without PK, set REPLICA IDENTITY to FULL level.
 ====
 
 The PostgreSQL connector's events are designed to work with link:https://kafka.apache.org/documentation/#compaction[Kafka log compaction], which allows for the removal of some older messages as long as at least the most recent message for every key is kept. This allows Kafka to reclaim storage space while ensuring the topic contains a complete dataset and can be used for reloading key-based state.
 
 [[postgresql-tombstone-events]]
+.Tombstone events
 When a row is deleted, the _delete_ event value listed above still works with log compaction, since Kafka can still remove all earlier messages with that same key. But only if the message value is `null` will Kafka know that it can remove _all messages_ with that same key. To make this possible, the PostgreSQL connector always follows the _delete_ event with a special _tombstone_ event that has the same key but `null` value.
 
-[[postgresql-transaction-metadata]]
-=== Transaction Metadata
-
-{prodname} can generate events that represents transaction metadata boundaries and enrich data messages.
-
-==== Transaction boundaries
-{prodname} generates events for every transaction `BEGIN` and `END`.
-Every event contains
-
-* `status` - `BEGIN` or `END`
-* `id` - string representation of unique transaction identifier
-* `event_count` (for `END` events) - total number of events emmitted by the transaction
-* `data_collections` (for `END` events) - an array of pairs of `data_collection` and `event_count` that provides number of events emitted by changes originating from given data collection
-
-Following is an example of what a message looks like:
-
-[source,json,indent=0,subs="attributes"]
-----
-{
-  "status": "BEGIN",
-  "id": "571",
-  "event_count": null,
-  "data_collections": null
-}
-
-{
-  "status": "END",
-  "id": "571",
-  "event_count": 2,
-  "data_collections": [
-    {
-      "data_collection": "s1.a",
-      "event_count": 1
-    },
-    {
-      "data_collection": "s2.a",
-      "event_count": 1
-    }
-  ]
-}
-----
-
-The transaction events are written to the topic named `<database.server.name>.transaction`.
-
-==== Data events enrichment
-When transaction metadata is enabled the data message `Envelope` is enriched with a new `transaction` field.
-This field provides information about every event in the form of a composite of fields:
-
-* `id` - string representation of unique transaction identifier
-* `total_order` - the absolute position of the event among all events generated by the transaction
-* `data_collection_order` - the per-data collection position of the event among all events that were emitted by the transaction
-
-Following is an example of what a message looks like:
-
-[source,json,indent=0,subs="attributes"]
-----
-{
-  "before": null,
-  "after": {
-    "pk": "2",
-    "aa": "1"
-  },
-  "source": {
-...
-  },
-  "op": "c",
-  "ts_ms": "1580390884335",
-  "transaction": {
-    "id": "571",
-    "total_order": "1",
-    "data_collection_order": "1"
-  }
-}
-----
-
+// Type: assembly
+// ModuleID: how-debezium-postgresql-connectors-map-data-types
+// Title: How {prodname} PostgreSQL connectors map data types
 [[postgresql-data-types]]
-==== Data Types
+== Data types
 
-As described above, the PostgreSQL connector represents the changes to rows with events that are structured like the table in which the row exist. The event contains a field for each column value, and how that value is represented in the event depends on the PostgreSQL data type of the column. This section describes this mapping.
+The PostgreSQL connector represents changes to rows with events that are structured like the table in which the row exist. The event contains a field for each column value. How that value is represented in the event depends on the PostgreSQL data type of the column. This section describes this mapping.
 
+ifdef::product[]
+Details are in the following sections: 
+
+* xref:how-debezium-maps-postgresql-basic-types[]
+* xref:how-debezium-maps-postgresql-temporal-types[]
+* xref:how-debezium-maps-postgresql-timestamp-type[]
+* xref:how-debezium-maps-postgresql-decimal-types[]
+* xref:how-debezium-maps-postgresql-hstore-type[]
+* xref:how-debezium-maps-postgresql-domain-types[]
+* xref:how-debezium-maps-postgresql-network-address-types[]
+* xref:how-debezium-maps-postgresql-postgis-types[]
+* xref:how-debezium-maps-postgresql-toasted-values[]
+
+endif::product[]
+
+// Type: concept
+// ModuleID: how-debezium-maps-postgresql-basic-types
+// Title: How {prodname} maps PostgreSQL basic types
+=== Basic types
 The following table describes how the connector maps each of the PostgreSQL data types to a _literal type_ and _semantic type_ within the events' fields.
 
 Here, the _literal type_ describes how the value is literally represented using Kafka Connect schema types, namely `INT8`, `INT16`, `INT32`, `INT64`, `FLOAT32`, `FLOAT64`, `BOOLEAN`, `STRING`, `BYTES`, `ARRAY`, `MAP`, and `STRUCT`.
@@ -1234,8 +1063,11 @@ The _semantic type_ describes how the Kafka Connect schema captures the _meaning
 
 Other data type mappings are described in the following sections.
 
+// Type: concept
+// ModuleID: how-debezium-maps-postgresql-temporal-types
+// Title: How {prodname} maps PostgreSQL temporal types
 [[postgresql-temporal-values]]
-===== Temporal Values
+=== Temporal types
 
 Other than PostgreSQL's `TIMESTAMPTZ` and `TIMETZ` data types (which contain time zone information), the other temporal types depend on the value of the `time.precision.mode` configuration property.  When the `time.precision.mode` configuration property is set to `adaptive` (the default), then the connector will determine the literal type and semantic type for the temporal types based on the column's data type definition so that events _exactly_ represent the values in the database:
 
@@ -1330,8 +1162,11 @@ When the `time.precision.mode` configuration property is set to `connect`, then 
 
 |===
 
+// Type: concept
+// ModuleID: how-debezium-maps-postgresql-timestamp-types
+// Title: How {prodname} maps PostgreSQL `TIMESTAMP` type
 [[postgresql-timestamp-values]]
-===== `TIMESTAMP` values
+=== `TIMESTAMP` type
 
 The `TIMESTAMP` type represents a timestamp without time zone information.
 Such columns are converted into an equivalent Kafka Connect value based on UTC.
@@ -1340,8 +1175,11 @@ So for instance the `TIMESTAMP` value "2018-06-20 15:13:16.945104" will be repre
 
 Note that the timezone of the JVM running Kafka Connect and {prodname} does not affect this conversion.
 
+// Type: concept
+// ModuleID: how-debezium-maps-postgresql-decimal-types
+// Title: How {prodname} maps PostgreSQL decimal types
 [[postgresql-decimal-values]]
-===== Decimal Values
+=== Decimal types
 
 When `decimal.handling.mode` configuration property is set to `precise`, then the connector will use the predefined Kafka Connect `org.apache.kafka.connect.data.Decimal` logical type for all `DECIMAL` and `NUMERIC` columns. This is the default mode.
 
@@ -1431,8 +1269,11 @@ The last option for `decimal.handling.mode` configuration property is `string`. 
 
 PostgreSQL supports `NaN` (not a number) special value to be stored in the `DECIMAL`/`NUMERIC` values. Only `string` and `double` modes are able to handle such values encoding them as either `Double.NaN` or string constant `NAN`.
 
+// Type: concept
+// ModuleID: how-debezium-maps-postgresql-hstore-type
+// Title: How {prodname} maps PostgreSQL `HSTORE` type
 [[postgresql-hstore-values]]
-===== HStore Values
+=== `HSTORE` type
 
 When `hstore.handling.mode` configuration property is set to `json` (the default), the connector will represent all `HSTORE` values as string-ified JSON values and encode them as follows:
 
@@ -1466,8 +1307,11 @@ When `hstore.handling.mode` configuration property is set to `map`, then the con
 
 |===
 
+// Type: concept
+// ModuleID: how-debezium-maps-postgresql-domain-types
+// Title: How {prodname} maps PostgreSQL domain types
 [[postgresql-domain-types]]
-==== PostgreSQL Domain Types
+=== PostgreSQL domain types
 
 PostgreSQL also supports the notion of user-defined types that are based upon other underlying types.
 When such column types are used, {prodname} exposes the column's representation based on the full type hierarchy.
@@ -1481,10 +1325,11 @@ When a column is defined using a domain type that extends one of the default dat
 When a column is defined using a domain type that extends another domain type that defines a custom length/scale, the generated schema will **not** inherit the defined length/scale because the PostgreSQL driver's column metadata implementation.
 ====
 
-[[postgresql-postgis-types]]
-
+// Type: concept
+// ModuleID: how-debezium-maps-postgresql-network-address-types
+// Title: How {prodname} maps PostgreSQL network address types
 [[postgresql-network-address-types]]
-===== Network Address Types
+=== Network address types
 
 PostgreSQL also have data types that can store IPv4, IPv6, and MAC addresses. It is better to use these instead of plain text types to store network addresses, because these types offer input error checking and specialized operators and functions.
 
@@ -1516,7 +1361,12 @@ PostgreSQL also have data types that can store IPv4, IPv6, and MAC addresses. It
 |MAC addresses in EUI-64 format
 
 |===
-===== PostGIS Types
+
+// Type: concept
+// ModuleID: how-debezium-maps-postgresql-postgis-types
+// Title: How {prodname} maps PostgreSQL PostGIS types
+[[postgresql-postgis-types]]
+=== PostGIS types
 
 The PostgreSQL connector also has full support for all of the http://postgis.net[PostGIS data types]
 
@@ -1548,12 +1398,15 @@ Please see http://www.opengeospatial.org/standards/sfa[Open Geospatial Consortiu
 
 |===
 
+// Type: concept
+// ModuleID: how-debezium-maps-postgresql-toasted-values
+// Title: How {prodname} maps PostgreSQL toasted values
 [[postgresql-toasted-values]]
-===== Toasted values
+=== Toasted values
 PostgreSQL has a hard limit on the page size.
 This means that values larger than ca. 8 KB need to be stored using https://www.postgresql.org/docs/current/storage-toast.html[TOAST storage].
 This impacts replication messages coming from database, as the values that were stored using the TOAST mechanism and have not been changed are not included in the message, unless they are part of the table's replica identity.
-There is no safe way for {prodname} to read the missing value out-of-bands directly from database, as this would lead into race conditions potentially.
+There is no safe way for {prodname} to read the missing value out-of-bands directly from the database, as this would lead into race conditions potentially.
 {prodname} thus follows these rules to handle the toasted values:
 
 * tables with `REPLICA IDENTITY FULL`: TOAST column values are part of the `before` and `after` blocks of change events as any other column
@@ -1564,75 +1417,335 @@ As {prodname} cannot safely provide the column value in this case, it returns a 
 
 [IMPORTANT]
 ====
-There is a specific problem related to Amazon RDS instances.
-`wal2json` plug-in has evolved over the time and there were releases that provided out-of-band toasted values.
-Amazon supports different versions of the plug-in for different PostgreSQL versions.
-Please consult Amazon's https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html[documentation] to obtain version to version mapping.
-For consistent toasted values handling we recommend to
+There is a problem related to Amazon RDS instances. The `wal2json` plug-in has evolved over the time and there were releases that provided out-of-band toasted values. Amazon supports different versions of the plug-in for different PostgreSQL versions. See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html[Amazon's documentation] to obtain version to version mapping. For consistent toasted values handling: 
 
-* use `pgoutput` plug-in for PostgreSQL 10+ instances
-* set `include-unchanged-toast=0` for older versions of the `wal2json` plug-in by using the `slot.stream.params` configuration option
+* Use the `pgoutput` plug-in for PostgreSQL 10+ instances.
+* Set `include-unchanged-toast=0` for older versions of the `wal2json` plug-in by using the `slot.stream.params` configuration option. 
 ====
 
-[[postgresql-deploying-a-connector]]
-== Deploying the PostgreSQL Connector
+// Type: assembly
+// ModuleID: setting-up-postgresql-to-run-a-debezium-connector
+// Title: Setting up PostgreSQL to run a {prodname} connector
+[[setting-up-postgresql]]
+== Set up
 
 ifdef::community[]
-If you've already installed https://zookeeper.apache.org[Zookeeper], http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect], then using {prodname}'s PostgreSQL connector is easy. Simply download the https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/{debezium-version}/debezium-connector-postgres-{debezium-version}-plugin.tar.gz[connector's plug-in archive], extract the JARs into your Kafka Connect environment, and add the directory with the JARs to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`]. Restart your Kafka Connect process to pick up the new JARs.
+Before using the PostgreSQL connector to monitor the changes committed on a PostgreSQL server, decide which logical decoder method you intend to use.
+If you plan *not* to use the native `pgoutput` logical replication stream support, then you must install the logical decoding plug-in into the PostgreSQL server. Afterward, enable a replication slot, and configure a user with sufficient privileges to perform the replication.
+
+If your database is hosted by a service such as link:https://www.heroku.com/postgres[Heroku Postgres] you might be unable to install the plug-in. If so, and if you are using PostgreSQL 10+, you can use the `pgoutput` decoder support to monitor your database. If that is not an option, you are unable to monitor your database with {prodname}.
 endif::community[]
 
 ifdef::product[]
-Installing the PostgreSQL connector is a simple process whereby you only need to download the JAR, extract it to your Kafka Connect environment, and ensure the plug-in's parent directory is specified in your Kafka Connect environment.
+This release of {prodname} supports only the native `pgoutput` logical replication stream. To set up PostgreSQL so that it uses the `pgoutput` plug-in, you must enable a replication slot, and configure a user with sufficient privileges to perform the replication.
+
+Details are in the following topics: 
+
+* xref:configuring-a-replication-slot-for-the-debezium-pgoutput-plug-in[]
+* xref:setting-up-postgresql-permissions-required-by-debezium-connectors[]
+* xref:[]
+
+// Type: concept
+// ModuleID: configuring-a-replication-slot-for-the-debezium-pgoutput-plug-in
+// Title: Configuring a replication slot for the {prodname} `pgoutput` plug-in
+=== Configuring replication slot
+
+PostgreSQL's logical decoding uses replication slots. To configure a replication slot, specify the following in the `postgresql.conf` file: 
+
+[source]
+----
+wal_level=logical
+max_wal_senders=1
+max_replication_slots=1
+----
+
+These settings instruct the PostgreSQL server as follows: 
+
+* `wal_level`: use logical decoding with the write-ahead log.
+* `max_wal_senders`: use a maximum of one separate process for processing WAL changes.
+* `max_replication_slots`: allow a maximum of one replication slot to be created for streaming WAL changes.
+
+Replication slots are guaranteed to retain all WAL entries that are required for {prodname} even during {prodname} outages. Consequently, it is important to closely monitor replication slots to avoid:
+
+* Too much disk consumption
+* Any conditions, such as catalog bloat, that can happen if a replication slot stays unused for too long
+
+For more information, see the link:https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION-SLOTS[PostgreSQL documentation for replication slots].
+
+[NOTE]
+====
+Familiarity with the mechanics and link:https://www.postgresql.org/docs/current/static/wal-configuration.html[configuration of the PostgreSQL write-ahead log] is helpful for using the {prodname} PostgreSQL connector. 
+====
+endif::product[]
+
+ifdef::community[]
+[[postgresql-on-amazon-rds]]
+=== PostgreSQL on Amazon RDS
+
+It is possible to monitor a PostgreSQL database that is running in link:https://aws.amazon.com/rds/[Amazon RDS]. To get it running, you must fulfill the following conditions
+
+* The instance parameter `rds.logical_replication` is set to `1`.
+* Verify that `wal_level` parameter is set to `logical` by running the query `SHOW wal_level` as DB master user; this might not be the case in multi-zone replication setups.
+You cannot set this option manually, it is (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html[automatically changed]) when the `rds.logical_replication` is set to `1`.
+If the `wal_level` is not `logical` after the change above, it is probably because the instance has to be restarted due to the parameter group change. This happens accordingly to your maintenance window or can be done manually.
+* Set `plugin.name` {prodname} parameter to `wal2json`.  You can skip this on PostgreSQL 10+ if you wish to use `pgoutput` logical replication stream support.
+* Use database master account for replication as RDS currently does not support setting of `REPLICATION` privilege for another account.
+
+[IMPORTANT]
+====
+Ensure that you use the latest versions of PostgreSQL 9.6, 10 or 11 on Amazon RDS.
+Otherwise, older versions of the `wal2json` plug-in might be installed
+(see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html[the official documentation] for the exact `wal2json` versions installed on Amazon RDS).
+In that case, replication messages received from the database may not carry complete information about type constraints like length or scale or `NULL`/`NOT NULL`,
+which in turn might cause creation of messages with an inconsistent schema for a short period of time in case of changes to a column's definition.
+
+As of January 2019, the following PostgreSQL versions on RDS come with an up-to-date version of wal2json and thus should be used:
+
+* PostgreSQL 9.6: 9.6.10 and newer
+* PostgreSQL 10: 10.5 and newer
+* PostgreSQL 11: any version
+====
+
+[[postgresql-output-plugin]]
+=== Installing the logical decoding output plug-in
+
+[TIP]
+====
+Also see {link-prefix}:{link-postgresql-plugins}[Logical Decoding Output Plug-in Installation for PostgreSQL] for more detailed instructions of setting up and testing logical decoding plug-ins.
+====
+
+[NOTE]
+====
+As of {prodname} 0.10, the connector supports PostgreSQL 10+ logical replication streaming using `pgoutput`.
+This means that a logical decoding output plug-in is no longer necessary and changes can be emitted directly from the replication stream by the connector.
+====
+
+As of PostgreSQL 9.4, the only way to read changes to the write-ahead-log is to first install a logical decoding output plug-in. Plug-ins are written in C, compiled, and installed on the machine that runs the PostgreSQL server. Plugins use  a number of PostgreSQL specific APIs, as described by the https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[_PostgreSQL documentation_].
+
+The PostgreSQL connector works with one of {prodname}'s supported logical decoding plug-ins to encode the changes in either https://github.com/google/protobuf[_Protobuf format_] or http://www.json.org/[_JSON_] format.
+See the documentation for your chosen plug-in (https://github.com/debezium/postgres-decoderbufs/blob/master/README.md[_protobuf_], https://github.com/eulerto/wal2json/blob/master/README.md[_wal2json_]) to learn more about the plug-in's requirements, limitations, and how to compile it.
+
+For simplicity, {prodname} also provides a Docker image based on a vanilla PostgreSQL server image on top of which it compiles and installs the plug-ins. We recommend https://github.com/debezium/docker-images/tree/master/postgres/9.6[_using this image_] as an example of the detailed steps required for the installation.
+
+[WARNING]
+====
+The {prodname} logical decoding plug-ins have been installed and tested on only  _Linux_ machines. For Windows and other operating systems, different installation steps might be required.
+====
+
+[[postgresql-differences-between-plugins]]
+==== Differences between plug-ins
+
+The plug-ins' behavior is not completely the same for all cases.
+So far these differences have been identified:
+
+* The `wal2json` plug-in is not able to process quoted identifiers (https://github.com/eulerto/wal2json/issues/35[issue]).
+* The `wal2json` and `decoderbufs` plug-ins emit events for tables without primary keys.
+* The `wal2json` plug-in does not support special values (such as, `NaN` or `infinity`) for floating point types.
+* The `wal2json` plug-in should be used with the `schema.refresh.mode` connector option set to `columns_diff_exclude_unchanged_toast`. Otherwise, when receiving a change event for a row that contains an unchanged `TOAST` column, no field for that column is contained in the emitted change event's `after` structure. This is because `wal2json` plug-in messages do not contain a field for such a column.
++
+The requirement for adding this is tracked under the link:https://github.com/eulerto/wal2json/issues/98[`wal2json` issue 98].
+See the documentation of `columns_diff_exclude_unchanged_toast` further below for implications of using it.
+
+* The `pgoutput` plug-in does not emit all the events for tables without primary keys. It emits only events for insert operations.
+
+All up-to-date differences are tracked in a test suite link:https://github.com/debezium/debezium/blob/master/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DecoderDifferences.java[Java class].
+
+[[postgresql-server-configuration]]
+=== Configuring the PostgreSQL server
+
+If you are using one of the supported {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-ins], that is, not `pgoutput`, and it has been installed, configure the PostgreSQL server as follows:  
+
+. To load the plug-in at startup, add the following to the `postgresql.conf` file::
++
+[source,properties]
+----
+# MODULES
+shared_preload_libraries = 'decoderbufs,wal2json' // <1>
+----
+<1> instructs the server to load the `decoderbufs` and `wal2json` logical decoding plug-ins at startup. The names of the plug-ins are set in the link:https://github.com/debezium/postgres-decoderbufs/blob/v0.3.0/Makefile[`Protobuf`] and link:https://github.com/eulerto/wal2json/blob/master/Makefile[`wal2json`] make files. 
+
+. To cnfigure the replication slot regardless of the decoder being used, specify the following in the `postgresql.conf` file: 
++
+[source,properties]
+----
+# REPLICATION
+wal_level = logical             // <1>
+max_wal_senders = 1             // <2>
+max_replication_slots = 1       // <3>
+----
+<1> instructs the server to use logical decoding with the write-ahead log.
+<2> instructs the server to use a maximum of `1` separate process for processing WAL changes.
+<3> instructs the server to allow a maximum of `1` replication slot to be created for streaming WAL changes.
+
+{prodname} uses PostgreSQL's logical decoding, which uses replication slots.
+Replication slots are guaranteed to retain all WAL required for {prodname} even during {prodname} outages.
+It is important for this reason to closely monitor replication slots to avoid too much disk consumption and other conditions that can happen such as catalog bloat if a replication slot stays unused for too long.
+For more information, see the link:https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION-SLOTS[PostgreSQL streaming replication documentation].
+
+If you are working with a `synchronous_commit` setting other than `on`,
+the recommendation is to set `wal_writer_delay` to a value such as 10 milliseconds to achieve a low latency of change events.
+Otherwise, its default value is applied, which adds a latency of about 200 milliseconds.
+
+[TIP]
+====
+Reading and understanding https://www.postgresql.org/docs/current/static/wal-configuration.html[PostgreSQL documentation about the mechanics and configuration of the PostgreSQL write-ahead log] is strongly recommended.
+====
+endif::community[]
+
+// Type: procedure
+// ModuleID: setting-up-postgresql-permissions-required-by-debezium-connectors
+// Title: Setting up PostgreSQL permissions required by {prodname} connectors
+[[postgresql-permissions]]
+=== Setting up permissions
+
+Setting up a PostgreSQL server to run a {prodname} connector requires a database user who can perform replications. Replication can be performed by only a database user who has appropriate permissions and only for a configured number of hosts. Also, you must configure the PostgreSQL server to allow replication to take place between the server machine and the host on which the PostgreSQL connector is running. 
 
 .Prerequisites
 
-* You have link:https://zookeeper.apache.org/[Zookeeper], link:http://kafka.apache.org/[Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] installed.
-* You have PostgreSQL installed and setup.
+* PostgreSQL administrative permissions. 
 
 .Procedure
 
+. To give replication permissions to a user, define a PostgreSQL role that has _at least_ the `REPLICATION` and `LOGIN` permissions. For example:
++
+[source,sql]
+----
+CREATE ROLE name REPLICATION LOGIN;
+----
++
+[NOTE]
+====
+By default, superusers have both of the above roles.
+====
+
+. Configure the PostgreSQL server to allow replication to take place between the server machine and the host on which the PostgreSQL connector is running. For example: 
+
+.pg_hba.conf
+[source]
+----
+local   replication     <youruser>                          trust   // <1>
+host    replication     <youruser>  127.0.0.1/32            trust   // <2>
+host    replication     <youruser>  ::1/128                 trust   // <3>
+----
+<1> Instructs the server to allow replication for `<youruser>` locally, that is, on the server machine.
+<2> Instructs the server to allow `<youruser>` on `localhost` to receive replication changes using `IPV4`.
+<3> Instructs the server to allow `<youruser>` on `localhost` to receive replication changes using `IPV6`.
+
+[NOTE]
+====
+For more information about network masks, see link:https://www.postgresql.org/docs/current/static/datatype-net-types.html[the PostgreSQL documentation].
+====
+
+ifdef::community[]
+[[supported-postgresql-topologies]]
+=== Supported PostgreSQL topologies
+
+The PostgreSQL connector can be used with a standalone PostgreSQL server or with a cluster of PostgreSQL servers.
+
+As mentioned {link-prefix}:{link-postgresql-connector}#postgresql-limitations[in the beginning], PostgreSQL (for all versions <= 12) supports only logical replication slots on `primary` servers. This means that a replica in a PostgreSQL cluster cannot be configured for logical replication, and consequently that the {prodname} PostgreSQL Connector can connect and communicate with only the primary server. Should this server fail, the connector stops. When the cluster is repaired, if the original primary server is once again promoted to `primary`, the connector can be restarted. However, if a different PostgreSQL server _with the plug-in and proper configuration_ is promoted to `primary`, the connector configuration must be changed to point to the new `primary` server and then can be restarted.
+endif::community[]
+
+// Type: concept
+// ModuleID: configuring-postgresql-to-manage-debezium-wal-disk-space-consumption
+// Title: Configuring PostgreSQL to manage {prodname} WAL disk space consumption
+[[postgresql-wal-disk-space]]
+=== WAL disk space consumption
+In certain cases, it is possible that PostgreSQL disk space consumed by WAL files either experiences spikes or increases out of usual proportions.
+There are three potential reasons that explain the situation:
+
+ * {prodname} regularly confirms LSN of processed events to the database.
+This is visible as `confirmed_flush_lsn` in the `pg_replication_slots` slots table.
+The database is responsible for reclaiming the disk space and the WAL size can be calculated from `restart_lsn` of the same table.
+So if the `confirmed_flush_lsn` is regularly increasing and `restart_lsn` lags then the database does need to reclaim the space.
+Disk space is usually reclaimed in batch blocks so this is expected behavior and no action on a user's side is necessary.
+ * There are many updates in a monitored database but only a minuscule amount relates to the monitored table(s) and/or schema(s).
+This situation can be easily solved by enabling periodic heartbeat events using `heartbeat.interval.ms` configuration option.
+ * The PostgreSQL instance contains multiple databases where one of them is a high-traffic database.
+ {prodname} monitors another database that is low-traffic in comparison to the other one.
+ {prodname} then cannot confirm the LSN as replication slots work per-database and {prodname} is not invoked.
+ As WAL is shared by all databases it tends to grow until an event is emitted by the database monitored by {prodname}.
+
+To overcome the third cause it is necessary to
+
+ * enable periodic heartbeat record generation using the `heartbeat.interval.ms` configuration option
+ * regularly emit change events from the database tracked by {prodname}
+ifdef::community[]
+ ** In the case of `wal2json` decoder plug-in, it is sufficient to generate empty events.
+ This can be achieved for example by truncating an empty temporary table.
+ ** For other decoder plug-ins, it is recommended to create a supplementary table that is not monitored by {prodname}.
+endif::community[]
+
+A separate process would then periodically update the table (either inserting a new event or updating the same row all over).
+PostgreSQL then will invoke {prodname} which will confirm the latest LSN and allow the database to reclaim the WAL space.
+This task can be automated by means of the `heartbeat.action.query` connector option (see below).
+
+ifdef::community[]
+[TIP]
+====
+For users on AWS RDS with Postgres, a similar situation to the third cause may occur on an idle environment,
+since AWS RDS makes writes to its own system tables not visible to the useres on a frequent basis (5 minutes).
+Again regularly emitting events will solve the problem.
+====
+endif::community[]
+
+// Type: assembly
+// ModuleID: deploying-debezium-postgresql-connectors
+// Title: Deploying {prodname} PostgreSQL connectors
+[[postgresql-deploying-a-connector]]
+== Deployment
+
+ifdef::community[]
+With https://zookeeper.apache.org[Zookeeper], http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect] installed, the remaining tasks to deploy a {prodname} PostgreSQL connector are to download the https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/{debezium-version}/debezium-connector-postgres-{debezium-version}-plugin.tar.gz[connector's plug-in archive], extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`]. Restart your Kafka Connect process to pick up the new JAR files.
+
+If you need immutable containers, see https://hub.docker.com/r/debezium/[{prodname}'s Docker images] for Zookeeper, Kafka, PostgreSQL and Kafka Connect with the PostgreSQL connector already installed and ready to run. You can also link:/blog/2016/05/31/Debezium-on-Kubernetes/[run {prodname} on Kubernetes and OpenShift].
+endif::community[]
+
+ifdef::product[]
+To deploy a {prodname} PostgreSQL connector, install the {prodname} PostgreSQL connector archive, configure the connector, and start it. Details are in the following topics: 
+
+* xref:steps-for-installing-debezium-postgresql-connectors[]
+* xref:debezium-postgresql-connector-configuration-example[]
+* xref:adding-debezium-postgresql-connector-configuration-to-kafka-connect[]
+* xref:monitoring-debezium-postgresql-connector-performance[]
+* xref:descriptions-of-debezium-postgresql-connector-configuration-properties[]
+
+// Type: concept
+[id="steps-for-installing-debezium-postgresql-connectors"]
+=== Steps for installing {prodname} PostgreSQL connectors
+
+To install the PostgreSQL connector, follow the procedures in {LinkCDCInstallOpenShift}[{NameCDCInstallOpenShift}]. The main steps are:
+
+. {LinkCDCUserGuide}#setting-up-postgresql-to-run-a-debezium-connector[Set up PostgreSQL to run a {prodname} connector].
+
+. Use link:https://access.redhat.com/products/red-hat-amq#streams[Red Hat AMQ Streams] to set up Apache Kafka and Kafka Connect on OpenShift. AMQ Streams offers operators and images that bring Kafka to OpenShift. 
+
 . Download the {prodname} link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions[PostgreSQL connector].
+
 . Extract the files into your Kafka Connect environment.
-. Add the plug-in's parent directory to your Kafka Connect `plugin.path`:
+. Add the plug-in's parent directory to your Kafka Connect `plugin.path`, for example: 
 +
 [source]
 ----
 plugin.path=/kafka/connect
 ----
++
+The above example assumes that you extracted the {prodname} PostgreSQL connector to the `/kafka/connect/{prodname}-connector-postgresql` path.
 
-NOTE: The above example assumes you have extracted the {prodname} PostgreSQL connector to the `/kafka/connect/{prodname}-connector-postgresql` path.
+. Restart your Kafka Connect process to ensure that the new JAR files are picked up.
 
-[start=4]
-. Restart your Kafka Connect process. This ensures the new JARs are picked up.
-
-.Additional resources
-
-For more information on the deployment process, and deploying connectors with AMQ Streams, refer to the {prodname} installation guides.
-
-* {LinkCDCInstallOpenShift}[{NameCDCInstallOpenShift}]
-* {LinkCDCInstallRHEL}[{NameCDCInstallRHEL}]
 endif::product[]
 
-ifdef::community[]
-If immutable containers are your thing, then check out https://hub.docker.com/r/debezium/[{prodname}'s Docker images] for Zookeeper, Kafka, PostgreSQL and Kafka Connect with the PostgreSQL connector already pre-installed and ready to go.  You can even link:/blog/2016/05/31/Debezium-on-Kubernetes/[run {prodname} on Kubernetes and OpenShift].
-endif::community[]
-
+// Type: concept
+// ModuleID:debezium-postgresql-connector-configuration-example
+// Title: {prodname} PostgreSQL connector configuration example
 [[postgresql-example-configuration]]
-=== Example Configuration
-
-To use the connector to produce change events for a particular PostgreSQL server or cluster:
-
-. Install the {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in]
-. Configure the {link-prefix}:{link-postgresql-connector}#postgresql-server-configuration[PostgreSQL server] to support logical replication
-. Create a configuration file for the PostgreSQL connector.
-
-When the connector starts, it will grab a consistent snapshot of the databases in your PostgreSQL server and start streaming changes, producing events for every inserted, updated, and deleted row. You can also choose to produce events for a subset of the schemas and tables.
-Optionally ignore, mask, or truncate columns that are sensitive, too large, or not needed.
+=== Connector configuration example
 
 ifdef::community[]
 
-Following is an example of the configuration for a PostgreSQL connector that monitors a PostgreSQL server at port 5432 on 192.168.99.100, which we logically name `fullfillment`.
-Typically, you configure the {prodname} PostgreSQL connector in a `.json` file using the configuration properties available for the connector.
+Following is an example of the configuration for a PostgreSQL connector that monitors a PostgreSQL server at port 5432 on 192.168.99.100, whose logical name is `fullfillment`. Typically, you configure the {prodname} PostgreSQL connector in a `.json` file using the configuration properties available for the connector.
+
+You can choose to produce events for a subset of the schemas and tables. Optionally, ignore, mask, or truncate columns that are sensitive, too large, or not needed.
 
 [source,json]
 ----
@@ -1665,8 +1778,9 @@ endif::community[]
 
 ifdef::product[]
 
-Following is an example of the configuration for a PostgreSQL connector that monitors a PostgreSQL server at port 5432 on 192.168.99.100, which we logically name `fullfillment`.
-Typically, you configure the {prodname} PostgreSQL connector in a `.yaml` file using the configuration properties available for the connector.
+Following is an example of the configuration for a PostgreSQL connector that monitors a PostgreSQL server at port 5432 on 192.168.99.100, whose logical name is `fullfillment`. Typically, you configure the {prodname} PostgreSQL connector in a `.yaml` file using the configuration properties available for the connector.
+
+You can choose to produce events for a subset of the schemas and tables. Optionally, ignore, mask, or truncate columns that are sensitive, too large, or not needed.
 
 [source,yaml,options="nowrap"]
 ----
@@ -1706,32 +1820,165 @@ endif::product[]
 
 See the {link-prefix}:{link-postgresql-connector}#postgresql-connector-properties[complete list of connector properties] that can be specified in these configurations.
 
-This configuration can be sent via POST to a running Kafka Connect service, which will then record the configuration and start up the one connector task that will connect to the PostgreSQL database and record events to Kafka topics.
+You can send this configuration with a `POST` command to a running Kafka Connect service. The service records the configuration and starts the connector task that connects to the PostgreSQL database and streams change event records to Kafka topics.
 
+// Type: procedure
+// ModuleID: adding-debezium-postgresql-connector-configuration-to-kafka-connect
+// Title: Adding {prodname} PostgreSQL connector configuration to Kafka Connect
+[[adding-connector-configuration]]
+=== Adding connector configuration
+
+ifdef::community[]
+To start running a PostgreSQL connector, create a connnector configuration file and add it to your Kafka Connect cluster. 
+
+.Prerequisites
+
+* The {link-prefix}:{link-postgresql-connector}#postgresql-server-configuration[PostgreSQL server] is configured to support logical replication.
+
+* The {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] is installed.
+
+* The PostgreSQL connector is installed. 
+
+.Procedure
+
+. Create a configuration file for the PostgreSQL connector.
+
+. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster. 
+
+endif::community[]
+
+ifdef::product[]
+You can use a provided {prodname} container to deploy a {prodname} PostgreSQL connector. In this procedure, you build a custom Kafka Connect container image for {prodname}, configure the {prodname} connector as needed, and then add your connector configuration to your Kafka Connect environment. 
+
+.Prerequisites
+
+* You have Podman installed and sufficient rights to create and manage containers.
+* You installed the {prodname} PostgreSQL connector archive. 
+
+.Procedure
+
+. Extract the {prodname} PostgreSQL connector archive to create a directory structure for the connector plug-in, for example: 
++
+[subs=+macros]
+----
+pass:quotes[*tree ./my-plugins/*]
+./my-plugins/
+├── debezium-connector-postgres
+│   ├── ...
+----
+
+. Create and publish a custom image for running your {prodname} connector:
+
+.. Create a new `Dockerfile` by using `{DockerKafkaConnect}` as the base image. In the following example, you would replace _my-plugins_ with the name of your plug-ins directory:
++
+[subs=+macros]
+----
+FROM registry.redhat.io/amq7/amq-streams-kafka-25:1.5.0
+USER root:root
+pass:quotes[COPY _./my-plugins/_ /opt/kafka/plugins/]
+USER 1001
+----
++
+Before Kafka Connect starts running the connector, Kafka Connect loads any third-party plug-ins that are in the `/opt/kafka/plugins` directory.
+
+.. Build the docker container image. For example, if you saved the docker file that you created in the previous step as `debezium-container-for-postgresql`, then you would run the following command:
++
+`docker build -t debezium-container-for-postgresql:latest`
+
+.. Push your custom image to your container registry, for example:
++
+`docker push debezium-container-for-postgresql:latest`
+
+.. Point to the new container image. Do one of the following:
++
+* Edit the `KafkaConnect.spec.image` property of the `KafkaConnect` custom resource. If set, this property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator. For example:
++
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+spec:
+  #...
+  image: debezium-container-for-postgresql
+----
++
+* In the `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml` file, edit the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable to point to the new container image and reinstall the Cluster Operator. If you edit this file you will need to apply it to your OpenShift cluster.
+
+. Create a `KafkaConnector` custom resource that defines your {prodname} PostgreSQL connector instance. See {LinkCDCUserGuide}#debezium-postgresql-connector-configuration-example[the connector configuration example].
+
+. Apply the connector instance, for example: 
++
+`oc apply -f inventory-connector.yaml`
++
+This registers `inventory-connector` and the connector starts to run against the `inventory` database.
+
+. Verify that the connector was created and has started to track changes in the specified database. You can verify the connector instance by watching the Kafka Connect log output as, for example, `inventory-connector` starts.
+
+.. Display the Kafka Connect log output:
++
+[source,shell,options="nowrap"]
+----
+oc logs $(oc get pods -o name -l strimzi.io/name=my-connect-cluster-connect)
+----
+
+.. Review the log output to verify that the initial snapshot has been executed. You should see something like the following lines: 
++
+[source,shell,options="nowrap"]
+----
+... INFO Starting snapshot for ...
+... INFO Snapshot is using user 'debezium' ... 
+----
+
+endif::product[]
+
+.Results
+
+When the connector starts, it {LinkCDCUserGuide}#how-debezium-postgresql-connectors-perform-database-snapshots[performs a consistent snapshot] of the PostgreSQL server databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics. 
+
+// Type: assembly
+// ModuleID: monitoring-debezium-postgresql-connector-performance
+// Title: Monitoring {prodname} PostgreSQL connector performance
 [[postgresql-monitoring]]
 === Monitoring
 
 The {prodname} PostgreSQL connector has two metric types in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect have.
+
+
+* {link-prefix}:{link-postgresql-connector}#postgresql-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot. 
+* {link-prefix}:{link-postgresql-connector}#postgresql-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records. 
+
+, streaming metrics>>; for monitoring the connector when processing change events via logical decoding
 
 * <<postgresql-snapshot-metrics, snapshot metrics>>; for monitoring the connector when performing snapshots
 * <<postgresql-streaming-metrics, streaming metrics>>; for monitoring the connector when processing change events via logical decoding
 
 Please refer to the {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[monitoring documentation] for details of how to expose these metrics via JMX.
 
+// Type: reference
+// ModuleID: monitoring-debezium-during-snapshots-of-postgresql-databases
+// Title: Monitoring {prodname} during snapshots of PostgreSQL databases
 [[postgresql-snapshot-metrics]]
-==== Snapshot Metrics
+==== Snapshot metrics
 
 The *MBean* is `debezium.postgres:type=connector-metrics,context=snapshot,server=_<database.server.name>_`.
 
 include::{partialsdir}/modules/cdc-all-connectors/r_connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
+// Type: reference
+// ModuleID: monitoring-debezium-postgresql-connector-record-streaming
+// Title: Monitoring {prodname} PostgreSQL connector record streaming
 [[postgresql-streaming-metrics]]
-==== Streaming Metrics
+==== Streaming metrics
 
 The *MBean* is `debezium.postgres:type=connector-metrics,context=streaming,server=_<database.server.name>_`.
 
 include::{partialsdir}/modules/cdc-all-connectors/r_connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 
+// Type: concept
+// ModuleID: descriptions-of-debezium-postgresql-connector-configuration-properties
+// Title: Description of {prodname} PostgreSQL connector configuration properties
 [[postgresql-connector-properties]]
 === Connector Properties
 
@@ -1757,7 +2004,7 @@ The following configuration properties are _required_ unless a default value is 
 
 |[[postgresql-property-plugin-name]]<<postgresql-property-plugin-name, `plugin.name`>>
 |`decoderbufs`
-|The name of the Postgres {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed on the server.
+|The name of the PostgreSQL {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed on the server.
 ifdef::product[]
 The only supported value is `pgoutput`.
 endif::product[]
@@ -1770,7 +2017,7 @@ In such cases it is possible to switch to so-called *streaming* mode when every 
 
 |[[postgresql-property-slot-name]]<<postgresql-property-slot-name, `slot.name`>>
 |`debezium`
-|The name of the Postgres logical decoding slot created for streaming changes from a plug-in and database instance. Values must conform to link:https://www.postgresql.org/docs/current/static/warm-standby.html#STREAMING-REPLICATION-SLOTS-MANIPULATION[Postgres replication slot naming rules] which state: _"Each replication slot has a name, which can contain lower-case letters, numbers, and the underscore character."_
+|The name of the PostgreSQL logical decoding slot created for streaming changes from a plug-in and database instance. Values must conform to link:https://www.postgresql.org/docs/current/static/warm-standby.html#STREAMING-REPLICATION-SLOTS-MANIPULATION[PostgreSQL replication slot naming rules] which state: _"Each replication slot has a name, which can contain lower-case letters, numbers, and the underscore character."_
 
 |[[postgresql-property-slot-drop-on-stop]]<<postgresql-property-slot-drop-on-stop, `slot.drop.on.stop`>>
 |`false`
@@ -1931,7 +2178,7 @@ Fully-qualified tables could be defined as _schemaName_._tableName_.
 
 |[[postgresql-publication-autocreate-mode]]<<postgresql-publication-autocreate-mode, `publication.autocreate.mode`>>
 |_all_tables_
-|Applies only when streaming changes using https://www.postgresql.org/docs/current/sql-createpublication.html[pgoutput].
+|Applies only when streaming changes using https://www.postgresql.org/docs/current/sql-createpublication.html[`pgoutput`].
 Determine how creation of a https://www.postgresql.org/docs/current/logical-replication-publication.html[publication] should work, the default is all_tables.
 _disabled_ - The connector will not attempt to create a publication at all. The expectation is
 that the user has created the publication up-front. If the publication isn't found to exist upon
@@ -2109,66 +2356,81 @@ The connector also supports _pass-through_ configuration properties that are use
 
 Be sure to consult the {link-kafka-docs}.html[Kafka documentation] for all of the configuration properties for Kafka producers and consumers. (The PostgreSQL connector does use the {link-kafka-docs}.html#newconsumerconfigs[new consumer].)
 
+// Type: assembly
+// ModuleID: how-debezium-postgresql-connectors-handle-faults-and-problems
+// Title: How {prodname} PostgreSQL connectors handle faults and problems
 [[postgresql-when-things-go-wrong]]
-== PostgreSQL common issues
+== Problem handling behavior
 
-{prodname} is a distributed system that captures all changes in multiple upstream databases, and will never miss or lose an event. Of course, when the system is operating nominally or being administered carefully, then {prodname} provides _exactly once_ delivery of every change event. However, if a fault does happen then the system will still not lose any events, although while it is recovering from the fault it may repeat some change events. Thus, in these abnormal situations {prodname}, like Kafka, provides _at least once_ delivery of change events.
+{prodname} is a distributed system that captures all changes in multiple upstream databases; it never misses or loses an event. When the system is operating normally or being managed carefully then {prodname} provides _exactly once_ delivery of every change event record. If a fault does happen then the system does not lose any events. However, while it is recovering from the fault, it might repeat some change events. In these abnormal situations, {prodname}, like Kafka, provides _at least once_ delivery of change events.
 
 The rest of this section describes how {prodname} handles various kinds of faults and problems.
 
-=== Configuration and Startup Errors
+// Type: continue
+=== Configuration and startup errors
 
-The connector will fail upon startup, report an error/exception in the log, and stop running when the connector's configuration is invalid, when the connector cannot successfully connect to PostgreSQL using the specified connectivity parameters, or when the connector is restarting from a previously-recorded position in the PostgreSQL WAL (via the LSN value) and PostgreSQL no longer has that history available.
+The connector will fail when trying to start, report an error/exception in the log, and stop running in these situations:
 
-In these cases, the error will have more details about the problem and possibly a suggested work around. The connector can be restarted when the configuration has been corrected or the PostgreSQL problem has been addressed.
+* The connector's configuration is invalid. 
+* The connector cannot successfully connect to PostgreSQL by using the specified connection parameters.
+* The connector is restarting from a previously-recorded position in the PostgreSQL WAL (by using the LSN) and PostgreSQL no longer has that history available.
 
-=== PostgreSQL Becomes Unavailable
+In these cases, the error message has details about the problem and possibly a suggested workaround. After you correct the configuration or address the PostgreSQL problem, restart the connector.
 
-Once the connector is running, if the PostgreSQL server it has been connected to becomes unavailable for any reason, the connector will fail with an error and the connector will stop. Simply restart the connector when the server is available.
+// Type: continue
+=== PostgreSQL becomes unavailable
 
-The PostgreSQL connector stores externally the last processed offset (in the form of a PostgreSQL `log sequence number` value). Once a connector is restarted and connects to a server instance, it will ask the server to continue streaming from that particular offset. This offset will always remain available so long as the {prodname} replication slot remains intact.  Never drop a replication slot on the primary or you will lose data. See the next section for failure cases when a slot has been removed.
+When the connector is running, the PostgreSQL server that it is connected to could become unavailable for any number of reasons. If this happens, the connector fails with an error and stops. When the server is available again, restart the connector.
 
-=== Cluster Failures
+The PostgreSQL connector externally stores the last processed offset in the form of a PostgreSQL LSN. After a connector restarts and connects to a server instance, the connector communicates with the server to continue streaming from that particular offset. This offset is available as long as the {prodname} replication slot remains intact.  Never drop a replication slot on the primary server or you will lose data. See the next section for failure cases in which a slot has been removed.
 
-As of `12`, PostgreSQL allows logical replication slots _only on primary servers_, which means that a PostgreSQL connector can only be pointed to the active primary of a database cluster.
-Also replication slots themselves are not propagated to replicas.
-If the primary node goes down, only after a new primary has been promoted (with the {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed) and a replication slot has been created there, the connector can be restarted and pointed to the new server.
+// Type: continue
+=== Cluster failures
 
-There are some really important caveats to failovers, and you should pause {prodname} until you can verify that you have a replication slot intact which has not lost data.  After a failover, you will miss change events unless your administration of failovers includes a process to recreate the {prodname} replication slot before the application is allowed to write to the *new* primary. You also may need to verify in a failover situation that {prodname} was able to read all changes in the slot **before the old primary failed**.
+As of release 12, PostgreSQL allows logical replication slots _only on primary servers_. This means that you can point a {prodname} PostgreSQL connector to only the active primary server of a database cluster.
+Also, replication slots themselves are not propagated to replicas.
+If the primary server goes down, a new primary must be promoted (with the {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed) and a replication slot must be created there. Only then can you point the connector to the new server and restart the connector. 
 
-One reliable method of recovering and verifying any lost changes (yet administratively difficult) is to recover a backup of your failed primary to the point immediately before it failed, which would allow you to inspect the replication slot for any unconsumed changes. In any case, it is crucial that you recreate the replication slot on the new primary prior to allowing writes to it.
+There are important caveats when failovers occur and you should pause {prodname} until you can verify that you have an intact replication slot that has not lost data. After a failover: 
+
+* There must be a process that re-creates the {prodname} replication slot before allowing the application to write to the *new* primary. This is crucial. Without this process, your application can miss change events. 
+
+* You might need to verify that {prodname} was able to read all changes in the slot **before the old primary failed**.
+
+One reliable method of recovering and verifying whether any changes were lost is to recover a backup of the failed primary to the point immediately before it failed. While this can be administratively difficult, it allows you to inspect the replication slot for any unconsumed changes. 
 
 ifdef::community[]
+
 [NOTE]
 ====
-There are discussions in the PostgreSQL community around a feature called `failover slots` which would help mitigate this problem, but as of `12` they have not been implemented yet.  However, there is active development for Postgres 13 to support logical decoding on standbys, which is a major requirement to make failover possible.  You can find more about this on the
-link:++https://www.postgresql.org/message-id/CAJ3gD9fE=0w50sRagcs+jrktBXuJAWGZQdSTMa57CCY+Dh-xbg@mail.gmail.com++[community thread].
+There are discussions in the PostgreSQL community around a feature called `failover slots` that would help mitigate this problem, but as of PostgreSQL 12, they have not been implemented.  However, there is active development for PostgreSQL 13 to support logical decoding on standbys, which is a major requirement to make failover possible. You can find more about this in this link:https://www.postgresql.org/message-id/CAJ3gD9fE=0w50sRagcs+jrktBXuJAWGZQdSTMa57CCY+Dh-xbg@mail.gmail.com[community thread].
 
-You can find out more about the concept of failover slots here http://blog.2ndquadrant.com/failover-slots-postgresql[this blog post].
+More about the concept of failover slots is in link:http://blog.2ndquadrant.com/failover-slots-postgresql[this blog post].
 ====
 endif::community[]
 
-=== Kafka Connect Process Stops Gracefully
+// Type: continue
+=== Kafka Connect process stops gracefully
 
-If Kafka Connect is being run in distributed mode, and a Kafka Connect process is stopped gracefully, then prior to shutdown of that processes Kafka Connect will migrate all of the process' connector tasks to another Kafka Connect process in that group, and the new connector tasks will pick up exactly where the prior tasks left off. There will be a short delay in processing while the connector tasks are stopped gracefully and restarted on the new processes.
+Suppose that Kafka Connect is being run in distributed mode and a Kafka Connect process is stopped gracefully. Prior to shutting down that process, Kafka Connect migrates all of the process' connector tasks to another Kafka Connect process in that group. The new connector tasks start processing exactly where the prior tasks stopped. There is a short delay in processing while the connector tasks are stopped gracefully and restarted on the new processes.
 
-=== Kafka Connect Process Crashes
+// Type: continue
+=== Kafka Connect process crashes
 
-If the Kafka Connector process stops unexpectedly, then any connector tasks it was running will obviously terminate without recording their most recently-processed offsets. When Kafka Connect is being run in distributed mode, it will restart those connector tasks on other processes. However, the PostgreSQL connectors will resume from the last offset _recorded_ by the earlier processes, which means that the new replacement tasks may generate some of the same change events that were processed just prior to the crash. The number of duplicate events will depend on the offset flush period and the volume of data changes just before the crash.
+If the Kafka Connector process stops unexpectedly, then any connector tasks it was running terminate without recording their most recently processed offsets. When Kafka Connect is being run in distributed mode, Kafka Connect restarts those connector tasks on other processes. However, PostgreSQL connectors resume from the last offset that was _recorded_ by the earlier processes. This means that the new replacement tasks might generate some of the same change events that were processed just prior to the crash. The number of duplicate events depends on the offset flush period and the volume of data changes just before the crash.
 
-[NOTE]
-====
-Because there is a chance that some events may be duplicated during a recovery from failure, consumers should always anticipate some events may be duplicated. {prodname} changes are idempotent, so a sequence of events always results in the same state.
+Because there is a chance that some events might be duplicated during a recovery from failure, consumers should always anticipate some duplicate events. {prodname} changes are idempotent, so a sequence of events always results in the same state.
 
-{prodname} also includes with each change event message the source-specific information about the origin of the event, including the PostgreSQL server's time of the event, the id of the server transaction and the position in the write-ahead log where the transaction changes were written. Consumers can keep track of this information (especially the LSN position) to know whether they have already seen a particular event.
-====
+In each change event record, {prodname} connectors insert source-specific information about the origin of the event, including the PostgreSQL server's time of the event, the ID of the server transaction, and the position in the write-ahead log where the transaction changes were written. Consumers can keep track of this information, especially the LSN, to determine whether an event is a duplicate. 
 
-=== Kafka Becomes Unavailable
+// Type: continue
+=== Kafka becomes unavailable
 
-As the connector generates change events, the Kafka Connect framework records those events in Kafka using the Kafka producer API. Kafka Connect will also periodically record the latest offset that appears in those change events, at a frequency you've specified in the Kafka Connect worker configuration. If the Kafka brokers become unavailable, the Kafka Connect worker process running the connectors will simply repeatedly attempt to reconnect to the Kafka brokers. In other words, the connector tasks will simply pause until a connection can be re-established, at which point the connectors will resume exactly where they left off.
+As the connector generates change events, the Kafka Connect framework records those events in Kafka by using the Kafka producer API. Periodically, at a frequency that you specify in the Kafka Connect worker configuration, Kafka Connect records the latest offset that appears in those change events. If the Kafka brokers become unavailable, the Kafka Connect worker process that is running the connectors repeatedly tries to reconnect to the Kafka brokers. In other words, the connector tasks pause until a connection can be re-established, at which point the connectors resume exactly where they left off.
 
-=== Connector Is Stopped for a Duration
+// Type: continue
+=== Connector is stopped for a duration
 
-If the connector is gracefully stopped, the database can continue to be used and any new changes will be recorded in the PostgreSQL WAL. When the connector is restarted, it will resume streaming changes where it last left off, recording change events for all of the changes that were made while the connector was stopped.
+If the connector is gracefully stopped, the database can continue to be used. Any changes are recorded in the PostgreSQL WAL. When the connector restarts, it resumes streaming changes where it left off. That is, it generates change event records for all database changes that were made while the connector was stopped.
 
-A properly configured Kafka cluster is able to handle massive throughput. Kafka Connect is written with Kafka best practices, and given enough resources will also be able to handle very large numbers of database change events. Because of this, when a connector has been restarted after a while, it is very likely to catch up with the database, though how quickly will depend upon the capabilities and performance of Kafka and the volume of changes being made to the data in PostgreSQL.
+A properly configured Kafka cluster is able to handle massive throughput. Kafka Connect is written according to Kafka best practices, and given enough resources a Kafka Connect connector can also handle very large numbers of database change events. Because of this, after being stopped for a while, when a {prodname} connector restarts, it is very likely to catch up with the database changes that were made while it was stopped. How quickly this happens depends on the capabilities and performance of Kafka and the volume of changes being made to the data in PostgreSQL.

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -323,7 +323,7 @@ In addition to a {link-prefix}:{link-postgresql-connector}#postgresql-events[_da
         "server": "fulfillment"
     },
     "sourceOffset": {
-        "lsn": "24023128",J
+        "lsn": "24023128",
         "txId": "555",
         "ts_ms": "1482918357011"
     },
@@ -2026,7 +2026,7 @@ If you are using a `wal2json` plug-in and transactions are very large, the JSON 
 
 endif::community[]
 ifdef::product[]
-The only supported value is `pgoutput`.
+The only supported value is `pgoutput`. You must explicitly set `plugin.name` to `pgoutput`.
 endif::product[]
 
 |[[postgresql-property-slot-name]]<<postgresql-property-slot-name, `slot.name`>>

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -96,7 +96,6 @@ Details are in the following topics:
 
 * xref:how-debezium-postgresql-connectors-perform-database-snapshots[]
 * xref:how-debezium-postgresql-connectors-stream-change-event-records[]
-* xref:postgresql-10-logical-decoding-support-pgoutput[]
 * xref:default-names-of-kafka-topics-that-receive-debezium-change-event-records[]
 * xref:metadata-in-debezium-change-event-records[]
 * xref:debezium-connector-generated-events-that-represent-transaction-boundaries[]
@@ -442,7 +441,7 @@ Details are in the following topics:
 
 * xref:about-keys-in-debezium-change-events[]
 * xref:about-values-in-debezium-change-events[]
-* xref:how-replica-identity-controls-data-that can-be-in-debezium-change-events[]
+* xref:how-replica-identity-controls-data-that-can-be-in-debezium-change-events[]
 * xref:about-debezium-change-events-for-operations-that-create-content[]
 * xref:about-debezium-change-events-for-operations-that-update-content[]
 * xref:about-debezium-change-events-for-primary-key-updates[]
@@ -2119,7 +2118,7 @@ If the publication already exists, either for all tables or configured with a su
 
 `double` represents values by using `double` values, which might result in a loss of precision but which is easier to use. 
 
-`string` encodes values as formatted strings, which are easy to consume but semantic information about the real type is lost. See <<postgresql-decimal-values>>.
+`string` encodes values as formatted strings, which are easy to consume but semantic information about the real type is lost. See {link-prefix}:{link-postgresql-connector}#postgresql-decimal-types[Decimal types].
 
 |[[postgresql-property-hstore-handling-mode]]<<postgresql-property-hstore-handling-mode, `hstore.handling.mode`>>
 |`map`

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -16,7 +16,7 @@ endif::community[]
 
 {prodname}'s PostgreSQL connector captures row-level changes in the schemas of a PostgreSQL database. PostgreSQL versions 10, 11, and 12 are supported. 
 
-The first time it connects to a PostgreSQL server or cluster, the connector takes a consistent snapshot of all schemas. After that snapshot is complete, the connector continuously streams changes that were committed to a PostgreSQL database and generates corresponding data change events for insert, update and delete operations. For each table, the default behavior is that all generated events are streamed to a separate Kafka topic for that table. Applications and services consume data change events from that topic. 
+The first time it connects to a PostgreSQL server or cluster, the connector takes a consistent snapshot of all schemas. After that snapshot is complete, the connector continuously captures row-level changes that insert, update, and delete database content and that were committed to a PostgreSQL database. The connector generates data change event records and streams them to Kafka topics. For each table, the default behavior is that the connector streams all generated events to a separate Kafka topic for that table. Applications and services consume data change event records from that topic. 
 
 ifdef::product[]
 Information and procedures for using a {prodname} PostgreSQL connector is organized as follows: 
@@ -26,48 +26,44 @@ Information and procedures for using a {prodname} PostgreSQL connector is organi
 * xref:descriptions-of-debezium-postgresql-connector-data-change-events[]
 * xref:how-debezium-postgresql-connectors-map-data-types[]
 * xref:setting-up-postgresql-to-run-a-debezium-connector[]
-* xref:deploying-debezium-postgresql-connectors[]
+* xref:deploying-and-managing-debezium-postgresql-connectors[]
 * xref:how-debezium-postgresql-connectors-handle-faults-and-problems[]
 
 endif::product[]
 
-// Type: assembly
+// Type: concept
 // Title: Overview of {prodname} PostgreSQL connector 
 // ModuleID: overview-of-debezium-postgresql-connector
 [[postgresql-overview]]
 == Overview
 
-PostgreSQL's https://www.postgresql.org/docs/current/static/logicaldecoding-explanation.html[_logical decoding_] feature was first introduced in version 9.4 and is a mechanism which allows the extraction of the changes which were committed to the transaction log and the processing of these changes in a user-friendly manner via the help of an https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[_output plug-in_]. This output plug-in must be installed prior to running the PostgreSQL server and enabled together with a replication slot in order for clients to be able to consume the changes.
+PostgreSQL's link:https://www.postgresql.org/docs/current/static/logicaldecoding-explanation.html[_logical decoding_] feature was introduced in version 9.4. It is a mechanism that allows the extraction of the changes that were committed to the transaction log and the processing of these changes in a user-friendly manner with the help of an link:https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[_output plug-in_]. You must install this output plug-in and configure a replication slot that uses the output plug-in before running the PostgreSQL server. This enables clients to consume the changes. 
 
-PostgreSQL connector contains two different parts which work together in order to be able to read and process server changes:
+The PostgreSQL connector contains two main parts that work together to read and process server changes:
 
 ifdef::product[]
-* A logical decoding output plug-in, which has to be installed and configured in the PostgreSQL server.
-* Java code (the actual Kafka Connect connector) which reads the changes produced by the plug-in, using PostgreSQL's https://www.postgresql.org/docs/current/static/logicaldecoding-walsender.html[_streaming replication protocol_], via the PostgreSQL https://github.com/pgjdbc/pgjdbc[_JDBC driver_]
+* A logical decoding output plug-in, which must be installed and configured in the PostgreSQL server.
+* Java code (the actual Kafka Connect connector), which reads the changes produced by the plug-in by using PostgreSQL's link:https://www.postgresql.org/docs/current/static/logicaldecoding-walsender.html[_streaming replication protocol_] and the PostgreSQL link:https://github.com/pgjdbc/pgjdbc[_JDBC driver_].
 endif::product[]
 
 ifdef::community[]
-* A logical decoding output plug-in, which has to be installed and configured in the PostgreSQL server. The plug-in is one of these: 
-** https://github.com/debezium/postgres-decoderbufs[`decoderbufs`] (maintained by the {prodname} community, based on ProtoBuf)
-** https://github.com/eulerto/wal2json[`wal2json`] (maintained by the wal2json community, based on JSON)
-** `pgoutput`, which is the standard logical decoding plug-in in PostgreSQL 10+ (maintained by the PostgreSQL community, used by PostgreSQL itself for https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication]). This plug-in is always present so no additional libraries need to be installed. The {prodname} connector interprets the raw replication event stream directly into change events.
-* Java code (the actual Kafka Connect connector) that reads the changes produced by the chosen plug-in, using PostgreSQL's link:https://www.postgresql.org/docs/current/static/logicaldecoding-walsender.html[_streaming replication protocol_], by means of the PostgreSQL link:https://github.com/pgjdbc/pgjdbc[_JDBC driver_]
+* A logical decoding output plug-in, which must be installed and configured in the PostgreSQL server. The plug-in is one of these: 
+** link:https://github.com/debezium/postgres-decoderbufs[`decoderbufs`] - maintained by the {prodname} community, based on ProtoBuf.
+** link:https://github.com/eulerto/wal2json[`wal2json`] - maintained by the wal2json community, based on JSON.
+** `pgoutput`, which is the standard logical decoding plug-in in PostgreSQL 10+. It is maintained by the PostgreSQL community, and used by PostgreSQL itself for link:https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication]. This plug-in is always present so no additional libraries need to be installed. The {prodname} connector interprets the raw replication event stream directly into change events.
+* Java code (the actual Kafka Connect connector) that reads the changes produced by the chosen plug-in. It uses PostgreSQL's link:https://www.postgresql.org/docs/current/static/logicaldecoding-walsender.html[_streaming replication protocol_], by means of the PostgreSQL link:https://github.com/pgjdbc/pgjdbc[_JDBC driver_]
 endif::community[]
 
-The connector then produces a _change event_ for every row-level insert, update, and delete operation that was received, recording all the change events for each table in a separate Kafka topic. Your client applications read the Kafka topics that correspond to the database tables they're interested in following, and react to every row-level event it sees in those topics.
+The connector produces a _change event_ for every row-level insert, update, and delete operation that was captured and sends change event records for each table in a separate Kafka topic. Your client applications read the Kafka topics that correspond to the database tables of interest, and can react to every row-level event they receive from those topics.
 
-PostgreSQL normally purges WAL segments after some period of time. This means that the connector does not have the complete history of all changes that have been made to the database. Therefore, when the PostgreSQL connector first connects to a particular PostgreSQL database, it starts by performing a _consistent snapshot_ of each of the database schemas. After the connector completes the snapshot, it continues streaming changes from the exact point at which the snapshot was made. This way, we start with a consistent view of all of the data, yet continue reading without having lost any of the changes made while the snapshot was taking place.
+PostgreSQL normally purges write-ahead log (WAL) segments after some period of time. This means that the connector does not have the complete history of all changes that have been made to the database. Therefore, when the PostgreSQL connector first connects to a particular PostgreSQL database, it starts by performing a _consistent snapshot_ of each of the database schemas. After the connector completes the snapshot, it continues streaming changes from the exact point at which the snapshot was made. This way, the connector starts with a consistent view of all of the data, and does not omit any changes that were made while the snapshot was being taken.
 
-The connector is also tolerant of failures. As the connector reads changes and produces events, it records the position in the write-ahead log with each event. If the connector stops for any reason (including communication failures, network problems, or crashes), upon restart it simply continues reading the WAL where it last left off. This includes snapshots: if the snapshot was not completed when the connector is stopped, upon restart it will begin a new snapshot.
+The connector is tolerant of failures. As the connector reads changes and produces events, it records the position in the WAL for each event. If the connector stops for any reason (including communication failures, network problems, or crashes), upon restart the connector continues reading the WAL where it last left off. This includes snapshots. If the connector stops during a snapshot, the connector begins a new snapshot when it restarts. 
 
 ifdef::product[]
 [[postgresql-output-plugin]]
 .Logical decoding output plug-in
-The `pgoutput` logical decoder is the only supported logical decoder in the Tecnhology Preview release of {prodname}.
-
-`pgoutput`, the standard logical decoding plug-in in PostgreSQL 10+, is maintained by the PostgreSQL community, and is also used by PostgreSQL for https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication].
-The `pgoutput` plug-in is always present, meaning that no additional libraries must be installed,
-and the connector will interpret the raw replication event stream into change events directly.
+The `pgoutput` logical decoding plug-in, the only supported logical decoding plug-in in this {prodname} release, is the standard logical decoding plug-in in PostgreSQL 10+, it is maintained by the PostgreSQL community, and it is also used by PostgreSQL for link:https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication]. The `pgoutput` plug-in is always present, meaning that no additional libraries must be installed. The connector directly interprets the raw replication event stream into change events records.
 endif::product[]
 
 [[postgresql-limitations]]
@@ -76,13 +72,15 @@ endif::product[]
 The connector relies on and reflects the PostgreSQL logical decoding feature, which has the following limitations:
 
 * Logical decoding does not support DDL changes. This means that the connector is unable to report DDL change events back to consumers.
-* Logical decoding replication slots are supported on only `primary` servers. When there is a cluster of PostgreSQL servers, the connector can run on only the active `primary` server. It cannot run on `hot` or `warm` standby replicas. If the `primary` server fails or is demoted, the connector stops. After the `primary` server has recovered, you can restart the connector. If a different PostgreSQL server has been promoted to `primary`, adjust the connector configuration before the connector is restarted. Make sure you read more about how the connector behaves {link-prefix}:{link-postgresql-connector}#postgresql-when-things-go-wrong[when things go wrong].
+* Logical decoding replication slots are supported on only `primary` servers. When there is a cluster of PostgreSQL servers, the connector can run on only the active `primary` server. It cannot run on `hot` or `warm` standby replicas. If the `primary` server fails or is demoted, the connector stops. After the `primary` server has recovered, you can restart the connector. If a different PostgreSQL server has been promoted to `primary`, adjust the connector configuration before restarting the connector. 
+
+{link-prefix}:{link-postgresql-connector}#postgresql-when-things-go-wrong[ Behavior when things go wrong] describes what the connector does when there is a problem. 
 ====
 
 [IMPORTANT]
 ====
-{prodname} currently supports only databases with UTF-8 character encoding.
-With a single byte character encoding it is not possible to correctly process strings that contain extended ASCII code characters.
+{prodname} currently supports databases with UTF-8 character encoding only.
+With a single byte character encoding, it is not possible to correctly process strings that contain extended ASCII code characters.
 ====
 
 // Type: assembly
@@ -111,40 +109,61 @@ endif::product[]
 [[postgresql-snapshots]]
 === Snapshots
 
-Most PostgreSQL servers are configured to not retain the complete history of the database in the WAL segments, so the PostgreSQL connector would be unable to see the entire history of the database by simply reading the WAL. So, by default the connector will upon first startup perform an initial _consistent snapshot_ of the database. Each snapshot consists of the following steps (when using the builtin snapshot modes, *custom* snapshot modes may override this):
+Most PostgreSQL servers are configured to not retain the complete history of the database in the WAL segments. This means that the PostgreSQL connector would be unable to see the entire history of the database by reading only the WAL. Consequently, the first time that the connector starts, it performs an initial _consistent snapshot_ of the database. The default behavior for performing a snapshot consists of the following steps. You can change this behavior by setting the {link-prefix}:{link-postgresql-connector}#postgresql-property-snapshot-mode[`snapshot.mode` connector configuration property] to a value other than `initial`. 
 
-1. Start a transaction with a https://www.postgresql.org/docs/current/static/sql-set-transaction.html[SERIALIZABLE, READ ONLY, DEFERRABLE] isolation level to ensure that all subsequent reads within this transaction are done against a single consistent version of the data. Any changes to the data due to subsequent `INSERT`, `UPDATE`, and `DELETE` operations by other clients will not be visible to this transaction.
-2. Obtain a `ACCESS SHARE MODE` lock on each of the monitored tables to ensure that no structural changes can occur to any of the tables while the snapshot is taking place. Note that these locks do not prevent table `INSERTS`, `UPDATES` and `DELETES` from taking place during the operation.  _This step is omitted when using the exported snapshot mode to allow for a lock-free snapshots_.
-3. Read the current position in the server's transaction log.
-4. Scan all of the database tables and schemas, and generate a `READ` event for each row and write that event to the appropriate table-specific Kafka topic.
-5. Commit the transaction.
-6. Record the successful completion of the snapshot in the connector offsets.
+. Start a transaction with a link:https://www.postgresql.org/docs/current/static/sql-set-transaction.html[SERIALIZABLE, READ ONLY, DEFERRABLE] isolation level to ensure that subsequent reads in this transaction are against a single consistent version of the data. Any changes to the data due to subsequent `INSERT`, `UPDATE`, and `DELETE` operations by other clients are not visible to this transaction.
+. Obtain an `ACCESS SHARE MODE` lock on each of the tables being tracked to ensure that no structural changes can occur to any of the tables while the snapshot is taking place. These locks do not prevent table `INSERT`, `UPDATE` and `DELETE` operations from taking place during the snapshot. 
++
+_This step is omitted when `snapshot.mode` is set to `exported`, which allows the connector to perform a lock-free snapshot_.
+. Read the current position in the server's transaction log.
+. Scan the database tables and schemas, generate a `READ` event for each row and write that event to the appropriate table-specific Kafka topic.
+. Commit the transaction.
+. Record the successful completion of the snapshot in the connector offsets.
 
-If the connector fails, is rebalanced, or stops after Step 1 begins but before Step 6 completes, upon restart the connector will begin a new snapshot. Once the connector does complete its initial snapshot, the PostgreSQL connector then continues streaming from the position read during step 3, ensuring that it does not miss any updates. If the connector stops again for any reason, upon restart it will simply continue streaming changes from where it previously left off.
-
-A second snapshot mode allows the connector to perform snapshots *always*. This behavior tells the connector to _always_ perform a snapshot when it starts up, and after the snapshot completes to continue streaming changes from step 3 in the above sequence. This mode can be used in cases when it is known that some WAL segments have been deleted and are no longer available, or in case of a cluster failure after a new primary has been promoted so that the connector does not miss any potential changes that could have taken place after the new primary had been promoted but before the connector was restarted on the new primary.
-
-The third snapshot mode instructs the connector to *never* performs snapshots. When a new connector is configured this way, if will either continue streaming changes from a previous stored offset or it will start from the point in time when the PostgreSQL logical replication slot was first created on the server. Note that this mode is useful only when you know all data of interest is still reflected in the WAL.
-
-The fourth snapshot mode, *initial only*, will perform a database snapshot and then stop before streaming any other changes. If the connector had started but did not complete a snapshot before stopping, the connector will restart the snapshot process and stop once the snapshot completes.
-
-The fifth snapshot mode, *exported*, will perform a database snapshot based on the point in time when the replication slot was created.  This mode is an excellent way to perform a snapshot in a lock-free way.
+If the connector fails, is rebalanced, or stops after Step 1 begins but before Step 6 completes, upon restart the connector begins a new snapshot. After the connector completes its initial snapshot, the PostgreSQL connector continues streaming from the position that it read in step 3. This ensures that the connector does not miss any updates. If the connector stops again for any reason, upon restart, the connector continues streaming changes from where it previously left off.
 
 [WARNING]
 ====
-It is strongly recommended to use *exported* mode. The *initial (only)* and *always* modes can lose few events while switching from snapshot to streaming mode when a database is under heavy load.
-This is a known issue and the affected modes will be reworked to use *exported* mode under the hood (https://issues.redhat.com/browse/DBZ-2337[DBZ-2337]).
+It is strongly recommended that you configure a PostgreSQL connector to set `snapshot.mode` to `exported`. The `initial`, `initial only` and `always` modes can lose a few events while a connector switches from performing the snapshot to streaming change event records when a database is under heavy load.
+This is a known issue and the affected snapshot modes will be reworked to use `exported` mode internally (link:https://issues.redhat.com/browse/DBZ-2337[DBZ-2337]).
 ====
 
+[id="snapshot-mode-settings"]
+.Settings for `snapshot.mode` connector configuration property
+[cols="20%a,80%a",options="header"]
+|===
+|Setting
+|Description
+
+|`always`
+|The connector always performs a snapshot when it starts. After the snapshot completes, the connector continues streaming changes from step 3 in the above sequence. This mode is useful in these situations: + 
+ 
+* It is known that some WAL segments have been deleted and are no longer available. +
+* After a cluster failure, a new primary has been promoted. The `always` snapshot mode ensures that the connector does not miss any changes that were made after the new primary had been promoted but before the connector was restarted on the new primary.
+
+|`never`
+|The connector never performs snapshots. When a connector is configured this way, its behavior when it starts is as follows. If there is a previously stored LSN in the Kafka offsets topic, the connector continues streaming changes from that position. If no LSN has been stored, the connector starts streaming changes from the point in time when the PostgreSQL logical replication slot was created on the server. The `never` snapshot mode is useful only when you know all data of interest is still reflected in the WAL.
+
+|`initial only`
+|The connector performs a database snapshot and stops before streaming any change event records. If the connector had started but did not complete a snapshot before stopping, the connector restarts the snapshot process and stops when the snapshot completes.
+
+|`exported`
+|The connector performs a database snapshot based on the point in time when the replication slot was created. This mode is an excellent way to perform a snapshot in a lock-free way.
+
 ifdef::community[]
-The final snapshot mode, *custom*, allows the user to inject their own implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface via the `snapshot.custom.class` configuration property, with the class on the classpath of your Kafka Connect cluster (or included in the JAR if using the `EmbeddedEngine`). For more details, see the {link-prefix}:{link-postgresql-connector}#postgresql-custom-snapshot[Custom Snapshot] section.
+|`custom`
+|The `custom` snapshot mode lets you inject your own implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. Set the `snapshot.custom.class` configuration property to the class on the classpath of your Kafka Connect cluster or included in the JAR if using the `EmbeddedEngine`. For more details, see {link-prefix}:{link-postgresql-connector}#postgresql-custom-snapshot[custom snapshotter SPI].
+endif::community[]
 
+|===
+
+ifdef::community[]
 [[postgresql-custom-snapshot]]
-=== Custom Snapshotter SPI
+=== Custom snapshotter SPI
 
-For more advanced usages, you can provide an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. This interfaces allows control of most of the aspects of how snapshots operate, such as whether to take a snapshot or not and the way the options used to open the snapshot transaction or take locks.
+For more advanced uses, you can provide an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. This interaces allows control of most of the aspects of how the connector performs snapshots. This includes whether or not to take a snapshot, the options for opening the snapshot transaction, and whether to take locks. 
 
-The full API of the interface can be seen here:
+Following is the full API for the interface. All built-in snapshot modes implement this interface.
 
 [source,java,indent=0,subs="+attributes"]
 ----
@@ -180,7 +199,7 @@ public interface Snapshotter {
 
     /**
      * @return true if when creating a slot, a snapshot should be exported, which
-     * can be used as an alternative to taking a lock
+     * can be used as an alternative to takFIRST BUILD OF SPLIT FILE: ing a lock
      */
     default boolean exportSnapshot() {
         return false;
@@ -226,7 +245,6 @@ public interface Snapshotter {
 }
 ----
 
-All built-in snapshot modes are implemented in terms of this interface as well.
 endif::community[]
 
 // Type: concept
@@ -235,29 +253,26 @@ endif::community[]
 [[postgresql-streaming-changes]]
 === Streaming changes
 
-The PostgreSQL connector typically spends the vast majority of its time streaming changes from the PostgreSQL server to which it is connected. This mechanism relies on https://www.postgresql.org/docs/current/static/protocol-replication.html[_PostgreSQL's replication protocol_] where the client can receive changes from the server as they are committed in the server's transaction log at certain positions (also known as Log Sequence Numbers or LSNs).
+The PostgreSQL connector typically spends the vast majority of its time streaming changes from the PostgreSQL server to which it is connected. This mechanism relies on link:https://www.postgresql.org/docs/current/static/protocol-replication.html[_PostgreSQL's replication protocol_]. This protocol enables clients to receive changes from the server as they are committed in the server's transaction log at certain positions, which are referred to as Log Sequence Numbers (LSNs).
 
-Whenever the server commits a transaction, a separate server process invokes a callback function from the {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in]. This function processes the changes from the transaction, converts them to a specific format (Protobuf or JSON in the case of {prodname} plug-in) and writes them on an output stream which can then be consumed by clients.
+Whenever the server commits a transaction, a separate server process invokes a callback function from the {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in]. This function processes the changes from the transaction, converts them to a specific format (Protobuf or JSON in the case of {prodname} plug-in) and writes them on an output stream, which can then be consumed by clients.
 
-The PostgreSQL connector acts as a PostgreSQL client, and when it receives these changes it transforms the events into {prodname} _create_, _update_, or _delete_ events that include the LSN position of the event. The PostgreSQL connector forwards these change events to the Kafka Connect framework (running in the same process), which then asynchronously writes them in the same order to the appropriate Kafka topic. Kafka Connect uses the term _offset_ for the source-specific position information that {prodname} includes with each event, and Kafka Connect periodically records the most recent offset in another Kafka topic.
+The {prodname} PostgreSQL connector acts as a PostgreSQL client. When the connector receives changes it transforms the events into {prodname} _create_, _update_, or _delete_ events that include the LSN of the event. The PostgreSQL connector forwards these change events in records to the Kafka Connect framework, which is running in the same process. The Kafka Connect process asynchronously writes the change event records in the same order in which they were generated to the appropriate Kafka topic. 
 
-When Kafka Connect gracefully shuts down, it stops the connectors, flushes all events to Kafka, and records the last offset received from each connector. Upon restart, Kafka Connect reads the last recorded offset for each connector, and starts the connector from that point. The PostgreSQL connector uses the LSN recorded in each change event as the offset, so that upon restart the connector requests the PostgreSQL server send it the events starting just after that position.
+Periodically, Kafka Connect records the most recent _offset_ in another Kafka topic. The offset indicates source-specific position information that {prodname} includes with each event. For the PostgreSQL connector, the LSN recorded in each change event is the offset.
+
+When Kafka Connect gracefully shuts down, it stops the connectors, flushes all event records to Kafka, and records the last offset received from each connector. When Kafka Connect restarts, it reads the last recorded offset for each connector, and starts each connector at its last recorded offset. When the connector restarts, it sends a request to the PostgreSQL server to send the events starting just after that position. 
 
 [NOTE]
 ====
-The PostgreSQL connector retrieves the schema information as part of the events sent by the logical decoder plug-in.
-The only exception is the information about which columns compose the primary key, as this information is obtained from the JDBC metadata (side channel).
-If the primary key definition of a table changes (by adding, removing or renaming PK columns),
-then there exists a slight risk of an unfortunate timing when the primary key information from JDBC
-will not be synchronized with the change data in the logical decoding event and a small amount of messages will be created with an inconsistent key structure.
-If this happens then a restart of the connector and a reprocessing of the messages will fix the issue.
-To prevent the issue completely it is recommended to synchronize updates to the primary key structure with {prodname} roughly using following sequence of operations:
+The PostgreSQL connector retrieves schema information as part of the events sent by the logical decoding plug-in. However, the connector does not retrieve information about which columns compose the primary key. The connector obtains this information from the JDBC metadata (side channel). If the primary key definition of a table changes (by adding, removing or renaming primary key columns), there is a tiny period of time when the primary key information from JDBC is not synchronized with the change event that the logical decoding plug-in generates. During this tiny period, a message could be created with an inconsistent key structure. To prevent this inconsistency, update primary key structures as follows: 
 
-* Put the database or an application into a read-only mode
-* Let {prodname} process all remaining events
-* Stop {prodname}
-* Update the primary key definition
-* Put the database or the application into read/write state and start {prodname} again
+. Put the database or an application into a read-only mode.
+. Let {prodname} process all remaining events.
+. Stop {prodname}.
+. Update the primary key definition in the relevant table.
+. Put the database or the application into read/write mode.
+. Restart {prodname}.
 ====
 
 // Type: concept
@@ -265,10 +280,10 @@ To prevent the issue completely it is recommended to synchronize updates to the 
 [[postgresql-pgoutput]]
 === PostgreSQL 10+ logical decoding support (`pgoutput`)
 
-As of PostgreSQL 10+, a new logical replication stream mode was introduced, called `pgoutput_`.  This logical replication stream mode is natively supported by PostgreSQL,
-which means that this connector can consume that replication stream
-without the need for additional plug-ins being installed.
-This is particularly valuable for environments where installation of plug-ins is not supported or allowed.
+As of PostgreSQL 10+, a new logical replication stream mode was introduced, called `pgoutput`. This logical replication stream mode is natively supported by PostgreSQL,
+which means that a {prodname} PostgreSQL connector can consume that replication stream
+without the need for additional plug-ins.
+This is particularly valuable for environments where installation of plug-ins is not supported or not allowed.
 
 See {link-prefix}:{link-postgresql-connector}#setting-up-postgresql[Setting up PostgreSQL] for more details.
 
@@ -278,16 +293,20 @@ See {link-prefix}:{link-postgresql-connector}#setting-up-postgresql[Setting up P
 [[postgresql-topic-names]]
 === Topics names
 
-The PostgreSQL connector writes events for all insert, update, and delete operations on a single table to a single Kafka topic. By default, the Kafka topic name is _serverName_._schemaName_._tableName_ where _serverName_ is the logical name of the connector as specified with the `database.server.name` configuration property, _schemaName_ is the name of the database schema where the operation occurred, and _tableName_ is the name of the database table on which the operation occurred.
+The PostgreSQL connector writes events for all insert, update, and delete operations on a single table to a single Kafka topic. By default, the Kafka topic name is _serverName_._schemaName_._tableName_ where: 
 
-For example, consider a PostgreSQL installation with a `postgres` database and an `inventory` schema that contains four tables: `products`, `products_on_hand`, `customers`, and `orders`. If the connector monitoring this database were given a logical server name of `fulfillment`, then the connector would produce events on these four Kafka topics:
+* _serverName_ is the logical name of the connector as specified with the `database.server.name` connector configuration property.
+* _schemaName_ is the name of the database schema where the operation occurred.
+* _tableName_ is the name of the database table in which the operation occurred.
+
+For example, suppose that `fulfillment` is the logical server name in the configuration for a connector that is capturing changes in a PostgreSQL installation that has a `postgres` database and an `inventory` schema that contains four tables: `products`, `products_on_hand`, `customers`, and `orders`. The connector would stream records to these four Kafka topics:
 
 * `fulfillment.inventory.products`
 * `fulfillment.inventory.products_on_hand`
 * `fulfillment.inventory.customers`
 * `fulfillment.inventory.orders`
 
-If on the other hand the tables were not part of a specific schema but rather created in the default `public` PostgreSQL schema, then the name of the Kafka topics would be:
+Now suppose that the tables are not part of a specific schema but were created in the default `public` PostgreSQL schema. The names of the Kafka topics would be:
 
 * `fulfillment.public.products`
 * `fulfillment.public.products_on_hand`
@@ -300,7 +319,7 @@ If on the other hand the tables were not part of a specific schema but rather cr
 [[postgresql-meta-information]]
 === Meta information
 
-Each `record` produced by the PostgreSQL connector has, in addition to the {link-prefix}:{link-postgresql-connector}#postgresql-events[_database event_], some metadata about where the event occurred on the server, the name of the source partition and the name of the Kafka topic and partition where the event should be placed:
+In addition to a {link-prefix}:{link-postgresql-connector}#postgresql-events[_database change event_], each record produced by a PostgreSQL connector contains some metadata. Metadata includes where the event occurred on the server, the name of the source partition and the name of the Kafka topic and partition where the event should go, for example: 
 
 [source,json,indent=0]
 ----
@@ -308,38 +327,36 @@ Each `record` produced by the PostgreSQL connector has, in addition to the {link
         "server": "fulfillment"
     },
     "sourceOffset": {
-        "lsn": "24023128",
+        "lsn": "24023128",J
         "txId": "555",
         "ts_ms": "1482918357011"
     },
     "kafkaPartition": null
 ----
 
-The PostgreSQL connector uses only 1 Kafka Connect _partition_ and it places the generated events into 1 Kafka partition. Therefore, the name of the `sourcePartition` will always default to the name of the `database.server.name` configuration property, while the `kafkaPartition` has the value `null` which means that the connector does not use a specific Kafka partition.
+* `sourcePartition` always defaults to the setting of the `database.server.name` connector configuration property. 
 
-The `sourceOffset` portion of the message contains information about the location of the server where the event occurred:
+* `sourceOffset` contains information about the location of the server where the event occurred:
 
-* `lsn` represents the PostgreSQL https://www.postgresql.org/docs/current/static/datatype-pg-lsn.html[_Log Sequence Number_] or `offset` in the transaction log
-* `txId` represents the identifier of the server transaction which caused the event
-* `ts_ms` represents the number of microseconds since Unix Epoch as the server time at which the transaction was committed
+** `lsn` represents the PostgreSQL https://www.postgresql.org/docs/current/static/datatype-pg-lsn.html[Log Sequence Number] or `offset` in the transaction log.
+** `txId` represents the identifier of the server transaction that caused the event.
+** `ts_ms` represents the server time at which the transaction was committed in the form of the number of microseconds since the epoch. 
+* `kafkaPartition` with a setting of `null` means that the connector does not use a specific Kafka partition. The PostgreSQL connector uses only one Kafka Connect partition and it places the generated events into one Kafka partition. 
 
 // Type: concept
 // ModuleID: debezium-connector-generated-events-that-represent-transaction-boundaries
-// Title: {prodname} connector generated events that represent transaction boundaries
+// Title: {prodname} connector-generated events that represent transaction boundaries
 [[postgresql-transaction-metadata]]
 === Transaction metadata
 
-{prodname} can generate events that represent transaction boundaries and that enrich change data event messages.
-
-{prodname} generates events for every transaction `BEGIN` and `END`.
-Every event contains
+{prodname} can generate events that represent transaction boundaries and that enrich change data event messages. For every transaction `BEGIN` and `END`, {prodname} generates tan event that contains: 
 
 * `status` - `BEGIN` or `END`
 * `id` - string representation of unique transaction identifier
-* `event_count` (for `END` events) - total number of events emmitted by the transaction
-* `data_collections` (for `END` events) - an array of pairs of `data_collection` and `event_count` that provides number of events emitted by changes originating from given data collection
+* `event_count` (for `END` events) - total number of events emitted by the transaction
+* `data_collections` (for `END` events) - an array of pairs of `data_collection` and `event_count` that provides the number of events emitted by changes originating from given data collection
 
-Following is an example message:
+.Examples
 
 [source,json,indent=0,subs="attributes"]
 ----
@@ -367,7 +384,7 @@ Following is an example message:
 }
 ----
 
-Transaction events are written to the topic named `<database.server.name>.transaction`.
+Transaction events are written to the topic named `_database.server.name_.transaction`.
 
 .Change data event enrichment
 
@@ -375,7 +392,7 @@ When transaction metadata is enabled the data message `Envelope` is enriched wit
 This field provides information about every event in the form of a composite of fields:
 
 * `id` - string representation of unique transaction identifier
-* `total_order` - the absolute position of the event among all events generated by the transaction
+* `total_order` - absolute position of the event among all events generated by the transaction
 * `data_collection_order` - the per-data collection position of the event among all events that were emitted by the transaction
 
 Following is an example of a message:
@@ -407,7 +424,7 @@ Following is an example of a message:
 [[postgresql-events]]
 == Data change events
 
-All data change events produced by the PostgreSQL connector have a key and a value. The structure of the key and value depend on the table from which the change events originated. The default behavior is that the connector stream change event records to {link-prefix}:{link-postgresql-connector}#postgresql-topic-names[topic names] that are the same as the event's originating table.
+Each data change event produced by the PostgreSQL connector has a key and a value. The structure of the key and value depends on the table from which the change event originates. The default behavior is that the connector streams change event records to {link-prefix}:{link-postgresql-connector}#postgresql-topic-names[topic names] that are the same as the event's originating table.
 
 [NOTE]
 ====
@@ -418,10 +435,10 @@ Starting with Kafka 0.10, Kafka can optionally record the event key and value wi
 ====
 The PostgreSQL connector ensures that all Kafka Connect _schema names_ are http://avro.apache.org/docs/current/spec.html#names[valid Avro schema names]. This means that the logical server name must start with a Latin letter or an underscore, that is, a-z, A-Z, or \_. Each remaining character in the logical server name and each character in the schema and table names must be a Latin letter, a digit, or an underscore, that is, a-z, A-Z, 0-9, or \_. If there is an invalid character it is replaced with an underscore character.
 
-This can lead to unexpected conflicts if the logical server name, a schema name, or a table name contain invalid characters, and the only characters that  distinguish names from one another are invalid and thus replaced with underscores.
+This can lead to unexpected conflicts if the logical server name, a schema name, or a table name contains invalid characters, and the only characters that  distinguish names from one another are invalid and thus replaced with underscores.
 ====
 
-{prodname} and Kafka Connect are designed around _continuous streams of event messages_, and the structure of these events may change over time. This could be difficult for consumers to handle, so to make it easier, Kafka Connect makes each event self-contained. Each message key and each message value has two parts: a _schema_ and a _payload_. The schema describes the structure of the payload, while the payload contains the actual data.
+{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To make it easier, Kafka Connect makes each event self-contained. Each message key and each message value has two parts: a _schema_ and a _payload_. The schema describes the structure of the payload, while the payload contains the actual data.
 
 ifdef::product[]
 Details are in the following topics:
@@ -429,10 +446,10 @@ Details are in the following topics:
 * xref:about-keys-in-debezium-change-events[]
 * xref:about-values-in-debezium-change-events[]
 * xref:how-replica-identity-controls-data-that can-be-in-debezium-change-events[]
-* xref:about-debezium-change-events-for-create-operations[]
-* xref:about-debezium-change-events-for-update-operations[]
-* xref:about-debezium-change-events-for-primary-key-update[]
-* xref:about-debezium-change-events-for-delete-operations[]
+* xref:about-debezium-change-events-for-operations-that-create-content[]
+* xref:about-debezium-change-events-for-operations-that-update-content[]
+* xref:about-debezium-change-events-for-primary-key-updates[]
+* xref:about-debezium-change-events-for-operations-that-delete-content[]
 
 endif::product[]
 
@@ -440,9 +457,9 @@ endif::product[]
 // ModuleID: about-keys-in-debezium-change-events
 // Title: About keys in {prodname} change events
 [[postgresql-change-events-key]]
-=== Change event key
+=== Change event keys
 
-For a given table, the change event's key will have a structure that contains a field for each column in the primary key (or unique key constraint with `REPLICA IDENTITY` set to `FULL` or `USING INDEX` on the table) of the table at the time the event was created.
+For a given table, the change event's key has a structure that contains a field for each column in the primary key of the table at the time the event was created. Alternatively, if the table has `REPLICA IDENTITY` set to `FULL` or `USING INDEX` there is a field for each unique key constraint. 
 
 Consider a `customers` table defined in the `public` database schema:
 
@@ -457,7 +474,7 @@ CREATE TABLE customers (
 );
 ----
 
-If the `database.server.name` configuration property has the value `PostgreSQL_server`, every change event for the `customers` table while it has this definition will feature the same key structure, which in JSON looks like this:
+If the `database.server.name` configuration property has the value `PostgreSQL_server`, every change event for the `customers` table while it has this definition has the same key structure, which in JSON looks like this:
 
 [source,json,indent=0]
 ----
@@ -483,64 +500,77 @@ If the `database.server.name` configuration property has the value `PostgreSQL_s
   }
 ----
 
-The `schema` portion of the key contains a Kafka Connect schema describing what is in the key portion. In this case, it means that the `payload` value is not optional, is a structure defined by a schema named `PostgreSQL_server.public.customers.Key`, and has one required field named `id` of type `int32`. If you look at the value of the key's `payload` field, you see that it is indeed a structure (which in JSON is just an object) with a single `id` field, whose value is `1`.
+The `schema` portion of the key contains a Kafka Connect schema that describes what is in the key's `payload` portion. In this case, it means that the `payload` value is not optional, is a structure defined by a schema named `PostgreSQL_server.public.customers.Key`, and has one required field named `id` of type `INT32`. If you look at the value of the key's `payload` field, you see that it is indeed a structure, which in JSON is just an object, with a single `id` field, whose value is `1`.
 
-Therefore, we interpret this key as describing the row in the `public.customers` table (output from the connector named `PostgreSQL_server`) whose `id` primary key column had a value of `1`.
+This key describes output from the connector named `PostgreSQL_server`,  for the row in the `public.customers` table, whose primary key, the `id` column, had a value of `1`.
 
 [NOTE]
 ====
-Although the `column.blacklist` and `column.whitelist` configuration properties allow you to capture only a subset of table columns, all columns in a primary or unique key are always included in the event's key.
+Although the `column.blacklist` and `column.whitelist` connector configuration properties allow you to capture only a subset of table columns, all columns in a primary or unique key are always included in the event's key.
 ====
 
 [WARNING]
 ====
-If the table does not have a primary or unique key, then the change event's key will be null. This makes sense since the rows in a table without a primary or unique key constraint cannot be uniquely identified.
+If the table does not have a primary or unique key, then the change event's key is null. The rows in a table without a primary or unique key constraint cannot be uniquely identified.
 ====
 
 // Type: concept
 // ModuleID: about-values-in-debezium-change-events
 // Title: About values in {prodname} change events
 [[postgresql-change-events-value]]
-===== Change Event's Value
+=== Change event values
 
-The value of the change event message is a bit more complicated. Like the message key, it has a _schema_ section and _payload_ section. The payload section of every change event value produced by the PostgreSQL connector has an _envelope_ structure with the following fields:
+The value in a change event record is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains a schema that describes the `Envelope` structure of the `payload` section, including its nested fields. The `payload` section has the following nested fields:  
 
-* `op` is a mandatory field that contains a string value describing the type of operation. Values for the PostgreSQL connector are `c` for create (or insert), `u` for update, `d` for delete, and `r` for read (in the case of a snapshot).
-* `before` is an optional field that if present contains the state of the row _before_ the event occurred. The structure will  be described by the `PostgreSQL_server.public.customers.Value` Kafka Connect schema, which the `PostgreSQL_server` connector uses for all rows in the `public.customers` table.
+* `before` is an optional field. If present, it contains the state of the row _before_ the event occurred. The structure of the `before` field is described by a Kafka Connect `Value` schema. For example, for each row operation in the `public.customers` table, the connector uses the `PostgreSQL_server.public.customers.Value` schema to provide the content of the `before` field.
 
-[WARNING]
+[NOTE]
 ====
-Whether or not this field is available is highly dependent on the {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[_REPLICA IDENTITY_] setting for each table
+Whether or not this field is available is dependent on the {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting for each table.
 ====
 
-* `after` is an optional field that if present contains the state of the row _after_ the event occurred. The structure is described by the same `PostgreSQL_server.public.customers.Value` Kafka Connect schema used in `before`.
-* `source` is a mandatory field that contains a structure describing the source metadata for the event, which in the case of PostgreSQL contains several fields: the {prodname} version, the connector name, the name of the affected database, schema and table, whether the event is part of an ongoing snapshot or not and the same fields from the record's {link-prefix}:{link-postgresql-connector}#postgresql-meta-information[_meta information_] section
-* `ts_ms` is optional and if present contains the time (using the system clock in the JVM running the Kafka Connect task) at which the connector processed the event.
+* `after` is an optional field. If present, it contains the state of the row _after_ the operation occurred. The structure is described by the same Kafka Connect `Value` schema that is used for the `before` field.
 
-And of course, the _schema_ portion of the event message's value contains a schema that describes this envelope structure and the nested fields within it.
+* `source` is a mandatory field that contains a structure that describes the source metadata for the event. For PostgreSQL connectors, the metadata provides: 
+
+** {prodname} version
+** Connector name
+** Names of the database, schema, and table that contains the change
+** Whether this event is part of an ongoing snapshot
+** {link-prefix}:{link-postgresql-connector}#postgresql-meta-information[Partition and offset metadata]
+
+* `op` is a mandatory field that contains a string value that describes the type of operation. Allowed values for the PostgreSQL connector are: 
+** `c` for create or insert
+** `u` for update
+** `d` for delete
+** `r` for read in the case of a snapshot
+
+* `ts_ms` is an optional field. If present, it contains the time at which the connector processed the event. This value reflects the system clock in the JVM running the Kafka Connect task. 
 
 // Type: concept
-// ModuleID: how-replica-identity-controls-data-that can-be-in-debezium-change-events
+// ModuleID: how-replica-identity-controls-data-that-can-be-in-debezium-change-events
 // Title: How `REPLICA IDENTITY` controls data that can be in {prodname}change events
 [[postgresql-replica-identity]]
 === Replica identity
 
-link:https://www.postgresql.org/docs/current/static/sql-altertable.html#SQL-CREATETABLE-REPLICA-IDENTITY[REPLICA IDENTITY] is a PostgreSQL specific table-level setting that determines the amount of information that is available to `logical decoding` in case of `UPDATE` and `DELETE` events. More specifically, this controls what (if any) information is available regarding the previous values of the table columns involved, whenever one of the aforementioned events occur.
+link:https://www.postgresql.org/docs/current/static/sql-altertable.html#SQL-CREATETABLE-REPLICA-IDENTITY[REPLICA IDENTITY] is a PostgreSQL-specific table-level setting that determines the amount of information that is available to the logical decoding plug-in for `UPDATE` and `DELETE` events. More specifically, the setting of `REPLICA IDENTITY` controls what (if any) information is available for the previous values of the table columns involved, whenever an `UPDATE` or `DELETE` event occurs.
 
 There are 4 possible values for `REPLICA IDENTITY`:
 
-* DEFAULT - `UPDATE` and `DELETE` events will only contain the previous values for the primary key columns of a table if a primary key column is specified. In case of `UPDATE` only the primary columns with changed values are present. If no primary keys columns are specified only `CREATE` events are emitted, `UPDATE` and `DELETE` events are considered empty `CREATE` statements and filtered
-* NOTHING - `UPDATE` and `DELETE` events will not contain any information about the previous value on any of the table columns
-* FULL - `UPDATE` and `DELETE` events will contain the previous values of all the table's columns
-* INDEX `index name` - `UPDATE` and `DELETE` events will contain the previous values of the columns contained in the index definition named `index name`, in case of `UPDATE` only the indexed columns with changed values are present
+* `DEFAULT` - The default behavior is that `UPDATE` and `DELETE` events contain the previous values for the primary key columns of a table if that table has a primary key. For an `UPDATE` event, only the primary key columns with changed values are present.
++
+If a table does not have a primary key, the connector does not emit `UPDATE` or `DELETE` events for that table. For a table without a primary key, the connector emits only _create_ events. Typically, a table without a primary key is used for appending messages to the end of the table, which means that `UPDATE` and `DELETE` events are not useful. 
+* `NOTHING` - Emitted events for `UPDATE` and `DELETE` operations do not contain any information about the previous value of any table column.
+* `FULL` - Emitted events for `UPDATE` and `DELETE` operations contain the previous values of all columns in the table.
+* `INDEX` _index-name_ - Emitted events for `UPDATE` and `DELETE` operations contain the previous values of the columns contained in the specified index. `UPDATE` events also contain the indexed columns with the updated values.
 
 // Type: concept
-// ModuleID: about-debezium-change-events-for-create-operations
-// Title: About {prodname} change events for `CREATE` operations
+// ModuleID: about-debezium-change-events-for-operations-that-create-content
+// Title: About {prodname} change events for operations that create content
 [[postgresql-create-events]]
-=== `CREATE` events
+=== _create_ events
 
-Let's look at what a _create_ event value might look like for our `customers` table:
+The following example shows a _create_ event value for the `customers` table:
 
 [source,json,indent=0,subs="attributes"]
 ----
@@ -709,30 +739,34 @@ Let's look at what a _create_ event value might look like for our `customers` ta
 }
 ----
 
-If we look at the `schema` portion of this event's _value_, we can see the schema for the _envelope_, the schema for the `source` structure (which is specific to the PostgreSQL connector and reused across all events), and the table-specific schemas for the `before` and `after` fields.
+In the `schema` portion of this event's value, you can see schemas for: 
+ 
+* `customers.Envelope`
+* The `source` structure, which is specific to the PostgreSQL connector and reused across all events.
+* The `before` and `after` fields, whose schemas are specific to the table. 
++
+The names of the schemas for the `before` and `after` fields are of the form `_logicalName_._schemaName_._tableName_.Value`, and thus are entirely independent from all other schemas for all other tables. This means that when using the Avro converter, the resulting Avro schemas for _each table_ in each _logical source_ have their own evolution and history.
+
+In the `payload` portion of this event's value, you can see:  
+
+* The `before` field is null, which means that the event does not contain any previous row values. 
+* The `after` field contains values for the inserted row's `id`, `first_name`, `last_name`, and `email` columns.
+* The `source` field contains metadata.
+* The `op` field contains `c` to indicate that a row was created. 
 
 [NOTE]
 ====
-The names of the schemas for the `before` and `after` fields are of the form _logicalName_._schemaName_._tableName_.Value, and thus are entirely independent from all other schemas for all other tables.
-
-This means that when using the Avro Converter, the resulting Avro schemas for _each table_ in each _logical source_ have their own evolution and history.
-====
-
-If we look at the `payload` portion of this event's _value_, we can see the information in the event, namely that it is describing that the row was created (since `op=c`), and that the `after` field value contains the values of the new inserted row's' `id`, `first_name`, `last_name`, and `email` columns.
-
-[NOTE]
-====
-It may appear that the JSON representations of the events are much larger than the rows they describe. This is true, because the JSON representation must include the _schema_ and the _payload_ portions of the message.
-
-It is possible and even recommended to use the Avro Converter to dramatically decrease the size of the actual messages written to the Kafka topics.
+JSON representations of events are much larger than the rows they describe. This is because the JSON representation must include the `schema` and the `payload` portions of the change event record. 
+It is possible and even recommended that you use the Avro converter to dramatically decrease the size of the records written to the Kafka topics.
 ====
 
 // Type: concept
-// ModuleID: about-debezium-change-events-for-update-operations
-// Title: About {prodname} change events for `UPDATE` operations
+// ModuleID: about-debezium-change-events-for-operations-that-update-content
+// Title: About {prodname} change events for operations that update content
 [[postgresql-update-events]]
-=== `UPDATE` events
-The value of an _update_ change event on this table will actually have the exact same _schema_, and its payload will be structured the same but will hold different values. Here's an example:
+=== _update_ events
+
+The value of an _update_ event on the sample `customers` table has the same `schema` specification as the _create_ event example. An _update_ event`s payload has the same structure as a _create_ event for the same table. However, the _update_ event's payload contains different values, as shown in this example: 
 
 [source,json,indent=0,subs="attributes"]
 ----
@@ -767,45 +801,45 @@ The value of an _update_ change event on this table will actually have the exact
 }
 ----
 
-When we compare this to the value in the _insert_ event, we see a couple of differences in the `payload` section:
+As compared with the payload section in the _create_ event, you can see the following differences in the payload section of the _update_ event:  
 
-* The `op` field value is now `u`, signifying that this row changed because of an update
-* The `before` field now has the state of the row with the values before the database commit, but only for the primary key column `id`. This is because the  {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[_REPLICA IDENTITY_] which is by default `DEFAULT`.
+* The `op` field value is `u` to indicate that the row changed because of an `UPDATE`.
+* The `before` field contains the values that were in the row before the database commit. In this example, only the primary key column, `id`, is present because the table's {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting is, by default, `DEFAULT`.
++
+For an _update_ event to contain the previous values of all columns in the row, you would have to change the `customers` table by running `ALTER TABLE customers REPLICA IDENTITY FULL`.
 
-[NOTE]
-====
-Should we want to see the previous values of all the columns for the row, we would have to change the `customers` table first by running `ALTER TABLE customers REPLICA IDENTITY FULL`
-====
+* The `after` field has the updated state of the row. As you can see, the `first_name` value is now `Anne Marie`.
 
-* The `after` field now has the updated state of the row, and here was can see that the `first_name` value is now `Anne Marie`.
-* The `source` field structure has the same fields as before, but the values are different since this event is from a different position in the WAL.
+* The `source` field structure has the same fields as the _create_ event, but the values are different since this event is from a different position in the WAL.
+
 * The `ts_ms` shows the timestamp that {prodname} processed this event.
 
-There are several things we can learn by just looking at this `payload` section. We can compare the `before` and `after` structures to determine what actually changed in this row because of the commit. The `source` structure tells us information about PostgreSQL's record of this change (providing traceability), but more importantly this has information we can compare to other events in this and other topics to know whether this event occurred before, after, or as part of the same PostgreSQL commit as other events.
+There are several things to learn by looking at this `payload` section. You can compare the `before` and `after` structures to determine what changed in this row because of the commit. The `source` structure provides information about PostgreSQL's record of this change, which enables tracing. Perhaps more importantly, this payload has information that you can compare to other events. For example, a comparison typically indicates whether this event occurred before, after, or as part of the same PostgreSQL commit as another event.
 
 [NOTE]
 ====
-When the columns for a row's primary/unique key are updated, the value of the row's key has changed so {prodname} will output _three_ events: a `DELETE` event and {link-prefix}:{link-postgresql-connector}#postgresql-tombstone-events[tombstone event] with the old key for the row, followed by an `INSERT` event with the new key for the row.
+Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a {link-prefix}:{link-postgresql-connector}#postgresql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row. Details are in the next section. 
 ====
 
 // Type: concept
-// ModuleID: about-debezium-change-events-for-primary-key-update
+// ModuleID: about-debezium-change-events-for-primary-key-updates
 // Title: About {prodname} change events for primary key updates
 === Primary key updates
 
-An update event that changes a row's primary key field(s) is known
-as a primary key change. For a primary key change, {prodname} sends a `DELETE` event for the old key and an `INSERT` event for the new (updated) key.
+An `UPDATE` operation that changes a row's primary key field(s) is known
+as a primary key change. For a primary key change, in place of sending an `UPDATE` event record, the connector sends a `DELETE` event record for the old key and a `CREATE` event record for the new (updated) key. These events have the usual structure and content, and in addition, each one has a message header related to the primary key change: 
 
-* The `DELETE` event produces a Kafka message that has `__debezium.oldkey` as a message header. The value of the message is the previous (old) primary key of the updated row.
+* The `DELETE` event record has `__debezium.newkey` as a message header. The value of this header is the new primary key for the updated row.
 
-* The `INSERT` event produces a Kafka message that has `__debezium.newkey` as a message header. The value of the message is the new primary key for the updated row.
+* The `CREATE` event record has `__debezium.oldkey` as a message header. The value of this header is the previous (old) primary key that the updated row had.
 
 // Type: concept
-// ModuleID: about-debezium-change-events-for-delete-operations
-// Title: About {prodname} change events for `DELETE` operations
+// ModuleID: about-debezium-change-events-for-operations-that-delete-content
+// Title: About {prodname} change events for operations that delete content
 [[postgresql-delete-events]]
-=== `DELETE` events
-So far we've seen samples of _create_ and _update_ events. Now, let's look at the value of a _delete_ event for the same table. Once again, the `schema` portion of the value will be exactly the same as with the _create_ and _update_ events:
+=== _delete_ events
+
+The value in a _delete_ event has the same `schema` portion as _create_ and _update_ events for the same table. The `payload` portion in a _delete_ event for the sample `customers` table looks like this: 
 
 [source,json,indent=0,subs="attributes"]
 ----
@@ -835,62 +869,61 @@ So far we've seen samples of _create_ and _update_ events. Now, let's look at th
 }
 ----
 
-If we look at the `payload` portion, we see a number of differences compared with the _create_ or _update_ event payloads:
+Compared with the _create_ or _update_ event payloads, the differences in a _delete_ event are: 
 
-* The `op` field value is now `d`, signifying that this row was deleted
-* The `before` field now has the state of the row that was deleted with the database commit. Again this only contains the primary key column due to the {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[_REPLICA IDENTITY_] setting
-* The `after` field is null, signifying that the row no longer exists
-* The `source` field structure has many of the same values as before, except the `ts_ms`, `lsn` and `txId` fields have changed
+* The `before` field has the state of the row that was deleted by the database commit. In this example, the `before` field contains only the primary key column because the table's {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting is `DEFAULT`.
+* The `after` field is null to indicate that the row no longer exists.
+* The `source` field structure has many of the same values as in the _create_ and _update_ events, except the `ts_ms`, `lsn` and `txId` fields have changed.
+* The `op` field value is `d` to indicate that this row was deleted.
 * The `ts_ms` shows the timestamp that {prodname} processed this event.
 
 This event gives a consumer all kinds of information that it can use to process the removal of this row.
 
 [WARNING]
 ====
-Please pay attention to the tables without PK, any delete messages from such table with REPLICA IDENTITY DEFAULT will have no `before` part (because they have no PK which is the only field for the default identity level) and therefore will be skipped as totally empty.
-To be able to process messages from tables without PK, set REPLICA IDENTITY to FULL level.
+For a consumer to be able to process a _delete_ event generated for a table that does not have a primary key, set the table's `REPLICA IDENTITY` to `FULL`. When a table does not have a primary key and the table's `REPLICA IDENTITY` is set to `DEFAULT` or `NOTHING`, a _delete_ event has no `before` field.
 ====
 
-The PostgreSQL connector's events are designed to work with link:https://kafka.apache.org/documentation/#compaction[Kafka log compaction], which allows for the removal of some older messages as long as at least the most recent message for every key is kept. This allows Kafka to reclaim storage space while ensuring the topic contains a complete dataset and can be used for reloading key-based state.
+PostgreSQL connector events are designed to work with link:https://kafka.apache.org/documentation/#compaction[Kafka log compaction]. Log compaction enables removal of some older messages as long as at least the most recent message for every key is kept. This lets Kafka reclaim storage space while ensuring that the topic contains a complete data set an can be used for reloading key-based state.
 
 [[postgresql-tombstone-events]]
 .Tombstone events
-When a row is deleted, the _delete_ event value listed above still works with log compaction, since Kafka can still remove all earlier messages with that same key. But only if the message value is `null` will Kafka know that it can remove _all messages_ with that same key. To make this possible, the PostgreSQL connector always follows the _delete_ event with a special _tombstone_ event that has the same key but `null` value.
+When a row is deleted, the _delete_ event value still works with log compaction, because Kafka can remove all earlier messages that have that same key. However, for Kafka to remove all messages that have that same key, the message value must be `null`. To make this possible, the PostgreSQL connector follows a _delete_ event with a special _tombstone_ event that has the same key but a `null` value.
 
-// Type: assembly
+// Type: reference
 // ModuleID: how-debezium-postgresql-connectors-map-data-types
 // Title: How {prodname} PostgreSQL connectors map data types
 [[postgresql-data-types]]
-== Data types
+== Data type mappings
 
-The PostgreSQL connector represents changes to rows with events that are structured like the table in which the row exist. The event contains a field for each column value. How that value is represented in the event depends on the PostgreSQL data type of the column. This section describes this mapping.
+The PostgreSQL connector represents changes to rows with events that are structured like the table in which the row exist. The event contains a field for each column value. How that value is represented in the event depends on the PostgreSQL data type of the column. This section describes these mappings.
 
 ifdef::product[]
 Details are in the following sections: 
 
-* xref:how-debezium-maps-postgresql-basic-types[]
-* xref:how-debezium-maps-postgresql-temporal-types[]
-* xref:how-debezium-maps-postgresql-timestamp-type[]
-* xref:how-debezium-maps-postgresql-decimal-types[]
-* xref:how-debezium-maps-postgresql-hstore-type[]
-* xref:how-debezium-maps-postgresql-domain-types[]
-* xref:how-debezium-maps-postgresql-network-address-types[]
-* xref:how-debezium-maps-postgresql-postgis-types[]
-* xref:how-debezium-maps-postgresql-toasted-values[]
+* xref:postgresql-basic-types[]
+* xref:postgresql-temporal-types[]
+* xref:postgresql-timestamp-type[]
+* xref:postgresql-decimal-types[]
+* xref:postgresql-hstore-type[]
+* xref:postgresql-domain-types[]
+* xref:postgresql-network-address-types[]
+* xref:postgresql-postgis-types[]
+* xref:postgresql-toasted-values[]
 
 endif::product[]
 
-// Type: concept
-// ModuleID: how-debezium-maps-postgresql-basic-types
-// Title: How {prodname} maps PostgreSQL basic types
+[id="postgresql-basic-types"]
 === Basic types
-The following table describes how the connector maps each of the PostgreSQL data types to a _literal type_ and _semantic type_ within the events' fields.
 
-Here, the _literal type_ describes how the value is literally represented using Kafka Connect schema types, namely `INT8`, `INT16`, `INT32`, `INT64`, `FLOAT32`, `FLOAT64`, `BOOLEAN`, `STRING`, `BYTES`, `ARRAY`, `MAP`, and `STRUCT`.
+The following table describes how the connector maps basic PostgreSQL data types to a _literal type_ and a _semantic type_ in event fields.
 
-The _semantic type_ describes how the Kafka Connect schema captures the _meaning_ of the field using the name of the Kafka Connect schema for the field.
+* _literal type_ describes how the value is literally represented using Kafka Connect schema types: `INT8`, `INT16`, `INT32`, `INT64`, `FLOAT32`, `FLOAT64`, `BOOLEAN`, `STRING`, `BYTES`, `ARRAY`, `MAP`, and `STRUCT`.
 
-[cols="20%a,15%a,30%a,35%a"]
+* _semantic type_ describes how the Kafka Connect schema captures the _meaning_ of the field using the name of the Kafka Connect schema for the field.
+
+.Mappings for PostgreSQL basic data types
+[cols="20%a,15%a,30%a,35%a",options="header"]
 |===
 |PostgreSQL Data Type
 |Literal type (schema type)
@@ -907,15 +940,10 @@ The _semantic type_ describes how the Kafka Connect schema captures the _meaning
 |n/a
 |
 
-|`BIT( > 1)`
+|`BIT( > 1)`, `BIT VARYING[(M)]`
 |`BYTES`
 |`io.debezium.data.Bits`
-|The `length` schema parameter contains an integer representing the number of bits. The resulting `byte[]` will contain the bits in little-endian form and will be sized to contain the specified number of bits (e.g., `numBytes = n/8 + (n % 8 == 0 ? 0 : 1)` where `n` is the number of bits).
-
-|`BIT VARYING[(M)]`
-|`BYTES`
-|`io.debezium.data.Bits`
-|The `length` schema parameter contains an integer representing the number of bits (2^31 - 1 in case no length was given for the column). The resulting `byte[]` will contain the bits in little-endian form and will be sized based on the content. The specified size (M) is stored in the length parameter of the io.debezium.data.Bits type.
+|The `length` schema parameter contains an integer that represents the number of bits. The resulting `byte[]` contains the bits in little-endian form, sized to contain at least the specified number of bits. For example, `numBytes = n/8 + (n%8== 0 ? 0 : 1)` where `n` is the number of bits.
 
 |`SMALLINT`, `SMALLSERIAL`
 |`INT16`
@@ -965,29 +993,29 @@ The _semantic type_ describes how the Kafka Connect schema captures the _meaning
 |`TIMESTAMPTZ`, `TIMESTAMP WITH TIME ZONE`
 |`STRING`
 |`io.debezium.time.ZonedTimestamp`
-| A string representation of a timestamp with timezone information, where the timezone is GMT
+| A string representation of a timestamp with timezone information, where the timezone is GMT.
 
 |`TIMETZ`, `TIME WITH TIME ZONE`
 |`STRING`
 |`io.debezium.time.ZonedTime`
-| A string representation of a time value with timezone information, where the timezone is GMT
+| A string representation of a time value with timezone information, where the timezone is GMT.
 
 |`INTERVAL [P]`
 |`INT64`
 |`io.debezium.time.MicroDuration` +
 (default)
-|The approximate number of microseconds for a time interval using the `365.25 / 12.0` formula for days per month average
+|The approximate number of microseconds for a time interval using the `365.25 / 12.0` formula for days per month average.
 
 |`INTERVAL [P]`
 |`STRING`
 |`io.debezium.time.Interval` +
 (when `interval.handling.mode` is set to `string`)
-|The string representation of the interval value that follows pattern `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`, e.g. `P1Y2M3DT4H5M6.78S`
+|The string representation of the interval value that follows the pattern `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`, for example,  `P1Y2M3DT4H5M6.78S`.
 
 |`BYTEA`
 |`BYTES` or `STRING`
 |n/a
-|Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the {link-prefix}:{link-postgresql-connector}#connector-property-binary-handling-mode[binary handling mode] setting
+|Either the raw bytes (the default), a base64-encoded string, or a hex-encoded string, based on the connector's {link-prefix}:{link-postgresql-connector}#connector-property-binary-handling-mode[binary handling mode] setting.
 
 |`JSON`, `JSONB`
 |`STRING`
@@ -997,22 +1025,22 @@ The _semantic type_ describes how the Kafka Connect schema captures the _meaning
 |`XML`
 |`STRING`
 |`io.debezium.data.Xml`
-|Contains the string representation of an XML document
+|Contains the string representation of an XML document.
 
 |`UUID`
 |`STRING`
 |`io.debezium.data.Uuid`
-|Contains the string representation of a PostgreSQL UUID value
+|Contains the string representation of a PostgreSQL UUID value.
 
 |`POINT`
 |`STRUCT`
 |`io.debezium.data.geometry.Point`
-|Contains a structure with 2 `FLOAT64` fields - `(x,y)` - each representing the coordinates of a geometric point
+|Contains a structure with two `FLOAT64` fields, `(x,y)`. Each field represents the coordinates of a geometric point.
 
 |`LTREE`
 |`STRING`
 |`io.debezium.data.Ltree`
-|Contains the string representation of a PostgreSQL LTREE value
+|Contains the string representation of a PostgreSQL LTREE value.
 
 |`CITEXT`
 |`STRING`
@@ -1027,27 +1055,27 @@ The _semantic type_ describes how the Kafka Connect schema captures the _meaning
 |`INT4RANGE`
 |`STRING`
 |n/a
-|Range of integer
+|Range of integer.
 
 |`INT8RANGE`
 |`STRING`
 |n/a
-|Range of bigint
+|Range of `bigint`.
 
 |`NUMRANGE`
 |`STRING`
 |n/a
-|Range of numeric
+|Range of `numeric`.
 
 |`TSRANGE`
 |`STRING`
 |n/a
-|Contains the string representation of timestamp range without time zone.
+|Contains the string representation of a timestamp range without a time zone.
 
 |`TSTZRANGE`
 |`STRING`
 |n/a
-|Contains the string representation of a timestamp range with (local system) time zone.
+|Contains the string representation of a timestamp range with the local system  time zone.
 
 |`DATERANGE`
 |`STRING`
@@ -1057,21 +1085,25 @@ The _semantic type_ describes how the Kafka Connect schema captures the _meaning
 |`ENUM`
 |`STRING`
 |`io.debezium.data.Enum`
-|Contains the string representation of the PostgreSQL ENUM value.   The set of allowed values are maintained in the schema parameter named `allowed`.
+|Contains the string representation of the PostgreSQL `ENUM` value. The set of allowed values is maintained in the `allowed` schema parameter.
 
 |===
 
-Other data type mappings are described in the following sections.
-
-// Type: concept
-// ModuleID: how-debezium-maps-postgresql-temporal-types
-// Title: How {prodname} maps PostgreSQL temporal types
-[[postgresql-temporal-values]]
+[id="postgresql-temporal-types"]
 === Temporal types
 
-Other than PostgreSQL's `TIMESTAMPTZ` and `TIMETZ` data types (which contain time zone information), the other temporal types depend on the value of the `time.precision.mode` configuration property.  When the `time.precision.mode` configuration property is set to `adaptive` (the default), then the connector will determine the literal type and semantic type for the temporal types based on the column's data type definition so that events _exactly_ represent the values in the database:
+Other than PostgreSQL's `TIMESTAMPTZ` and `TIMETZ` data types, which contain time zone information, how temporal types are mapped depends on the value of the `time.precision.mode` connector configuration property. The following sections describe these mappings: 
 
-[cols="20%a,15%a,30%a,35%a"]
+* xref:time-precision-mode-adaptive[`time.precision.mode=adaptive`]
+* xref:time-precision-mode-adaptive-time-microseconds[`time.precision.mode=adaptive_time_microseconds`]
+* xref:time-precision-mode-connect[`time.precision.mode=connect`]
+
+[[time-precision-mode-adaptive]]
+.`time.precision.mode=adaptive`
+When the `time.precision.mode` property is set to `adaptive`, the default, the connector determines the literal type and semantic type based on the column's data type definition. This ensures that events _exactly_ represent the values in the database. 
+
+.Mappings when `time.precision.mode` is `adaptive`
+[cols="20%a,15%a,30%a,35%a",options="header"]
 |===
 |PostgreSQL Data Type
 |Literal type (schema type)
@@ -1096,18 +1128,21 @@ Other than PostgreSQL's `TIMESTAMPTZ` and `TIMETZ` data types (which contain tim
 |`TIMESTAMP(1)`, `TIMESTAMP(2)`, `TIMESTAMP(3)`
 |`INT64`
 |`io.debezium.time.Timestamp`
-| Represents the number of milliseconds past epoch, and does not include timezone information.
+| Represents the number of milliseconds since the epoch, and does not include timezone information.
 
 |`TIMESTAMP(4)`, `TIMESTAMP(5)`, `TIMESTAMP(6)`, `TIMESTAMP`
 |`INT64`
 |`io.debezium.time.MicroTimestamp`
-| Represents the number of microseconds past epoch, and does not include timezone information.
+| Represents the number of microseconds since the epoch, and does not include timezone information.
 
 |===
 
-When the `time.precision.mode` configuration property is set to `adaptive_time_microseconds`, then the connector will determine the literal type and semantic type for the temporal types based on the column's data type definition so that events _exactly_ represent the values in the database, except that all TIME fields will be captured as microseconds:
+[[time-precision-mode-adaptive-time-microseconds]]
+.`time.precision.mode=adaptive_time_microseconds`
+When the `time.precision.mode` configuration property is set to `adaptive_time_microseconds`, the connector determines the literal type and semantic type for temporal types based on the column's data type definition. This ensures that events _exactly_ represent the values in the database, except all `TIME` fields are captured as microseconds.
 
-[cols="20%a,15%a,30%a,35%a"]
+.Mappings when `time.precision.mode` is `adaptive_time_microseconds`
+[cols="20%a,15%a,30%a,35%a",options="header"]
 |===
 |PostgreSQL Data Type
 |Literal type (schema type)
@@ -1136,9 +1171,12 @@ When the `time.precision.mode` configuration property is set to `adaptive_time_m
 
 |===
 
-When the `time.precision.mode` configuration property is set to `connect`, then the connector will use the predefined Kafka Connect logical types. This may be useful when consumers only know about the built-in Kafka Connect logical types and are unable to handle variable-precision time values. On the other hand, since PostgreSQL supports microsecond precision, the events generated by a connector with the `connect` time precision mode will *result in a loss of precision* when the database column has a _fractional second precision_ value greater than 3:
+[[time-precision-mode-connect]]
+.`time.precision.mode=connect`
+When the `time.precision.mode` configuration property is set to `connect`, the connector uses Kafka Connect logical types. This may be useful when consumers know about only the built-in Kafka Connect logical types and are unable to handle variable-precision time values. However, since PostgreSQL supports microsecond precision, the events generated by a connector with the `connect` time precision mode *results in a loss of precision* when the database column has a _fractional second precision_ value that is greater than 3.
 
-[cols="20%a,15%a,30%a,35%a"]
+.Mappings when `time.precision.mode` is `connect`
+[cols="20%a,15%a,30%a,35%a",options="header"]
 |===
 |PostgreSQL Data Type
 |Literal type (schema type)
@@ -1162,10 +1200,7 @@ When the `time.precision.mode` configuration property is set to `connect`, then 
 
 |===
 
-// Type: concept
-// ModuleID: how-debezium-maps-postgresql-timestamp-types
-// Title: How {prodname} maps PostgreSQL `TIMESTAMP` type
-[[postgresql-timestamp-values]]
+[id="postgresql-timestamp-type"]
 === `TIMESTAMP` type
 
 The `TIMESTAMP` type represents a timestamp without time zone information.
@@ -1175,15 +1210,15 @@ So for instance the `TIMESTAMP` value "2018-06-20 15:13:16.945104" will be repre
 
 Note that the timezone of the JVM running Kafka Connect and {prodname} does not affect this conversion.
 
-// Type: concept
-// ModuleID: how-debezium-maps-postgresql-decimal-types
-// Title: How {prodname} maps PostgreSQL decimal types
-[[postgresql-decimal-values]]
+[id="postgresql-decimal-types"]
 === Decimal types
 
-When `decimal.handling.mode` configuration property is set to `precise`, then the connector will use the predefined Kafka Connect `org.apache.kafka.connect.data.Decimal` logical type for all `DECIMAL` and `NUMERIC` columns. This is the default mode.
+The setting of the PostgreSQL connector configuration property, `decimal.handling.mode` determines how the connector maps decimal types. 
 
-[cols="15%a,15%a,35%a,35%a"]
+When the `decimal.handling.mode` property is set to `precise`, the connector uses the Kafka Connect `org.apache.kafka.connect.data.Decimal` logical type for all `DECIMAL` and `NUMERIC` columns. This is the default mode.
+
+.Mappings when `decimal.handling.mode` is `precise`
+[cols="15%a,15%a,35%a,35%a",options="header"]
 |===
 |PostgreSQL Data Type
 |Literal type (schema type)
@@ -1203,10 +1238,10 @@ When `decimal.handling.mode` configuration property is set to `precise`, then th
 |===
 
 There is an exception to this rule.
-When the `NUMERIC` or `DECIMAL` types are used without any scale constraints then it means that the values coming from the database have a different (variable) scale for each value.
-In this case a type `io.debezium.data.VariableScaleDecimal` is used and it contains both value and scale of the transferred value.
+When the `NUMERIC` or `DECIMAL` types are used without scale constraints, the values coming from the database have a different (variable) scale for each value. In this case, the connector uses `io.debezium.data.VariableScaleDecimal`, which contains both the value and the scale of the transferred value.
 
-[cols="15%a,15%a,35%a,35%a"]
+.Mappings of decimal types when there are no scale constraints
+[cols="15%a,15%a,35%a,35%a",options="header"]
 |===
 |PostgreSQL Data Type
 |Literal type (schema type)
@@ -1225,9 +1260,10 @@ In this case a type `io.debezium.data.VariableScaleDecimal` is used and it conta
 
 |===
 
-However, when `decimal.handling.mode` configuration property is set to `double`, then the connector will represent all `DECIMAL` and `NUMERIC` values as Java double values and encodes them as follows:
+When the `decimal.handling.mode` property is set to `double`, the connector represents all `DECIMAL` and `NUMERIC` values as Java double values and encodes them as shown in the following table.
 
-[cols="15%a,15%a,35%a,35%a"]
+.Mappings when `decimal.handling.mode` is `double`
+[cols="15%a,15%a,35%a,35%a",options="header"]
 |===
 |PostgreSQL Data Type
 |Literal type (schema type)
@@ -1246,9 +1282,10 @@ However, when `decimal.handling.mode` configuration property is set to `double`,
 
 |===
 
-The last option for `decimal.handling.mode` configuration property is `string`. In this case the connector will represent all `DECIMAL` and `NUMERIC` values as their formatted string representation and encodes them as follows:
+The last possible setting for the `decimal.handling.mode` configuration property is `string`. In this case, the connector represents `DECIMAL` and `NUMERIC` values as their formatted string representation, and encodes them as shown in the following table. 
 
-[cols="15%a,15%a,35%a,35%a"]
+.Mappings when `decimal.handling.mode` is `string`
+[cols="15%a,15%a,35%a,35%a",options="header"]
 |===
 |PostgreSQL Data Type
 |Literal type (schema type)
@@ -1267,17 +1304,15 @@ The last option for `decimal.handling.mode` configuration property is `string`. 
 
 |===
 
-PostgreSQL supports `NaN` (not a number) special value to be stored in the `DECIMAL`/`NUMERIC` values. Only `string` and `double` modes are able to handle such values encoding them as either `Double.NaN` or string constant `NAN`.
+PostgreSQL supports `NaN` (not a number) as a special value to be stored in `DECIMAL`/`NUMERIC` values when the setting of `decimal.handling.mode` is `string` or `double`. In this case, the connector encodes `NaN` as either `Double.NaN` or the string constant `NAN`.
 
-// Type: concept
-// ModuleID: how-debezium-maps-postgresql-hstore-type
-// Title: How {prodname} maps PostgreSQL `HSTORE` type
-[[postgresql-hstore-values]]
+[id="postgresql-hstore-type"]
 === `HSTORE` type
 
-When `hstore.handling.mode` configuration property is set to `json` (the default), the connector will represent all `HSTORE` values as string-ified JSON values and encode them as follows:
+When the `hstore.handling.mode` connector configuration property is set to `json` (the default), the connector represents `HSTORE` values as string representations of JSON values and encodes them as shown in the following table. When the `hstore.handling.mode` property is set to `map`, the connector uses the `MAP` schema type for `HSTORE` values. 
 
-[cols="15%a,15%a,35%a,35%a"]
+.Mappings for `HSTORE` data type
+[cols="15%a,15%a,35%a,35%a",options="header"]
 |===
 |PostgreSQL Data Type
 |Literal type (schema type)
@@ -1289,17 +1324,6 @@ When `hstore.handling.mode` configuration property is set to `json` (the default
 |`io.debezium.data.Json`
 | Example: output representation using the JSON converter is `{\"key\" : \"val\"}`
 
-|===
-
-When `hstore.handling.mode` configuration property is set to `map`, then the connector will use the `MAP` schema type for all `HSTORE` columns.
-
-[cols="15%a,15%a,35%a,35%a"]
-|===
-|PostgreSQL Data Type
-|Literal type (schema type)
-|Semantic type (schema name)
-|Notes
-
 |`HSTORE`
 |`MAP`
 |
@@ -1307,33 +1331,25 @@ When `hstore.handling.mode` configuration property is set to `map`, then the con
 
 |===
 
-// Type: concept
-// ModuleID: how-debezium-maps-postgresql-domain-types
-// Title: How {prodname} maps PostgreSQL domain types
-[[postgresql-domain-types]]
-=== PostgreSQL domain types
+[id="postgresql-domain-types"]
+=== Domain types
 
-PostgreSQL also supports the notion of user-defined types that are based upon other underlying types.
-When such column types are used, {prodname} exposes the column's representation based on the full type hierarchy.
+PostgreSQL supports user-defined types that are based on other underlying types. When such column types are used, {prodname} exposes the column's representation based on the full type hierarchy.
 
 [IMPORTANT]
 ====
-Special consideration should be taken when monitoring columns that use domain types.
+Capturing changes in columns that use PostgreSQL domain types requires special consideration. When a column is defined to contain a domain type that extends one of the default database types and the domain type defines a custom length or scale, the generated schema inherits that defined length or scale.
 
-When a column is defined using a domain type that extends one of the default database types and the domain type defines a custom length/scale, the generated schema will inherit that defined length/scale.
-
-When a column is defined using a domain type that extends another domain type that defines a custom length/scale, the generated schema will **not** inherit the defined length/scale because the PostgreSQL driver's column metadata implementation.
+When a column is defined to contain a domain type that extends another domain type that defines a custom length or scale, the generated schema does *not* inherit the defined length oe scale because of the PostgreSQL driver's column metadata implementation.
 ====
 
-// Type: concept
-// ModuleID: how-debezium-maps-postgresql-network-address-types
-// Title: How {prodname} maps PostgreSQL network address types
-[[postgresql-network-address-types]]
+[id="postgresql-network-address-types"]
 === Network address types
 
-PostgreSQL also have data types that can store IPv4, IPv6, and MAC addresses. It is better to use these instead of plain text types to store network addresses, because these types offer input error checking and specialized operators and functions.
+PostgreSQL haddata types that can store IPv4, IPv6, and MAC addresses. It is better to use these types instead of plain text types to store network addresses. Network address types offer input error checking and specialized operators and functions.
 
-[cols="15%a,15%a,35%a,35%a"]
+.Mappings for network address types
+[cols="15%a,15%a,35%a,35%a",options="header"]
 |===
 |PostgreSQL Data Type
 |Literal type (schema type)
@@ -1362,59 +1378,56 @@ PostgreSQL also have data types that can store IPv4, IPv6, and MAC addresses. It
 
 |===
 
-// Type: concept
-// ModuleID: how-debezium-maps-postgresql-postgis-types
-// Title: How {prodname} maps PostgreSQL PostGIS types
-[[postgresql-postgis-types]]
+[id="postgresql-postgis-types"]
 === PostGIS types
 
-The PostgreSQL connector also has full support for all of the http://postgis.net[PostGIS data types]
+The PostgreSQL connector supports all link:http://postgis.net[PostGIS data types].
 
-[cols="20%a,15%a,30%a,35%a"]
+.Mappings of PostGIS data types
+[cols="20%a,15%a,30%a,35%a",options="header"]
 |===
 |PostGIS Data Type
 |Literal type (schema type)
 |Semantic type (schema name)
 |Notes
+
 |`GEOMETRY` +
 (planar)
 |`STRUCT`
 |`io.debezium.data.geometry.Geometry`
-|Contains a structure with 2 fields +
+|Contains a structure with two fields: +
 
-* `srid (INT32)` - Spatial Reference System Identifier defining what type of geometry object is stored in the structure
-* `wkb (BYTES)` - a binary representation of the geometry object encoded in the Well-Known-Binary format.
-Please see http://www.opengeospatial.org/standards/sfa[Open Geospatial Consortium Simple Features Access specification] for the format details.
+* `srid (INT32)` - Spatial Reference System Identifier that defines what type of geometry object is stored in the structure.
+* `wkb (BYTES)` - A binary representation of the geometry object encoded in the Well-Known-Binary format. +
+
+For format details, see link:http://www.opengeospatial.org/standards/sfa[Open Geospatial Consortium Simple Features Access specification].
 
 |`GEOGRAPHY` +
 (spherical)
 |`STRUCT`
 |`io.debezium.data.geometry.Geography`
-|Contains a structure with 2 fields +
+|Contains a structure with two fields: +
 
-* `srid (INT32)` - Spatial Reference System Identifier defining what type of geography object is stored in the structure
-* `wkb (BYTES)` - a binary representation of the geometry object encoded in the Well-Known-Binary format.
-Please see http://www.opengeospatial.org/standards/sfa[Open Geospatial Consortium Simple Features Access specification] for the format details.
+* `srid (INT32)` - Spatial Reference System Identifier that defines what type of geography object is stored in the structure.
+* `wkb (BYTES)` - A binary representation of the geometry object encoded in the Well-Known-Binary format. +
+
+For format details, see http://www.opengeospatial.org/standards/sfa[Open Geospatial Consortium Simple Features Access specification].
 
 |===
 
-// Type: concept
-// ModuleID: how-debezium-maps-postgresql-toasted-values
-// Title: How {prodname} maps PostgreSQL toasted values
-[[postgresql-toasted-values]]
+[id="postgresql-toasted-values"]
 === Toasted values
 PostgreSQL has a hard limit on the page size.
-This means that values larger than ca. 8 KB need to be stored using https://www.postgresql.org/docs/current/storage-toast.html[TOAST storage].
-This impacts replication messages coming from database, as the values that were stored using the TOAST mechanism and have not been changed are not included in the message, unless they are part of the table's replica identity.
-There is no safe way for {prodname} to read the missing value out-of-bands directly from the database, as this would lead into race conditions potentially.
-{prodname} thus follows these rules to handle the toasted values:
+This means that values that are larger than around 8 KBs need to be stored by using link::https://www.postgresql.org/docs/current/storage-toast.html[TOAST storage].
+This impacts replication messages that are coming from the database. Values that were stored by using the TOAST mechanism and that have not been changed are not included in the message, unless they are part of the table's replica identity.
+There is no safe way for {prodname} to read the missing value out-of-bands directly from the database, as this would potentially lead to race conditions. Consequently, {prodname} follows these rules to handle toasted values:
 
-* tables with `REPLICA IDENTITY FULL`: TOAST column values are part of the `before` and `after` blocks of change events as any other column
-* tables with `REPLICA IDENTITY DEFAULT`: when receiving an `UPDATE` event from the database,
-any unchanged TOAST column value which is not part of the replica identity will not be part of that event;
-similarly, when receiving a `DELETE` event, any such TOAST column will not be part of the `before` block.
-As {prodname} cannot safely provide the column value in this case, it returns a placeholder value defined in configuration option `toasted.value.placeholder`.
+* Tables with `REPLICA IDENTITY FULL` - TOAST column values are part of the `before` and `after` fields in change events just like any other column.
+* Tables with `REPLICA IDENTITY DEFAULT` - When receiving an `UPDATE` event from the database, any unchanged TOAST column value that is not part of the replica identity is not contained in the event. 
+Similarly, when receiving a `DELETE` event, no TOAST columns, if any, are  in the `before` field.
+As {prodname} cannot safely provide the column value in this case, the connector returns a placeholder value as defined by the connector configuration property, `toasted.value.placeholder`.
 
+ifdef::community[]
 [IMPORTANT]
 ====
 There is a problem related to Amazon RDS instances. The `wal2json` plug-in has evolved over the time and there were releases that provided out-of-band toasted values. Amazon supports different versions of the plug-in for different PostgreSQL versions. See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html[Amazon's documentation] to obtain version to version mapping. For consistent toasted values handling: 
@@ -1422,6 +1435,7 @@ There is a problem related to Amazon RDS instances. The `wal2json` plug-in has e
 * Use the `pgoutput` plug-in for PostgreSQL 10+ instances.
 * Set `include-unchanged-toast=0` for older versions of the `wal2json` plug-in by using the `slot.stream.params` configuration option. 
 ====
+endif::community[]
 
 // Type: assembly
 // ModuleID: setting-up-postgresql-to-run-a-debezium-connector
@@ -1430,10 +1444,10 @@ There is a problem related to Amazon RDS instances. The `wal2json` plug-in has e
 == Set up
 
 ifdef::community[]
-Before using the PostgreSQL connector to monitor the changes committed on a PostgreSQL server, decide which logical decoder method you intend to use.
+Before using the PostgreSQL connector to monitor the changes committed on a PostgreSQL server, decide which logical decoding plug-in you intend to use.
 If you plan *not* to use the native `pgoutput` logical replication stream support, then you must install the logical decoding plug-in into the PostgreSQL server. Afterward, enable a replication slot, and configure a user with sufficient privileges to perform the replication.
 
-If your database is hosted by a service such as link:https://www.heroku.com/postgres[Heroku Postgres] you might be unable to install the plug-in. If so, and if you are using PostgreSQL 10+, you can use the `pgoutput` decoder support to monitor your database. If that is not an option, you are unable to monitor your database with {prodname}.
+If your database is hosted by a service such as link:https://www.heroku.com/postgres[Heroku Postgres] you might be unable to install the plug-in. If so, and if you are using PostgreSQL 10+, you can use the `pgoutput` decoder support to capture changes in your database. If that is not an option, you are unable to use {prodname} with your database.
 endif::community[]
 
 ifdef::product[]
@@ -1443,7 +1457,11 @@ Details are in the following topics:
 
 * xref:configuring-a-replication-slot-for-the-debezium-pgoutput-plug-in[]
 * xref:setting-up-postgresql-permissions-required-by-debezium-connectors[]
-* xref:[]
+* xref:configuring-postgresql-to-manage-debezium-wal-disk-space-consumption[]
+
+endif::product[]
+
+ifdef::product[]
 
 // Type: concept
 // ModuleID: configuring-a-replication-slot-for-the-debezium-pgoutput-plug-in
@@ -1461,9 +1479,9 @@ max_replication_slots=1
 
 These settings instruct the PostgreSQL server as follows: 
 
-* `wal_level`: use logical decoding with the write-ahead log.
-* `max_wal_senders`: use a maximum of one separate process for processing WAL changes.
-* `max_replication_slots`: allow a maximum of one replication slot to be created for streaming WAL changes.
+* `wal_level` - Use logical decoding with the write-ahead log.
+* `max_wal_senders` - Use a maximum of one separate process for processing WAL changes.
+* `max_replication_slots` - Allow a maximum of one replication slot to be created for streaming WAL changes.
 
 Replication slots are guaranteed to retain all WAL entries that are required for {prodname} even during {prodname} outages. Consequently, it is important to closely monitor replication slots to avoid:
 
@@ -1482,24 +1500,23 @@ ifdef::community[]
 [[postgresql-on-amazon-rds]]
 === PostgreSQL on Amazon RDS
 
-It is possible to monitor a PostgreSQL database that is running in link:https://aws.amazon.com/rds/[Amazon RDS]. To get it running, you must fulfill the following conditions
+It is possible to monitor a PostgreSQL database that is running in link:https://aws.amazon.com/rds/[Amazon RDS]. To get it running, you must fulfill the following conditions:
 
 * The instance parameter `rds.logical_replication` is set to `1`.
-* Verify that `wal_level` parameter is set to `logical` by running the query `SHOW wal_level` as DB master user; this might not be the case in multi-zone replication setups.
-You cannot set this option manually, it is (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html[automatically changed]) when the `rds.logical_replication` is set to `1`.
-If the `wal_level` is not `logical` after the change above, it is probably because the instance has to be restarted due to the parameter group change. This happens accordingly to your maintenance window or can be done manually.
-* Set `plugin.name` {prodname} parameter to `wal2json`.  You can skip this on PostgreSQL 10+ if you wish to use `pgoutput` logical replication stream support.
-* Use database master account for replication as RDS currently does not support setting of `REPLICATION` privilege for another account.
+* Verify that the `wal_level` parameter is set to `logical` by running the query `SHOW wal_level` as the database master user. This might not be the case in multi-zone replication setups.
+You cannot set this option manually. It is link:https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html[automatically changed]) when the `rds.logical_replication` is set to `1`.
+If the `wal_level` is not `logical` after the change above, it is probably because the instance has to be restarted due to the parameter group change. This happens according to your maintenance window or can be done manually.
+* Set the  {prodname} `plugin.name` parameter to `wal2json`. You can skip this on PostgreSQL 10+ if you plan to use `pgoutput` logical replication stream support.
+* Use the database master account for replication as RDS currently does not support setting of `REPLICATION` privilege for another account.
 
 [IMPORTANT]
 ====
 Ensure that you use the latest versions of PostgreSQL 9.6, 10 or 11 on Amazon RDS.
-Otherwise, older versions of the `wal2json` plug-in might be installed
-(see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html[the official documentation] for the exact `wal2json` versions installed on Amazon RDS).
-In that case, replication messages received from the database may not carry complete information about type constraints like length or scale or `NULL`/`NOT NULL`,
-which in turn might cause creation of messages with an inconsistent schema for a short period of time in case of changes to a column's definition.
+Otherwise, older versions of the `wal2json` plug-in might be installed. 
+See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html[the official documentation] for the exact `wal2json` versions installed on Amazon RDS.
+In the case of an older version, replication messages received from the database might not contain complete information about type constraints such as length or scale or `NULL`/`NOT NULL`. This might cause creation of messages with an inconsistent schema for a short period of time when there are changes to a column's definition.
 
-As of January 2019, the following PostgreSQL versions on RDS come with an up-to-date version of wal2json and thus should be used:
+As of January 2019, the following PostgreSQL versions on RDS come with an up-to-date version of `wal2json` and thus should be used:
 
 * PostgreSQL 9.6: 9.6.10 and newer
 * PostgreSQL 10: 10.5 and newer
@@ -1511,42 +1528,45 @@ As of January 2019, the following PostgreSQL versions on RDS come with an up-to-
 
 [TIP]
 ====
-Also see {link-prefix}:{link-postgresql-plugins}[Logical Decoding Output Plug-in Installation for PostgreSQL] for more detailed instructions of setting up and testing logical decoding plug-ins.
+See {link-prefix}:{link-postgresql-plugins}[Logical Decoding Output Plug-in Installation for PostgreSQL] for more detailed instructions for setting up and testing logical decoding plug-ins.
 ====
 
 [NOTE]
 ====
-As of {prodname} 0.10, the connector supports PostgreSQL 10+ logical replication streaming using `pgoutput`.
+As of {prodname} 0.10, the connector supports PostgreSQL 10+ logical replication streaming by using `pgoutput`.
 This means that a logical decoding output plug-in is no longer necessary and changes can be emitted directly from the replication stream by the connector.
 ====
 
-As of PostgreSQL 9.4, the only way to read changes to the write-ahead-log is to first install a logical decoding output plug-in. Plug-ins are written in C, compiled, and installed on the machine that runs the PostgreSQL server. Plugins use  a number of PostgreSQL specific APIs, as described by the https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[_PostgreSQL documentation_].
+As of PostgreSQL 9.4, the only way to read changes to the write-ahead-log is to install a logical decoding output plug-in. Plug-ins are written in C, compiled, and installed on the machine that runs the PostgreSQL server. Plug-ins use  a number of PostgreSQL specific APIs, as described by the link:https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[PostgreSQL documentation].
 
-The PostgreSQL connector works with one of {prodname}'s supported logical decoding plug-ins to encode the changes in either https://github.com/google/protobuf[_Protobuf format_] or http://www.json.org/[_JSON_] format.
-See the documentation for your chosen plug-in (https://github.com/debezium/postgres-decoderbufs/blob/master/README.md[_protobuf_], https://github.com/eulerto/wal2json/blob/master/README.md[_wal2json_]) to learn more about the plug-in's requirements, limitations, and how to compile it.
+The PostgreSQL connector works with one of {prodname}'s supported logical decoding plug-ins to encode the changes in either link:https://github.com/google/protobuf[Protobuf format] or link:http://www.json.org/[JSON] format.
+See the documentation for your chosen plug-in to learn more about the plug-in's requirements, limitations, and how to compile it. 
 
-For simplicity, {prodname} also provides a Docker image based on a vanilla PostgreSQL server image on top of which it compiles and installs the plug-ins. We recommend https://github.com/debezium/docker-images/tree/master/postgres/9.6[_using this image_] as an example of the detailed steps required for the installation.
+* link:https://github.com/debezium/postgres-decoderbufs/blob/master/README.md[`protobuf`]
+* link:https://github.com/eulerto/wal2json/blob/master/README.md[`wal2json`]
+
+For simplicity, {prodname} also provides a Docker image based on a vanilla PostgreSQL server image on top of which it compiles and installs the plug-ins. You can link:https://github.com/debezium/docker-images/tree/master/postgres/9.6[use this image] as an example of the detailed steps required for the installation.
 
 [WARNING]
 ====
-The {prodname} logical decoding plug-ins have been installed and tested on only  _Linux_ machines. For Windows and other operating systems, different installation steps might be required.
+The {prodname} logical decoding plug-ins have been installed and tested on only Linux machines. For Windows and other operating systems, different installation steps might be required.
 ====
 
 [[postgresql-differences-between-plugins]]
-==== Differences between plug-ins
+=== Differences between plug-ins
 
-The plug-ins' behavior is not completely the same for all cases.
-So far these differences have been identified:
+Plug-in behavior is not completely the same for all cases.
+These differences have been identified:
 
-* The `wal2json` plug-in is not able to process quoted identifiers (https://github.com/eulerto/wal2json/issues/35[issue]).
+* The `wal2json` plug-in is not able to process quoted identifiers (link:https://github.com/eulerto/wal2json/issues/35[issue]).
 * The `wal2json` and `decoderbufs` plug-ins emit events for tables without primary keys.
-* The `wal2json` plug-in does not support special values (such as, `NaN` or `infinity`) for floating point types.
-* The `wal2json` plug-in should be used with the `schema.refresh.mode` connector option set to `columns_diff_exclude_unchanged_toast`. Otherwise, when receiving a change event for a row that contains an unchanged `TOAST` column, no field for that column is contained in the emitted change event's `after` structure. This is because `wal2json` plug-in messages do not contain a field for such a column.
+* The `wal2json` plug-in does not support special values, such as `NaN` or `infinity`, for floating point types.
+* The `wal2json` plug-in should be used with the `schema.refresh.mode` connector configuration property set to `columns_diff_exclude_unchanged_toast`. Otherwise, when receiving a change event for a row that contains an unchanged `TOAST` column, no field for that column is contained in the emitted change event's `after` field. This is because `wal2json` plug-in messages do not contain a field for such a column.
 +
 The requirement for adding this is tracked under the link:https://github.com/eulerto/wal2json/issues/98[`wal2json` issue 98].
 See the documentation of `columns_diff_exclude_unchanged_toast` further below for implications of using it.
 
-* The `pgoutput` plug-in does not emit all the events for tables without primary keys. It emits only events for insert operations.
+* The `pgoutput` plug-in does not emit all events for tables without primary keys. It emits only events for `INSERT` operations.
 
 All up-to-date differences are tracked in a test suite link:https://github.com/debezium/debezium/blob/master/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DecoderDifferences.java[Java class].
 
@@ -1564,7 +1584,7 @@ shared_preload_libraries = 'decoderbufs,wal2json' // <1>
 ----
 <1> instructs the server to load the `decoderbufs` and `wal2json` logical decoding plug-ins at startup. The names of the plug-ins are set in the link:https://github.com/debezium/postgres-decoderbufs/blob/v0.3.0/Makefile[`Protobuf`] and link:https://github.com/eulerto/wal2json/blob/master/Makefile[`wal2json`] make files. 
 
-. To cnfigure the replication slot regardless of the decoder being used, specify the following in the `postgresql.conf` file: 
+. To configure the replication slot regardless of the decoder being used, specify the following in the `postgresql.conf` file: 
 +
 [source,properties]
 ----
@@ -1578,8 +1598,7 @@ max_replication_slots = 1       // <3>
 <3> instructs the server to allow a maximum of `1` replication slot to be created for streaming WAL changes.
 
 {prodname} uses PostgreSQL's logical decoding, which uses replication slots.
-Replication slots are guaranteed to retain all WAL required for {prodname} even during {prodname} outages.
-It is important for this reason to closely monitor replication slots to avoid too much disk consumption and other conditions that can happen such as catalog bloat if a replication slot stays unused for too long.
+Replication slots are guaranteed to retain all WAL segments required for {prodname} even during {prodname} outages. For this reason, it is important to closely monitor replication slots to avoid too much disk consumption and other conditions that can happen such as catalog bloat if a replication slot stays unused for too long.
 For more information, see the link:https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION-SLOTS[PostgreSQL streaming replication documentation].
 
 If you are working with a `synchronous_commit` setting other than `on`,
@@ -1588,7 +1607,7 @@ Otherwise, its default value is applied, which adds a latency of about 200 milli
 
 [TIP]
 ====
-Reading and understanding https://www.postgresql.org/docs/current/static/wal-configuration.html[PostgreSQL documentation about the mechanics and configuration of the PostgreSQL write-ahead log] is strongly recommended.
+Reading and understanding link:https://www.postgresql.org/docs/current/static/wal-configuration.html[PostgreSQL documentation about the mechanics and configuration of the PostgreSQL write-ahead log] is strongly recommended.
 ====
 endif::community[]
 
@@ -1598,7 +1617,7 @@ endif::community[]
 [[postgresql-permissions]]
 === Setting up permissions
 
-Setting up a PostgreSQL server to run a {prodname} connector requires a database user who can perform replications. Replication can be performed by only a database user who has appropriate permissions and only for a configured number of hosts. Also, you must configure the PostgreSQL server to allow replication to take place between the server machine and the host on which the PostgreSQL connector is running. 
+Setting up a PostgreSQL server to run a {prodname} connector requires a database user who can perform replications. Replication can be performed only by a database user who has appropriate permissions and only for a configured number of hosts. Also, you must configure the PostgreSQL server to allow replication to take place between the server machine and the host on which the PostgreSQL connector is running. 
 
 .Prerequisites
 
@@ -1618,9 +1637,9 @@ CREATE ROLE name REPLICATION LOGIN;
 By default, superusers have both of the above roles.
 ====
 
-. Configure the PostgreSQL server to allow replication to take place between the server machine and the host on which the PostgreSQL connector is running. For example: 
-
-.pg_hba.conf
+. Configure the PostgreSQL server to allow replication to take place between the server machine and the host on which the PostgreSQL connector is running. 
++
+.`pg_hba.conf` file example:
 [source]
 ----
 local   replication     <youruser>                          trust   // <1>
@@ -1642,7 +1661,7 @@ ifdef::community[]
 
 The PostgreSQL connector can be used with a standalone PostgreSQL server or with a cluster of PostgreSQL servers.
 
-As mentioned {link-prefix}:{link-postgresql-connector}#postgresql-limitations[in the beginning], PostgreSQL (for all versions <= 12) supports only logical replication slots on `primary` servers. This means that a replica in a PostgreSQL cluster cannot be configured for logical replication, and consequently that the {prodname} PostgreSQL Connector can connect and communicate with only the primary server. Should this server fail, the connector stops. When the cluster is repaired, if the original primary server is once again promoted to `primary`, the connector can be restarted. However, if a different PostgreSQL server _with the plug-in and proper configuration_ is promoted to `primary`, the connector configuration must be changed to point to the new `primary` server and then can be restarted.
+As mentioned {link-prefix}:{link-postgresql-connector}#postgresql-limitations[in the beginning], PostgreSQL (for all versions <= 12) supports logical replication slots on only `primary` servers. This means that a replica in a PostgreSQL cluster cannot be configured for logical replication, and consequently that the {prodname} PostgreSQL connector can connect and communicate with only the primary server. Should this server fail, the connector stops. When the cluster is repaired, if the original primary server is once again promoted to `primary`, you can retart the connector. However, if a different PostgreSQL server _with the plug-in and proper configuration_ is promoted to `primary`, you must change the connector configuration to point to the new `primary` server and then you can restart the connector.
 endif::community[]
 
 // Type: concept
@@ -1650,58 +1669,54 @@ endif::community[]
 // Title: Configuring PostgreSQL to manage {prodname} WAL disk space consumption
 [[postgresql-wal-disk-space]]
 === WAL disk space consumption
-In certain cases, it is possible that PostgreSQL disk space consumed by WAL files either experiences spikes or increases out of usual proportions.
-There are three potential reasons that explain the situation:
+In certain cases, it is possible for PostgreSQL disk space consumed by WAL files to spike or increase out of usual proportions.
+There are several possible reasons for this situation:
 
- * {prodname} regularly confirms LSN of processed events to the database.
-This is visible as `confirmed_flush_lsn` in the `pg_replication_slots` slots table.
-The database is responsible for reclaiming the disk space and the WAL size can be calculated from `restart_lsn` of the same table.
-So if the `confirmed_flush_lsn` is regularly increasing and `restart_lsn` lags then the database does need to reclaim the space.
-Disk space is usually reclaimed in batch blocks so this is expected behavior and no action on a user's side is necessary.
- * There are many updates in a monitored database but only a minuscule amount relates to the monitored table(s) and/or schema(s).
-This situation can be easily solved by enabling periodic heartbeat events using `heartbeat.interval.ms` configuration option.
- * The PostgreSQL instance contains multiple databases where one of them is a high-traffic database.
- {prodname} monitors another database that is low-traffic in comparison to the other one.
- {prodname} then cannot confirm the LSN as replication slots work per-database and {prodname} is not invoked.
- As WAL is shared by all databases it tends to grow until an event is emitted by the database monitored by {prodname}.
+* The LSN up to which the connector has received data is available in the `confirmed_flush_lsn` column of the server's `pg_replication_slots` view. Data that is older than this LSN is no longer available, and the database is responsible for reclaiming the disk space. 
++
+Also in the `pg_replication_slots` view, the `restart_lsn` column contains the LSN of the oldest WAL that the connector might require. If the value for `confirmed_flush_lsn` is regularly increasing and the value of  `restart_lsn` lags then the database needs to reclaim the space.
++
+The database typically reclaims disk space in batch blocks. This is expected behavior and no action by a user is necessary.
 
-To overcome the third cause it is necessary to
+* There are many updates in a database that is being tracked but only a tiny number of updates are related to the table(s) and schema(s) for which the connector is capturing changes. This situation can be easily solved with periodic heartbeat events. Set the {link-prefix}:{link-postgresql-connector}#postgresql-property-heartbeat-interval-ms[`heartbeat.interval.ms`] connector configuration property.
 
- * enable periodic heartbeat record generation using the `heartbeat.interval.ms` configuration option
- * regularly emit change events from the database tracked by {prodname}
+* The PostgreSQL instance contains multiple databases and one of them is a high-traffic database. {prodname} captures changes in another database that is low-traffic in comparison to the other database. {prodname} then cannot confirm the LSN as replication slots work per-database and {prodname} is not invoked. As WAL is shared by all databases, the amount used tends to grow until an event is emitted by the database for which {prodname} is capturing changes. To overcome this, it is necessary to:
+
+** Enable periodic heartbeat record generation with the `heartbeat.interval.ms` connector configuration property.
+** Regularly emit change events from the database for which {prodname} is capturing changes.
 ifdef::community[]
- ** In the case of `wal2json` decoder plug-in, it is sufficient to generate empty events.
- This can be achieved for example by truncating an empty temporary table.
- ** For other decoder plug-ins, it is recommended to create a supplementary table that is not monitored by {prodname}.
+
++
+In the case of `wal2json` decoder plug-in, it is sufficient to generate empty events. This can be achieved for example by truncating an empty temporary table. For other decoder plug-ins, the recommendation is to create a supplementary table for which {prodname} is not capturing changes.
 endif::community[]
 
-A separate process would then periodically update the table (either inserting a new event or updating the same row all over).
-PostgreSQL then will invoke {prodname} which will confirm the latest LSN and allow the database to reclaim the WAL space.
-This task can be automated by means of the `heartbeat.action.query` connector option (see below).
++
+A separate process would then periodically update the table by either inserting a new row or repeatedly updating the same row.
+PostgreSQL then invokes {prodname}, which confirms the latest LSN and allows the database to reclaim the WAL space.
+This task can be automated by means of the {link-prefix}:{link-postgresql-connector}#postgresql-property-heartbeat-action-query[`heartbeat.action.query`] connector configuration property.
 
 ifdef::community[]
 [TIP]
 ====
-For users on AWS RDS with Postgres, a similar situation to the third cause may occur on an idle environment,
-since AWS RDS makes writes to its own system tables not visible to the useres on a frequent basis (5 minutes).
-Again regularly emitting events will solve the problem.
+For users on AWS RDS with PostgreSQL, a situation similar to the high traffic/low traffic scenario can occur in an idle environment. AWS RDS causes writes to its own system tables to be invisible to clients on a frequent basis (5 minutes).
+Again, regularly emitting events solves the problem.
 ====
 endif::community[]
 
 // Type: assembly
-// ModuleID: deploying-debezium-postgresql-connectors
-// Title: Deploying {prodname} PostgreSQL connectors
+// ModuleID: deploying-and-managing-debezium-postgresql-connectors
+// Title: Deploying and managing {prodname} PostgreSQL connectors
 [[postgresql-deploying-a-connector]]
 == Deployment
 
 ifdef::community[]
-With https://zookeeper.apache.org[Zookeeper], http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect] installed, the remaining tasks to deploy a {prodname} PostgreSQL connector are to download the https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/{debezium-version}/debezium-connector-postgres-{debezium-version}-plugin.tar.gz[connector's plug-in archive], extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`]. Restart your Kafka Connect process to pick up the new JAR files.
+With link:https://zookeeper.apache.org[Zookeeper], link:http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect] installed, the remaining tasks to deploy a {prodname} PostgreSQL connector are to download the link: https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/{debezium-version}/debezium-connector-postgres-{debezium-version}-plugin.tar.gz[connector's plug-in archive], extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`]. You then need to restart your Kafka Connect process to pick up the new JAR files.
 
-If you need immutable containers, see https://hub.docker.com/r/debezium/[{prodname}'s Docker images] for Zookeeper, Kafka, PostgreSQL and Kafka Connect with the PostgreSQL connector already installed and ready to run. You can also link:/blog/2016/05/31/Debezium-on-Kubernetes/[run {prodname} on Kubernetes and OpenShift].
+If you need immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s Docker images] for Zookeeper, Kafka, PostgreSQL and Kafka Connect with the PostgreSQL connector already installed and ready to run. You can also link:/blog/2016/05/31/Debezium-on-Kubernetes/[run {prodname} on Kubernetes and OpenShift].
 endif::community[]
 
 ifdef::product[]
-To deploy a {prodname} PostgreSQL connector, install the {prodname} PostgreSQL connector archive, configure the connector, and start it. Details are in the following topics: 
+To deploy a {prodname} PostgreSQL connector, install the {prodname} PostgreSQL connector archive, configure the connector, and start the connector by adding its configuration to Kafka Connect. Details are in the following topics: 
 
 * xref:steps-for-installing-debezium-postgresql-connectors[]
 * xref:debezium-postgresql-connector-configuration-example[]
@@ -1743,7 +1758,7 @@ endif::product[]
 
 ifdef::community[]
 
-Following is an example of the configuration for a PostgreSQL connector that monitors a PostgreSQL server at port 5432 on 192.168.99.100, whose logical name is `fullfillment`. Typically, you configure the {prodname} PostgreSQL connector in a `.json` file using the configuration properties available for the connector.
+Following is an example of the configuration for a PostgreSQL connector that connects to a PostgreSQL server on port 5432 at 192.168.99.100, whose logical name is `fullfillment`. Typically, you configure the {prodname} PostgreSQL connector in a `.json` file using the configuration properties available for the connector.
 
 You can choose to produce events for a subset of the schemas and tables. Optionally, ignore, mask, or truncate columns that are sensitive, too large, or not needed.
 
@@ -1778,7 +1793,7 @@ endif::community[]
 
 ifdef::product[]
 
-Following is an example of the configuration for a PostgreSQL connector that monitors a PostgreSQL server at port 5432 on 192.168.99.100, whose logical name is `fullfillment`. Typically, you configure the {prodname} PostgreSQL connector in a `.yaml` file using the configuration properties available for the connector.
+Following is an example of the configuration for a PostgreSQL connector that connects to a PostgreSQL server on port 5432 at 192.168.99.100, whose logical name is `fullfillment`. Typically, you configure the {prodname} PostgreSQL connector in a `.yaml` file using the configuration properties available for the connector.
 
 You can choose to produce events for a subset of the schemas and tables. Optionally, ignore, mask, or truncate columns that are sensitive, too large, or not needed.
 
@@ -1810,15 +1825,15 @@ and it automatically distributes the running tasks across the cluster of Kafka C
 If any of the services stop or crash,
 those tasks will be redistributed to running services.
 <3> The connector’s configuration.
-<4> The database host, which is the name of the container running the PostgreSQL server (`postgresqldb`).
+<4> The database host, which is the name of the container that is running the PostgreSQL server (`postgresqldb`).
 <5> A unique server name.
 The server name is the logical identifier for the PostgreSQL server or cluster of servers.
-This name will be used as the prefix for all Kafka topics.
-<6> Only changes in the `public.inventory` database will be detected.
+This name is used as the prefix for all Kafka topics that receive change event records.
+<6> Changes in only the `public.inventory` database are captured.
 
 endif::product[]
 
-See the {link-prefix}:{link-postgresql-connector}#postgresql-connector-properties[complete list of connector properties] that can be specified in these configurations.
+See the {link-prefix}:{link-postgresql-connector}#postgresql-connector-properties[complete list of PostgreSQL connector properties] that can be specified in these configurations.
 
 You can send this configuration with a `POST` command to a running Kafka Connect service. The service records the configuration and starts the connector task that connects to the PostgreSQL database and streams change event records to Kafka topics.
 
@@ -1829,7 +1844,7 @@ You can send this configuration with a `POST` command to a running Kafka Connect
 === Adding connector configuration
 
 ifdef::community[]
-To start running a PostgreSQL connector, create a connnector configuration file and add it to your Kafka Connect cluster. 
+To start running a PostgreSQL connector, create a connector configuration file and add it to your Kafka Connect cluster. 
 
 .Prerequisites
 
@@ -1883,11 +1898,11 @@ Before Kafka Connect starts running the connector, Kafka Connect loads any third
 
 .. Build the docker container image. For example, if you saved the docker file that you created in the previous step as `debezium-container-for-postgresql`, then you would run the following command:
 +
-`docker build -t debezium-container-for-postgresql:latest`
+`podman build -t debezium-container-for-postgresql:latest`
 
 .. Push your custom image to your container registry, for example:
 +
-`docker push debezium-container-for-postgresql:latest`
+`podman push debezium-container-for-postgresql:latest`
 
 .. Point to the new container image. Do one of the following:
 +
@@ -1904,7 +1919,7 @@ spec:
   image: debezium-container-for-postgresql
 ----
 +
-* In the `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml` file, edit the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable to point to the new container image and reinstall the Cluster Operator. If you edit this file you will need to apply it to your OpenShift cluster.
+* In the `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml` file, edit the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable to point to the new container image and reinstall the Cluster Operator. If you edit this file you must apply it to your OpenShift cluster.
 
 . Create a `KafkaConnector` custom resource that defines your {prodname} PostgreSQL connector instance. See {LinkCDCUserGuide}#debezium-postgresql-connector-configuration-example[the connector configuration example].
 
@@ -1914,7 +1929,7 @@ spec:
 +
 This registers `inventory-connector` and the connector starts to run against the `inventory` database.
 
-. Verify that the connector was created and has started to track changes in the specified database. You can verify the connector instance by watching the Kafka Connect log output as, for example, `inventory-connector` starts.
+. Verify that the connector was created and has started to capture changes in the specified database. You can verify the connector instance by watching the Kafka Connect log output as, for example, `inventory-connector` starts.
 
 .. Display the Kafka Connect log output:
 +
@@ -1935,7 +1950,7 @@ endif::product[]
 
 .Results
 
-When the connector starts, it {LinkCDCUserGuide}#how-debezium-postgresql-connectors-perform-database-snapshots[performs a consistent snapshot] of the PostgreSQL server databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics. 
+When the connector starts, it {link-prefix}:{link-postgresql-connector}#postgresql-snapshots[performs a consistent snapshot] of the PostgreSQL server databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics. 
 
 // Type: assembly
 // ModuleID: monitoring-debezium-postgresql-connector-performance
@@ -1943,18 +1958,12 @@ When the connector starts, it {LinkCDCUserGuide}#how-debezium-postgresql-connect
 [[postgresql-monitoring]]
 === Monitoring
 
-The {prodname} PostgreSQL connector has two metric types in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect have.
-
+The {prodname} PostgreSQL connector provides two types of metrics that are in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect provide.
 
 * {link-prefix}:{link-postgresql-connector}#postgresql-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot. 
 * {link-prefix}:{link-postgresql-connector}#postgresql-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records. 
 
-, streaming metrics>>; for monitoring the connector when processing change events via logical decoding
-
-* <<postgresql-snapshot-metrics, snapshot metrics>>; for monitoring the connector when performing snapshots
-* <<postgresql-streaming-metrics, streaming metrics>>; for monitoring the connector when processing change events via logical decoding
-
-Please refer to the {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[monitoring documentation] for details of how to expose these metrics via JMX.
+{link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
 
 // Type: reference
 // ModuleID: monitoring-debezium-during-snapshots-of-postgresql-databases
@@ -1976,15 +1985,23 @@ The *MBean* is `debezium.postgres:type=connector-metrics,context=streaming,serve
 
 include::{partialsdir}/modules/cdc-all-connectors/r_connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 
-// Type: concept
+// Type: reference
 // ModuleID: descriptions-of-debezium-postgresql-connector-configuration-properties
 // Title: Description of {prodname} PostgreSQL connector configuration properties
 [[postgresql-connector-properties]]
-=== Connector Properties
+=== Connector configuration properties
 
+The {prodname} PostgreSQL connector has many configuration properties that you can use to achieve the right connector behavior for your application. Many properties have default values. Information about the properties is organized as follows: 
+
+* xref:postgresql-required-configuration-properties[Required configuration properties]
+* xref:postgresql-advanced-configuration-properties[Advanced configuration properties]
+* xref:postgresql-pass-through-properties[Pass-through configuration properties]
+
+[id="postgresql-required-configuration-properties"]
 The following configuration properties are _required_ unless a default value is available.
 
-[cols="30%a,25%a,45%a"]
+.Required connector configuration properties
+[cols="30%a,25%a,45%a",options="header"]
 |===
 |Property
 |Default
@@ -1992,7 +2009,7 @@ The following configuration properties are _required_ unless a default value is 
 
 |[[postgresql-property-name]]<<postgresql-property-name, `name`>>
 |
-|Unique name for the connector. Attempting to register again with the same name will fail. (This property is required by all Kafka Connect connectors.)
+|Unique name for the connector. Attempting to register again with the same name will fail. This property is required by all Kafka Connect connectors.
 
 |[[postgresql-property-connector-class]]<<postgresql-property-connector-class, `connector.class`>>
 |
@@ -2004,36 +2021,40 @@ The following configuration properties are _required_ unless a default value is 
 
 |[[postgresql-property-plugin-name]]<<postgresql-property-plugin-name, `plugin.name`>>
 |`decoderbufs`
-|The name of the PostgreSQL {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed on the server.
+|The name of the PostgreSQL {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed on the PostgreSQL server.
+
+ifdef::community[]
+Supported values are `decoderbufs`, `wal2json`, `wal2json_rds`, `wal2json_streaming`, `wal2json_rds_streaming` and `pgoutput`.
+
+If you are using a `wal2json` plug-in and transactions are very large, the JSON batch event that contains all transaction changes might not fit into the hard-coded memory buffer, which has a size of 1 GB. In such cases, switch to a streaming plug-in, by setting the `plugin-name` property to `wal2json_streaming` or  `wal2json_rds_streaming`. With a streaming plug-in, PostgreSQL sends the connector a separate message for each change in a transaction.
+
+endif::community[]
 ifdef::product[]
 The only supported value is `pgoutput`.
 endif::product[]
-ifdef::community[]
-Supported values are `decoderbufs`, `wal2json`, `wal2json_rds`, `wal2json_streaming`, `wal2json_rds_streaming` and `pgoutput`
-endif::community[]
-
-When the processed transactions are very large it is possible that the `JSON` batch event with all changes in the transaction will not fit into the hard-coded memory buffer of size 1 GB.
-In such cases it is possible to switch to so-called *streaming* mode when every change in transactions is sent as a separate message from PostgreSQL into {prodname}.
 
 |[[postgresql-property-slot-name]]<<postgresql-property-slot-name, `slot.name`>>
 |`debezium`
-|The name of the PostgreSQL logical decoding slot created for streaming changes from a plug-in and database instance. Values must conform to link:https://www.postgresql.org/docs/current/static/warm-standby.html#STREAMING-REPLICATION-SLOTS-MANIPULATION[PostgreSQL replication slot naming rules] which state: _"Each replication slot has a name, which can contain lower-case letters, numbers, and the underscore character."_
+|The name of the PostgreSQL logical decoding slot that was created for streaming changes from a particular plug-in for a particular database/schema. The server uses this slot to stream events to the {prodname} connector that you are configuring. 
+
+Slot names must conform to link:https://www.postgresql.org/docs/current/static/warm-standby.html#STREAMING-REPLICATION-SLOTS-MANIPULATION[PostgreSQL replication slot naming rules], which state: _"Each replication slot has a name, which can contain lower-case letters, numbers, and the underscore character."_
 
 |[[postgresql-property-slot-drop-on-stop]]<<postgresql-property-slot-drop-on-stop, `slot.drop.on.stop`>>
 |`false`
-|Whether or not to drop the logical replication slot when the connector finishes orderly. Should only be set to `true` in testing or development environments. Dropping the slot allows WAL segments to be discarded by the database, so it may happen that after a restart the connector cannot resume from the WAL position where it left off before.
+|Whether or not to delete the logical replication slot when the connector stops in a graceful, expected way. The default behavior is that the replication slot remains configured for the connector when the connector stops. When the connector restarts, having the same replication slot enables the connector to start processing where it left off. 
+
+Set to `true` in only testing or development environments. Dropping the slot allows the database to discard WAL segments. When the connector restarts it performs a new snapshot or it can continue from a persistent offset in the Kafka Connect offsets topic. 
 
 |[[postgresql-property-publication-name]]<<postgresql-property-publication-name, `publication.name`>>
 |`dbz_publication`
-|The name of the PostgreSQL publication created created for streaming changes when using `pgoutput`.
+|The name of the PostgreSQL publication created for streaming changes when using `pgoutput`.
 
-This publication is created at start-up if it does not already exist to include _all tables_.
-{prodname} will then use its own white-/blacklist filtering capabilities to limit change events to the specific tables of interest if configured.
-Note the connector user must have superuser permissions in order to create this publication,
-so it is usually preferable to create the publication upfront.
+This publication is created at start-up if it does not already exist and it includes _all tables_.
+{prodname} then applies its own whitelist/blacklist filtering, if configured, to limit the publication to change events for the specific tables of interest.
+The connector user must have superuser permissions to create this publication,
+so it is usually preferable to create the publication before starting the connector for the first time.
 
-If the publication already exists (either for all tables or configured with a subset of tables),
-{prodname} will instead use the publication as defined.
+If the publication already exists, either for all tables or configured with a subset of tables, {prodname} uses the publication as it is defined.
 
 |[[postgresql-property-database-hostname]]<<postgresql-property-database-hostname, `database.hostname`>>
 |
@@ -2045,7 +2066,7 @@ If the publication already exists (either for all tables or configured with a su
 
 |[[postgresql-property-database-user]]<<postgresql-property-database-user, `database.user`>>
 |
-|Name of the PostgreSQL database to use when connecting to the PostgreSQL database server.
+|Name of the PostgreSQL database user for connecting to the PostgreSQL database server.
 
 |[[postgresql-property-database-password]]<<postgresql-property-database-password, `database.password`>>
 |
@@ -2053,150 +2074,197 @@ If the publication already exists (either for all tables or configured with a su
 
 |[[postgresql-property-database-dbname]]<<postgresql-property-database-dbname, `database.dbname`>>
 |
-|The name of the PostgreSQL database from which to stream the changes
+|The name of the PostgreSQL database from which to stream the changes.
 
 |[[postgresql-property-database-server-name]]<<postgresql-property-database-server-name, `database.server.name`>>
 |
-|Logical name that identifies and provides a namespace for the particular PostgreSQL database server/cluster being monitored. The logical name should be unique across all other connectors, since it is used as a prefix for all Kafka topic names coming from this connector.
-Only alphanumeric characters and underscores should be used.
+|Logical name that identifies and provides a namespace for the particular PostgreSQL database server or cluster in which {prodname} is capturing changes. Only alphanumeric characters and underscores should be used in the database server logical name. The logical name should be unique across all other connectors, since it is used as a prefix for all Kafka topic names that receive records from this connector.
 
 |[[postgresql-property-schema-whitelist]]<<postgresql-property-schema-whitelist, `schema.whitelist`>>
 |
-|An optional comma-separated list of regular expressions that match schema names to be monitored; any schema name not included in the whitelist will be excluded from monitoring. By default all non-system schemas will be monitored. May not be used with `schema.blacklist`.
+|An optional, comma-separated list of regular expressions that match names of schemas for which you *want* to capture changes. Any schema name not included in the whitelist is excluded from having its changes captured. By default, all non-system schemas have their changes captured. Do not also set the `schema.blacklist` property.
 
 |[[postgresql-property-schema-blacklist]]<<postgresql-property-schema-blacklist, `schema.blacklist`>>
 |
-|An optional comma-separated list of regular expressions that match schema names to be excluded from monitoring; any schema name not included in the blacklist will be monitored, with the exception of system schemas. May not be used with `schema.whitelist`.
+|An optional, comma-separated list of regular expressions that match names of schemas for which you *do not* want to capture changes. Any schema whose name is not included in the blacklist has its changes captured, with the exception of system schemas. Do not also set the `schema.whitelist` property.
 
 |[[postgresql-property-table-whitelist]]<<postgresql-property-table-whitelist, `table.whitelist`>>
 |
-|An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be monitored; any table not included in the whitelist will be excluded from monitoring. Each identifier is of the form _schemaName_._tableName_. By default the connector will monitor every non-system table in each monitored schema. May not be used with `table.blacklist`.
+|An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you want to capture. Any table not included in the whitelist does not have its changes captured. Each identifier is of the form _schemaName_._tableName_. By default, the connector captures changes in every non-system table in each schema whose changes are being captured. Do not also set the `table.blacklist` property.
 
 |[[postgresql-property-table-blacklist]]<<postgresql-property-table-blacklist, `table.blacklist`>>
 |
-|An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be excluded from monitoring; any table not included in the blacklist will be monitored. Each identifier is of the form _schemaName_._tableName_. May not be used with `table.whitelist`.
+|An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you *do not* want to capture. Any table not included in the blacklist has it changes captured. Each identifier is of the form _schemaName_._tableName_. Do not also set the `table.whitelist` property.
 
 |[[postgresql-property-column-whitelist]]<<postgresql-property-column-whitelist, `column.whitelist`>>
 |
-|An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in change event message values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. May not be used with column.blacklist.
-
+|An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in change event record values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. Do not also set the `column.blacklist` property.
 
 |[[postgresql-property-column-blacklist]]<<postgresql-property-column-blacklist, `column.blacklist`>>
 |
-|An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event message values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. May not be used with column.whitelist.
+|An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event record values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. Do not also set the `column.whitelist` property.
 
 |[[postgresql-property-time-precision-mode]]<<postgresql-property-time-precision-mode, `time.precision.mode`>>
 |`adaptive`
-| Time, date, and timestamps can be represented with different kinds of precision, including: `adaptive` (the default) captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type; `adaptive_time_microseconds` captures the date, datetime and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type, with the exception of TIME type fields, which are always captured as microseconds; or `connect` always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which uses millisecond precision regardless of the database columns' precision. See {link-prefix}:{link-postgresql-connector}#postgresql-temporal-values[temporal values].
+| Time, date, and timestamps can be represented with different kinds of precision: 
+
+`adaptive` captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type. 
+
+`adaptive_time_microseconds` captures the date, datetime and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type. An exception is `TIME` type fields, which are always captured as microseconds.
+
+`connect` always represents time and timestamp values by using Kafka Connect's built-in representations for `Time`, `Date`, and `Timestamp`, which use millisecond precision regardless of the database columns' precision. See {link-prefix}:{link-postgresql-connector}#postgresql-temporal-values[temporal values].
 
 |[[postgresql-property-decimal-handling-mode]]<<postgresql-property-decimal-handling-mode, `decimal.handling.mode`>>
 |`precise`
-| Specifies how the connector should handle values for `DECIMAL` and `NUMERIC` columns: `precise` (the default) represents them precisely using `java.math.BigDecimal` values represented in change events in a binary form; or `double` represents them using `double` values, which may result in a loss of precision but will be far easier to use. `string` option encodes values as formatted string which is easy to consume but a semantic information about the real type is lost. See <<postgresql-decimal-values>>.
+| Specifies how the connector should handle values for `DECIMAL` and `NUMERIC` columns: 
+
+`precise` represents values by using `java.math.BigDecimal` to represent values in binary form in change events.
+
+`double` represents values by using `double` values, which might result in a loss of precision but which is easier to use. 
+
+`string` encodes values as formatted strings, which are easy to consume but semantic information about the real type is lost. See <<postgresql-decimal-values>>.
 
 |[[postgresql-property-hstore-handling-mode]]<<postgresql-property-hstore-handling-mode, `hstore.handling.mode`>>
 |`map`
-| Specifies how the connector should handle values for `hstore` columns: `map` (the default) represents using `MAP`; or `json` represents them using `json string`.`json` option encodes values as formatted string such as `{"key" : "val"}`. See <<postgresql-hstore-values>>.
+| Specifies how the connector should handle values for `hstore` columns:
+
+`map` represents values by using `MAP`.
+
+`json` represents values by using `json string`. This setting encodes values as formatted strings such as `{"key" : "val"}`. See {link-prefix}:{link-postgresql-connector}#postgresql-hstore-type[PostgreSQL `HSTORE` type].
 
 |[[postgresql-property-interval-handling-mode]]<<postgresql-property-interval-handling-mode, `interval.handling.mode`>>
 |`numeric`
-| Specifies how the connector should handle values for `interval` columns: `numeric` (the default) represents interval using approximate number of microseconds; `string` represents them exactly, using the string pattern representation `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`, e.g. `P1Y2M3DT4H5M6.78S`. See <<postgresql-data-types>>.
+| Specifies how the connector should handle values for `interval` columns:
+
+`numeric` represents intervals using approximate number of microseconds.
+
+`string` represents intervals exactly by using the string pattern representation `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`. For example: `P1Y2M3DT4H5M6.78S`. See {link-prefix}:{link-postgresql-connector}#postgresql-basic-types[PostgreSQL basic types].
 
 |[[postgresql-property-database-sslmode]]<<postgresql-property-database-sslmode, `database.sslmode`>>
 |`disable`
-|Whether to use an encrypted connection to the PostgreSQL server. Options include: *disable* (the default) to use an unencrypted connection ; *require* to use a secure (encrypted) connection, and fail if one cannot be established; *verify-ca* like `require` but additionally verify the server TLS certificate against the configured Certificate Authority (CA) certificates, or fail if no valid matching CA certificates are found; *verify-full* like `verify-ca` but additionally verify that the server certificate matches the host to which the connection is attempted. See https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
+|Whether to use an encrypted connection to the PostgreSQL server. Options include: 
+
+`disable` uses an unencrypted connection. 
+
+`require` uses a secure (encrypted) connection, and fails if one cannot be established. 
+
+`verify-ca` behaves like `require` but also verifies the server TLS certificate against the configured Certificate Authority (CA) certificates, or fails if no valid matching CA certificates are found. 
+
+`verify-full` behaves like `verify-ca` but also verifies that the server certificate matches the host to which the connector is trying to connect. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
 |[[postgresql-property-database-sslcert]]<<postgresql-property-database-sslcert, `database.sslcert`>>
 |
-|The path to the file containing the SSL Certificate for the client. See https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
+|The path to the file that contains the SSL certificate for the client. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
 |[[postgresql-property-database-sslkey]]<<postgresql-property-database-sslkey, `database.sslkey`>>
 |
-|The path to the file containing the SSL private key of the client. See https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
+|The path to the file that contains the SSL private key of the client. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
 |[[postgresql-property-database-sslpassword]]<<postgresql-property-database-sslpassword, `database.sslpassword`>>
 |
-|The password to access the client private key from the file specified by `database.sslkey`. See https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
+|The password to access the client private key from the file specified by `database.sslkey`. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
 |[[postgresql-property-database-sslrootcert]]<<postgresql-property-database-sslrootcert, `database.sslrootcert`>>
 |
-|The path to the file containing the root certificate(s) against which the server is validated. See https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
+|The path to the file that contains the root certificate(s) against which the server is validated. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
 |[[postgresql-property-database-tcpkeepalive]]<<postgresql-property-database-tcpkeepalive, `database.tcpKeepAlive`>>
-|
-|Enable TCP keep-alive probe to verify that database connection is still alive. (enabled by default). See https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
+|`true`
+|Enable TCP keep-alive probe to verify that the database connection is still alive. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
 |[[postgresql-property-tombstones-on-delete]]<<postgresql-property-tombstones-on-delete, `tombstones.on.delete`>>
 |`true`
-| Controls whether a tombstone event should be generated after a delete event. +
-When `true` the delete operations are represented by a delete event and a subsequent tombstone event. When `false` only a delete event is sent. +
-Emitting the tombstone event (the default behavior) allows Kafka to completely delete all events pertaining to the given key once the source record got deleted.
+| Controls whether a tombstone event should be generated after a _delete_ event. 
+
+`true` - delete operations are represented by a delete event and a subsequent tombstone event. 
+
+`false` - only a delete event is sent. 
+
+Emitting the tombstone event allows Kafka to completely delete all events that pertain to the given key after the source record is deleted.
 
 |[[postgresql-property-column-truncate-to-length-chars]]<<postgresql-property-column-truncate-to-length-chars, `column.truncate.to._length_.chars`>>
 |_n/a_
-|An optional comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be truncated in the change event message values if the field values are longer than the specified number of characters. Multiple properties with different lengths can be used in a single configuration, although in each the length must be a positive integer. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
+|An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event records, values in these columns are truncated if they are longer than the number of characters specified by _length_ in the property name. You can specify multiple properties with different lengths in a single configuration. Length must be a positive integer, for example, `column.truncate.to.20.chars`. 
 
 |[[postgresql-property-column-mask-with-length-chars]]<<postgresql-property-column-mask-with-length-chars, `column.mask.with._length_.chars`>>
 |_n/a_
-|An optional comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be replaced in the change event message values with a field value consisting of the specified number of asterisk (`*`) characters. Multiple properties with different lengths can be used in a single configuration, although in each the length must be a positive integer or zero. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
+|An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event values, the values in the specified table columns are replaced with _length_ number of asterisk (`*`) characters. You can specify multiple properties with different lengths in a single configuration. Length must be a positive integer or zero. When you specify zero, the connector replaces a value with an empty string.  
 
 |[[postgresql-property-column-mask-hash]]<<postgresql-property-column-mask-hash, `column.mask.hash._hashAlgorithm_.with.salt._salt_`>>
 |_n/a_
-|An optional comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be pseudonyms in the change event message values with a field value consisting of the hashed value using the algorithm `_hashAlgorithm_` and salt `_salt_`.
-Based on the used hash function referential integrity is kept while data is pseudonymized. Supported hash functions are described in the {link-java7-standard-names}[MessageDigest section] of the Java Cryptography Architecture Standard Algorithm Name Documentation.
-The hash is automatically shortened to the length of the column.
+|An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event values, the values in the specified columns are replaced with pseudonyms. 
 
-Multiple properties with different lengths can be used in a single configuration, although in each the length must be a positive integer or zero. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
+A pseudonym consists of the hashed value that results from applying the specifed _hashAlgorithm_ and _salt_. Based on the hash function that is used, referential integrity is kept while column values are replaced with pseudonyms. Supported hash functions are described in the {link-java7-standard-names}[MessageDigest section] of the Java Cryptography Architecture Standard Algorithm Name Documentation.
 
-Example:
+If necessary, the pseudonym is automatically shortened to the length of the column. You can specify multiple properties with different hash algorithms and salts in a single configuration. In the following example, `CzQMA0cB5K` is a randomly selected salt.
 
-    column.mask.hash.SHA-256.with.salt.CzQMA0cB5K = inventory.orders.customerName, inventory.shipment.customerName
+`column.mask.hash.SHA-256.with.salt.CzQMA0cB5K =inventory.orders.customerName,inventory.shipment.customerName`
 
-where `CzQMA0cB5K` is a randomly selected salt.
-
-Note: Depending on the `_hashAlgorithm_` used, the `_salt_` selected and the actual data set, the resulting masked data set may not be completely anonymized.
+Depending on the _hashAlgorithm_ used, the _salt_ selected, and the actual data set, the resulting masked data set might not be completely anonymized.
 
 |[[postgresql-property-column-propagate-source-type]]<<postgresql-property-column-propagate-source-type, `column.propagate.source.type`>>
 |_n/a_
-|An optional comma-separated list of regular expressions that match the fully-qualified names of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
-The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
-Useful to properly size corresponding columns in sink databases.
-Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_.
+|An optional, comma-separated list of regular expressions that match the fully-qualified names of columns. Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_.
+
+For each specified column, the connector adds the column's original type and original length as parameters to the corresponding field schemas in the emitted change records. The following added schema parameters propagate the original type name and also the original length for variable-width types:
+
+`pass:[_]pass:[_]debezium.source.column.type` `pass:[_]pass:[_]debezium.source.column.length` `pass:[_]pass:[_]debezium.source.column.scale`
+
+This property is useful for properly sizing corresponding columns in sink databases.
 
 |[[postgresql-property-datatype-propagate-source-type]]<<postgresql-property-datatype-propagate-source-type, `datatype.propagate.source.type`>>
 |_n/a_
-|An optional comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
-The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
-Useful to properly size corresponding columns in sink databases.
-Fully-qualified data type names are of the form _databaseName_._tableName_._typeName_, or _databaseName_._schemaName_._tableName_._typeName_.
+|An optional, comma-separated list of regular expressions that match the database-specific data type name for some columns. Fully-qualified data type names are of the form _databaseName_._tableName_._typeName_, or _databaseName_._schemaName_._tableName_._typeName_. 
+
+For these data types, the connector adds parameters to the corresponding field schemas in emitted change records. The added parameters specify the original type and length of the column: 
+
+`pass:[_]pass:[_]debezium.source.column.type` `pass:[_]pass:[_]debezium.source.column.length`  `pass:[_]pass:[_]debezium.source.column.scale` 
+
+These parameters propagate a column's original type name and length, for variable-width types, respectively. This property is useful for properly sizing corresponding columns in sink databases.
+
 See the {link-prefix}:{link-postgresql-connector}#postgresql-data-types[list of PostgreSQL-specific data type names].
 
 |[[postgresql-property-message-key-columns]]<<postgresql-property-message-key-columns, `message.key.columns`>>
 |_empty string_
-| A semi-colon list of regular expressions that match fully-qualified tables and columns to map a primary key. +
-Each item (regular expression) must match the fully-qualified `<fully-qualified table>:<a comma-separated list of columns>` representing the custom key. +
-Fully-qualified tables could be defined as _schemaName_._tableName_.
+|A semicolon separated list of tables with regular expressions that match table column names. The connector maps values in matching columns to key fields in change event records that it sends to Kafka topics. This is useful when a table does not have a primary key, or when you want to order change event records in a Kafka topic according to a field that is not a primary key. 
+
+Separate entries with semicolons. Insert a colon between the fully-qualified table name and its regular expression. The format is: 
+
+_schema-name_._table-name_:_regexp_;...
+
+For example, 
+
+`schemaA.table_a:regex_1;schemaB.table_b:regex_2;schemaC.table_c:regex_3`
+
+If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column that starts with `i`), the connector maps the value in `table_a`'s `id` column to a key field in change events that the connector sends to Kafka. 
 
 |[[postgresql-publication-autocreate-mode]]<<postgresql-publication-autocreate-mode, `publication.autocreate.mode`>>
 |_all_tables_
-|Applies only when streaming changes using https://www.postgresql.org/docs/current/sql-createpublication.html[`pgoutput`].
-Determine how creation of a https://www.postgresql.org/docs/current/logical-replication-publication.html[publication] should work, the default is all_tables.
-_disabled_ - The connector will not attempt to create a publication at all. The expectation is
-that the user has created the publication up-front. If the publication isn't found to exist upon
-startup, the connector will throw an exception and stop.
-_all_tables_ - If no publication exists, the connector will create a new publication for all tables. Note this requires
-that the configured user has access. If the publication already exists, it will be used. i.e `CREATE PUBLICATION <publication_name> FOR ALL TABLES;`
-_filtered_ - If no publication exists, the connector will create a new publication for all those tables matching the
-current filter configuration (see table/database whitelist/blacklist properties). If the publication already exists,
-it will be used. i.e `CREATE PUBLICATION <publication_name> FOR TABLE <tbl1, tbl2, etc>`
+|Applies only when streaming changes by using link:https://www.postgresql.org/docs/current/sql-createpublication.html[the `pgoutput` plug-in]. The setting determines how creation of a link:https://www.postgresql.org/docs/current/logical-replication-publication.html[publication] should work. Possible settings are:  
+
+`all_tables` - If a publication exists, the connector uses it. If a publication does not exist, the connector creates a publication for all tables in the database for which the connector is capturing changes. This requires that the database user who has permission to perform replications also has permission to create a publication. This is granted with `CREATE PUBLICATION <publication_name> FOR ALL TABLES;`.
+
+`disabled` - The connector does not attempt to create a publication. A database administrator or the user configured to perform replications must have created the publication before running the connector. If the connector cannot find the publication, the connector throws an exception and stops. 
+
+`filtered` - If a publication exists, the connector uses it. If no publication exists, the connector creates a new publication for tables that match the current filter configuration as specified by the `database.blacklist`, `database.whitelist`, `table.blacklist`, and `table.whitelist` connector configuration properties. For example: `CREATE PUBLICATION <publication_name> FOR TABLE <tbl1, tbl2, etc>`.
+
 |[[connector-property-binary-handling-mode]]<<connector-property-binary-handling-mode, `binary.handling.mode`>>
 |bytes
-|Specifies how binary (`bytea`) columns should be represented in change events, including: `bytes` represents binary data as byte array (default), `base64` represents binary data as base64-encoded String, `hex` represents binary data as hex-encoded (base16) String
+|Specifies how binary (`bytea`) columns should be represented in change events:
+
+`bytes` represents binary data as  byte array.
+
+`base64` represents binary data as base64-encoded strings. 
+
+`hex` represents binary data as hex-encoded (base16) strings.
 
 |===
 
-The following _advanced_ configuration properties have good defaults that will work in most situations and therefore rarely need to be specified in the connector's configuration.
+[id="postgresql-advanced-configuration-properties"]
+The following _advanced_ configuration properties have defaults that work in most situations and therefore rarely need to be specified in the connector's configuration.
 
-[cols="30%a,25%a,45%a"]
+.Advanced connector configuration properties
+[cols="30%a,25%a,45%a",options="header"]
 |===
 |Property
 |Default
@@ -2204,147 +2272,151 @@ The following _advanced_ configuration properties have good defaults that will w
 
 |[[postgresql-property-snapshot-mode]]<<postgresql-property-snapshot-mode, `snapshot.mode`>>
 |`initial`
-|Specifies the criteria for running a snapshot upon startup of the connector. The default is *initial*, and specifies the connector can run a snapshot only when no offsets have been recorded for the logical server name. The *always* option specifies that the connector run a snapshot each time on startup. The *never* option specifies that the connect should never use snapshots and that upon first startup with a logical server name the connector should read from either from where it last left off (last LSN position) or start from the beginning from the point of the view of the logical replication slot. The *initial_only* option specifies that the connector should only take an initial snapshot and then stop, without processing any subsequent changes. The *exported* option specifies that the database snapshot will be based on the point in time when the replication slot was created and is an excellent way to perform the snapshot in a lock-free way.
-ifdef::community[]
-Finally, if set to *custom* then the user must also set `snapshot.custom.class` which is a custom implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. See {link-prefix}:{link-postgresql-connector}#postgresql-snapshots[snapshots].
+|Specifies the criteria for performing a snapshot when the connector starts: 
 
+`initial` -  The connector performs a snapshot only when no offsets have been recorded for the logical server name. 
+
+`always` - The connector performs a snapshot each time the connector starts. 
+
+`never` - The connector never performs snapshots. When a connector is configured this way, its behavior when it starts is as follows. If there is a previously stored LSN in the Kafka offsets topic, the connector continues streaming changes from that position. If no LSN has been stored, the connector starts streaming changes from the point in time when the PostgreSQL logical replication slot was created on the server. The `never` snapshot mode is useful only when you know all data of interest is still reflected in the WAL.
+
+`initial_only` - The connector performs an initial snapshot and then stops, without processing any subsequent changes. 
+
+`exported` -  The connector performs a snapshot based on the point in time when the replication slot was created. This is an excellent way to perform the snapshot in a lock-free way.
+
+ifdef::community[]
+`custom` - The connector performs a snapshot according to the setting for the `snapshot.custom.class` property, which is a custom implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. 
+endif::community[]
+
+The{link-prefix}:{link-postgresql-connector}#snapshot-mode-settings[reference table for snapshot mode settings] has more details.
+
+ifdef::community[]
 |[[postgresql-property-snapshot-custom-class]]<<postgresql-property-snapshot-custom-class, `snapshot.custom.class`>>
 |
-| A full java class name that must be an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. Only used when `snapshot.mode` is *custom
+| A full Java class name that is an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. Required when the `snapshot.mode` property is set to `custom`. See {link-prefix}:{link-postgresql-connector}#postgresql-custom-snapshot[custom snapshotter SPI].
 endif::community[]
 
 |[[postgresql-property-snapshot-lock-timeout-ms]]<<postgresql-property-snapshot-lock-timeout-ms, `snapshot.lock.timeout.ms`>>
 |`10000`
-|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If table locks cannot be acquired in this time interval, the snapshot will fail. See {link-prefix}:{link-postgresql-connector}#postgresql-snapshots[snapshots]
+|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. {link-prefix}:{link-postgresql-connector}#postgresql-snapshots[How the connector performs snapshots] provides details. 
 
 |[[postgresql-property-snapshot-select-statement-overrides]]<<postgresql-property-snapshot-select-statement-overrides, `snapshot.select.statement.overrides`>>
 |
-|Controls which rows from tables will be included in snapshot. +
-This property contains a comma-separated list of fully-qualified tables _(DB_NAME.TABLE_NAME)_. Select statements for the individual tables are specified in further configuration properties, one for each table, identified by the id `snapshot.select.statement.overrides.[DB_NAME].[TABLE_NAME]`. The value of those properties is the SELECT statement to use when retrieving data from the specific table during snapshotting. _A possible use case for large append-only tables is setting a specific point where to start (resume) snapshotting, in case a previous snapshotting was interrupted._ +
-NOTE: This setting has impact on snapshots only. Events generated by logical decoder are not affected by it at all.
+|Controls which table rows are included in snapshots. This property affects snapshots only. It does not affect events that are generated by the logical decoding plug-in. Specify a comma-separated list of fully-qualified table names in the form _databaseName.tableName_. 
 
-|[[postgresql-property-event-processing-failure-handling-mode]]<<postgresql-property-event-processing-failure-handling-mode, `event.processing{zwsp}.failure.handling.mode`>>
+For each table that you specify, also specify another configuration property: `snapshot.select.statement.overrides._DB_NAME_._TABLE_NAME_`, for example: `snapshot.select.statement.overrides.customers.orders`. Set this property to a `SELECT` statement that obtains only the rows that you want in the snapshot. When the connector performs a snapshot, it executes this `SELECT` statement to retrieve data from that table. 
+
+A possible use case for setting these properties is large, append-only tables. You can specify a `SELECT` statement that sets a specific point for where to start a snapshot, or where to resume a snapshot if a previous snapshot was interrupted.
+
+|[[postgresql-property-event-processing-failure-handling-mode]]<<postgresql-property-event-processing-failure-handling-mode, `event.processing.failure.handling.mode`>>
 |`fail`
-| Specifies how the connector should react to exceptions during processing of events.
-`fail` will propagate the exception (indicating the offset of the problematic event), causing the connector to stop. +
-`warn` will cause the problematic event to be skipped and the offset of the problematic event to be logged. +
-`skip` will cause the problematic event to be skipped.
+| Specifies how the connector should react to exceptions during processing of events: 
+
+`fail` propagates the exception, indicates the offset of the problematic event, and causes the connector to stop.
+
+`warn` logs the offset of the problematic event, skips that event, and continues processing. 
+
+`skip` skips the problematic event and continues processing.
 
 |[[postgresql-property-max-queue-size]]<<postgresql-property-max-queue-size, `max.queue.size`>>
 |`20240`
-|Positive integer value that specifies the maximum size of the blocking queue into which change events received via streaming replication are placed before they are written to Kafka. This queue can provide backpressure when, for example, writes to Kafka are slower or if Kafka is not available.
+|Positive integer value for the maximum size of the blocking queue. The connector places change events received from streaming replication in the blocking queue before writing them to Kafka. This queue can provide backpressure when, for example, writing records to Kafka is slower that it should be or Kafka is not available.
 
 |[[postgresql-property-max-batch-size]]<<postgresql-property-max-batch-size, `max.batch.size`>>
 |`10240`
-|Positive integer value that specifies the maximum size of each batch of events that should be processed during each iteration of this connector.
+|Positive integer value that specifies the maximum size of each batch of events that the connector processes. 
 
 |[[postgresql-property-poll-interval-ms]]<<postgresql-property-poll-interval-ms, `poll.interval.ms`>>
 |`1000`
-|Positive integer value that specifies the number of milliseconds the connector should wait during each iteration for new change events to appear. Defaults to 1000 milliseconds, or 1 second.
+|Positive integer value that specifies the number of milliseconds the connector should wait for new change events to appear before it starts processing a batch of events. Defaults to 1000 milliseconds, or 1 second.
 
 |[[postgresql-property-include-unknown-datatypes]]<<postgresql-property-include-unknown-datatypes, `include.unknown.datatypes`>>
 |`false`
-|When {prodname} meets a field whose data type is unknown, then by default the field is omitted from the change event and a warning is logged.
-In some cases it may be preferable though to include the field and send it downstream to clients in the opaque binary representation so the clients will decode it themselves.
-Set to `false` to filter unknown data out of events and `true` to keep them in binary format.
-The exact representation can be controlled via the {link-prefix}:{link-postgresql-connector}#connector-property-binary-handling-mode[binary handling mode] setting
+|Specifies connector behavior when the connector encounters a field whose data type is unknown. The default behavior is that the connector omits the field from the change event and logs a warning. 
 
-NOTE: The clients risk backward compatibility issues. Not only may the database specific binary representation change between releases, but also when the datatype is supported by {prodname} eventually, it will be sent downstream in a logical type, requiring adjustments by consumers. In general, when encountering unsupported data types, please file a feature request so that support can be added.
+Set this property to `true` if you want the change event to contain an opaque binary representation of the field. This lets consumers decode the field. You can control the exact representation by setting the {link-prefix}:{link-postgresql-connector}#connector-property-binary-handling-mode[`binary handling mode`] property. 
+
+NOTE: Consumers risk backward compatibility issues when `include.unknown.datatypes` is set to `true`. Not only may the database-specific binary representation change between releases, but if the data type is eventually supported by {prodname}, the data type will be sent downstream in a logical type, which would require adjustments by consumers. In general, when encountering unsupported data types, create a feature request so that support can be added.
 
 |[[postgresql-property-database-initial-statements]]<<postgresql-property-database-initial-statements, `database.initial.statements`>>
 |
-|A semicolon separated list of SQL statements to be executed when a JDBC connection (not the transaction log reading connection) to the database is established.
-Use doubled semicolon (';;') to use a semicolon as a character and not as a delimiter.
+|A semicolon separated list of SQL statements that the connector executes when it establishes a JDBC connection to the database. To use a semicolon as a character and not as a delimiter, specify two consecutive semicolons, `;;`. 
 
-NOTE: The connector may establish JDBC connections at its own discretion, so this should typically be used for configuration of session parameters only, but not for executing DML statements.
+The connector may establish JDBC connections at its own discretion. Consequently, this property is useful for configuration of session parameters only, and not for executing DML statements.
+
+The connector does not execute these statements when it creates a connection for reading the transaction log. 
 
 |[[postgresql-property-heartbeat-interval-ms]]<<postgresql-property-heartbeat-interval-ms, `heartbeat.interval.ms`>>
 |`0`
-|Controls how frequently heartbeat messages are sent. +
-This property contains an interval in milli-seconds that defines how frequently the connector sends messages into a heartbeat topic.
-This can be used to monitor whether the connector is still receiving change events from the database.
-You also should leverage heartbeat messages in cases where only records in non-captured tables are changed for a longer period of time.
-In such situation the connector would proceed to read the log from the database but never emit any change messages into Kafka,
-which in turn means that no offset updates will be committed to Kafka.
-This will cause the WAL files to be retained by the database longer than needed
-(as the connector actually has processed them already but never got a chance to flush the latest retrieved LSN to the database)
-and also may result in more change events to be re-sent after a connector restart.
-Set this parameter to `0` to not send heartbeat messages at all. +
-Disabled by default.
+|Controls how frequently the connector sends heartbeat messages to a Kafka topic. The default behavior is that the connector does not send heartbeat messages. 
+
+Heartbeat messages are useful for monitoring whether the connector is receiving change events from the database. Heartbeat messages might help decrease the number of change events that need to be re-sent when a connector restarts. To send heartbeat messages, set this property to a positive integer, which indicates the number of milliseconds between heartbeat messages. 
+
+Heartbeat messages are needed when there are many updates in a database that is being tracked but only a tiny number of updates are related to the table(s) and schema(s) for which the connector is capturing changes. In this situation, the connector reads from the database transaction log as usual but rarely emits change records to Kafka. This means that no offset updates are committed to Kafka and the connector does not have an opportunity to send the latest retrieved LSN to the database. The database retains WAL files that contain events that have already been processed by the connector. Sending heartbeat messages enables the connector to send the latest retrieved LSN to the database, which allows the database to reclaim disk space being used by no longer needed WAL files. 
 
 |[[postgresql-property-heartbeat-topics-prefix]]<<postgresql-property-heartbeat-topics-prefix, `heartbeat.topics.prefix`>>
 |`__debezium-heartbeat`
-|Controls the naming of the topic to which heartbeat messages are sent. +
-The topic is named according to the pattern `<heartbeat.topics.prefix>.<server.name>`.
+|Controls the name of the topic to which the connector sends heartbeat messages. The topic name has this pattern: _<heartbeat.topics.prefix>_._<server.name>_. For example, if the database server name is `fullfillment`, the default topic name is `__debezium-heartbeat.fulfillment`.
 
 |[[postgresql-property-heartbeat-action-query]]<<postgresql-property-heartbeat-action-query, `heartbeat.action.query`>>
 |
-|If specified, this query will be executed upon every heartbeat against the source database.
+|Specifies a query that the connector executes on the source database when the connector sends a heartbeat message. 
 
-This can be used to overcome the situation described in {link-prefix}:{link-postgresql-connector}#postgresql-wal-disk-space[WAL Disk Space Consumption],
-where capturing changes from a low-traffic database on the same host as a high-traffic database prevents {prodname} from processing any WAL records and thus acknowledging WAL positions with the database.
+This is useful for resolving the situation described in {link-prefix}:{link-postgresql-connector}#postgresql-wal-disk-space[WAL disk space consumption], where capturing changes from a low-traffic database on the same host as a high-traffic database prevents {prodname} from processing WAL records and thus acknowledging WAL positions with the database. To address this situation, create a heartbeat table in the low-traffic database, and set this property to a statement that inserts records into that table, for example:  
 
-Inserting records into some heartbeat table (which must have been created upfront) will allow the connector to receive changes from the low-traffic database and acknowledge their LSNs,
-preventing an unbounded WAL growth on the database host.
+`INSERT INTO test_heartbeat_table (text) VALUES ('test_heartbeat')`
 
-Example: `INSERT INTO test_heartbeat_table (text) VALUES ('test_heartbeat')`
+This allows the connector to receive changes from the low-traffic database and acknowledge their LSNs, which prevents unbounded WAL growth on the database host. 
 
 |[[postgresql-property-schema-refresh-mode]]<<postgresql-property-schema-refresh-mode, `schema.refresh.mode`>>
 |`columns_diff`
 |Specify the conditions that trigger a refresh of the in-memory schema for a table.
 
-`columns_diff` (the default) is the safest mode, ensuring the in-memory schema stays in-sync with the database table's schema at all times.
+`columns_diff` is the safest mode. It ensures that the in-memory schema stays in sync with the database table's schema at all times.
 
-`columns_diff_exclude_unchanged_toast` instructs the connector to refresh the in-memory schema cache if there is a discrepancy between it
-and the schema derived from the incoming message, unless unchanged TOASTable data fully accounts for the discrepancy.
+`columns_diff_exclude_unchanged_toast` instructs the connector to refresh the in-memory schema cache if there is a discrepancy with the schema derived from the incoming message, unless unchanged TOASTable data fully accounts for the discrepancy.
 
-This setting can improve connector performance significantly if there are frequently-updated tables that
-have TOASTed data that are rarely part of these updates. However, it is possible for the in-memory schema to
+This setting can significantly improve connector performance if there are frequently-updated tables that have TOASTed data that are rarely part of updates. However, it is possible for the in-memory schema to
 become outdated if TOASTable columns are dropped from the table.
 
 |[[postgresql-property-snapshot-delay-ms]]<<postgresql-property-snapshot-delay-ms, `snapshot.delay.ms`>>
 |
-|An interval in milli-seconds that the connector should wait before taking a snapshot after starting up; +
-Can be used to avoid snapshot interruptions when starting multiple connectors in a cluster, which may cause re-balancing of connectors.
+|An interval in milliseconds that the connector should wait before performing a snapshot when the connector starts. If you are starting multiple connectors in a cluster, this property is useful for avoiding snapshot interruptions, which might cause re-balancing of connectors. 
 
 |[[postgresql-property-snapshot-fetch-size]]<<postgresql-property-snapshot-fetch-size, `snapshot.fetch.size`>>
 |`10240`
-|Specifies the maximum number of rows that should be read in one go from each table while taking a snapshot.
-The connector will read the table contents in multiple batches of this size. Defaults to 10240.
+|During a snapshot, the connector reads table content in batches of rows. This property specifies the maximum number of rows in a batch. 
 
 |[[postgresql-property-slot-stream-params]]<<postgresql-property-slot-stream-params, `slot.stream.params`>>
 |
-|Optional list of parameters to be passed to the configured logical decoding plug-in.
+|Semicolon separated list of parameters to pass to the configured logical decoding plug-in. For example, `add-tables=public.table,public.table2;include-lsn=true`.
+
 ifdef::community[]
-Can for instance be used to enable server-side table filtering when using the wal2json plug-in.
-Allowed values depend on the chosen plug-in are separated by semicolon.
+If you are using the `wal2json` plug-in, this property is useful for enabling server-side table filtering. Allowed values depend on the configured plug-in.
 endif::community[]
-For example, `add-tables=public.table,public.table2;include-lsn=true`.
 
 |[[postgresql-property-sanitize-field-names]]<<postgresql-property-sanitize-field-names, `sanitize.field.names`>>
-|`true` when connector configuration explicitly specifies the `key.converter` or `value.converter` parameters to use Avro, otherwise defaults to `false`.
-|Whether field names will be sanitized to adhere to Avro naming requirements.
-See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
+|`true` if connector configuration sets the `key.converter` or `value.converter` property to the Avro converter. 
+
+`false` if not.
+|Indicates whether field names are sanitized to adhere to {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming requirements].
 
 |[[postgresql-property-slot-max-retries]]<<postgresql-property-slot-max-retries, `slot.max.retries`>>
-|6
-|How many times to retry connecting to a replication slot when an attempt fails.
+|`6`
+|If connecting to a replication slot fails, this is the maximum number of consecutive attempts to connect.
 
 |[[postgresql-property-slot-retry-delay-ms]]<<postgresql-property-slot-retry-delay-ms, `slot.retry.delay.ms`>> +
-|10000 (10 seconds)
-|The number of milli-seconds to wait between retry attempts when the connector fails to connect to a replication slot.
+|`10000` (10 seconds)
+|The number of milliseconds to wait between retry attempts when the connector fails to connect to a replication slot.
 
 |[[postgresql-property-toasted-value-placeholder]]<<postgresql-property-toasted-value-placeholder, `toasted.value.placeholder`>>
 |`__debezium_unavailable_value`
-|Specify the constant that will be provided by {prodname} to indicate that the original value is a toasted value not provided by the database.
-If starts with `hex:` prefix it is expected that the rest of the string repesents hexadecimally encoded octets.
-See {link-prefix}:{link-postgresql-connector}#postgresql-toasted-values[Toasted Values] for additional details.
+|Specifies the constant that the connector provides to indicate that the original value is a toasted value that is not provided by the database.
+If the setting of `toasted.value.placeholder` starts with the `hex:` prefix it is expected that the rest of the string represents hexadecimally encoded octets. See {link-prefix}:{link-postgresql-connector}#postgresql-toasted-values[toasted values] for additional details.
 
 |[[postgresql-property-provide-transaction-metadata]]<<postgresql-property-provide-transaction-metadata, `provide.transaction.metadata`>>
 |`false`
-|When set to `true` {prodname} generates events with transaction boundaries and enriches data events envelope with transaction metadata.
-
-See {link-prefix}:{link-postgresql-connector}#postgresql-transaction-metadata[Transaction Metadata] for additional details.
+|Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See {link-prefix}:{link-postgresql-connector}#postgresql-transaction-metadata[Transaction metadata] for details.
 
 |[[postgresql-property-retriable-restart-connector-wait-ms]]<<postgresql-property-retriable-restart-connector-wait-ms, `retriable.restart{zwsp}.connector.wait.ms`>> +
 |10000 (10 seconds)
@@ -2352,24 +2424,42 @@ See {link-prefix}:{link-postgresql-connector}#postgresql-transaction-metadata[Tr
 
 |===
 
+[id="postgresql-pass-through-properties"]
+.Pass-through connector configuration properties
 The connector also supports _pass-through_ configuration properties that are used when creating the Kafka producer and consumer.
 
-Be sure to consult the {link-kafka-docs}.html[Kafka documentation] for all of the configuration properties for Kafka producers and consumers. (The PostgreSQL connector does use the {link-kafka-docs}.html#newconsumerconfigs[new consumer].)
+Be sure to consult the {link-kafka-docs}.html[Kafka documentation] for all of the configuration properties for Kafka producers and consumers. The PostgreSQL connector does use the {link-kafka-docs}.html#consumerconfigs[new consumer configuration properties].
 
 // Type: assembly
 // ModuleID: how-debezium-postgresql-connectors-handle-faults-and-problems
 // Title: How {prodname} PostgreSQL connectors handle faults and problems
 [[postgresql-when-things-go-wrong]]
-== Problem handling behavior
+== Behavior when things go wrong
 
-{prodname} is a distributed system that captures all changes in multiple upstream databases; it never misses or loses an event. When the system is operating normally or being managed carefully then {prodname} provides _exactly once_ delivery of every change event record. If a fault does happen then the system does not lose any events. However, while it is recovering from the fault, it might repeat some change events. In these abnormal situations, {prodname}, like Kafka, provides _at least once_ delivery of change events.
+{prodname} is a distributed system that captures all changes in multiple upstream databases; it never misses or loses an event. When the system is operating normally or being managed carefully then {prodname} provides _exactly once_ delivery of every change event record. 
 
+If a fault does happen then the system does not lose any events. However, while it is recovering from the fault, it might repeat some change events. In these abnormal situations, {prodname}, like Kafka, provides _at least once_ delivery of change events.
+
+ifdef::community[]
 The rest of this section describes how {prodname} handles various kinds of faults and problems.
+endif::community[]
 
-// Type: continue
+ifdef::product[]
+Details are in the following sections: 
+
+* xref:postgresql-connector-configuration-and-startup-errors[]
+* xref:postgresql-becomes-unavailable[]
+* xref:postgresql-cluster-failures[]
+* xref:postgresql-kafka-connect-process-stops-gracefully[]
+* xref:postgresql-kafka-connect-process-crashes[]
+* xref:postgresql-kafka-becomes-unavailable[]
+* xref:postgresql-connector-is-stopped-for-a-duration[]
+endif::product[]
+
+[id="postgresql-connector-configuration-and-startup-errors"]
 === Configuration and startup errors
 
-The connector will fail when trying to start, report an error/exception in the log, and stop running in these situations:
+In the following situations, the connector fails when trying to start, reports an error/exception in the log, and stops running:
 
 * The connector's configuration is invalid. 
 * The connector cannot successfully connect to PostgreSQL by using the specified connection parameters.
@@ -2377,19 +2467,19 @@ The connector will fail when trying to start, report an error/exception in the l
 
 In these cases, the error message has details about the problem and possibly a suggested workaround. After you correct the configuration or address the PostgreSQL problem, restart the connector.
 
-// Type: continue
+[id="postgresql-becomes-unavailable"]
 === PostgreSQL becomes unavailable
 
 When the connector is running, the PostgreSQL server that it is connected to could become unavailable for any number of reasons. If this happens, the connector fails with an error and stops. When the server is available again, restart the connector.
 
 The PostgreSQL connector externally stores the last processed offset in the form of a PostgreSQL LSN. After a connector restarts and connects to a server instance, the connector communicates with the server to continue streaming from that particular offset. This offset is available as long as the {prodname} replication slot remains intact.  Never drop a replication slot on the primary server or you will lose data. See the next section for failure cases in which a slot has been removed.
 
-// Type: continue
+[id="postgresql-cluster-failures"]
 === Cluster failures
 
 As of release 12, PostgreSQL allows logical replication slots _only on primary servers_. This means that you can point a {prodname} PostgreSQL connector to only the active primary server of a database cluster.
 Also, replication slots themselves are not propagated to replicas.
-If the primary server goes down, a new primary must be promoted (with the {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed) and a replication slot must be created there. Only then can you point the connector to the new server and restart the connector. 
+If the primary server goes down, a new primary must be promoted. The new primary must have the {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed and a replication slot that is configured for use by the plug-in. Only then can you point the connector to the new server and restart the connector. 
 
 There are important caveats when failovers occur and you should pause {prodname} until you can verify that you have an intact replication slot that has not lost data. After a failover: 
 
@@ -2409,26 +2499,26 @@ More about the concept of failover slots is in link:http://blog.2ndquadrant.com/
 ====
 endif::community[]
 
-// Type: continue
+[id="postgresql-kafka-connect-process-stops-gracefully"]
 === Kafka Connect process stops gracefully
 
-Suppose that Kafka Connect is being run in distributed mode and a Kafka Connect process is stopped gracefully. Prior to shutting down that process, Kafka Connect migrates all of the process' connector tasks to another Kafka Connect process in that group. The new connector tasks start processing exactly where the prior tasks stopped. There is a short delay in processing while the connector tasks are stopped gracefully and restarted on the new processes.
+Suppose that Kafka Connect is being run in distributed mode and a Kafka Connect process is stopped gracefully. Prior to shutting down that process, Kafka Connect migrates the process's connector tasks to another Kafka Connect process in that group. The new connector tasks start processing exactly where the prior tasks stopped. There is a short delay in processing while the connector tasks are stopped gracefully and restarted on the new processes.
 
-// Type: continue
+[id="postgresql-kafka-connect-process-crashes"]
 === Kafka Connect process crashes
 
-If the Kafka Connector process stops unexpectedly, then any connector tasks it was running terminate without recording their most recently processed offsets. When Kafka Connect is being run in distributed mode, Kafka Connect restarts those connector tasks on other processes. However, PostgreSQL connectors resume from the last offset that was _recorded_ by the earlier processes. This means that the new replacement tasks might generate some of the same change events that were processed just prior to the crash. The number of duplicate events depends on the offset flush period and the volume of data changes just before the crash.
+If the Kafka Connector process stops unexpectedly, any connector tasks it was running terminate without recording their most recently processed offsets. When Kafka Connect is being run in distributed mode, Kafka Connect restarts those connector tasks on other processes. However, PostgreSQL connectors resume from the last offset that was _recorded_ by the earlier processes. This means that the new replacement tasks might generate some of the same change events that were processed just prior to the crash. The number of duplicate events depends on the offset flush period and the volume of data changes just before the crash.
 
 Because there is a chance that some events might be duplicated during a recovery from failure, consumers should always anticipate some duplicate events. {prodname} changes are idempotent, so a sequence of events always results in the same state.
 
 In each change event record, {prodname} connectors insert source-specific information about the origin of the event, including the PostgreSQL server's time of the event, the ID of the server transaction, and the position in the write-ahead log where the transaction changes were written. Consumers can keep track of this information, especially the LSN, to determine whether an event is a duplicate. 
 
-// Type: continue
+[id="postgresql-kafka-becomes-unavailable"]
 === Kafka becomes unavailable
 
-As the connector generates change events, the Kafka Connect framework records those events in Kafka by using the Kafka producer API. Periodically, at a frequency that you specify in the Kafka Connect worker configuration, Kafka Connect records the latest offset that appears in those change events. If the Kafka brokers become unavailable, the Kafka Connect worker process that is running the connectors repeatedly tries to reconnect to the Kafka brokers. In other words, the connector tasks pause until a connection can be re-established, at which point the connectors resume exactly where they left off.
+As the connector generates change events, the Kafka Connect framework records those events in Kafka by using the Kafka producer API. Periodically, at a frequency that you specify in the Kafka Connect configuration, Kafka Connect records the latest offset that appears in those change events. If the Kafka brokers become unavailable, the Kafka Connect process that is running the connectors repeatedly tries to reconnect to the Kafka brokers. In other words, the connector tasks pause until a connection can be re-established, at which point the connectors resume exactly where they left off.
 
-// Type: continue
+[id="postgresql-connector-is-stopped-for-a-duration"]
 === Connector is stopped for a duration
 
 If the connector is gracefully stopped, the database can continue to be used. Any changes are recorded in the PostgreSQL WAL. When the connector restarts, it resumes streaming changes where it left off. That is, it generates change event records for all database changes that were made while the connector was stopped.

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -12,9 +12,12 @@ ifdef::community[]
 :source-highlighter: highlight.js
 
 toc::[]
-endif::community[]
 
+{prodname}'s PostgreSQL connector captures row-level changes in the schemas of a PostgreSQL database. PostgreSQL versions 9.6, 10, 11, and 12 are supported. 
+endif::community[]
+ifdef::product[]
 {prodname}'s PostgreSQL connector captures row-level changes in the schemas of a PostgreSQL database. PostgreSQL versions 10, 11, and 12 are supported. 
+endif::product[]
 
 The first time it connects to a PostgreSQL server or cluster, the connector takes a consistent snapshot of all schemas. After that snapshot is complete, the connector continuously captures row-level changes that insert, update, and delete database content and that were committed to a PostgreSQL database. The connector generates data change event records and streams them to Kafka topics. For each table, the default behavior is that the connector streams all generated events to a separate Kafka topic for that table. Applications and services consume data change event records from that topic. 
 
@@ -37,34 +40,31 @@ endif::product[]
 [[postgresql-overview]]
 == Overview
 
-PostgreSQL's link:https://www.postgresql.org/docs/current/static/logicaldecoding-explanation.html[_logical decoding_] feature was introduced in version 9.4. It is a mechanism that allows the extraction of the changes that were committed to the transaction log and the processing of these changes in a user-friendly manner with the help of an link:https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[_output plug-in_]. You must install this output plug-in and configure a replication slot that uses the output plug-in before running the PostgreSQL server. This enables clients to consume the changes. 
+PostgreSQL's link:https://www.postgresql.org/docs/current/static/logicaldecoding-explanation.html[_logical decoding_] feature was introduced in version 9.4. It is a mechanism that allows the extraction of the changes that were committed to the transaction log and the processing of these changes in a user-friendly manner with the help of an link:https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[_output plug-in_]. The output plug-in enables clients to consume the changes. 
 
-The PostgreSQL connector contains two main parts that work together to read and process server changes:
+The PostgreSQL connector contains two main parts that work together to read and process database changes:
 
-ifdef::product[]
-* A logical decoding output plug-in, which must be installed and configured in the PostgreSQL server.
-* Java code (the actual Kafka Connect connector), which reads the changes produced by the plug-in by using PostgreSQL's link:https://www.postgresql.org/docs/current/static/logicaldecoding-walsender.html[_streaming replication protocol_] and the PostgreSQL link:https://github.com/pgjdbc/pgjdbc[_JDBC driver_].
-endif::product[]
-
+[[postgresql-output-plugin]]
 ifdef::community[]
-* A logical decoding output plug-in, which must be installed and configured in the PostgreSQL server. The plug-in is one of these: 
-** link:https://github.com/debezium/postgres-decoderbufs[`decoderbufs`] - maintained by the {prodname} community, based on ProtoBuf.
-** link:https://github.com/eulerto/wal2json[`wal2json`] - maintained by the wal2json community, based on JSON.
-** `pgoutput`, which is the standard logical decoding plug-in in PostgreSQL 10+. It is maintained by the PostgreSQL community, and used by PostgreSQL itself for link:https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication]. This plug-in is always present so no additional libraries need to be installed. The {prodname} connector interprets the raw replication event stream directly into change events.
-* Java code (the actual Kafka Connect connector) that reads the changes produced by the chosen plug-in. It uses PostgreSQL's link:https://www.postgresql.org/docs/current/static/logicaldecoding-walsender.html[_streaming replication protocol_], by means of the PostgreSQL link:https://github.com/pgjdbc/pgjdbc[_JDBC driver_]
+* A logical decoding output plug-in. You might need to install the output plug-in that you choose to use. You must configure a replication slot that uses your chosen output plug-in before running the PostgreSQL server. The plug-in can be one of the following: 
+** link:https://github.com/debezium/postgres-decoderbufs[`decoderbufs`] is based on Protobuf and maintained by the {prodname} community.
+** link:https://github.com/eulerto/wal2json[`wal2json`] is based on JSON and maintained by the wal2json community.
+** `pgoutput` is the standard logical decoding output plug-in in PostgreSQL 10+. It is maintained by the PostgreSQL community, and used by PostgreSQL itself for link:https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication]. This plug-in is always present so no additional libraries need to be installed. The {prodname} connector interprets the raw replication event stream directly into change events.
+
+* Java code (the actual Kafka Connect connector) that reads the changes produced by the chosen logical decoding output plug-in. It uses PostgreSQL's link:https://www.postgresql.org/docs/current/static/logicaldecoding-walsender.html[_streaming replication protocol_], by means of the PostgreSQL link:https://github.com/pgjdbc/pgjdbc[_JDBC driver_]
 endif::community[]
 
-The connector produces a _change event_ for every row-level insert, update, and delete operation that was captured and sends change event records for each table in a separate Kafka topic. Your client applications read the Kafka topics that correspond to the database tables of interest, and can react to every row-level event they receive from those topics.
+ifdef::product[]
+* `pgoutput` is the standard logical decoding output plug-in in PostgreSQL 10+. This is the only supported logical decoding output plug-in in this {prodname} release. This plug-in is maintained by the PostgreSQL community, and used by PostgreSQL itself for link:https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication]. This plug-in is always present so no additional libraries need to be installed. The {prodname} connector interprets the raw replication event stream directly into change events.
+
+* Java code (the actual Kafka Connect connector) that reads the changes produced by the logical decoding output plug-in by using PostgreSQL's link:https://www.postgresql.org/docs/current/static/logicaldecoding-walsender.html[_streaming replication protocol_] and the PostgreSQL link:https://github.com/pgjdbc/pgjdbc[_JDBC driver_].
+endif::product[]
+
+The connector produces a _change event_ for every row-level insert, update, and delete operation that was captured and sends change event records for each table in a separate Kafka topic. Client applications read the Kafka topics that correspond to the database tables of interest, and can react to every row-level event they receive from those topics.
 
 PostgreSQL normally purges write-ahead log (WAL) segments after some period of time. This means that the connector does not have the complete history of all changes that have been made to the database. Therefore, when the PostgreSQL connector first connects to a particular PostgreSQL database, it starts by performing a _consistent snapshot_ of each of the database schemas. After the connector completes the snapshot, it continues streaming changes from the exact point at which the snapshot was made. This way, the connector starts with a consistent view of all of the data, and does not omit any changes that were made while the snapshot was being taken.
 
-The connector is tolerant of failures. As the connector reads changes and produces events, it records the position in the WAL for each event. If the connector stops for any reason (including communication failures, network problems, or crashes), upon restart the connector continues reading the WAL where it last left off. This includes snapshots. If the connector stops during a snapshot, the connector begins a new snapshot when it restarts. 
-
-ifdef::product[]
-[[postgresql-output-plugin]]
-.Logical decoding output plug-in
-The `pgoutput` logical decoding plug-in, the only supported logical decoding plug-in in this {prodname} release, is the standard logical decoding plug-in in PostgreSQL 10+, it is maintained by the PostgreSQL community, and it is also used by PostgreSQL for link:https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication]. The `pgoutput` plug-in is always present, meaning that no additional libraries must be installed. The connector directly interprets the raw replication event stream into change events records.
-endif::product[]
+The connector is tolerant of failures. As the connector reads changes and produces events, it records the WAL position for each event. If the connector stops for any reason (including communication failures, network problems, or crashes), upon restart the connector continues reading the WAL where it last left off. This includes snapshots. If the connector stops during a snapshot, the connector begins a new snapshot when it restarts. 
 
 [[postgresql-limitations]]
 [IMPORTANT]
@@ -161,7 +161,7 @@ ifdef::community[]
 [[postgresql-custom-snapshot]]
 === Custom snapshotter SPI
 
-For more advanced uses, you can provide an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. This interaces allows control of most of the aspects of how the connector performs snapshots. This includes whether or not to take a snapshot, the options for opening the snapshot transaction, and whether to take locks. 
+For more advanced uses, you can provide an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. This interface allows control of most of the aspects of how the connector performs snapshots. This includes whether or not to take a snapshot, the options for opening the snapshot transaction, and whether to take locks. 
 
 Following is the full API for the interface. All built-in snapshot modes implement this interface.
 
@@ -275,13 +275,10 @@ The PostgreSQL connector retrieves schema information as part of the events sent
 . Restart {prodname}.
 ====
 
-// Type: concept
-// ModuleID: postgresql-10-logical-decoding-support-pgoutput
 [[postgresql-pgoutput]]
 === PostgreSQL 10+ logical decoding support (`pgoutput`)
 
-As of PostgreSQL 10+, a new logical replication stream mode was introduced, called `pgoutput`. This logical replication stream mode is natively supported by PostgreSQL,
-which means that a {prodname} PostgreSQL connector can consume that replication stream
+As of PostgreSQL 10+, there is a logical replication stream mode, called `pgoutput` that is natively supported by PostgreSQL. This means that a {prodname} PostgreSQL connector can consume that replication stream
 without the need for additional plug-ins.
 This is particularly valuable for environments where installation of plug-ins is not supported or not allowed.
 
@@ -1075,7 +1072,7 @@ The following table describes how the connector maps basic PostgreSQL data types
 |`TSTZRANGE`
 |`STRING`
 |n/a
-|Contains the string representation of a timestamp range with the local system  time zone.
+|Contains the string representation of a timestamp range with the local system time zone.
 
 |`DATERANGE`
 |`STRING`
@@ -1340,13 +1337,13 @@ PostgreSQL supports user-defined types that are based on other underlying types.
 ====
 Capturing changes in columns that use PostgreSQL domain types requires special consideration. When a column is defined to contain a domain type that extends one of the default database types and the domain type defines a custom length or scale, the generated schema inherits that defined length or scale.
 
-When a column is defined to contain a domain type that extends another domain type that defines a custom length or scale, the generated schema does *not* inherit the defined length oe scale because of the PostgreSQL driver's column metadata implementation.
+When a column is defined to contain a domain type that extends another domain type that defines a custom length or scale, the generated schema does *not* inherit the defined length or scale because that information is not available in the PostgreSQL driver's column metadata.
 ====
 
 [id="postgresql-network-address-types"]
 === Network address types
 
-PostgreSQL haddata types that can store IPv4, IPv6, and MAC addresses. It is better to use these types instead of plain text types to store network addresses. Network address types offer input error checking and specialized operators and functions.
+PostgreSQL has data types that can store IPv4, IPv6, and MAC addresses. It is better to use these types instead of plain text types to store network addresses. Network address types offer input error checking and specialized operators and functions.
 
 .Mappings for network address types
 [cols="15%a,15%a,35%a,35%a",options="header"]
@@ -1523,7 +1520,7 @@ As of January 2019, the following PostgreSQL versions on RDS come with an up-to-
 * PostgreSQL 11: any version
 ====
 
-[[postgresql-output-plugin]]
+[[installing-postgresql-output-plugin]]
 === Installing the logical decoding output plug-in
 
 [TIP]
@@ -1850,7 +1847,7 @@ To start running a PostgreSQL connector, create a connector configuration file a
 
 * The {link-prefix}:{link-postgresql-connector}#postgresql-server-configuration[PostgreSQL server] is configured to support logical replication.
 
-* The {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] is installed.
+* The {link-prefix}:{link-postgresql-connector}#installing-postgresql-output-plugin[logical decoding plug-in] is installed.
 
 * The PostgreSQL connector is installed. 
 
@@ -2479,7 +2476,15 @@ The PostgreSQL connector externally stores the last processed offset in the form
 
 As of release 12, PostgreSQL allows logical replication slots _only on primary servers_. This means that you can point a {prodname} PostgreSQL connector to only the active primary server of a database cluster.
 Also, replication slots themselves are not propagated to replicas.
-If the primary server goes down, a new primary must be promoted. The new primary must have the {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed and a replication slot that is configured for use by the plug-in. Only then can you point the connector to the new server and restart the connector. 
+If the primary server goes down, a new primary must be promoted. 
+
+ifdef::community[]
+The new primary must have the {link-prefix}:{link-postgresql-connector}#installing-postgresql-output-plugin[logical decoding plug-in] installed and a replication slot that is configured for use by the plug-in and the database for which you want to capture changes. Only then can you point the connector to the new server and restart the connector. 
+endif::community[]
+
+ifdef::product[]
+The new primary must have a replication slot that is configured for use by the `pgoutput` plug-in and the database in which you want to capture changes. Only then can you point the connector to the new server and restart the connector. 
+endif::product[]
 
 There are important caveats when failovers occur and you should pause {prodname} until you can verify that you have an intact replication slot that has not lost data. After a failover: 
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -936,10 +936,15 @@ The following table describes how the connector maps basic PostgreSQL data types
 |n/a
 |
 
-|`BIT( > 1)`, `BIT VARYING[(M)]`
+|`BIT( > 1)`
 |`BYTES`
 |`io.debezium.data.Bits`
-|The `length` schema parameter contains an integer that represents the number of bits. The resulting `byte[]` contains the bits in little-endian form, sized to contain at least the specified number of bits. For example, `numBytes = n/8 + (n%8== 0 ? 0 : 1)` where `n` is the number of bits.
+|The `length` schema parameter contains an integer that represents the number of bits. The resulting `byte[]` contains the bits in little-endian form and is sized to contain the specified number of bits. For example, `numBytes = n/8 + (n % 8 == 0 ? 0 : 1)` where `n` is the number of bits.
+
+|`BIT VARYING[(M)]`
+|`BYTES`
+|`io.debezium.data.Bits`
+|The `length` schema parameter contains an integer that represents the number of bits (2^31 - 1 in case no length is given for the column). The resulting `byte[]` contains the bits in little-endian form and is sized based on the content. The specified size `(M)`` is stored in the length parameter of the `io.debezium.data.Bits` type.
 
 |`SMALLINT`, `SMALLSERIAL`
 |`INT16`


### PR DESCRIPTION
This is a major revision of the doc for the PostgreSQL connector.  The updates include:

- Comments that contain “Category”, “Type”, “ModuleID” and “Title” are annotations for splitting the upstream file into multiple downstream files. This lets us have one file upstream, and, as required, multiple assembly and module files downstream.
- Content revisions for consistency with Red Hat doc style conventions: 
   - Edits for clarity and completeness that focus on user tasks.
   - Present tense and not future tense. 
   - Active voice and not passive voice. 
   - No contractions or Latin phrases (i.e., e. g., via)
   - Shorter and complete sentences. 
   - Procedures have prerequisites.
   - Tables have headings. 
   - Headings use sentence case and not title case
- For downstream, sections that have many subsections have a minitoc for faster navigation. (Upstream, the right-side panel provides this.)
- There are a few instances of `endif` statements immediately followed by `ifdef` statements with the same qualifier, for example: 

   > endif::community[] 
   > ifdef::community[]

   This is intentional for addressing a problem that occurs when the upstream file is split. We’re looking for a better solution, but for now, this doesn’t hurt, though it might not help either. 

It's important for these updates to have a careful review. After this content is updated and merged, I will use this organization as a template for reorganizing the doc for the other connectors. Also, where content is the same for different connectors, I will copy that content from this updated file to the other files.  

To help you see the organization, outlines for before and after organization for both upstream and downstream are here: 
https://docs.google.com/document/d/1FEtKHZH0KLcjwpPOmkr7mAGpzeHkfnOpfg01wnFfR6k/edit?usp=sharing

Let me know what needs to change. 





