### PR TITLE
DBZ-2861 Fix Testing Module under Outreach Jobs

### DIFF
--- a/.github/workflows/jdk-outreach-workflow.yml
+++ b/.github/workflows/jdk-outreach-workflow.yml
@@ -223,4 +223,5 @@ jobs:
           java-version: ${{ steps.jdk.outputs.version }}
           jdkFile: ${{ steps.jdk.outputs.file }}
       - name: Maven Build
-        run: mvn clean install -B -pl debezium-testing -am -amd -Passembly -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+        run: mvn clean install -B -pl debezium-assembly-descriptors,debezium-core,debezium-testing -am -amd -Passembly -Dcheckstyle.skip=true -Dformat.skip=true -Drevapi.skip -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2861

As https://github.com/debezium/debezium/actions/runs/480375579 has passed after adding `debezium-assembly-descriptors` and `debezium-core` I believe it's going to work for the outreach testing module. FYI postgres test failure might be a blocker. I have logged a JIRA for that.