### PR TITLE
DBZ-2958 Fix incorrect link IDs in connectors snapshot metrics table

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
@@ -60,11 +60,11 @@
 Tables are incrementally added to the Map during processing.
 Updates every 10,000 rows scanned and upon completing a table.
 
-|[[connectors-strm-metric-maxqueuesizeinbytes_{context}]]<<connectors-snaps-metric-maxqueuesizeinbytes_{context}, `MaxQueueSizeInBytes`>>
+|[[connectors-snaps-metric-maxqueuesizeinbytes_{context}]]<<connectors-snaps-metric-maxqueuesizeinbytes_{context}, `MaxQueueSizeInBytes`>>
 |`long`
 |The maximum buffer of the queue in bytes. It will be enabled if `max.queue.size.in.bytes` is passed with a positive long value.
 
-|[[connectors-strm-metric-currentqueuesizeinbytes_{context}]]<<connectors-snaps-metric-currentqueuesizeinbytes_{context}, `CurrentQueueSizeInBytes`>>
+|[[connectors-snaps-metric-currentqueuesizeinbytes_{context}]]<<connectors-snaps-metric-currentqueuesizeinbytes_{context}, `CurrentQueueSizeInBytes`>>
 |`long`
 |The current data of records in the queue in bytes.
 


### PR DESCRIPTION
I thought that I had fixed this previously, but in doing a test build downstream I encountered errors related to duplicate IDs and traced the problem back to the  upstream source file. 
One point of confusion is that I would expect the `*QueueSizeInBytes` metrics to appear in the doc for other connectors that are part of the downstream product, but I don't see references to them. The following files all reference the same file (`ref-connector-monitoring-snapshot-metrics.adoc`):

```
modules/ROOT/pages/connectors/sqlserver.adoc
modules/ROOT/pages/connectors/postgresql.adoc
modules/ROOT/pages/connectors/oracle.adoc
modules/ROOT/pages/connectors/mysql.adoc
modules/ROOT/pages/connectors/db2.adoc
modules/ROOT/pages/connectors/mongodb.adoc
```

