### PR TITLE
DBZ-2585 : Add a configuration which sanatize value in mongodb

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentState.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentState.java
@@ -485,7 +485,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
 
         converter = new MongoDataConverter(
                 ArrayEncoding.parse(config.getString(ARRAY_ENCODING)),
-                FieldNameSelector.defaultNonRelationalSelector(config.getBoolean(SANITIZE_FIELD_NAMES)));
+                FieldNameSelector.defaultNonRelationalSelector(config.getBoolean(SANITIZE_FIELD_NAMES)), config.getBoolean(SANITIZE_FIELD_NAMES));
 
         addOperationHeader = config.getBoolean(OPERATION_HEADER);
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTestIT.java
@@ -1388,6 +1388,27 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
     }
 
     @Test
+    @FixFor("DBZ-2585")
+    public void testEmptyArray() throws InterruptedException, IOException {
+        final Map<String, String> transformationConfig = new HashMap<>();
+        transformationConfig.put("array.encoding", "array");
+        transformationConfig.put("sanitize.field.names", "true");
+        transformation.configure(transformationConfig);
+
+        // Test insert
+        primary().execute("insert", client -> {
+            client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
+                    .insertOne(Document.parse("{'empty_array': [] }"));
+        });
+        SourceRecords records = consumeRecordsByTopic(1);
+        assertThat(records.recordsForTopic(this.topicName()).size()).isEqualTo(1);
+
+        final SourceRecord insertRecord = records.recordsForTopic(this.topicName()).get(0);
+        final SourceRecord transformedInsert = transformation.apply(insertRecord);
+        assertThat(transformedInsert.valueSchema().field("empty_array")).isNull();
+    }
+
+    @Test
     @FixFor("DBZ-2455")
     public void testAddPatchFieldAfterUpdate() throws Exception {
         waitForStreamingRunning();


### PR DESCRIPTION
When you deals with avro files, you do not want that ExtractNewDocumentState put an empty array as an empty string array because it's maybe not a string. You prefer to remove the array if the array is empty