### PR TITLE
DBZ-2476 Second try at fixing include/exclude list property link rendering

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -803,22 +803,26 @@ Only alphanumeric characters and underscores should be used.
 |`false`
 |When SSL is enabled this setting controls whether strict hostname checking is disabled during connection phase. If `true` the connection will not prevent man-in-the-middle attacks.
 
-|[[mongodb-property-database-whitelist]]<<mongodb-property-database-whitelist [[mongodb-property-database-include-list]]<<mongodb-property-database-include-list , `database.include.list`>>
+|[[mongodb-property-database-whitelist]]
+[[mongodb-property-database-include-list]]<<mongodb-property-database-include-list, `database.include.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match database names to be monitored; any database name not included in `database.include.list` is excluded from monitoring. By default all databases are monitored.
 Must not be used with `database.exclude.list`.
 
-|[[mongodb-property-database-blacklist]]<<mongodb-property-database-blacklist [[mongodb-property-database-exclude-list]]<<mongodb-property-database-exclude-list, `database.exclude.list`>>
+|[[mongodb-property-database-blacklist]]
+[[mongodb-property-database-exclude-list]]<<mongodb-property-database-exclude-list, `database.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match database names to be excluded from monitoring; any database name not included in `database.exclude.list` is monitored.
 Must not be used with `database.include.list`.
 
-|[[mongodb-property-collection-whitelist]]<<mongodb-property-collection-whitelist [[mongodb-property-collection-include-list]]<<mongodb-property-collection-include-list, `collection.include.list`>>
+|[[mongodb-property-collection-whitelist]]
+[[mongodb-property-collection-include-list]]<<mongodb-property-collection-include-list, `collection.include.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified namespaces for MongoDB collections to be monitored; any collection not included in `collection.include.list` is excluded from monitoring. Each identifier is of the form _databaseName_._collectionName_. By default the connector will monitor all collections except those in the `local` and `admin` databases.
 Must not be used with `collection.exclude.list`.
 
-|[[mongodb-property-collection-blacklist]]<<mongodb-property-collection-blacklist [[mongodb-property-collection-exclude-list]]<<mongodb-property-collection-exclude-list , `collection.exclude.list`>>
+|[[mongodb-property-collection-blacklist]]
+[[mongodb-property-collection-exclude-list]]<<mongodb-property-collection-exclude-list, `collection.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified namespaces for MongoDB collections to be excluded from monitoring; any collection not included in `collection.exclude.list` is monitored. Each identifier is of the form _databaseName_._collectionName_.
 Must not be used with `collection.include.list`.
@@ -827,7 +831,8 @@ Must not be used with `collection.include.list`.
 |`initial`
 |Specifies the criteria for running a snapshot upon startup of the connector. The default is *initial*, and specifies the connector reads a snapshot when either no offset is found or if the oplog no longer contains the previous offset. The *never* option specifies that the connector should never use snapshots, instead the connector should proceed to tail the log.
 
-|[[mongodb-property-field-blacklist]]<<mongodb-property-field-blacklist [[mongodb-property-field-exclude-list]]<<mongodb-property-field-exclude-list, `field.exclude.list`>>
+|[[mongodb-property-field-blacklist]]
+[[mongodb-property-field-exclude-list]]<<mongodb-property-field-exclude-list, `field.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of the fully-qualified names of fields that should be excluded from change event message values. Fully-qualified names for fields are of the form _databaseName_._collectionName_._fieldName_._nestedFieldName_, where _databaseName_ and _collectionName_ may contain the wildcard (*) which matches any characters.
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2109,27 +2109,33 @@ If the publication already exists, either for all tables or configured with a su
 |
 |Logical name that identifies and provides a namespace for the particular PostgreSQL database server or cluster in which {prodname} is capturing changes. Only alphanumeric characters and underscores should be used in the database server logical name. The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
 
-|[[postgresql-property-schema-whitelist]]<<postgresql-property-schema-whitelist [[postgresql-property-schema-include-list]]<<postgresql-property-schema-include-list , `schema.include.list`>>
+|[[postgresql-property-schema-whitelist]]
+[[postgresql-property-schema-include-list]]<<postgresql-property-schema-include-list, `schema.include.list`>>
 |
 |An optional, comma-separated list of regular expressions that match names of schemas for which you *want* to capture changes. Any schema name not included in `schema.include.list` is excluded from having its changes captured. By default, all non-system schemas have their changes captured. Do not also set the `schema.exclude.list` property.
 
-|[[postgresql-property-schema-blacklist]]<<postgresql-property-schema-blacklist [[postgresql-property-schema-exclude-list]]<<postgresql-property-schema-exclude-list , `schema.exclude.list`>>
+|[[postgresql-property-schema-blacklist]]
+[[postgresql-property-schema-exclude-list]]<<postgresql-property-schema-exclude-list, `schema.exclude.list`>>
 |
 |An optional, comma-separated list of regular expressions that match names of schemas for which you *do not* want to capture changes. Any schema whose name is not included in `schema.exclude.list` has its changes captured, with the exception of system schemas. Do not also set the `schema.include.list` property.
 
-|[[postgresql-property-table-whitelist]]<<postgresql-property-table-whitelist [[postgresql-property-table-include-list]]<<postgresql-property-table-include-list, `table.include.list`>>
+|[[postgresql-property-table-whitelist]]
+[[postgresql-property-table-include-list]]<<postgresql-property-table-include-list, `table.include.list`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you want to capture. Any table not included in `table.include.list` does not have its changes captured. Each identifier is of the form _schemaName_._tableName_. By default, the connector captures changes in every non-system table in each schema whose changes are being captured. Do not also set the `table.exclude.list` property.
 
-|[[postgresql-property-table-blacklist]]<<postgresql-property-table-blacklist [[postgresql-property-table-exclude.list]]<<postgresql-property-table-exclude.list, `table.exclude.list`>>
+|[[postgresql-property-table-blacklist]]
+[[postgresql-property-table-exclude.list]]<<postgresql-property-table-exclude.list, `table.exclude.list`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you *do not* want to capture. Any table not included in `table.exclude.list` has it changes captured. Each identifier is of the form _schemaName_._tableName_. Do not also set the `table.include.list` property.
 
-|[[postgresql-property-column-whitelist]]<<postgresql-property-column-whitelist [[postgresql-property-column-include-list]]<<postgresql-property-column-include-list , `column.include.list`>>
+|[[postgresql-property-column-whitelist]]
+[[postgresql-property-column-include-list]]<<postgresql-property-column-include-list, `column.include.list`>>
 |
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in change event record values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. Do not also set the `column.exclude.list` property.
 
-|[[postgresql-property-column-blacklist]]<<postgresql-property-column-blacklist [[postgresql-property-column-exclude-list]]<<postgresql-property-column-exclude-list, `column.exclude.list`>>
+|[[postgresql-property-column-blacklist]]
+[[postgresql-property-column-exclude-list]]<<postgresql-property-column-exclude-list, `column.exclude.list`>>
 |
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event record values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. Do not also set the `column.include.list` property.
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1396,17 +1396,20 @@ Only alphanumeric characters and underscores should be used.
 |A list of host/port pairs that the connector will use for establishing an initial connection to the Kafka cluster.
 This connection is used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. This should point to the same Kafka cluster used by the Kafka Connect process.
 
-|[[sqlserver-property-table-whitelist]]<<sqlserver-property-table-whitelist [[sqlserver-property-table-include-list]]<<sqlserver-property-table-include-list , `table.include.list`>>
+|[[sqlserver-property-table-whitelist]]
+[[sqlserver-property-table-include-list]]<<sqlserver-property-table-include-list, `table.include.list`>>
 |
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be monitored; any table not included in `table.include.list` is excluded from monitoring. Each identifier is of the form _schemaName_._tableName_. By default the connector will monitor every non-system table in each monitored schema.
 Must not be used with `table.exclude.list`.
 
-|[[sqlserver-property-table-blacklist]]<<sqlserver-property-table-blacklist [[sqlserver-property-table-exclude-list]]<<sqlserver-property-table-exclude-list, `table.exclude.list`>>
+|[[sqlserver-property-table-blacklist]]
+[[sqlserver-property-table-exclude-list]]<<sqlserver-property-table-exclude-list, `table.exclude.list`>>
 |
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be excluded from monitoring; any table not included in `table.exclude.list` is monitored.
 Each identifier is of the form _schemaName_._tableName_. Must not be used with `table.include.list`.
 
-|[[sqlserver-property-column-blacklist]]<<sqlserver-property-column-blacklist [[sqlserver-property-column-exclude-list]]<<sqlserver-property-column-exclude-list , `column.exclude.list`>>
+|[[sqlserver-property-column-blacklist]]
+[[sqlserver-property-column-exclude-list]]<<sqlserver-property-column-exclude-list, `column.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event message values.
 Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.

--- a/documentation/modules/ROOT/partials/modules/mysql-connector/ref-mysql-connector-configuration-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/mysql-connector/ref-mysql-connector-configuration-properties.adoc
@@ -54,27 +54,32 @@ Only alphanumeric characters and underscores should be used.
 |
 |A list of host/port pairs that the connector will use for establishing an initial connection to the Kafka cluster. This connection will be used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. This should point to the same Kafka cluster used by the Kafka Connect process.
 
-|[[mysql-property-database-whitelist]]<<mysql-property-database-whitelist [[mysql-property-database-include-list]]<<mysql-property-database-include-list, `database.include.list`>>
+|[[mysql-property-database-whitelist]]
+[[mysql-property-database-include-list]]<<mysql-property-database-include-list, `database.include.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match database names to be monitored; any database name not included in `database.include.list` will be excluded from monitoring. By default all databases will be monitored.
 Must not be used with `database.exclude.list`.
 
-|[[mysql-property-database-blacklist]]<<mysql-property-database-blacklist[[mysql-property-database-exclude-list]]<<mysql-property-database-exclude-list, `database.exclude.list`>>
+|[[mysql-property-database-blacklist]]
+[[mysql-property-database-exclude-list]]<<mysql-property-database-exclude-list, `database.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match database names to be excluded from monitoring; any database name not included in `database.exclude.list` will be monitored.
 Must not be used with `database.include.list`.
 
-|[[mysql-property-table-whitelist]]<<mysql-property-table-whitelist [[mysql-property-table-include-list]]<<mysql-property-table-include-list, `table.include.list`>>
+|[[mysql-property-table-whitelist]]
+[[mysql-property-table-include-list]]<<mysql-property-table-include-list, `table.include.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be monitored; any table not included in `table.include.list` will be excluded from monitoring. Each identifier is of the form _databaseName_._tableName_. By default the connector will monitor every non-system table in each monitored database.
 Must not be used with `table.exclude.list`.
 
-|[[mysql-property-table-blacklist]]<<mysql-property-table-blacklist [[mysql-property-table-exclude-list]]<<mysql-property-table-exclude-list , `table.exclude.list`>>
+|[[mysql-property-table-blacklist]]
+[[mysql-property-table-exclude-list]]<<mysql-property-table-exclude-list, `table.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be excluded from monitoring; any table not included in `table.exclude.list` will be monitored. Each identifier is of the form _databaseName_._tableName_.
 Must not be used with `table.include.list`.
 
-|[[mysql-property-column-blacklist]]<<mysql-property-column-blacklist [[mysql-property-column-exclude-list]]<<mysql-property-column-exclude-list, `column.exclude.list`>>
+|[[mysql-property-column-blacklist]]
+[[mysql-property-column-exclude-list]]<<mysql-property-column-exclude-list, `column.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event message values. Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_.
 


### PR DESCRIPTION
DBZ-2476
@Naros  and @gunnarmorling 
This is a new PR. There are two commits. One for MongoDB, SQL Server, and MySQL. A second commit for just PostgreSQL.
This contains only fixes for the link rendering for the include/exclude list properties. 
