### PR TITLE
[DBZ-2785] shut down Quarkus server if debezium-server crashes

### DIFF
--- a/debezium-server/debezium-server-core/src/main/java/io/debezium/server/DebeziumServer.java
+++ b/debezium-server/debezium-server-core/src/main/java/io/debezium/server/DebeziumServer.java
@@ -35,6 +35,7 @@ import io.debezium.engine.DebeziumEngine.ChangeConsumer;
 import io.debezium.engine.format.Avro;
 import io.debezium.engine.format.Json;
 import io.debezium.engine.format.Protobuf;
+import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.Startup;
 
@@ -136,7 +137,14 @@ public class DebeziumServer {
                 .using((DebeziumEngine.CompletionCallback) health)
                 .build();
 
-        executor.execute(() -> engine.run());
+        executor.execute(() -> {
+            try {
+                engine.run();
+            }
+            finally {
+                Quarkus.asyncExit();
+            }
+        });
         LOGGER.info("Engine executor started");
     }
 


### PR DESCRIPTION
edit: https://issues.redhat.com/projects/DBZ/issues/DBZ-2785

I've started this from the merge-base of 1.3, 1.4, and master to keep it easy to move if you don't want this as a patch on 1.3.

As mentioned on the ticket, I haven't actually used Quarkus before & don't have the bandwidth to learn it to the extent needed for proper testing.  I have, however, tested locally with a bad SQL password to verify that the fix works.