### PR TITLE
DBZ-2399 Updates strimzi version attribute from 0.13.0 to 0.18.0

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -14,7 +14,7 @@ asciidoc:
     assemblies: '../assemblies'
     modules: '../../modules'
     mysql-version: '8.0'
-    strimzi-version: '0.13.0'
+    strimzi-version: '0.18.0'
     apicurio-version: '1.2.2.Final'
     community: true
     registry: 'Apicurio Registry'


### PR DESCRIPTION
DBZ-2399 is an ongoing Jira for issues like this one: unexpected, small, doc updates required for 1.2GA. 
This PR just updates the value of the AsciiDoc attribute, `strimzi-version`. 

This update belongs in the 1.2 branch. I don't know if that requires a backport. 

Link to Jira:  https://issues.redhat.com/browse/DBZ-2399