### PR TITLE
DBZ-2333 Some clean-up

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -762,7 +762,7 @@ It is possible and even recommended that you use the Avro converter to dramatica
 [[postgresql-update-events]]
 === _update_ events
 
-The value of an _update_ event on the sample `customers` table has the same `schema` specification as the _create_ event example. An _update_ event`s payload has the same structure as a _create_ event for the same table. However, the _update_ event's payload contains different values, as shown in this example: 
+The value of an _update_ event on the sample `customers` table has the same `schema` specification as the _create_ event example. An _update_ event's payload has the same structure as a _create_ event for the same table. However, the _update_ event's payload contains different values, as shown in this example: 
 
 [source,json,indent=0,subs="attributes"]
 ----
@@ -944,7 +944,7 @@ The following table describes how the connector maps basic PostgreSQL data types
 |`BIT VARYING[(M)]`
 |`BYTES`
 |`io.debezium.data.Bits`
-|The `length` schema parameter contains an integer that represents the number of bits (2^31 - 1 in case no length is given for the column). The resulting `byte[]` contains the bits in little-endian form and is sized based on the content. The specified size `(M)`` is stored in the length parameter of the `io.debezium.data.Bits` type.
+|The `length` schema parameter contains an integer that represents the number of bits (2^31 - 1 in case no length is given for the column). The resulting `byte[]` contains the bits in little-endian form and is sized based on the content. The specified size `(M)` is stored in the length parameter of the `io.debezium.data.Bits` type.
 
 |`SMALLINT`, `SMALLSERIAL`
 |`INT16`
@@ -2237,7 +2237,7 @@ For example,
 
 `schemaA.table_a:regex_1;schemaB.table_b:regex_2;schemaC.table_c:regex_3`
 
-If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column that starts with `i`), the connector maps the value in `table_a`'s `id` column to a key field in change events that the connector sends to Kafka. 
+If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column that starts with `i`), the connector maps the value in ``table_a``'s `id` column to a key field in change events that the connector sends to Kafka. 
 
 |[[postgresql-publication-autocreate-mode]]<<postgresql-publication-autocreate-mode, `publication.autocreate.mode`>>
 |_all_tables_

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1498,8 +1498,11 @@ Familiarity with the mechanics and link:https://www.postgresql.org/docs/current/
 endif::product[]
 
 ifdef::community[]
+[[postgresql-in-the-cloud]]
+=== PostgreSQL in the Cloud
+
 [[postgresql-on-amazon-rds]]
-=== PostgreSQL on Amazon RDS
+==== PostgreSQL on Amazon RDS
 
 It is possible to monitor a PostgreSQL database that is running in link:https://aws.amazon.com/rds/[Amazon RDS]. To get it running, you must fulfill the following conditions:
 
@@ -1522,6 +1525,26 @@ As of January 2019, the following PostgreSQL versions on RDS come with an up-to-
 * PostgreSQL 9.6: 9.6.10 and newer
 * PostgreSQL 10: 10.5 and newer
 * PostgreSQL 11: any version
+====
+
+[[postgresql-on-azure]]
+==== PostgreSQL on Azure
+
+It is possible to use Debezium with https://docs.microsoft.com/azure/postgresql/[Azure Database for PostgreSQL] that has support for `wal2json` and `pgoutput` plugins, both of which are supported by Debezium as well.
+
+Set the Azure replication support to `logical`. You can use the https://docs.microsoft.com/en-us/azure/postgresql/concepts-logical#using-azure-cli[Azure CLI] or the https://docs.microsoft.com/en-us/azure/postgresql/concepts-logical#using-azure-portal[Azure Portal] to configure this.
+
+For example, if you were to choose the Azure CLI, here are the https://docs.microsoft.com/cli/azure/postgres/server?view=azure-cli-latest[`az postgres server`] commands which you will need to execute:
+
+```
+az postgres server configuration set --resource-group mygroup --server-name myserver --name azure.replication_support --value logical
+
+az postgres server restart --resource-group mygroup --name myserver
+```
+
+[IMPORTANT]
+====
+While using the `pgoutput` plugin, it is recommended that you configure `filtered` as the {link-prefix}:{link-postgresql-connector}#postgresql-publication-autocreate-mode[`publication.autocreate.mode`]. If you use `all_tables` (which is the default value for `publication.autocreate.mode`) and the publication is not found, the connector will try to create one using `CREATE PUBLICATION <publication_name> FOR ALL TABLES;` which will fail due to lack of permissions.
 ====
 
 [[installing-postgresql-output-plugin]]

--- a/documentation/modules/ROOT/partials/modules/cdc-all-connectors/r_connector-monitoring-streaming-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/cdc-all-connectors/r_connector-monitoring-streaming-metrics.adoc
@@ -32,11 +32,11 @@
 
 |`Connected`
 |`boolean`
-|`Flag that denotes whether the connector is currently connected to the database server.
+|Flag that denotes whether the connector is currently connected to the database server.
 
 |`MilliSecondsBehindSource`
 |`long`
-|`The number of milliseconds between the last change event's timestamp and the connector processing it.
+|The number of milliseconds between the last change event's timestamp and the connector processing it.
 The values will incoporate any differences between the clocks on the machines where the database server and the connector are running.
 
 |`NumberOfCommittedTransactions`


### PR DESCRIPTION
Hey @TovaCohen and @Naros, some clean-up after the PG connector docs overhaul. Most importantly, there was a recent addition related to running the connector with an Azure-managed PG, which got lost during that PR. I've added this back. Otherwise, I agree with what Chris said elsewhere: the new structure of that page is much nicer to follow. Would love to see this being applied consistently for all the connectors.