### PR TITLE
DBZ-2577 Fix malformed attribute references in downstream title annotations

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/content-based-routing.adoc
+++ b/documentation/modules/ROOT/pages/configuration/content-based-routing.adoc
@@ -47,7 +47,7 @@ For example, for Groovy 3, you can download its JSR 223 implementation from http
 The JSR 223 implementation for GraalVM JavaScript is available at https://github.com/graalvm/graaljs.
 
 // Type: procedure
-// Title: Setting up the {prodname] content-based-routing SMT
+// Title: Setting up the {prodname} content-based-routing SMT
 // ModuleID: setting-up-the-debezium-content-based-routing-smt
 [[set-up-content-based-routing]]
 == Set up

--- a/documentation/modules/ROOT/pages/configuration/filtering.adoc
+++ b/documentation/modules/ROOT/pages/configuration/filtering.adoc
@@ -44,7 +44,7 @@ To use an expression language with {prodname}, you must download the JSR 223 scr
 For example, for Groovy 3, you can download its JSR 223 implementation from https://groovy-lang.org/. The JSR223 implementation for GraalVM JavaScript is available at https://github.com/graalvm/graaljs.
 
 // Type: procedure
-// Title: Setting up the {prodname] filter SMT
+// Title: Setting up the {prodname} filter SMT
 // ModuleID: setting-up-the-debezium-filter-smt
 [[set-up-filter]]
 == Set up


### PR DESCRIPTION
In a pair of files, the annotations that define the titles for the modularized downstream documentation included a typo in the attribute that represents the product name (a closing square bracket instead of the required curly brace). This fix corrects that error.  

The fix was already applied independently in the downstream docs. Fixing the error upstream to prevent overwriting the correction the next time we fetch from the source.

The fix has no visible effect on the upstream doc.

Fix to be backported to 1.2 branch.