### PR TITLE
DBZ-2897 Extended RecordCommitter interface to handle updated source offsets.

### DIFF
--- a/debezium-api/src/main/java/io/debezium/engine/DebeziumEngine.java
+++ b/debezium-api/src/main/java/io/debezium/engine/DebeziumEngine.java
@@ -121,6 +121,14 @@ public interface DebeziumEngine<R> extends Runnable, Closeable {
          * Should be called when a batch of records is finished being processed.
          */
         void markBatchFinished() throws InterruptedException;
+
+        /**
+         * Marks a record with updated source offsets as processed.
+         *
+         * @param record the record to commit
+         * @param sourceOffset the source offset to update the record with
+         */
+        void markProcessed(R record, Map<String, ?> sourceOffset) throws InterruptedException;
     }
 
     /**

--- a/debezium-api/src/main/java/io/debezium/engine/DebeziumEngine.java
+++ b/debezium-api/src/main/java/io/debezium/engine/DebeziumEngine.java
@@ -142,7 +142,7 @@ public interface DebeziumEngine<R> extends Runnable, Closeable {
      * Contract that should be passed to {@link RecordCommitter#markProcessed(Object, Offsets)} for marking a record
      * as processed with updated offsets.
      */
-    public static interface Offsets {
+    public interface Offsets {
 
         /**
          * Associates a key with a specific value, overwrites the value if the key is already present.

--- a/debezium-api/src/main/java/io/debezium/engine/DebeziumEngine.java
+++ b/debezium-api/src/main/java/io/debezium/engine/DebeziumEngine.java
@@ -126,9 +126,31 @@ public interface DebeziumEngine<R> extends Runnable, Closeable {
          * Marks a record with updated source offsets as processed.
          *
          * @param record the record to commit
-         * @param sourceOffset the source offset to update the record with
+         * @param sourceOffsets the source offsets to update the record with
          */
-        void markProcessed(R record, Map<String, ?> sourceOffset) throws InterruptedException;
+        void markProcessed(R record, Offsets sourceOffsets) throws InterruptedException;
+
+        /**
+         * Builds a new instance of an object implementing the {@link Offsets} contract.
+         *
+         * @return the object implementing the {@link Offsets} contract
+         */
+        Offsets buildOffsets();
+    }
+
+    /**
+     * Contract that should be passed to {@link RecordCommitter#markProcessed(Object, Offsets)} for marking a record
+     * as processed with updated offsets.
+     */
+    public static interface Offsets {
+
+        /**
+         * Associates a key with a specific value, overwrites the value if the key is already present.
+         *
+         * @param key key with which to associate the value
+         * @param value value to be associated with the key
+         */
+        void set(String key, Object value);
     }
 
     /**

--- a/debezium-embedded/src/main/java/io/debezium/embedded/ConvertingEngineBuilder.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/ConvertingEngineBuilder.java
@@ -7,6 +7,7 @@ package io.debezium.embedded;
 
 import java.io.IOException;
 import java.time.Clock;
+import java.util.Map;
 import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -92,6 +93,11 @@ public class ConvertingEngineBuilder<R> implements Builder<R> {
                             @Override
                             public void markBatchFinished() throws InterruptedException {
                                 committer.markBatchFinished();
+                            }
+
+                            @Override
+                            public void markProcessed(R record, Map<String, ?> sourceOffset) throws InterruptedException {
+                                committer.markProcessed(fromFormat.apply(record), sourceOffset);
                             }
                         }));
         return this;

--- a/debezium-embedded/src/main/java/io/debezium/embedded/ConvertingEngineBuilder.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/ConvertingEngineBuilder.java
@@ -7,7 +7,6 @@ package io.debezium.embedded;
 
 import java.io.IOException;
 import java.time.Clock;
-import java.util.Map;
 import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -96,8 +95,13 @@ public class ConvertingEngineBuilder<R> implements Builder<R> {
                             }
 
                             @Override
-                            public void markProcessed(R record, Map<String, ?> sourceOffset) throws InterruptedException {
-                                committer.markProcessed(fromFormat.apply(record), sourceOffset);
+                            public void markProcessed(R record, DebeziumEngine.Offsets sourceOffsets) throws InterruptedException {
+                                committer.markProcessed(fromFormat.apply(record), sourceOffsets);
+                            }
+
+                            @Override
+                            public DebeziumEngine.Offsets buildOffsets() {
+                                return committer.buildOffsets();
                             }
                         }));
         return this;

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -906,6 +906,14 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord> {
             public synchronized void markBatchFinished() throws InterruptedException {
                 maybeFlush(offsetWriter, offsetCommitPolicy, commitTimeout, task);
             }
+
+            @Override
+            public synchronized void markProcessed(SourceRecord record, Map<String, ?> sourceOffset) throws InterruptedException {
+                SourceRecord recordWithUpdatedOffsets = new SourceRecord(record.sourcePartition(), sourceOffset, record.topic(),
+                        record.kafkaPartition(), record.keySchema(), record.key(), record.valueSchema(), record.value(),
+                        record.timestamp(), record.headers());
+                markProcessed(recordWithUpdatedOffsets);
+            }
         };
     }
 

--- a/debezium-embedded/src/test/java/io/debezium/embedded/EmbeddedEngineTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/EmbeddedEngineTest.java
@@ -399,7 +399,7 @@ public class EmbeddedEngineTest extends AbstractConnectorTest {
                 }
             }
         }
-        assert containsCustomPartition;
+        assertThat(containsCustomPartition).isTrue();
 
         // Stop the connector ...
         stopConnector();

--- a/debezium-embedded/src/test/java/io/debezium/embedded/EmbeddedEngineTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/EmbeddedEngineTest.java
@@ -17,7 +17,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -358,9 +357,10 @@ public class EmbeddedEngineTest extends AbstractConnectorTest {
                     Integer groupCount = records.size() / NUMBER_OF_LINES;
 
                     for (RecordChangeEvent<SourceRecord> r : records) {
-                        Map<String, Long> newSourceOffset = Collections.singletonMap(CUSTOM_SOURCE_OFFSET_PARTITION, 1L);
+                        DebeziumEngine.Offsets offsets = committer.buildOffsets();
+                        offsets.set(CUSTOM_SOURCE_OFFSET_PARTITION, 1L);
                         logger.info(r.record().sourceOffset().toString());
-                        committer.markProcessed(r, newSourceOffset);
+                        committer.markProcessed(r, offsets);
                     }
 
                     committer.markBatchFinished();

--- a/documentation/modules/ROOT/pages/development/engine.adoc
+++ b/documentation/modules/ROOT/pages/development/engine.adoc
@@ -333,9 +333,10 @@ This interface has single function with the following signature:
 As mentioned in the Javadoc, the `RecordCommitter` object is to be called for each record and once each batch is finished.
 The `RecordCommitter` interface is threadsafe, which allows for flexible processing of records.
 
-You can optionally overwrite the offsets of the records that are processed. This is done by calling
-`RecordCommitter#markProcessed(SourceRecord record, Map<String, ?> sourceOffset)`, where the `sourceOffset` corresponds
-to the new offsets that will replace the offsets of the original record.
+You can optionally overwrite the offsets of the records that are processed. This is done by first building a new
+`Offsets` object by calling `RecordCommitter#buildOffsets()`, updating the offsets with `Offsets#set(String key, Object value)`,
+and then calling `RecordCommitter#markProcessed(SourceRecord record, Offsets sourceOffsets)`,
+with the updated `Offsets`.
 
 To use the `ChangeConsumer` API, you must pass an implementation of the interface to the `notifying` API, as seen below:
 

--- a/documentation/modules/ROOT/pages/development/engine.adoc
+++ b/documentation/modules/ROOT/pages/development/engine.adoc
@@ -333,6 +333,10 @@ This interface has single function with the following signature:
 As mentioned in the Javadoc, the `RecordCommitter` object is to be called for each record and once each batch is finished.
 The `RecordCommitter` interface is threadsafe, which allows for flexible processing of records.
 
+You can optionally overwrite the offsets of the records that are processed. This is done by calling
+`RecordCommitter#markProcessed(SourceRecord record, Map<String, ?> sourceOffset)`, where the `sourceOffset` corresponds
+to the new offsets that will replace the offsets of the original record.
+
 To use the `ChangeConsumer` API, you must pass an implementation of the interface to the `notifying` API, as seen below:
 
 [source,java,indent=0]

--- a/support/revapi/src/main/resources/revapi/debezium-api-changes.xml
+++ b/support/revapi/src/main/resources/revapi/debezium-api-changes.xml
@@ -1,5 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <analysisConfiguration>
+    <version-1.5.0>
+        <revapi.ignore>
+            <item>
+              <code>java.method.addedToInterface</code>
+              <class>io.debezium.engine.DebeziumEngine.RecordCommitter</class>
+              <justification>This interface is not supposed to be implemented by clients.</justification>
+            </item>
+        </revapi.ignore>
+    </version-1.5.0>
     <!-- No changes as of yet. This is just an example of how to tell Revapi to ignore intentional changes.
     <version-1.2.0>
         <revapi.ignore>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2897

Extended the DebeziumEngine interface to include a new method for marking a record processed with updated source offsets. Implemented the new interface method in both ConvertingEngineBuilder and EmbeddedEngine. EmbeddedEngine creates a new SourceRecord with the updated sourceOffsets and passes this to the original markProcessed method. Added a unit test in EmbeddedEngineTest that verifies that the file offset storage contains the updated source offset’s partition. Added a revapi ignore case to prevent failure from a method added to an interface without a default method. Updated docs for Debezium Engine that describe the new functionality.