### PR TITLE
DBZ-2583 MySQL connector - ignore statement-based logs

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -786,8 +786,18 @@ public class BinlogReader extends AbstractReader {
             return;
         }
         if (upperCasedStatementBegin.equals("INSERT ") || upperCasedStatementBegin.equals("UPDATE ") || upperCasedStatementBegin.equals("DELETE ")) {
-            throw new ConnectException(
-                    "Received DML '" + sql + "' for processing, binlog probably contains events generated with statement or mixed based replication format");
+            if (eventDeserializationFailureHandlingMode == EventProcessingFailureHandlingMode.FAIL) {
+                throw new ConnectException(
+                        "Received DML '" + sql + "' for processing, binlog probably contains events generated with statement or mixed based replication format");
+            }
+            else if (eventDeserializationFailureHandlingMode == EventProcessingFailureHandlingMode.WARN) {
+                logger.warn("Warning only: Received DML '" + sql
+                        + "' for processing, binlog probably contains events generated with statement or mixed based replication format");
+                return;
+            }
+            else {
+                return;
+            }
         }
         if (sql.equalsIgnoreCase("ROLLBACK")) {
             // We have hit a ROLLBACK which is not supported


### PR DESCRIPTION
Current mysql debezium connector fails once it sees an event generated
with statement or mixed based replication.

As users and programs can call SET SESSION binlog_format='STATEMENT'; as
they wish, they are able to break debezium connector. Only MySQL 8.0.14
is fixing this, but not everyone is on that version.

To prevent connector crashing in such cases, there should be an option
to log these issues and continue. That would be similar to processing
inconsistent schema (on the setting level).