### PR TITLE
DBZ-2476 Fix exclude.list and include.list link rendering in property tables

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -803,22 +803,26 @@ Only alphanumeric characters and underscores should be used.
 |`false`
 |When SSL is enabled this setting controls whether strict hostname checking is disabled during connection phase. If `true` the connection will not prevent man-in-the-middle attacks.
 
-|[[mongodb-property-database-whitelist]]<<mongodb-property-database-whitelist [[mongodb-property-database-include-list]]<<mongodb-property-database-include-list , `database.include.list`>>
+|[[mongodb-property-database-whitelist]]
+[[mongodb-property-database-include-list]]<<mongodb-property-database-include-list , `database.include.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match database names to be monitored; any database name not included in `database.include.list` is excluded from monitoring. By default all databases are monitored.
 Must not be used with `database.exclude.list`.
 
-|[[mongodb-property-database-blacklist]]<<mongodb-property-database-blacklist [[mongodb-property-database-exclude-list]]<<mongodb-property-database-exclude-list, `database.exclude.list`>>
+|[[mongodb-property-database-blacklist]]
+[[mongodb-property-database-exclude-list]]<<mongodb-property-database-exclude-list, `database.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match database names to be excluded from monitoring; any database name not included in `database.exclude.list` is monitored.
 Must not be used with `database.include.list`.
 
-|[[mongodb-property-collection-whitelist]]<<mongodb-property-collection-whitelist [[mongodb-property-collection-include-list]]<<mongodb-property-collection-include-list, `collection.include.list`>>
+|[[mongodb-property-collection-whitelist]]
+[[mongodb-property-collection-include-list]]<<mongodb-property-collection-include-list, `collection.include.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified namespaces for MongoDB collections to be monitored; any collection not included in `collection.include.list` is excluded from monitoring. Each identifier is of the form _databaseName_._collectionName_. By default the connector will monitor all collections except those in the `local` and `admin` databases.
 Must not be used with `collection.exclude.list`.
 
-|[[mongodb-property-collection-blacklist]]<<mongodb-property-collection-blacklist [[mongodb-property-collection-exclude-list]]<<mongodb-property-collection-exclude-list , `collection.exclude.list`>>
+|[[mongodb-property-collection-blacklist]]
+[[mongodb-property-collection-exclude-list]]<<mongodb-property-collection-exclude-list , `collection.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified namespaces for MongoDB collections to be excluded from monitoring; any collection not included in `collection.exclude.list` is monitored. Each identifier is of the form _databaseName_._collectionName_.
 Must not be used with `collection.include.list`.
@@ -827,7 +831,8 @@ Must not be used with `collection.include.list`.
 |`initial`
 |Specifies the criteria for running a snapshot upon startup of the connector. The default is *initial*, and specifies the connector reads a snapshot when either no offset is found or if the oplog no longer contains the previous offset. The *never* option specifies that the connector should never use snapshots, instead the connector should proceed to tail the log.
 
-|[[mongodb-property-field-blacklist]]<<mongodb-property-field-blacklist [[mongodb-property-field-exclude-list]]<<mongodb-property-field-exclude-list, `field.exclude.list`>>
+|[[mongodb-property-field-blacklist]]
+[[mongodb-property-field-exclude-list]]<<mongodb-property-field-exclude-list, `field.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of the fully-qualified names of fields that should be excluded from change event message values. Fully-qualified names for fields are of the form _databaseName_._collectionName_._fieldName_._nestedFieldName_, where _databaseName_ and _collectionName_ may contain the wildcard (*) which matches any characters.
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -96,9 +96,9 @@ Details are in the following topics:
 
 * xref:how-debezium-postgresql-connectors-perform-database-snapshots[]
 * xref:how-debezium-postgresql-connectors-stream-change-event-records[]
-* xref:default-names-of-kafka-topics-that-receive-debezium-change-event-records[]
-* xref:metadata-in-debezium-change-event-records[]
-* xref:debezium-connector-generated-events-that-represent-transaction-boundaries[]
+* xref:default-names-of-kafka-topics-that-receive-debezium-postgresql-change-event-records[]
+* xref:metadata-in-debezium-postgresql-change-event-records[]
+* xref:debezium-postgresql-connector-generated-events-that-represent-transaction-boundaries[]
 
 endif::product[]
 
@@ -284,8 +284,8 @@ This is particularly valuable for environments where installation of plug-ins is
 See {link-prefix}:{link-postgresql-connector}#setting-up-postgresql[Setting up PostgreSQL] for more details.
 
 // Type: concept
-// ModuleID: default-names-of-kafka-topics-that-receive-debezium-change-event-records
-// Title: Default names of Kafka topics that receive {prodname} change event records
+// ModuleID: default-names-of-kafka-topics-that-receive-debezium-postgresql-change-event-records
+// Title: Default names of Kafka topics that receive {prodname} PostgreSQL change event records
 [[postgresql-topic-names]]
 === Topics names
 
@@ -310,8 +310,8 @@ Now suppose that the tables are not part of a specific schema but were created i
 * `fulfillment.public.orders`
 
 // Type: concept
-// ModuleID: metadata-in-debezium-change-event-records
-// Title: Metadata in {prodname} change event records
+// ModuleID: metadata-in-debezium-postgresql-change-event-records
+// Title: Metadata in {prodname} PostgreSQL change event records
 [[postgresql-meta-information]]
 === Meta information
 
@@ -340,19 +340,19 @@ In addition to a {link-prefix}:{link-postgresql-connector}#postgresql-events[_da
 * `kafkaPartition` with a setting of `null` means that the connector does not use a specific Kafka partition. The PostgreSQL connector uses only one Kafka Connect partition and it places the generated events into one Kafka partition. 
 
 // Type: concept
-// ModuleID: debezium-connector-generated-events-that-represent-transaction-boundaries
-// Title: {prodname} connector-generated events that represent transaction boundaries
+// ModuleID: debezium-postgresql-connector-generated-events-that-represent-transaction-boundaries
+// Title: {prodname} PostgreSQL connector-generated events that represent transaction boundaries
 [[postgresql-transaction-metadata]]
 === Transaction metadata
 
-{prodname} can generate events that represent transaction boundaries and that enrich change data event messages. For every transaction `BEGIN` and `END`, {prodname} generates tan event that contains: 
+{prodname} can generate events that represent transaction boundaries and that enrich data change event messages. For every transaction `BEGIN` and `END`, {prodname} generates an event that contains the following fields: 
 
 * `status` - `BEGIN` or `END`
 * `id` - string representation of unique transaction identifier
 * `event_count` (for `END` events) - total number of events emitted by the transaction
 * `data_collections` (for `END` events) - an array of pairs of `data_collection` and `event_count` that provides the number of events emitted by changes originating from given data collection
 
-.Examples
+.Example
 
 [source,json,indent=0,subs="attributes"]
 ----
@@ -420,7 +420,11 @@ Following is an example of a message:
 [[postgresql-events]]
 == Data change events
 
-Each data change event produced by the PostgreSQL connector has a key and a value. The structure of the key and value depends on the table from which the change event originates. The default behavior is that the connector streams change event records to {link-prefix}:{link-postgresql-connector}#postgresql-topic-names[topic names] that are the same as the event's originating table.
+Each data change event produced by the {prodname} PostgreSQL connector contains a key and a value. The structure of the event key and event value depends on the table from which the change event originates. 
+
+{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To make it easier, Kafka Connect makes each event self-contained. Each event key and each event value has two parts: a _schema_ and a _payload_. In each part, the schema describes the structure of its payload, while the payload contains the actual data.
+
+By default behavior is that the connector streams change event records to {link-prefix}:{link-postgresql-connector}#postgresql-topic-names[topics with names that are the same as the event's originating table].
 
 [NOTE]
 ====
@@ -429,36 +433,35 @@ Starting with Kafka 0.10, Kafka can optionally record the event key and value wi
 
 [WARNING]
 ====
-The PostgreSQL connector ensures that all Kafka Connect _schema names_ are http://avro.apache.org/docs/current/spec.html#names[valid Avro schema names]. This means that the logical server name must start with a Latin letter or an underscore, that is, a-z, A-Z, or \_. Each remaining character in the logical server name and each character in the schema and table names must be a Latin letter, a digit, or an underscore, that is, a-z, A-Z, 0-9, or \_. If there is an invalid character it is replaced with an underscore character.
+The PostgreSQL connector ensures that all Kafka Connect schema names adhere to the http://avro.apache.org/docs/current/spec.html#names[Avro schema name format]. This means that the logical server name must start with a Latin letter or an underscore, that is, a-z, A-Z, or \_. Each remaining character in the logical server name and each character in the schema and table names must be a Latin letter, a digit, or an underscore, that is, a-z, A-Z, 0-9, or \_. If there is an invalid character it is replaced with an underscore character.
 
-This can lead to unexpected conflicts if the logical server name, a schema name, or a table name contains invalid characters, and the only characters that  distinguish names from one another are invalid and thus replaced with underscores.
+This can lead to unexpected conflicts if the logical server name, a schema name, or a table name contains invalid characters, and the only characters that distinguish names from one another are invalid and thus replaced with underscores.
 ====
-
-{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To make it easier, Kafka Connect makes each event self-contained. Each message key and each message value has two parts: a _schema_ and a _payload_. The schema describes the structure of the payload, while the payload contains the actual data.
 
 ifdef::product[]
 Details are in the following topics:
 
-* xref:about-keys-in-debezium-change-events[]
-* xref:about-values-in-debezium-change-events[]
+* xref:about-keys-in-debezium-postgresql-change-events[]
+* xref:about-values-in-debezium-postgresql-change-events[]
 * xref:how-replica-identity-controls-data-that-can-be-in-debezium-change-events[]
-* xref:about-debezium-change-events-for-operations-that-create-content[]
-* xref:about-debezium-change-events-for-operations-that-update-content[]
-* xref:about-debezium-change-events-for-primary-key-updates[]
-* xref:about-debezium-change-events-for-operations-that-delete-content[]
+* xref:about-debezium-postgresql-change-events-for-operations-that-create-content[]
+* xref:about-debezium-postgresql-change-events-for-operations-that-update-content[]
+* xref:about-debezium-postgresql-change-events-for-primary-key-updates[]
+* xref:about-debezium-postgresql-change-events-for-operations-that-delete-content[]
 
 endif::product[]
 
 // Type: concept
-// ModuleID: about-keys-in-debezium-change-events
-// Title: About keys in {prodname} change events
+// ModuleID: about-keys-in-debezium-postgresql-change-events
+// Title: About keys in {prodname} PostgreSQL change events
 [[postgresql-change-events-key]]
 === Change event keys
 
 For a given table, the change event's key has a structure that contains a field for each column in the primary key of the table at the time the event was created. Alternatively, if the table has `REPLICA IDENTITY` set to `FULL` or `USING INDEX` there is a field for each unique key constraint. 
 
-Consider a `customers` table defined in the `public` database schema:
+Consider a `customers` table defined in the `public` database schema and the example of a change event key for that table.
 
+.Example table
 [source,sql,indent=0]
 ----
 CREATE TABLE customers (
@@ -470,16 +473,18 @@ CREATE TABLE customers (
 );
 ----
 
-If the `database.server.name` configuration property has the value `PostgreSQL_server`, every change event for the `customers` table while it has this definition has the same key structure, which in JSON looks like this:
+=====
+.Example change event key
+If the `database.server.name` connector configuration property has the value `PostgreSQL_server`, every change event for the `customers` table while it has this definition has the same key structure, which in JSON looks like this:
 
 [source,json,indent=0]
 ----
   {
-    "schema": {
+    "schema": { <1>
       "type": "struct",
-      "name": "PostgreSQL_server.public.customers.Key",
-      "optional": false,
-      "fields": [
+      "name": "PostgreSQL_server.public.customers.Key", <2>
+      "optional": false, <3>
+      "fields": [ <4>
             {
                 "name": "id",
                 "index": "0",
@@ -490,15 +495,19 @@ If the `database.server.name` configuration property has the value `PostgreSQL_s
             }
         ]
     },
-    "payload": {
+    "payload": { <5>
         "id": "1"
     },
   }
 ----
+<1> The `schema` portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion. 
+<2> The `PostgreSQL_server.public.customers.Key` schema defines the structure of the key's payload. 
+<3> The key's `payload` value is not optional.
+<4> Specifies the type of fields expected in the `payload`. 
+<5> The payload itself, which in this case contains a single `id` field.
 
-The `schema` portion of the key contains a Kafka Connect schema that describes what is in the key's `payload` portion. In this case, it means that the `payload` value is not optional, is a structure defined by a schema named `PostgreSQL_server.public.customers.Key`, and has one required field named `id` of type `INT32`. If you look at the value of the key's `payload` field, you see that it is indeed a structure, which in JSON is just an object, with a single `id` field, whose value is `1`.
-
-This key describes output from the connector named `PostgreSQL_server`,  for the row in the `public.customers` table, whose primary key, the `id` column, had a value of `1`.
+This key describes output from the connector named `PostgreSQL_server`. The output is for the `public.customers` table row whose primary key, the `id` column, has a value of `1`.
+=====
 
 [NOTE]
 ====
@@ -511,12 +520,12 @@ If the table does not have a primary or unique key, then the change event's key 
 ====
 
 // Type: concept
-// ModuleID: about-values-in-debezium-change-events
-// Title: About values in {prodname} change events
+// ModuleID: about-values-in-debezium-postgresql-change-events
+// Title: About values in {prodname} PostgreSQL change events
 [[postgresql-change-events-value]]
 === Change event values
 
-The value in a change event record is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains a schema that describes the `Envelope` structure of the `payload` section, including its nested fields. The `payload` section has the following nested fields:  
+The value in a change event record is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. The `payload` section has the following nested fields:  
 
 * `before` is an optional field. If present, it contains the state of the row _before_ the event occurred. The structure of the `before` field is described by a Kafka Connect `Value` schema. For example, for each row operation in the `public.customers` table, the connector uses the `PostgreSQL_server.public.customers.Value` schema to provide the content of the `before` field.
 
@@ -544,8 +553,8 @@ Whether or not this field is available is dependent on the {link-prefix}:{link-p
 * `ts_ms` is an optional field. If present, it contains the time at which the connector processed the event. This value reflects the system clock in the JVM running the Kafka Connect task. 
 
 // Type: concept
-// ModuleID: how-replica-identity-controls-data-that-can-be-in-debezium-change-events
-// Title: How `REPLICA IDENTITY` controls data that can be in {prodname}change events
+// ModuleID: how-replica-identity-controls-data-that-can-be-in-debezium-postgresql-change-events
+// Title: How `REPLICA IDENTITY` controls data that can be in {prodname} PostgreSQL change events
 [[postgresql-replica-identity]]
 === Replica identity
 
@@ -561,8 +570,8 @@ If a table does not have a primary key, the connector does not emit `UPDATE` or 
 * `INDEX` _index-name_ - Emitted events for `UPDATE` and `DELETE` operations contain the previous values of the columns contained in the specified index. `UPDATE` events also contain the indexed columns with the updated values.
 
 // Type: concept
-// ModuleID: about-debezium-change-events-for-operations-that-create-content
-// Title: About {prodname} change events for operations that create content
+// ModuleID: about-debezium-postgresql-change-events-for-operations-that-create-content
+// Title: About {prodname} PostgreSQL change events for operations that create content
 [[postgresql-create-events]]
 === _create_ events
 
@@ -757,8 +766,8 @@ It is possible and even recommended that you use the Avro converter to dramatica
 ====
 
 // Type: concept
-// ModuleID: about-debezium-change-events-for-operations-that-update-content
-// Title: About {prodname} change events for operations that update content
+// ModuleID: about-debezium-postgresql-change-events-for-operations-that-update-content
+// Title: About {prodname} PostgreSQL change events for operations that update content
 [[postgresql-update-events]]
 === _update_ events
 
@@ -818,8 +827,8 @@ Updating the columns for a row's primary/unique key changes the value of the row
 ====
 
 // Type: concept
-// ModuleID: about-debezium-change-events-for-primary-key-updates
-// Title: About {prodname} change events for primary key updates
+// ModuleID: about-debezium-postgresql-change-events-for-primary-key-updates
+// Title: About {prodname} PostgreSQL change events for primary key updates
 === Primary key updates
 
 An `UPDATE` operation that changes a row's primary key field(s) is known
@@ -830,8 +839,8 @@ as a primary key change. For a primary key change, in place of sending an `UPDAT
 * The `CREATE` event record has `__debezium.oldkey` as a message header. The value of this header is the previous (old) primary key that the updated row had.
 
 // Type: concept
-// ModuleID: about-debezium-change-events-for-operations-that-delete-content
-// Title: About {prodname} change events for operations that delete content
+// ModuleID: about-debezium-postgresql-change-events-for-operations-that-delete-content
+// Title: About {prodname} PostgreSQL change events for operations that delete content
 [[postgresql-delete-events]]
 === _delete_ events
 
@@ -880,7 +889,7 @@ This event gives a consumer all kinds of information that it can use to process 
 For a consumer to be able to process a _delete_ event generated for a table that does not have a primary key, set the table's `REPLICA IDENTITY` to `FULL`. When a table does not have a primary key and the table's `REPLICA IDENTITY` is set to `DEFAULT` or `NOTHING`, a _delete_ event has no `before` field.
 ====
 
-PostgreSQL connector events are designed to work with link:https://kafka.apache.org/documentation/#compaction[Kafka log compaction]. Log compaction enables removal of some older messages as long as at least the most recent message for every key is kept. This lets Kafka reclaim storage space while ensuring that the topic contains a complete data set an can be used for reloading key-based state.
+PostgreSQL connector events are designed to work with link:https://kafka.apache.org/documentation/#compaction[Kafka log compaction]. Log compaction enables removal of some older messages as long as at least the most recent message for every key is kept. This lets Kafka reclaim storage space while ensuring that the topic contains a complete data set and can be used for reloading key-based state.
 
 [[postgresql-tombstone-events]]
 .Tombstone events
@@ -892,7 +901,7 @@ When a row is deleted, the _delete_ event value still works with log compaction,
 [[postgresql-data-types]]
 == Data type mappings
 
-The PostgreSQL connector represents changes to rows with events that are structured like the table in which the row exist. The event contains a field for each column value. How that value is represented in the event depends on the PostgreSQL data type of the column. This section describes these mappings.
+The PostgreSQL connector represents changes to rows with events that are structured like the table in which the row exists. The event contains a field for each column value. How that value is represented in the event depends on the PostgreSQL data type of the column. This section describes these mappings.
 
 ifdef::product[]
 Details are in the following sections: 
@@ -921,7 +930,7 @@ The following table describes how the connector maps basic PostgreSQL data types
 .Mappings for PostgreSQL basic data types
 [cols="20%a,15%a,30%a,35%a",options="header"]
 |===
-|PostgreSQL Data Type
+|PostgreSQL data type
 |Literal type (schema type)
 |Semantic type (schema name)
 |Notes
@@ -1095,18 +1104,18 @@ The following table describes how the connector maps basic PostgreSQL data types
 
 Other than PostgreSQL's `TIMESTAMPTZ` and `TIMETZ` data types, which contain time zone information, how temporal types are mapped depends on the value of the `time.precision.mode` connector configuration property. The following sections describe these mappings: 
 
-* xref:time-precision-mode-adaptive[`time.precision.mode=adaptive`]
-* xref:time-precision-mode-adaptive-time-microseconds[`time.precision.mode=adaptive_time_microseconds`]
-* xref:time-precision-mode-connect[`time.precision.mode=connect`]
+* xref:postgresql-time-precision-mode-adaptive[`time.precision.mode=adaptive`]
+* xref:postgresql-time-precision-mode-adaptive-time-microseconds[`time.precision.mode=adaptive_time_microseconds`]
+* xref:postgresql-time-precision-mode-connect[`time.precision.mode=connect`]
 
-[[time-precision-mode-adaptive]]
+[[postgresql-time-precision-mode-adaptive]]
 .`time.precision.mode=adaptive`
 When the `time.precision.mode` property is set to `adaptive`, the default, the connector determines the literal type and semantic type based on the column's data type definition. This ensures that events _exactly_ represent the values in the database. 
 
 .Mappings when `time.precision.mode` is `adaptive`
 [cols="20%a,15%a,30%a,35%a",options="header"]
 |===
-|PostgreSQL Data Type
+|PostgreSQL data type
 |Literal type (schema type)
 |Semantic type (schema name)
 |Notes
@@ -1114,31 +1123,31 @@ When the `time.precision.mode` property is set to `adaptive`, the default, the c
 |`DATE`
 |`INT32`
 |`io.debezium.time.Date`
-| Represents the number of days since epoch.
+|Represents the number of days since the epoch.
 
 |`TIME(1)`, `TIME(2)`, `TIME(3)`
 |`INT32`
 |`io.debezium.time.Time`
-| Represents the number of milliseconds past midnight, and does not include timezone information.
+|Represents the number of milliseconds past midnight, and does not include timezone information.
 
 |`TIME(4)`, `TIME(5)`, `TIME(6)`
 |`INT64`
 |`io.debezium.time.MicroTime`
-| Represents the number of microseconds past midnight, and does not include timezone information.
+|Represents the number of microseconds past midnight, and does not include timezone information.
 
 |`TIMESTAMP(1)`, `TIMESTAMP(2)`, `TIMESTAMP(3)`
 |`INT64`
 |`io.debezium.time.Timestamp`
-| Represents the number of milliseconds since the epoch, and does not include timezone information.
+|Represents the number of milliseconds since the epoch, and does not include timezone information.
 
 |`TIMESTAMP(4)`, `TIMESTAMP(5)`, `TIMESTAMP(6)`, `TIMESTAMP`
 |`INT64`
 |`io.debezium.time.MicroTimestamp`
-| Represents the number of microseconds since the epoch, and does not include timezone information.
+|Represents the number of microseconds since the epoch, and does not include timezone information.
 
 |===
 
-[[time-precision-mode-adaptive-time-microseconds]]
+[[postgresql-time-precision-mode-adaptive-time-microseconds]]
 .`time.precision.mode=adaptive_time_microseconds`
 When the `time.precision.mode` configuration property is set to `adaptive_time_microseconds`, the connector determines the literal type and semantic type for temporal types based on the column's data type definition. This ensures that events _exactly_ represent the values in the database, except all `TIME` fields are captured as microseconds.
 
@@ -1153,33 +1162,33 @@ When the `time.precision.mode` configuration property is set to `adaptive_time_m
 |`DATE`
 |`INT32`
 |`io.debezium.time.Date`
-| Represents the number of days since epoch.
+|Represents the number of days since epoch.
 
 |`TIME([P])`
 |`INT64`
 |`io.debezium.time.MicroTime`
-| Represents the time value in microseconds and does not include timezone information. PostgreSQL allows precision `P` to be in the range 0-6 to store up to microsecond precision.
+|Represents the time value in microseconds and does not include timezone information. PostgreSQL allows precision `P` to be in the range 0-6 to store up to microsecond precision.
 
 |`TIMESTAMP(1)` , `TIMESTAMP(2)`, `TIMESTAMP(3)`
 |`INT64`
 |`io.debezium.time.Timestamp`
-| Represents the number of milliseconds past epoch, and does not include timezone information.
+|Represents the number of milliseconds past epoch, and does not include timezone information.
 
 |`TIMESTAMP(4)` , `TIMESTAMP(5)`, `TIMESTAMP(6)`, `TIMESTAMP`
 |`INT64`
 |`io.debezium.time.MicroTimestamp`
-| Represents the number of microseconds past epoch, and does not include timezone information.
+|Represents the number of microseconds past epoch, and does not include timezone information.
 
 |===
 
-[[time-precision-mode-connect]]
+[[postgresql-time-precision-mode-connect]]
 .`time.precision.mode=connect`
-When the `time.precision.mode` configuration property is set to `connect`, the connector uses Kafka Connect logical types. This may be useful when consumers know about only the built-in Kafka Connect logical types and are unable to handle variable-precision time values. However, since PostgreSQL supports microsecond precision, the events generated by a connector with the `connect` time precision mode *results in a loss of precision* when the database column has a _fractional second precision_ value that is greater than 3.
+When the `time.precision.mode` configuration property is set to `connect`, the connector uses Kafka Connect logical types. This may be useful when consumers can handle only the built-in Kafka Connect logical types and are unable to handle variable-precision time values. However, since PostgreSQL supports microsecond precision, the events generated by a connector with the `connect` time precision mode *results in a loss of precision* when the database column has a _fractional second precision_ value that is greater than 3.
 
 .Mappings when `time.precision.mode` is `connect`
 [cols="20%a,15%a,30%a,35%a",options="header"]
 |===
-|PostgreSQL Data Type
+|PostgreSQL data type
 |Literal type (schema type)
 |Semantic type (schema name)
 |Notes
@@ -1187,17 +1196,17 @@ When the `time.precision.mode` configuration property is set to `connect`, the c
 |`DATE`
 |`INT32`
 |`org.apache.kafka.connect.data.Date`
-| Represents the number of days since epoch.
+|Represents the number of days since epoch.
 
 |`TIME([P])`
 |`INT64`
 |`org.apache.kafka.connect.data.Time`
-| Represents the number of milliseconds since midnight, and does not include timezone information. PostgreSQL allows `P` to be in the range 0-6 to store up to microsecond precision, though this mode results in a loss of precision when `P` > 3.
+|Represents the number of milliseconds since midnight, and does not include timezone information. PostgreSQL allows `P` to be in the range 0-6 to store up to microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
 
 |`TIMESTAMP([P])`
 |`INT64`
 |`org.apache.kafka.connect.data.Timestamp`
-| Represents the number of milliseconds since epoch, and does not include timezone information. PostgreSQL allows `P` to be in the range 0-6 to store up to microsecond precision, though this mode results in a loss of precision when `P` > 3.
+|Represents the number of milliseconds since the epoch, and does not include timezone information. PostgreSQL allows `P` to be in the range 0-6 to store up to microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
 
 |===
 
@@ -1205,11 +1214,9 @@ When the `time.precision.mode` configuration property is set to `connect`, the c
 === `TIMESTAMP` type
 
 The `TIMESTAMP` type represents a timestamp without time zone information.
-Such columns are converted into an equivalent Kafka Connect value based on UTC.
-So for instance the `TIMESTAMP` value "2018-06-20 15:13:16.945104" will be represented by a `io.debezium.time.MicroTimestamp` with the value "1529507596945104"
-(assuming `time.precision.mode` is not set to `connect`).
+Such columns are converted into an equivalent Kafka Connect value based on UTC. For example, the `TIMESTAMP` value "2018-06-20 15:13:16.945104" is represented by an `io.debezium.time.MicroTimestamp` with the value "1529507596945104" when `time.precision.mode` is not set to `connect`.
 
-Note that the timezone of the JVM running Kafka Connect and {prodname} does not affect this conversion.
+The timezone of the JVM running Kafka Connect and {prodname} does not affect this conversion.
 
 [id="postgresql-decimal-types"]
 === Decimal types
@@ -1221,7 +1228,7 @@ When the `decimal.handling.mode` property is set to `precise`, the connector use
 .Mappings when `decimal.handling.mode` is `precise`
 [cols="15%a,15%a,35%a,35%a",options="header"]
 |===
-|PostgreSQL Data Type
+|PostgreSQL data type
 |Literal type (schema type)
 |Semantic type (schema name)
 |Notes
@@ -1229,12 +1236,12 @@ When the `decimal.handling.mode` property is set to `precise`, the connector use
 |`NUMERIC[(M[,D])]`
 |`BYTES`
 |`org.apache.kafka.connect.data.Decimal`
-|The `scaled` schema parameter contains an integer representing how many digits the decimal point was shifted.
+|The `scale` schema parameter contains an integer representing how many digits the decimal point was shifted.
 
 |`DECIMAL[(M[,D])]`
 |`BYTES`
 |`org.apache.kafka.connect.data.Decimal`
-|The `scaled` schema parameter contains an integer representing how many digits the decimal point was shifted.
+|The `scale` schema parameter contains an integer representing how many digits the decimal point was shifted.
 
 |===
 
@@ -1244,7 +1251,7 @@ When the `NUMERIC` or `DECIMAL` types are used without scale constraints, the va
 .Mappings of decimal types when there are no scale constraints
 [cols="15%a,15%a,35%a,35%a",options="header"]
 |===
-|PostgreSQL Data Type
+|PostgreSQL data type
 |Literal type (schema type)
 |Semantic type (schema name)
 |Notes
@@ -1266,7 +1273,7 @@ When the `decimal.handling.mode` property is set to `double`, the connector repr
 .Mappings when `decimal.handling.mode` is `double`
 [cols="15%a,15%a,35%a,35%a",options="header"]
 |===
-|PostgreSQL Data Type
+|PostgreSQL data type
 |Literal type (schema type)
 |Semantic type (schema name)
 |Notes
@@ -1288,7 +1295,7 @@ The last possible setting for the `decimal.handling.mode` configuration property
 .Mappings when `decimal.handling.mode` is `string`
 [cols="15%a,15%a,35%a,35%a",options="header"]
 |===
-|PostgreSQL Data Type
+|PostgreSQL data type
 |Literal type (schema type)
 |Semantic type (schema name)
 |Notes
@@ -1315,7 +1322,7 @@ When the `hstore.handling.mode` connector configuration property is set to `json
 .Mappings for `HSTORE` data type
 [cols="15%a,15%a,35%a,35%a",options="header"]
 |===
-|PostgreSQL Data Type
+|PostgreSQL data type
 |Literal type (schema type)
 |Semantic type (schema name)
 |Notes
@@ -1352,7 +1359,7 @@ PostgreSQL has data types that can store IPv4, IPv6, and MAC addresses. It is be
 .Mappings for network address types
 [cols="15%a,15%a,35%a,35%a",options="header"]
 |===
-|PostgreSQL Data Type
+|PostgreSQL data type
 |Literal type (schema type)
 |Semantic type (schema name)
 |Notes
@@ -1387,7 +1394,7 @@ The PostgreSQL connector supports all link:http://postgis.net[PostGIS data types
 .Mappings of PostGIS data types
 [cols="20%a,15%a,30%a,35%a",options="header"]
 |===
-|PostGIS Data Type
+|PostGIS data type
 |Literal type (schema type)
 |Semantic type (schema name)
 |Notes
@@ -1732,9 +1739,9 @@ endif::community[]
 == Deployment
 
 ifdef::community[]
-With link:https://zookeeper.apache.org[Zookeeper], link:http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect] installed, the remaining tasks to deploy a {prodname} PostgreSQL connector are to download the link: https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/{debezium-version}/debezium-connector-postgres-{debezium-version}-plugin.tar.gz[connector's plug-in archive], extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`]. You then need to restart your Kafka Connect process to pick up the new JAR files.
+With link:https://zookeeper.apache.org[Zookeeper], link:http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect] installed, the remaining tasks to deploy a {prodname} PostgreSQL connector are to download the link:https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/{debezium-version}/debezium-connector-postgres-{debezium-version}-plugin.tar.gz[connector's plug-in archive], extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`]. You then need to restart your Kafka Connect process to pick up the new JAR files.
 
-If you need immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s Docker images] for Zookeeper, Kafka, PostgreSQL and Kafka Connect with the PostgreSQL connector already installed and ready to run. You can also link:/blog/2016/05/31/Debezium-on-Kubernetes/[run {prodname} on Kubernetes and OpenShift].
+If you need immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s Container images] for Zookeeper, Kafka, PostgreSQL and Kafka Connect with the PostgreSQL connector already installed and ready to run. You can also link:/blog/2016/05/31/Debezium-on-Kubernetes/[run {prodname} on Kubernetes and OpenShift].
 endif::community[]
 
 ifdef::product[]
@@ -1801,21 +1808,21 @@ You can choose to produce events for a subset of the schemas and tables. Optiona
   }
 }
 ----
-<1> The name of our connector when we register it with a Kafka Connect service.
+<1> The name of the connector when registered with a Kafka Connect service.
 <2> The name of this PostgreSQL connector class.
 <3> The address of the PostgreSQL server.
 <4> The port number of the PostgreSQL server.
 <5> The name of the PostgreSQL user that has the {link-prefix}:{link-postgresql-connector}#postgresql-permissions[required privileges].
 <6> The password for the PostgreSQL user that has the {link-prefix}:{link-postgresql-connector}#postgresql-permissions[required privileges].
 <7> The name of the PostgreSQL database to connect to
-<8> The logical name of the PostgreSQL server/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro Connector is used.
+<8> The logical name of the PostgreSQL server/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
 <9> A list of all tables hosted by this server that this connector will monitor. This is optional, and there are other properties for listing the schemas and tables to include or exclude from monitoring.
 
 endif::community[]
 
 ifdef::product[]
 
-Following is an example of the configuration for a PostgreSQL connector that connects to a PostgreSQL server on port 5432 at 192.168.99.100, whose logical name is `fullfillment`. Typically, you configure the {prodname} PostgreSQL connector in a `.yaml` file using the configuration properties available for the connector.
+Following is an example of the configuration for a PostgreSQL connector that connects to a PostgreSQL server on port 5432 at 192.168.99.100, whose logical name is `fullfillment`. Typically, you configure a {prodname} PostgreSQL connector in a `.yaml` file using the configuration properties available for the connector.
 
 You can choose to produce events for a subset of the schemas and tables. Optionally, ignore, mask, or truncate columns that are sensitive, too large, or not needed.
 
@@ -1862,7 +1869,7 @@ You can send this configuration with a `POST` command to a running Kafka Connect
 // Type: procedure
 // ModuleID: adding-debezium-postgresql-connector-configuration-to-kafka-connect
 // Title: Adding {prodname} PostgreSQL connector configuration to Kafka Connect
-[[adding-connector-configuration]]
+[[postgresql-adding-connector-configuration]]
 === Adding connector configuration
 
 ifdef::community[]
@@ -1928,12 +1935,12 @@ Before Kafka Connect starts running the connector, Kafka Connect loads any third
 
 .. Point to the new container image. Do one of the following:
 +
-* Edit the `KafkaConnect.spec.image` property of the `KafkaConnect` custom resource. If set, this property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator. For example:
+* Edit the `spec.image` property of the `KafkaConnector` custom resource. If set, this property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator. For example:
 +
 [source,yaml,subs=attributes+]
 ----
 apiVersion: {KafkaConnectApiVersion}
-kind: KafkaConnect
+kind: KafkaConnector
 metadata:
   name: my-connect-cluster
 spec:
@@ -2100,78 +2107,84 @@ If the publication already exists, either for all tables or configured with a su
 
 |[[postgresql-property-database-server-name]]<<postgresql-property-database-server-name, `database.server.name`>>
 |
-|Logical name that identifies and provides a namespace for the particular PostgreSQL database server or cluster in which {prodname} is capturing changes. Only alphanumeric characters and underscores should be used in the database server logical name. The logical name should be unique across all other connectors, since it is used as a prefix for all Kafka topic names that receive records from this connector.
+|Logical name that identifies and provides a namespace for the particular PostgreSQL database server or cluster in which {prodname} is capturing changes. Only alphanumeric characters and underscores should be used in the database server logical name. The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
 
-|[[postgresql-property-schema-whitelist]]<<postgresql-property-schema-whitelist [[postgresql-property-schema-inlcude-list]]<<postgresql-property-schema-include-list , `schema.include.list`>>
+|[[postgresql-property-schema-whitelist]]
+[[postgresql-property-schema-include-list]]<<postgresql-property-schema-include-list , `schema.include.list`>>
 |
 |An optional, comma-separated list of regular expressions that match names of schemas for which you *want* to capture changes. Any schema name not included in `schema.include.list` is excluded from having its changes captured. By default, all non-system schemas have their changes captured. Do not also set the `schema.exclude.list` property.
 
-|[[postgresql-property-schema-blacklist]]<<postgresql-property-schema-blacklist [[postgresql-property-schema-exclude-list]]<<postgresql-property-schema-exclude-list , `schema.exclude.list`>>
+|[[postgresql-property-schema-blacklist]]
+[[postgresql-property-schema-exclude-list]]<<postgresql-property-schema-exclude-list , `schema.exclude.list`>>
 |
 |An optional, comma-separated list of regular expressions that match names of schemas for which you *do not* want to capture changes. Any schema whose name is not included in `schema.exclude.list` has its changes captured, with the exception of system schemas. Do not also set the `schema.include.list` property.
 
-|[[postgresql-property-table-whitelist]]<<postgresql-property-table-whitelist [[postgresql-property-table-include-list]]<<postgresql-property-table-include-list, `table.include.list`>>
+|[[postgresql-property-table-whitelist]]
+[[postgresql-property-table-include-list]]<<postgresql-property-table-include-list, `table.include.list`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you want to capture. Any table not included in `table.include.list` does not have its changes captured. Each identifier is of the form _schemaName_._tableName_. By default, the connector captures changes in every non-system table in each schema whose changes are being captured. Do not also set the `table.exclude.list` property.
 
-|[[postgresql-property-table-blacklist]]<<postgresql-property-table-blacklist [[postgresql-property-table-exclude.list]]<<postgresql-property-table-exclude.list, `table.exclude.list`>>
+|[[postgresql-property-table-blacklist]]
+[[postgresql-property-table-exclude.list]]<<postgresql-property-table-exclude.list, `table.exclude.list`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you *do not* want to capture. Any table not included in `table.exclude.list` has it changes captured. Each identifier is of the form _schemaName_._tableName_. Do not also set the `table.include.list` property.
 
-|[[postgresql-property-column-whitelist]]<<postgresql-property-column-whitelist [[postgresql-property-column-include-list]]<<postgresql-property-column-include-list , `column.include.list`>>
+|[[postgresql-property-column-whitelist]]
+[[postgresql-property-column-include-list]]<<postgresql-property-column-include-list , `column.include.list`>>
 |
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in change event record values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. Do not also set the `column.exclude.list` property.
 
-|[[postgresql-property-column-blacklist]]<<postgresql-property-column-blacklist [[postgresql-property-column-exclude-list]]<<postgresql-property-column-exclude-list, `column.exclude.list`>>
+|[[postgresql-property-column-blacklist]]
+[[postgresql-property-column-exclude-list]]<<postgresql-property-column-exclude-list, `column.exclude.list`>>
 |
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event record values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. Do not also set the `column.include.list` property.
 
 |[[postgresql-property-time-precision-mode]]<<postgresql-property-time-precision-mode, `time.precision.mode`>>
 |`adaptive`
-| Time, date, and timestamps can be represented with different kinds of precision: 
-
-`adaptive` captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type. 
-
-`adaptive_time_microseconds` captures the date, datetime and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type. An exception is `TIME` type fields, which are always captured as microseconds.
-
+| Time, date, and timestamps can be represented with different kinds of precision: +
+ +
+`adaptive` captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type. +
+ +
+`adaptive_time_microseconds` captures the date, datetime and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type. An exception is `TIME` type fields, which are always captured as microseconds. +
+ +
 `connect` always represents time and timestamp values by using Kafka Connect's built-in representations for `Time`, `Date`, and `Timestamp`, which use millisecond precision regardless of the database columns' precision. See {link-prefix}:{link-postgresql-connector}#postgresql-temporal-values[temporal values].
 
 |[[postgresql-property-decimal-handling-mode]]<<postgresql-property-decimal-handling-mode, `decimal.handling.mode`>>
 |`precise`
-| Specifies how the connector should handle values for `DECIMAL` and `NUMERIC` columns: 
-
-`precise` represents values by using `java.math.BigDecimal` to represent values in binary form in change events.
-
-`double` represents values by using `double` values, which might result in a loss of precision but which is easier to use. 
-
+| Specifies how the connector should handle values for `DECIMAL` and `NUMERIC` columns: +
+ +
+`precise` represents values by using `java.math.BigDecimal` to represent values in binary form in change events. +
+ +
+`double` represents values by using `double` values, which might result in a loss of precision but which is easier to use. +
+ +
 `string` encodes values as formatted strings, which are easy to consume but semantic information about the real type is lost. See {link-prefix}:{link-postgresql-connector}#postgresql-decimal-types[Decimal types].
 
 |[[postgresql-property-hstore-handling-mode]]<<postgresql-property-hstore-handling-mode, `hstore.handling.mode`>>
 |`map`
-| Specifies how the connector should handle values for `hstore` columns:
-
-`map` represents values by using `MAP`.
-
+| Specifies how the connector should handle values for `hstore` columns: +
+ +
+`map` represents values by using `MAP`. +
+ +
 `json` represents values by using `json string`. This setting encodes values as formatted strings such as `{"key" : "val"}`. See {link-prefix}:{link-postgresql-connector}#postgresql-hstore-type[PostgreSQL `HSTORE` type].
 
 |[[postgresql-property-interval-handling-mode]]<<postgresql-property-interval-handling-mode, `interval.handling.mode`>>
 |`numeric`
-| Specifies how the connector should handle values for `interval` columns:
-
-`numeric` represents intervals using approximate number of microseconds.
-
+| Specifies how the connector should handle values for `interval` columns: +
+ +
+`numeric` represents intervals using approximate number of microseconds. +
+ +
 `string` represents intervals exactly by using the string pattern representation `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`. For example: `P1Y2M3DT4H5M6.78S`. See {link-prefix}:{link-postgresql-connector}#postgresql-basic-types[PostgreSQL basic types].
 
 |[[postgresql-property-database-sslmode]]<<postgresql-property-database-sslmode, `database.sslmode`>>
 |`disable`
-|Whether to use an encrypted connection to the PostgreSQL server. Options include: 
-
-`disable` uses an unencrypted connection. 
-
-`require` uses a secure (encrypted) connection, and fails if one cannot be established. 
-
-`verify-ca` behaves like `require` but also verifies the server TLS certificate against the configured Certificate Authority (CA) certificates, or fails if no valid matching CA certificates are found. 
-
+|Whether to use an encrypted connection to the PostgreSQL server. Options include: +
+ +
+`disable` uses an unencrypted connection. +
+ +
+`require` uses a secure (encrypted) connection, and fails if one cannot be established. +
+ +
+`verify-ca` behaves like `require` but also verifies the server TLS certificate against the configured Certificate Authority (CA) certificates, or fails if no valid matching CA certificates are found. +
+ +
 `verify-full` behaves like `verify-ca` but also verifies that the server certificate matches the host to which the connector is trying to connect. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
 |[[postgresql-property-database-sslcert]]<<postgresql-property-database-sslcert, `database.sslcert`>>
@@ -2196,13 +2209,13 @@ If the publication already exists, either for all tables or configured with a su
 
 |[[postgresql-property-tombstones-on-delete]]<<postgresql-property-tombstones-on-delete, `tombstones.on.delete`>>
 |`true`
-| Controls whether a tombstone event should be generated after a _delete_ event. 
-
-`true` - delete operations are represented by a delete event and a subsequent tombstone event. 
-
-`false` - only a delete event is sent. 
-
-Emitting the tombstone event allows Kafka to completely delete all events that pertain to the given key after the source record is deleted.
+| Controls whether a tombstone event should be generated after a _delete_ event. +
+ +
+`true` - delete operations are represented by a _delete_ event and a subsequent tombstone event. +
+ +
+`false` - only a _delete_ event is sent. +
+ +
+After a _delete_ operation, emitting a tombstone event enables Kafka to delete all change event records that have the same key as the deleted row. 
 
 |[[postgresql-property-column-truncate-to-length-chars]]<<postgresql-property-column-truncate-to-length-chars, `column.truncate.to._length_.chars`>>
 |_n/a_
@@ -2214,72 +2227,71 @@ Emitting the tombstone event allows Kafka to completely delete all events that p
 
 |[[postgresql-property-column-mask-hash]]<<postgresql-property-column-mask-hash, `column.mask.hash._hashAlgorithm_.with.salt._salt_`>>
 |_n/a_
-|An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event values, the values in the specified columns are replaced with pseudonyms. 
-
-A pseudonym consists of the hashed value that results from applying the specifed _hashAlgorithm_ and _salt_. Based on the hash function that is used, referential integrity is kept while column values are replaced with pseudonyms. Supported hash functions are described in the {link-java7-standard-names}[MessageDigest section] of the Java Cryptography Architecture Standard Algorithm Name Documentation.
-
-If necessary, the pseudonym is automatically shortened to the length of the column. You can specify multiple properties with different hash algorithms and salts in a single configuration. In the following example, `CzQMA0cB5K` is a randomly selected salt.
-
-`column.mask.hash.SHA-256.with.salt.CzQMA0cB5K =inventory.orders.customerName,inventory.shipment.customerName`
-
-Depending on the _hashAlgorithm_ used, the _salt_ selected, and the actual data set, the resulting masked data set might not be completely anonymized.
+|An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event values, the values in the specified columns are replaced with pseudonyms. +
+ +
+A pseudonym consists of the hashed value that results from applying the specifed _hashAlgorithm_ and _salt_. Based on the hash function that is used, referential integrity is kept while column values are replaced with pseudonyms. Supported hash functions are described in the {link-java7-standard-names}[MessageDigest section] of the Java Cryptography Architecture Standard Algorithm Name Documentation. +
+ +
+If necessary, the pseudonym is automatically shortened to the length of the column. You can specify multiple properties with different hash algorithms and salts in a single configuration. In the following example, `CzQMA0cB5K` is a randomly selected salt. +
+ +
+`column.mask.hash.SHA-256.with.salt.CzQMA0cB5K =inventory.orders.customerName,inventory.shipment.customerName` +
+ +
+Depending on the _hashAlgorithm_ used, the _salt_ selected, and the actual data set, the resulting masked data set might not be completely masked.
 
 |[[postgresql-property-column-propagate-source-type]]<<postgresql-property-column-propagate-source-type, `column.propagate.source.type`>>
 |_n/a_
-|An optional, comma-separated list of regular expressions that match the fully-qualified names of columns. Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_.
-
-For each specified column, the connector adds the column's original type and original length as parameters to the corresponding field schemas in the emitted change records. The following added schema parameters propagate the original type name and also the original length for variable-width types:
-
-`pass:[_]pass:[_]debezium.source.column.type` `pass:[_]pass:[_]debezium.source.column.length` `pass:[_]pass:[_]debezium.source.column.scale`
-
+|An optional, comma-separated list of regular expressions that match the fully-qualified names of columns. Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_. +
+ +
+For each specified column, the connector adds the column's original type and original length as parameters to the corresponding field schemas in the emitted change records. The following added schema parameters propagate the original type name and also the original length for variable-width types: +
+ +
+`pass:[_]pass:[_]debezium.source.column.type` + `pass:[_]pass:[_]debezium.source.column.length` + `pass:[_]pass:[_]debezium.source.column.scale` +
+ +
 This property is useful for properly sizing corresponding columns in sink databases.
 
 |[[postgresql-property-datatype-propagate-source-type]]<<postgresql-property-datatype-propagate-source-type, `datatype.propagate.source.type`>>
 |_n/a_
-|An optional, comma-separated list of regular expressions that match the database-specific data type name for some columns. Fully-qualified data type names are of the form _databaseName_._tableName_._typeName_, or _databaseName_._schemaName_._tableName_._typeName_. 
-
-For these data types, the connector adds parameters to the corresponding field schemas in emitted change records. The added parameters specify the original type and length of the column: 
-
-`pass:[_]pass:[_]debezium.source.column.type` `pass:[_]pass:[_]debezium.source.column.length`  `pass:[_]pass:[_]debezium.source.column.scale` 
-
-These parameters propagate a column's original type name and length, for variable-width types, respectively. This property is useful for properly sizing corresponding columns in sink databases.
-
+|An optional, comma-separated list of regular expressions that match the database-specific data type name for some columns. Fully-qualified data type names are of the form _databaseName_._tableName_._typeName_, or _databaseName_._schemaName_._tableName_._typeName_. +
+ +
+For these data types, the connector adds parameters to the corresponding field schemas in emitted change records. The added parameters specify the original type and length of the column: +
+ +
+`pass:[_]pass:[_]debezium.source.column.type` + `pass:[_]pass:[_]debezium.source.column.length` + `pass:[_]pass:[_]debezium.source.column.scale` +
+ +
+These parameters propagate a column's original type name and length, for variable-width types, respectively. This property is useful for properly sizing corresponding columns in sink databases. +
+ +
 See the {link-prefix}:{link-postgresql-connector}#postgresql-data-types[list of PostgreSQL-specific data type names].
 
 |[[postgresql-property-message-key-columns]]<<postgresql-property-message-key-columns, `message.key.columns`>>
 |_empty string_
-|A semicolon separated list of tables with regular expressions that match table column names. The connector maps values in matching columns to key fields in change event records that it sends to Kafka topics. This is useful when a table does not have a primary key, or when you want to order change event records in a Kafka topic according to a field that is not a primary key. 
-
-Separate entries with semicolons. Insert a colon between the fully-qualified table name and its regular expression. The format is: 
-
-_schema-name_._table-name_:_regexp_;...
-
-For example, 
-
-`schemaA.table_a:regex_1;schemaB.table_b:regex_2;schemaC.table_c:regex_3`
-
+|A semicolon separated list of tables with regular expressions that match table column names. The connector maps values in matching columns to key fields in change event records that it sends to Kafka topics. This is useful when a table does not have a primary key, or when you want to order change event records in a Kafka topic according to a field that is not a primary key. +
+ +
+Separate entries with semicolons. Insert a colon between the fully-qualified table name and its regular expression. The format is: +
+ +
+_schema-name_._table-name_:_regexp_;... +
+ +
+For example, +
+ +
+`schemaA.table_a:regex_1;schemaB.table_b:regex_2;schemaC.table_c:regex_3` +
+ +
 If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column that starts with `i`), the connector maps the value in ``table_a``'s `id` column to a key field in change events that the connector sends to Kafka. 
 
 |[[postgresql-publication-autocreate-mode]]<<postgresql-publication-autocreate-mode, `publication.autocreate.mode`>>
 |_all_tables_
-|Applies only when streaming changes by using link:https://www.postgresql.org/docs/current/sql-createpublication.html[the `pgoutput` plug-in]. The setting determines how creation of a link:https://www.postgresql.org/docs/current/logical-replication-publication.html[publication] should work. Possible settings are:  
-
-`all_tables` - If a publication exists, the connector uses it. If a publication does not exist, the connector creates a publication for all tables in the database for which the connector is capturing changes. This requires that the database user who has permission to perform replications also has permission to create a publication. This is granted with `CREATE PUBLICATION <publication_name> FOR ALL TABLES;`.
-
-`disabled` - The connector does not attempt to create a publication. A database administrator or the user configured to perform replications must have created the publication before running the connector. If the connector cannot find the publication, the connector throws an exception and stops. 
-
-`filtered` - If a publication exists, the connector uses it. If no publication exists, the connector creates a new publication for tables that match the current filter configuration as specified by the `database.exclude.list`, `database.include.list`, `table.exclude.list`, and `table.include.list` connector configuration properties. For example: `CREATE PUBLICATION <publication_name> FOR TABLE <tbl1, tbl2, etc>`.
+|Applies only when streaming changes by using link:https://www.postgresql.org/docs/current/sql-createpublication.html[the `pgoutput` plug-in]. The setting determines how creation of a link:https://www.postgresql.org/docs/current/logical-replication-publication.html[publication] should work. Possible settings are: +
+ +
+`all_tables` - If a publication exists, the connector uses it. If a publication does not exist, the connector creates a publication for all tables in the database for which the connector is capturing changes. This requires that the database user who has permission to perform replications also has permission to create a publication. This is granted with `CREATE PUBLICATION <publication_name> FOR ALL TABLES;`. +
+ +
+`disabled` - The connector does not attempt to create a publication. A database administrator or the user configured to perform replications must have created the publication before running the connector. If the connector cannot find the publication, the connector throws an exception and stops. +
+ +
+`filtered` - If a publication exists, the connector uses it. If no publication exists, the connector creates a new publication for tables that match the current filter configuration as specified by the `database.exclude.list`, `database.include.list`, `table.exclude.list`, and `table.include.list` connector configuration properties. For example: `CREATE PUBLICATION <publication_name> FOR TABLE <tbl1, tbl2, tbl3>`.
 
 |[[postgresql-property-binary-handling-mode]]<<postgresql-property-binary-handling-mode, `binary.handling.mode`>>
 |bytes
-|Specifies how binary (`bytea`) columns should be represented in change events:
-
-`bytes` represents binary data as  byte array.
-
-`base64` represents binary data as base64-encoded strings. 
-
-`hex` represents binary data as hex-encoded (base16) strings.
-
+|Specifies how binary (`bytea`) columns should be represented in change events: +
+ +
+`bytes` represents binary data as  byte array. +
+ +
+`base64` represents binary data as base64-encoded strings. +
+ +
+`hex` represents binary data as hex-encoded (base16) strings. +
 |===
 
 [id="postgresql-advanced-configuration-properties"]
@@ -2294,22 +2306,22 @@ The following _advanced_ configuration properties have defaults that work in mos
 
 |[[postgresql-property-snapshot-mode]]<<postgresql-property-snapshot-mode, `snapshot.mode`>>
 |`initial`
-|Specifies the criteria for performing a snapshot when the connector starts: 
-
-`initial` -  The connector performs a snapshot only when no offsets have been recorded for the logical server name. 
-
-`always` - The connector performs a snapshot each time the connector starts. 
-
-`never` - The connector never performs snapshots. When a connector is configured this way, its behavior when it starts is as follows. If there is a previously stored LSN in the Kafka offsets topic, the connector continues streaming changes from that position. If no LSN has been stored, the connector starts streaming changes from the point in time when the PostgreSQL logical replication slot was created on the server. The `never` snapshot mode is useful only when you know all data of interest is still reflected in the WAL.
-
-`initial_only` - The connector performs an initial snapshot and then stops, without processing any subsequent changes. 
-
-`exported` -  The connector performs a snapshot based on the point in time when the replication slot was created. This is an excellent way to perform the snapshot in a lock-free way.
-
+|Specifies the criteria for performing a snapshot when the connector starts: +
+ +
+`initial` -  The connector performs a snapshot only when no offsets have been recorded for the logical server name. +
+ +
+`always` - The connector performs a snapshot each time the connector starts. +
+ +
+`never` - The connector never performs snapshots. When a connector is configured this way, its behavior when it starts is as follows. If there is a previously stored LSN in the Kafka offsets topic, the connector continues streaming changes from that position. If no LSN has been stored, the connector starts streaming changes from the point in time when the PostgreSQL logical replication slot was created on the server. The `never` snapshot mode is useful only when you know all data of interest is still reflected in the WAL. +
+ +
+`initial_only` - The connector performs an initial snapshot and then stops, without processing any subsequent changes. +
+ +
+`exported` -  The connector performs a snapshot based on the point in time when the replication slot was created. This is an excellent way to perform the snapshot in a lock-free way. +
+ +
 ifdef::community[]
-`custom` - The connector performs a snapshot according to the setting for the `snapshot.custom.class` property, which is a custom implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. 
+`custom` - The connector performs a snapshot according to the setting for the `snapshot.custom.class` property, which is a custom implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. +
 endif::community[]
-
+ +
 The{link-prefix}:{link-postgresql-connector}#snapshot-mode-settings[reference table for snapshot mode settings] has more details.
 
 ifdef::community[]
@@ -2324,20 +2336,20 @@ endif::community[]
 
 |[[postgresql-property-snapshot-select-statement-overrides]]<<postgresql-property-snapshot-select-statement-overrides, `snapshot.select.statement.overrides`>>
 |
-|Controls which table rows are included in snapshots. This property affects snapshots only. It does not affect events that are generated by the logical decoding plug-in. Specify a comma-separated list of fully-qualified table names in the form _databaseName.tableName_. 
-
-For each table that you specify, also specify another configuration property: `snapshot.select.statement.overrides._DB_NAME_._TABLE_NAME_`, for example: `snapshot.select.statement.overrides.customers.orders`. Set this property to a `SELECT` statement that obtains only the rows that you want in the snapshot. When the connector performs a snapshot, it executes this `SELECT` statement to retrieve data from that table. 
-
+|Controls which table rows are included in snapshots. This property affects snapshots only. It does not affect events that are generated by the logical decoding plug-in. Specify a comma-separated list of fully-qualified table names in the form _databaseName.tableName_. +
+ +
+For each table that you specify, also specify another configuration property: `snapshot.select.statement.overrides._DB_NAME_._TABLE_NAME_`, for example: `snapshot.select.statement.overrides.customers.orders`. Set this property to a `SELECT` statement that obtains only the rows that you want in the snapshot. When the connector performs a snapshot, it executes this `SELECT` statement to retrieve data from that table. +
+ +
 A possible use case for setting these properties is large, append-only tables. You can specify a `SELECT` statement that sets a specific point for where to start a snapshot, or where to resume a snapshot if a previous snapshot was interrupted.
 
 |[[postgresql-property-event-processing-failure-handling-mode]]<<postgresql-property-event-processing-failure-handling-mode, `event.processing.failure.handling.mode`>>
 |`fail`
-| Specifies how the connector should react to exceptions during processing of events: 
-
-`fail` propagates the exception, indicates the offset of the problematic event, and causes the connector to stop.
-
-`warn` logs the offset of the problematic event, skips that event, and continues processing. 
-
+| Specifies how the connector should react to exceptions during processing of events: +
+ +
+`fail` propagates the exception, indicates the offset of the problematic event, and causes the connector to stop. +
+ +
+`warn` logs the offset of the problematic event, skips that event, and continues processing. +
+ +
 `skip` skips the problematic event and continues processing.
 
 |[[postgresql-property-max-queue-size]]<<postgresql-property-max-queue-size, `max.queue.size`>>
@@ -2354,50 +2366,54 @@ A possible use case for setting these properties is large, append-only tables. Y
 
 |[[postgresql-property-include-unknown-datatypes]]<<postgresql-property-include-unknown-datatypes, `include.unknown.datatypes`>>
 |`false`
-|Specifies connector behavior when the connector encounters a field whose data type is unknown. The default behavior is that the connector omits the field from the change event and logs a warning. 
-
+|Specifies connector behavior when the connector encounters a field whose data type is unknown. The default behavior is that the connector omits the field from the change event and logs a warning. +
+ +
 Set this property to `true` if you want the change event to contain an opaque binary representation of the field. This lets consumers decode the field. You can control the exact representation by setting the {link-prefix}:{link-postgresql-connector}#postgresql-property-binary-handling-mode[`binary handling mode`] property. 
 
 NOTE: Consumers risk backward compatibility issues when `include.unknown.datatypes` is set to `true`. Not only may the database-specific binary representation change between releases, but if the data type is eventually supported by {prodname}, the data type will be sent downstream in a logical type, which would require adjustments by consumers. In general, when encountering unsupported data types, create a feature request so that support can be added.
 
 |[[postgresql-property-database-initial-statements]]<<postgresql-property-database-initial-statements, `database.initial.statements`>>
 |
-|A semicolon separated list of SQL statements that the connector executes when it establishes a JDBC connection to the database. To use a semicolon as a character and not as a delimiter, specify two consecutive semicolons, `;;`. 
-
-The connector may establish JDBC connections at its own discretion. Consequently, this property is useful for configuration of session parameters only, and not for executing DML statements.
-
-The connector does not execute these statements when it creates a connection for reading the transaction log. 
+|A semicolon separated list of SQL statements that the connector executes when it establishes a JDBC connection to the database. To use a semicolon as a character and not as a delimiter, specify two consecutive semicolons, `;;`. +
+ +
+The connector may establish JDBC connections at its own discretion. Consequently, this property is useful for configuration of session parameters only, and not for executing DML statements. +
+ +
+The connector does not execute these statements when it creates a connection for reading the transaction log. +
 
 |[[postgresql-property-heartbeat-interval-ms]]<<postgresql-property-heartbeat-interval-ms, `heartbeat.interval.ms`>>
 |`0`
-|Controls how frequently the connector sends heartbeat messages to a Kafka topic. The default behavior is that the connector does not send heartbeat messages. 
-
-Heartbeat messages are useful for monitoring whether the connector is receiving change events from the database. Heartbeat messages might help decrease the number of change events that need to be re-sent when a connector restarts. To send heartbeat messages, set this property to a positive integer, which indicates the number of milliseconds between heartbeat messages. 
-
+|Controls how frequently the connector sends heartbeat messages to a Kafka topic. The default behavior is that the connector does not send heartbeat messages. +
+ +
+Heartbeat messages are useful for monitoring whether the connector is receiving change events from the database. Heartbeat messages might help decrease the number of change events that need to be re-sent when a connector restarts. To send heartbeat messages, set this property to a positive integer, which indicates the number of milliseconds between heartbeat messages. +
+ +
 Heartbeat messages are needed when there are many updates in a database that is being tracked but only a tiny number of updates are related to the table(s) and schema(s) for which the connector is capturing changes. In this situation, the connector reads from the database transaction log as usual but rarely emits change records to Kafka. This means that no offset updates are committed to Kafka and the connector does not have an opportunity to send the latest retrieved LSN to the database. The database retains WAL files that contain events that have already been processed by the connector. Sending heartbeat messages enables the connector to send the latest retrieved LSN to the database, which allows the database to reclaim disk space being used by no longer needed WAL files. 
 
 |[[postgresql-property-heartbeat-topics-prefix]]<<postgresql-property-heartbeat-topics-prefix, `heartbeat.topics.prefix`>>
 |`__debezium-heartbeat`
-|Controls the name of the topic to which the connector sends heartbeat messages. The topic name has this pattern: _<heartbeat.topics.prefix>_._<server.name>_. For example, if the database server name is `fullfillment`, the default topic name is `__debezium-heartbeat.fulfillment`.
+|Controls the name of the topic to which the connector sends heartbeat messages. The topic name has this pattern: +
+ +
+_<heartbeat.topics.prefix>_._<server.name>_ +
+ +
+For example, if the database server name is `fullfillment`, the default topic name is `__debezium-heartbeat.fulfillment`.
 
 |[[postgresql-property-heartbeat-action-query]]<<postgresql-property-heartbeat-action-query, `heartbeat.action.query`>>
 |
-|Specifies a query that the connector executes on the source database when the connector sends a heartbeat message. 
-
-This is useful for resolving the situation described in {link-prefix}:{link-postgresql-connector}#postgresql-wal-disk-space[WAL disk space consumption], where capturing changes from a low-traffic database on the same host as a high-traffic database prevents {prodname} from processing WAL records and thus acknowledging WAL positions with the database. To address this situation, create a heartbeat table in the low-traffic database, and set this property to a statement that inserts records into that table, for example:  
-
-`INSERT INTO test_heartbeat_table (text) VALUES ('test_heartbeat')`
-
+|Specifies a query that the connector executes on the source database when the connector sends a heartbeat message. +
+ +
+This is useful for resolving the situation described in {link-prefix}:{link-postgresql-connector}#postgresql-wal-disk-space[WAL disk space consumption], where capturing changes from a low-traffic database on the same host as a high-traffic database prevents {prodname} from processing WAL records and thus acknowledging WAL positions with the database. To address this situation, create a heartbeat table in the low-traffic database, and set this property to a statement that inserts records into that table, for example:  +
+ +
+`INSERT INTO test_heartbeat_table (text) VALUES ('test_heartbeat')` +
+ +
 This allows the connector to receive changes from the low-traffic database and acknowledge their LSNs, which prevents unbounded WAL growth on the database host. 
 
 |[[postgresql-property-schema-refresh-mode]]<<postgresql-property-schema-refresh-mode, `schema.refresh.mode`>>
 |`columns_diff`
-|Specify the conditions that trigger a refresh of the in-memory schema for a table.
-
-`columns_diff` is the safest mode. It ensures that the in-memory schema stays in sync with the database table's schema at all times.
-
-`columns_diff_exclude_unchanged_toast` instructs the connector to refresh the in-memory schema cache if there is a discrepancy with the schema derived from the incoming message, unless unchanged TOASTable data fully accounts for the discrepancy.
-
+|Specify the conditions that trigger a refresh of the in-memory schema for a table. +
+ +
+`columns_diff` is the safest mode. It ensures that the in-memory schema stays in sync with the database table's schema at all times. +
+ +
+`columns_diff_exclude_unchanged_toast` instructs the connector to refresh the in-memory schema cache if there is a discrepancy with the schema derived from the incoming message, unless unchanged TOASTable data fully accounts for the discrepancy. +
+ +
 This setting can significantly improve connector performance if there are frequently-updated tables that have TOASTed data that are rarely part of updates. However, it is possible for the in-memory schema to
 become outdated if TOASTable columns are dropped from the table.
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1396,17 +1396,20 @@ Only alphanumeric characters and underscores should be used.
 |A list of host/port pairs that the connector will use for establishing an initial connection to the Kafka cluster.
 This connection is used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. This should point to the same Kafka cluster used by the Kafka Connect process.
 
-|[[sqlserver-property-table-whitelist]]<<sqlserver-property-table-whitelist [[sqlserver-property-table-include-list]]<<sqlserver-property-table-include-list , `table.include.list`>>
+|[[sqlserver-property-table-whitelist]]
+[[sqlserver-property-table-include-list]]<<sqlserver-property-table-include-list , `table.include.list`>>
 |
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be monitored; any table not included in `table.include.list` is excluded from monitoring. Each identifier is of the form _schemaName_._tableName_. By default the connector will monitor every non-system table in each monitored schema.
 Must not be used with `table.exclude.list`.
 
-|[[sqlserver-property-table-blacklist]]<<sqlserver-property-table-blacklist [[sqlserver-property-table-exclude-list]]<<sqlserver-property-table-exclude-list, `table.exclude.list`>>
+|[[sqlserver-property-table-blacklist]]
+[[sqlserver-property-table-exclude-list]]<<sqlserver-property-table-exclude-list, `table.exclude.list`>>
 |
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be excluded from monitoring; any table not included in `table.exclude.list` is monitored.
 Each identifier is of the form _schemaName_._tableName_. Must not be used with `table.include.list`.
 
-|[[sqlserver-property-column-blacklist]]<<sqlserver-property-column-blacklist [[sqlserver-property-column-exclude-list]]<<sqlserver-property-column-exclude-list , `column.exclude.list`>>
+|[[sqlserver-property-column-blacklist]]
+[[sqlserver-property-column-exclude-list]]<<sqlserver-property-column-exclude-list , `column.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event message values.
 Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.

--- a/documentation/modules/ROOT/partials/modules/mysql-connector/ref-mysql-connector-configuration-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/mysql-connector/ref-mysql-connector-configuration-properties.adoc
@@ -54,27 +54,32 @@ Only alphanumeric characters and underscores should be used.
 |
 |A list of host/port pairs that the connector will use for establishing an initial connection to the Kafka cluster. This connection will be used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. This should point to the same Kafka cluster used by the Kafka Connect process.
 
-|[[mysql-property-database-whitelist]]<<mysql-property-database-whitelist [[mysql-property-database-include-list]]<<mysql-property-database-include-list, `database.include.list`>>
+|[[mysql-property-database-whitelist]]
+[[mysql-property-database-include-list]]<<mysql-property-database-include-list, `database.include.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match database names to be monitored; any database name not included in `database.include.list` will be excluded from monitoring. By default all databases will be monitored.
 Must not be used with `database.exclude.list`.
 
-|[[mysql-property-database-blacklist]]<<mysql-property-database-blacklist[[mysql-property-database-exclude-list]]<<mysql-property-database-exclude-list, `database.exclude.list`>>
+|[[mysql-property-database-blacklist]]
+[[mysql-property-database-exclude-list]]<<mysql-property-database-exclude-list, `database.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match database names to be excluded from monitoring; any database name not included in `database.exclude.list` will be monitored.
 Must not be used with `database.include.list`.
 
-|[[mysql-property-table-whitelist]]<<mysql-property-table-whitelist [[mysql-property-table-include-list]]<<mysql-property-table-include-list, `table.include.list`>>
+|[[mysql-property-table-whitelist]]
+[[mysql-property-table-include-list]]<<mysql-property-table-include-list, `table.include.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be monitored; any table not included in `table.include.list` will be excluded from monitoring. Each identifier is of the form _databaseName_._tableName_. By default the connector will monitor every non-system table in each monitored database.
 Must not be used with `table.exclude.list`.
 
-|[[mysql-property-table-blacklist]]<<mysql-property-table-blacklist [[mysql-property-table-exclude-list]]<<mysql-property-table-exclude-list , `table.exclude.list`>>
+|[[mysql-property-table-blacklist]]
+[[mysql-property-table-exclude-list]]<<mysql-property-table-exclude-list , `table.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be excluded from monitoring; any table not included in `table.exclude.list` will be monitored. Each identifier is of the form _databaseName_._tableName_.
 Must not be used with `table.include.list`.
 
-|[[mysql-property-column-blacklist]]<<mysql-property-column-blacklist [[mysql-property-column-exclude-list]]<<mysql-property-column-exclude-list, `column.exclude.list`>>
+|[[mysql-property-column-blacklist]]
+[[mysql-property-column-exclude-list]]<<mysql-property-column-exclude-list, `column.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event message values. Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_.
 


### PR DESCRIPTION
This is for DBZ-2476
I corrected the link format for these connectors: 
MySQL
MongoDB
PostgreSQL
SQL Server

I did not update the doc for any other connectors. Let me know if you want me to do anything else. 
I ran antora locally and confirmed that the links in the property tables render correctly. 