### PR TITLE
DBZ-2500 A few doc tweaks to correct formatting in db2 and postgresql doc

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1406,7 +1406,7 @@ VALUES ASNCDC.ASNCDCSERVICES('reinit','asncdc');
 {link-prefix}:{link-db2-connector}#managing-debezium-db2-connectors[Reference table for {prodname} Db2 management UDFs]
 
 // Type: assembly
-// ModuleID: deploying--debezium-db2-connectors
+// ModuleID: deploying-debezium-db2-connectors
 // Title: Deploying {prodname} Db2 connectors
 [[db2-deploying-a-connector]]
 == Deployment
@@ -2125,9 +2125,3 @@ However, when a table is in capture mode, after a change to a column name, the D
 . In the ASN register table, mark the tables as `INACTIVE`. This marks the old change-data tables as inactive, which allows the data in them to remain but they are no longer updated.
 . {link-prefix}:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
 . Optional. Restart the connector to see updated column names in change events. 
-
-ifdef::community[]
-=== Example
-
-To be added. 
-endif::community[]

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1463,7 +1463,7 @@ The above example assumes that you extracted the {prodname} Db2 connector to the
 endif::product[]
 
 // Type: concept
-// ModuleID:debezium-db2-connector-configuration-example
+// ModuleID: debezium-db2-connector-configuration-example
 // Title: {prodname} db2 connector configuration example
 [[db2-example]]
 [[db2-example-configuration]]

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -443,7 +443,7 @@ Details are in the following topics:
 
 * xref:about-keys-in-debezium-postgresql-change-events[]
 * xref:about-values-in-debezium-postgresql-change-events[]
-* xref:how-replica-identity-controls-data-that-can-be-in-debezium-change-events[]
+* xref:how-replica-identity-controls-data-that-can-be-in-debezium-postgresql-change-events[]
 * xref:about-debezium-postgresql-change-events-for-operations-that-create-content[]
 * xref:about-debezium-postgresql-change-events-for-operations-that-update-content[]
 * xref:about-debezium-postgresql-change-events-for-primary-key-updates[]

--- a/documentation/modules/ROOT/partials/modules/mysql-connector/con-how-the-mysql-connector-maps-data-types.adoc
+++ b/documentation/modules/ROOT/partials/modules/mysql-connector/con-how-the-mysql-connector-maps-data-types.adoc
@@ -234,7 +234,6 @@ a|`org.apache.kafka.connect.data.Timestamp`
 NOTE: Represents the number of milliseconds since epoch, and does not include time zone information.
 
 |===
-+
 
 == Decimal values
 


### PR DESCRIPTION
This is for DBZ-2500. 
A few tweaks are needed so the downstream user guide builds automatically after a fetch. 
Event thought the TBA example was conditionalized for upstream only, it was causing a build problem downstream. I don't know why. Hope it is okay to just remove it. 
Please backport this update to 1.2.
Thanks!