### PR TITLE
DBZ-2456 selective snapshot implementation

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
@@ -6,7 +6,6 @@
 package io.debezium.connector.mongodb;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -398,12 +397,12 @@ public class ConnectionContext implements AutoCloseable {
          *
          * @return the collection identifiers; never null
          */
-        public List<CollectionId> collections() {
+        public Set<CollectionId> collections() {
             String replicaSetName = replicaSet.replicaSetName();
 
             // For each database, get the list of collections ...
             return execute("get collections in databases", primary -> {
-                List<CollectionId> collections = new ArrayList<>();
+                Set<CollectionId> collections = new HashSet<>();
                 Set<String> databaseNames = databaseNames();
 
                 for (String dbName : databaseNames) {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.mongodb;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -397,12 +398,12 @@ public class ConnectionContext implements AutoCloseable {
          *
          * @return the collection identifiers; never null
          */
-        public Set<CollectionId> collections() {
+        public List<CollectionId> collections() {
             String replicaSetName = replicaSet.replicaSetName();
 
             // For each database, get the list of collections ...
             return execute("get collections in databases", primary -> {
-                Set<CollectionId> collections = new HashSet<>();
+                List<CollectionId> collections = new ArrayList<>();
                 Set<String> databaseNames = databaseNames();
 
                 for (String dbName : databaseNames) {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
@@ -17,6 +17,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.errors.ConnectException;
 import org.bson.BsonTimestamp;
@@ -342,7 +343,7 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
 
         LOGGER.info("Beginning snapshot of '{}' at {}", rsName, rsOffsetContext.getOffset());
 
-        final Set<CollectionId> collections = determineAllowedDataCollectionsForSnapshot(primaryClient.collections());
+        final List<CollectionId> collections = determineDataCollectionsToBeSnapshotted(primaryClient.collections()).collect(Collectors.toList());
         snapshotProgressListener.monitoredDataCollectionsDetermined(collections);
         if (connectionContext.maxNumberOfCopyThreads() > 1) {
             // Since multiple copy threads are to be used, create a thread pool and initiate the copy.

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
@@ -12,7 +12,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
@@ -12,6 +12,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -342,7 +343,7 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
 
         LOGGER.info("Beginning snapshot of '{}' at {}", rsName, rsOffsetContext.getOffset());
 
-        final List<CollectionId> collections = primaryClient.collections();
+        final Set<CollectionId> collections = determineAllowedDataCollectionsForSnapshot(primaryClient.collections());
         snapshotProgressListener.monitoredDataCollectionsDetermined(collections);
         if (connectionContext.maxNumberOfCopyThreads() > 1) {
             // Since multiple copy threads are to be used, create a thread pool and initiate the copy.

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -966,6 +966,7 @@ public class MongoDbConnectorIT extends AbstractConnectorTest {
     }
 
     @Test
+    @FixFor("DBZ-2456")
     public void shouldSelectivelySnapshot() throws InterruptedException {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -255,7 +255,7 @@ public class SnapshotReader extends AbstractReader {
         final List<TableId> tablesToSnapshotSchemaAfterUnlock = new ArrayList<>();
         Set<TableId> lockedTables = Collections.emptySet();
 
-        final Set<String> snapshotAllowedTables = context.getConnectorConfig().getSnapshotAllowedTables();
+        final Set<String> snapshotAllowedTables = context.getConnectorConfig().getDataCollectionsToBeSnapshotted();
         final Predicate<TableId> isAllowedForSnapshot = tableId -> snapshotAllowedTables.size() == 0
                 || snapshotAllowedTables.stream().anyMatch(s -> tableId.identifier().matches(s));
         try {
@@ -408,7 +408,6 @@ public class SnapshotReader extends AbstractReader {
                                 else {
                                     logger.info("\t '{}' is not added among known tables", id);
                                 }
-                                //
                                 if (filters.tableFilter().and(isAllowedForSnapshot).test(id)) {
                                     capturedTableIds.add(id);
                                     logger.info("\t including '{}' for further processing", id);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -104,7 +104,7 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
     protected void lockTablesForSchemaSnapshot(ChangeEventSourceContext sourceContext, RelationalSnapshotContext snapshotContext)
             throws SQLException, InterruptedException {
         final Duration lockTimeout = connectorConfig.snapshotLockTimeout();
-        final Optional<String> lockStatement = snapshotter.snapshotTableLockingStatement(lockTimeout, schema.tableIds());
+        final Optional<String> lockStatement = snapshotter.snapshotTableLockingStatement(lockTimeout, snapshotContext.capturedTables);
 
         if (lockStatement.isPresent()) {
             LOGGER.info("Waiting a maximum of '{}' seconds for each table lock", lockTimeout.getSeconds());

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -1159,6 +1159,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     }
 
     @Test
+    @FixFor("DBZ-2456")
     public void shouldAllowForSelectiveSnapshot() throws InterruptedException {
         TestHelper.execute(SETUP_TABLES_STMT);
         Configuration.Builder configBuilder = TestHelper.defaultConfig()

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
@@ -371,6 +371,7 @@ public class SnapshotIT extends AbstractConnectorTest {
     }
 
     @Test
+    @FixFor("DBZ-2456")
     public void shouldSelectivelySnapshotTables() throws SQLException, InterruptedException {
         connection.execute(
                 "CREATE TABLE table_a (id int, name varchar(30), amount integer primary key(id))",

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -312,7 +312,7 @@ public abstract class CommonConnectorConfig {
             .withValidation(Field::isNonNegativeInteger);
 
     public static final Field SNAPSHOT_MODE_TABLES = Field.create("snapshot.include.collection.list")
-            .withDisplayName("Snapshot Mode include Data Collection")
+            .withDisplayName("Snapshot mode include data collection")
             .withType(Type.LIST)
             .withWidth(Width.LONG)
             .withImportance(Importance.MEDIUM)
@@ -553,7 +553,7 @@ public abstract class CommonConnectorConfig {
         }
     }
 
-    public Set<String> getSnapshotAllowedTables() {
+    public Set<String> getDataCollectionsToBeSnapshotted() {
         return Optional.ofNullable(config.getString(SNAPSHOT_MODE_TABLES))
                 .map(tables -> Strings.setOf(tables, Function.identity()))
                 .orElseGet(Collections::emptySet);

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -311,11 +311,12 @@ public abstract class CommonConnectorConfig {
             .withDescription("The maximum number of records that should be loaded into memory while performing a snapshot")
             .withValidation(Field::isNonNegativeInteger);
 
-    public static final Field SNAPSHOT_MODE_TABLES = Field.create("snapshot.table")
-            .withDisplayName("Snapshot Mode Custom Tables")
+    public static final Field SNAPSHOT_MODE_TABLES = Field.create("snapshot.include.collection.list")
+            .withDisplayName("Snapshot Mode include Data Collection")
             .withType(Type.LIST)
             .withWidth(Width.LONG)
             .withImportance(Importance.MEDIUM)
+            .withValidation(Field::isListOfRegex)
             .withDescription(
                     "this setting must be set to specify a list of tables/collections whose snapshot must be taken on creating or restarting the connector.");
 

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -11,7 +11,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -309,6 +311,14 @@ public abstract class CommonConnectorConfig {
             .withDescription("The maximum number of records that should be loaded into memory while performing a snapshot")
             .withValidation(Field::isNonNegativeInteger);
 
+    public static final Field SNAPSHOT_MODE_TABLES = Field.create("snapshot.table")
+            .withDisplayName("Snapshot Mode Custom Tables")
+            .withType(Type.LIST)
+            .withWidth(Width.LONG)
+            .withImportance(Importance.MEDIUM)
+            .withDescription(
+                    "this setting must be set to specify a list of tables/collections whose snapshot must be taken on creating or restarting the connector.");
+
     public static final Field SOURCE_STRUCT_MAKER_VERSION = Field.create("source.struct.version")
             .withDisplayName("Source struct maker version")
             .withEnum(Version.class, Version.V2)
@@ -388,6 +398,7 @@ public abstract class CommonConnectorConfig {
                     PROVIDE_TRANSACTION_METADATA,
                     SKIPPED_OPERATIONS,
                     SNAPSHOT_DELAY_MS,
+                    SNAPSHOT_MODE_TABLES,
                     SNAPSHOT_FETCH_SIZE,
                     RETRIABLE_RESTART_WAIT,
                     QUERY_FETCH_SIZE)
@@ -539,6 +550,12 @@ public abstract class CommonConnectorConfig {
         else {
             return Collections.emptySet();
         }
+    }
+
+    public Set<String> getSnapshotAllowedTables() {
+        return Optional.ofNullable(config.getString(SNAPSHOT_MODE_TABLES))
+                .map(tables -> Strings.setOf(tables, Function.identity()))
+                .orElseGet(Collections::emptySet);
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
@@ -6,8 +6,9 @@
 package io.debezium.pipeline.source;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,15 +85,14 @@ public abstract class AbstractSnapshotChangeEventSource implements SnapshotChang
         }
     }
 
-    protected <T extends DataCollectionId> Set<T> determineAllowedDataCollectionsForSnapshot(final Set<T> allDataCollections) {
-        final Set<String> snapshotAllowedTables = connectorConfig.getSnapshotAllowedTables();
-        if (snapshotAllowedTables.size() == 0) {
-            return allDataCollections;
+    protected <T extends DataCollectionId> Stream<T> determineDataCollectionsToBeSnapshotted(final Collection<T> allDataCollections) {
+        final Set<String> snapshotAllowedDataCollections = connectorConfig.getDataCollectionsToBeSnapshotted();
+        if (snapshotAllowedDataCollections.size() == 0) {
+            return allDataCollections.stream();
         }
         else {
             return allDataCollections.stream()
-                    .filter(dataCollectionId -> snapshotAllowedTables.stream().anyMatch(s -> dataCollectionId.identifier().matches(s)))
-                    .collect(Collectors.toSet());
+                    .filter(dataCollectionId -> snapshotAllowedDataCollections.stream().anyMatch(s -> dataCollectionId.identifier().matches(s)));
         }
     }
 

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -186,7 +186,7 @@ public abstract class RelationalSnapshotChangeEventSource extends AbstractSnapsh
     }
 
     private void determineCapturedTables(RelationalSnapshotContext ctx) throws Exception {
-        Set<TableId> allTableIds = determineAllowedDataCollectionsForSnapshot(getAllTableIds(ctx));
+        Set<TableId> allTableIds = determineDataCollectionsToBeSnapshotted(getAllTableIds(ctx)).collect(Collectors.toSet());
 
         Set<TableId> capturedTables = new HashSet<>();
 

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -109,7 +109,7 @@ public abstract class RelationalSnapshotChangeEventSource extends AbstractSnapsh
             determineCapturedTables(ctx);
             snapshotProgressListener.monitoredDataCollectionsDetermined(ctx.capturedTables);
 
-            LOGGER.info("Snapshot step 3 - Locking captured tables");
+            LOGGER.info("Snapshot step 3 - Locking captured tables {}", ctx.capturedTables);
 
             if (snapshottingTask.snapshotSchema()) {
                 lockTablesForSchemaSnapshot(context, ctx);
@@ -186,7 +186,7 @@ public abstract class RelationalSnapshotChangeEventSource extends AbstractSnapsh
     }
 
     private void determineCapturedTables(RelationalSnapshotContext ctx) throws Exception {
-        Set<TableId> allTableIds = getAllTableIds(ctx);
+        Set<TableId> allTableIds = determineAllowedDataCollectionsForSnapshot(getAllTableIds(ctx));
 
         Set<TableId> capturedTables = new HashSet<>();
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1130,6 +1130,10 @@ Must not be used with `collection.include.list`.
 |`initial`
 |Specifies the criteria for running a snapshot upon startup of the connector. The default is *initial*, and specifies the connector reads a snapshot when either no offset is found or if the oplog no longer contains the previous offset. The *never* option specifies that the connector should never use snapshots, instead the connector should proceed to tail the log.
 
+|[[mongodb-property-snapshot-include-collection-list]]<<mongodb-property-snapshot-include-collection-list, `snapshot.include.collection.list`>>
+| All collections specified in `collection.include.list`
+|An optional, comma-separated list of regular expressions that match names of schemas specified in `table.include.list` for which you *want* to take the snapshot.
+
 |[[mongodb-property-field-blacklist]]
 [[mongodb-property-field-exclude-list]]<<mongodb-property-field-exclude-list, `field.exclude{zwsp}.list`>>
 |_empty string_

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1132,7 +1132,7 @@ Must not be used with `collection.include.list`.
 
 |[[mongodb-property-snapshot-include-collection-list]]<<mongodb-property-snapshot-include-collection-list, `snapshot.include.collection.list`>>
 | All collections specified in `collection.include.list`
-|An optional, comma-separated list of regular expressions that match names of schemas specified in `table.include.list` for which you *want* to take the snapshot.
+|An optional, comma-separated list of regular expressions that match names of schemas specified in `collection.include.list` for which you *want* to take the snapshot.
 
 |[[mongodb-property-field-blacklist]]
 [[mongodb-property-field-exclude-list]]<<mongodb-property-field-exclude-list, `field.exclude{zwsp}.list`>>

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2306,6 +2306,10 @@ a|Controls whether and how long the connector holds the global MySQL read lock, 
  +
 `none` - prevents the connector from acquiring any table locks during the snapshot. While this setting is allowed with all snapshot modes, it is safe to use if and _only_ if no schema changes are happening while the snapshot is running. For tables defined with MyISAM engine, the tables would still be locked despite this property being set as MyISAM acquires a table lock. This behavior is unlike InnoDB engine, which acquires row level locks.
 
+|[[mysql-property-snapshot-include-collection-list]]<<mysql-property-snapshot-include-collection-list, `snapshot.include.collection.list`>>
+| All tables specified in `table.include.list`
+|An optional, comma-separated list of regular expressions that match names of schemas specified in `table.include.list` for which you *want* to take the snapshot.
+
 |[[mysql-property-snapshot-select-statement-overrides]]<<mysql-property-snapshot-select-statement-overrides, `snapshot.select{zwsp}.statement{zwsp}.overrides`>>
 |
 |Controls which table rows are included in snapshots. This property affects snapshots only. It does not affect events captured from the binlog. Specify a comma-separated list of fully-qualified table names in the form _databaseName{zwsp}.tableName_. +

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2516,7 +2516,9 @@ ifdef::community[]
 |
 | A full Java class name that is an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. Required when the `snapshot.mode` property is set to `custom`. See {link-prefix}:{link-postgresql-connector}#postgresql-custom-snapshot[custom snapshotter SPI].
 endif::community[]
-
+|[[postgresql-property-snapshot-include-collection-list]]<<postgresql-property-snapshot-include-collection-list, `snapshot.include.collection.list`>>
+| All tables specified in `table.include.list`
+|An optional, comma-separated list of regular expressions that match names of schemas specified in `table.include.list` for which you *want* to take the snapshot when the `snapshot.mode` is not `never`
 |[[postgresql-property-snapshot-lock-timeout-ms]]<<postgresql-property-snapshot-lock-timeout-ms, `snapshot.lock{zwsp}.timeout.ms`>>
 |`10000`
 |Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. {link-prefix}:{link-postgresql-connector}#postgresql-snapshots[How the connector performs snapshots] provides details. 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1828,6 +1828,10 @@ Supported values are: +
 `initial_only`: Takes a snapshot of structure and data like `initial` but instead does not transition into streaming changes once the snapshot has completed. +
 `schema_only`: Takes a snapshot of the structure of captured tables only; useful if only changes happening from now onwards should be propagated to topics.
 
+|[[sqlserver-property-snapshot-include-collection-list]]<<sqlserver-property-snapshot-include-collection-list, `snapshot.include.collection.list`>>
+| All tables specified in `table.include.list`
+|An optional, comma-separated list of regular expressions that match names of schemas specified in `table.include.list` for which you *want* to take the snapshot.
+
 |[[sqlserver-property-snapshot-isolation-mode]]<<sqlserver-property-snapshot-isolation-mode, `snapshot.isolation{zwsp}.mode`>>
 |_repeatable_read_
 |Mode to control which transaction isolation level is used and how long the connector locks the monitored tables.


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2456

Hi @jpechane, @gunnarmorling as per your comments on #1766. I have re-modeled the change to include a property snapshot.table, which would allow for selectively taking the snapshot and is honored by all types of connectors. So Effectively only the subset of tables specified in the above configuration are considered for snapshots and are locked, post which streaming resumes. Could you please check and let me know if this suffices.

My apologies for creating a new PR as I had some problems in merging the refs from upstream.