### PR TITLE
DBZ-2626 upgrade Mysql driver jar version to 8.0.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <!-- Databases -->
         <version.postgresql.driver>42.2.14</version.postgresql.driver>
         <version.mysql.server>5.7</version.mysql.server>
-        <version.mysql.driver>8.0.16</version.mysql.driver>
+        <version.mysql.driver>8.0.19</version.mysql.driver>
         <version.mysql.binlog>0.23.1</version.mysql.binlog>
         <version.mongo.server>3.6</version.mongo.server>
         <version.mongo.driver>3.12.3</version.mongo.driver>


### PR DESCRIPTION
We met the issue that DATE column was truncated incorrectly with database.useCursorFetch": "true". It's fixed in a later release:
https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-19.html
> When retrieving TIME values using ResultSet.getTimestamp(), the fractional seconds are truncated when useCursorFetch=true. This patch corrects the problem by fixing the TIME value decoding in the MysqlBinaryValueDecoder. It also corrects some inconsistencies in formatting the fractional seconds when returning the TIME values as strings. (Bug #30119545, Bug #96383)