### PR TITLE
DBZ-2616 Fix negative years conversion

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -14,7 +14,9 @@ import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
@@ -937,7 +939,11 @@ public class PostgresValueConverter extends JdbcValueConverters {
         }
         final Timestamp timestamp = (Timestamp) data;
 
-        return timestamp.toLocalDateTime();
+        final Instant instant = timestamp.toInstant();
+        final LocalDateTime utcTime = LocalDateTime
+                .ofInstant(instant, ZoneOffset.systemDefault());
+
+        return utcTime;
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
+++ b/debezium-connector-postgres/src/test/resources/postgres_create_tables.ddl
@@ -34,6 +34,7 @@ CREATE TABLE time_table (pk SERIAL, ts TIMESTAMP, tsneg TIMESTAMP(6) WITHOUT TIM
     ts_max TIMESTAMP(6),
     ts_min TIMESTAMP(6),
     tz_max TIMESTAMPTZ,
+    tz_min TIMESTAMPTZ,
     PRIMARY KEY(pk));
 
 CREATE TABLE text_table (pk SERIAL, j JSON, jb JSONB, x XML, u Uuid, PRIMARY KEY(pk));


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2616

This PR fixes the unwanted negative/positive timestamp conversion.

Unfortunately it uncovered further issues related to database epoch to Instant/OffsetTimeDate mapping and Julian/Gregorian calendar handling - see comments for more details.

The further fixes would probably require significant effort and it is necessary to decide if we are goint to invest the time to it or leave it as is for now.

The breaking year seems to be 1581/1582 which coonforms to introduction of Gregorian calendar.

Regarding Instant mapping - it seems that PostgreSQL refuses to use year 0, only -1 is allowd but this maps to year ) of Instant;