### PR TITLE
DBZ-2580 Fix "The primary key cannot reference a non-existant column" error

### DIFF
--- a/debezium-connector-mysql/src/test/resources/ddl/connector_test_ro.sql
+++ b/debezium-connector-mysql/src/test/resources/ddl/connector_test_ro.sql
@@ -4,7 +4,8 @@
 
 -- Create and populate our products using a single insert with many rows
 CREATE TABLE Products (
-  id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  PRIMARY KEY (id),
+  id INTEGER NOT NULL AUTO_INCREMENT,
   name VARCHAR(255) NOT NULL,
   description VARCHAR(512),
   weight FLOAT

--- a/debezium-core/src/main/java/io/debezium/relational/TableEditorImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableEditorImpl.java
@@ -13,12 +13,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 class TableEditorImpl implements TableEditor {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(TableEditorImpl.class);
 
     private TableId id;
     private LinkedHashMap<String, Column> sortedColumns = new LinkedHashMap<>();
@@ -106,7 +101,8 @@ class TableEditorImpl implements TableEditor {
             this.pkColumnNames.removeIf(pkColumnName -> {
                 final boolean pkColumnDoesNotExists = !hasColumnWithName(pkColumnName);
                 if (pkColumnDoesNotExists) {
-                    LOGGER.warn("The column \"" + pkColumnName + "\" is referenced as PRIMARY KEY, but a matching column is not defined in table \"" + tableId() + "\"!");
+                    throw new IllegalArgumentException(
+                            "The column \"" + pkColumnName + "\" is referenced as PRIMARY KEY, but a matching column is not defined in table \"" + tableId() + "\"!");
                 }
                 return pkColumnDoesNotExists;
             });

--- a/debezium-core/src/test/java/io/debezium/relational/TableEditorTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/TableEditorTest.java
@@ -6,10 +6,8 @@
 package io.debezium.relational;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import java.sql.Types;
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Before;
@@ -51,7 +49,7 @@ public class TableEditorTest {
         assertThat(table.primaryKeyColumnNames()).isEmpty();
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     @FixFor("DBZ-2580")
     public void shouldNotAllowAddingPrimaryKeyColumnWhenNotFound() {
         editor.tableId(id);
@@ -60,7 +58,7 @@ public class TableEditorTest {
         Column c2 = columnEditor.name("C2").type("NUMBER").jdbcType(Types.NUMERIC).length(5).position(1).create();
         Column c3 = columnEditor.name("C3").type("DATE").jdbcType(Types.DATE).position(1).create();
         editor.addColumns(c1, c2, c3);
-        assertEquals(Arrays.asList("C1"), editor.create().primaryKeyColumnNames());
+        editor.create();
     }
 
     @Test

--- a/debezium-core/src/test/java/io/debezium/relational/TableEditorTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/TableEditorTest.java
@@ -6,12 +6,16 @@
 package io.debezium.relational;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import java.sql.Types;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import io.debezium.doc.FixFor;
 
 public class TableEditorTest {
 
@@ -47,14 +51,16 @@ public class TableEditorTest {
         assertThat(table.primaryKeyColumnNames()).isEmpty();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
+    @FixFor("DBZ-2580")
     public void shouldNotAllowAddingPrimaryKeyColumnWhenNotFound() {
         editor.tableId(id);
+        editor.setPrimaryKeyNames("C1", "WOOPS");
         Column c1 = columnEditor.name("C1").type("VARCHAR").jdbcType(Types.VARCHAR).length(10).position(1).create();
         Column c2 = columnEditor.name("C2").type("NUMBER").jdbcType(Types.NUMERIC).length(5).position(1).create();
         Column c3 = columnEditor.name("C3").type("DATE").jdbcType(Types.DATE).position(1).create();
         editor.addColumns(c1, c2, c3);
-        editor.setPrimaryKeyNames("C1", "WOOPS");
+        assertEquals(Arrays.asList("C1"), editor.create().primaryKeyColumnNames());
     }
 
     @Test

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_create.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_create.sql
@@ -34,6 +34,7 @@ create table add_test(col1 varchar(255), col2 int, col3 int);
 create table blob_test(id int, col1 blob(45));
 CREATE TABLE `user_account` ( `id1` bigint(20) unsigned NOT NULL DEFAULT nextval(`useraccount`.`user_account_id_seq`));
 create table žluťoučký (kůň int);
+CREATE TABLE staff (PRIMARY KEY (staff_num), staff_num INT(5) NOT NULL, first_name VARCHAR(100) NOT NULL, pens_in_drawer INT(2) NOT NULL, CONSTRAINT pens_in_drawer_range CHECK(pens_in_drawer BETWEEN 1 AND 99));
 #end
 #begin
 -- Rename table


### PR DESCRIPTION
DBZ-2580 Fix "The primary key cannot reference a non-existant column" error from MySQL DDL parser when CREATE TABLE statement starts with a primary key definition like
```
CREATE TABLE Products (
    PRIMARY KEY (id),
 ...
)
```
where the referenced primary key column is not yet defined.

closes https://issues.redhat.com/browse/DBZ-2580
