### PR TITLE
DBZ-2610 In downstream-only content, add context directory to podman command example

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1636,7 +1636,7 @@ USER 1001
 +
 Before Kafka Connect starts running the connector, Kafka Connect loads any third-party plug-ins that are in the `/opt/kafka/plugins` directory.
 
-.. Build the container image. For example, if you saved the `Dockerfile` that you created in the previous step as `debezium-container-for-db2`, and if the `Dockerfile` is in the current directory, then you would run the following command. 
+.. Build the container image. For example, if you saved the `Dockerfile` that you created in the previous step as `debezium-container-for-db2`, and if the `Dockerfile` is in the current directory, then you would run the following command:
 +
 `podman build -t debezium-container-for-db2:latest .`
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1636,9 +1636,9 @@ USER 1001
 +
 Before Kafka Connect starts running the connector, Kafka Connect loads any third-party plug-ins that are in the `/opt/kafka/plugins` directory.
 
-.. Build the container image. For example, if you saved the `Dockerfile` that you created in the previous step as `debezium-container-for-db2`, then you would run the following command:
+.. Build the container image. For example, if you saved the `Dockerfile` that you created in the previous step as `debezium-container-for-db2`, and if the `Dockerfile` is in the current directory, then you would run the following command. 
 +
-`podman build -t debezium-container-for-db2:latest`
+`podman build -t debezium-container-for-db2:latest .`
 
 .. Push your custom image to your container registry, for example:
 +

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -948,9 +948,9 @@ USER 1001
 +
 Before Kafka Connect starts running the connector, Kafka Connect loads any third-party plug-ins that are in the `/opt/kafka/plugins` directory.
 
-.. Build the container image. For example, if you saved the `Dockerfile` that you created in the previous step as `debezium-container-for-mongodb`, then you would run the following command:
+.. Build the container image. For example, if you saved the `Dockerfile` that you created in the previous step as `debezium-container-for-mongodb`, and if the `Dockerfile` is in the current directory, then you would run the following command:
 +
-`podman build -t debezium-container-for-mongodb:latest`
+`podman build -t debezium-container-for-mongodb:latest .`
 
 .. Push your custom image to your container registry, for example:
 +

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2112,9 +2112,9 @@ USER 1001
 +
 Before Kafka Connect starts running the connector, Kafka Connect loads any third-party plug-ins that are in the `/opt/kafka/plugins` directory.
 
-.. Build the container image. For example, if you saved the `Dockerfile` that you created in the previous step as `debezium-container-for-postgresql`, then you would run the following command:
+.. Build the container image. For example, if you saved the `Dockerfile` that you created in the previous step as `debezium-container-for-postgresql`, and if the `Dockerfile` is in the current directory, then you would run the following command:
 +
-`podman build -t debezium-container-for-postgresql:latest`
+`podman build -t debezium-container-for-postgresql:latest .`
 
 .. Push your custom image to your container registry, for example:
 +

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1576,9 +1576,9 @@ USER 1001
 +
 Before Kafka Connect starts running the connector, Kafka Connect loads any third-party plug-ins that are in the `/opt/kafka/plugins` directory.
 
-.. Build the container image. For example, if you saved the `Dockerfile` that you created in the previous step as `debezium-container-for-sqlserver`, then you would run the following command:
+.. Build the container image. For example, if you saved the `Dockerfile` that you created in the previous step as `debezium-container-for-sqlserver`, and if the `Dockerfile` is in the current directory, then you would run the following command:
 +
-`podman build -t debezium-container-for-sqlserver:latest`
+`podman build -t debezium-container-for-sqlserver:latest .`
 
 .. Push your custom image to your container registry, for example:
 +


### PR DESCRIPTION
[DBZ-2610](https://issues.redhat.com/browse/DBZ-2610) notes an error in the installation guide for installing Debezium on OpenShift. This is downstream only content, however the same content is in the user guide for each connector, and we fetch and reuse this upstream content in the downstream user guide. 

So this update makes the same edit to the doc for the MongoDB, DB2, PostgreSQL, and SQL Server connectors. I'll do the MySQL update in the open PR for the reunified content. 