### PR TITLE
DBZ-2681 From a new branch, two fixes, and moved one anchor ID into upstream-only content

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/configuration/event-flattening.adoc
@@ -98,7 +98,7 @@ To provide the needed Kafka record format for consumers, configure the event fla
 
 // Type: concept
 // ModuleID: behavior-of-debezium-event-flattening-transformation
-// Behavior of {prodname} event flattening transformation
+// Title: Behavior of {prodname} event flattening transformation
 [[event-flattening-behavior]]
 == Behavior
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1484,8 +1484,6 @@ The above example assumes that you extracted the {prodname} Db2 connector to the
 
 endif::product[]
 
-[[db2-example]]
-
 // Type: concept
 // ModuleID: debezium-db2-connector-configuration-example
 // Title: {prodname} Db2 connector configuration example
@@ -1493,6 +1491,8 @@ endif::product[]
 === Connector configuration example
 
 ifdef::community[]
+
+[[db2-example]]
 
 Following is an example of the configuration for a Db2 connector that connects to a Db2 server on port 50000 at 192.168.99.100, whose logical name is `fullfillment`. Typically, you configure the {prodname} Db2 connector in a `.json` file using the configuration properties available for the connector.
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2297,7 +2297,7 @@ If the publication already exists, either for all tables or configured with a su
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you want to capture. Any table not included in `table.include.list` does not have its changes captured. Each identifier is of the form _schemaName_._tableName_. By default, the connector captures changes in every non-system table in each schema whose changes are being captured. Do not also set the `table.exclude.list` property.
 
 |[[postgresql-property-table-blacklist]]
-[[postgresql-property-table-exclude.list]]<<postgresql-property-table-exclude.list, `table.exclude{zwsp}.list`>>
+[[postgresql-property-table-exclude-list]]<<postgresql-property-table-exclude-list, `table.exclude{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you *do not* want to capture. Any table not included in `table.exclude.list` has it changes captured. Each identifier is of the form _schemaName_._tableName_. Do not also set the `table.include.list` property.
 


### PR DESCRIPTION
I re-opened [DBZ-2681](https://issues.redhat.com/browse/DBZ-2681) because I missed three updates needed for downstream rendering. I accidentally added on to the previous PR, which was merged, so I cancelled that and created a new topic branch and pushed from that. Sorry for any confusion!

I think this should be the last of the needed tweaks for downstream. I'll fetch from master as soon as this is merged. 
No need to back port to 1.2.  THANKS in advance for merging this. 

@jpechane and @Naros 
