### PR TITLE
DBZ-2544 Fix test failure - PostgresConnectorIT#customSnapshotterSkipsTablesOnRestart

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -8,6 +8,7 @@ package io.debezium.connector.postgresql;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -342,8 +343,8 @@ public final class TestHelper {
                         .until(() -> getOpenIdleTransactions(connection).size() == 0);
             }
             catch (ConditionTimeoutException e) {
+                fail("Expected no open transactions but there was at least one.");
             }
-            assertThat(getOpenIdleTransactions(connection)).hasSize(0);
         }
     }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -6,7 +6,6 @@
 
 package io.debezium.connector.postgresql;
 
-import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2544

As some background, I think the underlying problem here is that we previously double dipped on the database check.  While locally testing, when the test would fail showed some metadata queries that the connector wasn't issuing but seemed to be coming from the JDBC driver itself.  Because of how we asserted the state, I think this is what lead to the inconsistent pass/fail of this test.

This PR instead changes the behavior to rely solely on the `Awaitility` API call and if that results in a time-out, we fail the test.  If that call results in success, that should be sufficient to allow the test to pass without the additional query & assertion check.