### PR TITLE
DBZ-2375 Hyperlink entries in the mysql metrics tables to facilitate sharing.

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc
@@ -2,35 +2,35 @@
 |===
 |Attributes |Type |Description
 
-|`Status`
+|[[connectors-shist-metric-status]]<<connectors-shist-metric-status, `Status`>>
 |`string`
 |One of `STOPPED`, `RECOVERING` (recovering history from the storage), `RUNNING` describing the state of the database history.
 
-|`RecoveryStartTime`
+|[[connectors-shist-metric-recoverystarttime]]<<connectors-shist-metric-recoverystarttime, `RecoveryStartTime`>>
 |`long`
 |The time in epoch seconds at what recovery has started.
 
-|`ChangesRecovered`
+|[[connectors-shist-metric-changesrecovered]]<<connectors-shist-metric-changesrecovered, `ChangesRecovered`>>
 |`long`
 |The number of changes that were read during recovery phase.
 
-|`ChangesApplied`
+|[[connectors-shist-metric-changesapplied]]<<connectors-shist-metric-changesapplied, `ChangesApplied`>>
 |`long`
 |the total number of schema changes applied during recovery and runtime.
 
-|`MilliSecondsSinceLastRecoveredChange`
+|[[connectors-shist-metric-millisecondssincelastrecoveredchange]]<<connectors-shist-metric-millisecondssincelastrecoveredchange, `MilliSecondsSinceLastRecoveredChange`>>
 |`long`
 |The number of milliseconds that elapsed since the last change was recovered from the history store.
 
-|`MilliSecondsSinceLastAppliedChange`
+|[[connectors-shist-metric-millisecondssincelastappliedchange]]<<connectors-shist-metric-millisecondssincelastappliedchange, `MilliSecondsSinceLastAppliedChange`>>
 |`long`
 |The number of milliseconds that elapsed since the last change was applied.
 
-|`LastRecoveredChange`
+|[[connectors-shist-metric-lastrecoveredchange]]<<connectors-shist-metric-lastrecoveredchange, `LastRecoveredChange`>>
 |`string`
 |The string representation of the last change recovered from the history store.
 
-|`LastAppliedChange`
+|[[connectors-shist-metric-lastappliedchange]]<<connectors-shist-metric-lastappliedchange, `LastAppliedChange`>>
 |`string`
 |The string representation of the last applied change.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
@@ -2,59 +2,59 @@
 |===
 |Attributes |Type |Description
 
-|`LastEvent`
+|[[connectors-snaps-metric-lastevent]]<<connectors-snaps-metric-lastevent, `LastEvent`>>
 |`string`
 |The last snapshot event that the connector has read.
 
-|`MilliSecondsSinceLastEvent`
+|[[connectors-snaps-metric-millisecondssincelastevent]]<<connectors-snaps-metric-millisecondssincelastevent, `MilliSecondsSinceLastEvent`>>
 |`long`
 |The number of milliseconds since the connector has read and processed the most recent event.
 
-|`TotalNumberOfEventsSeen`
+|[[connectors-snaps-metric-totalnumberofeventsseen]]<<connectors-snaps-metric-totalnumberofeventsseen, `TotalNumberOfEventsSeen`>>
 |`long`
 |The total number of events that this connector has seen since last started or reset.
 
-|`NumberOfEventsFiltered`
+|[[connectors-snaps-metric-numberofeventsfiltered]]<<connectors-snaps-metric-numberofeventsfiltered, `NumberOfEventsFiltered`>>
 |`long`
 | The number of events that have been filtered by whitelist or blacklist filtering rules configured on the connector.
 
-|`MonitoredTables`
+|[[connectors-snaps-metric-monitoredtables]]<<connectors-snaps-metric-monitoredtables, `MonitoredTables`>>
 |`string[]`
 |The list of tables that are monitored by the connector.
 
-|`QueueTotalCapacity`
+|[[connectors-snaps-metric-queuetotalcapacity]]<<connectors-snaps-metric-queuetotalcapacity, `QueueTotalCapacity`>>
 |`int`
 |The length the queue used to pass events between the snapshotter and the main Kafka Connect loop.
 
-|`QueueRemainingCapacity`
+|[[connectors-snaps-metric-queueremainingcapacity]]<<connectors-snaps-metric-queueremainingcapacity, `QueueRemainingCapacity`>>
 |`int`
 |The free capacity of the queue used to pass events between the snapshotter and the main Kafka Connect loop.
 
-|`TotalTableCount`
+|[[connectors-snaps-metric-totaltablecount]]<<connectors-snaps-metric-totaltablecount, `TotalTableCount`>>
 |`int`
 |The total number of tables that are being included in the snapshot.
 
-|`RemainingTableCount`
+|[[connectors-snaps-metric-remainingtablecount]]<<connectors-snaps-metric-remainingtablecount, `RemainingTableCount`>>
 |`int`
 |The number of tables that the snapshot has yet to copy.
 
-|`SnapshotRunning`
+|[[connectors-snaps-metric-snapshotrunning]]<<connectors-snaps-metric-snapshotrunning, `SnapshotRunning`>>
 |`boolean`
 |Whether the snapshot was started.
 
-|`SnapshotAborted`
+|[[connectors-snaps-metric-snapshotaborted]]<<connectors-snaps-metric-snapshotaborted, `SnapshotAborted`>>
 |`boolean`
 |Whether the snapshot was aborted.
 
-|`SnapshotCompleted`
+|[[connectors-snaps-metric-snapshotcompleted]]<<connectors-snaps-metric-snapshotcompleted, `SnapshotCompleted`>>
 |`boolean`
 |Whether the snapshot completed.
 
-|`SnapshotDurationInSeconds`
+|[[connectors-snaps-metric-snapshotdurationinseconds]]<<connectors-snaps-metric-snapshotdurationinseconds, `SnapshotDurationInSeconds`>>
 |`long`
 |The total number of seconds that the snapshot has taken so far, even if not complete.
 
-|`RowsScanned`
+|[[connectors-snaps-metric-rowsscanned]]<<connectors-snaps-metric-rowsscanned, `RowsScanned`>>
 |`Map<String, Long>`
 |Map containing the number of rows scanned for each table in the snapshot.
 Tables are incrementally added to the Map during processing.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc
@@ -2,52 +2,52 @@
 |===
 |Attributes |Type |Description
 
-|`LastEvent`
+|[[connectors-strm-metric-lastevent]]<<connectors-strm-metric-lastevent, `LastEvent`>>
 |`string`
 |The last streaming event that the connector has read.
 
-|`MilliSecondsSinceLastEvent`
+|[[connectors-strm-metric-millisecondssincelastevent]]<<connectors-strm-metric-millisecondssincelastevent, `MilliSecondsSinceLastEvent`>>
 |`long`
 |The number of milliseconds since the connector has read and processed the most recent event.
 
-|`TotalNumberOfEventsSeen`
+|[[connectors-strm-metric-totalnumberofeventsseen]]<<connectors-strm-metric-totalnumberofeventsseen, `TotalNumberOfEventsSeen`>>
 |`long`
 |The total number of events that this connector has seen since last started or reset.
 
-|`NumberOfEventsFiltered`
+|[[connectors-strm-metric-numberofeventsfiltered]]<<connectors-strm-metric-numberofeventsfiltered, `NumberOfEventsFiltered`>>
 |`long`
 |The number of events that have been filtered by whitelist or blacklist filtering rules configured on the connector.
 
-|`MonitoredTables`
+|[[connectors-strm-metric-monitoredtables]]<<connectors-strm-metric-monitoredtables, `MonitoredTables`>>
 |`string[]`
 |The list of tables that are monitored by the connector.
 
-|`QueueTotalCapacity`
+|[[connectors-strm-metric-queuetotalcapacity]]<<connectors-strm-metric-queuetotalcapacity, `QueueTotalCapacity`>>
 |`int`
 |The length the queue used to pass events between the streamer and the main Kafka Connect loop.
 
-|`QueueRemainingCapacity`
+|[[connectors-strm-metric-queueremainingcapacity]]<<connectors-strm-metric-queueremainingcapacity, `QueueRemainingCapacity`>>
 |`int`
 |The free capacity of the queue used to pass events between the streamer and the main Kafka Connect loop.
 
-|`Connected`
+|[[connectors-strm-metric-connected]]<<connectors-strm-metric-connected, `Connected`>>
 |`boolean`
 |Flag that denotes whether the connector is currently connected to the database server.
 
-|`MilliSecondsBehindSource`
+|[[connectors-strm-metric-millisecondsbehindsource]]<<connectors-strm-metric-millisecondsbehindsource, `MilliSecondsBehindSource`>>
 |`long`
 |The number of milliseconds between the last change event's timestamp and the connector processing it.
 The values will incoporate any differences between the clocks on the machines where the database server and the connector are running.
 
-|`NumberOfCommittedTransactions`
+|[[connectors-strm-metric-numberofcommittedtransactions]]<<connectors-strm-metric-numberofcommittedtransactions, `NumberOfCommittedTransactions`>>
 |`long`
 |The number of processed transactions that were committed.
 
-|`SourceEventPosition`
+|[[connectors-strm-metric-sourceeventposition]]<<connectors-strm-metric-sourceeventposition, `SourceEventPosition`>>
 |`Map<String, String>`
 |The coordinates of the last received event.
 
-|`LastTransactionId`
+|[[connectors-strm-metric-lasttransactionid]]<<connectors-strm-metric-lasttransactionid, `LastTransactionId`>>
 |`string`
 |Transaction identifier of the last processed transaction.
 

--- a/documentation/modules/ROOT/partials/modules/mysql-connector/ref-mysql-connector-monitoring-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/mysql-connector/ref-mysql-connector-monitoring-metrics.adoc
@@ -47,39 +47,39 @@ The {prodname} MySQL connector also provides the following custom binlog metrics
 |===
 |Attribute |Type |Description
 
-|`BinlogFilename`
+|[[mysql-metric-binlogfilename]]<<mysql-metric-binlogfilename, `BinlogFilename`>>
 |`string`
 |The name of the binlog filename that the connector has most recently read.
 
-|`BinlogPosition`
+|[[mysql-metric-binlogposition]]<<mysql-metric-binlogposition, `BinlogPosition`>>
 |`long`
 |The most recent position (in bytes) within the binlog that the connector has read.
 
-|`IsGtidModeEnabled`
+|[[mysql-metric-isgtidmodeenabled]]<<mysql-metric-isgtidmodeenabled, `IsGtidModeEnabled`>>
 |`boolean`
 |Flag that denotes whether the connector is currently tracking GTIDs from MySQL server.
 
-|`GtidSet`
+|[[mysql-metric-gtidset]]<<mysql-metric-gtidset, `GtidSet`>>
 |`string`
 |The string representation of the most recent GTID set seen by the connector when reading the binlog.
 
-|`NumberOfSkippedEvents`
+|[[mysql-metric-numberofskippedevents]]<<mysql-metric-numberofskippedevents, `NumberOfSkippedEvents`>>
 |`long`
 |The number of events that have been skipped by the MySQL connector.  Typically events are skipped due to a malformed or unparseable event from MySQL's binlog.
 
-|`NumberOfDisconnects`
+|[[mysql-metric-numberofdisconnects]]<<mysql-metric-numberofdisconnects, `NumberOfDisconnects`>>
 |`long`
 |The number of disconnects by the MySQL connector.
 
-|`NumberOfRolledBackTransactions`
+|[[mysql-metric-numberofrolledbacktransactions]]<<mysql-metric-numberofrolledbacktransactions, `NumberOfRolledBackTransactions`>>
 |`long`
 |The number of processed transactions that were rolled back and not streamed.
 
-|`NumberOfNotWellFormedTransactions`
+|[[mysql-metric-numberofnotwellformedtransactions]]<<mysql-metric-numberofnotwellformedtransactions, `NumberOfNotWellFormedTransactions`>>
 |`long`
 |The number of transactions that have not conformed to expected protocol `BEGIN` + `COMMIT`/`ROLLBACK`. Should be `0` under normal conditions.
 
-|`NumberOfLargeTransactions`
+|[[mysql-metric-numberoflargetransactions]]<<mysql-metric-numberoflargetransactions, `NumberOfLargeTransactions`>>
 |`long`
 |The number of transactions that have not fitted into the look-ahead buffer. Should be significantly smaller than `NumberOfCommittedTransactions` and `NumberOfRolledBackTransactions` for optimal performance.
 


### PR DESCRIPTION
DBZ-2375 Add links to entries in the mySQL metrics tables so that developers can share the anchor urls when responding to questions about the various metrics.