### PR TITLE
DBZ-2775 add option for setting snapshot events as reads

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -880,6 +880,15 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
                     + "point, both old and new binlog readers will be momentarily halted and new binlog reader will start that will read the binlog for all "
                     + "configured tables. The parallel binlog reader will have a configured server id of 10000 + the primary binlog reader's server id.");
 
+    public static final Field SNAPSHOT_EVENTS_AS_INSERTS = Field.create("snapshot.events.as.inserts")
+            .withDisplayName("Mark initial table snapshot events as insert events (op 'c')")
+            .withType(Type.BOOLEAN)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.MEDIUM)
+            .withDescription("Whether or not to mark snapshot events as normal inserts (op 'c'). If disabled, the standard functionality of emitting these records as"
+                    + " reads (op 'r') will be used.")
+            .withDefault(true);
+
     public static final Field TIME_PRECISION_MODE = RelationalDatabaseConnectorConfig.TIME_PRECISION_MODE
             .withEnum(TemporalPrecisionMode.class, TemporalPrecisionMode.ADAPTIVE_TIME_MICROSECONDS)
             .withValidation(MySqlConnectorConfig::validateTimePrecisionMode)
@@ -948,7 +957,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
             RelationalDatabaseConnectorConfig.MASK_COLUMN_WITH_HASH,
             RelationalDatabaseConnectorConfig.MASK_COLUMN,
             RelationalDatabaseConnectorConfig.TRUNCATE_COLUMN,
-            SNAPSHOT_MODE, SNAPSHOT_NEW_TABLES, SNAPSHOT_LOCKING_MODE,
+            SNAPSHOT_MODE, SNAPSHOT_NEW_TABLES, SNAPSHOT_LOCKING_MODE, SNAPSHOT_EVENTS_AS_INSERTS,
             RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
             GTID_SOURCE_INCLUDES, GTID_SOURCE_EXCLUDES,
             GTID_SOURCE_FILTER_DML_EVENTS,
@@ -1042,7 +1051,7 @@ public class MySqlConnectorConfig extends RelationalDatabaseConnectorConfig {
                 CommonConnectorConfig.TOMBSTONES_ON_DELETE, CommonConnectorConfig.SOURCE_STRUCT_MAKER_VERSION);
         Field.group(config, "Connector", CONNECTION_TIMEOUT_MS, KEEP_ALIVE, KEEP_ALIVE_INTERVAL_MS, CommonConnectorConfig.MAX_QUEUE_SIZE,
                 CommonConnectorConfig.MAX_BATCH_SIZE, CommonConnectorConfig.POLL_INTERVAL_MS,
-                SNAPSHOT_MODE, SNAPSHOT_LOCKING_MODE, SNAPSHOT_NEW_TABLES, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE,
+                SNAPSHOT_MODE, SNAPSHOT_LOCKING_MODE, SNAPSHOT_NEW_TABLES, SNAPSHOT_EVENTS_AS_INSERTS, TIME_PRECISION_MODE, DECIMAL_HANDLING_MODE,
                 BIGINT_UNSIGNED_HANDLING_MODE, SNAPSHOT_DELAY_MS, SNAPSHOT_FETCH_SIZE, ENABLE_TIME_ADJUSTER, BINARY_HANDLING_MODE);
         return config;
     }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -69,7 +69,7 @@ public final class MySqlConnectorTask extends BaseSourceTask {
         try {
             // Get the offsets for our partition ...
             boolean startWithSnapshot = false;
-            boolean snapshotEventsAreInserts = true;
+            boolean snapshotEventsAsInserts = config.getBoolean(MySqlConnectorConfig.SNAPSHOT_EVENTS_AS_INSERTS);
             Map<String, String> partition = Collect.hashMapOf(SourceInfo.SERVER_PARTITION_KEY, serverName);
             Map<String, ?> offsets = getRestartOffset(context.offsetStorageReader().offset(partition));
             final SourceInfo source;
@@ -188,7 +188,7 @@ public final class MySqlConnectorTask extends BaseSourceTask {
             if (startWithSnapshot) {
                 // We're supposed to start with a snapshot, so set that up ...
                 SnapshotReader snapshotReader = new SnapshotReader("snapshot", taskContext);
-                if (snapshotEventsAreInserts) {
+                if (snapshotEventsAsInserts) {
                     snapshotReader.generateInsertEvents();
                 }
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotReaderIT.java
@@ -347,12 +347,14 @@ public class SnapshotReaderIT {
 
     @Test
     public void shouldCreateSnapshotOfSingleDatabaseUsingReadEvents() throws Exception {
-        config = simpleConfig().with(MySqlConnectorConfig.DATABASE_INCLUDE_LIST, "connector_(.*)_" + DATABASE.getIdentifier()).build();
+        config = simpleConfig()
+                .with(MySqlConnectorConfig.DATABASE_INCLUDE_LIST, "connector_(.*)_" + DATABASE.getIdentifier())
+                .with(MySqlConnectorConfig.SNAPSHOT_EVENTS_AS_INSERTS, false)
+                .build();
         context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
         reader = new SnapshotReader("snapshot", context);
         reader.uponCompletion(completed::countDown);
-        reader.generateReadEvents();
 
         // Start the snapshot ...
         reader.start();

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2332,6 +2332,10 @@ For each table that you specify, also specify another configuration property: `s
  +
 A possible use case for setting these properties is large, append-only tables. You can specify a `SELECT` statement that sets a specific point for where to start a snapshot, or where to resume a snapshot if a previous snapshot was interrupted.
 
+|[[mysql-property-snapshot-events-as-inserts]]<<mysql-property-snapshot-events-as-inserts, `snapshot.events{zwsp}.as{zwsp}.inserts`>>
+|`true`
+|Controls whether or not to mark snapshot events as insert events (`"op": "c"`). If disabled, the Debezium default of marking snapshot events as reads (`"op": "r"`) will be used.
+
 |[[mysql-property-min-row-count-to-stream-results]]<<mysql-property-min-row-count-to-stream-results, `min.row.count.to{zwsp}.stream.results`>>
 |`1000`
 |During a snapshot, the connector queries each table for which the connector is configured to capture changes. The connector uses each query result to produce a read event that contains data for all rows in that table. This property determines whether the MySQL connector puts results for a table into memory, which is fast but requires large amounts of memory, or streams the results, which can be slower but work for very large tables. The setting of this property specifies the minimum number of rows a table must contain before the connector streams results. +


### PR DESCRIPTION
Adds a backwards compatible config for the mysql connectors snapshot events to be marked as reads.