### PR TITLE
DBZ-2808 Add Mongo DB default config helper to ConnectorConfiguration

### DIFF
--- a/debezium-testing/debezium-testing-testcontainers/pom.xml
+++ b/debezium-testing/debezium-testing-testcontainers/pom.xml
@@ -45,6 +45,10 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mongodb</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.easytesting</groupId>

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/ConnectorConfiguration.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/ConnectorConfiguration.java
@@ -8,6 +8,7 @@ package io.debezium.testing.testcontainers;
 import java.util.List;
 
 import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MongoDBContainer;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,10 +39,12 @@ public class ConnectorConfiguration {
 
     private static final String CONNECTOR = "connector.class";
     private static final String HOSTNAME = "database.hostname";
+    private static final String HOSTS = "mongodb.hosts";
     private static final String PORT = "database.port";
     private static final String USER = "database.user";
     private static final String PASSWORD = "database.password";
     private static final String DBNAME = "database.dbname";
+    private static final String AUTO_DISCOVER_MEMBERS = "mongodb.members.auto.discover";
 
     public static ConnectorConfiguration forJdbcContainer(JdbcDatabaseContainer<?> jdbcDatabaseContainer) {
         ConnectorConfiguration configuration = new ConnectorConfiguration();
@@ -61,6 +64,18 @@ public class ConnectorConfiguration {
         if (!isMySQL(driverClassName)) {
             configuration.with(DBNAME, jdbcDatabaseContainer.getDatabaseName());
         }
+
+        return configuration;
+    }
+
+    public static ConnectorConfiguration forMongoDbContainer(MongoDBContainer mongoDbContainer) {
+        final List<Integer> exposedPorts = mongoDbContainer.getExposedPorts();
+
+        ConnectorConfiguration configuration = new ConnectorConfiguration();
+        configuration.with(CONNECTOR, "io.debezium.connector.mongodb.MongoDbConnector")
+                .with(HOSTS, "rs0/" + mongoDbContainer.getContainerInfo().getConfig().getHostName()
+                        + ":" + exposedPorts.get(0))
+                .with(AUTO_DISCOVER_MEMBERS, false);
 
         return configuration;
     }


### PR DESCRIPTION
Add Mongo DB default config helper to ConnectorConfiguration in Debezium Testing Testcontainers package.

relates to: https://issues.redhat.com/browse/DBZ-2808