### PR TITLE
DBZ-2584 Replace ts_sec with ts_ms, clarify meaning of source.ts_ms

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -194,7 +194,7 @@ A message to the schema change topic contains a logical representation of the ta
       "version": "{debezium-version}",
       "connector": "db2",
       "name": "db2",
-      "ts_sec": 1588252618953,
+      "ts_ms": 1588252618953,
       "snapshot": "true",
       "db": "testdb",
       "schema": "DB2INST1",
@@ -700,7 +700,7 @@ The following example shows the value portion of a change event that the connect
           {
             "type": "int64",
             "optional": false,
-            "field": "ts_sec"
+            "field": "ts_ms"
           },
           {
             "type": "boolean",
@@ -764,7 +764,7 @@ The following example shows the value portion of a change event that the connect
       "version": "{debezium-version}",
       "connector": "db2",
       "name": "myconnector",
-      "ts_sec": 1559729468470,
+      "ts_ms": 1559729468470,
       "snapshot": false,
       "db": "mydatabase",
       "schema": "MYSCHEMA",
@@ -824,7 +824,7 @@ a| Mandatory field that describes the source metadata for the event. The `source
 
 * {prodname} version
 * Connector type and name
-* Timestamp for when the connector read the record
+* Timestamp for when the change was made in the database
 * Whether the event is part of an ongoing snapshot
 * Name of the database, schema, and table that contain the new row
 * Change LSN
@@ -841,7 +841,9 @@ a|Mandatory string that describes the type of operation that caused the connecto
 
 |10
 |`ts_ms`
-a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task. +
+ +
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
 
@@ -870,7 +872,7 @@ The value of a change event for an update in the sample `customers` table has th
       "version": "{debezium-version}",
       "connector": "db2",
       "name": "myconnector",
-      "ts_sec": 1559729995937,
+      "ts_ms": 1559729995937,
       "snapshot": false,
       "db": "mydatabase",
       "schema": "MYSCHEMA",
@@ -903,7 +905,7 @@ a|Mandatory field that describes the source metadata for the event. The `source`
 
 * {prodname} version
 * Connector type and name
-* Timestamp for when the connector read the record
+* Timestamp for when the change was made in the database
 * Whether the event is part of an ongoing snapshot
 * Name of the database, schema, and table that contain the new row
 * Change LSN
@@ -915,7 +917,9 @@ a|Mandatory string that describes the type of operation. In an _update_ event va
 
 |5
 |`ts_ms`
-a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task. +
+ +
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
 
@@ -946,7 +950,7 @@ The value in a _delete_ change event has the same `schema` portion as _create_ a
       "version": "{debezium-version}",
       "connector": "db2",
       "name": "myconnector",
-      "ts_sec": 1559730445243,
+      "ts_ms": 1559730445243,
       "snapshot": false,
       "db": "mydatabase",
       "schema": "MYSCHEMA",
@@ -979,7 +983,7 @@ a|Mandatory field that describes the source metadata for the event. In a _delete
 
 * {prodname} version
 * Connector type and name
-* Timestamp for when the connector read the record
+* Timestamp for when the change was made in the database
 * Whether the event is part of an ongoing snapshot
 * Name of the database, schema, and table that contain the new row
 * Change LSN
@@ -991,7 +995,9 @@ a|Mandatory string that describes the type of operation. The `op` field value is
 
 |5
 |`ts_ms`
-a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task. +
+ +
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -423,7 +423,7 @@ The following example shows the value portion of a change event that the connect
             {
               "type": "int64",
               "optional": false,
-              "field": "ts_sec"
+              "field": "ts_ms"
             },
             {
               "type": "boolean",
@@ -482,7 +482,7 @@ The following example shows the value portion of a change event that the connect
         "version": "{debezium-version}",
         "connector": "mongodb",
         "name": "fulfillment",
-        "ts_sec": 1558965508000,
+        "ts_ms": 1558965508000,
         "snapshot": false,
         "db": "inventory",
         "rs": "rs0",
@@ -539,7 +539,7 @@ a|Mandatory field that describes the source metadata for the event. This field c
 * Logical name of the MongoDB replica set, which forms a namespace for generated events and is used in Kafka topic names to which the connector writes.
 * Names of the collection and database that contain the new document.
 * If the event was part of a snapshot.
-* Timestamp for when the event occurred and ordinal of the event within the timestamp.
+* Timestamp for when the change was made in the database and ordinal of the event within the timestamp.
 * Unique identifier of the MongoDB operation, which depends on the version of MongoDB. It is either the `h` field in the oplog event, or a field named `stxnid`, which represents the `lsid` and `txnNumber` fields from the oplog event.
 
 |8
@@ -553,7 +553,9 @@ a|Mandatory string that describes the type of operation that caused the connecto
 
 |9
 |`ts_ms`
-a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.  +
+ +
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
 
@@ -581,7 +583,7 @@ Here is an example of a change event value in an event that the connector genera
         "version": "{debezium-version}",
         "connector": "mongodb",
         "name": "fulfillment",
-        "ts_sec": 1558965508000,
+        "ts_ms": 1558965508000,
         "snapshot": true,
         "db": "inventory",
         "rs": "rs0",
@@ -604,7 +606,9 @@ a|Mandatory string that describes the type of operation that caused the connecto
 
 |2
 |`ts_ms`
-a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.  +
+ +
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |3
 |`patch`
@@ -625,7 +629,7 @@ a|Mandatory field that describes the source metadata for the event. This field c
 * Logical name of the MongoDB replica set, which forms a namespace for generated events and is used in Kafka topic names to which the connector writes.
 * Names of the collection and database that contain the updated document.
 * If the event was part of a snapshot.
-* Timestamp for when the event occurred and ordinal of the event within the timestamp.
+* Timestamp for when the change was made in the database and ordinal of the event within the timestamp.
 * Unique identifier of the MongoDB operation, which depends on the version of MongoDB. It is either the `h` field in the oplog event, or a field named `stxnid`, which represents the `lsid` and `txnNumber` fields from the oplog event.
 
 |===
@@ -657,7 +661,7 @@ The value in a _delete_ change event has the same `schema` portion as _create_ a
         "version": "{debezium-version}",
         "connector": "mongodb",
         "name": "fulfillment",
-        "ts_sec": 1558965508000,
+        "ts_ms": 1558965508000,
         "snapshot": true,
         "db": "inventory",
         "rs": "rs0",
@@ -680,7 +684,9 @@ a|Mandatory string that describes the type of operation. The `op` field value is
 
 |2
 |`ts_ms`
-a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.  +
+ +
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |3
 |`filter`
@@ -695,7 +701,7 @@ a|Mandatory field that describes the source metadata for the event. This field c
 * Logical name of the MongoDB replica set, which forms a namespace for generated events and is used in Kafka topic names to which the connector writes.
 * Names of the collection and database that contained the deleted document.
 * If the event was part of a snapshot.
-* Timestamp for when the event occurred and ordinal of the event within the timestamp.
+* Timestamp for when the change was made in the database and ordinal of the event within the timestamp.
 * Unique identifier of the MongoDB operation, which depends on the version of MongoDB. It is either the `h` field in the `oplog` event, or a field named `stxnid`, which represents the `lsid` and `txnNumber` fields from the `oplog` event.
 
 |===

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -860,7 +860,7 @@ The value of a change event for an update in the sample `customers` table has th
       "query": "UPDATE customers SET first_name='Anne Marie' WHERE id=1004"
     },
     "op": "u", // <4>
-    "ts_ms": 1465581029523 
+    "ts_ms": 1465581029523 // <5>
   }
 }
 ----
@@ -898,6 +898,12 @@ If the {link-prefix}:{link-mysql-connector}#enable-query-log-events[`binlog_rows
 |4
 |`op`
 a|Mandatory string that describes the type of operation. In an _update_ event value, the `op` field value is `u`, signifying that this row changed because of an update.
+
+|5
+|`ts_ms`
+a| Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.  +
+ +
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -181,7 +181,7 @@ The schema change event record value contains a structure that includes the DDL 
           {
             "type": "int64",
             "optional": false,
-            "field": "ts_sec"
+            "field": "ts_ms"
           },
           {
             "type": "string",
@@ -240,7 +240,7 @@ The schema change event record value contains a structure that includes the DDL 
       "version": "{debezium-version}",
       "name": "mysql-server-1",
       "server_id": 0,
-      "ts_sec": 0,
+      "ts_ms": 0,
       "gtid": null,
       "file": "mysql-bin.000003",
       "pos": 154,
@@ -643,7 +643,7 @@ The following example shows the value portion of a change event that the connect
           {
             "type": "int64",
             "optional": false,
-            "field": "ts_sec"
+            "field": "ts_ms"
           },
           {
             "type": "boolean",
@@ -729,7 +729,7 @@ The following example shows the value portion of a change event that the connect
       "version": "{debezium-version}",
       "connector": "mysql",
       "name": "mysql-server-1",
-      "ts_sec": 0,
+      "ts_ms": 0,
       "snapshot": false,
       "db": "inventory",
       "table": "customers",
@@ -788,7 +788,9 @@ a| Mandatory string that describes the type of operation that caused the connect
 
 |7
 |`ts_ms`
-a| Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+a| Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.  +
+ +
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |8
 |`before`
@@ -811,7 +813,7 @@ a| Mandatory field that describes the source metadata for the event. This field 
 * Name of the database and table that contain the new row
 * ID of the MySQL thread that created the event (non-snapshot only)
 * MySQL server ID (if available)
-* Timestamp
+* Timestamp for when the change was made in the database
 
 If the {link-prefix}:{link-mysql-connector}#enable-query-log-events[`binlog_rows_query_log_events`] MySQL configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
 
@@ -845,7 +847,7 @@ The value of a change event for an update in the sample `customers` table has th
       "name": "mysql-server-1",
       "connector": "mysql",
       "name": "mysql-server-1",
-      "ts_sec": 1465581,
+      "ts_ms": 1465581029100,
       "snapshot": false,
       "db": "inventory",
       "table": "customers",
@@ -889,7 +891,7 @@ a|Mandatory field that describes the source metadata for the event. The `source`
 * Name of the database and table that contain the updated row
 * ID of the MySQL thread that created the event (non-snapshot only)
 * MySQL server ID (if available)
-* Timestamp
+* Timestamp for when the change was made in the database
 
 If the {link-prefix}:{link-mysql-connector}#enable-query-log-events[`binlog_rows_query_log_events`] MySQL configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
 
@@ -937,7 +939,7 @@ The value in a _delete_ change event has the same `schema` portion as _create_ a
       "version": "{debezium-version}",
       "connector": "mysql",
       "name": "mysql-server-1",
-      "ts_sec": 1465581,
+      "ts_ms": 1465581902300,
       "snapshot": false,
       "db": "inventory",
       "table": "customers",
@@ -981,7 +983,7 @@ a|Mandatory field that describes the source metadata for the event. In a _delete
 * Name of the database and table that contain the updated row
 * ID of the MySQL thread that created the event (non-snapshot only)
 * MySQL server ID (if available)
-* Timestamp
+* Timestamp for when the change was made in the database
 
 If the {link-prefix}:{link-mysql-connector}#enable-query-log-events[`binlog_rows_query_log_events`] MySQL configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
 
@@ -991,7 +993,9 @@ a|Mandatory string that describes the type of operation. The `op` field value is
 
 |5
 |`ts_ms`
-a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.  +
+ +
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -930,7 +930,7 @@ The value of a change event for an update in the sample `customers` table has th
             "xmin": null
         },
         "op": "u", // <4>
-        "ts_ms": 1465584025523
+        "ts_ms": 1465584025523  // <5>
     }
 }
 ----
@@ -966,6 +966,12 @@ a|Mandatory field that describes the source metadata for the event. The `source`
 |4
 |`op`
 a|Mandatory string that describes the type of operation. In an _update_ event value, the `op` field value is `u`, signifying that this row changed because of an update.
+
+|5
+|`ts_ms`
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.  +
+ +
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -347,7 +347,7 @@ In addition to a {link-prefix}:{link-postgresql-connector}#postgresql-events[_da
 
 ** `lsn` represents the PostgreSQL https://www.postgresql.org/docs/current/static/datatype-pg-lsn.html[Log Sequence Number] or `offset` in the transaction log.
 ** `txId` represents the identifier of the server transaction that caused the event.
-** `ts_ms` represents the server time at which the transaction was committed in the form of the number of microseconds since the epoch. 
+** `ts_ms` represents the server time at which the transaction was committed in the form of the number of milliseconds since the epoch. 
 * `kafkaPartition` with a setting of `null` means that the connector does not use a specific Kafka partition. The PostgreSQL connector uses only one Kafka Connect partition and it places the generated events into one Kafka partition. 
 
 // Type: concept
@@ -736,7 +736,7 @@ The following example shows the value portion of a change event that the connect
                     {
                         "type": "int64",
                         "optional": false,
-                        "field": "ts_sec"
+                        "field": "ts_ms"
                     },
                     {
                         "type": "boolean",
@@ -805,7 +805,7 @@ The following example shows the value portion of a change event that the connect
             "version": "{debezium-version}",
             "connector": "postgresql",
             "name": "PostgreSQL_server",
-            "ts_sec": 1559033904863,
+            "ts_ms": 1559033904863,
             "snapshot": true,
             "db": "postgres",
             "schema": "public",
@@ -877,7 +877,7 @@ a|Mandatory field that describes the source metadata for the event. This field c
 * If the event was part of a snapshot
 * ID of the transaction in which the operation was performed
 * Offset of the operation in the database log
-* Timestamp
+* Timestamp for when the change was made in the database
 
 |9
 |`op`
@@ -890,7 +890,9 @@ a|Mandatory string that describes the type of operation that caused the connecto
 
 |10
 |`ts_ms`
-a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.  +
+ +
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
 
@@ -918,7 +920,7 @@ The value of a change event for an update in the sample `customers` table has th
             "version": "{debezium-version}",
             "connector": "postgresql",
             "name": "PostgreSQL_server",
-            "ts_sec": 1559033904863,
+            "ts_ms": 1559033904863,
             "snapshot": null,
             "db": "postgres",
             "schema": "public",
@@ -959,7 +961,7 @@ a|Mandatory field that describes the source metadata for the event. The `source`
 * If the event was part of a snapshot
 * ID of the transaction in which the operation was performed
 * Offset of the operation in the database log
-* Timestamp
+* Timestamp for when the change was made in the database
 
 |4
 |`op`
@@ -1042,7 +1044,7 @@ a|Mandatory field that describes the source metadata for the event. In a _delete
 * If the event was part of a snapshot
 * ID of the transaction in which the operation was performed
 * Offset of the operation in the database log
-* Timestamp
+* Timestamp for when the change was made in the database
 
 |4
 |`op`
@@ -1050,7 +1052,9 @@ a|Mandatory string that describes the type of operation. The `op` field value is
 
 |5
 |`ts_ms`
-a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.  +
+ +
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -606,7 +606,7 @@ The following example shows the value portion of a change event that the connect
           {
             "type": "int64",
             "optional": false,
-            "field": "ts_sec"
+            "field": "ts_ms"
           },
           {
             "type": "boolean",
@@ -675,7 +675,7 @@ The following example shows the value portion of a change event that the connect
       "version": "{debezium-version}",
       "connector": "sqlserver",
       "name": "server1",
-      "ts_sec": 1559729468470,
+      "ts_ms": 1559729468470,
       "snapshot": false,
       "db": "testDB",
       "schema": "dbo",
@@ -738,7 +738,7 @@ a|Mandatory field that describes the source metadata for the event. This field c
 * {prodname} version
 * Connector type and name
 * Database and schema names
-* Timestamp
+* Timestamp for when the change was made in the database
 * If the event was part of a snapshot
 * Name of the table that contains the new row
 * Server log offsets
@@ -754,7 +754,9 @@ a|Mandatory string that describes the type of operation that caused the connecto
 
 |10
 |`ts_ms`
-a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task. +
+ +
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
 
@@ -784,7 +786,7 @@ The value of a change event for an update in the sample `customers` table has th
       "version": "{debezium-version}",
       "connector": "sqlserver",
       "name": "server1",
-      "ts_sec": 1559729995937,
+      "ts_ms": 1559729995937,
       "snapshot": false,
       "db": "testDB",
       "schema": "dbo",
@@ -794,7 +796,7 @@ The value of a change event for an update in the sample `customers` table has th
       "event_serial_no": "2"
     },
     "op": "u", // <4>
-    "ts_ms": 1559729998706
+    "ts_ms": 1559729998706  // <5>
   }
 }
 ----
@@ -820,7 +822,7 @@ a|Mandatory field that describes the source metadata for the event. The `source`
 * {prodname} version
 * Connector type and name
 * Database and schema names
-* Timestamp
+* Timestamp for when the change was made in the database
 * If the event was part of a snapshot
 * Name of the table that contains the new row
 * Server log offsets
@@ -835,6 +837,13 @@ Both operations share the same commit and change LSN and their event numbers are
 |4
 |`op`
 a|Mandatory string that describes the type of operation. In an _update_ event value, the `op` field value is `u`, signifying that this row changed because of an update.
+
+|5
+|`ts_ms`
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.  +
+ +
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
+
 
 |===
 
@@ -865,7 +874,7 @@ The value in a _delete_ change event has the same `schema` portion as _create_ a
       "version": "{debezium-version}",
       "connector": "sqlserver",
       "name": "server1",
-      "ts_sec": 1559730445243,
+      "ts_ms": 1559730445243,
       "snapshot": false,
       "db": "testDB",
       "schema": "dbo",
@@ -900,7 +909,7 @@ a|Mandatory field that describes the source metadata for the event. In a _delete
 * {prodname} version
 * Connector type and name
 * Database and schema names
-* Timestamp
+* Timestamp for when the change was made in the database
 * If the event was part of a snapshot
 * Name of the table that contains the new row
 * Server log offsets
@@ -911,7 +920,9 @@ a|Mandatory string that describes the type of operation. The `op` field value is
 
 |5
 |`ts_ms`
-a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.  +
+ +
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
 


### PR DESCRIPTION
[DBZ-2584](https://issues.redhat.com/browse/DBZ-2584) asks for clarifications in the descriptions of change data events. 
I made the following changes:
- Replace `ts_sec` with `ts_ms`
- Add that `source.ts_ms` is the timestamp of the change in the database
- Add that `payload.ms_ts` can be compared with `source.ts_ms` to determine lag

I did this for each connector that has downstream doc. 
I did a separate commit for each connector. 

It would be great to get this correction into the downstream Q3 published documentation. So let me know if this can be backported to 1.2. But if not, we can manually  update the downstream files. Please let me know about this. 