### PR TITLE
DBZ-2617 Failing heartbeats should put Postgres connector into FAILED state

### DIFF
--- a/debezium-core/src/main/java/io/debezium/heartbeat/DatabaseHeartbeatImpl.java
+++ b/debezium-core/src/main/java/io/debezium/heartbeat/DatabaseHeartbeatImpl.java
@@ -6,6 +6,7 @@
 package io.debezium.heartbeat;
 
 import java.sql.SQLException;
+import java.time.Duration;
 import java.util.Map;
 
 import org.apache.kafka.common.config.ConfigDef;
@@ -13,8 +14,6 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.debezium.DebeziumException;
-import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.function.BlockingConsumer;
 import io.debezium.jdbc.JdbcConnection;
@@ -36,12 +35,15 @@ public class DatabaseHeartbeatImpl extends HeartbeatImpl {
 
     private final String heartBeatActionQuery;
     private final JdbcConnection jdbcConnection;
+    private final HeartbeatErrorHandler errorHandler;
 
-    DatabaseHeartbeatImpl(Configuration configuration, String topicName, String key, JdbcConnection jdbcConnection, String heartBeatActionQuery) {
-        super(configuration, topicName, key);
+    DatabaseHeartbeatImpl(Duration heartbeatInterval, String topicName, String key, JdbcConnection jdbcConnection, String heartBeatActionQuery,
+                          HeartbeatErrorHandler errorHandler) {
+        super(heartbeatInterval, topicName, key);
 
         this.heartBeatActionQuery = heartBeatActionQuery;
         this.jdbcConnection = jdbcConnection;
+        this.errorHandler = errorHandler;
     }
 
     @Override
@@ -50,15 +52,10 @@ public class DatabaseHeartbeatImpl extends HeartbeatImpl {
             jdbcConnection.execute(heartBeatActionQuery);
         }
         catch (SQLException e) {
-            String sqlErrorId = e.getSQLState();
-            switch (sqlErrorId) {
-                case "57P01": // Postgres error admin_shutdown, see https://www.postgresql.org/docs/12/errcodes-appendix.html
-                case "57P03": // Postgres error cannot_connect_now, see https://www.postgresql.org/docs/12/errcodes-appendix.html
-                    throw new DebeziumException("Could not execute heartbeat action (Error: " + sqlErrorId + ")", e);
-                default:
-                    LOGGER.error("Could not execute heartbeat action (Error: " + sqlErrorId + ")", e);
-                    break;
+            if (errorHandler != null) {
+                errorHandler.onError(e);
             }
+            LOGGER.error("Could not execute heartbeat action (Error: " + e.getSQLState() + ")", e);
         }
         LOGGER.debug("Executed heartbeat action query");
 

--- a/debezium-core/src/main/java/io/debezium/heartbeat/Heartbeat.java
+++ b/debezium-core/src/main/java/io/debezium/heartbeat/Heartbeat.java
@@ -5,23 +5,21 @@
  */
 package io.debezium.heartbeat;
 
-import java.time.temporal.ChronoUnit;
+import java.time.Duration;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.connect.source.SourceRecord;
 
-import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.function.BlockingConsumer;
 import io.debezium.jdbc.JdbcConnection;
 
 /**
  * A class that is able to generate periodic heartbeat messages based on a pre-configured interval. The clients are
- * supposed to call method {@link #heartbeat(Consumer)} from a main loop of a connector.
+ * supposed to call method {@link #heartbeat(Map, Map, BlockingConsumer)} from a main loop of a connector.
  *
  * @author Jiri Pechanec
  *
@@ -40,7 +38,7 @@ public interface Heartbeat {
         Map<String, ?> offset();
     }
 
-    public static final Field HEARTBEAT_INTERVAL = Field.create(HEARTBEAT_INTERVAL_PROPERTY_NAME)
+    Field HEARTBEAT_INTERVAL = Field.create(HEARTBEAT_INTERVAL_PROPERTY_NAME)
             .withDisplayName("Connector heartbeat interval (milli-seconds)")
             .withType(Type.INT)
             .withWidth(Width.MEDIUM)
@@ -52,7 +50,7 @@ public interface Heartbeat {
             .withDefault(HeartbeatImpl.DEFAULT_HEARTBEAT_INTERVAL)
             .withValidation(Field::isNonNegativeInteger);
 
-    public static final Field HEARTBEAT_TOPICS_PREFIX = Field.create("heartbeat.topics.prefix")
+    Field HEARTBEAT_TOPICS_PREFIX = Field.create("heartbeat.topics.prefix")
             .withDisplayName("A prefix used for naming of heartbeat topics")
             .withType(Type.STRING)
             .withWidth(Width.MEDIUM)
@@ -64,7 +62,7 @@ public interface Heartbeat {
     /**
      * No-op Heartbeat implementation
      */
-    Heartbeat NULL = new Heartbeat() {
+    Heartbeat DEFAULT_NOOP_HEARTBEAT = new Heartbeat() {
 
         @Override
         public void heartbeat(Map<String, ?> partition, Map<String, ?> offset, BlockingConsumer<SourceRecord> consumer) throws InterruptedException {
@@ -94,8 +92,7 @@ public interface Heartbeat {
      * @param offset offset for the heartbeat record
      * @param consumer - a code to place record among others to be sent into Connect
      */
-    // TODO would be nice to pass OffsetContext here; not doing it for now, though, until MySQL is using OffsetContext,
-    // too
+    // TODO would be nice to pass OffsetContext here; not doing it for now, though, until MySQL is using OffsetContext, too
     void heartbeat(Map<String, ?> partition, Map<String, ?> offset, BlockingConsumer<SourceRecord> consumer) throws InterruptedException;
 
     /**
@@ -114,8 +111,7 @@ public interface Heartbeat {
      * @param offset offset for the heartbeat record
      * @param consumer - a code to place record among others to be sent into Connect
      */
-    // TODO would be nice to pass OffsetContext here; not doing it for now, though, until MySQL is using OffsetContext,
-    // too
+    // TODO would be nice to pass OffsetContext here; not doing it for now, though, until MySQL is using OffsetContext, too
     void forcedBeat(Map<String, ?> partition, Map<String, ?> offset, BlockingConsumer<SourceRecord> consumer) throws InterruptedException;
 
     /**
@@ -126,33 +122,24 @@ public interface Heartbeat {
     /**
      * Provide an instance of Heartbeat object
      *
-     * @param configuration connector configuration
+     * @param heartbeatInterval heartbeat interval config value as java.time.Duration
      * @param topicName topic to which the heartbeat messages will be sent
      * @param key kafka partition key to use for the heartbeat message
      */
-    static Heartbeat create(Configuration configuration, String topicName, String key) {
-        return configuration.getDuration(HeartbeatImpl.HEARTBEAT_INTERVAL, ChronoUnit.MILLIS).isZero() ? NULL : new HeartbeatImpl(configuration, topicName, key);
+    static Heartbeat create(Duration heartbeatInterval, String topicName, String key) {
+        return heartbeatInterval.isZero() ? DEFAULT_NOOP_HEARTBEAT : new HeartbeatImpl(heartbeatInterval, topicName, key);
     }
 
-    /**
-     * Provide an instance of Heartbeat object
-     *
-     * @param configuration connector configuration
-     * @param topicName topic to which the heartbeat messages will be sent
-     * @param key kafka partition key to use for the heartbeat message
-     * @param jdbcConnection a database connection
-     */
-    static Heartbeat create(Configuration configuration, String topicName, String key, JdbcConnection jdbcConnection) {
-        if (configuration.getDuration(HeartbeatImpl.HEARTBEAT_INTERVAL, ChronoUnit.MILLIS).isZero()) {
-            return NULL;
+    static Heartbeat create(Duration heartbeatInterval, String heartbeatQuery, String topicName, String key, JdbcConnection jdbcConnection,
+                            HeartbeatErrorHandler errorHandler) {
+        if (heartbeatInterval.isZero()) {
+            return DEFAULT_NOOP_HEARTBEAT;
         }
 
-        String heartBeatActionQuery = configuration.getString(DatabaseHeartbeatImpl.HEARTBEAT_ACTION_QUERY);
-
-        if (heartBeatActionQuery != null) {
-            return new DatabaseHeartbeatImpl(configuration, topicName, key, jdbcConnection, heartBeatActionQuery);
+        if (heartbeatQuery != null) {
+            return new DatabaseHeartbeatImpl(heartbeatInterval, topicName, key, jdbcConnection, heartbeatQuery, errorHandler);
         }
 
-        return new HeartbeatImpl(configuration, topicName, key);
+        return new HeartbeatImpl(heartbeatInterval, topicName, key);
     }
 }

--- a/debezium-core/src/main/java/io/debezium/heartbeat/Heartbeat.java
+++ b/debezium-core/src/main/java/io/debezium/heartbeat/Heartbeat.java
@@ -28,7 +28,7 @@ import io.debezium.jdbc.JdbcConnection;
  */
 public interface Heartbeat {
 
-    public static final String HEARTBEAT_INTERVAL_PROPERTY_NAME = "heartbeat.interval.ms";
+    String HEARTBEAT_INTERVAL_PROPERTY_NAME = "heartbeat.interval.ms";
 
     /**
      * Returns the offset to be used when emitting a heartbeat event. This supplier
@@ -36,7 +36,7 @@ public interface Heartbeat {
      * actually is sent, in cases where it's determination is costly.
      */
     @FunctionalInterface
-    public static interface OffsetProducer {
+    interface OffsetProducer {
         Map<String, ?> offset();
     }
 
@@ -64,7 +64,7 @@ public interface Heartbeat {
     /**
      * No-op Heartbeat implementation
      */
-    public static final Heartbeat NULL = new Heartbeat() {
+    Heartbeat NULL = new Heartbeat() {
 
         @Override
         public void heartbeat(Map<String, ?> partition, Map<String, ?> offset, BlockingConsumer<SourceRecord> consumer) throws InterruptedException {
@@ -130,7 +130,7 @@ public interface Heartbeat {
      * @param topicName topic to which the heartbeat messages will be sent
      * @param key kafka partition key to use for the heartbeat message
      */
-    public static Heartbeat create(Configuration configuration, String topicName, String key) {
+    static Heartbeat create(Configuration configuration, String topicName, String key) {
         return configuration.getDuration(HeartbeatImpl.HEARTBEAT_INTERVAL, ChronoUnit.MILLIS).isZero() ? NULL : new HeartbeatImpl(configuration, topicName, key);
     }
 
@@ -142,7 +142,7 @@ public interface Heartbeat {
      * @param key kafka partition key to use for the heartbeat message
      * @param jdbcConnection a database connection
      */
-    public static Heartbeat create(Configuration configuration, String topicName, String key, JdbcConnection jdbcConnection) {
+    static Heartbeat create(Configuration configuration, String topicName, String key, JdbcConnection jdbcConnection) {
         if (configuration.getDuration(HeartbeatImpl.HEARTBEAT_INTERVAL, ChronoUnit.MILLIS).isZero()) {
             return NULL;
         }

--- a/debezium-core/src/main/java/io/debezium/heartbeat/HeartbeatErrorHandler.java
+++ b/debezium-core/src/main/java/io/debezium/heartbeat/HeartbeatErrorHandler.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.heartbeat;
+
+import java.sql.SQLException;
+
+public interface HeartbeatErrorHandler {
+
+    HeartbeatErrorHandler DEFAULT_NOOP_ERRORHANDLER = exception -> {
+    };
+
+    void onError(SQLException exception) throws RuntimeException;
+
+}

--- a/debezium-core/src/main/java/io/debezium/heartbeat/HeartbeatImpl.java
+++ b/debezium-core/src/main/java/io/debezium/heartbeat/HeartbeatImpl.java
@@ -7,7 +7,6 @@ package io.debezium.heartbeat;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
@@ -17,7 +16,6 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.debezium.config.Configuration;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.function.BlockingConsumer;
 import io.debezium.util.Clock;
@@ -27,8 +25,6 @@ import io.debezium.util.Threads.Timer;
 
 /**
  * Default implementation of Heartbeat
- *
- * @author Jiri Pechanec
  *
  */
 class HeartbeatImpl implements Heartbeat {
@@ -49,11 +45,11 @@ class HeartbeatImpl implements Heartbeat {
 
     private static final String SERVER_NAME_KEY = "serverName";
 
-    private static Schema KEY_SCHEMA = SchemaBuilder.struct()
+    private static final Schema KEY_SCHEMA = SchemaBuilder.struct()
             .name(schemaNameAdjuster.adjust("io.debezium.connector.common.ServerNameKey"))
             .field(SERVER_NAME_KEY, Schema.STRING_SCHEMA)
             .build();
-    private static Schema VALUE_SCHEMA = SchemaBuilder.struct()
+    private static final Schema VALUE_SCHEMA = SchemaBuilder.struct()
             .name(schemaNameAdjuster.adjust("io.debezium.connector.common.Heartbeat"))
             .field(AbstractSourceInfo.TIMESTAMP_KEY, Schema.INT64_SCHEMA)
             .build();
@@ -64,11 +60,10 @@ class HeartbeatImpl implements Heartbeat {
 
     private volatile Timer heartbeatTimeout;
 
-    HeartbeatImpl(Configuration configuration, String topicName, String key) {
+    HeartbeatImpl(Duration heartbeatInterval, String topicName, String key) {
         this.topicName = topicName;
         this.key = key;
-
-        heartbeatInterval = configuration.getDuration(HeartbeatImpl.HEARTBEAT_INTERVAL, ChronoUnit.MILLIS);
+        this.heartbeatInterval = heartbeatInterval;
         heartbeatTimeout = resetHeartbeat();
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.pipeline;
 
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -20,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
 import io.debezium.connector.SnapshotRecord;
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.data.Envelope;
@@ -115,7 +117,10 @@ public class EventDispatcher<T extends DataCollectionId> {
             heartbeat = customHeartbeat;
         }
         else {
-            heartbeat = Heartbeat.create(connectorConfig.getConfig(), topicSelector.getHeartbeatTopic(),
+            Configuration configuration = connectorConfig.getConfig();
+            heartbeat = Heartbeat.create(
+                    configuration.getDuration(Heartbeat.HEARTBEAT_INTERVAL, ChronoUnit.MILLIS),
+                    topicSelector.getHeartbeatTopic(),
                     connectorConfig.getLogicalName());
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <quarkus.version>1.7.1.Final</quarkus.version>
 
         <!-- HTTP client -->
-        <version.okhttp>4.2.2</version.okhttp>
+        <version.okhttp>4.8.1</version.okhttp>
 
         <!-- Scripting -->
         <version.groovy>3.0.2</version.groovy>
@@ -99,7 +99,6 @@
         <version.awaitility>4.0.1</version.awaitility>
         <version.testcontainers>1.12.5</version.testcontainers>
         <version.jsonpath>2.4.0</version.jsonpath>
-        <version.okhttp>4.2.2</version.okhttp>
 
         <!-- Maven Plugins -->
         <version.compiler.plugin>3.8.1</version.compiler.plugin>


### PR DESCRIPTION
DBZ-2617 Failing heartbeats should put Postgres connector into FAILED state to allow proper shutdown of Postgres when shutdown was triggered with shutdown mode "fast"

closes https://issues.redhat.com/browse/DBZ-2617
