### PR TITLE
DBZ-2539 Insert file annotation to identify component for downstream doc

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/content-based-routing.adoc
+++ b/documentation/modules/ROOT/pages/configuration/content-based-routing.adoc
@@ -4,7 +4,7 @@
 // Title: Routing change event records to topics according to event content
 [id="content-based-routing"]
 = Content-based routing
-
+ifdef::community[]
 :toc:
 :toc-placement: macro
 :linkattrs:
@@ -12,7 +12,7 @@
 :source-highlighter: highlight.js
 
 toc::[]
-
+endif::community[]
 By default, {prodname} streams all of the change events that it reads from a table to a single static topic.
 However, there might be situations in which you might want to reroute selected events to other topics, based on the event content.
 The process of routing messages based on their content is described in the https://www.enterpriseintegrationpatterns.com/patterns/messaging/ContentBasedRouter.html[Content-based routing] messaging pattern. 

--- a/documentation/modules/ROOT/pages/configuration/filtering.adoc
+++ b/documentation/modules/ROOT/pages/configuration/filtering.adoc
@@ -1,3 +1,7 @@
+// Category: debezium-using
+// Type: assembly
+// ModuleID: filtering-debezium-change-event-records
+// Title: Filtering Debezium change event records
 [id="message-filtering"]
 = Message Filtering
 

--- a/documentation/modules/ROOT/pages/configuration/filtering.adoc
+++ b/documentation/modules/ROOT/pages/configuration/filtering.adoc
@@ -4,7 +4,7 @@
 // Title: Filtering Debezium change event records
 [id="message-filtering"]
 = Message Filtering
-
+ifdef::community[]
 :toc:
 :toc-placement: macro
 :linkattrs:
@@ -12,7 +12,7 @@
 :source-highlighter: highlight.js
 
 toc::[]
-
+endif::community[]
 By default, {prodname} delivers every data change event that it receives to the Kafka broker.
 However, in many cases, you might be interested in only a subset of the events emitted by the producer. 
 To enable you to process only the records that are relevant to you, {prodname} provides the _filter_ simple message transform (SMT).


### PR DESCRIPTION
This update inserts an annotation comment at the head of the doc to support the downstream build. 

Also, conditionalize :toc: entries In the filtering file and in content-based-routing.adoc so that render in the upstream doc only.

The update is required for 1.2. 