### PR TITLE
Only set filter info in offsets when snapshot.new.tables = parallel

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -223,14 +223,7 @@ public final class MySqlConnectorTask extends BaseSourceTask {
                 }
             }
             else {
-                if (!source.hasFilterInfo()) {
-                    // if we don't have filter info, then either
-                    // 1. the snapshot was taken in a version of debezium before the filter info was stored in the offsets, or
-                    // 2. this connector previously had no filter information.
-                    // either way, we have to assume that the filter information currently in the config accurately reflects
-                    // the current state of the connector.
-                    source.maybeSetFilterDataFromConfig(config);
-                }
+                source.maybeSetFilterDataFromConfig(config);
                 if (!rowBinlogEnabled) {
                     throw new ConnectException(
                             "The MySQL server does not appear to be using a full row-level binlog, which is required for this connector to work properly. Enable this mode and restart the connector.");

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
@@ -453,6 +453,15 @@ final class SourceInfo extends AbstractSourceInfo {
                 MySqlConnectorConfig.SnapshotNewTables.PARALLEL.getValue())) {
             setFilterDataFromConfig(config);
         }
+        else {
+            if (hasFilterInfo()) {
+                // Connector has filter info but snapshot.new.tables is disabled. Filter info should be unset.
+                this.databaseIncludeList = null;
+                this.databaseExcludeList = null;
+                this.tableIncludeList = null;
+                this.tableExcludeList = null;
+            }
+        }
     }
 
     /**

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
@@ -230,6 +230,29 @@ public class SourceInfoTest {
     }
 
     @Test
+    public void shouldRecoverSourceInfoFromOffsetWithoutFilterDataIfSnapshotNewTablesIsOff() {
+        final String databaseIncludeList = "a,b";
+        final String tableIncludeList = "c.foo,d.bar,d.baz";
+        Map<String, String> offset = offset(10, 10);
+        offset.put(SourceInfo.DATABASE_INCLUDE_LIST_KEY, databaseIncludeList);
+        offset.put(SourceInfo.TABLE_INCLUDE_LIST_KEY, tableIncludeList);
+
+        sourceWith(offset);
+        assertThat(source.hasFilterInfo()).isTrue();
+
+        final Configuration configuration = Configuration.create()
+                .with(MySqlConnectorConfig.DATABASE_INCLUDE_LIST, databaseIncludeList)
+                .with(MySqlConnectorConfig.TABLE_INCLUDE_LIST, tableIncludeList)
+                .with(MySqlConnectorConfig.SNAPSHOT_NEW_TABLES, MySqlConnectorConfig.SnapshotNewTables.OFF)
+                .build();
+        source.maybeSetFilterDataFromConfig(configuration);
+
+        assertThat(source.hasFilterInfo()).isFalse();
+        assertThat(source.getDatabaseIncludeList()).isNull();
+        assertThat(source.getTableIncludeList()).isNull();
+    }
+
+    @Test
     public void shouldStartSourceInfoFromBinlogCoordinatesWithGtidsAndZeroBinlogCoordinates() {
         sourceWith(offset(GTID_SET, 0, 0, false));
         assertThat(source.gtidSet()).isEqualTo(GTID_SET);


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/DBZ-2643

This PR adds a check to `maybeSetFilterDataFromConfig` for the case where a connector has filter info, but snapshot.new.tables is not set to parallel. In this case we unset the filters.

I'm also updating the `MySQLConnectorTask` to run `maybeSetFilterDataFromConfig` in every case where it's picking up from an existing offset, rather than only running the update when offsets are missing filter info.

I've tested this change in our staging environment.