### PR TITLE
DBZ-2408 Fix build errors with oracle documentation

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -49,3 +49,4 @@ asciidoc:
     link-db2-plugin-snapshot: 'https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.debezium&a=debezium-connector-db2&v=LATEST&c=plugin&e=tar.gz'
     link-cassandra-plugin-snapshot: 'https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=io.debezium&a=debezium-connector-cassandra&v=LATEST&c=plugin&e=tar.gz'
     link-kafka-docs: 'https://kafka.apache.org/documentation'
+    link-java7-standard-names: 'https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#MessageDigest'

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -990,7 +990,7 @@ The *MBean* is `debezium.oracle:type=connector-metrics,context=snapshot,server=_
 The *MBean* is `debezium.oracle:type=connector-metrics,context=streaming,server=_<database.server.name>_`.
 
 [cols="30%a,10%a,60%a",options="header"]
-|====
+|===
 |Attribute Name
 |Type
 |Description


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2408

This PR fixes a 2 mistakes when doing prior backports of commits to the 1.1 branch for the Oracle.  This should resolve the warnings the documentation build gets when pulling in branch 1.1.  