### PR TITLE
DBZ-2456 Selective Snapshot Mode

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
@@ -398,12 +398,12 @@ public class ConnectionContext implements AutoCloseable {
          *
          * @return the collection identifiers; never null
          */
-        public List<CollectionId> collections() {
+        public Set<CollectionId> collections() {
             String replicaSetName = replicaSet.replicaSetName();
 
             // For each database, get the list of collections ...
             return execute("get collections in databases", primary -> {
-                List<CollectionId> collections = new ArrayList<>();
+                Set<CollectionId> collections = new HashSet<>();
                 Set<String> databaseNames = databaseNames();
 
                 for (String dbName : databaseNames) {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
@@ -12,6 +12,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -342,7 +343,7 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
 
         LOGGER.info("Beginning snapshot of '{}' at {}", rsName, rsOffsetContext.getOffset());
 
-        final List<CollectionId> collections = primaryClient.collections();
+        final Set<CollectionId> collections = determineAllowedDataCollectionsForSnapshot(primaryClient.collections());
         snapshotProgressListener.monitoredDataCollectionsDetermined(collections);
         if (connectionContext.maxNumberOfCopyThreads() > 1) {
             // Since multiple copy threads are to be used, create a thread pool and initiate the copy.

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotReaderIT.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.config.Configuration.Builder;
 import io.debezium.data.KeyValueStore;
@@ -222,6 +223,58 @@ public class SnapshotReaderIT {
         else {
             fail("failed to complete the snapshot within 10 seconds");
         }
+    }
+
+    @Test
+    public void shouldCreateSnapshotSelectively() throws Exception {
+        config = simpleConfig()
+                .with(MySqlConnectorConfig.DATABASE_INCLUDE_LIST, "connector_(.*)_" + DATABASE.getIdentifier())
+                .with(CommonConnectorConfig.SNAPSHOT_MODE_TABLES, "connector_(.*).customers")
+                .build();
+
+        context = new MySqlTaskContext(config, new Filters.Builder(config).build());
+        context.start();
+        reader = new SnapshotReader("snapshot", context);
+
+        reader.uponCompletion(completed::countDown);
+        reader.generateReadEvents();
+        // Start the snapshot ...
+        reader.start();
+
+        // Poll for records ...
+        // Testing.Print.enable();
+        List<SourceRecord> records = null;
+        KeyValueStore store = KeyValueStore.createForTopicsBeginningWith(DATABASE.getServerName() + ".");
+        SchemaChangeHistory schemaChanges = new SchemaChangeHistory(DATABASE.getServerName());
+        while ((records = reader.poll()) != null) {
+            records.forEach(record -> {
+                VerifyRecord.isValid(record);
+                VerifyRecord.hasNoSourceQuery(record);
+                store.add(record);
+                schemaChanges.add(record);
+            });
+        }
+        // The last poll should always return null ...
+        assertThat(records).isNull();
+
+        // There should be no schema changes ...
+        assertThat(schemaChanges.recordCount()).isEqualTo(0);
+
+        // Check the records via the store ...
+        assertThat(store.databases()).containsOnly(DATABASE.getDatabaseName(), OTHER_DATABASE.getDatabaseName()); // 2 databases
+        assertThat(store.collectionCount()).isEqualTo(2); // 2 databases
+
+        Collection customers = store.collection(DATABASE.getDatabaseName(), "customers");
+        assertThat(customers.numberOfCreates()).isEqualTo(0);
+        assertThat(customers.numberOfUpdates()).isEqualTo(0);
+        assertThat(customers.numberOfDeletes()).isEqualTo(0);
+        assertThat(customers.numberOfReads()).isEqualTo(4);
+        assertThat(customers.numberOfTombstones()).isEqualTo(0);
+        assertThat(customers.numberOfKeySchemaChanges()).isEqualTo(1);
+        assertThat(customers.numberOfValueSchemaChanges()).isEqualTo(1);
+
+        Collection orders = store.collection(DATABASE.getDatabaseName(), "orders");
+        assertThat(orders).isNull();
     }
 
     @Test

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -94,7 +94,7 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
     protected void lockTablesForSchemaSnapshot(ChangeEventSourceContext sourceContext, RelationalSnapshotContext snapshotContext)
             throws SQLException, InterruptedException {
         final Duration lockTimeout = connectorConfig.snapshotLockTimeout();
-        final Optional<String> lockStatement = snapshotter.snapshotTableLockingStatement(lockTimeout, schema.tableIds());
+        final Optional<String> lockStatement = snapshotter.snapshotTableLockingStatement(lockTimeout, snapshotContext.capturedTables);
 
         if (lockStatement.isPresent()) {
             LOGGER.info("Waiting a maximum of '{}' seconds for each table lock", lockTimeout.getSeconds());

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -1158,6 +1158,57 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     }
 
     @Test
+    public void shouldAllowForSelectiveSnapshot() throws InterruptedException {
+        TestHelper.execute(SETUP_TABLES_STMT);
+        Configuration.Builder configBuilder = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.ALWAYS.name())
+                .with(CommonConnectorConfig.SNAPSHOT_MODE_TABLES, "s1.a")
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE);
+
+        start(PostgresConnector.class, configBuilder.build());
+        assertConnectorIsRunning();
+
+        /* Snapshot must be taken only for the listed tables */
+        SourceRecords actualRecords = consumeRecordsByTopic(1);
+        List<SourceRecord> s1recs = actualRecords.recordsForTopic(topicName("s1.a"));
+        List<SourceRecord> s2recs = actualRecords.recordsForTopic(topicName("s2.a"));
+
+        assertThat(s1recs.size()).isEqualTo(1);
+        assertThat(s2recs).isNull();
+        VerifyRecord.isValidRead(s1recs.get(0), PK_FIELD, 1);
+
+        /* streaming should work normally */
+        TestHelper.execute(INSERT_STMT);
+        actualRecords = consumeRecordsByTopic(2);
+
+        s1recs = actualRecords.recordsForTopic(topicName("s1.a"));
+        s2recs = actualRecords.recordsForTopic(topicName("s2.a"));
+
+        assertThat(s1recs.size()).isEqualTo(1);
+        assertThat(s2recs.size()).isEqualTo(1);
+        VerifyRecord.isValidInsert(s1recs.get(0), PK_FIELD, 2);
+        VerifyRecord.isValidInsert(s2recs.get(0), PK_FIELD, 2);
+
+        stopConnector();
+
+        /* start the connector back up and make sure snapshot is being taken */
+        start(PostgresConnector.class, configBuilder
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE_TABLES, "s2.a")
+                .build());
+        assertConnectorIsRunning();
+
+        actualRecords = consumeRecordsByTopic(2);
+        s1recs = actualRecords.recordsForTopic(topicName("s1.a"));
+        s2recs = actualRecords.recordsForTopic(topicName("s2.a"));
+
+        assertThat(s2recs.size()).isEqualTo(2);
+        assertThat(s1recs).isNull();
+        VerifyRecord.isValidRead(s2recs.get(0), PK_FIELD, 1);
+        VerifyRecord.isValidRead(s2recs.get(1), PK_FIELD, 2);
+    }
+
+    @Test
     @FixFor("DBZ-1035")
     public void shouldAllowForExportedSnapshot() throws Exception {
         TestHelper.dropDefaultReplicationSlot();

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -11,7 +11,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -308,6 +310,14 @@ public abstract class CommonConnectorConfig {
             .withDescription("The maximum number of records that should be loaded into memory while performing a snapshot")
             .withValidation(Field::isNonNegativeInteger);
 
+    public static final Field SNAPSHOT_MODE_TABLES = Field.create("snapshot.mode.tables")
+            .withDisplayName("Snapshot Mode Custom Tables")
+            .withType(Type.LIST)
+            .withWidth(Width.LONG)
+            .withImportance(Importance.MEDIUM)
+            .withDescription(
+                    "this setting must be set to specify a list of tables/collections whose snapshot must be taken on creating or restarting the connector.");
+
     public static final Field SOURCE_STRUCT_MAKER_VERSION = Field.create("source.struct.version")
             .withDisplayName("Source struct maker version")
             .withEnum(Version.class, Version.V2)
@@ -378,6 +388,7 @@ public abstract class CommonConnectorConfig {
                     PROVIDE_TRANSACTION_METADATA,
                     SKIPPED_OPERATIONS,
                     SNAPSHOT_DELAY_MS,
+                    SNAPSHOT_MODE_TABLES,
                     SNAPSHOT_FETCH_SIZE,
                     RETRIABLE_RESTART_WAIT)
             .events(
@@ -522,6 +533,12 @@ public abstract class CommonConnectorConfig {
         else {
             return Collections.emptySet();
         }
+    }
+
+    public Set<String> getSnapshotAllowedTables() {
+        return Optional.ofNullable(config.getString(SNAPSHOT_MODE_TABLES))
+                .map(tables -> Strings.setOf(tables, Function.identity()))
+                .orElseGet(Collections::emptySet);
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -110,7 +110,7 @@ public abstract class RelationalSnapshotChangeEventSource extends AbstractSnapsh
             determineCapturedTables(ctx);
             snapshotProgressListener.monitoredDataCollectionsDetermined(ctx.capturedTables);
 
-            LOGGER.info("Snapshot step 3 - Locking captured tables");
+            LOGGER.info("Snapshot step 3 - Locking captured tables {}", ctx.capturedTables);
 
             if (snapshottingTask.snapshotSchema()) {
                 lockTablesForSchemaSnapshot(context, ctx);
@@ -181,7 +181,7 @@ public abstract class RelationalSnapshotChangeEventSource extends AbstractSnapsh
     }
 
     private void determineCapturedTables(RelationalSnapshotContext ctx) throws Exception {
-        Set<TableId> allTableIds = getAllTableIds(ctx);
+        Set<TableId> allTableIds = determineAllowedDataCollectionsForSnapshot(getAllTableIds(ctx));
 
         Set<TableId> capturedTables = new HashSet<>();
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1769,6 +1769,10 @@ Depending on the `_hashAlgorithm_` used, the `_salt_` selected, and the actual d
  +
 After a _delete_ operation, emitting a tombstone event enables Kafka to delete all change event records that have the same key as the deleted row. 
 
+|[[db2-property-include-schema-changes]]<<db2-property-include-schema-changes, `include.schema.changes`>>
+|`true`
+|Boolean value that specifies whether the connector should publish changes in the database schema to a Kafka topic with the same name as the database server ID. Each schema change is recorded with a key that contains the database name and a value that is a JSON structure that describes the schema update. This is independent of how the connector internally records database history. 
+
 |[[db2-property-column-truncate-to-length-chars]]<<db2-property-column-truncate-to-length-chars, `column.truncate.to._length_.chars`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event records, values in these columns are truncated if they are longer than the number of characters specified by _length_ in the property name. You can specify multiple properties with different lengths in a single configuration. Length must be a positive integer, for example, `column.truncate.to.20.chars`. 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2456

Hi @jpechane, @gunnarmorling as per your comments on https://github.com/debezium/debezium/pull/1766. I have re-modeled the change to include a property `snapshot.mode.tables`, which would allow for selectively taking the snapshot and is honored by all types of connectors. So Effectively only the subset of tables specified in the above configuration are considered for snapshots and are locked, post which streaming resumes. 

My apologies for creating a new PR as I had some problems in merging the refs from upstream.