### PR TITLE
DBZ-2440 Fix "The job exceeded the maximum log length, and has been terminated." Travis CI error for Debezium Server

### DIFF
--- a/debezium-server/debezium-server-core/src/test/resources/log4j.properties
+++ b/debezium-server/debezium-server-core/src/test/resources/log4j.properties
@@ -3,6 +3,7 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p     %m (%c)%n
+log4j.appender.stdout.threshold=WARN
 
 # Root logger option
 log4j.rootLogger=INFO, stdout

--- a/debezium-server/debezium-server-eventhubs/src/test/resources/log4j.properties
+++ b/debezium-server/debezium-server-eventhubs/src/test/resources/log4j.properties
@@ -3,6 +3,7 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p     %m (%c)%n
+log4j.appender.stdout.threshold=WARN
 
 # Root logger option
 log4j.rootLogger=INFO, stdout

--- a/debezium-server/debezium-server-kinesis/src/test/resources/log4j.properties
+++ b/debezium-server/debezium-server-kinesis/src/test/resources/log4j.properties
@@ -3,6 +3,7 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p     %m (%c)%n
+log4j.appender.stdout.threshold=WARN
 
 # Root logger option
 log4j.rootLogger=INFO, stdout

--- a/debezium-server/debezium-server-pubsub/src/test/resources/log4j.properties
+++ b/debezium-server/debezium-server-pubsub/src/test/resources/log4j.properties
@@ -3,6 +3,7 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p     %m (%c)%n
+log4j.appender.stdout.threshold=WARN
 
 # Root logger option
 log4j.rootLogger=INFO, stdout

--- a/debezium-server/debezium-server-pulsar/src/test/resources/log4j.properties
+++ b/debezium-server/debezium-server-pulsar/src/test/resources/log4j.properties
@@ -3,6 +3,7 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p     %m (%c)%n
+log4j.appender.stdout.threshold=WARN
 
 # Root logger option
 log4j.rootLogger=INFO, stdout


### PR DESCRIPTION
Fixing "The job exceeded the maximum log length, and has been terminated." error that we currently see on PR builds:
https://travis-ci.org/github/debezium/debezium/jobs/742916040
https://travis-ci.org/github/debezium/debezium/jobs/742894070

could be first part of: https://issues.redhat.com/browse/DBZ-2440
