### PR TITLE
DBZ-2225 Introduce MongoDB timeout configuration options

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
@@ -142,8 +142,12 @@ public class ConnectionContext implements AutoCloseable {
         return config.getString(MongoDbConnectorConfig.HOSTS);
     }
 
-    public int pollPeriodInSeconds() {
-        return config.getInteger(MongoDbConnectorConfig.POLL_INTERVAL_SEC);
+    public Duration pollInterval() {
+        if (config.hasKey(MongoDbConnectorConfig.POLL_INTERVAL_SEC.name())) {
+            logger.warn("The option `mongodb.poll.interval.sec` is deprecated. Use `mongodb.poll.interval.ms` instead.");
+            return Duration.ofSeconds(config.getInteger(MongoDbConnectorConfig.POLL_INTERVAL_SEC));
+        }
+        return Duration.ofMillis(config.getLong(MongoDbConnectorConfig.MONGODB_POLL_INTERVAL_MS));
     }
 
     public int maxConnectionAttemptsForPrimary() {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
@@ -63,6 +63,10 @@ public class ConnectionContext implements AutoCloseable {
         final boolean useSSL = config.getBoolean(MongoDbConnectorConfig.SSL_ENABLED);
         final boolean sslAllowInvalidHostnames = config.getBoolean(MongoDbConnectorConfig.SSL_ALLOW_INVALID_HOSTNAMES);
 
+        final int connectTimeoutMs = config.getInteger(MongoDbConnectorConfig.CONNECT_TIMEOUT_MS);
+        final int socketTimeoutMs = config.getInteger(MongoDbConnectorConfig.SOCKET_TIMEOUT_MS);
+        final int serverSelectionTimeoutMs = config.getInteger(MongoDbConnectorConfig.SERVER_SELECTION_TIMEOUT_MS);
+
         // Set up the client pool so that it ...
         MongoClients.Builder clientBuilder = MongoClients.create();
         if (username != null || password != null) {
@@ -71,6 +75,12 @@ public class ConnectionContext implements AutoCloseable {
         if (useSSL) {
             clientBuilder.options().sslEnabled(true).sslInvalidHostNameAllowed(sslAllowInvalidHostnames);
         }
+
+        clientBuilder.options()
+                .serverSelectionTimeout(serverSelectionTimeoutMs)
+                .socketTimeout(socketTimeoutMs)
+                .connectTimeout(connectTimeoutMs);
+
         pool = clientBuilder.build();
 
         this.replicaSets = ReplicaSets.parse(hosts());

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
@@ -143,11 +143,13 @@ public class ConnectionContext implements AutoCloseable {
     }
 
     public Duration pollInterval() {
+        if (config.hasKey(MongoDbConnectorConfig.MONGODB_POLL_INTERVAL_MS.name())) {
+            return Duration.ofMillis(config.getLong(MongoDbConnectorConfig.MONGODB_POLL_INTERVAL_MS));
+        }
         if (config.hasKey(MongoDbConnectorConfig.POLL_INTERVAL_SEC.name())) {
             logger.warn("The option `mongodb.poll.interval.sec` is deprecated. Use `mongodb.poll.interval.ms` instead.");
-            return Duration.ofSeconds(config.getInteger(MongoDbConnectorConfig.POLL_INTERVAL_SEC));
         }
-        return Duration.ofMillis(config.getLong(MongoDbConnectorConfig.MONGODB_POLL_INTERVAL_MS));
+        return Duration.ofSeconds(config.getInteger(MongoDbConnectorConfig.POLL_INTERVAL_SEC));
     }
 
     public int maxConnectionAttemptsForPrimary() {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnector.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnector.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.mongodb;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -119,7 +118,7 @@ public class MongoDbConnector extends SourceConnector {
             // Set up and start the thread that monitors the members of all of the replica sets ...
             replicaSetMonitorExecutor = Threads.newSingleThreadExecutor(MongoDbConnector.class, taskContext.serverName(), "replica-set-monitor");
             ReplicaSetDiscovery monitor = new ReplicaSetDiscovery(taskContext);
-            monitorThread = new ReplicaSetMonitorThread(monitor::getReplicaSets, Duration.ofSeconds(connectionContext.pollPeriodInSeconds()),
+            monitorThread = new ReplicaSetMonitorThread(monitor::getReplicaSets, connectionContext.pollInterval(),
                     Clock.SYSTEM, () -> taskContext.configureLoggingContext("disc"), this::replicaSetsChanged);
             replicaSetMonitorExecutor.execute(monitorThread);
             logger.info("Successfully started MongoDB connector, and continuing to discover changes in replica set(s) at {}", connectionContext.hosts());

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -141,6 +141,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
             .withDefault(ReplicaSetDiscovery.ADMIN_DATABASE_NAME)
             .withDescription("Database containing user credentials.");
 
+    @Deprecated
     public static final Field POLL_INTERVAL_SEC = Field.create("mongodb.poll.interval.sec")
             .withDisplayName("Replica membership poll interval (sec)")
             .withType(Type.INT)
@@ -148,7 +149,17 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
             .withImportance(Importance.MEDIUM)
             .withDefault(30)
             .withValidation(Field::isPositiveInteger)
-            .withDescription("Frequency in seconds to look for new, removed, or changed replica sets. Defaults to 30 seconds.");
+            .withDescription("(Deprecated, use mongodb.poll.interval.ms) Frequency in seconds to look for new, removed, " +
+                    "or changed replica sets. Defaults to 30 seconds.");
+
+    public static final Field MONGODB_POLL_INTERVAL_MS = Field.create("mongodb.poll.interval.ms")
+            .withDisplayName("Replica membership poll interval (ms)")
+            .withType(Type.LONG)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.MEDIUM)
+            .withDefault(30000)
+            .withValidation(Field::isPositiveInteger)
+            .withDescription("Frequency in milliseconds to look for new, removed, or changed replica sets.  Defaults to 30000 milliseconds.");
 
     public static final Field SSL_ENABLED = Field.create("mongodb.ssl.enabled")
             .withDisplayName("Enable SSL connection to MongoDB")
@@ -351,6 +362,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
                     SOCKET_TIMEOUT_MS,
                     SERVER_SELECTION_TIMEOUT_MS,
                     POLL_INTERVAL_SEC,
+                    MONGODB_POLL_INTERVAL_MS,
                     MAX_FAILED_CONNECTIONS,
                     AUTO_DISCOVER_MEMBERS,
                     SSL_ENABLED,

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -308,6 +308,30 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
                     + "'initial' (the default) to specify the connector should always perform an initial sync when required; "
                     + "'never' to specify the connector should never perform an initial sync ");
 
+    public static final Field CONNECT_TIMEOUT_MS = Field.create("mongodb.connect.timeout.ms")
+            .withDisplayName("Connect Timeout MS")
+            .withType(Type.INT)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(10000)
+            .withDescription("The connection timeout in milliseconds");
+
+    public static final Field SERVER_SELECTION_TIMEOUT_MS = Field.create("mongodb.server.selection.timeout.ms")
+            .withDisplayName("Server selection timeout MS")
+            .withType(Type.INT)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(30000)
+            .withDescription("The server selection timeout in milliseconds");
+
+    public static final Field SOCKET_TIMEOUT_MS = Field.create("mongodb.socket.timeout.ms")
+            .withDisplayName("Socket timeout MS")
+            .withType(Type.INT)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDefault(0)
+            .withDescription("The socket timeout in milliseconds");
+
     protected static final Field TASK_ID = Field.create("mongodb.task.id")
             .withDescription("Internal use only")
             .withValidation(Field::isInteger)
@@ -323,6 +347,9 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
                     LOGICAL_NAME,
                     CONNECT_BACKOFF_INITIAL_DELAY_MS,
                     CONNECT_BACKOFF_MAX_DELAY_MS,
+                    CONNECT_TIMEOUT_MS,
+                    SOCKET_TIMEOUT_MS,
+                    SERVER_SELECTION_TIMEOUT_MS,
                     POLL_INTERVAL_SEC,
                     MAX_FAILED_CONNECTIONS,
                     AUTO_DISCOVER_MEMBERS,

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -157,7 +157,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
             .withType(Type.LONG)
             .withWidth(Width.SHORT)
             .withImportance(Importance.MEDIUM)
-            .withDefault(30000)
+            .withDefault(30000L)
             .withValidation(Field::isPositiveInteger)
             .withDescription("Frequency in milliseconds to look for new, removed, or changed replica sets.  Defaults to 30000 milliseconds.");
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -1088,6 +1088,7 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
                 .with(MongoDbConnectorConfig.LOGICAL_NAME, "mongo")
                 .with(MongoDbConnectorConfig.MAX_FAILED_CONNECTIONS, 0)
                 .with(MongoDbConnectorConfig.SSL_ENABLED, true)
+                .with(MongoDbConnectorConfig.SERVER_SELECTION_TIMEOUT_MS, 2000)
                 .build();
 
         // Set up the replication context for connections ...

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -947,6 +947,10 @@ See {link-prefix}:{link-mongodb-connector}#mongodb-transaction-metadata[Transact
 |10000 (10 seconds)
 |The number of milli-seconds to wait before restarting a connector after a retriable error occurs.
 
+|[[mongodb-property-mongodb-poll-interval-ms]]<<mongodb-property-mongodb-poll-interval-ms, `mongodb.poll.interval.ms`>> +
+|`30000`
+|The interval in which the connector polls for new, removed, or changed replica sets.
+
 |[[mongodb-property-mongodb-connect-timeout-ms]]<<mongodb-property-mongodb-connect-timeout-ms, `mongodb.connect.timeout.ms`>> +
 |10000 (10 seconds)
 |The number of milli-seconds the driver will wait before a new connection attempt is aborted.

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -947,6 +947,19 @@ See {link-prefix}:{link-mongodb-connector}#mongodb-transaction-metadata[Transact
 |10000 (10 seconds)
 |The number of milli-seconds to wait before restarting a connector after a retriable error occurs.
 
+|[[mongodb-property-mongodb-connect-timeout-ms]]<<mongodb-property-mongodb-connect-timeout-ms, `mongodb.connect.timeout.ms`>> +
+|10000 (10 seconds)
+|The number of milli-seconds the driver will wait before a new connection attempt is aborted.
+
+|[[mongodb-property-mongodb-socket-timeout-ms]]<<mongodb-property-mongodb-socket-timeout-ms, `mongodb.socket.timeout.ms`>> +
+|0
+|The number of milli-seconds before a send/receive on the socket can take before a timeout occurs.
+A value of `0` disables this behavior.
+
+|[[mongodb-property-mongodb-server-selection-timeout-ms]]<<mongodb-property-mongodb-server-selection-timeout-ms, `mongodb.server.selection.timeout.ms`>> +
+|30000 (30 seconds)
+|The number of milli-seconds the driver will wait to select a server before it times out and throws an error.
+
 |===
 
 [[mongodb-fault-tolerance]]


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2225

This PR not only addresses allowing a shorter configuration for the SSL test timeout as described in the issue but it also exposes a way for users to customize 3 different timeouts based on their needs:

* `server.selection.timeout.ms`
* `connect.timeout.ms`
* `socket.timeout.ms`