### PR TITLE
DBZ-2682: Mapper converters should leave empty dates as zero

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/TableSchemaBuilder.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableSchemaBuilder.java
@@ -344,13 +344,7 @@ public class TableSchemaBuilder {
             return converter;
         }
 
-        return (value) -> {
-            if (value != null) {
-                value = converter.convert(value);
-            }
-
-            return mappingConverter.convert(value);
-        };
+        return (value) -> mappingConverter.convert(converter.convert(value));
     }
 
     /**

--- a/debezium-core/src/test/java/io/debezium/junit/relational/TestRelationalDatabaseConfig.java
+++ b/debezium-core/src/test/java/io/debezium/junit/relational/TestRelationalDatabaseConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.junit.relational;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.SourceInfoStructMaker;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+import io.debezium.relational.Selectors;
+import io.debezium.relational.Tables;
+
+public class TestRelationalDatabaseConfig extends RelationalDatabaseConnectorConfig {
+
+    public TestRelationalDatabaseConfig(Configuration config, String logicalName, Tables.TableFilter systemTablesFilter,
+                                        Selectors.TableIdToStringMapper tableIdMapper, int defaultSnapshotFetchSize) {
+        super(config, logicalName, systemTablesFilter, tableIdMapper, defaultSnapshotFetchSize);
+    }
+
+    @Override
+    public String getContextName() {
+        return null;
+    }
+
+    @Override
+    public String getConnectorName() {
+        return null;
+    }
+
+    @Override
+    protected SourceInfoStructMaker<?> getSourceInfoStructMaker(Version version) {
+        return null;
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/relational/mapping/ColumnMappersTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/mapping/ColumnMappersTest.java
@@ -13,12 +13,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.debezium.config.Configuration;
-import io.debezium.connector.SourceInfoStructMaker;
+import io.debezium.junit.relational.TestRelationalDatabaseConfig;
 import io.debezium.relational.Column;
-import io.debezium.relational.RelationalDatabaseConnectorConfig;
-import io.debezium.relational.Selectors.TableIdToStringMapper;
 import io.debezium.relational.TableId;
-import io.debezium.relational.Tables.TableFilter;
 import io.debezium.relational.ValueConverter;
 import io.debezium.util.Strings;
 
@@ -34,29 +31,6 @@ public class ColumnMappersTest {
     private ColumnMappers mappers;
     private ValueConverter converter;
     private String fullyQualifiedNames;
-
-    private static class TestRelationalDatabaseConfig extends RelationalDatabaseConnectorConfig {
-
-        protected TestRelationalDatabaseConfig(Configuration config, String logicalName, TableFilter systemTablesFilter,
-                                               TableIdToStringMapper tableIdMapper, int defaultSnapshotFetchSize) {
-            super(config, logicalName, systemTablesFilter, tableIdMapper, defaultSnapshotFetchSize);
-        }
-
-        @Override
-        public String getContextName() {
-            return null;
-        }
-
-        @Override
-        public String getConnectorName() {
-            return null;
-        }
-
-        @Override
-        protected SourceInfoStructMaker<?> getSourceInfoStructMaker(Version version) {
-            return null;
-        }
-    }
 
     @Before
     public void beforeEach() {


### PR DESCRIPTION
1. Always call the underlying connector from the wrapper since it may convert NULL to a non-NULL.
2. Extract `TestRelationalDatabaseConfig` to a public class to be able to reuse it in the new test.