### PR TITLE
DBZ-2824 Fix xrefs, anchor ids, conditionals; standardize terminology

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -24,16 +24,16 @@ endif::community[]
 The {prodname} SQL Server connector captures row-level changes that occur in the schemas of a SQL Server database.
 
 ifdef::product[]
+
 For details about the {prodname} SQL Server connector and its use, see following topics: 
 
 * xref:overview-of-debezium-sql-server-connector[]
 * xref:how-debezium-sql-server-connectors-work[]
 * xref:descriptions-of-debezium-sql-server-connector-data-change-events[]
-* xref:how-debezium-SQL Server-connectors-map-data-types[]
+* xref:how-debezium-sql-server-connectors-map-data-types[]
 * xref:setting-up-sql-server-for-use-with-the-debezium-sql-server-connector[]
 * xref:deploying-debezium-sql-server-connectors[]
-* xref:Monitoring {prodname} SQL Server connector performance[]
-* xref:how-debezium-postgresql-connectors-handle-faults-and-problems[]
+* xref:monitoring-debezium-sql-server-connector-performance[]
 
 endif::product[]
 
@@ -86,16 +86,18 @@ That is, if the connector stops during a snapshot, the connector begins a new sn
 == How the SQL Server connector works
 
 To optimally configure and run a {prodname} SQL Server connector, it is helpful to understand how the connector performs snapshots, streams change events, determines Kafka topic names, and uses metadata. 
+
 ifdef::product[]
+
 For details about how the connector works, see the following sections: 
 
 * xref:how-debezium-sql-server-connectors-perform-database-snapshots[]
 * xref:how-the-debezium-sql-server-connector-reads-change-data-tables[]
 * xref:default-names-of-kafka-topics-that-receive-debezium-sql-server-change-event-records[]
-* xref:how-the-debezium-SQL Server connector-uses-the-schema-change-topic[]
+* xref:how-the-debezium-sql-server-connector-uses-the-schema-change-topic[]
 * xref:descriptions-of-debezium-sql-server-connector-data-change-events[]
 * xref:debezium-sql-server-connector-generated-events-that-represent-transaction-boundaries[]
-* xref:how-debezium-SQL Server-connectors-map-data-types[]
+
 endif::product[]
 
 // Type: concept
@@ -173,7 +175,7 @@ For more information about using the logical topic routing SMT to customize topi
 
  
 // Type: concept
-// ModuleID: how-the-debezium-SQL Server connector-uses-the-schema-change-topic
+// ModuleID: how-the-debezium-sql-server-connector-uses-the-schema-change-topic
 // Title: How the {prodname} SQL Server connector uses the schema change topic
 === Schema change topic
 
@@ -424,10 +426,12 @@ This can lead to unexpected conflicts if the logical server name, a database nam
 ====
 
 ifdef::product[]
+
 For details about change events, see the following topics:
 
 * xref:about-keys-in-debezium-sql-server-change-events[]
 * xref:about-values-in-debezium-sql-server-change-events[] 
+
 endif::product[]
 
 // Type: concept
@@ -542,9 +546,11 @@ CREATE TABLE customers (
 The value portion of a change event for a change to this table is described for each event type. 
 
 ifdef::product[]
+
 * <<sqlserver-create-events,_create_ events>>
 * <<sqlserver-update-events,_update_ events>>
 * <<sqlserver-delete-events,_delete_ events>>
+
 endif::product[]
 
 [[sqlserver-create-events]]
@@ -1009,6 +1015,8 @@ The following example shows a typical transaction boundary message:
 
 The transaction events are written to the topic named `<database.server.name>.transaction`.
 
+//Type: concept
+//ModuleID: change-data-event-enrichment
 ==== Change data event enrichment
 
 When transaction metadata is enabled, the data message `Envelope` is enriched with a new `transaction` field.
@@ -1042,7 +1050,7 @@ The following example shows what a typical message looks like:
 ----
 
 // Type: reference
-// ModuleID: how-debezium-SQL Server-connectors-map-data-types
+// ModuleID: how-debezium-sql-server-connectors-map-data-types
 // Title: How {prodname} SQL Server connectors map data types
 [[sqlserver-data-types]]
 === Data type mappings
@@ -1058,12 +1066,14 @@ Literal type:: Describes how the value is literally represented by using Kafka C
 Semantic type:: Describes how the Kafka Connect schema captures the _meaning_ of the field using the name of the Kafka Connect schema for the field.
 
 ifdef::product[]
+
 For more information about data type mappings, see the following sections:
 
-* xref:sqlserver-basic-values[]
-* xref:sqlserver-temporal-values[]
-* xref:sqlserver-decimal-values[]
-* xref:sqlserver-timestamp-values[]
+* xref:sql-server-basic-values[]
+* xref:sql-server-temporal-values[]
+* xref:sql-server-decimal-values[]
+* xref:sql-server-timestamp-values[]
+
 endif::product[]
 
 [id="sql-server-basic-values"]
@@ -1153,7 +1163,7 @@ ifdef::community[]
 Passing the default value helps though with satisfying the compatibility rules when {link-prefix}:{link-avro-serialization}[using Avro] as serialization format together with the Confluent schema registry.
 endif::community[]
 
-[[sqlserver-temporal-values]]
+[[sql-server-temporal-values]]
 ==== Temporal values
 
 Other than SQL Server's `DATETIMEOFFSET` data type (which contain time zone information), the other temporal types depend on the value of the `time.precision.mode` configuration property.  When the `time.precision.mode` configuration property is set to `adaptive` (the default), then the connector will determine the literal type and semantic type for the temporal types based on the column's data type definition so that events _exactly_ represent the values in the database:
@@ -1260,7 +1270,7 @@ Represents the number of milliseconds since the epoch, and does not include time
 
 |===
 
-[[sqlserver-timestamp-values]]
+[[sql-server-timestamp-values]]
 ===== Timestamp values
 
 The `DATETIME`, `SMALLDATETIME` and `DATETIME2` types represent a timestamp without time zone information.
@@ -1309,19 +1319,21 @@ For {prodname} to capture change events from SQL Server tables, a SQL Server adm
 The administrator must then enable CDC for each table that you want Debezium to capture.   
 
 ifdef::product[]
+
 For details about setting up SQL Server for use with the {prodname} connector, see the following sections:
 
-* xref:enabling-cdc-on the-sql-server-database[]
+* xref:enabling-cdc-on-the-sql-server-database[]
 * xref:enabling-cdc-on-a-sql-server-table[]
 * xref:verifying-debezium-connector-access-to-the-cdc-table[]
 * xref:debezium-sql-server-connector-on-azure[]
+
 endif::product[]
 
 After CDC is applied, it captures all of the `INSERT`, `UPDATE`, and `DELETE` operations that are committed to the tables for which CDD is enabled.
 The {prodname} connector can then capture these events and emit them to Kafka topics.
 
 // Type: procedure
-// ModuleID: enabling-cdc-on the-sql-server-database
+// ModuleID: enabling-cdc-on-the-sql-server-database
 === Enabling CDC on the SQL Server database
 
 Before you can enable CDC for a table, you must enable it for the SQL Server database.
@@ -1445,8 +1457,12 @@ If the result is empty, verify that the user has privileges to access both the c
 The {prodname} SQL Server connector has not been tested with SQL Server on Azure.
 
 ifdef::community[]
+
 We welcome any feedback from users who try the connector with SQL Server databases in managed environments.
 
+endif::community[]
+
+ifdef::community[]
 
 [[sqlserver-always-on-replica]]
 === SQL Server Always On
@@ -1462,12 +1478,15 @@ When {prodname} detects this configuration option then it will:
 
 ** set `snapshot.isolation.mode` to `snapshot` as this is the only one transaction isolation mode supported by read-only replicas
 ** commit the (read-only) transaction in every execution of the streaming query loop, as this is necessary to get the latest view on CDC data
+
 endif::community[]
 
-ifdef::product[]
+
 // Type: assembly
 // ModuleID: deploying-and-managing-debezium-sql-server-connectors
 == Deployment and management of {prodname} SQL Server connectors
+
+ifdef::product[]
 
 For details about deploying and managing SQL Server connectors, see the following sections:
 
@@ -1491,6 +1510,7 @@ If you are working with immutable containers, see link:https://hub.docker.com/r/
 endif::community[]
 
 ifdef::product[]
+
 For details about deploying the {prodname} SQL Server connector, see the following topics:
 
 * xref:installing-debezium-sql-server-connectors[]
@@ -1500,6 +1520,9 @@ For details about deploying the {prodname} SQL Server connector, see the followi
 
 To deploy a {prodname} SQL Server connector, install the {prodname} SQL Server connector archive, configure the connector, and start the connector by adding its configuration to Kafka Connect. 
 
+endif::product[]
+
+ifdef::product[]
 // Type: procedure
 // Title: Installing {prodname} SQL Server connectors
 [id="installing-debezium-sql-server-connectors"]
@@ -1509,7 +1532,8 @@ To install the SQL Server connector, follow the procedures in {LinkDebeziumInsta
 
 . Use link:https://access.redhat.com/products/red-hat-amq#streams[Red Hat AMQ Streams] to set up Apache Kafka and Kafka Connect on OpenShift. AMQ Streams offers operators and images that bring Kafka to OpenShift. 
 
-. Download the {prodname} link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions[SQL Server connector].
+. From a browser, open the link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions[Software Downloads page on the Red Hat Customer Portal], 
+and download the {prodname} SQL Server connector.
 
 . Extract the connector files into your Kafka Connect environment.
 . Add the connector plug-in's parent directory to your Kafka Connect `plugin.path`, for example: 
@@ -1519,11 +1543,11 @@ To install the SQL Server connector, follow the procedures in {LinkDebeziumInsta
 plugin.path=/kafka/connect
 ----
 +
-The above example assumes that you extracted the {prodname} SQL Server connector to the `/kafka/connect/{prodname}-connector-sqlserver` path.
+The preceding example assumes that you extracted the {prodname} SQL Server connector to the `/kafka/connect/{prodname}-connector-sqlserver` path.
 
-. Restart your Kafka Connect process to ensure that the new JAR files are picked up.
+. Restart your Kafka Connect process to ensure that it picks up the new JAR files.
 
-You also need to {LinkDebeziumUserGuide}#{LinkDebeziumUserGuide}#setting-up-sqlserver[set up SQL Server] to run a {prodname} connector.
+You also need to {LinkDebeziumUserGuide}#setting-up-sqlserver[set up SQL Server] to run a {prodname} connector.
 
 .Additional resources
 
@@ -1531,6 +1555,7 @@ For more information about the deployment process, and deploying connectors with
 
 * {LinkDebeziumInstallOpenShift}[{NameDebeziumInstallOpenShift}]
 * {LinkDebeziumInstallRHEL}[{NameDebeziumInstallRHEL}]
+
 endif::product[]
 
 
@@ -1586,6 +1611,7 @@ Typically, you configure the {prodname} SQL Server connector in a `.json` file u
 endif::community[]
 
 ifdef::product[]
+
 The following example shows the configuration for a connector instance with the logical name `fullfillment` that captures a SQL Server server at port 1433 on 192.168.99.100.
 Typically, you configure the {prodname} SQL Server connector in a `.yaml` file in which you assign values to the configuration properties that are available for the connector.
 
@@ -1681,6 +1707,7 @@ To run a {prodname} SQL Server connector, create a connector configuration and a
 endif::community[]
 
 ifdef::product[]
+
 You can use a provided {prodname} container to deploy a {prodname} SQL Server connector. 
 In this procedure, you build a custom Kafka Connect container image for {prodname}, configure the {prodname} connector as needed, 
 and then add your connector configuration to your Kafka Connect environment. 
@@ -2109,14 +2136,14 @@ As a {prodname} user, you must coordinate tasks with the SQL Server database ope
 
 You can use one of the following methods to update capture tables after a schema change:
 
-* xref:cold-schema-updates[]. In cold schema updates, capture tables are updated after you stop {prodname}.
-* xref:hot-schema-updates[]. In hot schema updates, capture tables are updated while {prodname} is running.
+* xref:offline-schema-updates[]. In offline schema updates, capture tables are updated after you stop the {prodname} connector.
+* xref:online-schema-updates[]. In online schema updates, capture tables are updated while the {prodname} connector is running.
 
 There are advantages and disadvantages to using each type of procedure.
 
 [WARNING]
 ====
-Whether you use the hot or cold update method, you must complete the entire schema update process before you apply subsequent schema updates on the same source table.
+Whether you use the online or offline update method, you must complete the entire schema update process before you apply subsequent schema updates on the same source table.
 The best practice is to execute all DDLs in a single batch so the procedure can be run only once.
 ====
 
@@ -2135,41 +2162,47 @@ Similarly, columns that had been defined as required (`NOT NULL`), retain that d
 ====
 
 // Type: procedure
-// ModuleID: debezium-sql-server-connector-running-a-cold-update-after-a-schema-change
-// Title: Running a cold update after a schema change 
-[id="cold-schema-updates"]
-==== Cold schema updates
+// ModuleID: debezium-sql-server-connector-running-an-offline-update-after-a-schema-change
+// Title: Running an offline update after a schema change 
+[id="offline-schema-updates"]
+==== Offline schema updates
 
-Cold schema updates provide the safest method for updating capture tables, but cold updates might not be feasible for use with applications that require high-availability.
+Offline schema updates provide the safest method for updating capture tables. 
+However, offline updates might not be feasible for use with applications that require high-availability.
 
 .Prerequisites
+* An update was committed to the schema of a SQL Server table that has CDC enabled.
 * You are a SQL Server database operator with elevated privileges.
 
 .Procedure
 
-1. Suspend the application that generates the database records.
-2. Wait for {prodname} to stream all unstreamed changes.
-3. Stop the connector.
+1. Suspend the application that updates the database.
+2. Wait for the {prodname} connector to stream all unstreamed change event records.
+3. Stop the {prodname} connector.
 4. Apply all changes to the source table schema.
 5. Create a new capture table for the update source table using `sys.sp_cdc_enable_table` procedure with a unique value for parameter `@capture_instance`.
-6. Resume the application.
-7. Start the connector.
-8. When {prodname} starts streaming from the new capture table it is possible to drop the old one using `sys.sp_cdc_disable_table` stored procedure with parameter `@capture_instance` set to the old capture instance name.
+6. Resume the application that you suspended in Step 1.
+7. Start the {prodname} connector.
+8. After the {prodname} connector starts streaming from the new capture table, drop the old capture table by running the stored procedure `sys.sp_cdc_disable_table` with the parameter `@capture_instance` set to the old capture instance name.
 
 // Type: procedure
-// ModuleID: debezium-sql-server-connector-running-a-cold-update-after-a-schema-change
-// Title: Running a cold update after a schema change 
-[id="hot-schema-updates"]
-==== Hot schema updates
+// ModuleID: debezium-sql-server-connector-running-an-online-update-after-a-schema-change
+// Title: Running an online update after a schema change 
+[id="online-schema-updates"]
+==== Online schema updates
 
-The procedure for completing a hot schema updates is simpler than the procedure for running a cold schema update, 
+The procedure for completing an online schema updates is simpler than the procedure for running an offline schema update, 
 and you can complete it without requiring any downtime in application and data processing.
-However, with hot schema updates, there is a potential processing gap after you update the schema in the source database, 
-and before you create the new capture instance.
+However, with online schema updates, a potential processing gap can occur after you update the schema in the source database, 
+but before you create the new capture instance.
 During that interval, change events continue to be captured by the old instance of the change table, Q
 and the change data that is saved to the old table retains the structure of the earlier schema.
 So, for example, if you added a new column to a source table, change events that are produced before the new capture table is ready, do not contain a field for the new column.
-If your application does not tolerate such a transition period, it is best to use the cold schema update procedure.
+If your application does not tolerate such a transition period, it is best to use the offline schema update procedure.
+
+.Prerequisites
+* An update was committed to the schema of a SQL Server table that has CDC enabled.
+* You are a SQL Server database operator with elevated privileges.
 
 .Procedure
 1. Apply all changes to the source table schema.
@@ -2177,9 +2210,9 @@ If your application does not tolerate such a transition period, it is best to us
 3. When {prodname} starts streaming from the new capture table, you can drop the old capture table by running the `sys.sp_cdc_disable_table` stored procedure with the parameter `@capture_instance` set to the old capture instance name.
 
 
-.Example: Running a hot schema update after a database schema change 
+.Example: Running an online schema update after a database schema change 
 ifdef::community[]
-Let's deploy the SQL Server based https://github.com/debezium/debezium-examples/tree/master/tutorial#using-sql-server[{prodname} tutorial] to demonstrate the hot schema update.
+Let's deploy the SQL Server based https://github.com/debezium/debezium-examples/tree/master/tutorial#using-sql-server[{prodname} tutorial] to demonstrate the online schema update.
 
 In the following example, a column `phone_number` is added to the `customers` table.
 
@@ -2189,13 +2222,10 @@ In the following example, a column `phone_number` is added to the `customers` ta
 docker-compose -f docker-compose-sqlserver.yaml exec sqlserver bash -c '/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD -d testDB'
 ----
 endif::community[]
+
 ifdef::product[]
-The following example shows how to complete a hot schema update in the change table after the column `phone_number` is added to the `customers` source table.
 
-.Prerequisites
-
-* You have SQL Server deployed.
-* You have the {prodname} SQL Server connector deployed.
+The following example shows how to complete an online schema update in the change table after the column `phone_number` is added to the `customers` source table.
 
 endif::product[]
 
@@ -2288,7 +2318,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-
 // Type: reference
 // ModuleID: debezium-sql-server-connector-streaming-metrics
 // Title: {prodname} SQL Server connector streaming metrics
-[sqlserver-streaming-metrics]]
+[[sqlserver-streaming-metrics]]
 ==== Streaming metrics
 
 The *MBean* is `debezium.sql_server:type=connector-metrics,context=streaming,server=_<database.server.name>_`.


### PR DESCRIPTION
This change fixes errors in the conditionalization statements and in the annotation comments that are used to parse the content for the downstream documentation build
Some annotations were missing, and others contained invalid space characters, or capital letters, that could result in unexpected behavior.
Other updates include changes to address inconsistencies in terminology and in the format of IDs, and removal of erroneous cross-reference links.
Tested successfully in local antora build.