### PR TITLE
DBZ-2632: Force closing the JDBC connection if failed to close it gracefully.

### DIFF
--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -41,6 +41,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.DebeziumException;
 import io.debezium.annotation.NotThreadSafe;
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.config.Configuration;
@@ -65,6 +66,7 @@ import io.debezium.util.Strings;
 @NotThreadSafe
 public class JdbcConnection implements AutoCloseable {
 
+    private static final int WAIT_FOR_CLOSE_SECONDS = 10;
     private static final char STATEMENT_DELIMITER = ';';
     private static final int STATEMENT_CACHE_CAPACITY = 10_000;
     private final static Logger LOGGER = LoggerFactory.getLogger(JdbcConnection.class);
@@ -929,16 +931,20 @@ public class JdbcConnection implements AutoCloseable {
         // attempting to close the connection gracefully
         Future<Object> futureClose = executor.submit(() -> {
             conn.close();
+            LOGGER.info("Connection gracefully closed");
             return null;
         });
         try {
-            futureClose.get(10, TimeUnit.SECONDS);
+            futureClose.get(WAIT_FOR_CLOSE_SECONDS, TimeUnit.SECONDS);
         }
         catch (ExecutionException e) {
             if (e.getCause() instanceof SQLException) {
                 throw (SQLException) e.getCause();
             }
-            throw (RuntimeException) e.getCause();
+            else if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            }
+            throw new DebeziumException(e.getCause());
         }
         catch (TimeoutException | InterruptedException e) {
             LOGGER.warn("Failed to close database connection by calling close(), attempting abort()");

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -27,6 +27,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -910,11 +916,36 @@ public class JdbcConnection implements AutoCloseable {
                 statementCache.values().forEach(this::cleanupPreparedStatement);
                 statementCache.clear();
                 LOGGER.trace("Closing database connection");
-                conn.close();
+                doClose();
             }
             finally {
                 conn = null;
             }
+        }
+    }
+
+    private void doClose() throws SQLException {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        // attempting to close the connection gracefully
+        Future<Object> futureClose = executor.submit(() -> {
+            conn.close();
+            return null;
+        });
+        try {
+            futureClose.get(10, TimeUnit.SECONDS);
+        }
+        catch (ExecutionException e) {
+            if (e.getCause() instanceof SQLException) {
+                throw (SQLException) e.getCause();
+            }
+            throw (RuntimeException) e.getCause();
+        }
+        catch (TimeoutException | InterruptedException e) {
+            LOGGER.warn("Failed to close database connection by calling close(), attempting abort()");
+            conn.abort(Runnable::run);
+        }
+        finally {
+            executor.shutdownNow();
         }
     }
 

--- a/debezium-core/src/test/java/io/debezium/jdbc/JdbcConnectionTest.java
+++ b/debezium-core/src/test/java/io/debezium/jdbc/JdbcConnectionTest.java
@@ -1,0 +1,353 @@
+package io.debezium.jdbc;
+
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.jdbc.JdbcConnection.ConnectionFactory;
+
+public class JdbcConnectionTest {
+
+    @Test
+    public void testNormalClose() throws SQLException {
+        ConnectionFactory connFactory = (config) -> new NormalConnection();
+        JdbcConnection conn = new JdbcConnection(Configuration.empty(), connFactory);
+        conn.connect();
+        conn.close();
+    }
+
+    @Test
+    public void testForceClose() throws SQLException {
+        ConnectionFactory connFactory = (config) -> new TimingOutConnection();
+        JdbcConnection conn = new JdbcConnection(Configuration.empty(), connFactory);
+        conn.connect();
+        conn.close();
+    }
+
+    @Test(expected = SQLException.class)
+    public void testRogueConnection() throws SQLException {
+        ConnectionFactory connFactory = (config) -> new RogueConnection();
+        JdbcConnection conn = new JdbcConnection(Configuration.empty(), connFactory);
+        conn.connect();
+        conn.close();
+    }
+
+    private static class RogueConnection extends NormalConnection {
+        @Override
+        public void close() throws SQLException {
+            throw new SQLException("something bad happened");
+        }
+    }
+
+    private static class TimingOutConnection extends NormalConnection {
+        @Override
+        public void close() throws SQLException {
+            try {
+                TimeUnit.SECONDS.sleep(20);
+                throw new SQLException("failed to close connection properly");
+            }
+            catch (InterruptedException e) {
+            }
+        }
+    }
+
+    private static class NormalConnection implements Connection {
+
+        @Override
+        public <T> T unwrap(Class<T> iface) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) throws SQLException {
+            return false;
+        }
+
+        @Override
+        public Statement createStatement() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public CallableStatement prepareCall(String sql) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public String nativeSQL(String sql) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void setAutoCommit(boolean autoCommit) throws SQLException {
+
+        }
+
+        @Override
+        public boolean getAutoCommit() throws SQLException {
+            return false;
+        }
+
+        @Override
+        public void commit() throws SQLException {
+
+        }
+
+        @Override
+        public void rollback() throws SQLException {
+
+        }
+
+        @Override
+        public void close() throws SQLException {
+
+        }
+
+        @Override
+        public boolean isClosed() throws SQLException {
+            return false;
+        }
+
+        @Override
+        public DatabaseMetaData getMetaData() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void setReadOnly(boolean readOnly) throws SQLException {
+
+        }
+
+        @Override
+        public boolean isReadOnly() throws SQLException {
+            return false;
+        }
+
+        @Override
+        public void setCatalog(String catalog) throws SQLException {
+
+        }
+
+        @Override
+        public String getCatalog() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void setTransactionIsolation(int level) throws SQLException {
+
+        }
+
+        @Override
+        public int getTransactionIsolation() throws SQLException {
+            return 0;
+        }
+
+        @Override
+        public SQLWarning getWarnings() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void clearWarnings() throws SQLException {
+
+        }
+
+        @Override
+        public Statement createStatement(int resultSetType, int resultSetConcurrency) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency)
+                throws SQLException {
+            return null;
+        }
+
+        @Override
+        public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Map<String, Class<?>> getTypeMap() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+
+        }
+
+        @Override
+        public void setHoldability(int holdability) throws SQLException {
+
+        }
+
+        @Override
+        public int getHoldability() throws SQLException {
+            return 0;
+        }
+
+        @Override
+        public Savepoint setSavepoint() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Savepoint setSavepoint(String name) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void rollback(Savepoint savepoint) throws SQLException {
+
+        }
+
+        @Override
+        public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+
+        }
+
+        @Override
+        public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+                throws SQLException {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency,
+                                                  int resultSetHoldability)
+                throws SQLException {
+            return null;
+        }
+
+        @Override
+        public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency,
+                                             int resultSetHoldability)
+                throws SQLException {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Clob createClob() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Blob createBlob() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public NClob createNClob() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public SQLXML createSQLXML() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public boolean isValid(int timeout) throws SQLException {
+            return false;
+        }
+
+        @Override
+        public void setClientInfo(String name, String value) throws SQLClientInfoException {
+
+        }
+
+        @Override
+        public void setClientInfo(Properties properties) throws SQLClientInfoException {
+
+        }
+
+        @Override
+        public String getClientInfo(String name) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Properties getClientInfo() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void setSchema(String schema) throws SQLException {
+
+        }
+
+        @Override
+        public String getSchema() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void abort(Executor executor) throws SQLException {
+
+        }
+
+        @Override
+        public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+
+        }
+
+        @Override
+        public int getNetworkTimeout() throws SQLException {
+            return 0;
+        }
+
+    }
+
+}

--- a/debezium-core/src/test/java/io/debezium/jdbc/JdbcConnectionTest.java
+++ b/debezium-core/src/test/java/io/debezium/jdbc/JdbcConnectionTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.jdbc;
 
 import java.sql.Array;


### PR DESCRIPTION
Upon investigation I found out that long running connections to an Aurora RDS MySQL database do not close properly and time out instead -- if the connection is still in the process of streaming data on another thread. 

It seems that AWS at least partially acknowledged this issue as a networking layer issue: https://forums.aws.amazon.com/thread.jspa?messageID=440379. 

But since it isn't feasible for us (and I imagine many others) to alter our security groups to circumvent this issue it would be better if we can solve it in the application layer. I tried using `socketTimeout` and `connectTimeout ` as a JDBC url parameter but to not avail as these parameters are ignored when you try to close a connection.

The solution I came up with was to attempt a graceful close of the connection, but if that fails resort to the `abort()` method on the `Connection` object which is more abrupt but will get the job done if all else fails.