### PR TITLE
DBZ-2681 Two more small corrections, and move one anchor ID inside upstream-only content

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
@@ -99,6 +99,7 @@ To provide the needed Kafka record format for consumers, configure the event fla
 // Type: concept
 // ModuleID: behavior-of-debezium-event-flattening-transformation
 // Behavior of {prodname} event flattening transformation
+[[event-flattening-behavior]]
 == Behavior
 
 The event flattening SMT extracts the `after` field from a {prodname} change event in a Kafka record. The SMT replaces the original change event with only its `after` field to create a simple Kafka record. 

--- a/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
@@ -98,7 +98,7 @@ To provide the needed Kafka record format for consumers, configure the event fla
 
 // Type: concept
 // ModuleID: behavior-of-debezium-event-flattening-transformation
-// Behavior of {prodname} event flattening transformation
+// Title: Behavior of {prodname} event flattening transformation
 [[event-flattening-behavior]]
 == Behavior
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1484,8 +1484,6 @@ The above example assumes that you extracted the {prodname} Db2 connector to the
 
 endif::product[]
 
-[[db2-example]]
-
 // Type: concept
 // ModuleID: debezium-db2-connector-configuration-example
 // Title: {prodname} Db2 connector configuration example
@@ -1493,6 +1491,8 @@ endif::product[]
 === Connector configuration example
 
 ifdef::community[]
+
+[[db2-example]]
 
 Following is an example of the configuration for a Db2 connector that connects to a Db2 server on port 50000 at 192.168.99.100, whose logical name is `fullfillment`. Typically, you configure the {prodname} Db2 connector in a `.json` file using the configuration properties available for the connector.
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1484,10 +1484,11 @@ The above example assumes that you extracted the {prodname} Db2 connector to the
 
 endif::product[]
 
+[[db2-example]]
+
 // Type: concept
 // ModuleID: debezium-db2-connector-configuration-example
 // Title: {prodname} Db2 connector configuration example
-[[db2-example]]
 [[db2-example-configuration]]
 === Connector configuration example
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2495,7 +2495,7 @@ The {prodname} MySQL connector also provides the following custom binlog metrics
 |`long`
 |The number of processed transactions that were rolled back and not streamed.
 
-|[[number-of-not-well-formed-transactions]]<<number-of-not-well-formed-transactions.`NumberOfNotWell{zwsp}FormedTransactions`>>
+|[[number-of-not-well-formed-transactions]]<<number-of-not-well-formed-transactions,`NumberOfNotWell{zwsp}FormedTransactions`>>
 |`long`
 |The number of transactions that have not conformed to the expected protocol of `BEGIN` + `COMMIT`/`ROLLBACK`. This value should be `0` under normal conditions.
 
@@ -2506,7 +2506,7 @@ The {prodname} MySQL connector also provides the following custom binlog metrics
 |===
 
 // Type: reference
-// ModuleID: monitoring-debezium-mysql-connector-schema history
+// ModuleID: monitoring-debezium-mysql-connector-schema-history
 // Title: Monitoring {prodname} MySQL connector schema history
 [[mysql-schema-history-metrics]]
 === Schema history metrics

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -30,7 +30,8 @@ Information and procedures for using a {prodname} PostgreSQL connector is organi
 * xref:descriptions-of-debezium-postgresql-connector-data-change-events[]
 * xref:how-debezium-postgresql-connectors-map-data-types[]
 * xref:setting-up-postgresql-to-run-a-debezium-connector[]
-* xref:deploying-and-managing-debezium-postgresql-connectors[]
+* xref:deployment-of-debezium-postgresql-connectors[]
+* xref:monitoring-debezium-postgresql-connector-performance[]
 * xref:how-debezium-postgresql-connectors-handle-faults-and-problems[]
 
 endif::product[]
@@ -501,11 +502,6 @@ Details are in the following topics:
 
 * xref:about-keys-in-debezium-postgresql-change-events[]
 * xref:about-values-in-debezium-postgresql-change-events[]
-* xref:how-replica-identity-controls-data-that-can-be-in-debezium-postgresql-change-events[]
-* xref:about-debezium-postgresql-change-events-for-operations-that-create-content[]
-* xref:about-debezium-postgresql-change-events-for-operations-that-update-content[]
-* xref:about-debezium-postgresql-change-events-for-primary-key-updates[]
-* xref:about-debezium-postgresql-change-events-for-operations-that-delete-content[]
 
 endif::product[]
 
@@ -992,6 +988,7 @@ as a primary key change. For a primary key change, in place of sending an `UPDAT
 
 * The `CREATE` event record has `__debezium.oldkey` as a message header. The value of this header is the previous (old) primary key that the updated row had.
 
+// Type: continue
 [[postgresql-delete-events]]
 === _delete_ events
 
@@ -1989,7 +1986,7 @@ For example, from a terminal window, enter the following:
 +
 [subs="+macros,+attributes"]
 ----
-pass:quotes[*cat <<EOF >debezium-container-for-postgresql.yaml*] // <1>
+pass:quotes[*cat &lt;&lt;EOF &gt;debezium-container-for-postgresql.yaml*] // <1>
 pass:quotes[*FROM {DockerKafkaConnect}*]
 pass:quotes[*USER root:root*]
 pass:quotes[*COPY ./my-plugins/ /opt/kafka/plugins/*] // <2>
@@ -1998,7 +1995,7 @@ pass:quotes[*EOF*]
 ----
 <1> You can specify any file name that you want.
 <2> Replace `my-plugins` with the name of your plug-ins directory.
-
++
 The command creates a Docker file with the name `debezium-container-for-postgresql.yaml` in the current directory.
 
 .. Build the container image from the `debezium-container-for-postgresql.yaml` Docker file that you created in the previous step. From the directory that contains the file, run the following command:
@@ -2021,7 +2018,7 @@ podman push debezium-container-for-postgresql:latest
 +
 [source,yaml,subs="+attributes"]
 ----
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnect
 metadata:
   name: my-connect-cluster
@@ -2048,9 +2045,9 @@ You configure a {prodname} PostgreSQL connector in a `.yaml` file that sets conn
 The following example configures a {prodname} connector that connects to a PostgreSQL server host, `192.168.99.100`, on port `5432`. This host has a database named `sampledb`, a schema named `public`, and `fulfillment` is the server's logical name. 
 +
 .`fulfillment-connector.yaml`
-[source,yaml,options="nowrap"]
+[source,yaml,options="nowrap",subs="+attributes"]
 ----
-apiVersion: kafka.strimzi.io/v1alpha1
+apiVersion: {KafkaConnectorApiVersion}
   kind: KafkaConnector
   metadata:
     name: fulfillment-connector  // <1>

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2297,7 +2297,7 @@ If the publication already exists, either for all tables or configured with a su
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you want to capture. Any table not included in `table.include.list` does not have its changes captured. Each identifier is of the form _schemaName_._tableName_. By default, the connector captures changes in every non-system table in each schema whose changes are being captured. Do not also set the `table.exclude.list` property.
 
 |[[postgresql-property-table-blacklist]]
-[[postgresql-property-table-exclude.list]]<<postgresql-property-table-exclude.list, `table.exclude{zwsp}.list`>>
+[[postgresql-property-table-exclude-list]]<<postgresql-property-table-exclude-list, `table.exclude{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you *do not* want to capture. Any table not included in `table.exclude.list` has it changes captured. Each identifier is of the form _schemaName_._tableName_. Do not also set the `table.include.list` property.
 


### PR DESCRIPTION
`[DBZ-2681](https://issues.redhat.com/browse/DBZ-2681)`

I missed three needed corrections downstream. With these updates, I think we are all set downstream. Thanks!

No need to backport to 1.2. 