### PR TITLE
DBZ-2606: Map new name for the fields and headers

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordStateConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordStateConfigDefinition.java
@@ -108,8 +108,10 @@ public class ExtractNewRecordStateConfigDefinition {
             .withWidth(ConfigDef.Width.LONG)
             .withImportance(ConfigDef.Importance.LOW)
             .withDefault("")
-            .withDescription("Adds each field listed, prefixed with __ (or __<struct>_ if the struct is specified) "
-                    + "Example: 'version,connector,source.ts_ms' would add __version, __connector and __source_ts_ms fields");
+            .withDescription("Adds each field listed, prefixed with __ (or __<struct>_ if the struct is specified). "
+                    + "Example: 'version,connector,source.ts_ms' would add __version, __connector and __source_ts_ms fields. "
+                    + "Optionally one can also map new field name like version:VERSION,connector:CONNECTOR,source.ts_ms:EVENT_TIMESTAMP."
+                    + "Please note that the new field name is case-sensitive.");
 
     public static final Field ADD_HEADERS_PREFIX = Field.create("add.headers.prefix")
             .withDisplayName("Header prefix to be added to each header.")
@@ -125,7 +127,9 @@ public class ExtractNewRecordStateConfigDefinition {
             .withWidth(ConfigDef.Width.LONG)
             .withImportance(ConfigDef.Importance.LOW)
             .withDefault("")
-            .withDescription("Adds each field listed to the header,  __ (or __<struct>_ if the struct is specified) "
-                    + "Example: 'version,connector,source.ts_ms' would add __version, __connector and __source_ts_ms fields");
+            .withDescription("Adds each field listed to the header,  __ (or __<struct>_ if the struct is specified). "
+                    + "Example: 'version,connector,source.ts_ms' would add __version, __connector and __source_ts_ms fields. "
+                    + "Optionally one can also map new field name like version:VERSION,connector:CONNECTOR,source.ts_ms:EVENT_TIMESTAMP."
+                    + "Please note that the new field name is case-sensitive.");
 
 }

--- a/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
@@ -265,6 +265,8 @@ If you are configuring the event flattening SMT on a sink connector, setting thi
 |
 |Set this option to a comma-separated list, with no spaces, of metadata fields to add to the simplified Kafka record's value. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
  +
+Optionally, you can override the field name via `<field name>:<new field name>`, e.g. like so: new field name like `version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP`. Please note that the `new field name` is case-sensitive. +
+ +
 When the SMT adds metadata fields to the simplified record's value, it prefixes each metadata field name with a double underscore. For a struct specification, the SMT also inserts an underscore between the struct name and the field name. +
  +
 If you specify a field that is not in the change event record, the SMT still adds the field to the record's value.
@@ -278,6 +280,8 @@ If you specify a field that is not in the change event record, the SMT still add
 |{link-prefix}:{link-event-flattening}#extract-new-record-state-add-headers[`add.headers`]
 |
 |Set this option to a comma-separated list, with no spaces, of metadata fields to add to the header of the simplified Kafka record. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
+ +
+Optionally, you can override the field name via `<field name>:<new field name>`, e.g. like so: new field name like `version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP`. Please note that the `new field name` is case-sensitive. +
  +
 When the SMT adds metadata fields to the simplified record's header, it prefixes each metadata field name with a double underscore. For a struct specification, the SMT also inserts an underscore between the struct name and the field name. +
  +


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2606

Added ability to map new name for the fields and headers.
The "new name" mapping is completely optional and we will not
be affecting the existing functionality.