### PR TITLE
DBZ-2522 Fixing index out of bounds for columns excluded from cdc tables

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeTablePointer.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeTablePointer.java
@@ -122,7 +122,7 @@ public class SqlServerChangeTablePointer extends ChangeTableResultSet<SqlServerC
         else {
             final IndicesMapping indicesMapping = new IndicesMapping(sourceTableColumns, resultColumns);
             return resultSet -> {
-                final Object[] data = new Object[resultColumnCount];
+                final Object[] data = new Object[sourceColumnCount];
                 for (int i = 0; i < resultColumnCount; i++) {
                     int index = indicesMapping.getSourceTableColumnIndex(i);
                     data[index] = getColumnData(resultSet, columnDataOffset + i);

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -360,8 +360,12 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
         this.databaseName = config.getString(DATABASE_NAME);
         this.snapshotMode = SnapshotMode.parse(config.getString(SNAPSHOT_MODE), SNAPSHOT_MODE.defaultValueAsString());
 
-        this.columnFilter = getColumnNameFilter(
-                config.getFallbackStringProperty(SqlServerConnectorConfig.COLUMN_EXCLUDE_LIST, SqlServerConnectorConfig.COLUMN_BLACKLIST));
+        if (columnIncludeList() != null) {
+            this.columnFilter = getColumnIncludeNameFilter(columnIncludeList());
+        }
+        else {
+            this.columnFilter = getColumnExcludeNameFilter(columnExcludeList());
+        }
         this.readOnlyDatabaseConnection = READ_ONLY_INTENT.equals(config.getString(APPLICATION_INTENT_KEY));
         if (readOnlyDatabaseConnection) {
             this.snapshotIsolationMode = SnapshotIsolationMode.SNAPSHOT;
@@ -374,10 +378,23 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
         this.sourceTimestampMode = SourceTimestampMode.fromMode(config.getString(SOURCE_TIMESTAMP_MODE_CONFIG_NAME));
     }
 
-    private static ColumnNameFilter getColumnNameFilter(String excludedColumnPatterns) {
+    private static ColumnNameFilter getColumnExcludeNameFilter(String excludedColumnPatterns) {
         return new ColumnNameFilter() {
 
             Predicate<ColumnId> delegate = Predicates.excludes(excludedColumnPatterns, ColumnId::toString);
+
+            @Override
+            public boolean matches(String catalogName, String schemaName, String tableName, String columnName) {
+                // ignore database name as it's not relevant here
+                return delegate.test(new ColumnId(new TableId(null, schemaName, tableName), columnName));
+            }
+        };
+    }
+
+    private static ColumnNameFilter getColumnIncludeNameFilter(String excludedColumnPatterns) {
+        return new ColumnNameFilter() {
+
+            Predicate<ColumnId> delegate = Predicates.includes(excludedColumnPatterns, ColumnId::toString);
 
             @Override
             public boolean matches(String catalogName, String schemaName, String tableName, String columnName) {

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/EventProcessingFailureHandlingIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/EventProcessingFailureHandlingIT.java
@@ -39,11 +39,10 @@ public class EventProcessingFailureHandlingIT extends AbstractConnectorTest {
         connection = TestHelper.testConnection();
         connection.execute(
                 "CREATE TABLE tablea (id int primary key, cola varchar(30))",
-                "CREATE TABLE tableb (id int primary key, colb varchar(30))",
+                "CREATE TABLE tableb (id int primary key, colb BIGINT NOT NULL)",
                 "CREATE TABLE tablec (id int primary key, colc varchar(30))");
         TestHelper.enableTableCdc(connection, "tablea");
         TestHelper.enableTableCdc(connection, "tableb");
-        connection.execute("ALTER TABLE dbo.tableb ADD colb2 INT");
 
         initializeConnectorTestFramework();
         Testing.Files.delete(TestHelper.DB_HISTORY_PATH);
@@ -70,12 +69,16 @@ public class EventProcessingFailureHandlingIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
         TestHelper.waitForSnapshotToBeCompleted();
 
+        // Will allow insertion of strings into what was originally a BIGINT NOT NULL column
+        // This will cause NumberFormatExceptions which return nulls and thus an error due to the column being NOT NULL
+        connection.execute("ALTER TABLE dbo.tableb ALTER COLUMN colb varchar(30)");
+
         for (int i = 0; i < RECORDS_PER_TABLE; i++) {
             final int id = ID_START_1 + i;
             connection.execute(
                     "INSERT INTO tablea VALUES(" + id + ", 'a')");
             connection.execute(
-                    "INSERT INTO tableb VALUES(" + id + ", 'b', 2)");
+                    "INSERT INTO tableb VALUES(" + id + ", 'b')");
         }
 
         SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE);
@@ -102,12 +105,16 @@ public class EventProcessingFailureHandlingIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
         TestHelper.waitForSnapshotToBeCompleted();
 
+        // Will allow insertion of strings into what was originally a BIGINT NOT NULL column
+        // This will cause NumberFormatExceptions which return nulls and thus an error due to the column being NOT NULL
+        connection.execute("ALTER TABLE dbo.tableb ALTER COLUMN colb varchar(30)");
+
         for (int i = 0; i < RECORDS_PER_TABLE; i++) {
             final int id = ID_START_1 + i;
             connection.execute(
                     "INSERT INTO tablea VALUES(" + id + ", 'a')");
             connection.execute(
-                    "INSERT INTO tableb VALUES(" + id + ", 'b', 2)");
+                    "INSERT INTO tableb VALUES(" + id + ", 'b')");
         }
 
         SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE);
@@ -128,12 +135,16 @@ public class EventProcessingFailureHandlingIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
         TestHelper.waitForSnapshotToBeCompleted();
 
+        // Will allow insertion of strings into what was originally a BIGINT NOT NULL column
+        // This will cause NumberFormatExceptions which return nulls and thus an error due to the column being NOT NULL
+        connection.execute("ALTER TABLE dbo.tableb ALTER COLUMN colb varchar(30)");
+
         for (int i = 0; i < RECORDS_PER_TABLE; i++) {
             final int id = ID_START_1 + i;
             connection.execute(
                     "INSERT INTO tablea VALUES(" + id + ", 'a')");
             connection.execute(
-                    "INSERT INTO tableb VALUES(" + id + ", 'b', 2)");
+                    "INSERT INTO tableb VALUES(" + id + ", 'b')");
         }
 
         SourceRecords records = consumeRecordsByTopic(1);

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -1294,26 +1294,26 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
     @FixFor("DBZ-2522")
     public void excludeColumnWhenCaptureInstanceExcludesColumnInMiddleOfTable() throws Exception {
         connection.execute(
-                "CREATE TABLE blacklist_column_table_a (id int, amount integer, name varchar(30), primary key(id))");
-        TestHelper.enableTableCdc(connection, "blacklist_column_table_a", "dbo_blacklist_column_table_a",
+                "CREATE TABLE exclude_list_column_table_a (id int, amount integer, name varchar(30), primary key(id))");
+        TestHelper.enableTableCdc(connection, "exclude_list_column_table_a", "dbo_exclude_list_column_table_a",
                 Arrays.asList("id", "name"));
 
         final Configuration config = TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
-                .with(SqlServerConnectorConfig.COLUMN_EXCLUDE_LIST, "dbo.blacklist_column_table_a.amount")
+                .with(SqlServerConnectorConfig.COLUMN_EXCLUDE_LIST, "dbo.exclude_list_column_table_a.amount")
                 .build();
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
 
-        connection.execute("INSERT INTO blacklist_column_table_a VALUES(10, 120, 'some_name')");
+        connection.execute("INSERT INTO exclude_list_column_table_a VALUES(10, 120, 'some_name')");
 
         final SourceRecords records = consumeRecordsByTopic(1);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.blacklist_column_table_a");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.exclude_list_column_table_a");
 
         Schema expectedSchemaA = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.blacklist_column_table_a.Value")
+                .name("server1.dbo.exclude_list_column_table_a.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
@@ -1333,27 +1333,27 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
     @FixFor("DBZ-2522")
     public void excludeMultipleColumnsWhenCaptureInstanceExcludesSingleColumn() throws Exception {
         connection.execute(
-                "CREATE TABLE blacklist_column_table_a (id int, amount integer, note varchar(30), name varchar(30), primary key(id))");
-        TestHelper.enableTableCdc(connection, "blacklist_column_table_a", "dbo_blacklist_column_table_a",
+                "CREATE TABLE exclude_list_column_table_a (id int, amount integer, note varchar(30), name varchar(30), primary key(id))");
+        TestHelper.enableTableCdc(connection, "exclude_list_column_table_a", "dbo_exclude_list_column_table_a",
                 Arrays.asList("id", "note", "name"));
 
         // Exclude the note column on top of the already excluded amount column
         final Configuration config = TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
-                .with(SqlServerConnectorConfig.COLUMN_BLACKLIST, "dbo.blacklist_column_table_a.amount,dbo.blacklist_column_table_a.note")
+                .with(SqlServerConnectorConfig.COLUMN_BLACKLIST, "dbo.exclude_list_column_table_a.amount,dbo.exclude_list_column_table_a.note")
                 .build();
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
 
-        connection.execute("INSERT INTO blacklist_column_table_a VALUES(10, 120, 'a note', 'some_name')");
+        connection.execute("INSERT INTO exclude_list_column_table_a VALUES(10, 120, 'a note', 'some_name')");
 
         final SourceRecords records = consumeRecordsByTopic(1);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.blacklist_column_table_a");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.exclude_list_column_table_a");
 
         Schema expectedSchemaA = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.blacklist_column_table_a.Value")
+                .name("server1.dbo.exclude_list_column_table_a.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -422,7 +422,7 @@ Therefore, you can interpret this key as describing the row in the `dbo.customer
 ifdef::community[]
 [NOTE]
 ====
-Although the `column.exclude.list` configuration property allows you to remove columns from the event values, all columns in a primary or unique key are always included in the event's key.
+Although the `column.exclude.list` and `column.include.list` connector configuration properties allow you to capture only a subset of table columns, all columns in a primary or unique key are always included in the event's key.
 ====
 
 [WARNING]
@@ -1445,12 +1445,22 @@ Must not be used with `table.exclude.list`.
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be excluded from monitoring; any table not included in `table.exclude.list` is monitored.
 Each identifier is of the form _schemaName_._tableName_. Must not be used with `table.include.list`.
 
+|[[sqlserver-property-column-whitelist]]
+[[sqlserver-property-column-include-list]]<<sqlserver-property-column-include-list, `column.include.list`>>
+|_empty string_
+|An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in the change event message values.
+Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
+Note that primary key columns are always included in the event's key, even if not included in the value.
+Do not also set the `column.exclude.list` property.
+
 |[[sqlserver-property-column-blacklist]]
 [[sqlserver-property-column-exclude-list]]<<sqlserver-property-column-exclude-list, `column.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event message values.
 Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 Note that primary key columns are always included in the event's key, also if excluded from the value.
+Do not also set the `column.include.list` property.
+
 
 |[[sqlserver-property-column-mask-hash]]<<sqlserver-property-column-mask-hash, `column.mask.hash._hashAlgorithm_.with.salt._salt_`>>
 |_n/a_


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2522

Updated the data array in the IndicesMapping to match the source column width. This prevents index-out-of-bounds exceptions when you exclude columns in the middle of the table.

Example: A source column looking like [0,1,2,3,4], and the cdc table with [1,4]; the resulting data column for us should be [null, 1, null, null, 4] while the previous implementation would only have an array of size 2 and error out when placing the '4'.