### PR TITLE
DBZ-2673 Read the raw bytes of a character-type field

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -169,6 +169,12 @@ public class SnapshotReader extends AbstractReader {
             // read it again to get correct scale
             return rs.getObject(fieldNo) == null ? null : rs.getInt(fieldNo);
         }
+        // DBZ-2673
+        else if (actualColumn.typeName().equals("CHAR") ||
+                actualColumn.typeName().equals("VARCHAR") ||
+                actualColumn.typeName().equals("TEXT")) {
+            return rs.getBytes(fieldNo);
+        }
         else {
             return rs.getObject(fieldNo);
         }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SnapshotReader.java
@@ -170,9 +170,11 @@ public class SnapshotReader extends AbstractReader {
             return rs.getObject(fieldNo) == null ? null : rs.getInt(fieldNo);
         }
         // DBZ-2673
-        else if (actualColumn.typeName().equals("CHAR") ||
-                actualColumn.typeName().equals("VARCHAR") ||
-                actualColumn.typeName().equals("TEXT")) {
+        // It is necessary to check the type names as types like ENUM and SET are
+        // also reported as JDBC type char
+        else if ("CHAR".equals(actualColumn.typeName()) ||
+                "VARCHAR".equals(actualColumn.typeName()) ||
+                "TEXT".equals(actualColumn.typeName())) {
             return rs.getBytes(fieldNo);
         }
         else {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotReaderIT.java
@@ -190,6 +190,20 @@ public class SnapshotReaderIT {
         assertThat(customers.numberOfKeySchemaChanges()).isEqualTo(1);
         assertThat(customers.numberOfValueSchemaChanges()).isEqualTo(1);
 
+        List<Struct> customerRecrods = new ArrayList<>();
+        customers.forEach(val -> {
+            customerRecrods.add(((Struct) val.value()).getStruct("after"));
+        });
+
+        Struct customer = customerRecrods.stream().sorted((a, b) -> a.getInt32("id").compareTo(b.getInt32("id"))).findFirst().get();
+        assertThat(customer.get("first_name")).isInstanceOf(String.class);
+        assertThat(customer.get("last_name")).isInstanceOf(String.class);
+        assertThat(customer.get("email")).isInstanceOf(String.class);
+
+        assertThat(customer.get("first_name")).isEqualTo("Sally");
+        assertThat(customer.get("last_name")).isEqualTo("Thomas");
+        assertThat(customer.get("email")).isEqualTo("sally.thomas@acme.com");
+
         Collection orders = store.collection(DATABASE.getDatabaseName(), "orders");
         assertThat(orders.numberOfCreates()).isEqualTo(5);
         assertThat(orders.numberOfUpdates()).isEqualTo(0);
@@ -250,6 +264,7 @@ public class SnapshotReaderIT {
 
         MySQLConnection db = MySQLConnection.forTestDatabase(DATABASE.getDatabaseName());
         Thread t = new Thread() {
+            @Override
             public void run() {
                 try {
                     JdbcConnection connection = db.connect();


### PR DESCRIPTION
One of our legacy databases stores binary data in a MySQL CHAR(32) Latin1 field. Converting this field to binary would be the ideal solution but unfortunately isn't easily feasible. 

The problem lies in the fact that the MySQL JDBC driver converts MySQL's latin1 charset to Windows-1252 whereas our legacy system stores these bytes using IANA Latin1 (or ISO-8859-1) charset and these implementations do not have a 1:1 mapping. 

An elegant way to solve this issue is by using Debezium's newly supported custom converters (https://debezium.io/documentation/reference/1.3/development/converters.html). 

The only issue with this approach is that MySQL's `SnapshotReader` does not return char-type fields' raw bytes making it impossible to encode the char field's raw bytes into the desired charset. This PR fixes that. 