### PR TITLE
DBZ-2849 Fix value converter field lookups with sanitized field names

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/TableSchemaBuilder.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableSchemaBuilder.java
@@ -318,7 +318,7 @@ public class TableSchemaBuilder {
         for (int i = 0; i < columns.size(); i++) {
             Column column = columns.get(i);
 
-            ValueConverter converter = createValueConverterFor(tableId, column, schema.field(column.name()));
+            ValueConverter converter = createValueConverterFor(tableId, column, schema.field(fieldNamer.fieldNameFor(column)));
             converter = wrapInMappingConverterIfNeeded(mappers, tableId, column, converter);
 
             if (converter == null) {

--- a/debezium-core/src/test/java/io/debezium/junit/logging/LogInterceptor.java
+++ b/debezium-core/src/test/java/io/debezium/junit/logging/LogInterceptor.java
@@ -37,6 +37,19 @@ public class LogInterceptor extends AppenderSkeleton {
         }
     }
 
+    public LogInterceptor(Class<?> clazz) {
+        try {
+            final Field field = Log4jLoggerAdapter.class.getDeclaredField("logger");
+            field.setAccessible(true);
+
+            Logger logger = (Logger) field.get(LoggerFactory.getLogger(clazz));
+            logger.addAppender(this);
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to obtain Log4j logger for log interceptor.");
+        }
+    }
+
     @Override
     protected void append(LoggingEvent loggingEvent) {
         this.events.add(loggingEvent);


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2849

@gunnarmorling @jpechane This issue was reported as a failure with the Oracle connector but through investigation the root cause is a bad lookup in debezium-core when sanitized field names are enabled for Avro serialization. 