### PR TITLE
DBZ-2558 Fix the Quarkus datasource configuration

### DIFF
--- a/debezium-quarkus-outbox/integration-tests/pom.xml
+++ b/debezium-quarkus-outbox/integration-tests/pom.xml
@@ -105,6 +105,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    </systemProperties>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -129,6 +138,7 @@
                                 </goals>
                                 <configuration>
                                     <systemProperties>
+                                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                                         <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
                                     </systemProperties>
                                 </configuration>

--- a/debezium-quarkus-outbox/integration-tests/src/main/resources/application.properties
+++ b/debezium-quarkus-outbox/integration-tests/src/main/resources/application.properties
@@ -1,7 +1,7 @@
-quarkus.datasource.driver=org.postgresql.Driver
-quarkus.datasource.url=jdbc:postgresql://localhost:5432/postgres
+quarkus.datasource.db-kind=postgresql
 quarkus.datasource.username=postgres
 quarkus.datasource.password=postgres
+quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/postgres
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQLDialect
 quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.log.sql=true

--- a/debezium-quarkus-outbox/integration-tests/src/test/java/io/debezium/outbox/quarkus/it/DatabaseTestResource.java
+++ b/debezium-quarkus-outbox/integration-tests/src/test/java/io/debezium/outbox/quarkus/it/DatabaseTestResource.java
@@ -39,7 +39,7 @@ public class DatabaseTestResource implements QuarkusTestResourceLifecycleManager
                     .withStartupTimeout(Duration.ofSeconds(30));
 
             container.start();
-            return Collections.singletonMap("quarkus.datasource.url", container.getJdbcUrl());
+            return Collections.singletonMap("quarkus.datasource.jdbc.url", container.getJdbcUrl());
         }
         catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Either we will need a new 1.2 version for Quarkus 1.9 (before October 6th) or a new DBZ release in Quarkus but that means some discussions with the Camel Quarkus team.

Having a new 1.2 ASAP would be very nice if it's not too much work for you. That would secure our CI and the release schedule.

/cc @ppalaga @lburgazzoli