### PR TITLE
DBZ-2669 Explicitly specifying source directories for Checkstyle;

### DIFF
--- a/debezium-microbenchmark/pom.xml
+++ b/debezium-microbenchmark/pom.xml
@@ -79,13 +79,6 @@
         </resources>
         <plugins>
             <plugin>
-                 <groupId>org.apache.maven.plugins</groupId>
-                 <artifactId>maven-checkstyle-plugin</artifactId>
-                 <configuration>
-                     <excludes>**/generated/**</excludes>
-                 </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -866,6 +866,10 @@
                     <linkXRef>false</linkXRef>
                     <violationSeverity>error</violationSeverity>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <sourceDirectories>
+                        <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                        <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
+                    </sourceDirectories>
                 </configuration>
                 <executions>
                     <execution>

--- a/support/checkstyle/src/main/resources/checkstyle-suppressions.xml
+++ b/support/checkstyle/src/main/resources/checkstyle-suppressions.xml
@@ -6,22 +6,9 @@
     Checkstyle file which allow for custom file/package exclusions
 -->
 <suppressions>
-    <!--we're only including the PG driver temporarily (hopefully) so we don't want to checkstyle it...-->
-    <suppress checks="." files="[\\/]org[\\/]postgresql[\\/].*\.java$"/>
-    <!--exclude any protobuf generated files-->
-    <suppress checks="." files=".[\\/]io[\\/]debezium[\\/]connector[\\/]postgresql[\\/]proto[\\/].*\.java$"/>
-
-    <!--exclude any antlr generated files-->
-    <suppress checks="." files=".[\\/]io[\\/]debezium[\\/]ddl[\\/]parser[\\/]mysql[\\/]generated[\\/].*\.java$"/>
-    <suppress checks="." files=".[\\/]io[\\/]debezium[\\/]ddl[\\/]parser[\\/]oracle[\\/]generated[\\/].*\.java$"/>
-
     <!--exclude files from antlr which has to be copied into the module, because they are not included in library-->
     <suppress checks="." files=".[\\/]io[\\/]debezium[\\/]antlr[\\/]CaseChangingCharStream\.java$"/>
     <suppress checks="." files=".[\\/]io[\\/]debezium[\\/]antlr[\\/]ProxyParseTreeListener\.java$"/>
 
     <suppress checks="." files=".[\\/]io[\\/]debezium[\\/]util[\\/]BoundedConcurrentHashMap\.java$"/>
-
-    <!--exclude quarkus generated files-->
-    <suppress checks="." files=".[\\/]annotations[\\/]io[\\/]debezium[\\/]outbox[\\/]quarkus[\\/]internal[\\/].*\.java$" />
-    <suppress checks="." files=".[\\/]annotations[\\/]io[\\/]debezium[\\/]outbox[\\/]quarkus[\\/].*\.java$" />
 </suppressions>


### PR DESCRIPTION
That way, any generated sources won't be parsed to begin with, instead of only discarding their violations. This saves ~30 sec. for the DDL parser module.

https://issues.redhat.com/browse/DBZ-2669