### PR TITLE
DBZ-2563 JSON processing can ignore deserialization errors

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -172,6 +172,11 @@ public class BinlogReader extends AbstractReader {
         }
     }
 
+    @FunctionalInterface
+    public static interface ParsingErrorHandler {
+        void error(String message, Exception exception);
+    }
+
     /**
      * Create a binlog reader.
      *

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/BinlogReader.java
@@ -172,11 +172,6 @@ public class BinlogReader extends AbstractReader {
         }
     }
 
-    @FunctionalInterface
-    public static interface ParsingErrorHandler {
-        void error(String message, Exception exception);
-    }
-
     /**
      * Create a binlog reader.
      *

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSchema.java
@@ -154,7 +154,7 @@ public class MySqlSchema extends RelationalDatabaseSchema {
         final boolean timeAdjusterEnabled = configuration.getConfig().getBoolean(MySqlConnectorConfig.ENABLE_TIME_ADJUSTER);
         // TODO With MySQL connector rewrite the error handling should report also binlog coordinates
         return new MySqlValueConverters(decimalMode, timePrecisionMode, bigIntUnsignedMode,
-                timeAdjusterEnabled ? MySqlValueConverters::adjustTemporal : x -> x, configuration.binaryHandlingMode(),
+                configuration.binaryHandlingMode(), timeAdjusterEnabled ? MySqlValueConverters::adjustTemporal : x -> x,
                 (message, exception) -> {
                     if (configuration
                             .getEventProcessingFailureHandlingMode() == EventProcessingFailureHandlingMode.FAIL) {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
@@ -112,9 +112,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
         return temporal;
     }
 
-    private ParsingErrorHandler parsingErrorHandler = (message, exception) -> {
-        throw new DebeziumException(message, exception);
-    };
+    private final ParsingErrorHandler parsingErrorHandler;
 
     /**
      * Create a new instance that always uses UTC for the default time zone when_needed converting values without timezone information
@@ -130,27 +128,9 @@ public class MySqlValueConverters extends JdbcValueConverters {
      */
     public MySqlValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode, BigIntUnsignedMode bigIntUnsignedMode,
                                 BinaryHandlingMode binaryMode) {
-        this(decimalMode, temporalPrecisionMode, ZoneOffset.UTC, bigIntUnsignedMode, x -> x, binaryMode);
-    }
-
-    /**
-     * Create a new instance, and specify the time zone offset that should be used only when converting values without timezone
-     * information to values that require timezones. This default offset should not be needed when values are highly-correlated
-     * with the expected SQL/JDBC types.
-     *
-     * @param decimalMode how {@code DECIMAL} and {@code NUMERIC} values should be treated; may be null if
-     *            {@link io.debezium.jdbc.JdbcValueConverters.DecimalMode#PRECISE} is to be used
-     * @param temporalPrecisionMode temporal precision mode based on {@link io.debezium.jdbc.TemporalPrecisionMode}
-     * @param defaultOffset the zone offset that is to be used when converting non-timezone related values to values that do
-     *            have timezones; may be null if UTC is to be used
-     * @param bigIntUnsignedMode how {@code BIGINT UNSIGNED} values should be treated; may be null if
-     *            {@link io.debezium.jdbc.JdbcValueConverters.BigIntUnsignedMode#PRECISE} is to be used
-     * @param adjuster a temporal adjuster to make a database specific time modification before conversion
-     * @param binaryMode how binary columns should be represented
-     */
-    public MySqlValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode, ZoneOffset defaultOffset, BigIntUnsignedMode bigIntUnsignedMode,
-                                TemporalAdjuster adjuster, BinaryHandlingMode binaryMode) {
-        super(decimalMode, temporalPrecisionMode, defaultOffset, adjuster, bigIntUnsignedMode, binaryMode);
+        this(decimalMode, temporalPrecisionMode, bigIntUnsignedMode, binaryMode, x -> x, (message, exception) -> {
+            throw new DebeziumException(message, exception);
+        });
     }
 
     /**
@@ -163,13 +143,14 @@ public class MySqlValueConverters extends JdbcValueConverters {
      * @param temporalPrecisionMode temporal precision mode based on {@link io.debezium.jdbc.TemporalPrecisionMode}
      * @param bigIntUnsignedMode how {@code BIGINT UNSIGNED} values should be treated; may be null if
      *            {@link io.debezium.jdbc.JdbcValueConverters.BigIntUnsignedMode#PRECISE} is to be used
-     * @param adjuster a temporal adjuster to make a database specific time modification before conversion
      * @param binaryMode how binary columns should be represented
+     * @param adjuster a temporal adjuster to make a database specific time modification before conversion
      * @param handler for errors during postponed binlog parsing
      */
-    public MySqlValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode, BigIntUnsignedMode bigIntUnsignedMode, TemporalAdjuster adjuster,
-                                BinaryHandlingMode binaryMode, ParsingErrorHandler parsingErrorHandler) {
-        this(decimalMode, temporalPrecisionMode, ZoneOffset.UTC, bigIntUnsignedMode, adjuster, binaryMode);
+    public MySqlValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode, BigIntUnsignedMode bigIntUnsignedMode,
+                                BinaryHandlingMode binaryMode,
+                                TemporalAdjuster adjuster, ParsingErrorHandler parsingErrorHandler) {
+        super(decimalMode, temporalPrecisionMode, ZoneOffset.UTC, adjuster, bigIntUnsignedMode, binaryMode);
         this.parsingErrorHandler = parsingErrorHandler;
     }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
@@ -43,7 +43,6 @@ import com.mysql.cj.CharsetMapping;
 import io.debezium.DebeziumException;
 import io.debezium.annotation.Immutable;
 import io.debezium.config.CommonConnectorConfig.BinaryHandlingMode;
-import io.debezium.connector.mysql.BinlogReader.ParsingErrorHandler;
 import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
 import io.debezium.data.Json;
 import io.debezium.jdbc.JdbcValueConverters;
@@ -70,6 +69,11 @@ import io.debezium.util.Strings;
  */
 @Immutable
 public class MySqlValueConverters extends JdbcValueConverters {
+
+    @FunctionalInterface
+    public static interface ParsingErrorHandler {
+        void error(String message, Exception exception);
+    }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MySqlValueConverters.class);
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlValueConvertersTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlValueConvertersTest.java
@@ -112,8 +112,8 @@ public class MySqlValueConvertersTest {
         String sql = "CREATE TABLE JSON_TABLE (" + "    A JSON," + "    B JSON NOT NULL" + ");";
 
         MySqlValueConverters converters = new MySqlValueConverters(JdbcValueConverters.DecimalMode.DOUBLE,
-                TemporalPrecisionMode.CONNECT, JdbcValueConverters.BigIntUnsignedMode.LONG, x -> x,
-                BinaryHandlingMode.BYTES, (message, exception) -> {
+                TemporalPrecisionMode.CONNECT, JdbcValueConverters.BigIntUnsignedMode.LONG, BinaryHandlingMode.BYTES,
+                x -> x, (message, exception) -> {
                     errorCount.incrementAndGet();
                 });
 
@@ -141,8 +141,8 @@ public class MySqlValueConvertersTest {
         String sql = "CREATE TABLE JSON_TABLE (" + "    A JSON," + "    B JSON NOT NULL" + ");";
 
         MySqlValueConverters converters = new MySqlValueConverters(JdbcValueConverters.DecimalMode.DOUBLE,
-                TemporalPrecisionMode.CONNECT, JdbcValueConverters.BigIntUnsignedMode.LONG, x -> x,
-                BinaryHandlingMode.BYTES, (message, exception) -> {
+                TemporalPrecisionMode.CONNECT, JdbcValueConverters.BigIntUnsignedMode.LONG, BinaryHandlingMode.BYTES,
+                x -> x, (message, exception) -> {
                     throw new DebeziumException(message, exception);
                 });
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2563

This is not top quality implementation. The best approach would be unification of errors in `BinlogReader` but this would be quite invasive. So the code should be handled like an interim solution with the final one in the rewritten connector.