### PR TITLE
DBZ-2860 Explicitly declare to Quarkus that ORM XML mapping is required for the outbox extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <antlr.version>4.7.2</antlr.version>
 
         <!-- Quarkus -->
-        <quarkus.version>1.7.1.Final</quarkus.version>
+        <quarkus.version>1.11.0.Beta2</quarkus.version>
 
         <!-- Tracing -->
         <version.opentracing.strimzi>0.33.0</version.opentracing.strimzi>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2860

Creating as a draft, since Quarkus 1.11.0.Beta1 hasn't been released yet.

To test this:

* Get [that PR](https://github.com/quarkusio/quarkus/pull/13929) in your local clone of Quarkus, then build it with `./mvnw -U -Dquickly`
* Go to your local clone of Debezium and get this PR
* `mvn clean install -DskipTests -DskipITs -Dquarkus.version=999-SNAPSHOT`
* `cd debezium-quarkus-outbox`
* `TESTCONTAINERS_RYUK_DISABLED=true mvn clean install  -Dquarkus.version=999-SNAPSHOT`