### PR TITLE
DBZ-2049 Add deployment steps to the doc for each connector

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -10,6 +10,7 @@ asciidoc:
     debezium-dev-version: '1.3'
     debezium-kafka-version: '2.6.0'
     debezium-docker-label: '1.2'
+    DockerKafkaConnect: registry.redhat.io/amq7/amq-streams-kafka-25:1.5.0
     install-version: '1.2'
     assemblies: '../assemblies'
     modules: '../../modules'

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1430,8 +1430,8 @@ With https://zookeeper.apache.org[Zookeeper], http://kafka.apache.org/[Kafka], a
 . {link-prefix}:{link-db2-connector}#db2-adding-connector-configuration[Configure the connector and add the configuration to your Kafka Connect cluster.]
 . Restart your Kafka Connect process to pick up the new JAR files.
 
-If you need immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s Container images] for Zookeeper, Kafka and Kafka Connect with the Db2 connector already installed and ready to run.
-You can also link:/docs/openshift/[run {prodname} on OpenShift].
+If you are working with immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s Container images] for Zookeeper, Kafka and Kafka Connect with the Db2 connector already installed and ready to run.
+You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and OpenShift].
 endif::community[]
 
 ifdef::product[]
@@ -1538,12 +1538,31 @@ apiVersion: kafka.strimzi.io/v1beta1
       database.server.name: fullfillment   // <5>
       database.include.list: public.inventory   // <6>
 ----
-<1> The name of the connector.
-<2> Only one task should operate at any one time.
-<3> The connector’s configuration.
-<4> The database host, which is the address of the Db2 instance.
-<5> The logical name of the Db2 instance/cluster, which forms a namespace and is used in the names of the Kafka topics to which the connector writes, the names of Kafka Connect schemas, and the namespaces of the corresponding Avro schema when the {link-prefix}:{link-avro-serialization}[Avro Connector] is used.
-<6> Changes in only the `public.inventory` database are captured.
+
+.Descriptions of connector configuration settings
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|The name of the connector.
+
+|2
+|Only one task should operate at any one time.
+
+|3
+|The connector’s configuration.
+
+|4
+|The database host, which is the address of the Db2 instance. 
+
+|5
+|The logical name of the Db2 instance/cluster, which forms a namespace and is used in the names of the Kafka topics to which the connector writes, the names of Kafka Connect schemas, and the namespaces of the corresponding Avro schema when the {link-prefix}:{link-avro-serialization}[Avro Connector] is used.
+
+|6
+|Changes in only the `public.inventory` database are captured.
+
+|===
 
 endif::product[]
 
@@ -1558,7 +1577,7 @@ You can send this configuration with a `POST` command to a running Kafka Connect
 === Adding connector configuration
 
 ifdef::community[]
-To start running a Db2 connector, create a connector configuration file and add it to your Kafka Connect cluster.
+To start running a Db2 connector, create a connector configuration and add the configuration to your Kafka Connect cluster. 
 
 .Prerequisites
 
@@ -1568,7 +1587,7 @@ To start running a Db2 connector, create a connector configuration file and add 
 
 .Procedure
 
-. Create a configuration file for the Db2 connector.
+. Create a configuration for the Db2 connector.
 
 . Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster.
 
@@ -1579,8 +1598,8 @@ You can use a provided {prodname} container to deploy a {prodname} Db2 connector
 
 .Prerequisites
 
-* You have Podman installed and sufficient rights to create and manage containers.
-* You installed the {prodname} Db2 connector archive.
+* Podman or Docker is installed with sufficient rights to create and manage containers.
+* You installed the {prodname} Db2 connector archive. 
 
 .Procedure
 
@@ -1600,7 +1619,7 @@ pass:quotes[*tree ./my-plugins/*]
 +
 [subs=+macros]
 ----
-FROM registry.redhat.io/amq7/amq-streams-kafka-25:1.5.0
+FROM {DockerKafkaConnect}
 USER root:root
 pass:quotes[COPY _./my-plugins/_ /opt/kafka/plugins/]
 USER 1001
@@ -1608,7 +1627,7 @@ USER 1001
 +
 Before Kafka Connect starts running the connector, Kafka Connect loads any third-party plug-ins that are in the `/opt/kafka/plugins` directory.
 
-.. Build the docker container image. For example, if you saved the docker file that you created in the previous step as `debezium-container-for-db2`, then you would run the following command:
+.. Build the container image. For example, if you saved the `Dockerfile` that you created in the previous step as `debezium-container-for-db2`, then you would run the following command:
 +
 `podman build -t debezium-container-for-db2:latest`
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1598,7 +1598,7 @@ You can use a provided {prodname} container to deploy a {prodname} Db2 connector
 
 .Prerequisites
 
-* Podman or Docker is installed with sufficient rights to create and manage containers.
+* Podman or Docker is installed and you have sufficient rights to create and manage containers.
 * You installed the {prodname} Db2 connector archive. 
 
 .Procedure

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -796,7 +796,7 @@ endif::[]
 extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to  {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`]. You then need to 
 restart your Kafka Connect process to pick up the new JAR files.
 
-If you need immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s Container images] for Zookeeper, Kafka, and Kafka Connect with the MongoDB connector already installed and ready to run. You can also link:https://debezium.io/blog/2016/05/31/Debezium-on-Kubernetes/[run {prodname} on Kubernetes and OpenShift].
+If you are working with immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s Container images] for Zookeeper, Kafka, and Kafka Connect with the MongoDB connector already installed and ready to run. You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and OpenShift].
 
 The {prodname} xref:tutorial.adoc[tutorial] walks you through using these images, and this is a great way to learn about {prodname}. 
 endif::community[]
@@ -898,7 +898,7 @@ This configuration can be sent via POST to a running Kafka Connect service, whic
 === Adding connector configuration
 
 ifdef::community[]
-To run a {prodname} MongoDB connector, create a connector configuration file and add it to your Kafka Connect cluster. 
+To run a {prodname} MongoDB connector, create a connector configuration and add the configuration to your Kafka Connect cluster. 
 
 .Prerequisites
 
@@ -908,7 +908,7 @@ To run a {prodname} MongoDB connector, create a connector configuration file and
 
 .Procedure
 
-. Create a configuration file for the MongoDB connector.
+. Create a configuration for the MongoDB connector.
 
 . Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster. 
 
@@ -919,7 +919,7 @@ You can use a provided {prodname} container to deploy a {prodname} MongoDB conne
 
 .Prerequisites
 
-* You have Podman installed and sufficient rights to create and manage containers.
+* You have Podman or Docker installed and sufficient rights to create and manage containers.
 * You installed the {prodname} MongoDB connector archive. 
 
 .Procedure
@@ -938,9 +938,9 @@ pass:quotes[*tree ./my-plugins/*]
 
 .. Create a new `Dockerfile` by using `{DockerKafkaConnect}` as the base image. In the following example, you would replace _my-plugins_ with the name of your plug-ins directory:
 +
-[subs=+macros]
+[subs=+macros,subs="+attributes"]
 ----
-FROM registry.redhat.io/amq7/amq-streams-kafka-25:1.5.0
+FROM {DockerKafkaConnect}
 USER root:root
 pass:quotes[COPY _./my-plugins/_ /opt/kafka/plugins/]
 USER 1001
@@ -948,7 +948,7 @@ USER 1001
 +
 Before Kafka Connect starts running the connector, Kafka Connect loads any third-party plug-ins that are in the `/opt/kafka/plugins` directory.
 
-.. Build the docker container image. For example, if you saved the docker file that you created in the previous step as `debezium-container-for-mongodb`, then you would run the following command:
+.. Build the container image. For example, if you saved the `Dockerfile` that you created in the previous step as `debezium-container-for-mongodb`, then you would run the following command:
 +
 `podman build -t debezium-container-for-mongodb:latest`
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -919,7 +919,7 @@ You can use a provided {prodname} container to deploy a {prodname} MongoDB conne
 
 .Prerequisites
 
-* You have Podman or Docker installed and sufficient rights to create and manage containers.
+* Podman or Docker is installed and you have sufficient rights to create and manage containers.
 * You installed the {prodname} MongoDB connector archive. 
 
 .Procedure

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -785,54 +785,52 @@ Following is an example of what a message looks like:
 == Deploying the MongoDB connector
 
 ifdef::community[]
-If you have already installed https://zookeeper.apache.org[Zookeeper], http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect], then using {prodname}'s MongoDB connector is easy.
-Simply download the
+With https://zookeeper.apache.org[Zookeeper], http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect] installed, the remaining tasks to deploy a {prodname} MongoDB connector are to 
+download the
 ifeval::['{page-version}' == 'master']
 {link-mongodb-plugin-snapshot}[connector's plug-in archive],
 endif::[]
 ifeval::['{page-version}' != 'master']
 https://repo1.maven.org/maven2/io/debezium/debezium-connector-mongodb/{debezium-version}/debezium-connector-mongodb-{debezium-version}-plugin.tar.gz[connector's plug-in archive],
 endif::[]
-extract the JARs into your Kafka Connect environment, and add the directory with the JARs to Kafka Connect's `plugin.path` by using the {link-kafka-docs}/#connectconfigs[plugin.path] configuration property.
-Restart your Kafka Connect process to pick up the new JARs.
+extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to  {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`]. You then need to 
+restart your Kafka Connect process to pick up the new JAR files.
+
+If you need immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s Container images] for Zookeeper, Kafka, and Kafka Connect with the MongoDB connector already installed and ready to run. You can also link:https://debezium.io/blog/2016/05/31/Debezium-on-Kubernetes/[run {prodname} on Kubernetes and OpenShift].
+
+The {prodname} xref:tutorial.adoc[tutorial] walks you through using these images, and this is a great way to learn about {prodname}. 
 endif::community[]
 
 ifdef::product[]
-Installing the MongoDB connector is a simple process whereby you only need to download the JAR, extract it to your Kafka Connect environment, and ensure the plug-in's parent directory is specified in your Kafka Connect environment.
+To deploy a {prodname} MongoDB connector, install the {prodname} MongoDB connector archive, configure the connector, and start the connector by adding its configuration to Kafka Connect. 
 
-.Prerequisites
+To install the MongoDB connector, follow the procedures in {LinkDebeziumInstallOpenShift}[{NameDebeziumInstallOpenShift}]. The main steps are:
 
-* You have link:https://zookeeper.apache.org/[Zookeeper], link:http://kafka.apache.org/[Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] installed.
-* You have MongoDB installed and setup.
-
-.Procedure
+. Use link:https://access.redhat.com/products/red-hat-amq#streams[Red Hat AMQ Streams] to set up Apache Kafka and Kafka Connect on OpenShift. AMQ Streams offers operators and images that bring Kafka to OpenShift. 
 
 . Download the {prodname} link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions[MongoDB connector].
-. Extract the files into your Kafka Connect environment.
-. Add the plug-in's parent directory to your Kafka Connect `plugin.path`:
+
+. Extract the connector files into your Kafka Connect environment.
+. Add the connector plug-in's parent directory to your Kafka Connect `plugin.path`, for example: 
 +
 [source]
 ----
 plugin.path=/kafka/connect
 ----
++
+The above example assumes that you extracted the {prodname} MongoDB connector to the `/kafka/connect/{prodname}-connector-mongodb` path.
 
-NOTE: The above example assumes you have extracted the {prodname} MongoDB connector to the `/kafka/connect/{prodname}-connector-mongodb` path.
+. Restart your Kafka Connect process to ensure that the new JAR files are picked up.
 
-[start=4]
-. Restart your Kafka Connect process. This ensures the new JARs are picked up.
+You also need to {LinkDebeziumUserGuide}#setting-up-mongodb[set up MongoDB] to run a {prodname} connector.
 
 .Additional resources
 
-For more information on the deployment process, and deploying connectors with AMQ Streams, refer to the {prodname} installation guides.
+For more information about the deployment process, and deploying connectors with AMQ Streams, see the {prodname} installation guides.
 
 * {LinkDebeziumInstallOpenShift}[{NameDebeziumInstallOpenShift}]
 * {LinkDebeziumInstallRHEL}[{NameDebeziumInstallRHEL}]
 endif::product[]
-
-ifdef::community[]
-If immutable containers are your thing, then check out https://hub.docker.com/r/debezium/[{prodname}'s Docker images] for Zookeeper, Kafka, and Kafka Connect with the MongoDB connector already pre-installed and ready to go.
-Our xref:tutorial.adoc[tutorial] even walks you through using these images, and this is a great way to learn what {prodname} is all about. You can even link:/blog/2016/05/31/Debezium-on-Kubernetes/[run {prodname} on Kubernetes and OpenShift].
-endif::community[]
 
 [[mongodb-example-configuration]]
 === Example configuration
@@ -849,12 +847,12 @@ Typically, you configure the {prodname} MongoDB connector in a `.json` file usin
 [source,json]
 ----
 {
-  "name": "inventory-connector",  // <1>
+  "name": "inventory-connector", <1>
   "config": {
-    "connector.class": "io.debezium.connector.mongodb.MongoDbConnector", // <2>
-    "mongodb.hosts": "rs0/192.168.99.100:27017", // <3>
-    "mongodb.name": "fullfillment", // <4>
-    "collection.include.list": "inventory[.]*", // <5>
+    "connector.class": "io.debezium.connector.mongodb.MongoDbConnector", <2>
+    "mongodb.hosts": "rs0/192.168.99.100:27017", <3>
+    "mongodb.name": "fullfillment", <4>
+    "collection.include.list": "inventory[.]*", <5>
   }
 }
 ----
@@ -875,14 +873,14 @@ Typically, you configure the {prodname} MongoDB connector in a `.yaml` file usin
 apiVersion: kafka.strimzi.io/v1beta1
   kind: KafkaConnector
   metadata:
-    name: inventory-connector  // <1>
+    name: inventory-connector <1>
     labels: strimzi.io/cluster: my-connect-cluster
   spec:
-    class: io.debezium.connector.mongodb.MongoDbConnector // <2>
+    class: io.debezium.connector.mongodb.MongoDbConnector <2>
     config:  
-     mongodb.hosts: rs0/192.168.99.100:27017 // <3>
-     mongodb.name: fulfillment // <4>
-     collection.include.list: inventory[.]* // <5>
+     mongodb.hosts: rs0/192.168.99.100:27017 <3>
+     mongodb.name: fulfillment <4>
+     collection.include.list: inventory[.]* <5>
 ----
 <1> The name of our connector when we register it with a Kafka Connect service.
 <2> The name of the MongoDB connector class.
@@ -895,6 +893,116 @@ endif::product[]
 See the {link-prefix}:{link-mongodb-connector}#mongodb-connector-properties[complete list of connector properties] that can be specified in these configurations.
 
 This configuration can be sent via POST to a running Kafka Connect service, which will then record the configuration and start up the one connector task that will connect to the MongoDB replica set or sharded cluster, assign tasks for each replica set, perform a snapshot if necessary, read the oplog, and record events to Kafka topics.
+
+[[mongodb-adding-connector-configuration]]
+=== Adding connector configuration
+
+ifdef::community[]
+To run a {prodname} MongoDB connector, create a connector configuration file and add it to your Kafka Connect cluster. 
+
+.Prerequisites
+
+* MongoDB is set up to run a {prodname} connector.
+
+* A {prodname} MongoDB connector is installed. 
+
+.Procedure
+
+. Create a configuration file for the MongoDB connector.
+
+. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster. 
+
+endif::community[]
+
+ifdef::product[]
+You can use a provided {prodname} container to deploy a {prodname} MongoDB connector. In this procedure, you build a custom Kafka Connect container image for {prodname}, configure the {prodname} connector as needed, and then add your connector configuration to your Kafka Connect environment. 
+
+.Prerequisites
+
+* You have Podman installed and sufficient rights to create and manage containers.
+* You installed the {prodname} MongoDB connector archive. 
+
+.Procedure
+
+. Extract the {prodname} MongoDB connector archive to create a directory structure for the connector plug-in, for example: 
++
+[subs=+macros]
+----
+pass:quotes[*tree ./my-plugins/*]
+./my-plugins/
+├── debezium-connector-mongodb
+│   ├── ...
+----
+
+. Create and publish a custom image for running your {prodname} connector:
+
+.. Create a new `Dockerfile` by using `{DockerKafkaConnect}` as the base image. In the following example, you would replace _my-plugins_ with the name of your plug-ins directory:
++
+[subs=+macros]
+----
+FROM registry.redhat.io/amq7/amq-streams-kafka-25:1.5.0
+USER root:root
+pass:quotes[COPY _./my-plugins/_ /opt/kafka/plugins/]
+USER 1001
+----
++
+Before Kafka Connect starts running the connector, Kafka Connect loads any third-party plug-ins that are in the `/opt/kafka/plugins` directory.
+
+.. Build the docker container image. For example, if you saved the docker file that you created in the previous step as `debezium-container-for-mongodb`, then you would run the following command:
++
+`podman build -t debezium-container-for-mongodb:latest`
+
+.. Push your custom image to your container registry, for example:
++
+`podman push debezium-container-for-mongodb:latest`
+
+.. Point to the new container image. Do one of the following:
++
+* Edit the `spec.image` property of the `KafkaConnector` custom resource. If set, this property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator. For example:
++
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnector
+metadata:
+  name: my-connect-cluster
+spec:
+  #...
+  image: debezium-container-for-mongodb
+----
++
+* In the `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml` file, edit the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable to point to the new container image and reinstall the Cluster Operator. If you edit this file you must apply it to your OpenShift cluster.
+
+. Create a `KafkaConnector` custom resource that defines your {prodname} MongoDB connector instance. See {LinkDebeziumUserGuide}#mongodb-example-configuration[the connector configuration example].
+
+. Apply the connector instance, for example: 
++
+`oc apply -f inventory-connector.yaml`
++
+This registers `inventory-connector` and the connector starts to run against the `inventory` database.
+
+. Verify that the connector was created and has started to capture changes in the specified database. You can verify the connector instance by watching the Kafka Connect log output as, for example, `inventory-connector` starts.
+
+.. Display the Kafka Connect log output:
++
+[source,shell,options="nowrap"]
+----
+oc logs $(oc get pods -o name -l strimzi.io/name=my-connect-cluster-connect)
+----
+
+.. Review the log output to verify that the initial snapshot has been executed. You should see something like the following lines: 
++
+[source,shell,options="nowrap"]
+----
+... INFO Starting snapshot for ...
+... INFO Snapshot is using user 'debezium' ... 
+----
+
+endif::product[]
+
+.Results
+
+When the connector starts, it {link-prefix}:{link-mongodb-connector}#mongodb-performing-a-snapshot[performs a consistent snapshot] of the MongoDB databases that the connector is configured for. The connector then starts generating data change events for document-level operations and streaming change event records to Kafka topics. 
 
 [[mongodb-monitoring]]
 === Monitoring

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1909,7 +1909,7 @@ endif::community[]
 ifdef::community[]
 With link:https://zookeeper.apache.org[Zookeeper], link:http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect] installed, the remaining tasks to deploy a {prodname} PostgreSQL connector are to download the link:https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/{debezium-version}/debezium-connector-postgres-{debezium-version}-plugin.tar.gz[connector's plug-in archive], extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`]. You then need to restart your Kafka Connect process to pick up the new JAR files.
 
-If you need immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s Container images] for Zookeeper, Kafka, PostgreSQL and Kafka Connect with the PostgreSQL connector already installed and ready to run. You can also link:/blog/2016/05/31/Debezium-on-Kubernetes/[run {prodname} on Kubernetes and OpenShift].
+If you need immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s Container images] for Zookeeper, Kafka, PostgreSQL and Kafka Connect with the PostgreSQL connector already installed and ready to run. You can also link:https://debezium.io/blog/2016/05/31/Debezium-on-Kubernetes/[run {prodname} on Kubernetes and OpenShift].
 endif::community[]
 
 ifdef::product[]

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1909,7 +1909,7 @@ endif::community[]
 ifdef::community[]
 With link:https://zookeeper.apache.org[Zookeeper], link:http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect] installed, the remaining tasks to deploy a {prodname} PostgreSQL connector are to download the link:https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/{debezium-version}/debezium-connector-postgres-{debezium-version}-plugin.tar.gz[connector's plug-in archive], extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`]. You then need to restart your Kafka Connect process to pick up the new JAR files.
 
-If you need immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s Container images] for Zookeeper, Kafka, PostgreSQL and Kafka Connect with the PostgreSQL connector already installed and ready to run. You can also link:https://debezium.io/blog/2016/05/31/Debezium-on-Kubernetes/[run {prodname} on Kubernetes and OpenShift].
+If you are working with immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s Container images] for Zookeeper, Kafka, PostgreSQL and Kafka Connect with the PostgreSQL connector already installed and ready to run. You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and OpenShift].
 endif::community[]
 
 ifdef::product[]
@@ -2041,7 +2041,7 @@ You can send this configuration with a `POST` command to a running Kafka Connect
 === Adding connector configuration
 
 ifdef::community[]
-To start running a PostgreSQL connector, create a connector configuration file and add it to your Kafka Connect cluster. 
+To start running a PostgreSQL connector, create a connector configuration and add the configuration to your Kafka Connect cluster. 
 
 .Prerequisites
 
@@ -2053,7 +2053,7 @@ To start running a PostgreSQL connector, create a connector configuration file a
 
 .Procedure
 
-. Create a configuration file for the PostgreSQL connector.
+. Create a configuration for the PostgreSQL connector.
 
 . Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster. 
 
@@ -2064,7 +2064,7 @@ You can use a provided {prodname} container to deploy a {prodname} PostgreSQL co
 
 .Prerequisites
 
-* You have Podman installed and sufficient rights to create and manage containers.
+* Podman or Docker is installed and you have sufficient rights to create and manage containers.
 * You installed the {prodname} PostgreSQL connector archive. 
 
 .Procedure
@@ -2083,9 +2083,9 @@ pass:quotes[*tree ./my-plugins/*]
 
 .. Create a new `Dockerfile` by using `{DockerKafkaConnect}` as the base image. In the following example, you would replace _my-plugins_ with the name of your plug-ins directory:
 +
-[subs=+macros]
+[subs=+macros,subs="+attributes"]
 ----
-FROM registry.redhat.io/amq7/amq-streams-kafka-25:1.5.0
+FROM {DockerKafkaConnect}
 USER root:root
 pass:quotes[COPY _./my-plugins/_ /opt/kafka/plugins/]
 USER 1001
@@ -2093,7 +2093,7 @@ USER 1001
 +
 Before Kafka Connect starts running the connector, Kafka Connect loads any third-party plug-ins that are in the `/opt/kafka/plugins` directory.
 
-.. Build the docker container image. For example, if you saved the docker file that you created in the previous step as `debezium-container-for-postgresql`, then you would run the following command:
+.. Build the container image. For example, if you saved the `Dockerfile` that you created in the previous step as `debezium-container-for-postgresql`, then you would run the following command:
 +
 `podman build -t debezium-container-for-postgresql:latest`
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -190,7 +190,7 @@ The format of messages that a connector emits to its schema change topic is in a
 
 A message to the schema change topic contains a logical representation of the table schema, for example: 
 
-[source,json,indent=0,subs="attributes"]
+[source,json,indent=0,subs="+attributes"]
 ----
 {
   "schema": {
@@ -210,19 +210,19 @@ A message to the schema change topic contains a logical representation of the ta
       "commit_lsn": "00000025:00000d98:00a2",
       "event_serial_no": null
     },
-    "databaseName": "testDB", // <1>
+    "databaseName": "testDB", <1>
     "schemaName": "dbo",
-    "ddl": null, // <2>
-    "tableChanges": [ // <3>
+    "ddl": null, <2>
+    "tableChanges": [ <3>
       {
-        "type": "CREATE", // <4>
-        "id": "\"testDB\".\"dbo\".\"customers\"", // <5>
-        "table": { // <6>
+        "type": "CREATE", <4>
+        "id": "\"testDB\".\"dbo\".\"customers\"", <5>
+        "table": { <6>
           "defaultCharsetName": null,
-          "primaryKeyColumnNames": [ // <7>
+          "primaryKeyColumnNames": [ <7>
             "id"
           ],
-          "columns": [ // <8>
+          "columns": [ <8>
             {
               "name": "id",
               "jdbcType": 4,
@@ -1373,50 +1373,45 @@ The `connect.decimal.precision` schema parameter contains an integer representin
 |===
 
 [[sqlserver-deploying-a-connector]]
-== Deploying the SQL Server connector
+== Deployment
 
 ifdef::community[]
-If you have already installed https://zookeeper.apache.org[Zookeeper], http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect], then using {prodname}'s SQL Server` connector is easy.
-Simply download the https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/{debezium-version}/debezium-connector-sqlserver-{debezium-version}-plugin.tar.gz[connector's plug-in archive], extract the JARs into your Kafka Connect environment, and add the directory with the JARs to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
-Restart your Kafka Connect process to pick up the new JARs.
+With link:https://zookeeper.apache.org[Zookeeper], http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect] installed, the remaining tasks to deploy a {prodname} SQL Server connector are to download the https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/{debezium-version}/debezium-connector-sqlserver-{debezium-version}-plugin.tar.gz[connector's plug-in archive], extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
+Restart your Kafka Connect process to pick up the new JAR files.
+
+If you need immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s container images] for Zookeeper, Kafka, SQL Server and Kafka Connect with the SQL Server connector already installed and ready to run. You can also link:https://debezium.io/blog/2016/05/31/Debezium-on-Kubernetes/[run {prodname} on Kubernetes and OpenShift].
 endif::community[]
 
 ifdef::product[]
-Installing the SQL Server connector is a simple process whereby you only need to download the JAR, extract it to your Kafka Connect environment, and ensure the plug-in's parent directory is specified in your Kafka Connect environment.
+To deploy a {prodname} SQL Server connector, install the {prodname} SQL Server connector archive, configure the connector, and start the connector by adding its configuration to Kafka Connect. 
 
-.Prerequisites
+To install the SQL Server connector, follow the procedures in {LinkDebeziumInstallOpenShift}[{NameDebeziumInstallOpenShift}]. The main steps are:
 
-* You have link:https://zookeeper.apache.org/[Zookeeper], link:http://kafka.apache.org/[Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] installed.
-* You have SQL Server installed and setup.
-
-.Procedure
+. Use link:https://access.redhat.com/products/red-hat-amq#streams[Red Hat AMQ Streams] to set up Apache Kafka and Kafka Connect on OpenShift. AMQ Streams offers operators and images that bring Kafka to OpenShift. 
 
 . Download the {prodname} link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions[SQL Server connector].
-. Extract the files into your Kafka Connect environment.
-. Add the plug-in's parent directory to your Kafka Connect `plugin.path`:
+
+. Extract the connector files into your Kafka Connect environment.
+. Add the connector plug-in's parent directory to your Kafka Connect `plugin.path`, for example: 
 +
 [source]
 ----
 plugin.path=/kafka/connect
 ----
++
+The above example assumes that you extracted the {prodname} SQL Server connector to the `/kafka/connect/{prodname}-connector-sqlserver` path.
 
-NOTE: The above example assumes you have extracted the {prodname} SQL Server connector to the `/kafka/connect/debezium-connector-sqlserver` path.
+. Restart your Kafka Connect process to ensure that the new JAR files are picked up.
 
-[start=4]
-. Restart your Kafka Connect process. This ensures the new JARs are picked up.
+You also need to {LinkDebeziumUserGuide}#{LinkDebeziumUserGuide}#setting-up-sqlserver[set up SQL Server] to run a {prodname} connector.
 
 .Additional resources
 
-For more information on the deployment process, and deploying connectors with AMQ Streams, refer to the {prodname} installation guides.
+For more information about the deployment process, and deploying connectors with AMQ Streams, see the {prodname} installation guides.
 
 * {LinkDebeziumInstallOpenShift}[{NameDebeziumInstallOpenShift}]
 * {LinkDebeziumInstallRHEL}[{NameDebeziumInstallRHEL}]
 endif::product[]
-
-ifdef::community[]
-If immutable containers are your thing, then check out https://hub.docker.com/r/debezium/[{prodname}'s Docker images] for Zookeeper, Kafka and Kafka Connect with the SQL Server connector already pre-installed and ready to go.
-You can even link:/docs/openshift/[run {prodname} on OpenShift].
-endif::community[]
 
 [[sqlserver-example-configuration]]
 === Example configuration
@@ -1437,18 +1432,18 @@ Typically, you configure the {prodname} SQL Server connector in a `.json` file u
 [source,json]
 ----
 {
-  "name": "inventory-connector",  // <1>
+  "name": "inventory-connector", <1>
   "config": {
-    "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector", // <2>
-    "database.hostname": "192.168.99.100", // <3>
-    "database.port": "1433", // <4>
-    "database.user": "sa", // <5>
-    "database.password": "Password!", // <6>
-    "database.dbname": "testDB", // <7>
-    "database.server.name": "fullfillment", // <8>
-    "table.include.list": "dbo.customers", // <9>
-    "database.history.kafka.bootstrap.servers": "kafka:9092", // <10>
-    "database.history.kafka.topic": "dbhistory.fullfillment" // <11>
+    "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector", <2>
+    "database.hostname": "192.168.99.100", <3>
+    "database.port": "1433", <4>
+    "database.user": "sa", <5>
+    "database.password": "Password!", <6>
+    "database.dbname": "testDB", <7>
+    "database.server.name": "fullfillment", <8>
+    "table.include.list": "dbo.customers", <9>
+    "database.history.kafka.bootstrap.servers": "kafka:9092", <10>
+    "database.history.kafka.topic": "dbhistory.fullfillment" <11>
   }
 }
 ----
@@ -1475,20 +1470,20 @@ Typically, you configure the {prodname} SQL Server connector in a `.yaml` file u
 apiVersion: kafka.strimzi.io/v1beta1 
   kind: KafkaConnector
   metadata:
-    name: inventory-connector  // <1>
+    name: inventory-connector <1>
     labels: strimzi.io/cluster: my-connect-cluster
   spec:
-    class: io.debezium.connector.sqlserver.SqlServerConnector // <2>
+    class: io.debezium.connector.sqlserver.SqlServerConnector <2>
     config:  
-      database.hostname: 192.168.99.100  // <3>
-      database.port: 1433 //<4>
-      database.user: debezium  //<5>
-      database.password: dbz  //<6>
-      database.dbname: testDB  //<7>
-      database.server.name: fullfullment //<8>
-      database.include.list: dbo.customers   //<9>
-      database.history.kafka.bootstrap.servers: my-cluster-kafka-bootstrap:9092  //<10> 
-      database.history.kafka.topic: dbhistory.fullfillment  //<11>
+      database.hostname: 192.168.99.100 <3>
+      database.port: 1433 <4>
+      database.user: debezium <5>
+      database.password: dbz <6>
+      database.dbname: testDB <7>
+      database.server.name: fullfullment <8>
+      database.include.list: dbo.customers <9>
+      database.history.kafka.bootstrap.servers: my-cluster-kafka-bootstrap:9092 <10> 
+      database.history.kafka.topic: dbhistory.fullfillment <11>
 
 ----
 <1> The name of our connector when we register it with a Kafka Connect service.
@@ -1508,6 +1503,117 @@ endif::product[]
 See the {link-prefix}:{link-sqlserver-connector}#sqlserver-connector-properties[complete list of connector properties] that can be specified in these configurations.
 
 This configuration can be sent via POST to a running Kafka Connect service, which will then record the configuration and start up the one connector task that will connect to the SQL Server database, read the transaction log, and record events to Kafka topics.
+
+
+[[sqlserver-adding-connector-configuration]]
+=== Adding connector configuration
+
+ifdef::community[]
+To run a {prodname} SQL Server connector, create a connector configuration file and add it to your Kafka Connect cluster. 
+
+.Prerequisites
+
+* SQL Server is set up to run a {prodname} connector.
+
+* A {prodname} SQL Server connector is installed. 
+
+.Procedure
+
+. Create a configuration file for the SQL Server connector.
+
+. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster. 
+
+endif::community[]
+
+ifdef::product[]
+You can use a provided {prodname} container to deploy a {prodname} SQL Server connector. In this procedure, you build a custom Kafka Connect container image for {prodname}, configure the {prodname} connector as needed, and then add your connector configuration to your Kafka Connect environment. 
+
+.Prerequisites
+
+* Podman is installed and you have sufficient rights to create and manage containers.
+* You installed the {prodname} SQL Server connector archive. 
+
+.Procedure
+
+. Extract the {prodname} SQL Server connector archive to create a directory structure for the connector plug-in, for example: 
++
+[subs=+macros]
+----
+pass:quotes[*tree ./my-plugins/*]
+./my-plugins/
+├── debezium-connector-sqlserver
+│   ├── ...
+----
+
+. Create and publish a custom image for running your {prodname} connector:
+
+.. Create a new `Dockerfile` by using `{DockerKafkaConnect}` as the base image. In the following example, you would replace _my-plugins_ with the name of your plug-ins directory:
++
+[subs=+macros]
+----
+FROM registry.redhat.io/amq7/amq-streams-kafka-25:1.5.0
+USER root:root
+pass:quotes[COPY _./my-plugins/_ /opt/kafka/plugins/]
+USER 1001
+----
++
+Before Kafka Connect starts running the connector, Kafka Connect loads any third-party plug-ins that are in the `/opt/kafka/plugins` directory.
+
+.. Build the docker container image. For example, if you saved the docker file that you created in the previous step as `debezium-container-for-sqlserver`, then you would run the following command:
++
+`podman build -t debezium-container-for-sqlserver:latest`
+
+.. Push your custom image to your container registry, for example:
++
+`podman push debezium-container-for-sqlserver:latest`
+
+.. Point to the new container image. Do one of the following:
++
+* Edit the `spec.image` property of the `KafkaConnector` custom resource. If set, this property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator. For example:
++
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnector
+metadata:
+  name: my-connect-cluster
+spec:
+  #...
+  image: debezium-container-for-sqlserver
+----
++
+* In the `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml` file, edit the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable to point to the new container image and reinstall the Cluster Operator. If you edit this file you must apply it to your OpenShift cluster.
+
+. Create a `KafkaConnector` custom resource that defines your {prodname} SQL Server connector instance. See {LinkDebeziumUserGuide}#sqlserver-example-configuration[the connector configuration example].
+
+. Apply the connector instance, for example: 
++
+`oc apply -f inventory-connector.yaml`
++
+This registers `inventory-connector` and the connector starts to run against the `inventory` database.
+
+. Verify that the connector was created and has started to capture changes in the specified database. You can verify the connector instance by watching the Kafka Connect log output as, for example, `inventory-connector` starts.
+
+.. Display the Kafka Connect log output:
++
+[source,shell,options="nowrap"]
+----
+oc logs $(oc get pods -o name -l strimzi.io/name=my-connect-cluster-connect)
+----
+
+.. Review the log output to verify that the initial snapshot has been executed. You should see something like the following lines: 
++
+[source,shell,options="nowrap"]
+----
+... INFO Starting snapshot for ...
+... INFO Snapshot is using user 'debezium' ... 
+----
+
+endif::product[]
+
+.Results
+
+When the connector starts, it {link-prefix}:{link-sqlserver-connector}#sqlserver-snapshots[performs a consistent snapshot] of the SQL Server databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics. 
 
 [[sqlserver-monitoring]]
 === Monitoring

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1379,7 +1379,7 @@ ifdef::community[]
 With link:https://zookeeper.apache.org[Zookeeper], http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect] installed, the remaining tasks to deploy a {prodname} SQL Server connector are to download the https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/{debezium-version}/debezium-connector-sqlserver-{debezium-version}-plugin.tar.gz[connector's plug-in archive], extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
 Restart your Kafka Connect process to pick up the new JAR files.
 
-If you need immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s container images] for Zookeeper, Kafka, SQL Server and Kafka Connect with the SQL Server connector already installed and ready to run. You can also link:https://debezium.io/blog/2016/05/31/Debezium-on-Kubernetes/[run {prodname} on Kubernetes and OpenShift].
+If you are working with immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s container images] for Zookeeper, Kafka, SQL Server and Kafka Connect with the SQL Server connector already installed and ready to run. You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and OpenShift].
 endif::community[]
 
 ifdef::product[]
@@ -1470,33 +1470,62 @@ Typically, you configure the {prodname} SQL Server connector in a `.yaml` file u
 apiVersion: kafka.strimzi.io/v1beta1 
   kind: KafkaConnector
   metadata:
-    name: inventory-connector <1>
+    name: inventory-connector // <1>
     labels: strimzi.io/cluster: my-connect-cluster
   spec:
-    class: io.debezium.connector.sqlserver.SqlServerConnector <2>
+    class: io.debezium.connector.sqlserver.SqlServerConnector // <2>
     config:  
-      database.hostname: 192.168.99.100 <3>
-      database.port: 1433 <4>
-      database.user: debezium <5>
-      database.password: dbz <6>
-      database.dbname: testDB <7>
-      database.server.name: fullfullment <8>
-      database.include.list: dbo.customers <9>
-      database.history.kafka.bootstrap.servers: my-cluster-kafka-bootstrap:9092 <10> 
-      database.history.kafka.topic: dbhistory.fullfillment <11>
+      database.hostname: 192.168.99.100 // <3>
+      database.port: 1433 // <4>
+      database.user: debezium // <5>
+      database.password: dbz // <6>
+      database.dbname: testDB // <7>
+      database.server.name: fullfullment // <8>
+      database.include.list: dbo.customers // <9>
+      database.history.kafka.bootstrap.servers: my-cluster-kafka-bootstrap:9092 // <10> 
+      database.history.kafka.topic: dbhistory.fullfillment // <11>
 
 ----
-<1> The name of our connector when we register it with a Kafka Connect service.
-<2> The name of this SQL Server connector class.
-<3> The address of the SQL Server instance.
-<4> The port number of the SQL Server instance.
-<5> The name of the SQL Server user
-<6> The password for the SQL Server user
-<7> The name of the database to capture changes from.
-<8> The logical name of the SQL Server instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
-<9> A list of all tables whose changes {prodname} should capture.
-<10> The list of Kafka brokers that this connector will use to write and recover DDL statements to the database history topic.
-<11> The name of the database history topic where the connector will write and recover DDL statements. This topic is for internal use only and should not be used by consumers.
+
+.Descriptions of connector configuration settings
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|The name of our connector when we register it with a Kafka Connect service.
+
+|2
+|The name of this SQL Server connector class.
+
+|3
+|The address of the SQL Server instance.
+
+|4
+|The port number of the SQL Server instance.
+
+|5
+|The name of the SQL Server user.
+
+|6
+|The password for the SQL Server user.
+
+|7
+|The name of the database to capture changes from.
+
+|8
+|The logical name of the SQL Server instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
+
+|9
+|A list of all tables whose changes {prodname} should capture.
+
+|10
+|The list of Kafka brokers that this connector will use to write and recover DDL statements to the database history topic.
+
+|11
+|The name of the database history topic where the connector will write and recover DDL statements. This topic is for internal use only and should not be used by consumers.
+
+|===
 
 endif::product[]
 
@@ -1509,7 +1538,7 @@ This configuration can be sent via POST to a running Kafka Connect service, whic
 === Adding connector configuration
 
 ifdef::community[]
-To run a {prodname} SQL Server connector, create a connector configuration file and add it to your Kafka Connect cluster. 
+To run a {prodname} SQL Server connector, create a connector configuration and add the configuration to your Kafka Connect cluster. 
 
 .Prerequisites
 
@@ -1519,7 +1548,7 @@ To run a {prodname} SQL Server connector, create a connector configuration file 
 
 .Procedure
 
-. Create a configuration file for the SQL Server connector.
+. Create a configuration for the SQL Server connector.
 
 . Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster. 
 
@@ -1530,7 +1559,7 @@ You can use a provided {prodname} container to deploy a {prodname} SQL Server co
 
 .Prerequisites
 
-* Podman is installed and you have sufficient rights to create and manage containers.
+* Podman or Docker is installed and you have sufficient rights to create and manage containers.
 * You installed the {prodname} SQL Server connector archive. 
 
 .Procedure
@@ -1551,7 +1580,7 @@ pass:quotes[*tree ./my-plugins/*]
 +
 [subs=+macros]
 ----
-FROM registry.redhat.io/amq7/amq-streams-kafka-25:1.5.0
+FROM {DockerKafkaConnect}
 USER root:root
 pass:quotes[COPY _./my-plugins/_ /opt/kafka/plugins/]
 USER 1001
@@ -1559,7 +1588,7 @@ USER 1001
 +
 Before Kafka Connect starts running the connector, Kafka Connect loads any third-party plug-ins that are in the `/opt/kafka/plugins` directory.
 
-.. Build the docker container image. For example, if you saved the docker file that you created in the previous step as `debezium-container-for-sqlserver`, then you would run the following command:
+.. Build the container image. For example, if you saved the `Dockerfile` that you created in the previous step as `debezium-container-for-sqlserver`, then you would run the following command:
 +
 `podman build -t debezium-container-for-sqlserver:latest`
 

--- a/documentation/modules/ROOT/partials/assemblies/mysql-connector/assembly-deploy-the-mysql-connector.adoc
+++ b/documentation/modules/ROOT/partials/assemblies/mysql-connector/assembly-deploy-the-mysql-connector.adoc
@@ -12,6 +12,8 @@ include::{partialsdir}/modules/mysql-connector/proc-install-the-mysql-connector.
 
 include::{partialsdir}/modules/mysql-connector/proc-configure-the-mysql-connector.adoc[leveloffset=+1]
 
+include::{partialsdir}/modules/mysql-connector/proc-add-mysql-connector-configuration-to-kafka-connect.adoc[leveloffset=+1]
+
 include::{partialsdir}/modules/mysql-connector/ref-mysql-connector-configuration-properties.adoc[leveloffset=+1]
 
 include::{partialsdir}/modules/mysql-connector/ref-mysql-connector-monitoring-metrics.adoc[leveloffset=+1]

--- a/documentation/modules/ROOT/partials/modules/mysql-connector/proc-add-mysql-connector-configuration-to-kafka-connect.adoc
+++ b/documentation/modules/ROOT/partials/modules/mysql-connector/proc-add-mysql-connector-configuration-to-kafka-connect.adoc
@@ -5,7 +5,7 @@
 = Adding MySQL connector configuration to Kafka Connect
 
 ifdef::community[]
-To start running a MySQL connector, create a connector configuration file and add it to your Kafka Connect cluster. 
+To start running a MySQL connector, configure a connector and add the configuration to your Kafka Connect cluster. 
 
 .Prerequisites
 
@@ -16,7 +16,7 @@ set up for a {prodname} connector.
 
 .Procedure
 
-. Create a configuration file for the MySQL connector.
+. Create a configuration for the MySQL connector.
 
 . Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster. 
 
@@ -27,7 +27,7 @@ You can use a provided {prodname} container to deploy a {prodname} MySQL connect
 
 .Prerequisites
 
-* Podman is installed and you have sufficient rights to create and manage containers.
+* Podman or Docker is installed and you have sufficient rights to create and manage containers.
 * You installed the {prodname} MySQL connector archive. 
 
 .Procedure
@@ -46,9 +46,9 @@ pass:quotes[*tree ./my-plugins/*]
 
 .. Create a new `Dockerfile` by using `{DockerKafkaConnect}` as the base image. In the following example, you would replace _my-plugins_ with the name of your plug-ins directory:
 +
-[subs=+macros]
+[subs=+macros,subs="+attributes"]
 ----
-FROM registry.redhat.io/amq7/amq-streams-kafka-25:1.5.0
+FROM {DockerKafkaConnect}
 USER root:root
 pass:quotes[COPY _./my-plugins/_ /opt/kafka/plugins/]
 USER 1001
@@ -56,7 +56,7 @@ USER 1001
 +
 Before Kafka Connect starts running the connector, Kafka Connect loads any third-party plug-ins that are in the `/opt/kafka/plugins` directory.
 
-.. Build the docker container image. For example, if you saved the docker file that you created in the previous step as `debezium-container-for-mysql`, then you would run the following command:
+.. Build the container image. For example, if you saved the `Dockerfile` that you created in the previous step as `debezium-container-for-mysql`, then you would run the following command:
 +
 `podman build -t debezium-container-for-mysql:latest`
 

--- a/documentation/modules/ROOT/partials/modules/mysql-connector/proc-add-mysql-connector-configuration-to-kafka-connect.adoc
+++ b/documentation/modules/ROOT/partials/modules/mysql-connector/proc-add-mysql-connector-configuration-to-kafka-connect.adoc
@@ -1,0 +1,113 @@
+// Metadata created by nebel
+//
+
+[id="add-mysql-connector-configuration-to-kafka-connect"]
+= Adding MySQL connector configuration to Kafka Connect
+
+ifdef::community[]
+To start running a MySQL connector, create a connector configuration file and add it to your Kafka Connect cluster. 
+
+.Prerequisites
+
+* {link-prefix}:{link-mysql-connector}#setup-the-mysql-server[MySQL server] is 
+set up for a {prodname} connector.
+
+* {prodname} MySQL connector is installed. 
+
+.Procedure
+
+. Create a configuration file for the MySQL connector.
+
+. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster. 
+
+endif::community[]
+
+ifdef::product[]
+You can use a provided {prodname} container to deploy a {prodname} MySQL connector. In this procedure, you build a custom Kafka Connect container image for {prodname}, configure the {prodname} connector as needed, and then add your connector configuration to your Kafka Connect environment. 
+
+.Prerequisites
+
+* Podman is installed and you have sufficient rights to create and manage containers.
+* You installed the {prodname} MySQL connector archive. 
+
+.Procedure
+
+. Extract the {prodname} MySQL connector archive to create a directory structure for the connector plug-in, for example: 
++
+[subs=+macros]
+----
+pass:quotes[*tree ./my-plugins/*]
+./my-plugins/
+├── debezium-connector-mysql
+│   ├── ...
+----
+
+. Create and publish a custom image for running your {prodname} connector:
+
+.. Create a new `Dockerfile` by using `{DockerKafkaConnect}` as the base image. In the following example, you would replace _my-plugins_ with the name of your plug-ins directory:
++
+[subs=+macros]
+----
+FROM registry.redhat.io/amq7/amq-streams-kafka-25:1.5.0
+USER root:root
+pass:quotes[COPY _./my-plugins/_ /opt/kafka/plugins/]
+USER 1001
+----
++
+Before Kafka Connect starts running the connector, Kafka Connect loads any third-party plug-ins that are in the `/opt/kafka/plugins` directory.
+
+.. Build the docker container image. For example, if you saved the docker file that you created in the previous step as `debezium-container-for-mysql`, then you would run the following command:
++
+`podman build -t debezium-container-for-mysql:latest`
+
+.. Push your custom image to your container registry, for example:
++
+`podman push debezium-container-for-mysql:latest`
+
+.. Point to the new container image. Do one of the following:
++
+* Edit the `spec.image` property of the `KafkaConnector` custom resource. If set, this property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator. For example:
++
+[source,yaml,subs=attributes+]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnector
+metadata:
+  name: my-connect-cluster
+spec:
+  #...
+  image: debezium-container-for-mysql
+----
++
+* In the `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml` file, edit the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable to point to the new container image and reinstall the Cluster Operator. If you edit this file you must apply it to your OpenShift cluster.
+
+. Create a `KafkaConnector` custom resource that defines your {prodname} MySQL connector instance. See {LinkDebeziumUserGuide}#configure-the-mysql-connector_{context}[the connector configuration example].
+
+. Apply the connector instance, for example: 
++
+`oc apply -f inventory-connector.yaml`
++
+This registers `inventory-connector` and the connector starts to run against the `inventory` database.
+
+. Verify that the connector was created and has started to capture changes in the specified database. You can verify the connector instance by watching the Kafka Connect log output as, for example, `inventory-connector` starts.
+
+.. Display the Kafka Connect log output:
++
+[source,shell,options="nowrap"]
+----
+oc logs $(oc get pods -o name -l strimzi.io/name=my-connect-cluster-connect)
+----
+
+.. Review the log output to verify that the initial snapshot has been executed. You should see something like the following lines: 
++
+[source,shell,options="nowrap"]
+----
+... INFO Starting snapshot for ...
+... INFO Snapshot is using user 'debezium' ... 
+----
+
+endif::product[]
+
+.Results
+
+When the connector starts, it {link-prefix}:{link-mysql-connector}#how-the-mysql-connector-performs-database-snapshots_{context}[performs a consistent snapshot] of the MySQL databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics. 

--- a/documentation/modules/ROOT/partials/modules/mysql-connector/proc-configure-the-mysql-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/mysql-connector/proc-configure-the-mysql-connector.adoc
@@ -94,21 +94,42 @@ TIP: For a complete list of configuration properties, see {link-prefix}:{link-my
       database.history.kafka.bootstrap.servers: my-cluster-kafka-bootstrap:9092  // <7>
       database.history.kafka.topic: schema-changes.inventory  // <7>
 ----
-<1> The name of the connector.
-<2> Only one task should operate at any one time.
+
+.Descriptions of connector configuration settings
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|The name of the connector.
+
+|2
+|Only one task should operate at any one time.
 Because the MySQL connector reads the MySQL server’s `binlog`,
 using a single connector task ensures proper order and event handling.
 The Kafka Connect service uses connectors to start one or more tasks that do the work,
 and it automatically distributes the running tasks across the cluster of Kafka Connect services.
 If any of the services stop or crash,
 those tasks will be redistributed to running services.
-<3> The connector’s configuration.
-<4> The database host, which is the name of the container running the MySQL server (`mysql`).
-<5> A unique server ID and name.
+
+|3
+|The connector’s configuration.
+
+|4
+|The database host, which is the name of the container running the MySQL server (`mysql`).
+
+|5
+|A unique server ID and name.
 The server name is the logical identifier for the MySQL server or cluster of servers.
 This name will be used as the prefix for all Kafka topics.
-<6> Only changes in the `inventory` database will be detected.
-<7> The connector will store the history of the database schemas in Kafka using this broker (the same broker to which you are sending events) and topic name.
+
+|6
+Only changes in the `inventory` database will be detected.
+
+|7
+|The connector will store the history of the database schemas in Kafka using this broker (the same broker to which you are sending events) and topic name.
 Upon restart, the connector will recover the schemas of the database that existed at the point in time in the `binlog` when the connector should begin reading.
+
+|===
 
 endif::product[]


### PR DESCRIPTION
These updates are for [DBZ-2049](https://issues.redhat.com/browse/DBZ-2049).
I used the deployment instructions that we updated in the PostgreSQL connector doc as the model to update and add deployment instructions for each connector. 
There is a separate commit for the updates in each connector. 
I manually copied the updated files downstream to make sure that the downstream book builds. You might notice a few updates that seem unrelated to this update, but I had to make them to get the book to build. 
In the PostgreSQL connector doc, I updated a link target URL. 
I confirmed that Antora builds the doc. 
These updates are not required for 1.2, but it would be nice to be able to provide them in the downstream 1.2 doc. 
Let me know what needs to change. 