### PR TITLE
DBZ-2827 fix try-with-resources block should not be used when OkHttp Response object is returned

### DIFF
--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/DebeziumContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/DebeziumContainer.java
@@ -162,12 +162,11 @@ public class DebeziumContainer extends GenericContainer<DebeziumContainer> {
     }
 
     protected static Response executeGETRequestSuccessfully(Request request) {
-        try (final Response response = executeGETRequest(request)) {
-            if (!response.isSuccessful()) {
-                handleFailedResponse(response);
-            }
-            return response;
+        final Response response = executeGETRequest(request);
+        if (!response.isSuccessful()) {
+            handleFailedResponse(response);
         }
+        return response;
     }
 
     public boolean connectorIsNotRegistered(String connectorName) {


### PR DESCRIPTION
* fix try-with-resources block should not be used when OkHttp Response object is returned in DebeziumContainer

closes https://issues.redhat.com/browse/DBZ-2827
