### PR TITLE
Dbz 2593 add missing link text

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/content-based-routing.adoc
+++ b/documentation/modules/ROOT/pages/configuration/content-based-routing.adoc
@@ -69,6 +69,7 @@ With https://zookeeper.apache.org[Zookeeper], http://kafka.apache.org/[Kafka], {
 endif::community[]
 
 ifdef::product[]
+.Procedure
 . Download the {prodname} scripting SMT archive (`debezium-scripting-{debezium-version}.tar.gz`) from https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions.
 . Extract the contents of the archive into the {prodname} plug-in directories of your Kafka Connect environment.
 . Obtain a JSR-223 script engine implementation and add its contents to the {prodname} plug-in directories of your Kafka Connect environment.
@@ -118,13 +119,13 @@ the SMT can look up and interpret the values of these variables to evaluate cond
 The following table lists the variables that {prodname} binds into the evaluation context for the content-based routing SMT:
 
 .Content-based routing expression variables
-[options="header"]
-|=======================
+[cols="25%a,35%a,40%a",subs="+attributes",options="header"]
+|===
 |Name |Description |Type
-|`key`   |A key of the message. |`org.apache.kafka.connect.data.Struct`
-|`value` |A value of the message. |`org.apache.kafka.connect.data.Struct`
-|`keySchema` |Schema of the message key.|`org.apache.kafka.connect.data.Schema`
-|`valueSchema`|Schema of the message value.| `org.apache.kafka.connect.data.Schema`
+|`key`   |A key of the message. |`org.apache.kafka.connect{zwsp}.data{zwsp}.Struct`
+|`value` |A value of the message. |`org.apache.kafka.connect{zwsp}.data{zwsp}.Struct`
+|`keySchema` |Schema of the message key.|`org.apache.kafka.connect{zwsp}.data{zwsp}.Schema`
+|`valueSchema`|Schema of the message value.| `org.apache.kafka.connect{zwsp}.data{zwsp}.Schema`
 |`topic`|Name of the target topic.| String
 |`headers`
 a|A Java map of message headers. The key field is the header name. 
@@ -132,10 +133,10 @@ The `headers` variable exposes the following properties:
 
 * `value` (of type `Object`) 
 
-* `schema` (of type `org.apache.kafka.connect.data.Schema`)
+* `schema` (of type `org.apache.kafka{zwsp}.connect{zwsp}.data{zwsp}.Schema`)
 
-| `java.util.Map<String, io.debezium.transforms.scripting.RecordHeader>`
-|=======================
+| `java.util.Map{zwsp}<String,{zwsp} io.debezium{zwsp}.transforms{zwsp}.scripting{zwsp}.RecordHeader>`
+|===
 
 An expression can invoke arbitrary methods on its variables. 
 Expressions should resolve to a Boolean value that determines how the SMT dispositions the message.
@@ -206,7 +207,7 @@ If the name of the topic does not match the value in `topic.regex`, the SMT pass
 
 |[[content-based-router-language]]<<content-based-router-language, `language`>>
 |
-|The language in which the expression is written. Must begin with `jsr223.`, e.g. `jsr223.groovy`, or `jsr223.graal.js`. {prodname} supports bootstrapping through the https://jcp.org/en/jsr/detail?id=223[JSR 223 API ("Scripting for the Java (TM) Platform")] only.
+|The language in which the expression is written. Must begin with `jsr223.`, for example, `jsr223.groovy`, or `jsr223.graal.js`. {prodname} supports bootstrapping through the https://jcp.org/en/jsr/detail?id=223[JSR 223 API ("Scripting for the Java (TM) Platform")] only.
 
 |[[content-based-router-topic-expression]]<<content-based-router-topic-expression, `topic.expression`>>
 |

--- a/documentation/modules/ROOT/pages/configuration/content-based-routing.adoc
+++ b/documentation/modules/ROOT/pages/configuration/content-based-routing.adoc
@@ -150,7 +150,7 @@ Expressions should not result in any side-effects. That is, they should not modi
 == Language specifics
 
 The way that you express content-based routing conditions depends on the scripting language that you use.
-For example, as shown in {link-prefix}:{link-content-based-routing}#example-basic-content-based-routing-configuration[], when you use `Groovy` as the expression language, 
+For example, as shown in the {link-prefix}:{link-content-based-routing}#example-basic-content-based-routing-configuration[basic configuration example], when you use `Groovy` as the expression language, 
 the following expression reroutes all update (`u`) records to the `updates` topic, while routing other records to the default topic:
 
 [source,groovy]
@@ -178,7 +178,7 @@ value.get('op') == 'u' ? 'updates' : null
 ----
 
 .Javascript with Graal.js
-When you create coentent-based routing conditions by using JavaScript with Graal.js, you use an approach that is similar to the one use with Groovy.
+When you create content-based routing conditions by using JavaScript with Graal.js, you use an approach that is similar to the one use with Groovy.
 For example:
 
 [source,javascript]

--- a/documentation/modules/ROOT/pages/configuration/filtering.adoc
+++ b/documentation/modules/ROOT/pages/configuration/filtering.adoc
@@ -146,7 +146,7 @@ Expressions should not result in any side-effects. That is, they should not modi
 
 The way that you express filtering conditions depends on the scripting language that you use.
 
-For example, as shown in the {link-prefix}:{link-filtering}#example-basic-debezium-filter-smt-configuration[basic configuration example], when you use `Groovy` as the expression language, 
+For example, as shown in the {link-prefix}:{link-filtering}#example-basic-filter-configuration-example[basic configuration example], when you use `Groovy` as the expression language, 
 the following expression removes all messages, except for update records that have `id` values set to `2`:
 
 [source,groovy]

--- a/documentation/modules/ROOT/pages/configuration/filtering.adoc
+++ b/documentation/modules/ROOT/pages/configuration/filtering.adoc
@@ -113,13 +113,13 @@ By binding variables, {prodname} enables the SMT to look up and interpret their 
 The following table lists the variables that {prodname} binds into the evaluation context for the filter SMT:
 
 .Filter expression variables
-[options="header"]
-|=======================
+[cols="25%a,35%a,40%a",subs="+attributes",options="header"]
+|===
 |Name |Description |Type
-|`key`   |A key of the message. |`org.apache.kafka.connect.data.Struct`
-|`value` |A value of the message. |`org.apache.kafka.connect.data.Struct`
-|`keySchema` |Schema of the message key.|`org.apache.kafka.connect.data.Schema`
-|`valueSchema`|Schema of the message value.| `org.apache.kafka.connect.data.Schema`
+|`key`   |A key of the message. |`org.apache.kafka.connect{zwsp}.data{zwsp}.Struct`
+|`value` |A value of the message. |`org.apache.kafka.connect.data{zwsp}.Struct`
+|`keySchema` |Schema of the message key.|`org.apache.kafka.connect{zwsp}.data{zwsp}.Schema`
+|`valueSchema`|Schema of the message value.| `org.apache.kafka.connect{zwsp}.data{zwsp}.Schema`
 |`topic`|Name of the target topic.| String
 |`headers`
 a|A Java map of message headers. The key field is the header name. 
@@ -127,10 +127,10 @@ The `headers` variable exposes the following properties:
 
 * `value` (of type `Object`) 
 
-* `schema` (of type `org.apache.kafka.connect.data.Schema`)
+* `schema` (of type `org.apache.kafka{zwsp}.connect{zwsp}.data{zwsp}.Schema`)
 
-| `java.util.Map<String, io.debezium.transforms.scripting.RecordHeader>`
-|=======================
+| `java.util.Map{zwsp}<String, {zwsp}io.debezium.transforms{zwsp}.scripting{zwsp}.RecordHeader>`
+|===
 
 An expression can invoke arbitrary methods on its variables. 
 Expressions should resolve to a Boolean value that determines how the SMT dispositions the message.
@@ -204,7 +204,7 @@ If the name of the topic does not match the value in `topic.regex`, the SMT pass
 
 |[[filter-language]]<<filter-language, `language`>>
 |
-|The language in which the expression is written. Must begin with `jsr223.`, e.g. `jsr223.groovy`, or `jsr223.graal.js`. 
+|The language in which the expression is written. Must begin with `jsr223.`, for example, `jsr223.groovy`, or `jsr223.graal.js`. 
 {prodname} supports bootstrapping through the https://jcp.org/en/jsr/detail?id=223[JSR 223 API ("Scripting for the Java (TM) Platform")] only.
 
 |[[filter-condition]]<<filter-condition, `condition`>>

--- a/documentation/modules/ROOT/pages/configuration/filtering.adoc
+++ b/documentation/modules/ROOT/pages/configuration/filtering.adoc
@@ -146,7 +146,7 @@ Expressions should not result in any side-effects. That is, they should not modi
 
 The way that you express filtering conditions depends on the scripting language that you use.
 
-For example, as shown in {link-prefix}:{link-filtering}#example-basic-debezium-filter-smt-configuration[], when you use `Groovy` as the expression language, 
+For example, as shown in the {link-prefix}:{link-filtering}#example-basic-debezium-filter-smt-configuration[basic configuration example], when you use `Groovy` as the expression language, 
 the following expression removes all messages, except for update records that have `id` values set to `2`:
 
 [source,groovy]


### PR DESCRIPTION
This update fixes an issue in the docs for the filter and content-based routing SMTs, in which a link in the  _Language specifics_  sections does not render, because the link specification omits any link text.

Also fixed issues with table formatting (col width, bad line breaks in cells, removal of extra delimiter characters).

Testing via a local antora build confirmed that the links work as intended.

This fix requires a backport to 1.2.
 