### PR TITLE
Update typo in database.user description

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -1636,7 +1636,7 @@ The following configuration properties are _required_ unless a default value is 
 
 |`database.user`
 |
-|Name of the MySQL database to use when connecting to the MySQL database server.
+|Name of the MySQL user to use when connecting to the MySQL database server.
 
 |`database.password`
 |


### PR DESCRIPTION
| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready | Documentation | Low  |

## Description
- Fix the description in the `database.user` section.
- Name of the MySQL ~~database~~ / user to use when connecting to the MySQL database server.