### PR TITLE
DBZ-2569 : MongoDB ExtractNewDocumentState can not extract array of array

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/MongoDataConverter.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.mongodb.transforms;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -161,58 +162,14 @@ public class MongoDataConverter {
                             ArrayList<Object> list = new ArrayList<>();
 
                             arrValues.stream().forEach(arrValue -> {
-                                if (arrValue.getBsonType() == BsonType.STRING && valueType == BsonType.STRING) {
-                                    String temp = arrValue.asString().getValue();
-                                    list.add(temp);
+                                final Schema valueSchema;
+                                if (Arrays.asList(BsonType.ARRAY, BsonType.DOCUMENT).contains(valueType)) {
+                                    valueSchema = schema.field(keyvalueforStruct.getKey()).schema().valueSchema();
                                 }
-                                else if (arrValue.getBsonType() == BsonType.JAVASCRIPT && valueType == BsonType.JAVASCRIPT) {
-                                    String temp = arrValue.asJavaScript().getCode();
-                                    list.add(temp);
+                                else {
+                                    valueSchema = null;
                                 }
-                                else if (arrValue.getBsonType() == BsonType.OBJECT_ID && valueType == BsonType.OBJECT_ID) {
-                                    String temp = arrValue.asObjectId().getValue().toString();
-                                    list.add(temp);
-                                }
-                                else if (arrValue.getBsonType() == BsonType.DOUBLE && valueType == BsonType.DOUBLE) {
-                                    double temp = arrValue.asDouble().getValue();
-                                    list.add(temp);
-                                }
-                                else if (arrValue.getBsonType() == BsonType.BINARY && valueType == BsonType.BINARY) {
-                                    byte[] temp = arrValue.asBinary().getData();
-                                    list.add(temp);
-                                }
-                                else if (arrValue.getBsonType() == BsonType.INT32 && valueType == BsonType.INT32) {
-                                    int temp = arrValue.asInt32().getValue();
-                                    list.add(temp);
-                                }
-                                else if (arrValue.getBsonType() == BsonType.INT64 && valueType == BsonType.INT64) {
-                                    long temp = arrValue.asInt64().getValue();
-                                    list.add(temp);
-                                }
-                                else if (arrValue.getBsonType() == BsonType.DATE_TIME && valueType == BsonType.DATE_TIME) {
-                                    Date temp = new Date(arrValue.asInt64().getValue());
-                                    list.add(temp);
-                                }
-                                else if (arrValue.getBsonType() == BsonType.DECIMAL128 && valueType == BsonType.DECIMAL128) {
-                                    String temp = arrValue.asDecimal128().getValue().toString();
-                                    list.add(temp);
-                                }
-                                else if (arrValue.getBsonType() == BsonType.TIMESTAMP && valueType == BsonType.TIMESTAMP) {
-                                    Date temp = new Date(1000L * arrValue.asInt32().getValue());
-                                    list.add(temp);
-                                }
-                                else if (arrValue.getBsonType() == BsonType.BOOLEAN && valueType == BsonType.BOOLEAN) {
-                                    boolean temp = arrValue.asBoolean().getValue();
-                                    list.add(temp);
-                                }
-                                else if (arrValue.getBsonType() == BsonType.DOCUMENT && valueType == BsonType.DOCUMENT) {
-                                    Schema schema1 = schema.field(keyvalueforStruct.getKey()).schema().valueSchema();
-                                    Struct struct1 = new Struct(schema1);
-                                    for (Entry<String, BsonValue> entry9 : arrValue.asDocument().entrySet()) {
-                                        convertFieldValue(entry9, struct1, schema1);
-                                    }
-                                    list.add(struct1);
-                                }
+                                convertFieldValue(valueSchema, valueType, arrValue, list);
                             });
                             colValue = list;
                             break;
@@ -238,6 +195,74 @@ public class MongoDataConverter {
                 return;
         }
         struct.put(key, keyvalueforStruct.getValue().isNull() ? null : colValue);
+    }
+
+    private void convertFieldValue(Schema valueSchema, BsonType valueType, BsonValue arrValue, ArrayList<Object> list) {
+        if (arrValue.getBsonType() == BsonType.STRING && valueType == BsonType.STRING) {
+            String temp = arrValue.asString().getValue();
+            list.add(temp);
+        }
+        else if (arrValue.getBsonType() == BsonType.JAVASCRIPT && valueType == BsonType.JAVASCRIPT) {
+            String temp = arrValue.asJavaScript().getCode();
+            list.add(temp);
+        }
+        else if (arrValue.getBsonType() == BsonType.OBJECT_ID && valueType == BsonType.OBJECT_ID) {
+            String temp = arrValue.asObjectId().getValue().toString();
+            list.add(temp);
+        }
+        else if (arrValue.getBsonType() == BsonType.DOUBLE && valueType == BsonType.DOUBLE) {
+            double temp = arrValue.asDouble().getValue();
+            list.add(temp);
+        }
+        else if (arrValue.getBsonType() == BsonType.BINARY && valueType == BsonType.BINARY) {
+            byte[] temp = arrValue.asBinary().getData();
+            list.add(temp);
+        }
+        else if (arrValue.getBsonType() == BsonType.INT32 && valueType == BsonType.INT32) {
+            int temp = arrValue.asInt32().getValue();
+            list.add(temp);
+        }
+        else if (arrValue.getBsonType() == BsonType.INT64 && valueType == BsonType.INT64) {
+            long temp = arrValue.asInt64().getValue();
+            list.add(temp);
+        }
+        else if (arrValue.getBsonType() == BsonType.DATE_TIME && valueType == BsonType.DATE_TIME) {
+            Date temp = new Date(arrValue.asInt64().getValue());
+            list.add(temp);
+        }
+        else if (arrValue.getBsonType() == BsonType.DECIMAL128 && valueType == BsonType.DECIMAL128) {
+            String temp = arrValue.asDecimal128().getValue().toString();
+            list.add(temp);
+        }
+        else if (arrValue.getBsonType() == BsonType.TIMESTAMP && valueType == BsonType.TIMESTAMP) {
+            Date temp = new Date(1000L * arrValue.asInt32().getValue());
+            list.add(temp);
+        }
+        else if (arrValue.getBsonType() == BsonType.BOOLEAN && valueType == BsonType.BOOLEAN) {
+            boolean temp = arrValue.asBoolean().getValue();
+            list.add(temp);
+        }
+        else if (arrValue.getBsonType() == BsonType.DOCUMENT && valueType == BsonType.DOCUMENT) {
+            Struct struct1 = new Struct(valueSchema);
+            for (Entry<String, BsonValue> entry9 : arrValue.asDocument().entrySet()) {
+                convertFieldValue(entry9, struct1, valueSchema);
+            }
+            list.add(struct1);
+        }
+        else if (arrValue.getBsonType() == BsonType.ARRAY && valueType == BsonType.ARRAY) {
+            ArrayList<Object> subList = new ArrayList<>();
+            final Schema subValueSchema;
+            if (Arrays.asList(BsonType.ARRAY, BsonType.DOCUMENT).contains(arrValue.asArray().get(0).getBsonType())) {
+                subValueSchema = valueSchema.valueSchema();
+            }
+            else {
+                subValueSchema = null;
+            }
+            for (BsonValue v : arrValue.asArray()) {
+                convertFieldValue(subValueSchema, v.getBsonType(), v, subList);
+            }
+            list.add(subList);
+        }
     }
 
     protected String arrayElementStructName(int i) {
@@ -329,71 +354,10 @@ public class MongoDataConverter {
                 else {
                     switch (arrayEncoding) {
                         case ARRAY:
-                            BsonType valueType = keyValuesforSchema.getValue().asArray().get(0).getBsonType();
-                            for (BsonValue element : keyValuesforSchema.getValue().asArray()) {
-                                if (element.getBsonType() != valueType) {
-                                    throw new ConnectException("Field " + key + " of schema " + builder.name() + " is not a homogenous array.\n"
-                                            + "Check option 'struct' of parameter 'array.encoding'");
-                                }
-                            }
-
-                            switch (valueType) {
-                                case NULL:
-                                case STRING:
-                                case JAVASCRIPT:
-                                case OBJECT_ID:
-                                case DECIMAL128:
-                                    builder.field(key, SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build());
-                                    break;
-                                case DOUBLE:
-                                    builder.field(key, SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build());
-                                    break;
-                                case BINARY:
-                                    builder.field(key, SchemaBuilder.array(Schema.OPTIONAL_BYTES_SCHEMA).optional().build());
-                                    break;
-
-                                case INT32:
-                                    builder.field(key, SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).optional().build());
-                                    break;
-
-                                case INT64:
-                                    builder.field(key, SchemaBuilder.array(Schema.OPTIONAL_INT64_SCHEMA).optional().build());
-                                    break;
-
-                                case TIMESTAMP:
-                                case DATE_TIME:
-                                    builder.field(key, org.apache.kafka.connect.data.Timestamp.builder().optional().build());
-                                    break;
-
-                                case BOOLEAN:
-                                    builder.field(key, SchemaBuilder.array(Schema.OPTIONAL_BOOLEAN_SCHEMA).optional().build());
-                                    break;
-
-                                case DOCUMENT:
-                                    final SchemaBuilder documentSchemaBuilder = SchemaBuilder.struct().name(builder.name() + "." + key).optional();
-                                    final Map<String, BsonType> union = new HashMap<>();
-                                    for (BsonValue element : keyValuesforSchema.getValue().asArray()) {
-                                        final BsonDocument arrayDocs = element.asDocument();
-                                        for (Entry<String, BsonValue> arrayDoc : arrayDocs.entrySet()) {
-                                            final BsonType prevType = union.putIfAbsent(arrayDoc.getKey(), arrayDoc.getValue().getBsonType());
-                                            if (prevType == null) {
-                                                addFieldSchema(arrayDoc, documentSchemaBuilder);
-                                            }
-                                            else if (prevType != arrayDoc.getValue().getBsonType()) {
-                                                throw new ConnectException("Field " + arrayDoc.getKey() + " of schema " + documentSchemaBuilder.name()
-                                                        + " is not the same type for all documents in the array.\n"
-                                                        + "Check option 'struct' of parameter 'array.encoding'");
-                                            }
-                                        }
-                                    }
-
-                                    Schema build = documentSchemaBuilder.build();
-                                    builder.field(key, SchemaBuilder.array(build).optional().build());
-                                    break;
-
-                                default:
-                                    break;
-                            }
+                            BsonArray value = keyValuesforSchema.getValue().asArray();
+                            BsonType valueType = value.get(0).getBsonType();
+                            testType(builder, key, keyValuesforSchema.getValue(), valueType);
+                            builder.field(key, SchemaBuilder.array(subSchema(builder, key, valueType, value)).optional().build());
                             break;
                         case DOCUMENT:
                             final BsonArray array = keyValuesforSchema.getValue().asArray();
@@ -410,6 +374,92 @@ public class MongoDataConverter {
                 break;
             default:
                 break;
+        }
+    }
+
+    private Schema subSchema(SchemaBuilder builder, String key, BsonType valueType, BsonValue value) {
+        switch (valueType) {
+            case NULL:
+            case STRING:
+            case JAVASCRIPT:
+            case OBJECT_ID:
+            case DECIMAL128:
+                return Schema.OPTIONAL_STRING_SCHEMA;
+            case DOUBLE:
+                return Schema.OPTIONAL_FLOAT64_SCHEMA;
+            case BINARY:
+                return Schema.OPTIONAL_BYTES_SCHEMA;
+            case INT32:
+                return Schema.OPTIONAL_INT32_SCHEMA;
+            case INT64:
+                return Schema.OPTIONAL_INT64_SCHEMA;
+            case TIMESTAMP:
+            case DATE_TIME:
+                return org.apache.kafka.connect.data.Timestamp.builder().optional().build();
+            case BOOLEAN:
+                return Schema.OPTIONAL_BOOLEAN_SCHEMA;
+            case DOCUMENT:
+                final SchemaBuilder documentSchemaBuilder = SchemaBuilder.struct().name(builder.name() + "." + key).optional();
+                final Map<String, BsonType> union = new HashMap<>();
+                if (value.isArray()) {
+                    for (BsonValue element : value.asArray()) {
+                        subSchema(documentSchemaBuilder, union, element.asDocument());
+                    }
+                }
+                else {
+                    subSchema(documentSchemaBuilder, union, value.asDocument());
+                }
+                return documentSchemaBuilder.build();
+            case ARRAY:
+                BsonType subValueType = value.asArray().get(0).asArray().get(0).getBsonType();
+                return SchemaBuilder.array(subSchema(builder, key, subValueType, value.asArray().get(0))).optional().build();
+            default:
+                throw new IllegalArgumentException("The value type '" + valueType + " is not yet supported inside for a subSchema.");
+        }
+    }
+
+    private void subSchema(SchemaBuilder documentSchemaBuilder, Map<String, BsonType> union, BsonDocument arrayDocs) {
+        for (Entry<String, BsonValue> arrayDoc : arrayDocs.entrySet()) {
+            final BsonType prevType = union.putIfAbsent(arrayDoc.getKey(), arrayDoc.getValue().getBsonType());
+            if (prevType == null) {
+                addFieldSchema(arrayDoc, documentSchemaBuilder);
+            }
+            else if (prevType != arrayDoc.getValue().getBsonType()) {
+                throw new ConnectException("Field " + arrayDoc.getKey() + " of schema " + documentSchemaBuilder.name()
+                        + " is not the same type for all documents in the array.\n"
+                        + "Check option 'struct' of parameter 'array.encoding'");
+            }
+        }
+    }
+
+    private void testType(SchemaBuilder builder, String key, BsonValue value, BsonType valueType) {
+        if (valueType == BsonType.DOCUMENT) {
+            final Map<String, BsonType> union = new HashMap<>();
+            for (BsonValue element : value.asArray()) {
+                final BsonDocument arrayDocs = element.asDocument();
+                for (Entry<String, BsonValue> arrayDoc : arrayDocs.entrySet()) {
+                    final BsonType prevType = union.putIfAbsent(arrayDoc.getKey(), arrayDoc.getValue().getBsonType());
+                    if (prevType != null && prevType != arrayDoc.getValue().getBsonType()) {
+                        throw new ConnectException("Field " + arrayDoc.getKey() + " of schema " + builder.name()
+                                + " is not the same type for all documents in the array.\n"
+                                + "Check option 'struct' of parameter 'array.encoding'");
+                    }
+                }
+            }
+        }
+        else if (valueType == BsonType.ARRAY) {
+            for (BsonValue element : value.asArray()) {
+                BsonType subValueType = element.asArray().get(0).getBsonType();
+                testType(builder, key, element, subValueType);
+            }
+        }
+        else {
+            for (BsonValue element : value.asArray()) {
+                if (element.getBsonType() != valueType) {
+                    throw new ConnectException("Field " + key + " of schema " + builder.name() + " is not a homogenous array.\n"
+                            + "Check option 'struct' of parameter 'array.encoding'");
+                }
+            }
         }
     }
 }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTestIT.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -1447,6 +1448,157 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
         assertThat(value.schema().field("a").schema()).isEqualTo(SchemaBuilder.OPTIONAL_INT32_SCHEMA);
         assertThat(value.schema().field("__patch").schema()).isEqualTo(io.debezium.data.Json.builder().optional().build());
         assertThat(value.schema().fields()).hasSize(3);
+    }
+
+    @Test
+    @FixFor("DBZ-2569")
+    public void testMatrixType() throws InterruptedException, IOException {
+        final Map<String, String> transformationConfig = new HashMap<>();
+        transformationConfig.put("array.encoding", "array");
+        transformationConfig.put(CONFIG_DROP_TOMBSTONES, "false");
+        transformationConfig.put(HANDLE_DELETES, "none");
+        transformation.configure(transformationConfig);
+
+        // Test insert
+        primary().execute("insert", client -> {
+            client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
+                    .insertOne(Document.parse(
+                            "{"
+                                    + "  'matrix': ["
+                                    + "    [1,2,3],"
+                                    + "    [4,5,6],"
+                                    + "    [7,8,9],"
+                                    + "  ]"
+                                    + "  ,'array_complex': ["
+                                    + "    {'k1' : 'v1','k2' : 1},{'k1' : 'v2','k2' : 2},"
+                                    + "  ]"
+                                    + "  ,'matrix_complex': ["
+                                    + "    [{'k3' : 'v111','k4' : [1,2,3]},{'k3' : 'v211','k4' : [4,5,6]}],"
+                                    + "    [{'k3' : 'v112','k4' : [7,8]},{'k3' : 'v212','k4' : [8]}],"
+                                    + "  ]"
+                                    + "}"));
+        });
+        SourceRecords records = consumeRecordsByTopic(1);
+        assertThat(records.recordsForTopic(this.topicName()).size()).isEqualTo(1);
+
+        final SourceRecord insertRecord = records.recordsForTopic(this.topicName()).get(0);
+        final SourceRecord transformedInsert = transformation.apply(insertRecord);
+        final Struct transformedInsertValue = (Struct) transformedInsert.value();
+
+        final Schema matrixSchema = transformedInsert.valueSchema().field("matrix").schema();
+        assertThat(matrixSchema.type()).isEqualTo(Schema.Type.ARRAY);
+        final Schema subMatrixSchema = matrixSchema.valueSchema().schema();
+        assertThat(subMatrixSchema.type()).isEqualTo(Schema.Type.ARRAY);
+        assertThat(subMatrixSchema.valueSchema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
+        assertThat(transformedInsertValue.get("matrix")).isEqualTo(Arrays.asList(Arrays.asList(1, 2, 3), Arrays.asList(4, 5, 6), Arrays.asList(7, 8, 9)));
+
+        final Schema arrayComplexSchema = transformedInsert.valueSchema().field("array_complex").schema();
+        assertThat(arrayComplexSchema.type()).isEqualTo(Schema.Type.ARRAY);
+        final Schema subArrayComplexSchema = arrayComplexSchema.valueSchema().schema();
+        assertThat(subArrayComplexSchema.type()).isEqualTo(Schema.Type.STRUCT);
+        assertThat(subArrayComplexSchema.field("k1").schema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
+        assertThat(subArrayComplexSchema.field("k2").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
+        final Field k1 = subArrayComplexSchema.field("k1");
+        final Field k2 = subArrayComplexSchema.field("k2");
+        final Struct subStruct1 = new Struct(subArrayComplexSchema);
+        subStruct1.put(k1, "v1");
+        subStruct1.put(k2, 1);
+        final Struct subStruct2 = new Struct(subArrayComplexSchema);
+        subStruct2.put(k1, "v2");
+        subStruct2.put(k2, 2);
+        assertThat(transformedInsertValue.get("array_complex")).isEqualTo(Arrays.asList(subStruct1, subStruct2));
+
+        final Schema matrixComplexSchema = transformedInsert.valueSchema().field("matrix_complex").schema();
+        assertThat(matrixComplexSchema.type()).isEqualTo(Schema.Type.ARRAY);
+        final Schema subMatrixComplexSchema = matrixComplexSchema.valueSchema().schema();
+        assertThat(subMatrixComplexSchema.type()).isEqualTo(Schema.Type.ARRAY);
+        Schema strucSchema = subMatrixComplexSchema.valueSchema();
+        assertThat(strucSchema.schema().type()).isEqualTo(Schema.Type.STRUCT);
+        assertThat(strucSchema.field("k3").schema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
+        assertThat(strucSchema.field("k4").schema().type()).isEqualTo(Schema.Type.ARRAY);
+        assertThat(strucSchema.field("k4").schema().valueSchema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
+        final Field k3 = strucSchema.field("k3");
+        final Field k4 = strucSchema.field("k4");
+        final Struct subStruct11 = new Struct(strucSchema.schema());
+        subStruct11.put(k3, "v111");
+        subStruct11.put(k4, Arrays.asList(1, 2, 3));
+        final Struct subStruct12 = new Struct(strucSchema.schema());
+        subStruct12.put(k3, "v112");
+        subStruct12.put(k4, Arrays.asList(7, 8));
+        final Struct subStruct21 = new Struct(strucSchema.schema());
+        subStruct21.put(k3, "v211");
+        subStruct21.put(k4, Arrays.asList(4, 5, 6));
+        final Struct subStruct22 = new Struct(strucSchema.schema());
+        subStruct22.put(k3, "v212");
+        subStruct22.put(k4, Arrays.asList(8));
+        assertThat(transformedInsertValue.get("matrix_complex"))
+                .isEqualTo(Arrays.asList(Arrays.asList(subStruct11, subStruct21), Arrays.asList(subStruct12, subStruct22)));
+    }
+
+    @Test
+    @FixFor("DBZ-2569")
+    public void testMatrixArrayAsDocumentType() throws InterruptedException, IOException {
+        final Map<String, String> transformationConfig = new HashMap<>();
+        transformationConfig.put("array.encoding", "document");
+        transformationConfig.put(CONFIG_DROP_TOMBSTONES, "false");
+        transformationConfig.put(HANDLE_DELETES, "none");
+        transformation.configure(transformationConfig);
+
+        // Test insert
+        primary().execute("insert", client -> {
+            client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
+                    .insertOne(Document.parse(
+                            "{"
+                                    + "  'matrix': ["
+                                    + "    [1,'aa',3],"
+                                    + "    [4,5,'6'],"
+                                    + "    [7.0,8],"
+                                    + "  ]"
+                                    + "}"));
+        });
+        SourceRecords records = consumeRecordsByTopic(1);
+        assertThat(records.recordsForTopic(this.topicName()).size()).isEqualTo(1);
+
+        final SourceRecord insertRecord = records.recordsForTopic(this.topicName()).get(0);
+        final SourceRecord transformedInsert = transformation.apply(insertRecord);
+
+        final Schema matrixSchema = transformedInsert.valueSchema().field("matrix").schema();
+        assertThat(matrixSchema.type()).isEqualTo(Schema.Type.STRUCT);
+        assertThat(matrixSchema.fields().size()).isEqualTo(3);
+        final Schema firstSubSchema = matrixSchema.field("_0").schema();
+        assertThat(firstSubSchema.type()).isEqualTo(Schema.Type.STRUCT);
+        assertThat(firstSubSchema.fields().size()).isEqualTo(3);
+        assertThat(firstSubSchema.field("_0").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
+        assertThat(firstSubSchema.field("_1").schema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
+        assertThat(firstSubSchema.field("_2").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
+        final Schema secondSubSchema = matrixSchema.field("_1").schema();
+        assertThat(secondSubSchema.type()).isEqualTo(Schema.Type.STRUCT);
+        assertThat(secondSubSchema.fields().size()).isEqualTo(3);
+        assertThat(secondSubSchema.field("_0").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
+        assertThat(secondSubSchema.field("_1").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
+        assertThat(secondSubSchema.field("_2").schema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
+        final Schema thirdSubSchema = matrixSchema.field("_2").schema();
+        assertThat(thirdSubSchema.type()).isEqualTo(Schema.Type.STRUCT);
+        assertThat(thirdSubSchema.fields().size()).isEqualTo(2);
+        assertThat(thirdSubSchema.field("_0").schema()).isEqualTo(Schema.OPTIONAL_FLOAT64_SCHEMA);
+        assertThat(thirdSubSchema.field("_1").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
+        final Struct transformedInsertValue = (Struct) transformedInsert.value();
+        final Struct firstSubStruct = new Struct(firstSubSchema);
+        firstSubStruct.put(firstSubSchema.field("_0"), 1);
+        firstSubStruct.put(firstSubSchema.field("_1"), "aa");
+        firstSubStruct.put(firstSubSchema.field("_2"), 3);
+        final Struct secondSubStruct = new Struct(secondSubSchema);
+        secondSubStruct.put(secondSubSchema.field("_0"), 4);
+        secondSubStruct.put(secondSubSchema.field("_1"), 5);
+        secondSubStruct.put(secondSubSchema.field("_2"), "6");
+        final Struct thirdSubStruct = new Struct(thirdSubSchema);
+        thirdSubStruct.put(thirdSubSchema.field("_0"), 7.0);
+        thirdSubStruct.put(thirdSubSchema.field("_1"), 8);
+        final Struct struct = new Struct(matrixSchema);
+        struct.put(matrixSchema.field("_0"), firstSubStruct);
+        struct.put(matrixSchema.field("_1"), secondSubStruct);
+        struct.put(matrixSchema.field("_2"), thirdSubStruct);
+        assertThat(transformedInsertValue.get("matrix")).isEqualTo(struct);
     }
 
     private SourceRecord createCreateRecord() throws Exception {


### PR DESCRIPTION
When you try to convert a document with an array of array like 
'matrix': [ [1,2,3],[4,5,6],[7,8,9] ] ExtractNewDocumentState will failed