### PR TITLE
DBZ-2501 Unify doc for each connector to have consistent event descriptions

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -194,7 +194,7 @@ A message to the schema change topic contains a logical representation of the ta
       "version": "{debezium-version}",
       "connector": "db2",
       "name": "db2",
-      "ts_ms": 1588252618953,
+      "ts_sec": 1588252618953,
       "snapshot": "true",
       "db": "testdb",
       "schema": "DB2INST1",
@@ -462,7 +462,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 |`schema`
 |The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed. +
  +
-Rarely, converter configuration overrides the key column with some other structure. In this case, the first schema field describes that structure.
+It is possible to override the table's primary key by setting the {link-prefix}:{link-db2-connector}#db2-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the the key identified by that property.
 
 |2
 |`payload`
@@ -700,7 +700,7 @@ The following example shows the value portion of a change event that the connect
           {
             "type": "int64",
             "optional": false,
-            "field": "ts_ms"
+            "field": "ts_sec"
           },
           {
             "type": "boolean",
@@ -764,7 +764,7 @@ The following example shows the value portion of a change event that the connect
       "version": "{debezium-version}",
       "connector": "db2",
       "name": "myconnector",
-      "ts_ms": 1559729468470,
+      "ts_sec": 1559729468470,
       "snapshot": false,
       "db": "mydatabase",
       "schema": "MYSCHEMA",
@@ -864,7 +864,7 @@ The value of a change event for an update in the sample `customers` table has th
       "version": "{debezium-version}",
       "connector": "db2",
       "name": "myconnector",
-      "ts_ms": 1559729995937,
+      "ts_sec": 1559729995937,
       "snapshot": false,
       "db": "mydatabase",
       "schema": "MYSCHEMA",
@@ -940,7 +940,7 @@ The value in a _delete_ change event has the same `schema` portion as _create_ a
       "version": "{debezium-version}",
       "connector": "db2",
       "name": "myconnector",
-      "ts_ms": 1559730445243,
+      "ts_sec": 1559730445243,
       "snapshot": false,
       "db": "mydatabase",
       "schema": "MYSCHEMA",

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -676,7 +676,7 @@ The following example shows the value portion of a change event that the connect
           }
         ],
         "optional": true,
-        "name": "mydatabase.MYSCHEMA.CUSTOMERS.Value",  // <2>
+        "name": "mydatabase.MYSCHEMA.CUSTOMERS.Value", 
         "field": "after"
       },
       {
@@ -735,7 +735,7 @@ The following example shows the value portion of a change event that the connect
           },
         ],
         "optional": false,
-        "name": "io.debezium.connector.db2.Source",  // <2>
+        "name": "io.debezium.connector.db2.Source",  // <3>
         "field": "source"
       },
       {
@@ -750,17 +750,17 @@ The following example shows the value portion of a change event that the connect
       }
     ],
     "optional": false,
-    "name": "mydatabase.MYSCHEMA.CUSTOMERS.Envelope"  // <2>
+    "name": "mydatabase.MYSCHEMA.CUSTOMERS.Envelope"  // <4>
   },
-  "payload": {  // <3>
-    "before": null,  // <4>
-    "after": {  // <5>
+  "payload": {  // <5>
+    "before": null,  // <6>
+    "after": {  // <7>
       "ID": 1005,
       "FIRST_NAME": "john",
       "LAST_NAME": "doe",
       "EMAIL": "john.doe@example.org"
     },
-    "source": {  // <6>
+    "source": {  // <8>
       "version": "{debezium-version}",
       "connector": "db2",
       "name": "myconnector",
@@ -772,8 +772,8 @@ The following example shows the value portion of a change event that the connect
       "change_lsn": "00000027:00000758:0003",
       "commit_lsn": "00000027:00000758:0005",
     },
-    "op": "c",  // <7>
-    "ts_ms": 1559729471739  // <8>
+    "op": "c",  // <9>
+    "ts_ms": 1559729471739  // <10>
   }
 }
 ----
@@ -789,30 +789,36 @@ The following example shows the value portion of a change event that the connect
 
 |2
 |`name`
-a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. In this example: 
-
-* `mydatabase.MYSCHEMA.CUSTOMERS.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table. The connector uses this schema for all rows in the `MYSCHEMA.CUSTOMERS` table. Names of schemas for `before` and `after` fields are of the form `_logicalName_._schemaName_._tableName_.Value`, which ensures that the schema name is unique in the database. This means that when using the {link-prefix}:{link-avro-serialization}[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
-
-* `io.debezium.connector.db2.Source` is the schema for the payload's `source` field. This schema is specific to the Db2 connector. The connector uses it for all events that it generates. 
-
-* `mydatabase.MYSCHEMA.CUSTOMERS.Envelope` is the schema for the overall structure of the payload, where `mydatabase` is the database, `MYSCHEMA` is the schema, and `CUSTOMERS` is the table.
+a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. +
+ +
+`mydatabase.MYSCHEMA.CUSTOMERS.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table. The connector uses this schema for all rows in the `MYSCHEMA.CUSTOMERS` table. +
+ +
+Names of schemas for `before` and `after` fields are of the form `_logicalName_._schemaName_._tableName_.Value`, which ensures that the schema name is unique in the database. This means that when using the {link-prefix}:{link-avro-serialization}[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
 
 |3
-|`payload`
-|The value's actual data. This is the information that the change event is providing. 
+|`name`
+a|`io.debezium.connector.db2.Source` is the schema for the payload's `source` field. This schema is specific to the Db2 connector. The connector uses it for all events that it generates. 
 
+|4
+|`name`
+a|`mydatabase.MYSCHEMA.CUSTOMERS.Envelope` is the schema for the overall structure of the payload, where `mydatabase` is the database, `MYSCHEMA` is the schema, and `CUSTOMERS` is the table.
+
+|5 
+|`payload`
+|The value's actual data. This is the information that the change event is providing. +
+ +
 It may appear that JSON representations of events are much larger than the rows they describe. This is because a JSON representation must include the schema portion and the payload portion of the message.
 However, by using the {link-prefix}:{link-avro-serialization}[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
 
-|4
-|`before`
-| An optional field that specifies the state of the row before the event occurred. When the `op` field is `c` for create, as it is in this example, the `before` field is `null` since this change event is for new content. 
-
-|5
-|`after`
-| An optional field that specifies the state of the row after the event occurred. In this example, the `after` field contains the values of the new row's `ID`, `FIRST_NAME`, `LAST_NAME`, and `EMAIL` columns.
-
 |6
+|`before`
+|An optional field that specifies the state of the row before the event occurred. When the `op` field is `c` for create, as it is in this example, the `before` field is `null` since this change event is for new content. 
+
+|7
+|`after`
+|An optional field that specifies the state of the row after the event occurred. In this example, the `after` field contains the values of the new row's `ID`, `FIRST_NAME`, `LAST_NAME`, and `EMAIL` columns.
+
+|8
 |`source`
 a| Mandatory field that describes the source metadata for the event. The `source` structure shows Db2 information about this change, which provides traceability. It also has information you can use to compare to other events in the same topic or in other topics to know whether this event occurred before, after, or as part of the same commit as other events. The source metadata includes: 
 
@@ -824,18 +830,18 @@ a| Mandatory field that describes the source metadata for the event. The `source
 * Change LSN
 * Commit LSN (omitted if this event is part of a snapshot)
 
-|7
+|9
 |`op`
-a| Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are: 
+a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are: 
 
 * `c` = create
 * `u` = update
 * `d` = delete
 * `r` = read (applies to only snapshots)
 
-|8
+|10
 |`ts_ms`
-a| Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -199,19 +199,73 @@ Kafka maintains total order only for events written to a single topic partition.
 Partitioning the events by key does mean that all events with the same key always go to the same partition. This ensures that all events for a specific document are always totally ordered.
 
 [[mongodb-events]]
-=== Events
+=== Data change events
 
-All data change events produced by the MongoDB connector have a key and a value.
+The {prodname} MongoDB connector generates a data change event for each document-level operation that inserts, updates, or deletes data. Each event contains a key and a value. The structure of the key and the value depends on the collection that was changed. 
 
-{prodname} and Kafka Connect are designed around _continuous streams of event messages_, and the structure of these events could potentially change over time if the source of those events changed in structure or if the connector is improved or changed.
-This could be difficult for consumers to deal with, so to make it very easy Kafka Connect makes each event self-contained. Every message key and value has two parts: a _schema_ and _payload_. The schema describes the structure of the payload, while the payload contains the actual data.
+{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry. This makes each event self-contained. 
+
+The following skeleton JSON shows the basic four parts of a change event. However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of these four parts in change events. A `schema` field is in a change event only when you configure the converter to produce it. Likewise, the event key and event payload are in a change event only if you configure a converter to produce it. If you use the JSON converver and you configure it to produce all four basic change event parts, change events have this structure: 
+
+[source,json,index=0]
+----
+{
+ "schema": { //<1>
+   ...
+  },
+ "payload": { //<2>
+   ...
+ },
+ "schema": { //<3> 
+   ...
+ },
+ "payload": { //<4>
+   ...
+ },
+}
+----
+
+.Overview of change event basic content
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
+
+|1
+|`schema`
+|The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the key for the document that was changed. 
+
+|2
+|`payload`
+|The first `payload` field is part of the event key. It has the structure described by the previous `schema` field and it contains the key for the document that was changed. 
+
+|3
+|`schema`
+|The second `schema` field is part of the event value. It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion. In other words, the second `schema` describes the structure of the document that was changed. Typically, this schema contains nested schemas. 
+
+|4
+|`payload`
+|The second `payload` field is part of the event value. It has the structure described by the previous `schema` field and it contains the actual data for the document that was changed.
+
+|===
+
+By default, the connector streams change event records to topics with names that are the same as the event's originating collection. See {link-prefix}:{link-mongodb-connector}#mongodb-topic-names[topic names].
+
+[WARNING]
+====
+The MongoDB connector ensures that all Kafka Connect schema names adhere to the link:http://avro.apache.org/docs/current/spec.html#names[Avro schema name format]. This means that the logical server name must start with a Latin letter or an underscore, that is, a-z, A-Z, or \_. Each remaining character in the logical server name and each character in the database and collection names must be a Latin letter, a digit, or an underscore, that is, a-z, A-Z, 0-9, or \_. If there is an invalid character it is replaced with an underscore character.
+
+This can lead to unexpected conflicts if the logical server name, a database name, or a collection name contains invalid characters, and the only characters that distinguish names from one another are invalid and thus replaced with underscores.
+====
 
 [[mongodb-change-events-key]]
-==== Change event's key
+==== Change event keys
 
-For a given collection, the change event's key contains a single `id` field.
-Its value is the document's identifier represented as string which is derived from the https://docs.mongodb.com/manual/reference/mongodb-extended-json/[MongoDB extended JSON serialization in strict mode]. Consider a connector with a logical name of `fulfillment`, a replica set containing an `inventory` database with a `customers` collection containing documents such as:
+A change event's key contains the schema for the changed document's key and the changed document's actual key. For a given collection, both the schema and its corresponding payload contain a single `id` field.
+The value of this field is the document's identifier represented as a string that is derived from link:https://docs.mongodb.com/manual/reference/mongodb-extended-json/[MongoDB extended JSON serialization strict mode].
 
+Consider a connector with a logical name of `fulfillment`, a replica set containing an `inventory` database, and a `customers` collection that contains documents such as the following. 
+
+.Example document
 [source,json,indent=0]
 ----
   {
@@ -222,16 +276,17 @@ Its value is the document's identifier represented as string which is derived fr
   }
 ----
 
-Every change event for the `customers` collection will feature the same key structure, which in JSON looks like this:
+.Example change event key
+Every change event that captures a change to the `customers` collection has the same event key schema. For as long as the `customers` collection has the previous definition, every change event that captures a change to the `customers` collection has the following key structure. In JSON, it looks like this:
 
 [source,json,indent=0]
 ----
   {
-    "schema": {
+    "schema": { <1>
       "type": "struct",
-      "name": "fulfillment.inventory.customers.Key"
-      "optional": false,
-      "fields": [
+      "name": "fulfillment.inventory.customers.Key" <2>
+      "optional": false, <3>
+      "fields": [ <4>
         {
           "field": "id",
           "type": "string",
@@ -239,77 +294,111 @@ Every change event for the `customers` collection will feature the same key stru
         }
       ]
     },
-    "payload": {
+    "payload": { <5>
       "id": "1004"
     }
   }
 ----
 
-The `schema` portion of the key contains a Kafka Connect schema describing what is in the payload portion. In this case, it means that the `payload` value is not optional, is a structure defined by a schema named `fulfillment.inventory.customers.Key`, and has one required field named `id` of type `string`. If you look at the value of the key's `payload` field, you can see that it is indeed a structure (which in JSON is just an object) with a single `id` field, whose value is a string containing the integer `1004`.
+.Description of change event key
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
 
-This example used a document with an integer identifier, but any valid MongoDB document identifier (including documents) will work. The value of the `id` field in the payload will simply be a string representing a MongoDB extended JSON serialization (strict mode) of the original document's `_id` field. Find below a few examples showing how `_id` fields of
-different types will get encoded as the event key's payload:
+|1
+|`schema`
+|The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion. 
 
+|2
+|`fulfillment.inventory.customers.Key`
+a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the key for the document that was changed. Key schema names have the format _connector-name_._database-name_._collection-name_.`Key`. In this example: + 
+
+* `fulfillment` is the name of the connector that generated this event. + 
+* `inventory` is the database that contains the collection that was changed. +
+* `customers` is the collection that contains the document that was updated.
+
+|3
+|`optional`
+|Indicates whether the event key must contain a value in its `payload` field. In this example, a value in the key's payload is required. A value in the key's payload field is optional when a document does not have a key.
+
+|4
+|`fields` 
+|Specifies each field that is expected in the `payload`, including each field's name, type, and whether it is required.
+
+|5
+|`payload`
+|Contains the key for the document for which this change event was generated. In this example, the key contains a single `id` field of type `string` whose value is `1004`.
+
+|===
+
+This example uses a document with an integer identifier, but any valid MongoDB document identifier works the same way, including a document identifier. For a document identifier, an event key's `payload.id` value is a string that represents the updated document's original `_id` field as a MongoDB extended JSON serialization that uses strict mode. The following table provides examples of how different types of `_id` fields are represented. 
+
+.Examples of representing document `_id` fields in event key payloads
 [options="header",role="code-wordbreak-col2 code-wordbreak-col3"]
 |===
 |Type    |MongoDB `_id` Value|Key's payload
 |Integer |1234|`{ "id" : "1234" }`
 |Float   |12.34|`{ "id" : "12.34" }`
 |String  |"1234"|`{ "id" : "\"1234\"" }`
-|Document|{ "hi" : "kafka", "nums" : [10.0, 100.0, 1000.0] }|`{ "id" : "{\"hi\" : \"kafka\", \"nums\" : [10.0, 100.0, 1000.0]}" }`
-|ObjectId|ObjectId("596e275826f08b2730779e1f")|`{ "id" : "{\"$oid\" : \"596e275826f08b2730779e1f\"}" }`
-|Binary  |BinData("a2Fma2E=",0)|`{ "id" : "{\"$binary\" : \"a2Fma2E=\", \"$type\" : \"00\"}" }`
+|Document|`{ "hi" : "kafka", "nums" : [10.0, 100.0, 1000.0] }`|`{ "id" : "{\"hi\" : \"kafka\", \"nums\" : [10.0, 100.0, 1000.0]}" }`
+|`ObjectId|ObjectId("596e275826f08b2730779e1f")``|`{ "id" : "{\"$oid\" : \"596e275826f08b2730779e1f\"}" }`
+|Binary  |`BinData("a2Fma2E=",0)`|`{ "id" : "{\"$binary\" : \"a2Fma2E=\", \"$type\" : \"00\"}" }`
 |===
 
-ifdef::community[]
-[WARNING]
-====
-The MongoDB connector ensures that all Kafka Connect _schema names_ are http://avro.apache.org/docs/current/spec.html#names[valid Avro schema names]. This means that the logical server name must start with Latin letters or an underscore (e.g., [a-z,A-Z,\_]), and the remaining characters in the logical server name and all characters in the database and collections names must be Latin letters, digits, or an underscore (e.g., [a-z,A-Z,0-9,\_]). If not, then all invalid characters will automatically be replaced with an underscore character.
-
-This can lead to unexpected conflicts in schemas names when the logical server name, database names, and collection names contain other characters, and the only distinguishing characters between collection full names are invalid and thus replaced with underscores. The connector attempts to produce an exception in this such cases, but only when the conflicts exist between schemas used within a single connector.
-====
-endif::community[]
-
 [[mongodb-change-events-value]]
-==== Change event's value
+==== Change event values
 
-The value of the change event message is a bit more complicated.
-Like the key message, it has a _schema_ section and _payload_ section.
-The payload section of every change event value produced by the MongoDB connector has an _envelope_ structure with the following fields:
+The value in a change event is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. Change events for operations that create, update or delete data all have a value payload with an envelope structure. 
 
-* `op` is a mandatory field that contains a string value describing the type of operation. Values for the MongoDB connector are `c` for create (or insert), `u` for update, `d` for delete, and `r` for read (in the case of a snapshot).
-* `after` is an optional field that if present contains the state of the document _after_ the event occurred. MongoDB's oplog entries only contain the full state of a document for _create_ events, so these are the only events that contain an _after_ field.
-* `source` is a mandatory field that contains a structure describing the source metadata for the event, which in the case of MongoDB contains several fields: the {prodname} version, the logical name, the replica set's name, the namespace of the collection, the MongoDB timestamp (and ordinal of the event within the timestamp) at which the event occurred, a unique identifier of the MongoDB operation (depending on the version of MongoDB, either the `h` field in the oplog event, or a field named `stxnid`, representing the `lsid` and `txnNumber` fields from the oplog event), and the `snapshot` flag if the event resulted during a snapshot.
-* `ts_ms` is optional and if present contains the time (using the system clock in the JVM running the Kafka Connect task) at which the connector processed the event.
+Consider the same sample document that was used to show an example of a change event key: 
 
-And of course, the _schema_ portion of the event message's value contains a schema that describes this envelope structure and the nested fields within it.
 
-Let's look at what a _create_/_read_ event value might look like for our `customers` collection:
+.Example document
+[source,json,indent=0]
+----
+  {
+    "_id": 1004,
+    "first_name": "Anne",
+    "last_name": "Kretchmar",
+    "email": "annek@noanswer.org"
+  }
+----
 
-[source,json,indent=0,subs="attributes"]
+The value portion of a change event for a change to this document is described for each event type: 
+
+* <<mongodb-create-events,_create_ events>>
+* <<mongodb-update-events,_update_ events>>
+* <<mongodb-delete-events,_delete_ events>>
+
+[id="mongodb-create-events"]
+==== _create_ events
+
+The following example shows the value portion of a change event that the connector generates for an operation that creates data in the `customers` collection: 
+
+[source,json,options="nowrap",indent=0,subs="+attributes"]
 ----
 {
-    "schema": {
+    "schema": { <1>
       "type": "struct",
       "fields": [
         {
           "type": "string",
           "optional": true,
-          "name": "io.debezium.data.Json",
+          "name": "io.debezium.data.Json", <2>
           "version": 1,
           "field": "after"
         },
         {
           "type": "string",
           "optional": true,
-          "name": "io.debezium.data.Json",
+          "name": "io.debezium.data.Json", <2>
           "version": 1,
           "field": "patch"
         },
         {
           "type": "string",
           "optional": true,
-          "name": "io.debezium.data.Json",
+          "name": "io.debezium.data.Json", <2>
           "version": 1,
           "field": "filter"
         },
@@ -334,7 +423,7 @@ Let's look at what a _create_/_read_ event value might look like for our `custom
             {
               "type": "int64",
               "optional": false,
-              "field": "ts_ms"
+              "field": "ts_sec"
             },
             {
               "type": "boolean",
@@ -369,7 +458,7 @@ Let's look at what a _create_/_read_ event value might look like for our `custom
             }
           ],
           "optional": false,
-          "name": "io.debezium.connector.mongo.Source",
+          "name": "io.debezium.connector.mongo.Source", <2>
           "field": "source"
         },
         {
@@ -384,57 +473,111 @@ Let's look at what a _create_/_read_ event value might look like for our `custom
         }
       ],
       "optional": false,
-      "name": "dbserver1.inventory.customers.Envelope"
+      "name": "dbserver1.inventory.customers.Envelope" <2>
       },
-    "payload": {
-      "after": "{\"_id\" : {\"$numberLong\" : \"1004\"},\"first_name\" : \"Anne\",\"last_name\" : \"Kretchmar\",\"email\" : \"annek@noanswer.org\"}",
+    "payload": { <3>
+      "after": "{\"_id\" : {\"$numberLong\" : \"1004\"},\"first_name\" : \"Anne\",\"last_name\" : \"Kretchmar\",\"email\" : \"annek@noanswer.org\"}", <4>
       "patch": null,
-      "source": {
+      "source": { <5>
         "version": "{debezium-version}",
         "connector": "mongodb",
         "name": "fulfillment",
-        "ts_ms": 1558965508000,
-        "snapshot": true,
+        "ts_sec": 1558965508000,
+        "snapshot": false,
         "db": "inventory",
         "rs": "rs0",
         "collection": "customers",
         "ord": 31,
         "h": 1546547425148721999
       },
-      "op": "r",
-      "ts_ms": 1558965515240
+      "op": "c", <6>
+      "ts_ms": 1558965515240 <7>
     }
   }
 ----
 
-If we look at the `schema` portion of this event's _value_, we can see the schema for the _envelope_ is specific to the collection, and the schema for the `source` structure (which is specific to the MongoDB connector and reused across all events). Also note that the `after` value is always a string, and that by convention it will contain a JSON representation of the document.
+.Descriptions of _create_ event value fields
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
 
-If we look at the `payload` portion of this event's _value_, we can see the information in the event, namely that it is describing that the document was read as part of an snapshot (since `op=r` and `snapshot=true`), and that the `after` field value contains the JSON string representation of the document.
+|1
+|`schema`
+|The value's schema, which describes the structure of the value's payload. A change event's value schema is the same in every change event that the connector generates for a particular collection. 
 
-[NOTE]
-====
-It may appear that the JSON representations of the events are much larger than the rows they describe. This is true, because the JSON representation must include the _schema_ and the _payload_ portions of the message.
-ifdef::community[]
-It is possible and even recommended to use the link:/docs/faq/#avro-converter[Avro Converter] to dramatically decrease the size of the actual messages written to the Kafka topics.
-endif::community[]
-====
+|2
+|`name`
+a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. In this example: 
 
-The value of an _update_ change event on this collection will actually have the exact same _schema_, and its payload is structured the same but will hold different values. Specifically, an update event will not have an `after` value and will instead have a `patch` string containing the JSON representation of the idempotent update operation and a `filter` string containing the JSON representation of the selection criteria for the update.  The `filter` string can include multiple shard key fields for sharded collections. Here's an example:
+* `io.debezium.data.Json` is the schema for the payload's `after`, `patch`, and `filter` fields. This schema is specific to the `customers` collection. A _create_ event is the only kind of event that contains an `after` field. An _update_ event contains a `filter` field and a `patch` field. A _delete_ event contains a `filter` field, but not an `after` field nor a `patch` field. 
 
-[source,json,indent=0,subs="attributes"]
+* `io.debezium.connector.mongo.Source` is the schema for the payload's `source` field. This schema is specific to the MongoDB connector. The connector uses it for all events that it generates. 
+
+* `dbserver1.inventory.customers.Envelope` is the schema for the overall structure of the payload, where `dbserver1` is the connector name, `inventory` is the database, and `customers` is the collection. This schema is specific to the collection. 
+
+|3
+|`payload`
+|The value's actual data. This is the information that the change event is providing. 
+
+It may appear that the JSON representations of the events are much larger than the documents they describe. This is because the JSON representation must include the schema and the payload portions of the message.
+However, by using the {link-prefix}:{link-avro-serialization}[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
+
+|4
+|`after`
+| An optional field that specifies the state of the document after the event occurred. In this example, the `after` field contains the values of the new document's `\_id`, `first_name`, `last_name`, and `email` fields. The `after` value is always a string. By convention, it contains a JSON representation of the document. MongoDB's oplog entries contain the full state of a document only for _create_ events; in other words, a _create_ event is the only kind of event that contains an _after_ field.
+
+|5
+|`source`
+a| Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes: 
+
+* {prodname} version.
+* Name of the connector that generated the event.
+* Logical name of the MongoDB replica set, which forms a namespace for generated events and is used in Kafka topic names to which the connector writes.
+* Names of the collection and database that contain the new document.
+* If the event was part of a snapshot.
+* Timestamp for when the event occurred and ordinal of the event within the timestamp.
+* Unique identifier of the MongoDB operation, which depends on the version of MongoDB. It is either the `h` field in the oplog event, or a field named `stxnid`, which represents the `lsid` and `txnNumber` fields from the oplog event.
+
+|6
+|`op`
+a| Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a document. Valid values are: 
+
+* `c` = create
+* `u` = update
+* `d` = delete
+* `r` = read (applies to only snapshots)
+
+|7
+|`ts_ms`
+a| Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+
+|===
+
+[id="mongodb-update-events"]
+==== _update_ events
+
+The value of a change event for an update in the sample `customers` collection has the same schema as a _create_ event for that collection. Likewise, the event value's payload has the same structure. However, the event value payload contains different values in an _update_ event. An _update_ event does not have an `after` value. Instead, it has these two fields:  
+
+* `patch` is a string field that contains the JSON representation of the idempotent update operation 
+
+* `filter` is a string field that contains the JSON representation of the selection criteria for the update. The `filter` string can include multiple shard key fields for sharded collections. 
+
+Here is an example of a change event value in an event that the connector generates for an update in the `customers` collection: 
+
+[source,json,indent=0,options="nowrap",subs="+attributes"]
 ----
 {
     "schema": { ... },
     "payload": {
-      "op": "u",
-      "ts_ms": 1465491461815,
-      "patch": "{\"$set\":{\"first_name\":\"Anne Marie\"}}",
-      "filter": "{\"_id\" : {\"$numberLong\" : \"1004\"}}",
-      "source": {
+      "op": "u", <1>
+      "ts_ms": 1465491461815, <2>
+      "patch": "{\"$set\":{\"first_name\":\"Anne Marie\"}}", <3>
+      "filter": "{\"_id\" : {\"$numberLong\" : \"1004\"}}", <4>
+      "source": { <5>
         "version": "{debezium-version}",
         "connector": "mongodb",
         "name": "fulfillment",
-        "ts_ms": 1558965508000,
+        "ts_sec": 1558965508000,
         "snapshot": true,
         "db": "inventory",
         "rs": "rs0",
@@ -446,46 +589,71 @@ The value of an _update_ change event on this collection will actually have the 
   }
 ----
 
-When we compare this to the value in the _insert_ event, we see a couple of differences in the `payload` section:
+.Descriptions of _update_ event value fields
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
 
-* The `op` field value is now `u`, signifying that this document changed because of an update
-* The `patch` field appears and has the stringified JSON representation of the actual MongoDB idempotent change to the document, which in this example involves setting the `first_name` field to a new value
-* The `filter` field appears and has the stringified JSON representation of the MongoDB selection criteria used for the update
-* The `after` field no longer appears
-* The `source` field structure has the same fields as before, but the values are different since this event is from a different position in the oplog
-* The `ts_ms` shows the timestamp that {prodname} processed this event
+|1
+|`op`
+a| Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `u` indicates that the operation updated a document. 
+
+|2
+|`ts_ms`
+a| Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+
+|3
+|`patch`
+|Contains the JSON string representation of the actual MongoDB idempotent change to the document. In this example, the update changed the `first_name` field to a new value. +
+ +
+An _update_ event value does not contain an `after` field. 
+
+|4
+|`filter`
+|Contains the JSON string representation of the MongoDB selection criteria that was used to identify the document to be updated. 
+
+|5
+|`source`
+a| Mandatory field that describes the source metadata for the event. This field contains the same information as a _create_ event for the same collection, but the values are different since this event is from a different position in the oplog. The source metadata includes: 
+
+* {prodname} version.
+* Name of the connector that generated the event.
+* Logical name of the MongoDB replica set, which forms a namespace for generated events and is used in Kafka topic names to which the connector writes.
+* Names of the collection and database that contain the updated document.
+* If the event was part of a snapshot.
+* Timestamp for when the event occurred and ordinal of the event within the timestamp.
+* Unique identifier of the MongoDB operation, which depends on the version of MongoDB. It is either the `h` field in the oplog event, or a field named `stxnid`, which represents the `lsid` and `txnNumber` fields from the oplog event.
+
+|===
 
 [WARNING]
 ====
-The content of the patch field is provided by MongoDB itself and its exact format depends on the specific database version.
-You should therefore be prepared for potential changes to the format when upgrading the MongoDB instance to a new version.
-
-All examples in this document were obtained from MongoDB 3.4 and might differ if you use a different one.
+In a {prodname} change event, MongoDB provides the content of the `patch` field. The format of this field depends on the version of the MongoDB database. Consequently, be prepared for potential changes to the format when you upgrade to a newer MongoDB database version. Examples in this document were obtained from MongoDB 3.4, In your application, event formats might be different.
 ====
 
 [NOTE]
 ====
-Update events in MongoDB's oplog do not have the _before_ or _after_ states of the changed document, so there's no way for the connector to provide this information.
-However, because _create_ or _read_ events _do_ contain the starting state, downstream consumers of the stream can actually fully-reconstruct the state by keeping the latest state for each document and applying each event to that state. {prodname} connector's are not able to keep such state, so it is not able to do this.
+In MongoDB's oplog, _update_ events do not contain the _before_ or _after_ states of the changed document. Consequently, it is not possible for a {prodname} connector to provide this information. However, MongoDB's oplog contains a document's starting state in _create_ and _read_ events. Downstream consumers of the stream can reconstruct document state by keeping the latest state for each document and comparing the state in a new event with the saved state. {prodname} connector's are not able to keep this state. 
 ====
 
-So far, you have seen samples of _create_/_read_ and _update_ events. The following sample shows the value of a _delete_ event for the same collection.
-The value of a _delete_ event on this collection has the exact same _schema_, and its payload is structured the same but it holds different values.
-In particular, a delete event does not have an `after` value nor a `patch` value:
+[id="mongodb-delete-events"]
+==== _delete_ events
 
-[source,json,indent=0,subs="attributes"]
+The value in a _delete_ change event has the same `schema` portion as _create_ and _update_ events for the same collection. The `payload` portion in a _delete_ event contains values that are different from _create_ and _update_ events for the same collection. In particular, a _delete_ event contains neither an `after` value nor a `patch` value. Here is an example of a _delete_ event for a document in the `customers` collection: 
+
+[source,json,indent=0,subs="+attributes"]
 ----
 {
     "schema": { ... },
     "payload": {
-      "op": "d",
-      "ts_ms": 1465495462115,
-      "filter": "{\"_id\" : {\"$numberLong\" : \"1004\"}}",
-      "source": {
+      "op": "d", <1>
+      "ts_ms": 1465495462115, <2>
+      "filter": "{\"_id\" : {\"$numberLong\" : \"1004\"}}", <3>
+      "source": { <4>
         "version": "{debezium-version}",
         "connector": "mongodb",
         "name": "fulfillment",
-        "ts_ms": 1558965508000,
+        "ts_sec": 1558965508000,
         "snapshot": true,
         "db": "inventory",
         "rs": "rs0",
@@ -497,23 +665,42 @@ In particular, a delete event does not have an `after` value nor a `patch` value
   }
 ----
 
-When we compare this to the value in the other events, we see a couple of differences in the `payload` section:
+.Descriptions of _delete_ event value fields
+[cols="1,2,7",options="header",subs="+attributes"]
+|===
+|Item |Field name |Description
 
-* The `op` field value is now `d`, signifying that this document was deleted
-* The `patch` field does not appear
-* The `after` field does not appear
-* The `filter` field appears and has the stringified JSON representation of the MongoDB selection criteria used for the delete
-* The `source` field structure has the same fields as before, but the values are different since this event is from a different position in the oplog
-* The `ts_ms` shows the timestamp that {prodname} processed this event
+|1
+|`op`
+a|Mandatory string that describes the type of operation. The `op` field value is `d`, signifying that this document was deleted.
 
-The MongoDB connector provides one other kind of event. Each _delete_ event is followed by a _tombstone_ event that has the same key as the _delete_ event but a `null` value. This provides Kafka with the information needed to run its link:https://kafka.apache.org/documentation/#compaction[log compaction] mechanism to remove _all_ messages with that key.
+|2
+|`ts_ms`
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
 
-[NOTE]
-====
-All MongoDB connector events are designed to work with link:https://kafka.apache.org/documentation/#compaction[Kafka log compaction], which allows for the removal of older messages as long as at least the most recent message for every key is kept. This is how Kafka can reclaim storage space while ensuring that the topic contains a complete dataset and can be used for reloading key-based state.
+|3
+|`filter`
+|Contains the JSON string representation of the MongoDB selection criteria that was used to identify the document to be deleted.  
 
-All MongoDB connector events for a uniquely identified document have exactly the same key, signaling to Kafka that only the latest event be kept. A tombstone event informs Kafka that _all_ messages with that same key can be removed.
-====
+|4
+|`source`
+a| Mandatory field that describes the source metadata for the event. This field contains the same information as a _create_ or _update_ event for the same collection, but the values are different since this event is from a different position in the oplog. The source metadata includes: 
+
+* {prodname} version.
+* Name of the connector that generated the event.
+* Logical name of the MongoDB replica set, which forms a namespace for generated events and is used in Kafka topic names to which the connector writes.
+* Names of the collection and database that contained the deleted document.
+* If the event was part of a snapshot.
+* Timestamp for when the event occurred and ordinal of the event within the timestamp.
+* Unique identifier of the MongoDB operation, which depends on the version of MongoDB. It is either the `h` field in the `oplog` event, or a field named `stxnid`, which represents the `lsid` and `txnNumber` fields from the `oplog` event.
+
+|===
+
+MongoDB connector events are designed to work with link:{link-kafka-docs}/#compaction[Kafka log compaction]. Log compaction enables removal of some older messages as long as at least the most recent message for every key is kept. This lets Kafka reclaim storage space while ensuring that the topic contains a complete data set and can be used for reloading key-based state.
+
+[id="mongodb-tombstone-events"]
+.Tombstone events
+All MongoDB connector events for a uniquely identified document have exactly the same key. When a document is deleted, the _delete_ event value still works with log compaction because Kafka can remove all earlier messages that have that same key. However, for Kafka to remove all messages that have that key, the message value must be `null`. To make this possible, after {prodname}’s MongoDB connector emits a _delete_ event, the connector emits a special tombstone event that has the same key but a `null` value. A tombstone event informs Kafka that all messages with that same key can be removed.
 
 [[mongodb-transaction-metadata]]
 === Transaction Metadata
@@ -647,7 +834,7 @@ endif::community[]
 === Example configuration
 
 To use the connector to produce change events for a particular MongoDB replica set or sharded cluster, create a configuration file in JSON.
-When the connector starts, it will perform a snapshot of the collections in your MongoDB replica sets and start reading the replica sets' oplogs, producing events for every inserted, updated, and deleted row.
+When the connector starts, it will perform a snapshot of the collections in your MongoDB replica sets and start reading the replica sets' oplogs, producing events for every inserted, updated, and deleted document.
 Optionally filter out collections that are not needed.
 
 ifdef::community[]

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -378,27 +378,27 @@ The following example shows the value portion of a change event that the connect
 [source,json,options="nowrap",indent=0,subs="+attributes"]
 ----
 {
-    "schema": { <1>
+    "schema": { // <1>
       "type": "struct",
       "fields": [
         {
           "type": "string",
           "optional": true,
-          "name": "io.debezium.data.Json", <2>
+          "name": "io.debezium.data.Json", // <2>
           "version": 1,
           "field": "after"
         },
         {
           "type": "string",
           "optional": true,
-          "name": "io.debezium.data.Json", <2>
+          "name": "io.debezium.data.Json", 
           "version": 1,
           "field": "patch"
         },
         {
           "type": "string",
           "optional": true,
-          "name": "io.debezium.data.Json", <2>
+          "name": "io.debezium.data.Json", 
           "version": 1,
           "field": "filter"
         },
@@ -458,7 +458,7 @@ The following example shows the value portion of a change event that the connect
             }
           ],
           "optional": false,
-          "name": "io.debezium.connector.mongo.Source", <2>
+          "name": "io.debezium.connector.mongo.Source", // <3>
           "field": "source"
         },
         {
@@ -473,12 +473,12 @@ The following example shows the value portion of a change event that the connect
         }
       ],
       "optional": false,
-      "name": "dbserver1.inventory.customers.Envelope" <2>
+      "name": "dbserver1.inventory.customers.Envelope" // <4>
       },
-    "payload": { <3>
-      "after": "{\"_id\" : {\"$numberLong\" : \"1004\"},\"first_name\" : \"Anne\",\"last_name\" : \"Kretchmar\",\"email\" : \"annek@noanswer.org\"}", <4>
+    "payload": { // <5>
+      "after": "{\"_id\" : {\"$numberLong\" : \"1004\"},\"first_name\" : \"Anne\",\"last_name\" : \"Kretchmar\",\"email\" : \"annek@noanswer.org\"}", // <6>
       "patch": null,
-      "source": { <5>
+      "source": { // <7>
         "version": "{debezium-version}",
         "connector": "mongodb",
         "name": "fulfillment",
@@ -490,8 +490,8 @@ The following example shows the value portion of a change event that the connect
         "ord": 31,
         "h": 1546547425148721999
       },
-      "op": "c", <6>
-      "ts_ms": 1558965515240 <7>
+      "op": "c", // <8>
+      "ts_ms": 1558965515240 // <9>
     }
   }
 ----
@@ -507,28 +507,32 @@ The following example shows the value portion of a change event that the connect
 
 |2
 |`name`
-a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. In this example: 
-
-* `io.debezium.data.Json` is the schema for the payload's `after`, `patch`, and `filter` fields. This schema is specific to the `customers` collection. A _create_ event is the only kind of event that contains an `after` field. An _update_ event contains a `filter` field and a `patch` field. A _delete_ event contains a `filter` field, but not an `after` field nor a `patch` field. 
-
-* `io.debezium.connector.mongo.Source` is the schema for the payload's `source` field. This schema is specific to the MongoDB connector. The connector uses it for all events that it generates. 
-
-* `dbserver1.inventory.customers.Envelope` is the schema for the overall structure of the payload, where `dbserver1` is the connector name, `inventory` is the database, and `customers` is the collection. This schema is specific to the collection. 
+a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. +
+ +
+`io.debezium.data.Json` is the schema for the payload's `after`, `patch`, and `filter` fields. This schema is specific to the `customers` collection. A _create_ event is the only kind of event that contains an `after` field. An _update_ event contains a `filter` field and a `patch` field. A _delete_ event contains a `filter` field, but not an `after` field nor a `patch` field. 
 
 |3
-|`payload`
-|The value's actual data. This is the information that the change event is providing. 
+|`name`
+a|`io.debezium.connector.mongo.Source` is the schema for the payload's `source` field. This schema is specific to the MongoDB connector. The connector uses it for all events that it generates. 
 
+|4
+|`name`
+a|`dbserver1.inventory.customers.Envelope` is the schema for the overall structure of the payload, where `dbserver1` is the connector name, `inventory` is the database, and `customers` is the collection. This schema is specific to the collection. 
+
+|5
+|`payload`
+|The value's actual data. This is the information that the change event is providing. +
+ +
 It may appear that the JSON representations of the events are much larger than the documents they describe. This is because the JSON representation must include the schema and the payload portions of the message.
 However, by using the {link-prefix}:{link-avro-serialization}[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
 
-|4
+|6
 |`after`
-| An optional field that specifies the state of the document after the event occurred. In this example, the `after` field contains the values of the new document's `\_id`, `first_name`, `last_name`, and `email` fields. The `after` value is always a string. By convention, it contains a JSON representation of the document. MongoDB's oplog entries contain the full state of a document only for _create_ events; in other words, a _create_ event is the only kind of event that contains an _after_ field.
+|An optional field that specifies the state of the document after the event occurred. In this example, the `after` field contains the values of the new document's `\_id`, `first_name`, `last_name`, and `email` fields. The `after` value is always a string. By convention, it contains a JSON representation of the document. MongoDB's oplog entries contain the full state of a document only for _create_ events; in other words, a _create_ event is the only kind of event that contains an _after_ field.
 
-|5
+|7
 |`source`
-a| Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes: 
+a|Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes: 
 
 * {prodname} version.
 * Name of the connector that generated the event.
@@ -538,18 +542,18 @@ a| Mandatory field that describes the source metadata for the event. This field 
 * Timestamp for when the event occurred and ordinal of the event within the timestamp.
 * Unique identifier of the MongoDB operation, which depends on the version of MongoDB. It is either the `h` field in the oplog event, or a field named `stxnid`, which represents the `lsid` and `txnNumber` fields from the oplog event.
 
-|6
+|8
 |`op`
-a| Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a document. Valid values are: 
+a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a document. Valid values are: 
 
 * `c` = create
 * `u` = update
 * `d` = delete
 * `r` = read (applies to only snapshots)
 
-|7
+|9
 |`ts_ms`
-a| Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
 
 |===
 
@@ -569,11 +573,11 @@ Here is an example of a change event value in an event that the connector genera
 {
     "schema": { ... },
     "payload": {
-      "op": "u", <1>
-      "ts_ms": 1465491461815, <2>
-      "patch": "{\"$set\":{\"first_name\":\"Anne Marie\"}}", <3>
-      "filter": "{\"_id\" : {\"$numberLong\" : \"1004\"}}", <4>
-      "source": { <5>
+      "op": "u", // <1>
+      "ts_ms": 1465491461815, // <2>
+      "patch": "{\"$set\":{\"first_name\":\"Anne Marie\"}}", // <3>
+      "filter": "{\"_id\" : {\"$numberLong\" : \"1004\"}}", // <4>
+      "source": { // <5>
         "version": "{debezium-version}",
         "connector": "mongodb",
         "name": "fulfillment",
@@ -596,11 +600,11 @@ Here is an example of a change event value in an event that the connector genera
 
 |1
 |`op`
-a| Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `u` indicates that the operation updated a document. 
+a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `u` indicates that the operation updated a document. 
 
 |2
 |`ts_ms`
-a| Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
 
 |3
 |`patch`
@@ -614,7 +618,7 @@ An _update_ event value does not contain an `after` field.
 
 |5
 |`source`
-a| Mandatory field that describes the source metadata for the event. This field contains the same information as a _create_ event for the same collection, but the values are different since this event is from a different position in the oplog. The source metadata includes: 
+a|Mandatory field that describes the source metadata for the event. This field contains the same information as a _create_ event for the same collection, but the values are different since this event is from a different position in the oplog. The source metadata includes: 
 
 * {prodname} version.
 * Name of the connector that generated the event.
@@ -646,10 +650,10 @@ The value in a _delete_ change event has the same `schema` portion as _create_ a
 {
     "schema": { ... },
     "payload": {
-      "op": "d", <1>
-      "ts_ms": 1465495462115, <2>
-      "filter": "{\"_id\" : {\"$numberLong\" : \"1004\"}}", <3>
-      "source": { <4>
+      "op": "d", // <1>
+      "ts_ms": 1465495462115, // <2>
+      "filter": "{\"_id\" : {\"$numberLong\" : \"1004\"}}", // <3>
+      "source": { // <4>
         "version": "{debezium-version}",
         "connector": "mongodb",
         "name": "fulfillment",
@@ -684,7 +688,7 @@ a|Optional field that displays the time at which the connector processed the eve
 
 |4
 |`source`
-a| Mandatory field that describes the source metadata for the event. This field contains the same information as a _create_ or _update_ event for the same collection, but the values are different since this event is from a different position in the oplog. The source metadata includes: 
+a|Mandatory field that describes the source metadata for the event. This field contains the same information as a _create_ or _update_ event for the same collection, but the values are different since this event is from a different position in the oplog. The source metadata includes: 
 
 * {prodname} version.
 * Name of the connector that generated the event.

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -633,7 +633,7 @@ In a {prodname} change event, MongoDB provides the content of the `patch` field.
 
 [NOTE]
 ====
-In MongoDB's oplog, _update_ events do not contain the _before_ or _after_ states of the changed document. Consequently, it is not possible for a {prodname} connector to provide this information. However, MongoDB's oplog contains a document's starting state in _create_ and _read_ events. Downstream consumers of the stream can reconstruct document state by keeping the latest state for each document and comparing the state in a new event with the saved state. {prodname} connector's are not able to keep this state. 
+In MongoDB's oplog, _update_ events do not contain the _before_ or _after_ states of the changed document. Consequently, it is not possible for a {prodname} connector to provide this information. However, a {prodname} connector provides a document's starting state in _create_ and _read_ events. Downstream consumers of the stream can reconstruct document state by keeping the latest state for each document and comparing the state in a new event with the saved state. {prodname} connector's are not able to keep this state. 
 ====
 
 [id="mongodb-delete-events"]

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -431,9 +431,55 @@ Following is an example of a message:
 [[postgresql-events]]
 == Data change events
 
-Each data change event produced by the {prodname} PostgreSQL connector contains a key and a value. The structure of the event key and event value depends on the table from which the change event originates. 
+The {prodname} PostgreSQL connector generates a data change event for each row-level `INSERT`, `UPDATE`, and `DELETE` operation. Each event contains a key and a value. The structure of the key and the value depends on the table that was changed. 
 
-{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To make it easier, Kafka Connect makes each event self-contained. Each event key and each event value has two parts: a _schema_ and a _payload_. In each part, the schema describes the structure of its payload, while the payload contains the actual data.
+{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry. This makes each event self-contained. 
+
+The following skeleton JSON shows the basic four parts of a change event. However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of these four parts in change events. A `schema` field is in a change event only when you configure the converter to produce it. Likewise, the event key and event payload are in a change event only if you configure a converter to produce it. If you use the JSON converver and you configure it to produce all four basic change event parts, change events have this structure: 
+
+[source,json,index=0]
+----
+{
+ "schema": { //<1>
+   ...
+  },
+ "payload": { //<2>
+   ...
+ },
+ "schema": { //<3> 
+   ...
+ },
+ "payload": { //<4>
+   ...
+ },
+}
+----
+
+.Overview of change event basic content
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
+
+|1
+|`schema`
+|The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed. +
+ +
+It is possible to override the table's primary key by setting the {link-prefix}:{link-postgresql-connector}#postgresql-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
+
+|2
+|`payload`
+|The first `payload` field is part of the event key. It has the structure described by the previous `schema` field and it contains the key for the row that was changed. 
+
+|3
+|`schema`
+|The second `schema` field is part of the event value. It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion. In other words, the second `schema` describes the structure of the row that was changed. Typically, this schema contains nested schemas. 
+
+|4
+|`payload`
+|The second `payload` field is part of the event value. It has the structure described by the previous `schema` field and it contains the actual data for the row that was changed.
+
+|===
+
 
 By default behavior is that the connector streams change event records to {link-prefix}:{link-postgresql-connector}#postgresql-topic-names[topics with names that are the same as the event's originating table].
 
@@ -484,7 +530,6 @@ CREATE TABLE customers (
 );
 ----
 
-=====
 .Example change event key
 If the `database.server.name` connector configuration property has the value `PostgreSQL_server`, every change event for the `customers` table while it has this definition has the same key structure, which in JSON looks like this:
 
@@ -511,14 +556,37 @@ If the `database.server.name` connector configuration property has the value `Po
     },
   }
 ----
-<1> The `schema` portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion. 
-<2> The `PostgreSQL_server.public.customers.Key` schema defines the structure of the key's payload. 
-<3> The key's `payload` value is not optional.
-<4> Specifies the type of fields expected in the `payload`. 
-<5> The payload itself, which in this case contains a single `id` field.
 
-This key describes output from the connector named `PostgreSQL_server`. The output is for the `public.customers` table row whose primary key, the `id` column, has a value of `1`.
-=====
+.Description of change event key
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
+
+|1
+|`schema`
+|The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion. 
+
+|2
+|`PostgreSQL_server.inventory.customers.Key`
+a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._database-name_._table-name_.`Key`. In this example: + 
+
+* `PostgreSQL_server` is the name of the connector that generated this event. + 
+* `public` is the database that contains the table that was changed. +
+* `customers` is the table that was updated.
+
+|3
+|`optional`
+|Indicates whether the event key must contain a value in its `payload` field. In this example, a value in the key's payload is required. A value in the key's payload field is optional when a table does not have a primary key.
+
+|4
+|`fields` 
+|Specifies each field that is expected in the `payload`, including each field's name, index, and schema.
+
+|5
+|`payload`
+|Contains the key for the row for which this change event was generated. In this example, the key, contains a single `id` field whose value is `1`.
+
+|===
 
 [NOTE]
 ====
@@ -536,36 +604,34 @@ If the table does not have a primary or unique key, then the change event's key 
 [[postgresql-change-events-value]]
 === Change event values
 
-The value in a change event record is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. The `payload` section has the following nested fields:  
+The value in a change event is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. Change events for operations that create, update or delete data all have a value payload with an envelope structure. 
 
-* `before` is an optional field. If present, it contains the state of the row _before_ the event occurred. The structure of the `before` field is described by a Kafka Connect `Value` schema. For example, for each row operation in the `public.customers` table, the connector uses the `PostgreSQL_server.public.customers.Value` schema to provide the content of the `before` field.
+Consider the same sample table that was used to show an example of a change event key: 
 
-[NOTE]
-====
-Whether or not this field is available is dependent on the {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting for each table.
-====
+[source,sql,indent=0]
+----
+CREATE TABLE customers (
+  id SERIAL,
+  first_name VARCHAR(255) NOT NULL,
+  last_name VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  PRIMARY KEY(id)
+);
+----
 
-* `after` is an optional field. If present, it contains the state of the row _after_ the operation occurred. The structure is described by the same Kafka Connect `Value` schema that is used for the `before` field.
+The value portion of a change event for a change to this table varies according to the `REPLICA IDENTITY` setting and the operation that the event is for. 
 
-* `source` is a mandatory field that contains a structure that describes the source metadata for the event. For PostgreSQL connectors, the metadata provides: 
+ifdef::product[]
+Details follow in these sections: 
 
-** {prodname} version
-** Connector name
-** Names of the database, schema, and table that contains the change
-** Whether this event is part of an ongoing snapshot
-** {link-prefix}:{link-postgresql-connector}#postgresql-meta-information[Partition and offset metadata]
+* <<postgresql-replica-identity, Replica identity>>
+* <<postgresql-create-events,_create_ events>>
+* <<postgresql-update-events,_update_ events>>
+* <<postgresql-primary-key-updates, Primary key updates>>
+* <<postgreswl-delete-events,_delete_ events>>
+* <<postgresql-tombstone-events, Tombstone events>>
+endif::product[]
 
-* `op` is a mandatory field that contains a string value that describes the type of operation. Allowed values for the PostgreSQL connector are: 
-** `c` for create or insert
-** `u` for update
-** `d` for delete
-** `r` for read in the case of a snapshot
-
-* `ts_ms` is an optional field. If present, it contains the time at which the connector processed the event. This value reflects the system clock in the JVM running the Kafka Connect task. 
-
-// Type: concept
-// ModuleID: how-replica-identity-controls-data-that-can-be-in-debezium-postgresql-change-events
-// Title: How `REPLICA IDENTITY` controls data that can be in {prodname} PostgreSQL change events
 [[postgresql-replica-identity]]
 === Replica identity
 
@@ -580,18 +646,15 @@ If a table does not have a primary key, the connector does not emit `UPDATE` or 
 * `FULL` - Emitted events for `UPDATE` and `DELETE` operations contain the previous values of all columns in the table.
 * `INDEX` _index-name_ - Emitted events for `UPDATE` and `DELETE` operations contain the previous values of the columns contained in the specified index. `UPDATE` events also contain the indexed columns with the updated values.
 
-// Type: concept
-// ModuleID: about-debezium-postgresql-change-events-for-operations-that-create-content
-// Title: About {prodname} PostgreSQL change events for operations that create content
 [[postgresql-create-events]]
 === _create_ events
 
-The following example shows a _create_ event value for the `customers` table:
+The following example shows the value portion of a change event that the connector generates for an operation that creates data in the `customers` table: 
 
-[source,json,indent=0,subs="attributes"]
+[source,json,options="nowrap",indent=0,subs="+attributes"]
 ----
 {
-    "schema": {
+    "schema": { <1>
         "type": "struct",
         "fields": [
             {
@@ -619,7 +682,7 @@ The following example shows a _create_ event value for the `customers` table:
                     }
                 ],
                 "optional": true,
-                "name": "PostgreSQL_server.inventory.customers.Value",
+                "name": "PostgreSQL_server.inventory.customers.Value", <2>
                 "field": "before"
             },
             {
@@ -647,7 +710,7 @@ The following example shows a _create_ event value for the `customers` table:
                     }
                 ],
                 "optional": true,
-                "name": "PostgreSQL_server.inventory.customers.Value",
+                "name": "PostgreSQL_server.inventory.customers.Value", <2>
                 "field": "after"
             },
             {
@@ -671,7 +734,7 @@ The following example shows a _create_ event value for the `customers` table:
                     {
                         "type": "int64",
                         "optional": false,
-                        "field": "ts_ms"
+                        "field": "ts_sec"
                     },
                     {
                         "type": "boolean",
@@ -711,7 +774,7 @@ The following example shows a _create_ event value for the `customers` table:
                     }
                 ],
                 "optional": false,
-                "name": "io.debezium.connector.postgresql.Source",
+                "name": "io.debezium.connector.postgresql.Source", <2>
                 "field": "source"
             },
             {
@@ -726,21 +789,21 @@ The following example shows a _create_ event value for the `customers` table:
             }
         ],
         "optional": false,
-        "name": "PostgreSQL_server.inventory.customers.Envelope"
+        "name": "PostgreSQL_server.inventory.customers.Envelope" <2>
     },
-    "payload": {
-        "before": null,
-        "after": {
+    "payload": { <3>
+        "before": null, <4>
+        "after": { <5>
             "id": 1,
             "first_name": "Anne",
             "last_name": "Kretchmar",
             "email": "annek@noanswer.org"
         },
-        "source": {
+        "source": { <6>
             "version": "{debezium-version}",
             "connector": "postgresql",
             "name": "PostgreSQL_server",
-            "ts_ms": 1559033904863,
+            "ts_sec": 1559033904863,
             "snapshot": true,
             "db": "postgres",
             "schema": "public",
@@ -749,60 +812,106 @@ The following example shows a _create_ event value for the `customers` table:
             "lsn": 24023128,
             "xmin": null
         },
-        "op": "c",
-        "ts_ms": 1559033904863
+        "op": "c", <7>
+        "ts_ms": 1559033904863 <8>
     }
 }
 ----
 
-In the `schema` portion of this event's value, you can see schemas for: 
- 
-* `customers.Envelope`
-* The `source` structure, which is specific to the PostgreSQL connector and reused across all events.
-* The `before` and `after` fields, whose schemas are specific to the table. 
-+
-The names of the schemas for the `before` and `after` fields are of the form `_logicalName_._schemaName_._tableName_.Value`, and thus are entirely independent from all other schemas for all other tables. This means that when using the Avro converter, the resulting Avro schemas for _each table_ in each _logical source_ have their own evolution and history.
 
-In the `payload` portion of this event's value, you can see:  
+.Descriptions of _create_ event value fields
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
 
-* The `before` field is null, which means that the event does not contain any previous row values. 
-* The `after` field contains values for the inserted row's `id`, `first_name`, `last_name`, and `email` columns.
-* The `source` field contains metadata.
-* The `op` field contains `c` to indicate that a row was created. 
+|1
+|`schema`
+|The value's schema, which describes the structure of the value's payload. A change event's value schema is the same in every change event that the connector generates for a particular table. 
 
-[NOTE]
-====
-JSON representations of events are much larger than the rows they describe. This is because the JSON representation must include the `schema` and the `payload` portions of the change event record. 
-It is possible and even recommended that you use the Avro converter to dramatically decrease the size of the records written to the Kafka topics.
-====
+|2
+|`name`
+a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. In this example: 
 
-// Type: concept
-// ModuleID: about-debezium-postgresql-change-events-for-operations-that-update-content
-// Title: About {prodname} PostgreSQL change events for operations that update content
+* `PostgreSQL_server.inventory.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table.
+
+* `io.debezium.connector.postgresql.Source` is the schema for the payload's `source` field. This schema is specific to the PostgreSQL connector. The connector uses it for all events that it generates. 
+
+* `PostgreSQL_server.inventory.customers.Envelope` is the schema for the overall structure of the payload, where `PostgreSQL_server` is the connector name, `inventory` is the database, and `customers` is the table.
+
+Names of schemas for `before` and `after` fields are of the form `_logicalName_._tableName_.Value`, which ensures that the schema name is unique in the database. This means that when using the {link-prefix}:{link-avro-serialization}[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
+
+|3
+|`payload`
+|The value's actual data. This is the information that the change event is providing. 
+
+It may appear that the JSON representations of the events are much larger than the rows they describe. This is because the JSON representation must include the schema and the payload portions of the message.
+However, by using the {link-prefix}:{link-avro-serialization}[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
+
+|4
+|`before`
+a|An optional field that specifies the state of the row before the event occurred. When the `op` field is `c` for create, as it is in this example, the `before` field is `null` since this change event is for new content.  +
+ +
+ [NOTE]
+ ====
+ Whether or not this field is available is dependent on the {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting for each table.
+ ====
+
+|5
+|`after`
+|An optional field that specifies the state of the row after the event occurred. In this example, the `after` field contains the values of the new row's `id`, `first_name`, `last_name`, and `email` columns.
+
+|6
+|`source`
+a|Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes: +
+ +
+* {prodname} version
+* Connector type and name
+* Database and table that contains the new row
+* Schema name
+* If the event was part of a snapshot
+* ID of the transaction in which the operation was performed
+* Offset of the operation in the database log
+* Timestamp
+
+|7
+|`op`
+a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are: 
+
+* `c` = create
+* `u` = update
+* `d` = delete
+* `r` = read (applies to only snapshots)
+
+|8
+|`ts_ms`
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+
+|===
+
 [[postgresql-update-events]]
 === _update_ events
 
-The value of an _update_ event on the sample `customers` table has the same `schema` specification as the _create_ event example. An _update_ event's payload has the same structure as a _create_ event for the same table. However, the _update_ event's payload contains different values, as shown in this example: 
+The value of a change event for an update in the sample `customers` table has the same schema as a _create_ event for that table. Likewise, the event value's payload has the same structure. However, the event value payload contains different values in an _update_ event. Here is an example of a change event value in an event that the connector generates for an update in the `customers` table: 
 
-[source,json,indent=0,subs="attributes"]
+[source,json,indent=0,options="nowrap",subs="attributes"]
 ----
 {
     "schema": { ... },
     "payload": {
-        "before": {
+        "before": { <1>
             "id": 1
         },
-        "after": {
+        "after": { <2>
             "id": 1,
             "first_name": "Anne Marie",
             "last_name": "Kretchmar",
             "email": "annek@noanswer.org"
         },
-        "source": {
+        "source": { <3>
             "version": "{debezium-version}",
             "connector": "postgresql",
             "name": "PostgreSQL_server",
-            "ts_ms": 1559033904863,
+            "ts_sec": 1559033904863,
             "snapshot": null,
             "db": "postgres",
             "schema": "public",
@@ -811,35 +920,52 @@ The value of an _update_ event on the sample `customers` table has the same `sch
             "lsn": 24023128,
             "xmin": null
         },
-        "op": "u",
+        "op": "u", <4>
         "ts_ms": 1465584025523
     }
 }
 ----
 
-As compared with the payload section in the _create_ event, you can see the following differences in the payload section of the _update_ event:  
+.Descriptions of _update_ event value fields
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
 
-* The `op` field value is `u` to indicate that the row changed because of an `UPDATE`.
-* The `before` field contains the values that were in the row before the database commit. In this example, only the primary key column, `id`, is present because the table's {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting is, by default, `DEFAULT`.
+|1
+|`before`
+|An optional field that contains values that were in the row before the database commit. In this example, only the primary key column, `id`, is present because the table's {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting is, by default, `DEFAULT`.
 +
 For an _update_ event to contain the previous values of all columns in the row, you would have to change the `customers` table by running `ALTER TABLE customers REPLICA IDENTITY FULL`.
 
-* The `after` field has the updated state of the row. As you can see, the `first_name` value is now `Anne Marie`.
+|2
+|`after`
+| An optional field that specifies the state of the row after the event occurred. In this example, the `first_name` value is now `Anne Marie`. 
 
-* The `source` field structure has the same fields as the _create_ event, but the values are different since this event is from a different position in the WAL.
+|3
+|`source`
+a|Mandatory field that describes the source metadata for the event. The `source` field structure has the same fields as in a _create_ event, but some values are different. The source metadata includes: 
 
-* The `ts_ms` shows the timestamp that {prodname} processed this event.
+* {prodname} version
+* Connector type and name
+* Database and table that contains the new row
+* Schema name
+* If the event was part of a snapshot
+* ID of the transaction in which the operation was performed
+* Offset of the operation in the database log
+* Timestamp
 
-There are several things to learn by looking at this `payload` section. You can compare the `before` and `after` structures to determine what changed in this row because of the commit. The `source` structure provides information about PostgreSQL's record of this change, which enables tracing. Perhaps more importantly, this payload has information that you can compare to other events. For example, a comparison typically indicates whether this event occurred before, after, or as part of the same PostgreSQL commit as another event.
+|4
+|`op`
+a|Mandatory string that describes the type of operation. In an _update_ event value, the `op` field value is `u`, signifying that this row changed because of an update.
+
+|===
 
 [NOTE]
 ====
 Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a {link-prefix}:{link-postgresql-connector}#postgresql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row. Details are in the next section. 
 ====
 
-// Type: concept
-// ModuleID: about-debezium-postgresql-change-events-for-primary-key-updates
-// Title: About {prodname} PostgreSQL change events for primary key updates
+[[postgresql-primary-key-updates]]
 === Primary key updates
 
 An `UPDATE` operation that changes a row's primary key field(s) is known
@@ -849,24 +975,21 @@ as a primary key change. For a primary key change, in place of sending an `UPDAT
 
 * The `CREATE` event record has `__debezium.oldkey` as a message header. The value of this header is the previous (old) primary key that the updated row had.
 
-// Type: concept
-// ModuleID: about-debezium-postgresql-change-events-for-operations-that-delete-content
-// Title: About {prodname} PostgreSQL change events for operations that delete content
 [[postgresql-delete-events]]
 === _delete_ events
 
-The value in a _delete_ event has the same `schema` portion as _create_ and _update_ events for the same table. The `payload` portion in a _delete_ event for the sample `customers` table looks like this: 
+The value in a _delete_ change event has the same `schema` portion as _create_ and _update_ events for the same table. The `payload` portion in a _delete_ event for the sample `customers` table looks like this:  
 
-[source,json,indent=0,subs="attributes"]
+[source,json,indent=0,subs="+attributes"]
 ----
 {
     "schema": { ... },
     "payload": {
-        "before": {
+        "before": { <1>
             "id": 1
         },
-        "after": null,
-        "source": {
+        "after": null, <2>
+        "source": { <3>
             "version": "{debezium-version}",
             "connector": "postgresql",
             "name": "PostgreSQL_server",
@@ -879,28 +1002,58 @@ The value in a _delete_ event has the same `schema` portion as _create_ and _upd
             "lsn": 46523128,
             "xmin": null
         },
-        "op": "d",
-        "ts_ms": 1465581902461
+        "op": "d", <4>
+        "ts_ms": 1465581902461 <5>
     }
 }
 ----
 
-Compared with the _create_ or _update_ event payloads, the differences in a _delete_ event are: 
+.Descriptions of _delete_ event value fields
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
 
-* The `before` field has the state of the row that was deleted by the database commit. In this example, the `before` field contains only the primary key column because the table's {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting is `DEFAULT`.
-* The `after` field is null to indicate that the row no longer exists.
-* The `source` field structure has many of the same values as in the _create_ and _update_ events, except the `ts_ms`, `lsn` and `txId` fields have changed.
-* The `op` field value is `d` to indicate that this row was deleted.
-* The `ts_ms` shows the timestamp that {prodname} processed this event.
+|1
+|`before`
+|Optional field that specifies the state of the row before the event occurred. In a _delete_ event value, the `before` field contains the values that were in the row before it was deleted with the database commit. +
+ +
+In this example, the `before` field contains only the primary key column because the table's {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting is `DEFAULT`.
 
-This event gives a consumer all kinds of information that it can use to process the removal of this row.
+|2
+|`after`
+| Optional field that specifies the state of the row after the event occurred. In a _delete_ event value, the `after` field is `null`, signifying that the row no longer exists.
+
+|3
+|`source`
+a|Mandatory field that describes the source metadata for the event. In a _delete_ event value, the `source` field structure is the same as for _create_ and _update_ events for the same table. Many `source` field values are also the same. In a _delete_ event value, the `ts_ms` and `lsn` field values, as well as other values, might have changed. But the `source` field in a _delete_ event value provides the same metadata: 
+
+* {prodname} version
+* Connector type and name
+* Database and table that contains the new row
+* Schema name
+* If the event was part of a snapshot
+* ID of the transaction in which the operation was performed
+* Offset of the operation in the database log
+* Timestamp
+
+|4
+|`op`
+a|Mandatory string that describes the type of operation. The `op` field value is `d`, signifying that this row was deleted.
+
+|5
+|`ts_ms`
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+
+|===
+
+A _delete_ change event record provides a consumer with the information it needs to process the removal of this row. 
 
 [WARNING]
 ====
 For a consumer to be able to process a _delete_ event generated for a table that does not have a primary key, set the table's `REPLICA IDENTITY` to `FULL`. When a table does not have a primary key and the table's `REPLICA IDENTITY` is set to `DEFAULT` or `NOTHING`, a _delete_ event has no `before` field.
 ====
 
-PostgreSQL connector events are designed to work with link:https://kafka.apache.org/documentation/#compaction[Kafka log compaction]. Log compaction enables removal of some older messages as long as at least the most recent message for every key is kept. This lets Kafka reclaim storage space while ensuring that the topic contains a complete data set and can be used for reloading key-based state.
+PostgreSQL connector events are designed to work with link:{link-kafka-docs}#compaction[Kafka log compaction]. Log compaction enables removal of some older messages as long as at least the most recent message for every key is kept. This lets Kafka reclaim storage space while ensuring that the topic contains a complete data set and can be used for reloading key-based state.
 
 [[postgresql-tombstone-events]]
 .Tombstone events

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -654,7 +654,7 @@ The following example shows the value portion of a change event that the connect
 [source,json,options="nowrap",indent=0,subs="+attributes"]
 ----
 {
-    "schema": { <1>
+    "schema": { // <1>
         "type": "struct",
         "fields": [
             {
@@ -682,7 +682,7 @@ The following example shows the value portion of a change event that the connect
                     }
                 ],
                 "optional": true,
-                "name": "PostgreSQL_server.inventory.customers.Value", <2>
+                "name": "PostgreSQL_server.inventory.customers.Value", // <2>
                 "field": "before"
             },
             {
@@ -710,7 +710,7 @@ The following example shows the value portion of a change event that the connect
                     }
                 ],
                 "optional": true,
-                "name": "PostgreSQL_server.inventory.customers.Value", <2>
+                "name": "PostgreSQL_server.inventory.customers.Value", 
                 "field": "after"
             },
             {
@@ -774,7 +774,7 @@ The following example shows the value portion of a change event that the connect
                     }
                 ],
                 "optional": false,
-                "name": "io.debezium.connector.postgresql.Source", <2>
+                "name": "io.debezium.connector.postgresql.Source", // <3>
                 "field": "source"
             },
             {
@@ -789,17 +789,17 @@ The following example shows the value portion of a change event that the connect
             }
         ],
         "optional": false,
-        "name": "PostgreSQL_server.inventory.customers.Envelope" <2>
+        "name": "PostgreSQL_server.inventory.customers.Envelope" // <4>
     },
-    "payload": { <3>
-        "before": null, <4>
-        "after": { <5>
+    "payload": { // <5>
+        "before": null, // <6>
+        "after": { // <7>
             "id": 1,
             "first_name": "Anne",
             "last_name": "Kretchmar",
             "email": "annek@noanswer.org"
         },
-        "source": { <6>
+        "source": { // <8>
             "version": "{debezium-version}",
             "connector": "postgresql",
             "name": "PostgreSQL_server",
@@ -812,8 +812,8 @@ The following example shows the value portion of a change event that the connect
             "lsn": 24023128,
             "xmin": null
         },
-        "op": "c", <7>
-        "ts_ms": 1559033904863 <8>
+        "op": "c", // <9>
+        "ts_ms": 1559033904863 // <10>
     }
 }
 ----
@@ -830,40 +830,44 @@ The following example shows the value portion of a change event that the connect
 
 |2
 |`name`
-a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. In this example: 
-
-* `PostgreSQL_server.inventory.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table.
-
-* `io.debezium.connector.postgresql.Source` is the schema for the payload's `source` field. This schema is specific to the PostgreSQL connector. The connector uses it for all events that it generates. 
-
-* `PostgreSQL_server.inventory.customers.Envelope` is the schema for the overall structure of the payload, where `PostgreSQL_server` is the connector name, `inventory` is the database, and `customers` is the table.
-
+a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. +
+ +
+`PostgreSQL_server.inventory.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table. +
+ +
 Names of schemas for `before` and `after` fields are of the form `_logicalName_._tableName_.Value`, which ensures that the schema name is unique in the database. This means that when using the {link-prefix}:{link-avro-serialization}[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
 
 |3
-|`payload`
-|The value's actual data. This is the information that the change event is providing. 
+|`name`
+a|`io.debezium.connector.postgresql.Source` is the schema for the payload's `source` field. This schema is specific to the PostgreSQL connector. The connector uses it for all events that it generates. 
 
+|4
+|`name`
+a|`PostgreSQL_server.inventory.customers.Envelope` is the schema for the overall structure of the payload, where `PostgreSQL_server` is the connector name, `inventory` is the database, and `customers` is the table.
+
+|5
+|`payload`
+|The value's actual data. This is the information that the change event is providing. +
+ +
 It may appear that the JSON representations of the events are much larger than the rows they describe. This is because the JSON representation must include the schema and the payload portions of the message.
 However, by using the {link-prefix}:{link-avro-serialization}[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
 
-|4
+|6
 |`before`
 a|An optional field that specifies the state of the row before the event occurred. When the `op` field is `c` for create, as it is in this example, the `before` field is `null` since this change event is for new content.  +
  +
- [NOTE]
- ====
- Whether or not this field is available is dependent on the {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting for each table.
- ====
+[NOTE]
+====
+Whether or not this field is available is dependent on the {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting for each table.
+====
 
-|5
+|7
 |`after`
 |An optional field that specifies the state of the row after the event occurred. In this example, the `after` field contains the values of the new row's `id`, `first_name`, `last_name`, and `email` columns.
 
-|6
+|8
 |`source`
-a|Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes: +
- +
+a|Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes: 
+
 * {prodname} version
 * Connector type and name
 * Database and table that contains the new row
@@ -873,7 +877,7 @@ a|Mandatory field that describes the source metadata for the event. This field c
 * Offset of the operation in the database log
 * Timestamp
 
-|7
+|9
 |`op`
 a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are: 
 
@@ -882,7 +886,7 @@ a|Mandatory string that describes the type of operation that caused the connecto
 * `d` = delete
 * `r` = read (applies to only snapshots)
 
-|8
+|10
 |`ts_ms`
 a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
 
@@ -898,16 +902,16 @@ The value of a change event for an update in the sample `customers` table has th
 {
     "schema": { ... },
     "payload": {
-        "before": { <1>
+        "before": { // <1>
             "id": 1
         },
-        "after": { <2>
+        "after": { // <2>
             "id": 1,
             "first_name": "Anne Marie",
             "last_name": "Kretchmar",
             "email": "annek@noanswer.org"
         },
-        "source": { <3>
+        "source": { // <3>
             "version": "{debezium-version}",
             "connector": "postgresql",
             "name": "PostgreSQL_server",
@@ -920,7 +924,7 @@ The value of a change event for an update in the sample `customers` table has th
             "lsn": 24023128,
             "xmin": null
         },
-        "op": "u", <4>
+        "op": "u", // <4>
         "ts_ms": 1465584025523
     }
 }
@@ -939,7 +943,7 @@ For an _update_ event to contain the previous values of all columns in the row, 
 
 |2
 |`after`
-| An optional field that specifies the state of the row after the event occurred. In this example, the `first_name` value is now `Anne Marie`. 
+|An optional field that specifies the state of the row after the event occurred. In this example, the `first_name` value is now `Anne Marie`. 
 
 |3
 |`source`
@@ -985,11 +989,11 @@ The value in a _delete_ change event has the same `schema` portion as _create_ a
 {
     "schema": { ... },
     "payload": {
-        "before": { <1>
+        "before": { // <1>
             "id": 1
         },
-        "after": null, <2>
-        "source": { <3>
+        "after": null, // <2>
+        "source": { // <3>
             "version": "{debezium-version}",
             "connector": "postgresql",
             "name": "PostgreSQL_server",
@@ -1002,8 +1006,8 @@ The value in a _delete_ change event has the same `schema` portion as _create_ a
             "lsn": 46523128,
             "xmin": null
         },
-        "op": "d", <4>
-        "ts_ms": 1465581902461 <5>
+        "op": "d", // <4>
+        "ts_ms": 1465581902461 // <5>
     }
 }
 ----
@@ -1021,7 +1025,7 @@ In this example, the `before` field contains only the primary key column because
 
 |2
 |`after`
-| Optional field that specifies the state of the row after the event occurred. In a _delete_ event value, the `after` field is `null`, signifying that the row no longer exists.
+|Optional field that specifies the state of the row after the event occurred. In a _delete_ event value, the `after` field is `null`, signifying that the row no longer exists.
 
 |3
 |`source`

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -532,7 +532,7 @@ The following example shows the value portion of a change event that the connect
 [source,json,indent=0,subs="+attributes"]
 ----
 {
-  "schema": { <1>
+  "schema": { // <1>
     "type": "struct",
     "fields": [
       {
@@ -560,7 +560,7 @@ The following example shows the value portion of a change event that the connect
           }
         ],
         "optional": true,
-        "name": "server1.dbo.customers.Value", <2>
+        "name": "server1.dbo.customers.Value", // <2>
         "field": "before"
       },
       {
@@ -588,7 +588,7 @@ The following example shows the value portion of a change event that the connect
           }
         ],
         "optional": true,
-        "name": "server1.dbo.customers.Value", <2>
+        "name": "server1.dbo.customers.Value", 
         "field": "after"
       },
       {
@@ -652,7 +652,7 @@ The following example shows the value portion of a change event that the connect
           }
         ],
         "optional": false,
-        "name": "io.debezium.connector.sqlserver.Source", <2>
+        "name": "io.debezium.connector.sqlserver.Source", // <3>
         "field": "source"
       },
       {
@@ -667,17 +667,17 @@ The following example shows the value portion of a change event that the connect
       }
     ],
     "optional": false,
-    "name": "server1.dbo.customers.Envelope" <2>
+    "name": "server1.dbo.customers.Envelope" // <4>
   },
-  "payload": { <3>
-    "before": null, <4>
-    "after": { <5>
+  "payload": { // <5>
+    "before": null, // <6>
+    "after": { // <7>
       "id": 1005,
       "first_name": "john",
       "last_name": "doe",
       "email": "john.doe@example.org"
     },
-    "source": { <6>
+    "source": { // <8>
       "version": "{debezium-version}",
       "connector": "sqlserver",
       "name": "server1",
@@ -690,8 +690,8 @@ The following example shows the value portion of a change event that the connect
       "commit_lsn": "00000027:00000758:0005",
       "event_serial_no": "1"
     },
-    "op": "c", <7>
-    "ts_ms": 1559729471739 <8>
+    "op": "c", // <9>
+    "ts_ms": 1559729471739 <10>
   }
 }
 ----
@@ -708,34 +708,38 @@ The following example shows the value portion of a change event that the connect
 
 |2
 |`name`
-a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. In this example: 
-
-* `server1.dbo.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table.
-
-* `io.debezium.connector.sqlserver.Source` is the schema for the payload's `source` field. This schema is specific to the SQL Server connector. The connector uses it for all events that it generates. 
-
-* `server1.dbo.customers.Envelope` is the schema for the overall structure of the payload, where `server1` is the connector name, `dbo` is the database schema name, and `customers` is the table.
-
-Names of schemas for `before` and `after` fields are of the form `_logicalName_._database-schemaName_._tableName_.Value`, which ensures that the schema name is unique in the database. This means that when using the {link-prefix}:{link-avro-serialization}[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
+a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. +
+ +
+`server1.dbo.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table. +
+ +
+ Names of schemas for `before` and `after` fields are of the form `_logicalName_._database-schemaName_._tableName_.Value`, which ensures that the schema name is unique in the database. This means that when using the {link-prefix}:{link-avro-serialization}[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
 
 |3
-|`payload`
-|The value's actual data. This is the information that the change event is providing. 
+|`name`
+a|`io.debezium.connector.sqlserver.Source` is the schema for the payload's `source` field. This schema is specific to the SQL Server connector. The connector uses it for all events that it generates. 
 
+|4
+|`name`
+a|`server1.dbo.customers.Envelope` is the schema for the overall structure of the payload, where `server1` is the connector name, `dbo` is the database schema name, and `customers` is the table.
+
+|5
+|`payload`
+|The value's actual data. This is the information that the change event is providing. +
+ +
 It may appear that the JSON representations of the events are much larger than the rows they describe. This is because the JSON representation must include the schema and the payload portions of the message.
 However, by using the {link-prefix}:{link-avro-serialization}[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
 
-|4
-|`before`
-| An optional field that specifies the state of the row before the event occurred. When the `op` field is `c` for create, as it is in this example, the `before` field is `null` since this change event is for new content. 
-
-|5
-|`after`
-| An optional field that specifies the state of the row after the event occurred. In this example, the `after` field contains the values of the new row's `id`, `first_name`, `last_name`, and `email` columns.
-
 |6
+|`before`
+|An optional field that specifies the state of the row before the event occurred. When the `op` field is `c` for create, as it is in this example, the `before` field is `null` since this change event is for new content. 
+
+|7
+|`after`
+|An optional field that specifies the state of the row after the event occurred. In this example, the `after` field contains the values of the new row's `id`, `first_name`, `last_name`, and `email` columns.
+
+|8
 |`source`
-a| Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes: 
+a|Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes: 
 
 * {prodname} version
 * Connector type and name
@@ -745,18 +749,18 @@ a| Mandatory field that describes the source metadata for the event. This field 
 * Name of the table that contains the new row
 * Server log offsets
 
-|7
+|9
 |`op`
-a| Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are: 
+a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are: 
 
 * `c` = create
 * `u` = update
 * `d` = delete
 * `r` = read (applies to only snapshots)
 
-|8
+|10
 |`ts_ms`
-a| Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -354,31 +354,157 @@ In messages to the schema change topic, the key is the name of the database that
 }
 ----
 
-=== Events
+=== Change data events
 
-All data change events produced by the SQL Server connector have a key and a value, although the structure of the key and value depend on the table from which the change events originated (see {link-prefix}:{link-sqlserver-connector}#sqlserver-topic-names[Topic names]).
+The {prodname} SQL Server connector generates a data change event for each row-level `INSERT`, `UPDATE`, and `DELETE` operation. Each event contains a key and a value. The structure of the key and the value depends on the table that was changed. 
+
+{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry. This makes each event self-contained. 
+
+The following skeleton JSON shows the basic four parts of a change event. However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of these four parts in change events. A `schema` field is in a change event only when you configure the converter to produce it. Likewise, the event key and event payload are in a change event only if you configure a converter to produce it. If you use the JSON converver and you configure it to produce all four basic change event parts, change events have this structure: 
+
+[source,json,index=0]
+----
+{
+ "schema": { //<1>
+   ...
+  },
+ "payload": { //<2>
+   ...
+ },
+ "schema": { //<3> 
+   ...
+ },
+ "payload": { //<4>
+   ...
+ },
+}
+----
+
+.Overview of change event basic content
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
+
+|1
+|`schema`
+|The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed. +
+ +
+It is possible to override the table's primary key by setting the {link-prefix}:{link-sqlserver-connector}#sqlserver-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
+
+|2
+|`payload`
+|The first `payload` field is part of the event key. It has the structure described by the previous `schema` field and it contains the key for the row that was changed. 
+
+|3
+|`schema`
+|The second `schema` field is part of the event value. It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion. In other words, the second `schema` describes the structure of the row that was changed. Typically, this schema contains nested schemas. 
+
+|4
+|`payload`
+|The second `payload` field is part of the event value. It has the structure described by the previous `schema` field and it contains the actual data for the row that was changed.
+
+|===
+
+By default, the connector streams change event records to topics with names that are the same as the event's originating table. See {link-prefix}:{link-sqlserver-connector}#sqlserver-topic-names[topic names].
 
 [WARNING]
 ====
-The SQL Server connector ensures that all Kafka Connect _schema names_ are http://avro.apache.org/docs/current/spec.html#names[valid Avro schema names].
-This means that the logical server name must start with Latin letters or an underscore (e.g., [a-z,A-Z,\_]),
-and the remaining characters in the logical server name and all characters in the schema and table names must be Latin letters, digits, or an underscore (e.g., [a-z,A-Z,0-9,\_]).
-If not, then all invalid characters will automatically be replaced with an underscore character.
+The SQL Server connector ensures that all Kafka Connect schema names adhere to the link:http://avro.apache.org/docs/current/spec.html#names[Avro schema name format]. This means that the logical server name must start with a Latin letter or an underscore, that is, a-z, A-Z, or \_. Each remaining character in the logical server name and each character in the database and table names must be a Latin letter, a digit, or an underscore, that is, a-z, A-Z, 0-9, or \_. If there is an invalid character it is replaced with an underscore character.
 
-This can lead to unexpected conflicts when the logical server name, schema names, and table names contain other characters, and the only distinguishing characters between table full names are invalid and thus replaced with underscores.
+This can lead to unexpected conflicts if the logical server name, a database name, or a table name contains invalid characters, and the only characters that distinguish names from one another are invalid and thus replaced with underscores.
 ====
-
-{prodname} and Kafka Connect are designed around _continuous streams of event messages_, and the structure of these events may change over time.
-This could be difficult for consumers to deal with, so to make it easy Kafka Connect makes each event self-contained.
-Every message key and value has two parts: a _schema_ and _payload_.
-The schema describes the structure of the payload, while the payload contains the actual data.
 
 [[sqlserver-change-event-keys]]
 ==== Change Event Keys
 
-For a given table, the change event's key will have a structure that contains a field for each column in the primary key (or unique key constraint) of the table at the time the event was created.
+A change event's key contains the schema for the changed table's key and the changed row's actual key. Both the schema and its corresponding payload contain a field for each column in the changed table's primary key (or unique key constraint) at the time the connector created the event.
 
-Consider a `customers` table defined in the `inventory` database's schema `dbo`:
+Consider the following `customers` table, which is followed by an example of a change event key for this table. 
+
+.Example table
+[source,sql,indent=0]
+----
+CREATE TABLE customers (
+  id INTEGER IDENTITY(1001,1) NOT NULL PRIMARY KEY,
+  first_name VARCHAR(255) NOT NULL,
+  last_name VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL UNIQUE
+);
+----
+
+.Example change event key
+Every change event that captures a change to the `customers` table has the same event key schema. For as long as the `customers` table has the previous definition, every change event that captures a change to the `customers` table has the following key structure, which in JSON, looks like this:
+
+[source,json,indent=0]
+----
+{
+    "schema": { <1>
+        "type": "struct",
+        "fields": [ <2>
+            {
+                "type": "int32",
+                "optional": false,
+                "field": "id"
+            }
+        ],
+        "optional": false, <3>
+        "name": "server1.dbo.customers.Key" <4>
+    },
+    "payload": { <5>
+        "id": 1004
+    }
+}
+----
+
+.Description of change event key
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
+
+|1
+|`schema`
+|The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion. 
+
+|2
+|`fields` 
+|Specifies each field that is expected in the `payload`, including each field's name, type, and whether it is required. In this example, there is one required field named `id` of type `int32`.
+
+|3
+|`optional`
+|Indicates whether the event key must contain a value in its `payload` field. In this example, a value in the key's payload is required. A value in the key's payload field is optional when a table does not have a primary key.
+
+|4
+|`server1.dbo.customers.Key`
+a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._database-schema-name_._table-name_.`Key`. In this example: + 
+
+* `server1` is the name of the connector that generated this event. + 
+* `dbo` is the database schema for the table that was changed. +
+* `customers` is the table that was updated.
+
+|5
+|`payload`
+|Contains the key for the row for which this change event was generated. In this example, the key, contains a single `id` field whose value is `1004`.
+
+|===
+
+ifdef::community[]
+[NOTE]
+====
+Although the `column.exclude.list` configuration property allows you to remove columns from the event values, all columns in a primary or unique key are always included in the event's key.
+====
+
+[WARNING]
+====
+If the table does not have a primary or unique key, then the change event's key is null. This makes sense since the rows in a table without a primary or unique key constraint cannot be uniquely identified.
+====
+endif::community[]
+
+[[sqlserver-change-event-values]]
+==== Change event values
+
+The value in a change event is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. Change events for operations that create, update or delete data all have a value payload with an envelope structure. 
+
+Consider the same sample table that was used to show an example of a change event key: 
 
 [source,sql,indent=0]
 ----
@@ -390,81 +516,23 @@ CREATE TABLE customers (
 );
 ----
 
-If the `database.server.name` configuration property has the value `server1`,
-every change event for the `customers` table while it has this definition will feature the same key structure, which in JSON looks like this:
+The value portion of a change event for a change to this table is described for each event type. 
 
-[source,json,indent=0]
-----
-{
-    "schema": {
-        "type": "struct",
-        "fields": [
-            {
-                "type": "int32",
-                "optional": false,
-                "field": "id"
-            }
-        ],
-        "optional": false,
-        "name": "server1.dbo.customers.Key"
-    },
-    "payload": {
-        "id": 1004
-    }
-}
-----
-
-The `schema` portion of the key contains a Kafka Connect schema describing what is in the key portion. In this case, it means that the `payload` value is not optional, is a structure defined by a schema named `server1.dbo.customers.Key`, and has one required field named `id` of type `int32`.
-If you look at the value of the key's `payload` field, you can see that it is indeed a structure (which in JSON is just an object) with a single `id` field, whose value is `1004`.
-
-Therefore, you can interpret this key as describing the row in the `dbo.customers` table (output from the connector named `server1`) whose `id` primary key column had a value of `1004`.
-
-ifdef::community[]
-[NOTE]
-====
-Although the `column.exclude.list` configuration property allows you to remove columns from the event values, all columns in a primary or unique key are always included in the event's key.
-====
-
-[WARNING]
-====
-If the table does not have a primary or unique key, then the change event's key will be null. This makes sense since the rows in a table without a primary or unique key constraint cannot be uniquely identified.
-====
-endif::community[]
-
-[[sqlserver-change-event-values]]
-==== Change Event Values
-
-Like the message key, the value of a change event message has a _schema_ section and _payload_ section.
-The payload section of every change event value produced by the SQL Server connector has an _envelope_ structure with the following fields:
-
-* `op` is a mandatory field that contains a string value describing the type of operation. Values for the SQL Server connector are `c` for create (or insert), `u` for update, `d` for delete, and `r` for read (in the case of a snapshot).
-* `before` is an optional field that if present contains the state of the row _before_ the event occurred. The structure is described by the `server1.dbo.customers.Value` Kafka Connect schema, which the `server1` connector uses for all rows in the `dbo.customers` table.
-
-* `after` is an optional field that if present contains the state of the row _after_ the event occurred. The structure is described by the same `server1.dbo.customers.Value` Kafka Connect schema used in `before`.
-* `source` is a mandatory field that contains a structure describing the source metadata for the event, which in the case of SQL Server contains these fields: the {prodname} version, the connector name, whether the event is part of an ongoing snapshot or not, the commit LSN (not while snapshotting), the LSN of the change, database, schema and table where the change happened, and a timestamp representing the point in time when the record was changed in the source database (during snapshotting, this is the point in time of snapshotting).
-+
-Also a field `event_serial_no` is present during streaming.
-This is used to differentiate among events that have the same commit and change LSN.
-There are mostly two situations when you can see it present with value different from `1`:
-+
-** update events will have the value set to `2`, this is because the update generates two events in the CDC change table of SQL Server (https://docs.microsoft.com/en-us/sql/relational-databases/system-tables/cdc-capture-instance-ct-transact-sql?view=sql-server-2017[source documentation]).
-The first one contains the old values and the second one contains new values.
-So the first one is dropped and the values from it are used with the second one to create the {prodname} change event.
-** when a primary key is updated, then SQL Server emits two records - `delete` to remove the record with the old primary key value and `insert` to create the record with the new primary key.
-Both operations share the same commit and change LSN and their event numbers are `1` and `2`.
-* `ts_ms` is optional and if present contains the time (using the system clock in the JVM running the Kafka Connect task) at which the connector processed the event.
-
-And of course, the _schema_ portion of the event message's value contains a schema that describes this envelope structure and the nested fields within it.
+ifdef::product[]
+* <<sqlserver-create-events,_create_ events>>
+* <<sqlserver-update-events,_update_ events>>
+* <<sqlserver-delete-events,_delete_ events>>
+endif::product[]
 
 [[sqlserver-create-events]]
-===== Create events
+===== _create_ events
 
-Let's look at what a _create_ event value might look like for our `customers` table:
+The following example shows the value portion of a change event that the connector generates for an operation that creates data in the `customers` table: 
 
-[source,json,indent=0,subs="attributes"]
+[source,json,indent=0,subs="+attributes"]
 ----
 {
-  "schema": {
+  "schema": { <1>
     "type": "struct",
     "fields": [
       {
@@ -492,7 +560,7 @@ Let's look at what a _create_ event value might look like for our `customers` ta
           }
         ],
         "optional": true,
-        "name": "server1.dbo.customers.Value",
+        "name": "server1.dbo.customers.Value", <2>
         "field": "before"
       },
       {
@@ -520,7 +588,7 @@ Let's look at what a _create_ event value might look like for our `customers` ta
           }
         ],
         "optional": true,
-        "name": "server1.dbo.customers.Value",
+        "name": "server1.dbo.customers.Value", <2>
         "field": "after"
       },
       {
@@ -544,7 +612,7 @@ Let's look at what a _create_ event value might look like for our `customers` ta
           {
             "type": "int64",
             "optional": false,
-            "field": "ts_ms"
+            "field": "ts_sec"
           },
           {
             "type": "boolean",
@@ -584,7 +652,7 @@ Let's look at what a _create_ event value might look like for our `customers` ta
           }
         ],
         "optional": false,
-        "name": "io.debezium.connector.sqlserver.Source",
+        "name": "io.debezium.connector.sqlserver.Source", <2>
         "field": "source"
       },
       {
@@ -599,21 +667,21 @@ Let's look at what a _create_ event value might look like for our `customers` ta
       }
     ],
     "optional": false,
-    "name": "server1.dbo.customers.Envelope"
+    "name": "server1.dbo.customers.Envelope" <2>
   },
-  "payload": {
-    "before": null,
-    "after": {
+  "payload": { <3>
+    "before": null, <4>
+    "after": { <5>
       "id": 1005,
       "first_name": "john",
       "last_name": "doe",
       "email": "john.doe@example.org"
     },
-    "source": {
+    "source": { <6>
       "version": "{debezium-version}",
       "connector": "sqlserver",
       "name": "server1",
-      "ts_ms": 1559729468470,
+      "ts_sec": 1559729468470,
       "snapshot": false,
       "db": "testDB",
       "schema": "dbo",
@@ -622,56 +690,103 @@ Let's look at what a _create_ event value might look like for our `customers` ta
       "commit_lsn": "00000027:00000758:0005",
       "event_serial_no": "1"
     },
-    "op": "c",
-    "ts_ms": 1559729471739
+    "op": "c", <7>
+    "ts_ms": 1559729471739 <8>
   }
 }
 ----
 
-If we look at the `schema` portion of this event's _value_, we can see the schema for the _envelope_, the schema for the `source` structure (which is specific to the SQL Server connector and reused across all events), and the table-specific schemas for the `before` and `after` fields.
 
-[NOTE]
-====
-The names of the schemas for the `before` and `after` fields are of the form _logicalName_._schemaName_._tableName_.Value, and thus are entirely independent from all other schemas for all other tables.
-This means that when using the Avro Converter, the resulting Avro schemas for _each table_ in each _logical source_ have their own evolution and history.
-====
+.Descriptions of _create_ event value fields
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
 
-If we look at the `payload` portion of this event's _value_, we can see the information in the event, namely that it is describing that the row was created (since `op=c`), and that the `after` field value contains the values of the new inserted row's' `id`, `first_name`, `last_name`, and `email` columns.
+|1
+|`schema`
+|The value's schema, which describes the structure of the value's payload. A change event's value schema is the same in every change event that the connector generates for a particular table. 
 
-[NOTE]
-====
-It may appear that the JSON representations of the events are much larger than the rows they describe.
-This is true, because the JSON representation must include the _schema_ and the _payload_ portions of the message.
-It is possible and even recommended to use the to dramatically decrease the size of the actual messages written to the Kafka topics.
-====
+|2
+|`name`
+a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. In this example: 
+
+* `server1.dbo.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table.
+
+* `io.debezium.connector.sqlserver.Source` is the schema for the payload's `source` field. This schema is specific to the SQL Server connector. The connector uses it for all events that it generates. 
+
+* `server1.dbo.customers.Envelope` is the schema for the overall structure of the payload, where `server1` is the connector name, `dbo` is the database schema name, and `customers` is the table.
+
+Names of schemas for `before` and `after` fields are of the form `_logicalName_._database-schemaName_._tableName_.Value`, which ensures that the schema name is unique in the database. This means that when using the {link-prefix}:{link-avro-serialization}[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
+
+|3
+|`payload`
+|The value's actual data. This is the information that the change event is providing. 
+
+It may appear that the JSON representations of the events are much larger than the rows they describe. This is because the JSON representation must include the schema and the payload portions of the message.
+However, by using the {link-prefix}:{link-avro-serialization}[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
+
+|4
+|`before`
+| An optional field that specifies the state of the row before the event occurred. When the `op` field is `c` for create, as it is in this example, the `before` field is `null` since this change event is for new content. 
+
+|5
+|`after`
+| An optional field that specifies the state of the row after the event occurred. In this example, the `after` field contains the values of the new row's `id`, `first_name`, `last_name`, and `email` columns.
+
+|6
+|`source`
+a| Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes: 
+
+* {prodname} version
+* Connector type and name
+* Database and schema names
+* Timestamp
+* If the event was part of a snapshot
+* Name of the table that contains the new row
+* Server log offsets
+
+|7
+|`op`
+a| Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are: 
+
+* `c` = create
+* `u` = update
+* `d` = delete
+* `r` = read (applies to only snapshots)
+
+|8
+|`ts_ms`
+a| Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+
+|===
 
 [[sqlserver-update-events]]
-===== Update events
-The value of an _update_ change event on this table will actually have the exact same _schema_, and its payload is structured the same but will hold different values.
-Here's an example:
+===== _update_ events
 
-[source,json,indent=0,subs="attributes"]
+The value of a change event for an update in the sample `customers` table has the same schema as a _create_ event for that table. Likewise, the event value's payload has the same structure. However, the event value payload contains different values in an _update_ event. Here is an example of a change event value in an event that the connector generates for an update in the `customers` table: 
+
+[source,json,indent=0,subs="+attributes"]
 ----
 {
   "schema": { ... },
   "payload": {
-    "before": {
+    "before": { <1>
       "id": 1005,
       "first_name": "john",
       "last_name": "doe",
       "email": "john.doe@example.org"
     },
-    "after": {
+    "after": { <2>
       "id": 1005,
       "first_name": "john",
       "last_name": "doe",
       "email": "noreply@example.org"
     },
-    "source": {
+    "source": { <3>
       "version": "{debezium-version}",
       "connector": "sqlserver",
       "name": "server1",
-      "ts_ms": 1559729995937,
+      "ts_sec": 1559729995937,
       "snapshot": false,
       "db": "testDB",
       "schema": "dbo",
@@ -680,55 +795,79 @@ Here's an example:
       "commit_lsn": "00000027:00000ac0:0007",
       "event_serial_no": "2"
     },
-    "op": "u",
+    "op": "u", <4>
     "ts_ms": 1559729998706
   }
 }
 ----
 
-When we compare this to the value in the _insert_ event, we see a couple of differences in the `payload` section:
 
-* The `op` field value is now `u`, signifying that this row changed because of an update
-* The `before` field now has the state of the row with the values before the database commit
-* The `after` field now has the updated state of the row, and here was can see that the `email` value is now `noreply@example.org`.
-* The `source` field structure has the same fields as before, but the values are different since this event is from a different position in the transaction log.
-* The `event_serial_no` field has value `2`.
-That is due to the update event composed of two events behind the scenes and we are exposing only the second one.
-If you are interested in details please check the https://docs.microsoft.com/en-us/sql/relational-databases/system-tables/cdc-capture-instance-ct-transact-sql?view=sql-server-2017[source documentation] and refer to the field `$operation`.
-* The `ts_ms` shows the timestamp that {prodname} processed this event.
+.Descriptions of _update_ event value fields
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
 
-There are several things we can learn by just looking at this `payload` section. We can compare the `before` and `after` structures to determine what actually changed in this row because of the commit.
-The `source` structure tells us information about SQL Server's record of this change (providing traceability), but more importantly this has information we can compare to other events in this and other topics to know whether this event occurred before, after, or as part of the same SQL Server commit as other events.
+|1
+|`before`
+|An optional field that specifies the state of the row before the event occurred. In an _update_ event value, the `before` field contains a field for each table column and the value that was in that column before the database commit. In this example, the `email` value is `john.doe@example.org.`
+
+|2
+|`after`
+| An optional field that specifies the state of the row after the event occurred. You can compare the `before` and `after` structures to determine what the update to this row was. In the example, the `email` value is now `noreply@example.org`. 
+
+|3
+|`source`
+a|Mandatory field that describes the source metadata for the event. The `source` field structure has the same fields as in a _create_ event, but some values are different, for example, the sample _update_ event has a different offset. The source metadata includes: 
+
+* {prodname} version
+* Connector type and name
+* Database and schema names
+* Timestamp
+* If the event was part of a snapshot
+* Name of the table that contains the new row
+* Server log offsets
+
+The `event_serial_no` field differentiates events that have the same commit and change LSN. Typical situations for when this field has a value other than `1`:
+
+* _update_ events have the value set to `2` because the update generates two events in the CDC change table of SQL Server (link:https://docs.microsoft.com/en-us/sql/relational-databases/system-tables/cdc-capture-instance-ct-transact-sql?view=sql-server-2017[see the source documentation for details]). The first event contains the old values and the second contains contains new values. The connector uses values in the first event to create the second event. The connector drops the first event. 
+
+* When a primary key is updated SQL Server emits two evemts. A _delete_ event for the removal of the record with the old primary key value and a _create_ event for the addition of the record with the new primary key.
+Both operations share the same commit and change LSN and their event numbers are `1` and `2`, respectively. 
+
+|4
+|`op`
+a|Mandatory string that describes the type of operation. In an _update_ event value, the `op` field value is `u`, signifying that this row changed because of an update.
+
+|===
 
 [NOTE]
 ====
-When the columns for a row's primary/unique key are updated, the value of the row's key has changed so {prodname} will output _three_ events: a `DELETE` event and a {link-prefix}:{link-sqlserver-connector}#sqlserver-tombstone-events[tombstone event] with the old key for the row, followed by an `INSERT` event with the new key for the row.
+Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a _delete_ event and a {link-prefix}:{link-sqlserver-connector}#sqlserver-tombstone-events[tombstone event] with the old key for the row, followed by a _create_ event with the new key for the row.
 ====
 
 [[sqlserver-delete-events]]
-===== Delete events
+===== _delete_ events
 
-So far, you have seen samples of _create_ and _update_ events.
-The following sample shows the value of a _delete_ event for the same table. Once again, the `schema` portion of the value is exactly the same as with the _create_ and _update_ events:
+The value in a _delete_ change event has the same `schema` portion as _create_ and _update_ events for the same table. The `payload` portion in a _delete_ event for the sample `customers` table looks like this:  
 
-[source,json,indent=0,subs="attributes"]
+[source,json,indent=0,subs="+attributes"]
 ----
 {
   "schema": { ... },
   },
   "payload": {
-    "before": {
+    "before": { <>
       "id": 1005,
       "first_name": "john",
       "last_name": "doe",
       "email": "noreply@example.org"
     },
-    "after": null,
-    "source": {
+    "after": null, <2>
+    "source": { <3>
       "version": "{debezium-version}",
       "connector": "sqlserver",
       "name": "server1",
-      "ts_ms": 1559730445243,
+      "ts_sec": 1559730445243,
       "snapshot": false,
       "db": "testDB",
       "schema": "dbo",
@@ -737,30 +876,52 @@ The following sample shows the value of a _delete_ event for the same table. Onc
       "commit_lsn": "00000027:00000db0:0007",
       "event_serial_no": "1"
     },
-    "op": "d",
-    "ts_ms": 1559730450205
+    "op": "d", <4>
+    "ts_ms": 1559730450205 <5>
   }
 }
 ----
 
-If we look at the `payload` portion, we see a number of differences compared with the _create_ or _update_ event payloads:
+.Descriptions of _delete_ event value fields
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
 
-* The `op` field value is now `d`, signifying that this row was deleted
-* The `before` field now has the state of the row that was deleted with the database commit.
-* The `after` field is null, signifying that the row no longer exists
-* The `source` field structure has many of the same values as before, except the `ts_ms`, `commit_lsn` and `change_lsn` fields have changed
-* The `ts_ms` shows the timestamp that {prodname} processed this event.
+|1
+|`before`
+|Optional field that specifies the state of the row before the event occurred. In a _delete_ event value, the `before` field contains the values that were in the row before it was deleted with the database commit.
 
-This event gives a consumer all kinds of information that it can use to process the removal of this row.
+|2
+|`after`
+| Optional field that specifies the state of the row after the event occurred. In a _delete_ event value, the `after` field is `null`, signifying that the row no longer exists.
 
-The SQL Server connector's events are designed to work with https://cwiki.apache.org/confluence/display/KAFKA/Log+Compaction[Kafka log compaction],
-which allows for the removal of some older messages as long as at least the most recent message for every key is kept.
-This allows Kafka to reclaim storage space while ensuring the topic contains a complete dataset and can be used for reloading key-based state.
+|3
+|`source`
+a|Mandatory field that describes the source metadata for the event. In a _delete_ event value, the `source` field structure is the same as for _create_ and _update_ events for the same table. Many `source` field values are also the same. In a _delete_ event value, the `ts_ms` and `pos` field values, as well as other values, might have changed. But the `source` field in a _delete_ event value provides the same metadata: 
+
+* {prodname} version
+* Connector type and name
+* Database and schema names
+* Timestamp
+* If the event was part of a snapshot
+* Name of the table that contains the new row
+* Server log offsets
+
+|4
+|`op`
+a|Mandatory string that describes the type of operation. The `op` field value is `d`, signifying that this row was deleted.
+
+|5
+|`ts_ms`
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+
+|===
+
+SQL Server connector events are designed to work with link:{link-kafka-docs}/#compaction[Kafka log compaction]. Log compaction enables removal of some older messages as long as at least the most recent message for every key is kept. This lets Kafka reclaim storage space while ensuring that the topic contains a complete data set and can be used for reloading key-based state.
 
 [[sqlserver-tombstone-events]]
-When a row is deleted, the _delete_ event value listed above still works with log compaction, since Kafka can still remove all earlier messages with that same key.
-But only if the message value is `null` will Kafka know that it can remove _all messages_ with that same key.
-To make this possible, the SQL Server connector always follows the _delete_ event with a special _tombstone_ event that has the same key but `null` value.
+.Tombstone events
+When a row is deleted, the _delete_ event value still works with log compaction, because Kafka can remove all earlier messages that have that same key. However, for Kafka to remove all messages that have that same key, the message value must be `null`. To make this possible, after {prodname}’s SQL Server connector emits a _delete_ event, the connector emits a special tombstone event that has the same key but a `null` value.
 
 [[sqlserver-transaction-metadata]]
 === Transaction Metadata

--- a/documentation/modules/ROOT/partials/modules/mysql-connector/con-mysql-connector-events.adoc
+++ b/documentation/modules/ROOT/partials/modules/mysql-connector/con-mysql-connector-events.adoc
@@ -298,7 +298,7 @@ The following example shows the value portion of a change event that the connect
           }
         ],
         "optional": false,
-        "name": "io.product.connector.mysql.Source", // <2>
+        "name": "io.debezium.connector.mysql.Source", // <2>
         "field": "source"
       },
       {
@@ -360,7 +360,7 @@ a|In the `schema` section, each `name` field specifies the schema for a field in
 
 * `mysql-server-1.inventory.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table.
 
-* `io.product.connector.mysql.Source` is the schema for the payload's `source` field. This schema is specific to the MySQL connector. The connector uses it for all events that it generates. 
+* `io.debezium.connector.mysql.Source` is the schema for the payload's `source` field. This schema is specific to the MySQL connector. The connector uses it for all events that it generates. 
 
 * `mysql-server-1.inventory.customers.Envelope` is the schema for the overall structure of the payload, where `mysql-server-1` is the connector name, `inventory` is the database, and `customers` is the table.
 

--- a/documentation/modules/ROOT/partials/modules/mysql-connector/con-mysql-connector-events.adoc
+++ b/documentation/modules/ROOT/partials/modules/mysql-connector/con-mysql-connector-events.adoc
@@ -36,7 +36,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 |`schema`
 |The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed. +
  +
-It is possible to override the table's primary key by setting the {link-prefix}:{link-mysql-connector}#mysql-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the the key identified by that property.
+It is possible to override the table's primary key by setting the {link-prefix}:{link-mysql-connector}#mysql-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
 
 |2
 |`payload`

--- a/documentation/modules/ROOT/partials/modules/mysql-connector/con-mysql-connector-events.adoc
+++ b/documentation/modules/ROOT/partials/modules/mysql-connector/con-mysql-connector-events.adoc
@@ -219,7 +219,7 @@ The following example shows the value portion of a change event that the connect
           }
         ],
         "optional": true,
-        "name": "mysql-server-1.inventory.customers.Value", // <2>
+        "name": "mysql-server-1.inventory.customers.Value", 
         "field": "after"
       },
       {
@@ -298,7 +298,7 @@ The following example shows the value portion of a change event that the connect
           }
         ],
         "optional": false,
-        "name": "io.debezium.connector.mysql.Source", // <2>
+        "name": "io.debezium.connector.mysql.Source", // <3>
         "field": "source"
       },
       {
@@ -313,19 +313,19 @@ The following example shows the value portion of a change event that the connect
       }
     ],
     "optional": false,
-    "name": "mysql-server-1.inventory.customers.Envelope" // <2>
+    "name": "mysql-server-1.inventory.customers.Envelope" // <4>
   },
-  "payload": { // <3>
-    "op": "c", // <4>
-    "ts_ms": 1465491411815, // <5>
-    "before": null, // <6>
-    "after": { // <7>
+  "payload": { // <5>
+    "op": "c", // <6>
+    "ts_ms": 1465491411815, // <7>
+    "before": null, // <8>
+    "after": { // <9>
       "id": 1004,
       "first_name": "Anne",
       "last_name": "Kretchmar",
       "email": "annek@noanswer.org"
     },
-    "source": { // <8>
+    "source": { // <10>
       "version": "{debezium-version}",
       "connector": "mysql",
       "name": "mysql-server-1",
@@ -356,26 +356,28 @@ The following example shows the value portion of a change event that the connect
 
 |2
 |`name`
-a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. In this example: 
-
-* `mysql-server-1.inventory.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table.
-
-* `io.debezium.connector.mysql.Source` is the schema for the payload's `source` field. This schema is specific to the MySQL connector. The connector uses it for all events that it generates. 
-
-* `mysql-server-1.inventory.customers.Envelope` is the schema for the overall structure of the payload, where `mysql-server-1` is the connector name, `inventory` is the database, and `customers` is the table.
-
-ifdef::community[]
+a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. +
+ +
+`mysql-server-1.inventory.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table. +
+ +
 Names of schemas for `before` and `after` fields are of the form `_logicalName_._tableName_.Value`, which ensures that the schema name is unique in the database. This means that when using the {link-prefix}:{link-avro-serialization}[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
-endif::community[]
 
 |3
-|`payload`
-|The value's actual data. This is the information that the change event is providing. 
+|`name`
+|`io.debezium.connector.mysql.Source` is the schema for the payload's `source` field. This schema is specific to the MySQL connector. The connector uses it for all events that it generates. 
 
+|4
+|`name`
+|`mysql-server-1.inventory.customers.Envelope` is the schema for the overall structure of the payload, where `mysql-server-1` is the connector name, `inventory` is the database, and `customers` is the table.
+
+|5
+|`payload`
+|The value's actual data. This is the information that the change event is providing. +
+ +
 It may appear that the JSON representations of the events are much larger than the rows they describe. This is because the JSON representation must include the schema and the payload portions of the message.
 However, by using the {link-prefix}:{link-avro-serialization}[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
 
-|4
+|6
 |`op`
 a| Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are: 
 
@@ -384,19 +386,19 @@ a| Mandatory string that describes the type of operation that caused the connect
 * `d` = delete
 * `r` = read (applies to only snapshots)
 
-|5
+|7
 |`ts_ms`
 a| Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
 
-|6
+|8
 |`before`
 | An optional field that specifies the state of the row before the event occurred. When the `op` field is `c` for create, as it is in this example, the `before` field is `null` since this change event is for new content. 
 
-|7
+|9
 |`after`
 | An optional field that specifies the state of the row after the event occurred. In this example, the `after` field contains the values of the new row's `id`, `first_name`, `last_name`, and `email` columns.
 
-|8
+|10
 |`source`
 a| Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes: 
 


### PR DESCRIPTION
This is for [DBZ-2501](https://issues.redhat.com/browse/DBZ-2501).

The updated doc for the descriptions of the MySQL events was merged in https://github.com/debezium/debezium/pull/1747. 
For DBZ-2501, the work was to use the updated MySQL content as a model for the event descriptions in the doc for each of the other connectors. 

This PR updates the event description doc for each connector. There is a separate commit for each connector. 