### PR TITLE
DBZ-2609 Updated value of DockerKafkaConnect attribute to add "rhel7" to the path

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -10,7 +10,7 @@ asciidoc:
     debezium-dev-version: '1.3'
     debezium-kafka-version: '2.6.0'
     debezium-docker-label: '1.3'
-    DockerKafkaConnect: registry.redhat.io/amq7/amq-streams-kafka-25:1.5.0
+    DockerKafkaConnect: registry.redhat.io/amq7/amq-streams-kafka-25-rhel7:1.5.0
     install-version: '1.3'
     assemblies: '../assemblies'
     modules: '../../modules'


### PR DESCRIPTION
[DBZ-2609](https://issues.redhat.com/browse/DBZ-2609) reports an error in the path for a container image. This path is set by the :DockerKafkaConnect: attribute, and we use in in only downstream Debezium doc. However, this attribute is in the antora.yml file so I am updating it. 