### PR TITLE
[DBZ-2912] Add support for binary.handling.mode to the SQL Server connector

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -346,7 +346,8 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
                     SNAPSHOT_MODE,
                     SNAPSHOT_ISOLATION_MODE,
                     SOURCE_TIMESTAMP_MODE,
-                    MAX_LSN_OPTIMIZATION)
+                    MAX_LSN_OPTIMIZATION,
+                    BINARY_HANDLING_MODE)
             .excluding(
                     SCHEMA_WHITELIST,
                     SCHEMA_INCLUDE_LIST,

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -61,7 +61,8 @@ public class SqlServerConnectorTask extends BaseSourceTask {
         final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(config);
         final TopicSelector<TableId> topicSelector = SqlServerTopicSelector.defaultSelector(connectorConfig);
         final SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create(LOGGER);
-        final SqlServerValueConverters valueConverters = new SqlServerValueConverters(connectorConfig.getDecimalMode(), connectorConfig.getTemporalPrecisionMode());
+        final SqlServerValueConverters valueConverters = new SqlServerValueConverters(connectorConfig.getDecimalMode(),
+                connectorConfig.getTemporalPrecisionMode(), connectorConfig.binaryHandlingMode());
 
         // By default do not load whole result sets into memory
         config = config.edit()

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerValueConverters.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerValueConverters.java
@@ -13,6 +13,7 @@ import java.time.ZoneOffset;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.data.SpecialValueDecimal;
 import io.debezium.jdbc.JdbcValueConverters;
 import io.debezium.jdbc.TemporalPrecisionMode;
@@ -47,8 +48,9 @@ public class SqlServerValueConverters extends JdbcValueConverters {
      * @param temporalPrecisionMode
      *            date/time value will be represented either as Connect datatypes or Debezium specific datatypes
      */
-    public SqlServerValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode) {
-        super(decimalMode, temporalPrecisionMode, ZoneOffset.UTC, null, null, null);
+    public SqlServerValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode,
+                                    CommonConnectorConfig.BinaryHandlingMode binaryMode) {
+        super(decimalMode, temporalPrecisionMode, ZoneOffset.UTC, null, null, binaryMode);
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerBinaryModeIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerBinaryModeIT.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.ByteBuffer;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.fest.assertions.Assertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.CommonConnectorConfig.BinaryHandlingMode;
+import io.debezium.config.Configuration;
+import io.debezium.connector.sqlserver.util.TestHelper;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.util.Testing;
+
+public class SqlServerBinaryModeIT extends AbstractConnectorTest {
+
+    private SqlServerConnection connection;
+
+    @Before
+    public void before() throws SQLException {
+        TestHelper.createTestDatabase();
+        connection = TestHelper.testConnection();
+
+        connection.execute(
+                "CREATE TABLE binary_mode_test (id INT IDENTITY (1, 1) PRIMARY KEY, binary_col BINARY(3) NOT NULL, varbinary_col VARBINARY(3) NOT NULL)",
+                "INSERT INTO binary_mode_test (binary_col, varbinary_col) VALUES (0x010203, 0x010203)");
+        TestHelper.enableTableCdc(connection, "binary_mode_test");
+
+        initializeConnectorTestFramework();
+        Testing.Files.delete(TestHelper.DB_HISTORY_PATH);
+    }
+
+    @After
+    public void after() throws SQLException {
+        stopConnector();
+
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void shouldReceiveRawBinary() throws InterruptedException {
+        Struct data = consume(BinaryHandlingMode.BYTES);
+
+        ByteBuffer expectedValue = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
+        assertEquals(expectedValue, data.get("binary_col"));
+        assertEquals(expectedValue, data.get("varbinary_col"));
+    }
+
+    @Test
+    public void shouldReceiveHexBinary() throws InterruptedException {
+        Struct data = consume(BinaryHandlingMode.HEX);
+
+        String expectedValue = "010203";
+        assertEquals(expectedValue, data.get("binary_col"));
+        assertEquals(expectedValue, data.get("varbinary_col"));
+    }
+
+    @Test
+    public void shouldReceiveBase64Binary() throws InterruptedException {
+        Struct data = consume(BinaryHandlingMode.BASE64);
+
+        String expectedValue = "AQID";
+        assertEquals(expectedValue, data.get("binary_col"));
+        assertEquals(expectedValue, data.get("varbinary_col"));
+    }
+
+    private Struct consume(BinaryHandlingMode binaryMode) throws InterruptedException {
+        final Configuration config = TestHelper.defaultConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SqlServerConnectorConfig.SnapshotMode.INITIAL)
+                .with(SqlServerConnectorConfig.TABLE_INCLUDE_LIST, "dbo\\.binary_mode_test")
+                .with(SqlServerConnectorConfig.BINARY_HANDLING_MODE, binaryMode)
+                .build();
+
+        start(SqlServerConnector.class, config);
+        assertConnectorIsRunning();
+        TestHelper.waitForSnapshotToBeCompleted();
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        final List<SourceRecord> results = records.recordsForTopic("server1.dbo.binary_mode_test");
+        Assertions.assertThat(results).hasSize(1);
+
+        return (Struct) ((Struct) results.get(0).value()).get("after");
+    }
+}

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -211,12 +211,12 @@ public class TestHelper {
 
     public static SqlServerConnection adminConnection() {
         return new SqlServerConnection(TestHelper.adminJdbcConfig(), Clock.system(), SourceTimestampMode.getDefaultMode(),
-                new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE));
+                new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE, null));
     }
 
     public static SqlServerConnection testConnection() {
         return new SqlServerConnection(TestHelper.defaultJdbcConfig(), Clock.system(), SourceTimestampMode.getDefaultMode(),
-                new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE));
+                new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE, null));
     }
 
     /**

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1948,6 +1948,10 @@ See {link-prefix}:{link-sqlserver-connector}#sqlserver-data-types[SQL Server dat
 | A semi-colon list of regular expressions that match fully-qualified tables and columns to map a primary key. +
 Each item (regular expression) must match the fully-qualified `<fully-qualified table>:<a comma-separated list of columns>` representing the custom key. +
 Fully-qualified tables could be defined as _schemaName_._tableName_.
+
+|[[sqlserver-property-binary-handling-mode]]<<sqlserver-property-binary-handling-mode, `binary.handling.mode`>>
+|bytes
+|Specifies how binary (`binary`, `varbinary`) columns should be represented in change events, including: `bytes` represents binary data as byte array (default), `base64` represents binary data as base64-encoded String, `hex` represents binary data as hex-encoded (base16) String
 |===
 
 The following _advanced_ configuration properties have good defaults that will work in most situations and therefore rarely need to be specified in the connector's configuration.


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2912

- [x] Pass binary handling mode from configuration to the converter provider. The provider already supports it since it extends the JDBC converter provider.
- [x] Copy/paste documentation from the MySQL connector.
- [x] Add an integration test similar to `MySqlBinaryModeIT`.