### PR TITLE
DBZ-2523 remove duplicate surefire version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,6 @@
         <version.checkstyle.plugin>3.1.1</version.checkstyle.plugin>
         <version.release.plugin>2.5.3</version.release.plugin>
         <version.impsort>1.3.2</version.impsort>
-        <version.surefire.plugin>2.22.2</version.surefire.plugin>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.checkstyle>8.32</version.checkstyle>
         <version.revapi.plugin>0.11.5</version.revapi.plugin>


### PR DESCRIPTION
Closes DBZ-2523. 
- Removes a duplicate `<version.surefire.plugin>` which already exists [here](https://github.com/debezium/debezium/compare/master...eric-weaver:DBZ-2523-remove-duplicate-surefire-version-property?expand=1#diff-600376dffeb79835ede4a0b285078036R121)
- Fixes what appears to have been a regression introduced in https://github.com/debezium/debezium/pull/1085 where maven-surefire-plugin and maven-failsafe-plugin were incidentally dropped from version 3.0.0-M3 to 2.22.2