### PR TITLE
DBZ-2966 Correct anchor id to `exclude-list` vs. `include-list`

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/cassandra.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cassandra.adoc
@@ -1004,7 +1004,7 @@ refreshing the cached Cassandra table schemas.
 |`false`
 |Whether deletion events should have a subsequent tombstone event (true) or not (false). It's important to note that in Cassandra, two events with the same key may be updating different columns of a given table. So this could potentially result in records being lost during compaction if they have not been consumed by the consumer yet. In other words, do NOT set this to true if you have Kafka compaction turned on.
 
-|[[cassandra-property-field-include-list]]
+|[[cassandra-property-field-exclude-list]]
 [[cassandra-property-field-exclude-list]]<<cassandra-property-field-exclude-list, `field.exclude.list`>>
 |
 |A comma-separated list of fully-qualified names of fields that should be excluded from change event message values. Fully-qualified names for fields are in the form keyspace_name>.<field_name>.<nested_field_name>.


### PR DESCRIPTION
[DBZ-2966](https://issues.redhat.com/browse/DBZ-2966) After reviewing the merged PR for DBZ-2918 I noticed that I incorrectly replaced one instance of `blacklist` with `include-list` instead of `exclude-list`.  This change correctly sets the anchor ID to `exclude-list`.