### PR TITLE
DBZ-2843 Delete closing `]` from ModuleID for zookeeper jmx topic

### DIFF
--- a/documentation/modules/ROOT/pages/operations/monitoring.adoc
+++ b/documentation/modules/ROOT/pages/operations/monitoring.adoc
@@ -58,7 +58,7 @@ you enable JMX by setting the appropriate environment variables when you start e
 
 // Category: debezium-using
 // Type: reference
-// ModuleID: debezium-zookeeper-jmx-environment-variables]
+// ModuleID: debezium-zookeeper-jmx-environment-variables
 [id="zookeeper-jmx-environment-variables"]
 === Zookeeper JMX environment variables
 


### PR DESCRIPTION
This change removes a closing square bracket ( `]` ) from the ModuleID comment for the heading `=== Zookeeper JMX environment variables`. The extra character caused a build failure in the downstream documentation.