### PR TITLE
DBZ-2710 Remove self-referential link in pass-through config properties

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2403,7 +2403,9 @@ endif::community[]
 [id="mysql-pass-through-configuration-properties"]
 .Pass-through configuration properties
 
-The MySQL connector also supports {link-prefix}:{link-mysql-connector}#mysql-pass-through-configuration-properties[pass-through configuration properties] that are used when creating the Kafka producer and consumer. Specifically, all connector configuration properties that begin with the `database.history.producer.` prefix are used (without the prefix) when creating the Kafka producer that writes to the database history. All properties that begin with the prefix `database.history.consumer.` are used (without the prefix) when creating the Kafka consumer that reads the database history upon connector start-up.
+The MySQL connector also supports pass-through configuration properties that are used when creating the Kafka producer and consumer. 
+Specifically, all connector configuration properties that begin with the `database.history.producer.` prefix are used (without the prefix) when creating the Kafka producer that writes to the database history. 
+All properties that begin with the prefix `database.history.consumer.` are used (without the prefix) when creating the Kafka consumer that reads the database history upon connector start-up.
 
 For example, the following connector configuration properties can be used to secure connections to the Kafka broker:
 


### PR DESCRIPTION
Removes link in first sentence of section that targets the title of the same section.