### PR TITLE
DBZ-2387 fix NPE in ParallelHaltingPredicate

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -558,7 +558,7 @@ public class BinlogReader extends AbstractReader {
         // contains only *seconds* precision ...
         EventHeader eventHeader = event.getHeader();
         if (!eventHeader.getEventType().equals(EventType.HEARTBEAT)) {
-            //HEARTBEAT events have no timestamp; only set the timestamp if the event is not a HEARTBEAT
+            // HEARTBEAT events have no timestamp; only set the timestamp if the event is not a HEARTBEAT
             source.setBinlogTimestampSeconds(eventHeader.getTimestamp() / 1000L); // client returns milliseconds,
                                                                                   // but only second precision
         }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -557,8 +557,12 @@ public class BinlogReader extends AbstractReader {
         // Update the source offset info. Note that the client returns the value in *milliseconds*, even though the binlog
         // contains only *seconds* precision ...
         EventHeader eventHeader = event.getHeader();
-        source.setBinlogTimestampSeconds(eventHeader.getTimestamp() / 1000L); // client returns milliseconds, but only second
-                                                                              // precision
+        if (!eventHeader.getEventType().equals(EventType.HEARTBEAT)) {
+            //HEARTBEAT events have no timestamp; only set the timestamp if the event is not a HEARTBEAT
+            source.setBinlogTimestampSeconds(eventHeader.getTimestamp() / 1000L); // client returns milliseconds,
+                                                                                  // but only second precision
+        }
+
         source.setBinlogServerId(eventHeader.getServerId());
         EventType eventType = eventHeader.getEventType();
         if (eventType == EventType.ROTATE) {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/ParallelSnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/ParallelSnapshotReader.java
@@ -225,14 +225,17 @@ public class ParallelSnapshotReader implements Reader {
             // we assume if we ever end up near the end of the binlog, then we will remain there.
             if (!thisReaderNearEnd.get()) {
                 Long sourceRecordTimestamp = (Long) ourSourceRecord.sourceOffset().get(SourceInfo.TIMESTAMP_KEY);
-                Instant recordTimestamp = Instant.ofEpochSecond(sourceRecordTimestamp);
-                Instant now = Instant.now();
-                Duration durationToEnd = Duration.between(recordTimestamp, now);
+                // the timestamp will be null if we have not read any binlog events yet.
+                if (sourceRecordTimestamp != null) {
+                    Instant recordTimestamp = Instant.ofEpochSecond(sourceRecordTimestamp);
+                    Instant now = Instant.now();
+                    Duration durationToEnd = Duration.between(recordTimestamp, now);
 
-                if (durationToEnd.compareTo(minHaltingDuration) <= 0) {
-                    // we are within minHaltingDuration of the end
-                    LOGGER.debug("Parallel halting predicate: this reader near end");
-                    thisReaderNearEnd.set(true);
+                    if (durationToEnd.compareTo(minHaltingDuration) <= 0) {
+                        // we are within minHaltingDuration of the end
+                        LOGGER.debug("Parallel halting predicate: this reader near end");
+                        thisReaderNearEnd.set(true);
+                    }
                 }
             }
             // return false if both readers are near end, true otherwise.


### PR DESCRIPTION
I ended up making two changes here:

1. don't change the timestamp to a 0 if we get a heartbeat event. This partially because it seems more correct and also in a related ticket Gunnar suggested doing that: https://issues.redhat.com/browse/DBZ-1989?focusedCommentId=14048603&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14048603
2. Even if we don't change the timestamp to a 0 (when we get a heartbeat), there is still the possibility of a 0/null timestamp reaching the halting predicate, because we could have only a heartbeat event after a snapshot, with no "real" binlog events with timestamps (snapshot events do not set a binlog timestamp). I think the safest thing to do in this case is just ignore events with no timestamps in the halting predicate, so that's what I'm doing.