### PR TITLE
DBZ-2564 format updates for better downstream rendering

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
@@ -225,7 +225,7 @@ endif::community[]
 The following table describes the options that you can specify to configure the event flattening SMT. 
 
 .Descriptions of event flattening SMT configuration options
-[cols="30%a,25%a,45%a",subs="+attributes"]
+[cols="30%a,25%a,45%a",subs="+attributes",options="header"]
 |===
 |Option
 |Default

--- a/documentation/modules/ROOT/pages/configuration/outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/configuration/outbox-event-router.adoc
@@ -135,7 +135,7 @@ payload       | jsonb                  |
 ----
 
 .Descriptions of expected outbox table columns
-[cols="30%a,70%a"]
+[cols="30%a,70%a",options="header"]
 |===
 |Column
 |Effect
@@ -242,7 +242,7 @@ transforms.outbox.table.fields.additional.placement=type:envelope:eventType
 The following table describes the options that you can specify for the outbox event router SMT. In the table, the *Group* column indicates a  configuration option classification for Kafka.
 
 .Descriptions of outbox event router SMT configuration options
-[cols="30%a,20%a,10%a,40%a"]
+[cols="30%a,20%a,10%a,40%a",options="header"]
 |===
 |Option
 |Default

--- a/documentation/modules/ROOT/pages/configuration/outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/configuration/outbox-event-router.adoc
@@ -146,9 +146,9 @@ payload       | jsonb                  |
 To obtain the unique ID of the event from a different outbox table column, set the {link-prefix}:{link-outbox-event-router}#outbox-event-router-property-table-field-event-id[`table.field.event.id` SMT option] in the connector configuration.  
 
 |[[route-by-field-example]]`aggregatetype`
-|Contains a value that the SMT appends to the name of the topic to which the connector emits an outbox message. The default behavior is that this value replaces the default `${routedByValue}` variable in the {link-prefix}:{link-outbox-event-router}#outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option. +
+|Contains a value that the SMT appends to the name of the topic to which the connector emits an outbox message. The default behavior is that this value replaces the default `pass:[${routedByValue}]` variable in the {link-prefix}:{link-outbox-event-router}#outbox-event-router-property-route-topic-replacement[`route.topic.replacement`] SMT option. +
  +
-For example, in a default configuration, the {link-prefix}:{link-outbox-event-router}#outbox-event-router-property-route-by-field[`route.by.field`] SMT option is set to `aggregatetype` and the `route.topic.replacement` SMT option is set to `outbox.event.${routedByValue}`. Suppose that your application adds two records to the outbox table. In the first record, the value in the `aggregatetype` column is `customers`. In the second record, the value in the `aggregatetype` column is `orders`. The connector emits the first record to the `outbox.event.customers` topic. The connector emits the second record to the `outbox.event.orders` topic. +
+For example, in a default configuration, the {link-prefix}:{link-outbox-event-router}#outbox-event-router-property-route-by-field[`route.by.field`] SMT option is set to `aggregatetype` and the `route.topic.replacement` SMT option is set to `outbox.event.pass:[${routedByValue}]`. Suppose that your application adds two records to the outbox table. In the first record, the value in the `aggregatetype` column is `customers`. In the second record, the value in the `aggregatetype` column is `orders`. The connector emits the first record to the `outbox.event.customers` topic. The connector emits the second record to the `outbox.event.orders` topic. +
  +
 To obtain this value from a different outbox table column, set the {link-prefix}:{link-outbox-event-router}#outbox-event-router-property-route-by-field[`route.by.field` SMT option] in the connector configuration. 
 
@@ -304,7 +304,7 @@ Configuration examples are in {link-prefix}:{link-outbox-event-router}#emitting-
 |Router
 |Specifies a regular expression that the outbox SMT applies in the RegexRouter to outbox table records. This regular expression is part of the setting of the `route.topic.replacement` SMT option. +
  +
-The default behavior is that the SMT replaces the default `${routedByValue}` variable in the setting of the `route.topic.replacement` SMT option with the setting of the `route.by.field` outbox SMT option.  
+The default behavior is that the SMT replaces the default `pass:[${routedByValue}]` variable in the setting of the `route.topic.replacement` SMT option with the setting of the `route.by.field` outbox SMT option.  
 
 |[[outbox-event-router-property-route-topic-replacement]]<<outbox-event-router-property-route-topic-replacement, `route.topic.replacement`>>
 |`outbox.event{zwsp}.pass:[${routedByValue}]`

--- a/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
+++ b/documentation/modules/ROOT/pages/configuration/topic-routing.adoc
@@ -145,7 +145,7 @@ endif::community[]
 The following table describes topic routing SMT configuration options.
 
 .Topic routing SMT configuration options
-[cols="30%a,25%a,45%a",subs="+attributes"]
+[cols="30%a,25%a,45%a",subs="+attributes",options="header"]
 |===
 |Option
 |Default

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -438,16 +438,16 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 [source,json,index=0]
 ----
 {
- "schema": { //<1>
+ "schema": { // <1>
    ...
   },
- "payload": { //<2>
+ "payload": { // <2>
    ...
  },
- "schema": { //<3>
+ "schema": { // <3>
    ...
  },
- "payload": { //<4>
+ "payload": { // <4>
    ...
  },
 }
@@ -1032,109 +1032,100 @@ The following table describes how the connector maps each of the Db2 data types 
 * _semantic type_ describes how the Kafka Connect schema captures the _meaning_ of the field using the name of the Kafka Connect schema for the field.
 
 .Mappings for Db2 basic data types
-[cols="20%a,15%a,30%a,35%a",options="header"]
+[cols="25%a,20%a,55%a",options="header"]
 |===
-|Db2 data type |Literal type (schema type) |Semantic type (schema name) |Notes
+|Db2 data type 
+|Literal type (schema type) 
+|Semantic type (schema name) and Notes
 
 |`BOOLEAN`
 |`BOOLEAN`
 |n/a
-|
+
 
 |`BIGINT`
 |`INT64`
 |n/a
-|
 
 |`BINARY`
 |`BYTES`
 |n/a
-|
 
 |`BLOB`
 |`BYTES`
 |n/a
-|
 
 |`CHAR[(N)]`
 |`STRING`
 |n/a
-|
 
 |`CLOB`
 |`STRING`
 |n/a
-|
 
 |`DATE`
 |`INT32`
-|`io.debezium.time.Date`
-|String representation of a timestamp without timezone information
+|`io.debezium.time.Date` +
+ +
+String representation of a timestamp without timezone information
 
 |`DECFLOAT`
 |`BYTES`
 |`org.apache.kafka.connect.data.Decimal`
-|
 
 |`DECIMAL`
 |`BYTES`
 |`org.apache.kafka.connect.data.Decimal`
-|
 
 |`DBCLOB`
 |`STRING`
 |n/a
-|
 
 |`DOUBLE`
 |`FLOAT64`
 |n/a
-|
 
 |`INTEGER`
 |`INT32`
 |n/a
-|
 
 |`REAL`
 |`FLOAT32`
 |n/a
-|
 
 |`SMALLINT`
 |`INT16`
 |n/a
-|
 
 |`TIME`
 |`INT32`
-|`io.debezium.time.Time`
-|String representation of a time without timezone information
+|`io.debezium.time.Time` +
+ +
+String representation of a time without timezone information
 
 |`TIMESTAMP`
 |`INT64`
-|`io.debezium.time.MicroTimestamp`
-|String representation of a timestamp without timezone information
+|`io.debezium.time.MicroTimestamp` +
+ +
+String representation of a timestamp without timezone information
 
 |`VARBINARY`
 |`BYTES`
 |n/a
-|
 
 |`VARCHAR[(N)]`
 |`STRING`
 |n/a
-|
 
 |`VARGRAPHIC`
 |`STRING`
 |n/a
-|
 
 |`XML`
 |`STRING`
-|`io.debezium.data.Xml`
-|String representation of an XML document
+|`io.debezium.data.Xml` +
+ +
+String representation of an XML document
 |===
 
 If present, a column's default value is propagated to the corresponding field's Kafka Connect schema. Change events contain the field's default value unless an explicit column value had been given. Consequently, there is rarely a need to obtain the default value from the schema.
@@ -1155,54 +1146,63 @@ Other than Db2's `DATETIMEOFFSET` data type, which contains time zone informatio
 When the `time.precision.mode` configuration property is set to `adaptive`, the default, the connector determines the literal type and semantic type based on the column's data type definition. This ensures that events _exactly_ represent the values in the database.
 
 .Mappings when `time.precision.mode` is `adaptive`
-[cols="20%a,15%a,30%a,35%a",options="header"]
+[cols="25%a,20%a,55%a",options="header"]
 |===
-|Db2 data type |Literal type (schema type) |Semantic type (schema name) |Notes
+|Db2 data type |Literal type (schema type) |Semantic type (schema name) and Notes
 
 |`DATE`
 |`INT32`
-|`io.debezium.time.Date`
-|Represents the number of days since the epoch.
+|`io.debezium.time.Date` +
+ +
+Represents the number of days since the epoch.
 
 |`TIME(0)`, `TIME(1)`, `TIME(2)`, `TIME(3)`
 |`INT32`
-|`io.debezium.time.Time`
-|Represents the number of milliseconds past midnight, and does not include timezone information.
+|`io.debezium.time.Time` +
+ +
+Represents the number of milliseconds past midnight, and does not include timezone information.
 
 |`TIME(4)`, `TIME(5)`, `TIME(6)`
 |`INT64`
-|`io.debezium.time.MicroTime`
-|Represents the number of microseconds past midnight, and does not include timezone information.
+|`io.debezium.time.MicroTime` +
+ +
+Represents the number of microseconds past midnight, and does not include timezone information.
 
 |`TIME(7)`
 |`INT64`
-|`io.debezium.time.NanoTime`
-|Represents the number of nanoseconds past midnight, and does not include timezone information.
+|`io.debezium.time.NanoTime` +
+ +
+Represents the number of nanoseconds past midnight, and does not include timezone information.
 
 |`DATETIME`
 |`INT64`
-|`io.debezium.time.Timestamp`
-|Represents the number of milliseconds since the epoch, and does not include timezone information.
+|`io.debezium.time.Timestamp` +
+ +
+Represents the number of milliseconds since the epoch, and does not include timezone information.
 
 |`SMALLDATETIME`
 |`INT64`
-|`io.debezium.time.Timestamp`
-|Represents the number of milliseconds since the epoch, and does not include timezone information.
+|`io.debezium.time.Timestamp` +
+ +
+Represents the number of milliseconds since the epoch, and does not include timezone information.
 
 |`DATETIME2(0)`, `DATETIME2(1)`, `DATETIME2(2)`, `DATETIME2(3)`
 |`INT64`
-|`io.debezium.time.Timestamp`
-|Represents the number of milliseconds since the epoch, and does not include timezone information.
+|`io.debezium.time.Timestamp` +
+ +
+Represents the number of milliseconds since the epoch, and does not include timezone information.
 
 |`DATETIME2(4)`, `DATETIME2(5)`, `DATETIME2(6)`
 |`INT64`
-|`io.debezium.time.MicroTimestamp`
-|Represents the number of microseconds since the epoch, and does not include timezone information.
+|`io.debezium.time.MicroTimestamp` +
+ +
+Represents the number of microseconds since the epoch, and does not include timezone information.
 
 |`DATETIME2(7)`
 |`INT64`
-|`io.debezium.time.NanoTimestamp`
-|Represents the number of nanoseconds past the epoch, and does not include timezone information.
+|`io.debezium.time.NanoTimestamp` +
+ +
+Represents the number of nanoseconds past the epoch, and does not include timezone information.
 |===
 
 [[db2-time-precision-mode-connect]]
@@ -1210,34 +1210,39 @@ When the `time.precision.mode` configuration property is set to `adaptive`, the 
 When the `time.precision.mode` configuration property is set to `connect`, the connector uses Kafka Connect logical types. This may be useful when consumers can handle only the built-in Kafka Connect logical types and are unable to handle variable-precision time values. However, since Db2 supports tenth of a microsecond precision, the events generated by a connector with the `connect` time precision *results in a loss of precision* when the database column has a _fractional second precision_ value that is greater than 3.
 
 .Mappings when `time.precision.mode` is `connect`
-[cols="20%a,15%a,30%a,35%a",options="header"]
+[cols="25%a,20%a,55%a",options="header"]
 |===
-|Db2 data type |Literal type (schema type) |Semantic type (schema name) |Notes
+|Db2 data type |Literal type (schema type) |Semantic type (schema name) and Notes
 
 |`DATE`
 |`INT32`
-|`org.apache.kafka.connect.data.Date`
-| Represents the number of days since the epoch.
+|`org.apache.kafka.connect.data.Date` +
+ +
+Represents the number of days since the epoch.
 
 |`TIME([P])`
 |`INT64`
-|`org.apache.kafka.connect.data.Time`
-| Represents the number of milliseconds since midnight, and does not include timezone information. Db2 allows `P` to be in the range 0-7 to store up to tenth of a microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
+|`org.apache.kafka.connect.data.Time` +
+ +
+Represents the number of milliseconds since midnight, and does not include timezone information. Db2 allows `P` to be in the range 0-7 to store up to tenth of a microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
 
 |`DATETIME`
 |`INT64`
-|`org.apache.kafka.connect.data.Timestamp`
-| Represents the number of milliseconds since the epoch, and does not include timezone information.
+|`org.apache.kafka.connect.data.Timestamp` +
+ +
+Represents the number of milliseconds since the epoch, and does not include timezone information.
 
 |`SMALLDATETIME`
 |`INT64`
-|`org.apache.kafka.connect.data.Timestamp`
-| Represents the number of milliseconds since the epoch, and does not include timezone information.
+|`org.apache.kafka.connect.data.Timestamp` +
+ +
+Represents the number of milliseconds since the epoch, and does not include timezone information.
 
 |`DATETIME2`
 |`INT64`
-|`org.apache.kafka.connect.data.Timestamp`
-| Represents the number of milliseconds since the epoch, and does not include timezone information. Db2 allows `P` to be in the range 0-7 to store up to tenth of a microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
+|`org.apache.kafka.connect.data.Timestamp` +
+ +
+Represents the number of milliseconds since the epoch, and does not include timezone information. Db2 allows `P` to be in the range 0-7 to store up to tenth of a microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
 |===
 
 [[db2-timestamp-types]]
@@ -1251,32 +1256,36 @@ The timezone of the JVM running Kafka Connect and {prodname} does not affect thi
 [[db2-decimal-types]]
 === Decimal types
 
-[cols="15%a,15%a,35%a,35%a",options="header"]
+[cols="27%a,18%a,55%a",options="header"]
 |===
-|Db2 data type |Literal type (schema type) |Semantic type (schema name) |Notes
+|Db2 data type |Literal type (schema type) |Semantic type (schema name) and Notes
 
 |`NUMERIC[(P[,S])]`
 |`BYTES`
-|`org.apache.kafka.connect.data.Decimal`
-|The `scale` schema parameter contains an integer that represents how many digits the decimal point is shifted.
+|`org.apache.kafka.connect.data.Decimal` +
+ +
+The `scale` schema parameter contains an integer that represents how many digits the decimal point is shifted.
 The `connect.decimal.precision` schema parameter contains an integer that represents the precision of the given decimal value.
 
 |`DECIMAL[(P[,S])]`
 |`BYTES`
-|`org.apache.kafka.connect.data.Decimal`
-|The `scale` schema parameter contains an integer that represents how many digits the decimal point is shifted.
+|`org.apache.kafka.connect.data.Decimal` +
+ +
+The `scale` schema parameter contains an integer that represents how many digits the decimal point is shifted.
 The `connect.decimal.precision` schema parameter contains an integer that  represents the precision of the given decimal value.
 
 |`SMALLMONEY`
 |`BYTES`
-|`org.apache.kafka.connect.data.Decimal`
-|The `scale` schema parameter contains an integer that represents how many digits the decimal point iss shifted.
+|`org.apache.kafka.connect.data.Decimal` +
+ +
+The `scale` schema parameter contains an integer that represents how many digits the decimal point iss shifted.
 The `connect.decimal.precision` schema parameter contains an integer that represents the precision of the given decimal value.
 
 |`MONEY`
 |`BYTES`
-|`org.apache.kafka.connect.data.Decimal`
-|The `scale` schema parameter contains an integer that represents how many digits the decimal point is shifted.
+|`org.apache.kafka.connect.data.Decimal` +
+ +
+The `scale` schema parameter contains an integer that represents how many digits the decimal point is shifted.
 The `connect.decimal.precision` schema parameter contains an integer that represents the precision of the given decimal value.
 |===
 
@@ -1470,7 +1479,7 @@ endif::product[]
 
 // Type: concept
 // ModuleID: debezium-db2-connector-configuration-example
-// Title: {prodname} db2 connector configuration example
+// Title: {prodname} Db2 connector configuration example
 [[db2-example]]
 [[db2-example-configuration]]
 === Connector configuration example
@@ -1519,9 +1528,9 @@ Following is an example of the configuration for a Db2 connector that connects t
 
 You can choose to produce events for a subset of the schemas and tables. Optionally, ignore, mask, or truncate columns that are sensitive, too large, or not needed.
 
-[source,yaml,options="nowrap"]
+[source,yaml,options="nowrap",subs="+attributes"]
 ----
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: {KafkaConnectApiVersion}
   kind: KafkaConnector
   metadata:
     name: inventory-connector  // <1>
@@ -1617,7 +1626,7 @@ pass:quotes[*tree ./my-plugins/*]
 
 .. Create a new `Dockerfile` by using `{DockerKafkaConnect}` as the base image. In the following example, you would replace _my-plugins_ with the name of your plug-ins directory:
 +
-[subs=+macros]
+[subs="+macros,+attributes"]
 ----
 FROM {DockerKafkaConnect}
 USER root:root
@@ -1639,7 +1648,7 @@ Before Kafka Connect starts running the connector, Kafka Connect loads any third
 +
 * Edit the `spec.image` property of the `KafkaConnector` custom resource. If set, this property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator. For example:
 +
-[source,yaml,subs=attributes+]
+[source,yaml,subs="+attributes"]
 ----
 apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnector
@@ -1735,15 +1744,15 @@ The following configuration properties are _required_ unless a default value is 
 |
 |The name of the Db2 database from which to stream the changes
 
-|[[db2-property-database-server-name]]<<db2-property-database-server-name, `database.server.name`>>
+|[[db2-property-database-server-name]]<<db2-property-database-server-name, `database.server{zwsp}.name`>>
 |
 |Logical name that identifies and provides a namespace for the particular Db2 database server that hosts the database for which {prodname} is capturing changes. Only alphanumeric characters and underscores should be used in the database server logical name. The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
 
-|[[db2-property-database-history-kafka-topic]]<<db2-property-database-history-kafka-topic, `database.history.kafka.topic`>>
+|[[db2-property-database-history-kafka-topic]]<<db2-property-database-history-kafka-topic, `database.history{zwsp}.kafka.topic`>>
 |
 |The full name of the Kafka topic where the connector stores the database schema history.
 
-|[[db2-property-database-history-kafka-bootstrap-servers]]<<db2-property-database-history-kafka-bootstrap-servers, `database.history{zwsp}.kafka.bootstrap.servers`>>
+|[[db2-property-database-history-kafka-bootstrap-servers]]<<db2-property-database-history-kafka-bootstrap-servers, `database.history{zwsp}.kafka.bootstrap{zwsp}.servers`>>
 |
 |A list of host/port pairs that the connector uses to establish an initial connection to the Kafka cluster. This connection is used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. Each pair should point to the same Kafka cluster used by the {prodname} Kafka Connect process.
 
@@ -1764,7 +1773,7 @@ The following configuration properties are _required_ unless a default value is 
 Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 Primary key columns are always included in the event's key, even if they are excluded from the value.
 
-|[[db2-property-column-mask-hash]]<<db2-property-column-mask-hash, `column.mask.hash._hashAlgorithm_.with.salt._salt_`>>
+|[[db2-property-column-mask-hash]]<<db2-property-column-mask-hash, `column.mask{zwsp}.hash._hashAlgorithm_{zwsp}.with.salt._salt_`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be pseudonyms in change event values. A pseudonym is a field value that  consists of the hashed value obtained by applying the `_hashAlgorithm_` algorithm and the `_salt_` salt that you specify in the property name. +
  +
@@ -1787,7 +1796,7 @@ Depending on the `_hashAlgorithm_` used, the `_salt_` selected, and the actual d
  +
 `connect` always represents time and timestamp values by using Kafka Connect's built-in representations for `Time`, `Date`, and `Timestamp`, which uses millisecond precision regardless of the database columns' precision. See {link-prefix}:{link-db2-connector}#db2-temporal-values[temporal values].
 
-|[[db2-property-tombstones-on-delete]]<<db2-property-tombstones-on-delete, `tombstones.on.delete`>>
+|[[db2-property-tombstones-on-delete]]<<db2-property-tombstones-on-delete, `tombstones.on{zwsp}.delete`>>
 |`true`
 | Controls whether a tombstone event should be generated after a _delete_ event. +
  +
@@ -1797,19 +1806,19 @@ Depending on the `_hashAlgorithm_` used, the `_salt_` selected, and the actual d
  +
 After a _delete_ operation, emitting a tombstone event enables Kafka to delete all change event records that have the same key as the deleted row.
 
-|[[db2-property-include-schema-changes]]<<db2-property-include-schema-changes, `include.schema.changes`>>
+|[[db2-property-include-schema-changes]]<<db2-property-include-schema-changes, `include.schema{zwsp}.changes`>>
 |`true`
 |Boolean value that specifies whether the connector should publish changes in the database schema to a Kafka topic with the same name as the database server ID. Each schema change is recorded with a key that contains the database name and a value that is a JSON structure that describes the schema update. This is independent of how the connector internally records database history.
 
-|[[db2-property-column-truncate-to-length-chars]]<<db2-property-column-truncate-to-length-chars, `column.truncate.to._length_.chars`>>
+|[[db2-property-column-truncate-to-length-chars]]<<db2-property-column-truncate-to-length-chars, `column.truncate.to.{zwsp}_length_.chars`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event records, values in these columns are truncated if they are longer than the number of characters specified by _length_ in the property name. You can specify multiple properties with different lengths in a single configuration. Length must be a positive integer, for example, `column.truncate.to.20.chars`.
 
-|[[db2-property-column-mask-with-length-chars]]<<db2-property-column-mask-with-length-chars, `column.mask.with._length_.chars`>>
+|[[db2-property-column-mask-with-length-chars]]<<db2-property-column-mask-with-length-chars, `column.mask{zwsp}.with._length_.chars`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event values, the values in the specified table columns are replaced with _length_ number of asterisk (`*`) characters. You can specify multiple properties with different lengths in a single configuration. Length must be a positive integer or zero. When you specify zero, the connector replaces a value with an empty string.
 
-|[[db2-property-column-propagate-source-type]]<<db2-property-column-propagate-source-type, `column.propagate.source.type`>>
+|[[db2-property-column-propagate-source-type]]<<db2-property-column-propagate-source-type, `column.propagate{zwsp}.source.type`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns. Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_. +
  +
@@ -1819,7 +1828,7 @@ For each specified column, the connector adds the column's original type and ori
  +
 This property is useful for properly sizing corresponding columns in sink databases.
 
-|[[db2-property-datatype-propagate-source-type]]<<db2-property-datatype-propagate-source-type, `datatype.propagate.source.type`>>
+|[[db2-property-datatype-propagate-source-type]]<<db2-property-datatype-propagate-source-type, `datatype.propagate{zwsp}.source.type`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the database-specific data type name for some columns. Fully-qualified data type names are of the form _databaseName_._tableName_._typeName_, or _databaseName_._schemaName_._tableName_._typeName_. +
  +
@@ -1831,9 +1840,9 @@ These parameters propagate a column's original type name and length, for variabl
  +
 See {link-prefix}:{link-db2-connector}#db2-data-types[Db2 data types] for the list of Db2-specific data type names.
 
-|[[db2-property-message-key-columns]]<<db2-property-message-key-columns, `message.key.columns`>>
+|[[db2-property-message-key-columns]]<<db2-property-message-key-columns, `message.key{zwsp}.columns`>>
 |_empty string_
-A semicolon separated list of tables with regular expressions that match table column names. The connector maps values in matching columns to key fields in change event records that it sends to Kafka topics. This is useful when a table does not have a primary key, or when you want to order change event records in a Kafka topic according to a field that is not a primary key. +
+|A semicolon separated list of tables with regular expressions that match table column names. The connector maps values in matching columns to key fields in change event records that it sends to Kafka topics. This is useful when a table does not have a primary key, or when you want to order change event records in a Kafka topic according to a field that is not a primary key. +
  +
 Separate entries with semicolons. Insert a colon between the fully-qualified table name and its regular expression. The format is: +
  +
@@ -1863,7 +1872,7 @@ The following _advanced_ configuration properties have defaults that work in mos
  +
 `schema_only` - For tables in capture mode, the connector takes a snapshot of only the schema for the table. This is useful when only the changes that are happening from now on need to be emitted to Kafka topics. After the snapshot is complete, the connector continues by reading change events from the database's redo logs.
 
-|[[db2-property-snapshot-isolation-mode]]<<db2-property-snapshot-isolation-mode, `snapshot.isolation.mode`>>
+|[[db2-property-snapshot-isolation-mode]]<<db2-property-snapshot-isolation-mode, `snapshot.isolation{zwsp}.mode`>>
 |`repeatable_read`
 |During a snapshot, controls the transaction isolation level and how long the connector locks the tables that are in capture mode. The possible values are: +
  +
@@ -1875,7 +1884,7 @@ The following _advanced_ configuration properties have defaults that work in mos
  +
 `exclusive` - Uses repeatable read isolation level but takes an  exclusive lock for all tables to be read. This mode prevents other transactions from updating table rows during an initial snapshot. Only `exclusive` mode guarantees full consistency; the initial snapshot and streaming logs constitute a linear history.
 
-|[[db2-property-event-processing-failure-handling-mode]]<<db2-property-event-processing-failure-handling-mode, `event.processing{zwsp}.failure.handling.mode`>>
+|[[db2-property-event-processing-failure-handling-mode]]<<db2-property-event-processing-failure-handling-mode, `event.processing{zwsp}.failure.handling{zwsp}.mode`>>
 |`fail`
 |Specifies how the connector handles exceptions during processing of events. The possible values are: +
  +
@@ -1897,7 +1906,7 @@ The following _advanced_ configuration properties have defaults that work in mos
 |`2048`
 |Positive integer value that specifies the maximum size of each batch of events that the connector processes.
 
-|[[db2-property-heartbeat-interval-ms]]<<db2-property-heartbeat-interval-ms, `heartbeat.interval.ms`>>
+|[[db2-property-heartbeat-interval-ms]]<<db2-property-heartbeat-interval-ms, `heartbeat.interval{zwsp}.ms`>>
 |`0`
 |Controls how frequently the connector sends heartbeat messages to a Kafka topic. The default behavior is that the connector does not send heartbeat messages. +
  +
@@ -1905,7 +1914,7 @@ Heartbeat messages are useful for monitoring whether the connector is receiving 
  +
 Heartbeat messages are useful when there are many updates in a database that is being tracked but only a tiny number of updates are in tables that are in capture mode. In this situation, the connector reads from the database transaction log as usual but rarely emits change records to Kafka. This means that the connector has few opportunities to send the latest offset to Kafka. Sending heartbeat messages enables the connector to send the latest offset to Kafka.
 
-|[[db2-property-heartbeat-topics-prefix]]<<db2-property-heartbeat-topics-prefix, `heartbeat.topics.prefix`>>
+|[[db2-property-heartbeat-topics-prefix]]<<db2-property-heartbeat-topics-prefix, `heartbeat.topics{zwsp}.prefix`>>
 |`__debezium-heartbeat`
 |Specifies the prefix for the name of the topic to which the connector sends heartbeat messages. The format for this topic name is  `<heartbeat.topics.prefix>.<server.name>`.
 
@@ -1917,7 +1926,7 @@ Heartbeat messages are useful when there are many updates in a database that is 
 |`2000`
 |During a snapshot, the connector reads table content in batches of rows. This property specifies the maximum number of rows in a batch.
 
-|[[db2-property-snapshot-lock-timeout-ms]]<<db2-property-snapshot-lock-timeout-ms, `snapshot.lock.timeout.ms`>>
+|[[db2-property-snapshot-lock-timeout-ms]]<<db2-property-snapshot-lock-timeout-ms, `snapshot.lock{zwsp}.timeout.ms`>>
 |`10000`
 |Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this interval, the snapshot fails. {link-prefix}:{link-db2-connector}#db2-snapshots[How the connector performs snapshots] provides details. Other possible settings are: +
  +
@@ -1925,7 +1934,7 @@ Heartbeat messages are useful when there are many updates in a database that is 
  +
 `-1` - The connector waits infinitely.
 
-|[[db2-property-snapshot-select-statement-overrides]]<<db2-property-snapshot-select-statement-overrides, `snapshot.select.statement.overrides`>>
+|[[db2-property-snapshot-select-statement-overrides]]<<db2-property-snapshot-select-statement-overrides, `snapshot.select{zwsp}.statement{zwsp}.overrides`>>
 |
 |Controls which table rows are included in snapshots. This property affects snapshots only. It does not affect events that the connector reads from the log. Specify a comma-separated list of fully-qualified table names in the form _schemaName.tableName_. +
  +
@@ -1933,13 +1942,13 @@ For each table that you specify, also specify another configuration property: `s
  +
 A possible use case for setting these properties is large, append-only tables. You can specify a `SELECT` statement that sets a specific point for where to start a snapshot, or where to resume a snapshot if a previous snapshot was interrupted.
 
-|[[db2-property-sanitize-field-names]]<<db2-property-sanitize-field-names, `sanitize.field.names`>>
+|[[db2-property-sanitize-field-names]]<<db2-property-sanitize-field-names, `sanitize.field{zwsp}.names`>>
 |`true` if connector configuration sets the `key.converter` or `value.converter` property to the Avro converter.
 
 `false` if not.
 |Indicates whether field names are sanitized to adhere to {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming requirements].
 
-|[[db2-property-provide-transaction-metadata]]<<db2-property-provide-transaction-metadata, `provide.transaction.metadata`>>
+|[[db2-property-provide-transaction-metadata]]<<db2-property-provide-transaction-metadata, `provide.transaction{zwsp}.metadata`>>
 |`false`
 |Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See  {link-prefix}:{link-db2-connector}#db2-transaction-metadata[Transaction metadata] for details.
 
@@ -2032,33 +2041,31 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-hi
 After you deploy a {prodname} Db2 connector, use the {prodname} management UDFs to control Db2 replication (ASN) with SQL commands. Some of the UDFs expect a return value in which case you use the  SQL `VALUE` statement to invoke them. For other UDFs, use the SQL `CALL` statement.
 
 .Descriptions of {prodname} management UDFs
-[cols="1,3, 2",options="header"]
+[cols="1,4",options="header"]
 |===
-|Task |Command |Notes
+|Task |Command and notes
 
 |[[debezium-db2-start-asn-agent]]<<debezium-db2-start-asn-agent,Start the ASN agent>>
 |`VALUES ASNCDC.ASNCDCSERVICES('start','asncdc');`
-|
 
 |[[debezium-db2-stop-asn-agent]]<<debezium-db2-stop-asn-agent,Stop the ASN agent>>
 |`VALUES ASNCDC.ASNCDCSERVICES('stop','asncdc');`
-|
 
 |[[debezium-db2-check-asn-agent]]<<debezium-db2-check-asn-agent,Check the status of the ASN agent>>
 |`VALUES ASNCDC.ASNCDCSERVICES('status','asncdc');`
-|
 
 |[[debezium-db2-put-capture-mode]]<<debezium-db2-put-capture-mode,Put a table into capture mode>>
-|`CALL ASNCDC.ADDTABLE('MYSCHEMA', 'MYTABLE');`
-|Replace `MYSCHEMA`  with the name of the schema that contains the table you want to put into capture mode. Likewise, replace `MYTABLE` with the name of the table to put into capture mode.
+|`CALL ASNCDC.ADDTABLE('MYSCHEMA', 'MYTABLE');` +
+ +
+Replace `MYSCHEMA`  with the name of the schema that contains the table you want to put into capture mode. Likewise, replace `MYTABLE` with the name of the table to put into capture mode.
 
 |[[debezium-db2-remove-capture-mode]]<<debezium-db2-remove-capture-mode,Remove a table from capture mode>>
 |`CALL ASNCDC.REMOVETABLE('MYSCHEMA', 'MYTABLE');`
-|
 
 |[[debezium-db2-reinitialize-asn-service]]<<debezium-db2-reinitialize-asn-service,Reinitialize the ASN service>>
-|`VALUES ASNCDC.ASNCDCSERVICES('reinit','asncdc');`
-|Do this after you put a table into capture mode or after you remove a table from capture mode.
+|`VALUES ASNCDC.ASNCDCSERVICES('reinit','asncdc');` +
+ +
+Do this after you put a table into capture mode or after you remove a table from capture mode.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -284,7 +284,7 @@ Every change event that captures a change to the `customers` collection has the 
   {
     "schema": { // <1>
       "type": "struct",
-      "name": "fulfillment.inventory.customers.Key," // <2>
+      "name": "fulfillment.inventory.customers.Key", // <2>
       "optional": false, // <3>
       "fields": [ // <4>
         {

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1,5 +1,5 @@
 [id="debezium-connector-for-mongodb"]
-= {prodname} Connector for MongoDB
+= {prodname} connector for MongoDB
 
 ifdef::community[]
 
@@ -210,16 +210,16 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 [source,json,index=0]
 ----
 {
- "schema": { //<1>
+ "schema": { // <1>
    ...
   },
- "payload": { //<2>
+ "payload": { // <2>
    ...
  },
- "schema": { //<3> 
+ "schema": { // <3> 
    ...
  },
- "payload": { //<4>
+ "payload": { // <4>
    ...
  },
 }
@@ -282,11 +282,11 @@ Every change event that captures a change to the `customers` collection has the 
 [source,json,indent=0]
 ----
   {
-    "schema": { <1>
+    "schema": { // <1>
       "type": "struct",
-      "name": "fulfillment.inventory.customers.Key" <2>
-      "optional": false, <3>
-      "fields": [ <4>
+      "name": "fulfillment.inventory.customers.Key," // <2>
+      "optional": false, // <3>
+      "fields": [ // <4>
         {
           "field": "id",
           "type": "string",
@@ -294,7 +294,7 @@ Every change event that captures a change to the `customers` collection has the 
         }
       ]
     },
-    "payload": { <5>
+    "payload": { // <5>
       "id": "1004"
     }
   }
@@ -310,7 +310,7 @@ Every change event that captures a change to the `customers` collection has the 
 |The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion. 
 
 |2
-|`fulfillment.inventory.customers.Key`
+|`fulfillment{zwsp}.inventory{zwsp}.customers{zwsp}.Key`
 a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the key for the document that was changed. Key schema names have the format _connector-name_._database-name_._collection-name_.`Key`. In this example: + 
 
 * `fulfillment` is the name of the connector that generated this event. + 
@@ -341,7 +341,7 @@ This example uses a document with an integer identifier, but any valid MongoDB d
 |Float   |12.34|`{ "id" : "12.34" }`
 |String  |"1234"|`{ "id" : "\"1234\"" }`
 |Document|`{ "hi" : "kafka", "nums" : [10.0, 100.0, 1000.0] }`|`{ "id" : "{\"hi\" : \"kafka\", \"nums\" : [10.0, 100.0, 1000.0]}" }`
-|`ObjectId|ObjectId("596e275826f08b2730779e1f")``|`{ "id" : "{\"$oid\" : \"596e275826f08b2730779e1f\"}" }`
+|ObjectId |`ObjectId("596e275826f08b2730779e1f")`|`{ "id" : "{\"$oid\" : \"596e275826f08b2730779e1f\"}" }`
 |Binary  |`BinData("a2Fma2E=",0)`|`{ "id" : "{\"$binary\" : \"a2Fma2E=\", \"$type\" : \"00\"}" }`
 |===
 
@@ -722,7 +722,7 @@ Every event contains
 
 Following is an example of what a message looks like:
 
-[source,json,indent=0,subs="attributes"]
+[source,json,indent=0,subs="+attributes"]
 ----
 {
   "status": "BEGIN",
@@ -760,7 +760,7 @@ This field provides information about every event in the form of a composite of 
 
 Following is an example of what a message looks like: 
 
-[source,json,indent=0,subs="attributes"]
+[source,json,indent=0,subs="+attributes"]
 ----
 {
   "before": null,
@@ -847,12 +847,12 @@ Typically, you configure the {prodname} MongoDB connector in a `.json` file usin
 [source,json]
 ----
 {
-  "name": "inventory-connector", <1>
+  "name": "inventory-connector", // <1>
   "config": {
-    "connector.class": "io.debezium.connector.mongodb.MongoDbConnector", <2>
-    "mongodb.hosts": "rs0/192.168.99.100:27017", <3>
-    "mongodb.name": "fullfillment", <4>
-    "collection.include.list": "inventory[.]*", <5>
+    "connector.class": "io.debezium.connector.mongodb.MongoDbConnector", // <2>
+    "mongodb.hosts": "rs0/192.168.99.100:27017", // <3>
+    "mongodb.name": "fullfillment", // <4>
+    "collection.include.list": "inventory[.]*", // <5>
   }
 }
 ----
@@ -868,19 +868,19 @@ ifdef::product[]
 Following is an example of the configuration for a MongoDB connector that monitors a MongoDB replica set `rs0` at port 27017 on 192.168.99.100, which we logically name `fullfillment`.
 Typically, you configure the {prodname} MongoDB connector in a `.yaml` file using the configuration properties available for the connector.
 
-[source,yaml,options="nowrap"]
+[source,yaml,options="nowrap",subs="+attributes"]
 ----
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: {KafkaConnectApiVersion}
   kind: KafkaConnector
   metadata:
-    name: inventory-connector <1>
+    name: inventory-connector // <1>
     labels: strimzi.io/cluster: my-connect-cluster
   spec:
-    class: io.debezium.connector.mongodb.MongoDbConnector <2>
+    class: io.debezium.connector.mongodb.MongoDbConnector // <2>
     config:  
-     mongodb.hosts: rs0/192.168.99.100:27017 <3>
-     mongodb.name: fulfillment <4>
-     collection.include.list: inventory[.]* <5>
+     mongodb.hosts: rs0/192.168.99.100:27017 // <3>
+     mongodb.name: fulfillment // <4>
+     collection.include.list: inventory[.]* // <5>
 ----
 <1> The name of our connector when we register it with a Kafka Connect service.
 <2> The name of the MongoDB connector class.
@@ -926,7 +926,7 @@ You can use a provided {prodname} container to deploy a {prodname} MongoDB conne
 
 . Extract the {prodname} MongoDB connector archive to create a directory structure for the connector plug-in, for example: 
 +
-[subs=+macros]
+[subs="+macros,+attributes"]
 ----
 pass:quotes[*tree ./my-plugins/*]
 ./my-plugins/
@@ -938,7 +938,7 @@ pass:quotes[*tree ./my-plugins/*]
 
 .. Create a new `Dockerfile` by using `{DockerKafkaConnect}` as the base image. In the following example, you would replace _my-plugins_ with the name of your plug-ins directory:
 +
-[subs=+macros,subs="+attributes"]
+[subs="+macros,+attributes"]
 ----
 FROM {DockerKafkaConnect}
 USER root:root
@@ -1023,7 +1023,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-
 
 The {prodname} MongoDB connector also provides the following custom snapshot metrics:
 
-[cols="3,2,5"]
+[cols="3,2,5",options="header"]
 |===
 |Attribute |Type |Description
 
@@ -1042,7 +1042,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming
 
 The {prodname} MongoDB connector also provides the following custom streaming metrics:
 
-[cols="3,2,5"]
+[cols="3,2,5",options="header"]
 |===
 |Attribute |Type |Description
 
@@ -1061,7 +1061,7 @@ The {prodname} MongoDB connector also provides the following custom streaming me
 
 The following configuration properties are _required_ unless a default value is available.
 
-[cols="30%a,25%a,45%a"]
+[cols="30%a,25%a,45%a",options="header"]
 |===
 |Property |Default |Description
 
@@ -1098,30 +1098,30 @@ Only alphanumeric characters and underscores should be used.
 |`false`
 |Connector will use SSL to connect to MongoDB instances.
 
-|[[mongodb-property-mongodb-ssl-invalid-hostname-allowed]]<<mongodb-property-mongodb-ssl-invalid-hostname-allowed, `mongodb.ssl.invalid.hostname.allowed`>>
+|[[mongodb-property-mongodb-ssl-invalid-hostname-allowed]]<<mongodb-property-mongodb-ssl-invalid-hostname-allowed, `mongodb.ssl.invalid{zwsp}.hostname.allowed`>>
 |`false`
 |When SSL is enabled this setting controls whether strict hostname checking is disabled during connection phase. If `true` the connection will not prevent man-in-the-middle attacks.
 
 |[[mongodb-property-database-whitelist]]
-[[mongodb-property-database-include-list]]<<mongodb-property-database-include-list, `database.include.list`>>
+[[mongodb-property-database-include-list]]<<mongodb-property-database-include-list, `database.include{zwsp}.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match database names to be monitored; any database name not included in `database.include.list` is excluded from monitoring. By default all databases are monitored.
 Must not be used with `database.exclude.list`.
 
 |[[mongodb-property-database-blacklist]]
-[[mongodb-property-database-exclude-list]]<<mongodb-property-database-exclude-list, `database.exclude.list`>>
+[[mongodb-property-database-exclude-list]]<<mongodb-property-database-exclude-list, `database.exclude{zwsp}.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match database names to be excluded from monitoring; any database name not included in `database.exclude.list` is monitored.
 Must not be used with `database.include.list`.
 
 |[[mongodb-property-collection-whitelist]]
-[[mongodb-property-collection-include-list]]<<mongodb-property-collection-include-list, `collection.include.list`>>
+[[mongodb-property-collection-include-list]]<<mongodb-property-collection-include-list, `collection{zwsp}.include.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified namespaces for MongoDB collections to be monitored; any collection not included in `collection.include.list` is excluded from monitoring. Each identifier is of the form _databaseName_._collectionName_. By default the connector will monitor all collections except those in the `local` and `admin` databases.
 Must not be used with `collection.exclude.list`.
 
 |[[mongodb-property-collection-blacklist]]
-[[mongodb-property-collection-exclude-list]]<<mongodb-property-collection-exclude-list, `collection.exclude.list`>>
+[[mongodb-property-collection-exclude-list]]<<mongodb-property-collection-exclude-list, `collection{zwsp}.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified namespaces for MongoDB collections to be excluded from monitoring; any collection not included in `collection.exclude.list` is monitored. Each identifier is of the form _databaseName_._collectionName_.
 Must not be used with `collection.include.list`.
@@ -1131,7 +1131,7 @@ Must not be used with `collection.include.list`.
 |Specifies the criteria for running a snapshot upon startup of the connector. The default is *initial*, and specifies the connector reads a snapshot when either no offset is found or if the oplog no longer contains the previous offset. The *never* option specifies that the connector should never use snapshots, instead the connector should proceed to tail the log.
 
 |[[mongodb-property-field-blacklist]]
-[[mongodb-property-field-exclude-list]]<<mongodb-property-field-exclude-list, `field.exclude.list`>>
+[[mongodb-property-field-exclude-list]]<<mongodb-property-field-exclude-list, `field.exclude{zwsp}.list`>>
 |_empty string_
 |An optional comma-separated list of the fully-qualified names of fields that should be excluded from change event message values. Fully-qualified names for fields are of the form _databaseName_._collectionName_._fieldName_._nestedFieldName_, where _databaseName_ and _collectionName_ may contain the wildcard (*) which matches any characters.
 
@@ -1143,11 +1143,11 @@ Must not be used with `collection.include.list`.
 |`1`
 |The maximum number of tasks that should be created for this connector. The MongoDB connector will attempt to use a separate task for each replica set, so the default is acceptable when using the connector with a single MongoDB replica set. When using the connector with a MongoDB sharded cluster, we recommend specifying a value that is equal to or more than the number of shards in the cluster, so that the work for each replica set can be distributed by Kafka Connect.
 
-|[[mongodb-property-initial-sync-max-threads]]<<mongodb-property-initial-sync-max-threads, `initial.sync.max.threads`>>
+|[[mongodb-property-initial-sync-max-threads]]<<mongodb-property-initial-sync-max-threads, `initial.sync{zwsp}.max.threads`>>
 |`1`
 |Positive integer value that specifies the maximum number of threads used to perform an intial sync of the collections in a replica set. Defaults to 1.
 
-|[[mongodb-property-tombstones-on-delete]]<<mongodb-property-tombstones-on-delete, `tombstones.on.delete`>>
+|[[mongodb-property-tombstones-on-delete]]<<mongodb-property-tombstones-on-delete, `tombstones.on{zwsp}.delete`>>
 |`true`
 | Controls whether a tombstone event should be generated after a delete event. +
 When `true` the delete operations are represented by a delete event and a subsequent tombstone event. When `false` only a delete event is sent. +
@@ -1155,7 +1155,7 @@ Emitting the tombstone event (the default behavior) allows Kafka to completely d
 
 |[[mongodb-property-snapshot-delay-ms]]<<mongodb-property-snapshot-delay-ms, `snapshot.delay.ms`>>
 |
-|An interval in milli-seconds that the connector should wait before taking a snapshot after starting up; +
+|An interval in milliseconds that the connector should wait before taking a snapshot after starting up; +
 Can be used to avoid snapshot interruptions when starting multiple connectors in a cluster, which may cause re-balancing of connectors.
 
 |[[mongodb-property-snapshot-fetch-size]]<<mongodb-property-snapshot-fetch-size, `snapshot.fetch.size`>>
@@ -1169,7 +1169,7 @@ Defaults to 0, which indicates that the server chooses an appropriate fetch size
 
 The following _advanced_ configuration properties have good defaults that will work in most situations and therefore rarely need to be specified in the connector's configuration.
 
-[cols="30%a,25%a,45%a"]
+[cols="30%a,25%a,45%a",options="header"]
 |===
 |Property
 |Default
@@ -1187,24 +1187,24 @@ The following _advanced_ configuration properties have good defaults that will w
 |`1000`
 |Positive integer value that specifies the number of milliseconds the connector should wait during each iteration for new change events to appear. Defaults to 1000 milliseconds, or 1 second.
 
-|[[mongodb-property-connect-backoff-initial-delay-ms]]<<mongodb-property-connect-backoff-initial-delay-ms, `connect.backoff.initial.delay.ms`>>
+|[[mongodb-property-connect-backoff-initial-delay-ms]]<<mongodb-property-connect-backoff-initial-delay-ms, `connect.backoff{zwsp}.initial.delay.ms`>>
 |`1000`
 |Positive integer value that specifies the initial delay when trying to reconnect to a primary after the first failed connection attempt or when no primary is available. Defaults to 1 second (1000 ms).
 
-|[[mongodb-property-connect-backoff-max-delay-ms]]<<mongodb-property-connect-backoff-max-delay-ms, `connect.backoff.max.delay.ms`>>
+|[[mongodb-property-connect-backoff-max-delay-ms]]<<mongodb-property-connect-backoff-max-delay-ms, `connect.backoff{zwsp}.max.delay.ms`>>
 |`1000`
 |Positive integer value that specifies the maximum delay when trying to reconnect to a primary after repeated failed connection attempts or when no primary is available. Defaults to 120 seconds (120,000 ms).
 
-|[[mongodb-property-connect-max-attempts]]<<mongodb-property-connect-max-attempts, `connect.max.attempts`>>
+|[[mongodb-property-connect-max-attempts]]<<mongodb-property-connect-max-attempts, `connect.max{zwsp}.attempts`>>
 |`16`
 |Positive integer value that specifies the maximum number of failed connection attempts to a replica set primary before an exception occurs and task is aborted. Defaults to 16, which with the defaults for `connect.backoff.initial.delay.ms` and `connect.backoff.max.delay.ms` results in just over 20 minutes of attempts before failing.
 
-|[[mongodb-property-mongodb-members-auto-discover]]<<mongodb-property-mongodb-members-auto-discover, `mongodb.members.auto.discover`>>
+|[[mongodb-property-mongodb-members-auto-discover]]<<mongodb-property-mongodb-members-auto-discover, `mongodb.members{zwsp}.auto.discover`>>
 |`true`
 |Boolean value that specifies whether the addresses in 'mongodb.hosts' are seeds that should be used to discover all members of the cluster or replica set (`true`), or whether the address(es) in `mongodb.hosts` should be used as is (`false`). The default is `true` and should be used in all cases except where MongoDB is {link-prefix}:{link-mongodb-connector}#mongodb-replicaset[fronted by a proxy].
 
 ifdef::community[]
-|[[mongodb-property-source-struct-version]]<<mongodb-property-source-struct-version, `source.struct.version`>>
+|[[mongodb-property-source-struct-version]]<<mongodb-property-source-struct-version, `source.struct{zwsp}.version`>>
 |v2
 |Schema version for the `source` block in CDC events. {prodname} 0.10 introduced a few breaking +
 changes to the structure of the `source` block in order to unify the exposed structure across
@@ -1213,10 +1213,10 @@ By setting this option to `v1` the structure used in earlier versions can be pro
 Note that this setting is not recommended and is planned for removal in a future {prodname} version.
 endif::community[]
 
-|[[mongodb-property-heartbeat-interval-ms]]<<mongodb-property-heartbeat-interval-ms, `heartbeat.interval.ms`>>
+|[[mongodb-property-heartbeat-interval-ms]]<<mongodb-property-heartbeat-interval-ms, `heartbeat.interval{zwsp}.ms`>>
 |`0`
 |Controls how frequently heartbeat messages are sent. +
-This property contains an interval in milli-seconds that defines how frequently the connector sends messages into a heartbeat topic.
+This property contains an interval in milliseconds that defines how frequently the connector sends messages into a heartbeat topic.
 This can be used to monitor whether the connector is still receiving change events from the database.
 You also should leverage heartbeat messages in cases where only records in non-captured collections are changed for a longer period of time.
 In such situation the connector would proceed to read the oplog from the database but never emit any change messages into Kafka,
@@ -1226,12 +1226,12 @@ This will cause the oplog files to be rotated out but connector will not notice 
 Set this parameter to `0` to not send heartbeat messages at all. +
 Disabled by default.
 
-|[[mongodb-property-heartbeat-topics-prefix]]<<mongodb-property-heartbeat-topics-prefix, `heartbeat.topics.prefix`>>
+|[[mongodb-property-heartbeat-topics-prefix]]<<mongodb-property-heartbeat-topics-prefix, `heartbeat.topics{zwsp}.prefix`>>
 |`__debezium-heartbeat`
 |Controls the naming of the topic to which heartbeat messages are sent. +
 The topic is named according to the pattern `<heartbeat.topics.prefix>.<server.name>`.
 
-|[[mongodb-property-sanitize-field-names]]<<mongodb-property-sanitize-field-names, `sanitize.field.names`>>
+|[[mongodb-property-sanitize-field-names]]<<mongodb-property-sanitize-field-names, `sanitize.field{zwsp}.names`>>
 |`true` when connector configuration explicitly specifies the `key.converter` or `value.converter` parameters to use Avro, otherwise defaults to `false`.
 |Whether field names are sanitized to adhere to Avro naming requirements.
 ifdef::community[]
@@ -1244,32 +1244,32 @@ endif::community[]
 The operations include: `i` for inserts, `u` for updates, and `d` for deletes.
 By default, no operations are skipped.
 
-|[[mongodb-property-provide-transaction-metadata]]<<mongodb-property-provide-transaction-metadata, `provide.transaction.metadata`>>
+|[[mongodb-property-provide-transaction-metadata]]<<mongodb-property-provide-transaction-metadata, `provide.transaction{zwsp}.metadata`>>
 |`false`
 |When set to `true` {prodname} generates events with transaction boundaries and enriches data events envelope with transaction metadata.
 
 See {link-prefix}:{link-mongodb-connector}#mongodb-transaction-metadata[Transaction Metadata] for additional details.
 
-|[[mongodb-property-retriable-restart-connector-wait-ms]]<<mongodb-property-retriable-restart-connector-wait-ms, `retriable.restart{zwsp}.connector.wait.ms`>> +
+|[[mongodb-property-retriable-restart-connector-wait-ms]]<<mongodb-property-retriable-restart-connector-wait-ms, `retriable.restart{zwsp}.connector.wait.ms`>> 
 |10000 (10 seconds)
-|The number of milli-seconds to wait before restarting a connector after a retriable error occurs.
+|The number of milliseconds to wait before restarting a connector after a retriable error occurs.
 
-|[[mongodb-property-mongodb-poll-interval-ms]]<<mongodb-property-mongodb-poll-interval-ms, `mongodb.poll.interval.ms`>> +
+|[[mongodb-property-mongodb-poll-interval-ms]]<<mongodb-property-mongodb-poll-interval-ms, `mongodb.poll{zwsp}.interval.ms`>> 
 |`30000`
 |The interval in which the connector polls for new, removed, or changed replica sets.
 
-|[[mongodb-property-mongodb-connect-timeout-ms]]<<mongodb-property-mongodb-connect-timeout-ms, `mongodb.connect.timeout.ms`>> +
+|[[mongodb-property-mongodb-connect-timeout-ms]]<<mongodb-property-mongodb-connect-timeout-ms, `mongodb.connect{zwsp}.timeout.ms`>> 
 |10000 (10 seconds)
-|The number of milli-seconds the driver will wait before a new connection attempt is aborted.
+|The number of milliseconds the driver will wait before a new connection attempt is aborted.
 
-|[[mongodb-property-mongodb-socket-timeout-ms]]<<mongodb-property-mongodb-socket-timeout-ms, `mongodb.socket.timeout.ms`>> +
+|[[mongodb-property-mongodb-socket-timeout-ms]]<<mongodb-property-mongodb-socket-timeout-ms, `mongodb.socket{zwsp}.timeout.ms`>> 
 |0
-|The number of milli-seconds before a send/receive on the socket can take before a timeout occurs.
+|The number of milliseconds before a send/receive on the socket can take before a timeout occurs.
 A value of `0` disables this behavior.
 
-|[[mongodb-property-mongodb-server-selection-timeout-ms]]<<mongodb-property-mongodb-server-selection-timeout-ms, `mongodb.server.selection.timeout.ms`>> +
+|[[mongodb-property-mongodb-server-selection-timeout-ms]]<<mongodb-property-mongodb-server-selection-timeout-ms, `mongodb.server{zwsp}.selection{zwsp}.timeout.ms`>> 
 |30000 (30 seconds)
-|The number of milli-seconds the driver will wait to select a server before it times out and throws an error.
+|The number of milliseconds the driver will wait to select a server before it times out and throws an error.
 
 |===
 
@@ -1299,7 +1299,7 @@ The attempts to reconnect are controlled by three properties:
 
 Each delay is double that of the prior delay, up to the maximum delay. Given the default values, the following table shows the delay for each failed connection attempt and the total accumulated time before failure.
 
-[cols="30%a,30%a,40%a"]
+[cols="30%a,30%a,40%a",options="header"]
 |===
 |Reconnection attempt number
 |Delay before attempt, in seconds

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -365,7 +365,7 @@ In addition to a {link-prefix}:{link-postgresql-connector}#postgresql-events[_da
 
 .Example
 
-[source,json,indent=0,subs="attributes"]
+[source,json,indent=0,subs="+attributes"]
 ----
 {
   "status": "BEGIN",
@@ -404,7 +404,7 @@ This field provides information about every event in the form of a composite of 
 
 Following is an example of a message:
 
-[source,json,indent=0,subs="attributes"]
+[source,json,indent=0,subs="+attributes"]
 ----
 {
   "before": null,
@@ -440,16 +440,16 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 [source,json,index=0]
 ----
 {
- "schema": { //<1>
+ "schema": { // <1>
    ...
   },
- "payload": { //<2>
+ "payload": { // <2>
    ...
  },
- "schema": { //<3> 
+ "schema": { // <3> 
    ...
  },
- "payload": { //<4>
+ "payload": { // <4>
    ...
  },
 }
@@ -536,11 +536,11 @@ If the `database.server.name` connector configuration property has the value `Po
 [source,json,indent=0]
 ----
   {
-    "schema": { <1>
+    "schema": { // <1>
       "type": "struct",
-      "name": "PostgreSQL_server.public.customers.Key", <2>
-      "optional": false, <3>
-      "fields": [ <4>
+      "name": "PostgreSQL_server.public.customers.Key", // <2>
+      "optional": false, // <3>
+      "fields": [ // <4>
             {
                 "name": "id",
                 "index": "0",
@@ -551,7 +551,7 @@ If the `database.server.name` connector configuration property has the value `Po
             }
         ]
     },
-    "payload": { <5>
+    "payload": { // <5>
         "id": "1"
     },
   }
@@ -567,11 +567,11 @@ If the `database.server.name` connector configuration property has the value `Po
 |The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion. 
 
 |2
-|`PostgreSQL_server.inventory.customers.Key`
+|`PostgreSQL_server{zwsp}.inventory.customers{zwsp}.Key`
 a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._database-name_._table-name_.`Key`. In this example: + 
 
 * `PostgreSQL_server` is the name of the connector that generated this event. + 
-* `public` is the database that contains the table that was changed. +
+* `inventory` is the database that contains the table that was changed. +
 * `customers` is the table that was updated.
 
 |3
@@ -628,10 +628,11 @@ Details follow in these sections:
 * <<postgresql-create-events,_create_ events>>
 * <<postgresql-update-events,_update_ events>>
 * <<postgresql-primary-key-updates, Primary key updates>>
-* <<postgreswl-delete-events,_delete_ events>>
+* <<postgresql-delete-events,_delete_ events>>
 * <<postgresql-tombstone-events, Tombstone events>>
 endif::product[]
 
+// Type: continue
 [[postgresql-replica-identity]]
 === Replica identity
 
@@ -646,6 +647,7 @@ If a table does not have a primary key, the connector does not emit `UPDATE` or 
 * `FULL` - Emitted events for `UPDATE` and `DELETE` operations contain the previous values of all columns in the table.
 * `INDEX` _index-name_ - Emitted events for `UPDATE` and `DELETE` operations contain the previous values of the columns contained in the specified index. `UPDATE` events also contain the indexed columns with the updated values.
 
+// Type: continue
 [[postgresql-create-events]]
 === _create_ events
 
@@ -892,12 +894,13 @@ a|Optional field that displays the time at which the connector processed the eve
 
 |===
 
+// Type: continue
 [[postgresql-update-events]]
 === _update_ events
 
 The value of a change event for an update in the sample `customers` table has the same schema as a _create_ event for that table. Likewise, the event value's payload has the same structure. However, the event value payload contains different values in an _update_ event. Here is an example of a change event value in an event that the connector generates for an update in the `customers` table: 
 
-[source,json,indent=0,options="nowrap",subs="attributes"]
+[source,json,indent=0,options="nowrap",subs="+attributes"]
 ----
 {
     "schema": { ... },
@@ -969,6 +972,7 @@ a|Mandatory string that describes the type of operation. In an _update_ event va
 Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a {link-prefix}:{link-postgresql-connector}#postgresql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row. Details are in the next section. 
 ====
 
+// Type: continue
 [[postgresql-primary-key-updates]]
 === Primary key updates
 
@@ -1059,6 +1063,7 @@ For a consumer to be able to process a _delete_ event generated for a table that
 
 PostgreSQL connector events are designed to work with link:{link-kafka-docs}#compaction[Kafka log compaction]. Log compaction enables removal of some older messages as long as at least the most recent message for every key is kept. This lets Kafka reclaim storage space while ensuring that the topic contains a complete data set and can be used for reloading key-based state.
 
+// Type: continue
 [[postgresql-tombstone-events]]
 .Tombstone events
 When a row is deleted, the _delete_ event value still works with log compaction, because Kafka can remove all earlier messages that have that same key. However, for Kafka to remove all messages that have that same key, the message value must be `null`. To make this possible, the PostgreSQL connector follows a _delete_ event with a special _tombstone_ event that has the same key but a `null` value.
@@ -1096,174 +1101,179 @@ The following table describes how the connector maps basic PostgreSQL data types
 * _semantic type_ describes how the Kafka Connect schema captures the _meaning_ of the field using the name of the Kafka Connect schema for the field.
 
 .Mappings for PostgreSQL basic data types
-[cols="20%a,15%a,30%a,35%a",options="header"]
+[cols="25%a,20%a,55%a",options="header"]
 |===
 |PostgreSQL data type
 |Literal type (schema type)
-|Semantic type (schema name)
-|Notes
+|Semantic type (schema name) and Notes
 
 |`BOOLEAN`
 |`BOOLEAN`
 |n/a
-|
 
 |`BIT(1)`
 |`BOOLEAN`
 |n/a
-|
 
 |`BIT( > 1)`
 |`BYTES`
-|`io.debezium.data.Bits`
-|The `length` schema parameter contains an integer that represents the number of bits. The resulting `byte[]` contains the bits in little-endian form and is sized to contain the specified number of bits. For example, `numBytes = n/8 + (n % 8 == 0 ? 0 : 1)` where `n` is the number of bits.
+|`io.debezium.data.Bits` +
+ +
+The `length` schema parameter contains an integer that represents the number of bits. The resulting `byte[]` contains the bits in little-endian form and is sized to contain the specified number of bits. For example, `numBytes = n/8 + (n % 8 == 0 ? 0 : 1)` where `n` is the number of bits.
 
 |`BIT VARYING[(M)]`
 |`BYTES`
-|`io.debezium.data.Bits`
-|The `length` schema parameter contains an integer that represents the number of bits (2^31 - 1 in case no length is given for the column). The resulting `byte[]` contains the bits in little-endian form and is sized based on the content. The specified size `(M)` is stored in the length parameter of the `io.debezium.data.Bits` type.
+|`io.debezium.data.Bits` +
+ +
+The `length` schema parameter contains an integer that represents the number of bits (2^31 - 1 in case no length is given for the column). The resulting `byte[]` contains the bits in little-endian form and is sized based on the content. The specified size `(M)` is stored in the length parameter of the `io.debezium.data.Bits` type.
 
 |`SMALLINT`, `SMALLSERIAL`
 |`INT16`
 |n/a
-|
 
 |`INTEGER`, `SERIAL`
 |`INT32`
 |n/a
-|
 
 |`BIGINT`, `BIGSERIAL`
 |`INT64`
 |n/a
-|
 
 |`REAL`
 |`FLOAT32`
 |n/a
-|
 
 |`DOUBLE PRECISION`
 |`FLOAT64`
 |n/a
-|
 
 |`CHAR[(M)]`
 |`STRING`
 |n/a
-|
 
 |`VARCHAR[(M)]`
 |`STRING`
 |n/a
-|
 
 |`CHARACTER[(M)]`
 |`STRING`
 |n/a
-|
 
 |`CHARACTER VARYING[(M)]`
 |`STRING`
 |n/a
-|
 
 |`TIMESTAMPTZ`, `TIMESTAMP WITH TIME ZONE`
 |`STRING`
-|`io.debezium.time.ZonedTimestamp`
-| A string representation of a timestamp with timezone information, where the timezone is GMT.
+|`io.debezium.time.ZonedTimestamp` +
+ +
+A string representation of a timestamp with timezone information, where the timezone is GMT.
 
 |`TIMETZ`, `TIME WITH TIME ZONE`
 |`STRING`
-|`io.debezium.time.ZonedTime`
-| A string representation of a time value with timezone information, where the timezone is GMT.
+|`io.debezium.time.ZonedTime` +
+ +
+A string representation of a time value with timezone information, where the timezone is GMT.
 
 |`INTERVAL [P]`
 |`INT64`
 |`io.debezium.time.MicroDuration` +
-(default)
-|The approximate number of microseconds for a time interval using the `365.25 / 12.0` formula for days per month average.
+(default) +
+ +
+The approximate number of microseconds for a time interval using the `365.25 / 12.0` formula for days per month average.
 
 |`INTERVAL [P]`
 |`STRING`
 |`io.debezium.time.Interval` +
-(when `interval.handling.mode` is set to `string`)
-|The string representation of the interval value that follows the pattern `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`, for example,  `P1Y2M3DT4H5M6.78S`.
+(when `interval.handling.mode` is set to `string`) +
+ +
+The string representation of the interval value that follows the pattern `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`, for example,  `P1Y2M3DT4H5M6.78S`.
 
 |`BYTEA`
 |`BYTES` or `STRING`
-|n/a
-|Either the raw bytes (the default), a base64-encoded string, or a hex-encoded string, based on the connector's {link-prefix}:{link-postgresql-connector}#postgresql-property-binary-handling-mode[binary handling mode] setting.
+|n/a +
+ +
+Either the raw bytes (the default), a base64-encoded string, or a hex-encoded string, based on the connector's {link-prefix}:{link-postgresql-connector}#postgresql-property-binary-handling-mode[binary handling mode] setting.
 
 |`JSON`, `JSONB`
 |`STRING`
-|`io.debezium.data.Json`
-|Contains the string representation of a JSON document, array, or scalar.
+|`io.debezium.data.Json` +
+ +
+Contains the string representation of a JSON document, array, or scalar.
 
 |`XML`
 |`STRING`
-|`io.debezium.data.Xml`
-|Contains the string representation of an XML document.
+|`io.debezium.data.Xml` +
+ +
+Contains the string representation of an XML document.
 
 |`UUID`
 |`STRING`
-|`io.debezium.data.Uuid`
-|Contains the string representation of a PostgreSQL UUID value.
+|`io.debezium.data.Uuid` +
+ +
+Contains the string representation of a PostgreSQL UUID value.
 
 |`POINT`
 |`STRUCT`
-|`io.debezium.data.geometry.Point`
-|Contains a structure with two `FLOAT64` fields, `(x,y)`. Each field represents the coordinates of a geometric point.
+|`io.debezium.data.geometry.Point` +
+ +
+Contains a structure with two `FLOAT64` fields, `(x,y)`. Each field represents the coordinates of a geometric point.
 
 |`LTREE`
 |`STRING`
-|`io.debezium.data.Ltree`
-|Contains the string representation of a PostgreSQL LTREE value.
+|`io.debezium.data.Ltree` +
+ +
+Contains the string representation of a PostgreSQL LTREE value.
 
 |`CITEXT`
 |`STRING`
 |n/a
-|
 
 |`INET`
 |`STRING`
 |n/a
-|
 
 |`INT4RANGE`
 |`STRING`
-|n/a
-|Range of integer.
+|n/a +
+ +
+Range of integer.
 
 |`INT8RANGE`
 |`STRING`
-|n/a
-|Range of `bigint`.
+|n/a +
+ +
+Range of `bigint`.
 
 |`NUMRANGE`
 |`STRING`
-|n/a
-|Range of `numeric`.
+|n/a +
+ +
+Range of `numeric`.
 
 |`TSRANGE`
 |`STRING`
-|n/a
-|Contains the string representation of a timestamp range without a time zone.
+|n/a +
+ +
+Contains the string representation of a timestamp range without a time zone.
 
 |`TSTZRANGE`
 |`STRING`
-|n/a
-|Contains the string representation of a timestamp range with the local system time zone.
+|n/a +
+ +
+Contains the string representation of a timestamp range with the local system time zone.
 
 |`DATERANGE`
 |`STRING`
-|n/a
-|Contains the string representation of a date range. It always has an exclusive upper-bound.
+|n/a +
+ +
+Contains the string representation of a date range. It always has an exclusive upper-bound.
 
 |`ENUM`
 |`STRING`
-|`io.debezium.data.Enum`
-|Contains the string representation of the PostgreSQL `ENUM` value. The set of allowed values is maintained in the `allowed` schema parameter.
+|`io.debezium.data.Enum` +
+ +
+Contains the string representation of the PostgreSQL `ENUM` value. The set of allowed values is maintained in the `allowed` schema parameter.
 
 |===
 
@@ -1281,37 +1291,41 @@ Other than PostgreSQL's `TIMESTAMPTZ` and `TIMETZ` data types, which contain tim
 When the `time.precision.mode` property is set to `adaptive`, the default, the connector determines the literal type and semantic type based on the column's data type definition. This ensures that events _exactly_ represent the values in the database. 
 
 .Mappings when `time.precision.mode` is `adaptive`
-[cols="20%a,15%a,30%a,35%a",options="header"]
+[cols="25%a,20%a,55%a",options="header"]
 |===
 |PostgreSQL data type
 |Literal type (schema type)
-|Semantic type (schema name)
-|Notes
+|Semantic type (schema name) and Notes
 
 |`DATE`
 |`INT32`
-|`io.debezium.time.Date`
-|Represents the number of days since the epoch.
+|`io.debezium.time.Date` +
+ +
+Represents the number of days since the epoch.
 
 |`TIME(1)`, `TIME(2)`, `TIME(3)`
 |`INT32`
-|`io.debezium.time.Time`
-|Represents the number of milliseconds past midnight, and does not include timezone information.
+|`io.debezium.time.Time` +
+ +
+Represents the number of milliseconds past midnight, and does not include timezone information.
 
 |`TIME(4)`, `TIME(5)`, `TIME(6)`
 |`INT64`
-|`io.debezium.time.MicroTime`
-|Represents the number of microseconds past midnight, and does not include timezone information.
+|`io.debezium.time.MicroTime` +
+ +
+Represents the number of microseconds past midnight, and does not include timezone information.
 
 |`TIMESTAMP(1)`, `TIMESTAMP(2)`, `TIMESTAMP(3)`
 |`INT64`
-|`io.debezium.time.Timestamp`
-|Represents the number of milliseconds since the epoch, and does not include timezone information.
+|`io.debezium.time.Timestamp` +
+ +
+Represents the number of milliseconds since the epoch, and does not include timezone information.
 
 |`TIMESTAMP(4)`, `TIMESTAMP(5)`, `TIMESTAMP(6)`, `TIMESTAMP`
 |`INT64`
-|`io.debezium.time.MicroTimestamp`
-|Represents the number of microseconds since the epoch, and does not include timezone information.
+|`io.debezium.time.MicroTimestamp` +
+ +
+Represents the number of microseconds since the epoch, and does not include timezone information.
 
 |===
 
@@ -1320,32 +1334,35 @@ When the `time.precision.mode` property is set to `adaptive`, the default, the c
 When the `time.precision.mode` configuration property is set to `adaptive_time_microseconds`, the connector determines the literal type and semantic type for temporal types based on the column's data type definition. This ensures that events _exactly_ represent the values in the database, except all `TIME` fields are captured as microseconds.
 
 .Mappings when `time.precision.mode` is `adaptive_time_microseconds`
-[cols="20%a,15%a,30%a,35%a",options="header"]
+[cols="25%a,20%a,55%a",options="header"]
 |===
-|PostgreSQL Data Type
+|PostgreSQL data type
 |Literal type (schema type)
-|Semantic type (schema name)
-|Notes
+|Semantic type (schema name) and Notes
 
 |`DATE`
 |`INT32`
-|`io.debezium.time.Date`
-|Represents the number of days since epoch.
+|`io.debezium.time.Date` +
+ +
+Represents the number of days since the epoch.
 
 |`TIME([P])`
 |`INT64`
-|`io.debezium.time.MicroTime`
-|Represents the time value in microseconds and does not include timezone information. PostgreSQL allows precision `P` to be in the range 0-6 to store up to microsecond precision.
+|`io.debezium.time.MicroTime` +
+ +
+Represents the time value in microseconds and does not include timezone information. PostgreSQL allows precision `P` to be in the range 0-6 to store up to microsecond precision.
 
 |`TIMESTAMP(1)` , `TIMESTAMP(2)`, `TIMESTAMP(3)`
 |`INT64`
-|`io.debezium.time.Timestamp`
-|Represents the number of milliseconds past epoch, and does not include timezone information.
+|`io.debezium.time.Timestamp` +
+ +
+Represents the number of milliseconds past the epoch, and does not include timezone information.
 
 |`TIMESTAMP(4)` , `TIMESTAMP(5)`, `TIMESTAMP(6)`, `TIMESTAMP`
 |`INT64`
-|`io.debezium.time.MicroTimestamp`
-|Represents the number of microseconds past epoch, and does not include timezone information.
+|`io.debezium.time.MicroTimestamp` +
+ +
+Represents the number of microseconds past the epoch, and does not include timezone information.
 
 |===
 
@@ -1354,32 +1371,34 @@ When the `time.precision.mode` configuration property is set to `adaptive_time_m
 When the `time.precision.mode` configuration property is set to `connect`, the connector uses Kafka Connect logical types. This may be useful when consumers can handle only the built-in Kafka Connect logical types and are unable to handle variable-precision time values. However, since PostgreSQL supports microsecond precision, the events generated by a connector with the `connect` time precision mode *results in a loss of precision* when the database column has a _fractional second precision_ value that is greater than 3.
 
 .Mappings when `time.precision.mode` is `connect`
-[cols="20%a,15%a,30%a,35%a",options="header"]
+[cols="25%a,20%a,55%a",options="header"]
 |===
 |PostgreSQL data type
 |Literal type (schema type)
-|Semantic type (schema name)
-|Notes
+|Semantic type (schema name) and Notes
 
 |`DATE`
 |`INT32`
-|`org.apache.kafka.connect.data.Date`
-|Represents the number of days since epoch.
+|`org.apache.kafka.connect.data.Date` +
+ +
+Represents the number of days since the epoch.
 
 |`TIME([P])`
 |`INT64`
-|`org.apache.kafka.connect.data.Time`
-|Represents the number of milliseconds since midnight, and does not include timezone information. PostgreSQL allows `P` to be in the range 0-6 to store up to microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
+|`org.apache.kafka.connect.data.Time` +
+ +
+Represents the number of milliseconds since midnight, and does not include timezone information. PostgreSQL allows `P` to be in the range 0-6 to store up to microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
 
 |`TIMESTAMP([P])`
 |`INT64`
-|`org.apache.kafka.connect.data.Timestamp`
-|Represents the number of milliseconds since the epoch, and does not include timezone information. PostgreSQL allows `P` to be in the range 0-6 to store up to microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
+|`org.apache.kafka.connect.data.Timestamp` +
+ +
+Represents the number of milliseconds since the epoch, and does not include timezone information. PostgreSQL allows `P` to be in the range 0-6 to store up to microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
 
 |===
 
 [id="postgresql-timestamp-type"]
-=== `TIMESTAMP` type
+=== TIMESTAMP type
 
 The `TIMESTAMP` type represents a timestamp without time zone information.
 Such columns are converted into an equivalent Kafka Connect value based on UTC. For example, the `TIMESTAMP` value "2018-06-20 15:13:16.945104" is represented by an `io.debezium.time.MicroTimestamp` with the value "1529507596945104" when `time.precision.mode` is not set to `connect`.
@@ -1394,22 +1413,23 @@ The setting of the PostgreSQL connector configuration property, `decimal.handlin
 When the `decimal.handling.mode` property is set to `precise`, the connector uses the Kafka Connect `org.apache.kafka.connect.data.Decimal` logical type for all `DECIMAL` and `NUMERIC` columns. This is the default mode.
 
 .Mappings when `decimal.handling.mode` is `precise`
-[cols="15%a,15%a,35%a,35%a",options="header"]
+[cols="28%a,17%a,55%a",options="header"]
 |===
 |PostgreSQL data type
 |Literal type (schema type)
-|Semantic type (schema name)
-|Notes
+|Semantic type (schema name) and Notes
 
 |`NUMERIC[(M[,D])]`
 |`BYTES`
-|`org.apache.kafka.connect.data.Decimal`
-|The `scale` schema parameter contains an integer representing how many digits the decimal point was shifted.
+|`org.apache.kafka.connect.data.Decimal` +
+ +
+The `scale` schema parameter contains an integer representing how many digits the decimal point was shifted.
 
 |`DECIMAL[(M[,D])]`
 |`BYTES`
-|`org.apache.kafka.connect.data.Decimal`
-|The `scale` schema parameter contains an integer representing how many digits the decimal point was shifted.
+|`org.apache.kafka.connect.data.Decimal` +
+ +
+The `scale` schema parameter contains an integer representing how many digits the decimal point was shifted.
 
 |===
 
@@ -1417,43 +1437,41 @@ There is an exception to this rule.
 When the `NUMERIC` or `DECIMAL` types are used without scale constraints, the values coming from the database have a different (variable) scale for each value. In this case, the connector uses `io.debezium.data.VariableScaleDecimal`, which contains both the value and the scale of the transferred value.
 
 .Mappings of decimal types when there are no scale constraints
-[cols="15%a,15%a,35%a,35%a",options="header"]
+[cols="25%a,20%a,55%a",options="header"]
 |===
 |PostgreSQL data type
 |Literal type (schema type)
-|Semantic type (schema name)
-|Notes
+|Semantic type (schema name) and Notes
 
 |`NUMERIC`
 |`STRUCT`
-|`io.debezium.data.VariableScaleDecimal`
-|Contains a structure with two fields: `scale` of type `INT32` that contains the scale of the transferred value and `value` of type `BYTES` containing the original value in an unscaled form.
+|`io.debezium.data.VariableScaleDecimal` +
+ +
+Contains a structure with two fields: `scale` of type `INT32` that contains the scale of the transferred value and `value` of type `BYTES` containing the original value in an unscaled form.
 
 |`DECIMAL`
 |`STRUCT`
-|`io.debezium.data.VariableScaleDecimal`
-|Contains a structure with two fields: `scale` of type `INT32` that contains the scale of the transferred value and `value` of type `BYTES` containing the original value in an unscaled form.
+|`io.debezium.data.VariableScaleDecimal` +
+ +
+Contains a structure with two fields: `scale` of type `INT32` that contains the scale of the transferred value and `value` of type `BYTES` containing the original value in an unscaled form.
 
 |===
 
 When the `decimal.handling.mode` property is set to `double`, the connector represents all `DECIMAL` and `NUMERIC` values as Java double values and encodes them as shown in the following table.
 
 .Mappings when `decimal.handling.mode` is `double`
-[cols="15%a,15%a,35%a,35%a",options="header"]
+[cols="30%a,30%a,40%a",options="header"]
 |===
 |PostgreSQL data type
 |Literal type (schema type)
 |Semantic type (schema name)
-|Notes
 
 |`NUMERIC[(M[,D])]`
 |`FLOAT64`
 |
-|
 
 |`DECIMAL[(M[,D])]`
 |`FLOAT64`
-|
 |
 
 |===
@@ -1461,21 +1479,18 @@ When the `decimal.handling.mode` property is set to `double`, the connector repr
 The last possible setting for the `decimal.handling.mode` configuration property is `string`. In this case, the connector represents `DECIMAL` and `NUMERIC` values as their formatted string representation, and encodes them as shown in the following table. 
 
 .Mappings when `decimal.handling.mode` is `string`
-[cols="15%a,15%a,35%a,35%a",options="header"]
+[cols="30%a,30%a,40%a",options="header"]
 |===
 |PostgreSQL data type
 |Literal type (schema type)
 |Semantic type (schema name)
-|Notes
 
 |`NUMERIC[(M[,D])]`
 |`STRING`
 |
-|
 
 |`DECIMAL[(M[,D])]`
 |`STRING`
-|
 |
 
 |===
@@ -1483,27 +1498,28 @@ The last possible setting for the `decimal.handling.mode` configuration property
 PostgreSQL supports `NaN` (not a number) as a special value to be stored in `DECIMAL`/`NUMERIC` values when the setting of `decimal.handling.mode` is `string` or `double`. In this case, the connector encodes `NaN` as either `Double.NaN` or the string constant `NAN`.
 
 [id="postgresql-hstore-type"]
-=== `HSTORE` type
+=== HSTORE type
 
 When the `hstore.handling.mode` connector configuration property is set to `json` (the default), the connector represents `HSTORE` values as string representations of JSON values and encodes them as shown in the following table. When the `hstore.handling.mode` property is set to `map`, the connector uses the `MAP` schema type for `HSTORE` values. 
 
 .Mappings for `HSTORE` data type
-[cols="15%a,15%a,35%a,35%a",options="header"]
+[cols="25%a,20%a,55%a",options="header"]
 |===
 |PostgreSQL data type
 |Literal type (schema type)
-|Semantic type (schema name)
-|Notes
+|Semantic type (schema name) and Notes
 
 |`HSTORE`
 |`STRING`
-|`io.debezium.data.Json`
-| Example: output representation using the JSON converter is `{\"key\" : \"val\"}`
+|`io.debezium.data.Json` +
+ +
+Example: output representation using the JSON converter is `{\"key\" : \"val\"}`
 
 |`HSTORE`
 |`MAP`
-|
-| Example: output representation  using the JSON converter is `{"key" : "val"}`
+|n/a +
+ +
+Example: output representation  using the JSON converter is `{"key" : "val"}`
 
 |===
 
@@ -1525,32 +1541,35 @@ When a column is defined to contain a domain type that extends another domain ty
 PostgreSQL has data types that can store IPv4, IPv6, and MAC addresses. It is better to use these types instead of plain text types to store network addresses. Network address types offer input error checking and specialized operators and functions.
 
 .Mappings for network address types
-[cols="15%a,15%a,35%a,35%a",options="header"]
+[cols="25%a,20%a,55%a",options="header"]
 |===
 |PostgreSQL data type
 |Literal type (schema type)
-|Semantic type (schema name)
-|Notes
+|Semantic type (schema name) and Notes
 
 |`INET`
 |`STRING`
-|
-|IPv4 and IPv6 networks
+|n/a +
+ +
+IPv4 and IPv6 networks
 
 |`CIDR`
 |`STRING`
-|
-|IPv4 and IPv6 hosts and networks
+|n/a +
+ +
+IPv4 and IPv6 hosts and networks
 
 |`MACADDR`
 |`STRING`
-|
-|MAC addresses
+|n/a +
+ +
+MAC addresses
 
 |`MACADDR8`
 |`STRING`
-|
-|MAC addresses in EUI-64 format
+|n/a +
+ +
+MAC addresses in EUI-64 format
 
 |===
 
@@ -1560,18 +1579,18 @@ PostgreSQL has data types that can store IPv4, IPv6, and MAC addresses. It is be
 The PostgreSQL connector supports all link:http://postgis.net[PostGIS data types].
 
 .Mappings of PostGIS data types
-[cols="20%a,15%a,30%a,35%a",options="header"]
+[cols="25%a,20%a,55%a",options="header"]
 |===
 |PostGIS data type
 |Literal type (schema type)
-|Semantic type (schema name)
-|Notes
+|Semantic type (schema name) and Notes
 
 |`GEOMETRY` +
 (planar)
-|`STRUCT`
-|`io.debezium.data.geometry.Geometry`
-|Contains a structure with two fields: +
+|`STRUCT` 
+a|`io.debezium.data.geometry.Geometry` +
+ +
+Contains a structure with two fields: +
 
 * `srid (INT32)` - Spatial Reference System Identifier that defines what type of geometry object is stored in the structure.
 * `wkb (BYTES)` - A binary representation of the geometry object encoded in the Well-Known-Binary format. +
@@ -1581,8 +1600,9 @@ For format details, see link:http://www.opengeospatial.org/standards/sfa[Open Ge
 |`GEOGRAPHY` +
 (spherical)
 |`STRUCT`
-|`io.debezium.data.geometry.Geography`
-|Contains a structure with two fields: +
+|`io.debezium.data.geometry.Geography` +
+ +
+Contains a structure with two fields: +
 
 * `srid (INT32)` - Spatial Reference System Identifier that defines what type of geography object is stored in the structure.
 * `wkb (BYTES)` - A binary representation of the geometry object encoded in the Well-Known-Binary format. +
@@ -1779,7 +1799,7 @@ If you are using one of the supported {link-prefix}:{link-postgresql-connector}#
 # MODULES
 shared_preload_libraries = 'decoderbufs,wal2json' // <1>
 ----
-<1> instructs the server to load the `decoderbufs` and `wal2json` logical decoding plug-ins at startup. The names of the plug-ins are set in the link:https://github.com/debezium/postgres-decoderbufs/blob/v0.3.0/Makefile[`Protobuf`] and link:https://github.com/eulerto/wal2json/blob/master/Makefile[`wal2json`] make files. 
+<1> Instructs the server to load the `decoderbufs` and `wal2json` logical decoding plug-ins at startup. The names of the plug-ins are set in the link:https://github.com/debezium/postgres-decoderbufs/blob/v0.3.0/Makefile[`Protobuf`] and link:https://github.com/eulerto/wal2json/blob/master/Makefile[`wal2json`] make files. 
 
 . To configure the replication slot regardless of the decoder being used, specify the following in the `postgresql.conf` file: 
 +
@@ -2083,7 +2103,7 @@ pass:quotes[*tree ./my-plugins/*]
 
 .. Create a new `Dockerfile` by using `{DockerKafkaConnect}` as the base image. In the following example, you would replace _my-plugins_ with the name of your plug-ins directory:
 +
-[subs=+macros,subs="+attributes"]
+[subs="+macros,+attributes"]
 ----
 FROM {DockerKafkaConnect}
 USER root:root
@@ -2105,7 +2125,7 @@ Before Kafka Connect starts running the connector, Kafka Connect loads any third
 +
 * Edit the `spec.image` property of the `KafkaConnector` custom resource. If set, this property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator. For example:
 +
-[source,yaml,subs=attributes+]
+[source,yaml,subs="+attributes"]
 ----
 apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnector
@@ -2243,7 +2263,7 @@ Slot names must conform to link:https://www.postgresql.org/docs/current/static/w
 Set to `true` in only testing or development environments. Dropping the slot allows the database to discard WAL segments. When the connector restarts it performs a new snapshot or it can continue from a persistent offset in the Kafka Connect offsets topic. 
 
 |[[postgresql-property-publication-name]]<<postgresql-property-publication-name, `publication.name`>>
-|`dbz_publication`
+|`dbz_{zwsp}publication`
 |The name of the PostgreSQL publication created for streaming changes when using `pgoutput`.
 
 This publication is created at start-up if it does not already exist and it includes _all tables_.
@@ -2273,43 +2293,43 @@ If the publication already exists, either for all tables or configured with a su
 |
 |The name of the PostgreSQL database from which to stream the changes.
 
-|[[postgresql-property-database-server-name]]<<postgresql-property-database-server-name, `database.server.name`>>
+|[[postgresql-property-database-server-name]]<<postgresql-property-database-server-name, `database.server{zwsp}.name`>>
 |
 |Logical name that identifies and provides a namespace for the particular PostgreSQL database server or cluster in which {prodname} is capturing changes. Only alphanumeric characters and underscores should be used in the database server logical name. The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
 
 |[[postgresql-property-schema-whitelist]]
-[[postgresql-property-schema-include-list]]<<postgresql-property-schema-include-list, `schema.include.list`>>
+[[postgresql-property-schema-include-list]]<<postgresql-property-schema-include-list, `schema.include{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match names of schemas for which you *want* to capture changes. Any schema name not included in `schema.include.list` is excluded from having its changes captured. By default, all non-system schemas have their changes captured. Do not also set the `schema.exclude.list` property.
 
 |[[postgresql-property-schema-blacklist]]
-[[postgresql-property-schema-exclude-list]]<<postgresql-property-schema-exclude-list, `schema.exclude.list`>>
+[[postgresql-property-schema-exclude-list]]<<postgresql-property-schema-exclude-list, `schema.exclude{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match names of schemas for which you *do not* want to capture changes. Any schema whose name is not included in `schema.exclude.list` has its changes captured, with the exception of system schemas. Do not also set the `schema.include.list` property.
 
 |[[postgresql-property-table-whitelist]]
-[[postgresql-property-table-include-list]]<<postgresql-property-table-include-list, `table.include.list`>>
+[[postgresql-property-table-include-list]]<<postgresql-property-table-include-list, `table.include{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you want to capture. Any table not included in `table.include.list` does not have its changes captured. Each identifier is of the form _schemaName_._tableName_. By default, the connector captures changes in every non-system table in each schema whose changes are being captured. Do not also set the `table.exclude.list` property.
 
 |[[postgresql-property-table-blacklist]]
-[[postgresql-property-table-exclude.list]]<<postgresql-property-table-exclude.list, `table.exclude.list`>>
+[[postgresql-property-table-exclude.list]]<<postgresql-property-table-exclude.list, `table.exclude{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you *do not* want to capture. Any table not included in `table.exclude.list` has it changes captured. Each identifier is of the form _schemaName_._tableName_. Do not also set the `table.include.list` property.
 
 |[[postgresql-property-column-whitelist]]
-[[postgresql-property-column-include-list]]<<postgresql-property-column-include-list, `column.include.list`>>
+[[postgresql-property-column-include-list]]<<postgresql-property-column-include-list, `column.include{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in change event record values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. Do not also set the `column.exclude.list` property.
 
 |[[postgresql-property-column-blacklist]]
-[[postgresql-property-column-exclude-list]]<<postgresql-property-column-exclude-list, `column.exclude.list`>>
+[[postgresql-property-column-exclude-list]]<<postgresql-property-column-exclude-list, `column.exclude{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event record values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. Do not also set the `column.include.list` property.
 
 |[[postgresql-property-time-precision-mode]]<<postgresql-property-time-precision-mode, `time.precision.mode`>>
 |`adaptive`
-| Time, date, and timestamps can be represented with different kinds of precision: +
+|Time, date, and timestamps can be represented with different kinds of precision: +
  +
 `adaptive` captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type. +
  +
@@ -2317,9 +2337,9 @@ If the publication already exists, either for all tables or configured with a su
  +
 `connect` always represents time and timestamp values by using Kafka Connect's built-in representations for `Time`, `Date`, and `Timestamp`, which use millisecond precision regardless of the database columns' precision. See {link-prefix}:{link-postgresql-connector}#postgresql-temporal-values[temporal values].
 
-|[[postgresql-property-decimal-handling-mode]]<<postgresql-property-decimal-handling-mode, `decimal.handling.mode`>>
+|[[postgresql-property-decimal-handling-mode]]<<postgresql-property-decimal-handling-mode, `decimal.handling{zwsp}.mode`>>
 |`precise`
-| Specifies how the connector should handle values for `DECIMAL` and `NUMERIC` columns: +
+|Specifies how the connector should handle values for `DECIMAL` and `NUMERIC` columns: +
  +
 `precise` represents values by using `java.math.BigDecimal` to represent values in binary form in change events. +
  +
@@ -2327,7 +2347,7 @@ If the publication already exists, either for all tables or configured with a su
  +
 `string` encodes values as formatted strings, which are easy to consume but semantic information about the real type is lost. See {link-prefix}:{link-postgresql-connector}#postgresql-decimal-types[Decimal types].
 
-|[[postgresql-property-hstore-handling-mode]]<<postgresql-property-hstore-handling-mode, `hstore.handling.mode`>>
+|[[postgresql-property-hstore-handling-mode]]<<postgresql-property-hstore-handling-mode, `hstore.handling{zwsp}.mode`>>
 |`map`
 | Specifies how the connector should handle values for `hstore` columns: +
  +
@@ -2335,7 +2355,7 @@ If the publication already exists, either for all tables or configured with a su
  +
 `json` represents values by using `json string`. This setting encodes values as formatted strings such as `{"key" : "val"}`. See {link-prefix}:{link-postgresql-connector}#postgresql-hstore-type[PostgreSQL `HSTORE` type].
 
-|[[postgresql-property-interval-handling-mode]]<<postgresql-property-interval-handling-mode, `interval.handling.mode`>>
+|[[postgresql-property-interval-handling-mode]]<<postgresql-property-interval-handling-mode, `interval.handling{zwsp}.mode`>>
 |`numeric`
 | Specifies how the connector should handle values for `interval` columns: +
  +
@@ -2363,19 +2383,19 @@ If the publication already exists, either for all tables or configured with a su
 |
 |The path to the file that contains the SSL private key of the client. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
-|[[postgresql-property-database-sslpassword]]<<postgresql-property-database-sslpassword, `database.sslpassword`>>
+|[[postgresql-property-database-sslpassword]]<<postgresql-property-database-sslpassword, `database{zwsp}.sslpassword`>>
 |
 |The password to access the client private key from the file specified by `database.sslkey`. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
-|[[postgresql-property-database-sslrootcert]]<<postgresql-property-database-sslrootcert, `database.sslrootcert`>>
+|[[postgresql-property-database-sslrootcert]]<<postgresql-property-database-sslrootcert, `database{zwsp}.sslrootcert`>>
 |
 |The path to the file that contains the root certificate(s) against which the server is validated. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
-|[[postgresql-property-database-tcpkeepalive]]<<postgresql-property-database-tcpkeepalive, `database.tcpKeepAlive`>>
+|[[postgresql-property-database-tcpkeepalive]]<<postgresql-property-database-tcpkeepalive, `database{zwsp}.tcpKeepAlive`>>
 |`true`
 |Enable TCP keep-alive probe to verify that the database connection is still alive. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
-|[[postgresql-property-tombstones-on-delete]]<<postgresql-property-tombstones-on-delete, `tombstones.on.delete`>>
+|[[postgresql-property-tombstones-on-delete]]<<postgresql-property-tombstones-on-delete, `tombstones.on{zwsp}.delete`>>
 |`true`
 | Controls whether a tombstone event should be generated after a _delete_ event. +
  +
@@ -2385,15 +2405,15 @@ If the publication already exists, either for all tables or configured with a su
  +
 After a _delete_ operation, emitting a tombstone event enables Kafka to delete all change event records that have the same key as the deleted row. 
 
-|[[postgresql-property-column-truncate-to-length-chars]]<<postgresql-property-column-truncate-to-length-chars, `column.truncate.to._length_.chars`>>
+|[[postgresql-property-column-truncate-to-length-chars]]<<postgresql-property-column-truncate-to-length-chars, `column.truncate.to{zwsp}._length_.chars`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event records, values in these columns are truncated if they are longer than the number of characters specified by _length_ in the property name. You can specify multiple properties with different lengths in a single configuration. Length must be a positive integer, for example, `column.truncate.to.20.chars`. 
 
-|[[postgresql-property-column-mask-with-length-chars]]<<postgresql-property-column-mask-with-length-chars, `column.mask.with._length_.chars`>>
+|[[postgresql-property-column-mask-with-length-chars]]<<postgresql-property-column-mask-with-length-chars, `column.mask.with{zwsp}._length_.chars`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event values, the values in the specified table columns are replaced with _length_ number of asterisk (`*`) characters. You can specify multiple properties with different lengths in a single configuration. Length must be a positive integer or zero. When you specify zero, the connector replaces a value with an empty string.  
 
-|[[postgresql-property-column-mask-hash]]<<postgresql-property-column-mask-hash, `column.mask.hash._hashAlgorithm_.with.salt._salt_`>>
+|[[postgresql-property-column-mask-hash]]<<postgresql-property-column-mask-hash, `column.mask{zwsp}.hash._hashAlgorithm_{zwsp}.with.salt._salt_`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event values, the values in the specified columns are replaced with pseudonyms. +
  +
@@ -2405,7 +2425,7 @@ If necessary, the pseudonym is automatically shortened to the length of the colu
  +
 Depending on the _hashAlgorithm_ used, the _salt_ selected, and the actual data set, the resulting masked data set might not be completely masked.
 
-|[[postgresql-property-column-propagate-source-type]]<<postgresql-property-column-propagate-source-type, `column.propagate.source.type`>>
+|[[postgresql-property-column-propagate-source-type]]<<postgresql-property-column-propagate-source-type, `column.propagate{zwsp}.source.type`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns. Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_. +
  +
@@ -2415,7 +2435,7 @@ For each specified column, the connector adds the column's original type and ori
  +
 This property is useful for properly sizing corresponding columns in sink databases.
 
-|[[postgresql-property-datatype-propagate-source-type]]<<postgresql-property-datatype-propagate-source-type, `datatype.propagate.source.type`>>
+|[[postgresql-property-datatype-propagate-source-type]]<<postgresql-property-datatype-propagate-source-type, `datatype.propagate{zwsp}.source.type`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the database-specific data type name for some columns. Fully-qualified data type names are of the form _databaseName_._tableName_._typeName_, or _databaseName_._schemaName_._tableName_._typeName_. +
  +
@@ -2427,7 +2447,7 @@ These parameters propagate a column's original type name and length, for variabl
  +
 See the {link-prefix}:{link-postgresql-connector}#postgresql-data-types[list of PostgreSQL-specific data type names].
 
-|[[postgresql-property-message-key-columns]]<<postgresql-property-message-key-columns, `message.key.columns`>>
+|[[postgresql-property-message-key-columns]]<<postgresql-property-message-key-columns, `message.key{zwsp}.columns`>>
 |_empty string_
 |A semicolon separated list of tables with regular expressions that match table column names. The connector maps values in matching columns to key fields in change event records that it sends to Kafka topics. This is useful when a table does not have a primary key, or when you want to order change event records in a Kafka topic according to a field that is not a primary key. +
  +
@@ -2441,7 +2461,7 @@ For example, +
  +
 If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column that starts with `i`), the connector maps the value in ``table_a``'s `id` column to a key field in change events that the connector sends to Kafka. 
 
-|[[postgresql-publication-autocreate-mode]]<<postgresql-publication-autocreate-mode, `publication.autocreate.mode`>>
+|[[postgresql-publication-autocreate-mode]]<<postgresql-publication-autocreate-mode, `publication{zwsp}.autocreate.mode`>>
 |_all_tables_
 |Applies only when streaming changes by using link:https://www.postgresql.org/docs/current/sql-createpublication.html[the `pgoutput` plug-in]. The setting determines how creation of a link:https://www.postgresql.org/docs/current/logical-replication-publication.html[publication] should work. Possible settings are: +
  +
@@ -2451,7 +2471,7 @@ If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column tha
  +
 `filtered` - If a publication exists, the connector uses it. If no publication exists, the connector creates a new publication for tables that match the current filter configuration as specified by the `database.exclude.list`, `database.include.list`, `table.exclude.list`, and `table.include.list` connector configuration properties. For example: `CREATE PUBLICATION <publication_name> FOR TABLE <tbl1, tbl2, tbl3>`.
 
-|[[postgresql-property-binary-handling-mode]]<<postgresql-property-binary-handling-mode, `binary.handling.mode`>>
+|[[postgresql-property-binary-handling-mode]]<<postgresql-property-binary-handling-mode, `binary.handling{zwsp}.mode`>>
 |bytes
 |Specifies how binary (`bytea`) columns should be represented in change events: +
  +
@@ -2466,7 +2486,7 @@ If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column tha
 The following _advanced_ configuration properties have defaults that work in most situations and therefore rarely need to be specified in the connector's configuration.
 
 .Advanced connector configuration properties
-[cols="30%a,25%a,45%a",options="header"]
+[cols="30%a,28%a,42%a",options="header"]
 |===
 |Property
 |Default
@@ -2498,11 +2518,11 @@ ifdef::community[]
 | A full Java class name that is an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. Required when the `snapshot.mode` property is set to `custom`. See {link-prefix}:{link-postgresql-connector}#postgresql-custom-snapshot[custom snapshotter SPI].
 endif::community[]
 
-|[[postgresql-property-snapshot-lock-timeout-ms]]<<postgresql-property-snapshot-lock-timeout-ms, `snapshot.lock.timeout.ms`>>
+|[[postgresql-property-snapshot-lock-timeout-ms]]<<postgresql-property-snapshot-lock-timeout-ms, `snapshot.lock{zwsp}.timeout.ms`>>
 |`10000`
 |Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. {link-prefix}:{link-postgresql-connector}#postgresql-snapshots[How the connector performs snapshots] provides details. 
 
-|[[postgresql-property-snapshot-select-statement-overrides]]<<postgresql-property-snapshot-select-statement-overrides, `snapshot.select.statement.overrides`>>
+|[[postgresql-property-snapshot-select-statement-overrides]]<<postgresql-property-snapshot-select-statement-overrides, `snapshot.select{zwsp}.statement{zwsp}.overrides`>>
 |
 |Controls which table rows are included in snapshots. This property affects snapshots only. It does not affect events that are generated by the logical decoding plug-in. Specify a comma-separated list of fully-qualified table names in the form _databaseName.tableName_. +
  +
@@ -2510,7 +2530,7 @@ For each table that you specify, also specify another configuration property: `s
  +
 A possible use case for setting these properties is large, append-only tables. You can specify a `SELECT` statement that sets a specific point for where to start a snapshot, or where to resume a snapshot if a previous snapshot was interrupted.
 
-|[[postgresql-property-event-processing-failure-handling-mode]]<<postgresql-property-event-processing-failure-handling-mode, `event.processing.failure.handling.mode`>>
+|[[postgresql-property-event-processing-failure-handling-mode]]<<postgresql-property-event-processing-failure-handling-mode, `event.processing{zwsp}.failure.handling{zwsp}.mode`>>
 |`fail`
 | Specifies how the connector should react to exceptions during processing of events: +
  +
@@ -2532,7 +2552,7 @@ A possible use case for setting these properties is large, append-only tables. Y
 |`1000`
 |Positive integer value that specifies the number of milliseconds the connector should wait for new change events to appear before it starts processing a batch of events. Defaults to 1000 milliseconds, or 1 second.
 
-|[[postgresql-property-include-unknown-datatypes]]<<postgresql-property-include-unknown-datatypes, `include.unknown.datatypes`>>
+|[[postgresql-property-include-unknown-datatypes]]<<postgresql-property-include-unknown-datatypes, `include.unknown{zwsp}.datatypes`>>
 |`false`
 |Specifies connector behavior when the connector encounters a field whose data type is unknown. The default behavior is that the connector omits the field from the change event and logs a warning. +
  +
@@ -2540,7 +2560,7 @@ Set this property to `true` if you want the change event to contain an opaque bi
 
 NOTE: Consumers risk backward compatibility issues when `include.unknown.datatypes` is set to `true`. Not only may the database-specific binary representation change between releases, but if the data type is eventually supported by {prodname}, the data type will be sent downstream in a logical type, which would require adjustments by consumers. In general, when encountering unsupported data types, create a feature request so that support can be added.
 
-|[[postgresql-property-database-initial-statements]]<<postgresql-property-database-initial-statements, `database.initial.statements`>>
+|[[postgresql-property-database-initial-statements]]<<postgresql-property-database-initial-statements, `database.initial{zwsp}.statements`>>
 |
 |A semicolon separated list of SQL statements that the connector executes when it establishes a JDBC connection to the database. To use a semicolon as a character and not as a delimiter, specify two consecutive semicolons, `;;`. +
  +
@@ -2548,7 +2568,7 @@ The connector may establish JDBC connections at its own discretion. Consequently
  +
 The connector does not execute these statements when it creates a connection for reading the transaction log. +
 
-|[[postgresql-property-heartbeat-interval-ms]]<<postgresql-property-heartbeat-interval-ms, `heartbeat.interval.ms`>>
+|[[postgresql-property-heartbeat-interval-ms]]<<postgresql-property-heartbeat-interval-ms, `heartbeat.interval{zwsp}.ms`>>
 |`0`
 |Controls how frequently the connector sends heartbeat messages to a Kafka topic. The default behavior is that the connector does not send heartbeat messages. +
  +
@@ -2556,7 +2576,7 @@ Heartbeat messages are useful for monitoring whether the connector is receiving 
  +
 Heartbeat messages are needed when there are many updates in a database that is being tracked but only a tiny number of updates are related to the table(s) and schema(s) for which the connector is capturing changes. In this situation, the connector reads from the database transaction log as usual but rarely emits change records to Kafka. This means that no offset updates are committed to Kafka and the connector does not have an opportunity to send the latest retrieved LSN to the database. The database retains WAL files that contain events that have already been processed by the connector. Sending heartbeat messages enables the connector to send the latest retrieved LSN to the database, which allows the database to reclaim disk space being used by no longer needed WAL files. 
 
-|[[postgresql-property-heartbeat-topics-prefix]]<<postgresql-property-heartbeat-topics-prefix, `heartbeat.topics.prefix`>>
+|[[postgresql-property-heartbeat-topics-prefix]]<<postgresql-property-heartbeat-topics-prefix, `heartbeat.topics{zwsp}.prefix`>>
 |`__debezium-heartbeat`
 |Controls the name of the topic to which the connector sends heartbeat messages. The topic name has this pattern: +
  +
@@ -2564,7 +2584,7 @@ _<heartbeat.topics.prefix>_._<server.name>_ +
  +
 For example, if the database server name is `fullfillment`, the default topic name is `__debezium-heartbeat.fulfillment`.
 
-|[[postgresql-property-heartbeat-action-query]]<<postgresql-property-heartbeat-action-query, `heartbeat.action.query`>>
+|[[postgresql-property-heartbeat-action-query]]<<postgresql-property-heartbeat-action-query, `heartbeat.action{zwsp}.query`>>
 |
 |Specifies a query that the connector executes on the source database when the connector sends a heartbeat message. +
  +
@@ -2601,7 +2621,7 @@ ifdef::community[]
 If you are using the `wal2json` plug-in, this property is useful for enabling server-side table filtering. Allowed values depend on the configured plug-in.
 endif::community[]
 
-|[[postgresql-property-sanitize-field-names]]<<postgresql-property-sanitize-field-names, `sanitize.field.names`>>
+|[[postgresql-property-sanitize-field-names]]<<postgresql-property-sanitize-field-names, `sanitize.field{zwsp}.names`>>
 |`true` if connector configuration sets the `key.converter` or `value.converter` property to the Avro converter. 
 
 `false` if not.
@@ -2615,18 +2635,18 @@ endif::community[]
 |`10000` (10 seconds)
 |The number of milliseconds to wait between retry attempts when the connector fails to connect to a replication slot.
 
-|[[postgresql-property-toasted-value-placeholder]]<<postgresql-property-toasted-value-placeholder, `toasted.value.placeholder`>>
+|[[postgresql-property-toasted-value-placeholder]]<<postgresql-property-toasted-value-placeholder, `toasted.value{zwsp}.placeholder`>>
 |`__debezium_unavailable_value`
 |Specifies the constant that the connector provides to indicate that the original value is a toasted value that is not provided by the database.
 If the setting of `toasted.value.placeholder` starts with the `hex:` prefix it is expected that the rest of the string represents hexadecimally encoded octets. See {link-prefix}:{link-postgresql-connector}#postgresql-toasted-values[toasted values] for additional details.
 
-|[[postgresql-property-provide-transaction-metadata]]<<postgresql-property-provide-transaction-metadata, `provide.transaction.metadata`>>
+|[[postgresql-property-provide-transaction-metadata]]<<postgresql-property-provide-transaction-metadata, `provide.transaction{zwsp}.metadata`>>
 |`false`
 |Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See {link-prefix}:{link-postgresql-connector}#postgresql-transaction-metadata[Transaction metadata] for details.
 
 |[[postgresql-property-retriable-restart-connector-wait-ms]]<<postgresql-property-retriable-restart-connector-wait-ms, `retriable.restart{zwsp}.connector.wait.ms`>> +
 |10000 (10 seconds)
-|The number of milli-seconds to wait before restarting a connector after a retriable error occurs.
+|The number of milliseconds to wait before restarting a connector after a retriable error occurs.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1,5 +1,5 @@
 [id="debezium-connector-for-sql-server"]
-= {prodname} Connector for SQL Server
+= {prodname} connector for SQL Server
 
 ifdef::community[]
 
@@ -210,19 +210,19 @@ A message to the schema change topic contains a logical representation of the ta
       "commit_lsn": "00000025:00000d98:00a2",
       "event_serial_no": null
     },
-    "databaseName": "testDB", <1>
+    "databaseName": "testDB", // <1>
     "schemaName": "dbo",
-    "ddl": null, <2>
-    "tableChanges": [ <3>
+    "ddl": null, // <2>
+    "tableChanges": [ // <3>
       {
-        "type": "CREATE", <4>
-        "id": "\"testDB\".\"dbo\".\"customers\"", <5>
-        "table": { <6>
+        "type": "CREATE", // <4>
+        "id": "\"testDB\".\"dbo\".\"customers\"", // <5>
+        "table": { // <6>
           "defaultCharsetName": null,
-          "primaryKeyColumnNames": [ <7>
+          "primaryKeyColumnNames": [ // <7>
             "id"
           ],
-          "columns": [ <8>
+          "columns": [ // <8>
             {
               "name": "id",
               "jdbcType": 4,
@@ -288,7 +288,7 @@ A message to the schema change topic contains a logical representation of the ta
 ----
 
 .Descriptions of fields in messages emitted to the schema change topic
-[cols="1,3,6",options="header"]
+[cols="1,4,5",options="header"]
 |===
 |Item |Field name |Description
 
@@ -333,7 +333,7 @@ a|Describes the kind of change. The value is one of the following:
 
 In messages to the schema change topic, the key is the name of the database that contains the schema change. In the following example, the `payload` field contains the key:
 
-[source,json,indent=0,subs="attributes"]
+[source,json,indent=0,subs="+attributes"]
 ----
 {
   "schema": {
@@ -365,16 +365,16 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 [source,json,index=0]
 ----
 {
- "schema": { //<1>
+ "schema": { // <1>
    ...
   },
- "payload": { //<2>
+ "payload": { // <2>
    ...
  },
- "schema": { //<3> 
+ "schema": { // <3> 
    ...
  },
- "payload": { //<4>
+ "payload": { // <4>
    ...
  },
 }
@@ -438,19 +438,19 @@ Every change event that captures a change to the `customers` table has the same 
 [source,json,indent=0]
 ----
 {
-    "schema": { <1>
+    "schema": { // <1>
         "type": "struct",
-        "fields": [ <2>
+        "fields": [ // <2>
             {
                 "type": "int32",
                 "optional": false,
                 "field": "id"
             }
         ],
-        "optional": false, <3>
-        "name": "server1.dbo.customers.Key" <4>
+        "optional": false, // <3>
+        "name": "server1.dbo.customers.Key" // <4>
     },
-    "payload": { <5>
+    "payload": { // <5>
         "id": 1004
     }
 }
@@ -474,7 +474,7 @@ Every change event that captures a change to the `customers` table has the same 
 |Indicates whether the event key must contain a value in its `payload` field. In this example, a value in the key's payload is required. A value in the key's payload field is optional when a table does not have a primary key.
 
 |4
-|`server1.dbo.customers.Key`
+|`server1.dbo{zwsp}.customers{zwsp}.Key`
 a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._database-schema-name_._table-name_.`Key`. In this example: + 
 
 * `server1` is the name of the connector that generated this event. + 
@@ -774,19 +774,19 @@ The value of a change event for an update in the sample `customers` table has th
 {
   "schema": { ... },
   "payload": {
-    "before": { <1>
+    "before": { // <1>
       "id": 1005,
       "first_name": "john",
       "last_name": "doe",
       "email": "john.doe@example.org"
     },
-    "after": { <2>
+    "after": { // <2>
       "id": 1005,
       "first_name": "john",
       "last_name": "doe",
       "email": "noreply@example.org"
     },
-    "source": { <3>
+    "source": { // <3>
       "version": "{debezium-version}",
       "connector": "sqlserver",
       "name": "server1",
@@ -799,7 +799,7 @@ The value of a change event for an update in the sample `customers` table has th
       "commit_lsn": "00000027:00000ac0:0007",
       "event_serial_no": "2"
     },
-    "op": "u", <4>
+    "op": "u", // <4>
     "ts_ms": 1559729998706
   }
 }
@@ -943,7 +943,7 @@ Every event contains
 
 Following is an example of what a message looks like:
 
-[source,json,indent=0,subs="attributes"]
+[source,json,indent=0,subs="+attributes"]
 ----
 {
   "status": "BEGIN",
@@ -981,7 +981,7 @@ This field provides information about every event in the form of a composite of 
 
 Following is an example of what a message looks like:
 
-[source,json,indent=0,subs="attributes"]
+[source,json,indent=0,subs="+attributes"]
 ----
 {
   "before": null,
@@ -1140,87 +1140,75 @@ The following table describes how the connector maps each of the SQL Server data
 Here, the _literal type_ describes how the value is literally represented using Kafka Connect schema types, namely `INT8`, `INT16`, `INT32`, `INT64`, `FLOAT32`, `FLOAT64`, `BOOLEAN`, `STRING`, `BYTES`, `ARRAY`, `MAP`, and `STRUCT`.
 The _semantic type_ describes how the Kafka Connect schema captures the _meaning_ of the field using the name of the Kafka Connect schema for the field.
 
-[cols="20%a,15%a,30%a,35%a"]
+[cols="30%a,25%a,45%a",options="header"]
 |===
-|SQL Server Data Type
+|SQL Server data type
 |Literal type (schema type)
-|Semantic type (schema name)
-|Notes
+|Semantic type (schema name) and Notes
 
 |`BIT`
 |`BOOLEAN`
 |n/a
-|
 
 |`TINYINT`
 |`INT16`
 |n/a
-|
 
 |`SMALLINT`
 |`INT16`
 |n/a
-|
 
 |`INT`
 |`INT32`
 |n/a
-|
 
 |`BIGINT`
 |`INT64`
 |n/a
-|
 
 |`REAL`
 |`FLOAT32`
 |n/a
-|
 
 |`FLOAT[(N)]`
 |`FLOAT64`
 |n/a
-|
 
 |`CHAR[(N)]`
 |`STRING`
 |n/a
-|
 
 |`VARCHAR[(N)]`
 |`STRING`
 |n/a
-|
 
 |`TEXT`
 |`STRING`
 |n/a
-|
 
 |`NCHAR[(N)]`
 |`STRING`
 |n/a
-|
 
 |`NVARCHAR[(N)]`
 |`STRING`
 |n/a
-|
 
 |`NTEXT`
 |`STRING`
 |n/a
-|
 
 |`XML`
 |`STRING`
-|`io.debezium.data.Xml`
-|Contains the string representation of a XML document
+|`io.debezium.data.Xml` +
+ +
+Contains the string representation of an XML document
 
 |`DATETIMEOFFSET[(P)]`
 |`STRING`
-|`io.debezium.time.ZonedTimestamp`
-| A string representation of a timestamp with timezone information, where the timezone is GMT
+|`io.debezium.time.ZonedTimestamp` +
+ +
+A string representation of a timestamp with timezone information, where the timezone is GMT
 
 |===
 
@@ -1238,93 +1226,105 @@ endif::community[]
 
 Other than SQL Server's `DATETIMEOFFSET` data type (which contain time zone information), the other temporal types depend on the value of the `time.precision.mode` configuration property.  When the `time.precision.mode` configuration property is set to `adaptive` (the default), then the connector will determine the literal type and semantic type for the temporal types based on the column's data type definition so that events _exactly_ represent the values in the database:
 
-[cols="20%a,15%a,30%a,35%a"]
+[cols="30%a,25%a,45%a",options="header"]
 |===
-|SQL Server Data Type
+|SQL Server data type
 |Literal type (schema type)
-|Semantic type (schema name)
-|Notes
+|Semantic type (schema name) and Notes
 
 |`DATE`
 |`INT32`
-|`io.debezium.time.Date`
-| Represents the number of days since epoch.
+|`io.debezium.time.Date` +
+ +
+Represents the number of days since the epoch.
 
 |`TIME(0)`, `TIME(1)`, `TIME(2)`, `TIME(3)`
 |`INT32`
-|`io.debezium.time.Time`
-| Represents the number of milliseconds past midnight, and does not include timezone information.
+|`io.debezium.time.Time` +
+ +
+Represents the number of milliseconds past midnight, and does not include timezone information.
 
 |`TIME(4)`, `TIME(5)`, `TIME(6)`
 |`INT64`
-|`io.debezium.time.MicroTime`
-| Represents the number of microseconds past midnight, and does not include timezone information.
+|`io.debezium.time.MicroTime` +
+ +
+Represents the number of microseconds past midnight, and does not include timezone information.
 
 |`TIME(7)`
 |`INT64`
-|`io.debezium.time.NanoTime`
-| Represents the number of nanoseconds past midnight, and does not include timezone information.
+|`io.debezium.time.NanoTime` +
+ +
+Represents the number of nanoseconds past midnight, and does not include timezone information.
 
 |`DATETIME`
 |`INT64`
-|`io.debezium.time.Timestamp`
-| Represents the number of milliseconds past epoch, and does not include timezone information.
+|`io.debezium.time.Timestamp` +
+ +
+Represents the number of milliseconds past the epoch, and does not include timezone information.
 
 |`SMALLDATETIME`
 |`INT64`
-|`io.debezium.time.Timestamp`
-| Represents the number of milliseconds past epoch, and does not include timezone information.
+|`io.debezium.time.Timestamp` +
+ +
+Represents the number of milliseconds past the epoch, and does not include timezone information.
 
 |`DATETIME2(0)`, `DATETIME2(1)`, `DATETIME2(2)`, `DATETIME2(3)`
 |`INT64`
-|`io.debezium.time.Timestamp`
-| Represents the number of milliseconds past epoch, and does not include timezone information.
+|`io.debezium.time.Timestamp` +
+ +
+Represents the number of milliseconds past the epoch, and does not include timezone information.
 
 |`DATETIME2(4)`, `DATETIME2(5)`, `DATETIME2(6)`
 |`INT64`
-|`io.debezium.time.MicroTimestamp`
-| Represents the number of microseconds past epoch, and does not include timezone information.
+|`io.debezium.time.MicroTimestamp` +
+ +
+Represents the number of microseconds past the epoch, and does not include timezone information.
 
 |`DATETIME2(7)`
 |`INT64`
-|`io.debezium.time.NanoTimestamp`
-| Represents the number of nanoseconds past epoch, and does not include timezone information.
+|`io.debezium.time.NanoTimestamp` +
+ +
+Represents the number of nanoseconds past the epoch, and does not include timezone information.
 
 |===
 
 When the `time.precision.mode` configuration property is set to `connect`, then the connector will use the predefined Kafka Connect logical types. This may be useful when consumers only know about the built-in Kafka Connect logical types and are unable to handle variable-precision time values. On the other hand, since SQL Server supports tenth of microsecond precision, the events generated by a connector with the `connect` time precision mode will *result in a loss of precision* when the database column has a _fractional second precision_ value greater than 3:
 
-[cols="20%a,15%a,30%a,35%a"]
+[cols="25%a,20%a,55%a",options="header"]
 |===
-|SQL Server Data Type
+|SQL Server data type
 |Literal type (schema type)
-|Semantic type (schema name)
-|Notes
+|Semantic type (schema name) and Notes
 
 |`DATE`
 |`INT32`
-|`org.apache.kafka.connect.data.Date`
-| Represents the number of days since epoch.
+|`org.apache.kafka.connect.data.Date` +
+ +
+Represents the number of days since the epoch.
 
 |`TIME([P])`
 |`INT64`
-|`org.apache.kafka.connect.data.Time`
-| Represents the number of milliseconds since midnight, and does not include timezone information. SQL Server allows `P` to be in the range 0-7 to store up to tenth of microsecond precision, though this mode results in a loss of precision when `P` > 3.
+|`org.apache.kafka.connect.data.Time` +
+ +
+Represents the number of milliseconds since midnight, and does not include timezone information. SQL Server allows `P` to be in the range 0-7 to store up to tenth of a microsecond precision, though this mode results in a loss of precision when `P` > 3.
 
 |`DATETIME`
 |`INT64`
-|`org.apache.kafka.connect.data.Timestamp`
-| Represents the number of milliseconds since epoch, and does not include timezone information.
+|`org.apache.kafka.connect.data.Timestamp` +
+ +
+Represents the number of milliseconds since the epoch, and does not include timezone information.
 
 |`SMALLDATETIME`
 |`INT64`
-|`org.apache.kafka.connect.data.Timestamp`
-| Represents the number of milliseconds past epoch, and does not include timezone information.
+|`org.apache.kafka.connect.data.Timestamp` +
+ +
+Represents the number of milliseconds past the epoch, and does not include timezone information.
 
 |`DATETIME2`
 |`INT64`
-|`org.apache.kafka.connect.data.Timestamp`
-| Represents the number of milliseconds since epoch, and does not include timezone information. SQL Server allows `P` to be in the range 0-7 to store up to tenth of microsecond precision, though this mode results in a loss of precision when `P` > 3.
+|`org.apache.kafka.connect.data.Timestamp` +
+ +
+Represents the number of milliseconds since the epoch, and does not include timezone information. SQL Server allows `P` to be in the range 0-7 to store up to tenth of a microsecond precision, though this mode results in a loss of precision when `P` > 3.
 
 |===
 
@@ -1339,38 +1339,32 @@ Note that the timezone of the JVM running Kafka Connect and {prodname} does not 
 
 ==== Decimal values
 
-[cols="15%a,15%a,35%a,35%a"]
+[cols="30%a,17%a,53%a",options="header"]
 |===
-|SQL Server Data Type
+|SQL Server data type
 |Literal type (schema type)
 |Semantic type (schema name)
-|Notes
 
 |`NUMERIC[(P[,S])]`
 |`BYTES`
-|`org.apache.kafka.connect.data.Decimal`
-|The `scale` schema parameter contains an integer representing how many digits the decimal point was shifted.
-The `connect.decimal.precision` schema parameter contains an integer representing the precision of the given decimal value.
+|`org.apache.kafka.connect.data.Decimal` 
 
 |`DECIMAL[(P[,S])]`
 |`BYTES`
-|`org.apache.kafka.connect.data.Decimal`
-|The `scale` schema parameter contains an integer representing how many digits the decimal point was shifted.
-The `connect.decimal.precision` schema parameter contains an integer representing the precision of the given decimal value.
+|`org.apache.kafka.connect.data.Decimal` 
 
 |`SMALLMONEY`
 |`BYTES`
 |`org.apache.kafka.connect.data.Decimal`
-|The `scale` schema parameter contains an integer representing how many digits the decimal point was shifted.
-The `connect.decimal.precision` schema parameter contains an integer representing the precision of the given decimal value.
 
 |`MONEY`
 |`BYTES`
 |`org.apache.kafka.connect.data.Decimal`
-|The `scale` schema parameter contains an integer representing how many digits the decimal point was shifted.
-The `connect.decimal.precision` schema parameter contains an integer representing the precision of the given decimal value.
 
 |===
+
+The `scale` schema parameter contains an integer that represents how many digits the decimal point was shifted.
+The `connect.decimal.precision` schema parameter contains an integer that represents the precision of the given decimal value.
 
 [[sqlserver-deploying-a-connector]]
 == Deployment
@@ -1432,18 +1426,18 @@ Typically, you configure the {prodname} SQL Server connector in a `.json` file u
 [source,json]
 ----
 {
-  "name": "inventory-connector", <1>
+  "name": "inventory-connector", // <1>
   "config": {
-    "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector", <2>
-    "database.hostname": "192.168.99.100", <3>
-    "database.port": "1433", <4>
-    "database.user": "sa", <5>
-    "database.password": "Password!", <6>
-    "database.dbname": "testDB", <7>
-    "database.server.name": "fullfillment", <8>
-    "table.include.list": "dbo.customers", <9>
-    "database.history.kafka.bootstrap.servers": "kafka:9092", <10>
-    "database.history.kafka.topic": "dbhistory.fullfillment" <11>
+    "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector", // <2>
+    "database.hostname": "192.168.99.100", // <3>
+    "database.port": "1433", // <4>
+    "database.user": "sa", // <5>
+    "database.password": "Password!", // <6>
+    "database.dbname": "testDB", // <7>
+    "database.server.name": "fullfillment", // <8>
+    "table.include.list": "dbo.customers", // <9>
+    "database.history.kafka.bootstrap.servers": "kafka:9092", // <10>
+    "database.history.kafka.topic": "dbhistory.fullfillment" // <11>
   }
 }
 ----
@@ -1578,7 +1572,7 @@ pass:quotes[*tree ./my-plugins/*]
 
 .. Create a new `Dockerfile` by using `{DockerKafkaConnect}` as the base image. In the following example, you would replace _my-plugins_ with the name of your plug-ins directory:
 +
-[subs=+macros]
+[subs="+macros,+attributes"]
 ----
 FROM {DockerKafkaConnect}
 USER root:root
@@ -1681,7 +1675,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-hi
 
 The following configuration properties are _required_ unless a default value is available.
 
-[cols="30%a,25%a,45%a"]
+[cols="30%a,25%a,45%a",options="header"]
 |===
 |Property
 |Default
@@ -1719,16 +1713,16 @@ The following configuration properties are _required_ unless a default value is 
 |
 |The name of the SQL Server database from which to stream the changes
 
-|[[sqlserver-property-database-server-name]]<<sqlserver-property-database-server-name, `database.server.name`>>
+|[[sqlserver-property-database-server-name]]<<sqlserver-property-database-server-name, `database.server{zwsp}.name`>>
 |
 |Logical name that identifies and provides a namespace for the particular SQL Server database server being monitored. The logical name should be unique across all other connectors, since it is used as a prefix for all Kafka topic names emanating from this connector.
 Only alphanumeric characters and underscores should be used.
 
-|[[sqlserver-property-database-history-kafka-topic]]<<sqlserver-property-database-history-kafka-topic, `database.history.kafka.topic`>>
+|[[sqlserver-property-database-history-kafka-topic]]<<sqlserver-property-database-history-kafka-topic, `database.history{zwsp}.kafka.topic`>>
 |
 |The full name of the Kafka topic where the connector will store the database schema history.
 
-|[[sqlserver-property-database-history-kafka-bootstrap-servers]]<<sqlserver-property-database-history-kafka-bootstrap-servers, `database.history{zwsp}.kafka.bootstrap.servers`>>
+|[[sqlserver-property-database-history-kafka-bootstrap-servers]]<<sqlserver-property-database-history-kafka-bootstrap-servers, `database.history{zwsp}.kafka.bootstrap{zwsp}.servers`>>
 |
 |A list of host/port pairs that the connector will use for establishing an initial connection to the Kafka cluster.
 This connection is used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. This should point to the same Kafka cluster used by the Kafka Connect process.
@@ -1762,7 +1756,7 @@ Note that primary key columns are always included in the event's key, also if ex
 Do not also set the `column.include.list` property.
 
 
-|[[sqlserver-property-column-mask-hash]]<<sqlserver-property-column-mask-hash, `column.mask.hash._hashAlgorithm_.with.salt._salt_`>>
+|[[sqlserver-property-column-mask-hash]]<<sqlserver-property-column-mask-hash, `column.mask{zwsp}.hash._hashAlgorithm_{zwsp}.with.salt._salt_`>>
 |_n/a_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be pseudonyms in the change event message values with a field value consisting of the hashed value using the algorithm `_hashAlgorithm_` and salt `_salt_`.
 Based on the used hash function referential integrity is kept while data is pseudonymized. Supported hash functions are described in the {link-java7-standard-names}[MessageDigest section] of the Java Cryptography Architecture Standard Algorithm Name Documentation.
@@ -1778,36 +1772,36 @@ where `CzQMA0cB5K` is a randomly selected salt.
 
 Note: Depending on the `_hashAlgorithm_` used, the `_salt_` selected and the actual data set, the resulting masked data set may not be completely anonymized.
 
-|[[sqlserver-property-time-precision-mode]]<<sqlserver-property-time-precision-mode, `time.precision.mode`>>
+|[[sqlserver-property-time-precision-mode]]<<sqlserver-property-time-precision-mode, `time.precision{zwsp}.mode`>>
 |`adaptive`
 | Time, date, and timestamps can be represented with different kinds of precision, including: `adaptive` (the default) captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type; or `connect` always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which uses millisecond precision regardless of the database columns' precision. See {link-prefix}:{link-sqlserver-connector}#sqlserver-temporal-values[temporal values].
 
-|[[sqlserver-property-include-schema-changes]]<<sqlserver-property-include-schema-changes, `include.schema.changes`>>
+|[[sqlserver-property-include-schema-changes]]<<sqlserver-property-include-schema-changes, `include.schema{zwsp}.changes`>>
 |`true`
 |Boolean value that specifies whether the connector should publish changes in the database schema to a Kafka topic with the same name as the database server ID. Each schema change is recorded with a key that contains the database name and a value that is a JSON structure that describes the schema update. This is independent of how the connector internally records database history. The default is `true`.
 
-|[[sqlserver-property-tombstones-on-delete]]<<sqlserver-property-tombstones-on-delete, `tombstones.on.delete`>>
+|[[sqlserver-property-tombstones-on-delete]]<<sqlserver-property-tombstones-on-delete, `tombstones.on{zwsp}.delete`>>
 |`true`
 | Controls whether a tombstone event should be generated after a delete event. +
 When `true` the delete operations are represented by a delete event and a subsequent tombstone event. When `false` only a delete event is sent. +
 Emitting the tombstone event (the default behavior) allows Kafka to completely delete all events pertaining to the given key once the source record got deleted.
 
-|[[sqlserver-property-column-truncate-to-length-chars]]<<sqlserver-property-column-truncate-to-length-chars, `column.truncate.to._length_.chars`>>
+|[[sqlserver-property-column-truncate-to-length-chars]]<<sqlserver-property-column-truncate-to-length-chars, `column.truncate.to{zwsp}._length_.chars`>>
 |_n/a_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be truncated in the change event message values if the field values are longer than the specified number of characters. Multiple properties with different lengths can be used in a single configuration, although in each the length must be a positive integer. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 
-|[[sqlserver-property-column-mask-with-length-chars]]<<sqlserver-property-column-mask-with-length-chars, `column.mask.with._length_.chars`>>
+|[[sqlserver-property-column-mask-with-length-chars]]<<sqlserver-property-column-mask-with-length-chars, `column.mask.with{zwsp}._length_.chars`>>
 |_n/a_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be replaced in the change event message values with a field value consisting of the specified number of asterisk (`*`) characters. Multiple properties with different lengths can be used in a single configuration, although in each the length must be a positive integer or zero. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 
-|[[sqlserver-property-column-propagate-source-type]]<<sqlserver-property-column-propagate-source-type, `column.propagate.source.type`>>
+|[[sqlserver-property-column-propagate-source-type]]<<sqlserver-property-column-propagate-source-type, `column.propagate{zwsp}.source.type`>>
 |_n/a_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
 The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` is used to propagate the original type name and length (for variable-width types), respectively.
 Useful to properly size corresponding columns in sink databases.
 Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 
-|[[sqlserver-property-datatype-propagate-source-type]]<<sqlserver-property-datatype-propagate-source-type,`datatype.propagate.source.type`>>
+|[[sqlserver-property-datatype-propagate-source-type]]<<sqlserver-property-datatype-propagate-source-type,`datatype.propagate{zwsp}.source.type`>>
 |_n/a_
 |An optional comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
 The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
@@ -1824,7 +1818,7 @@ Fully-qualified tables could be defined as _schemaName_._tableName_.
 
 The following _advanced_ configuration properties have good defaults that will work in most situations and therefore rarely need to be specified in the connector's configuration.
 
-[cols="30%a,25%a,45%a"]
+[cols="30%a,25%a,45%a",options="header"]
 |===
 |Property
 |Default
@@ -1840,7 +1834,7 @@ Supported values are: +
 `initial_only`: Takes a snapshot of structure and data like `initial` but instead does not transition into streaming changes once the snapshot has completed. +
 `schema_only`: Takes a snapshot of the structure of captured tables only; useful if only changes happening from now onwards should be propagated to topics.
 
-|[[sqlserver-property-snapshot-isolation-mode]]<<sqlserver-property-snapshot-isolation-mode, `snapshot.isolation.mode`>>
+|[[sqlserver-property-snapshot-isolation-mode]]<<sqlserver-property-snapshot-isolation-mode, `snapshot.isolation{zwsp}.mode`>>
 |_repeatable_read_
 |Mode to control which transaction isolation level is used and how long the connector locks the monitored tables.
 There are five possible values: `read_uncommitted`, `read_committed`, `repeatable_read`, `snapshot`, and `exclusive` (
@@ -1857,13 +1851,13 @@ twice - once in initial snapshot and once in streaming phase. Nonetheless, that 
 data mirroring.
 For `read_uncommitted` there are no data consistency guarantees at all (some data might be lost or corrupted).
 
-|[[sqlserver-property-source-timestamp-mode]]<<sqlserver-property-source-timestamp-mode, `source.timestamp.mode`>>
+|[[sqlserver-property-source-timestamp-mode]]<<sqlserver-property-source-timestamp-mode, `source.timestamp{zwsp}.mode`>>
 |_commit_
 |String representing the criteria of the attached timestamp within the source record (ts_ms).
 `commit` will set the source timestamp to the instant where the record was committed in the database (default and current behavior).
 `processing` will set the source timestamp to the instant where the record was processed by {prodname}. This option could be used when either we want to set the top level `ts_ms` value here or when we want to skip the query to extract the timestamp of that LSN.
 
-|[[sqlserver-property-event-processing-failure-handling-mode]]<<sqlserver-property-event-processing-failure-handling-mode, `event.processing{zwsp}.failure.handling.mode`>>
+|[[sqlserver-property-event-processing-failure-handling-mode]]<<sqlserver-property-event-processing-failure-handling-mode, `event.processing{zwsp}.failure.handling{zwsp}.mode`>>
 |`fail`
 | Specifies how the connector should react to exceptions during processing of events.
 `fail` will propagate the exception (indicating the offset of the problematic event), causing the connector to stop. +
@@ -1882,7 +1876,7 @@ For `read_uncommitted` there are no data consistency guarantees at all (some dat
 |`2048`
 |Positive integer value that specifies the maximum size of each batch of events that should be processed during each iteration of this connector. Defaults to 2048.
 
-|[[sqlserver-property-heartbeat-interval-ms]]<<sqlserver-property-heartbeat-interval-ms, `heartbeat.interval.ms`>>
+|[[sqlserver-property-heartbeat-interval-ms]]<<sqlserver-property-heartbeat-interval-ms, `heartbeat.interval{zwsp}.ms`>>
 |`0`
 |Controls how frequently heartbeat messages are sent. +
 This property contains an interval in milli-seconds that defines how frequently the connector sends messages into a heartbeat topic.
@@ -1894,7 +1888,7 @@ This may result in more change events to be re-sent after a connector restart.
 Set this parameter to `0` to not send heartbeat messages at all. +
 Disabled by default.
 
-|[[sqlserver-property-heartbeat-topics-prefix]]<<sqlserver-property-heartbeat-topics-prefix, `heartbeat.topics.prefix`>>
+|[[sqlserver-property-heartbeat-topics-prefix]]<<sqlserver-property-heartbeat-topics-prefix, `heartbeat.topics{zwsp}.prefix`>>
 |`__debezium-heartbeat`
 |Controls the naming of the topic to which heartbeat messages are sent. +
 The topic is named according to the pattern `<heartbeat.topics.prefix>.<server.name>`.
@@ -1914,12 +1908,12 @@ The connector will read the table contents in multiple batches of this size. Def
 |Specifies the number of rows that will be fetched for each database round-trip of a given query.
 Defaults to the JDBC driver's default fetch size.
 
-|[[sqlserver-property-snapshot-lock-timeout-ms]]<<sqlserver-property-snapshot-lock-timeout-ms, `snapshot.lock.timeout.ms`>>
+|[[sqlserver-property-snapshot-lock-timeout-ms]]<<sqlserver-property-snapshot-lock-timeout-ms, `snapshot.lock{zwsp}.timeout.ms`>>
 |`10000`
 |An integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If table locks cannot be acquired in this time interval, the snapshot will fail (also see {link-prefix}:{link-sqlserver-connector}#sqlserver-snapshots[snapshots]). +
 When set to `0` the connector will fail immediately when it cannot obtain the lock. Value `-1` indicates infinite waiting.
 
-|[[sqlserver-property-snapshot-select-statement-overrides]]<<sqlserver-property-snapshot-select-statement-overrides, `snapshot.select.statement.overrides`>>
+|[[sqlserver-property-snapshot-select-statement-overrides]]<<sqlserver-property-snapshot-select-statement-overrides, `snapshot.select{zwsp}.statement{zwsp}.overrides`>>
 |
 |Controls which rows from tables are included in snapshot. +
 This property contains a comma-separated list of fully-qualified tables _(SCHEMA_NAME.TABLE_NAME)_. Select statements for the individual tables are specified in further configuration properties, one for each table, identified by the id `snapshot.select.statement.overrides.[SCHEMA_NAME].[TABLE_NAME]`. The value of those properties is the SELECT statement to use when retrieving data from the specific table during snapshotting. _A possible use case for large append-only tables is setting a specific point where to start (resume) snapshotting, in case a previous snapshotting was interrupted._ +
@@ -1935,14 +1929,14 @@ By setting this option to `v1` the structure used in earlier versions can be pro
 Note that this setting is not recommended and is planned for removal in a future {prodname} version.
 endif::community[]
 
-|[[sqlserver-property-sanitize-field-names]]<<sqlserver-property-sanitize-field-names, `sanitize.field.names`>>
+|[[sqlserver-property-sanitize-field-names]]<<sqlserver-property-sanitize-field-names, `sanitize.field{zwsp}.names`>>
 |`true` when connector configuration explicitly specifies the `key.converter` or `value.converter` parameters to use Avro, otherwise defaults to `false`.
 |Whether field names are sanitized to adhere to Avro naming requirements.
 ifdef::community[]
 See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 endif::community[]
 
-|[[sqlserver-property-database-server-timezone]]<<sqlserver-property-database-server-timezone, `database.server.timezone`>>
+|[[sqlserver-property-database-server-timezone]]<<sqlserver-property-database-server-timezone, `database.server{zwsp}.timezone`>>
 |
 | Timezone of the server.
 
@@ -1950,7 +1944,7 @@ This is used to define the timezone of the transaction timestamp (ts_ms) retriev
 When unset, default behavior is to use the timezone of the VM running the {prodname} connector. In this case, when running on on SQL Server 2014 or older and using different timezones on server and the connector, incorrect ts_ms values may be produced. +
 Possible values include "Z", "UTC", offset values like "+02:00", short zone ids like "CET", and long zone ids like "Europe/Paris".
 
-|[[sqlserver-property-provide-transaction-metadata]]<<sqlserver-property-provide-transaction-metadata, `provide.transaction.metadata`>>
+|[[sqlserver-property-provide-transaction-metadata]]<<sqlserver-property-provide-transaction-metadata, `provide.transaction{zwsp}.metadata`>>
 |`false`
 |When set to `true` {prodname} generates events with transaction boundaries and enriches data events envelope with transaction metadata.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc
@@ -1,4 +1,4 @@
-[cols="45%a,25%a,30%a"]
+[cols="45%a,25%a,30%a",options="header"]
 |===
 |Attributes |Type |Description
 
@@ -18,11 +18,11 @@
 |`long`
 |the total number of schema changes applied during recovery and runtime.
 
-|[[connectors-shist-metric-millisecondssincelastrecoveredchange]]<<connectors-shist-metric-millisecondssincelastrecoveredchange, `MilliSecondsSinceLastRecoveredChange`>>
+|[[connectors-shist-metric-millisecondssincelastrecoveredchange]]<<connectors-shist-metric-millisecondssincelastrecoveredchange, `MilliSecondsSinceLast{zwsp}RecoveredChange`>>
 |`long`
 |The number of milliseconds that elapsed since the last change was recovered from the history store.
 
-|[[connectors-shist-metric-millisecondssincelastappliedchange]]<<connectors-shist-metric-millisecondssincelastappliedchange, `MilliSecondsSinceLastAppliedChange`>>
+|[[connectors-shist-metric-millisecondssincelastappliedchange]]<<connectors-shist-metric-millisecondssincelastappliedchange, `MilliSecondsSinceLast{zwsp}AppliedChange`>>
 |`long`
 |The number of milliseconds that elapsed since the last change was applied.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
@@ -1,4 +1,4 @@
-[cols="45%a,25%a,30%a"]
+[cols="45%a,25%a,30%a",options="header"]
 |===
 |Attributes |Type |Description
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc
@@ -1,4 +1,4 @@
-[cols="45%a,25%a,30%a"]
+[cols="45%a,25%a,30%a",options="header"]
 |===
 |Attributes |Type |Description
 


### PR DESCRIPTION
[DBZ-2564](https://issues.redhat.com/browse/DBZ-2564)
I already made these changes downstream for the Q3 release so these updates do NOT need to be backported to 1.2. 
There are separate commits for each connector's doc and for other groups of similar changes. 

There are no updates in the doc for the MySQL connector. I'm about to re-unify the doc for MySQL into one file and updating format for MySQL will be part of that work. 

