### PR TITLE
DBZ-1865 First draft of MySQL rewrite

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/EventBuffer.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/EventBuffer.java
@@ -15,7 +15,8 @@ import com.github.shyiko.mysql.binlog.event.Event;
 import com.github.shyiko.mysql.binlog.event.EventType;
 import com.github.shyiko.mysql.binlog.event.QueryEventData;
 
-import io.debezium.connector.mysql.BinlogReader.BinlogPosition;
+import io.debezium.connector.mysql.MySqlStreamingChangeEventSource.BinlogPosition;
+import io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContext;
 
 /**
  * This class represents a look-ahead buffer that allows Debezium to accumulate binlog events and decide
@@ -47,8 +48,9 @@ class EventBuffer {
 
     private final int capacity;
     private final Queue<Event> buffer;
-    private final BinlogReader reader;
+    private final MySqlStreamingChangeEventSource streamingChangeEventSource;
     private boolean txStarted = false;
+    private final ChangeEventSourceContext changeEventSourceContext;
 
     /**
      * Contains the position of the first event that has not fit into the buffer.
@@ -61,10 +63,11 @@ class EventBuffer {
      */
     private BinlogPosition forwardTillPosition;
 
-    public EventBuffer(int capacity, BinlogReader reader) {
+    public EventBuffer(int capacity, MySqlStreamingChangeEventSource streamingChangeEventSource, ChangeEventSourceContext changeEventSourceContext) {
         this.capacity = capacity;
         this.buffer = new ArrayBlockingQueue<>(capacity);
-        this.reader = reader;
+        this.streamingChangeEventSource = streamingChangeEventSource;
+        this.changeEventSourceContext = changeEventSourceContext;
     }
 
     /**
@@ -80,12 +83,12 @@ class EventBuffer {
         // buffer was full and the end of the TX; in this case there's nothing to do
         // besides directly emitting the events
         if (isReplayingEventsBeyondBufferCapacity()) {
-            reader.handleEvent(event);
+            streamingChangeEventSource.handleEvent(event);
             return;
         }
 
         if (event.getHeader().getEventType() == EventType.QUERY) {
-            QueryEventData command = reader.unwrapData(event);
+            QueryEventData command = streamingChangeEventSource.unwrapData(event);
             LOGGER.debug("Received query command: {}", event);
             String sql = command.getSql().trim();
             if (sql.equalsIgnoreCase("BEGIN")) {
@@ -114,7 +117,7 @@ class EventBuffer {
      */
     private boolean isReplayingEventsBeyondBufferCapacity() {
         if (forwardTillPosition != null) {
-            if (forwardTillPosition.equals(reader.getCurrentBinlogPosition())) {
+            if (forwardTillPosition.equals(streamingChangeEventSource.getCurrentBinlogPosition())) {
                 forwardTillPosition = null;
             }
             return true;
@@ -141,9 +144,9 @@ class EventBuffer {
     }
 
     private void switchToBufferFullMode() {
-        largeTxNotBufferedPosition = reader.getCurrentBinlogPosition();
+        largeTxNotBufferedPosition = streamingChangeEventSource.getCurrentBinlogPosition();
         LOGGER.info("Buffer full, will need to re-read part of the transaction from binlog from {}", largeTxNotBufferedPosition);
-        reader.getMetrics().onLargeTransaction();
+        streamingChangeEventSource.getMetrics().onLargeTransaction();
         // Position for TABLE_MAP is not stored by com.github.shyiko.mysql.binlog.BinaryLogClient.updateClientBinlogFilenameAndPosition(Event)
         if (buffer.peek().getHeader().getEventType() == EventType.TABLE_MAP) {
             buffer.remove();
@@ -159,7 +162,7 @@ class EventBuffer {
             addToBuffer(event);
         }
         else {
-            reader.handleEvent(event);
+            streamingChangeEventSource.handleEvent(event);
         }
     }
 
@@ -192,16 +195,16 @@ class EventBuffer {
         }
         LOGGER.debug("Executing events from buffer");
         for (Event e : buffer) {
-            reader.handleEvent(e);
+            streamingChangeEventSource.handleEvent(e);
         }
         LOGGER.debug("Executing events from binlog that have not fit into buffer");
         if (isInBufferFullMode()) {
-            forwardTillPosition = reader.getCurrentBinlogPosition();
-            reader.rewindBinaryLogClient(largeTxNotBufferedPosition);
+            forwardTillPosition = streamingChangeEventSource.getCurrentBinlogPosition();
+            streamingChangeEventSource.rewindBinaryLogClient(changeEventSourceContext, largeTxNotBufferedPosition);
         }
-        reader.getMetrics().onCommittedTransaction();
+        streamingChangeEventSource.getMetrics().onCommittedTransaction();
         if (!wellFormed) {
-            reader.getMetrics().onNotWellFormedTransaction();
+            streamingChangeEventSource.getMetrics().onNotWellFormedTransaction();
         }
         clear();
     }
@@ -213,9 +216,9 @@ class EventBuffer {
             LOGGER.warn("Rollback requested but TX was not started before");
             wellFormed = false;
         }
-        reader.getMetrics().onRolledBackTransaction();
+        streamingChangeEventSource.getMetrics().onRolledBackTransaction();
         if (!wellFormed) {
-            reader.getMetrics().onNotWellFormedTransaction();
+            streamingChangeEventSource.getMetrics().onNotWellFormedTransaction();
         }
         clear();
     }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceFactory.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
+import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.relational.TableId;
+import io.debezium.util.Clock;
+
+public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory {
+
+    private final MySqlConnectorConfig configuration;
+    private final MySqlConnection connection;
+    private final ErrorHandler errorHandler;
+    private final EventDispatcher<TableId> dispatcher;
+    private final Clock clock;
+    private final MySqlTaskContext taskContext;
+    private final MySqlStreamingChangeEventSourceMetrics streamingMetrics;
+
+    public MySqlChangeEventSourceFactory(MySqlConnectorConfig configuration, MySqlConnection connection,
+                                         ErrorHandler errorHandler, EventDispatcher<TableId> dispatcher, Clock clock, MySqlDatabaseSchema schema,
+                                         MySqlTaskContext taskContext, MySqlStreamingChangeEventSourceMetrics streamingMetrics) {
+        this.configuration = configuration;
+        this.connection = connection;
+        this.errorHandler = errorHandler;
+        this.dispatcher = dispatcher;
+        this.clock = clock;
+        this.taskContext = taskContext;
+        this.streamingMetrics = streamingMetrics;
+    }
+
+    @Override
+    public SnapshotChangeEventSource getSnapshotChangeEventSource(OffsetContext offsetContext, SnapshotProgressListener snapshotProgressListener) {
+        return new MySqlSnapshotChangeEventSource(configuration, (MySqlOffsetContext) offsetContext, connection, taskContext.getSchema(), dispatcher, clock,
+                (MySqlSnapshotChangeEventSourceMetrics) snapshotProgressListener);
+    }
+
+    @Override
+    public StreamingChangeEventSource getStreamingChangeEventSource(OffsetContext offsetContext) {
+        return new MySqlStreamingChangeEventSource(
+                configuration,
+                (MySqlOffsetContext) offsetContext,
+                connection,
+                dispatcher,
+                errorHandler,
+                clock,
+                taskContext,
+                streamingMetrics);
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceMetricsFactory.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceMetricsFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import io.debezium.connector.base.ChangeEventQueueMetrics;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.pipeline.metrics.DefaultChangeEventSourceMetricsFactory;
+import io.debezium.pipeline.metrics.SnapshotChangeEventSourceMetrics;
+import io.debezium.pipeline.metrics.StreamingChangeEventSourceMetrics;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+
+/**
+ * @author Jiri Pechanec
+ */
+public class MySqlChangeEventSourceMetricsFactory extends DefaultChangeEventSourceMetricsFactory {
+
+    final MySqlStreamingChangeEventSourceMetrics streamingMetrics;
+
+    public MySqlChangeEventSourceMetricsFactory(MySqlStreamingChangeEventSourceMetrics streamingMetrics) {
+        this.streamingMetrics = streamingMetrics;
+    }
+
+    @Override
+    public <T extends CdcSourceTaskContext> SnapshotChangeEventSourceMetrics getSnapshotMetrics(T taskContext,
+                                                                                                ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                                EventMetadataProvider eventMetadataProvider) {
+        return new MySqlSnapshotChangeEventSourceMetrics((MySqlTaskContext) taskContext, changeEventQueueMetrics, eventMetadataProvider);
+    }
+
+    @Override
+    public <T extends CdcSourceTaskContext> StreamingChangeEventSourceMetrics getStreamingMetrics(T taskContext,
+                                                                                                  ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                                  EventMetadataProvider eventMetadataProvider) {
+        return streamingMetrics;
+    }
+
+    @Override
+    public boolean connectionMetricHandledByCoordinator() {
+        return false;
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeRecordEmitter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeRecordEmitter.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.data.Envelope;
+import io.debezium.pipeline.spi.ChangeRecordEmitter;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.txmetadata.TransactionContext;
+import io.debezium.schema.DataCollectionId;
+import io.debezium.schema.DataCollectionSchema;
+
+/**
+ * Emits change data.
+ *
+ * @author Jiri Pechanec
+ */
+public class MySqlChangeRecordEmitter implements ChangeRecordEmitter {
+
+    private final Envelope.Operation operation;
+    private final SourceRecord record;
+    private final OffsetContext offset;
+
+    public MySqlChangeRecordEmitter(OffsetContext offset, Envelope.Operation operation, SourceRecord record) {
+        this.offset = offset;
+        this.operation = operation;
+        this.record = record;
+    }
+
+    @Override
+    public void emitChangeRecords(DataCollectionSchema schema, Receiver receiver) throws InterruptedException {
+        final Struct value = (Struct) record.value();
+        if (value == null) {
+            return;
+        }
+        final String op = value.getString(Envelope.FieldName.OPERATION);
+        receiver.changeRecord(schema, Envelope.Operation.forCode(op), record.key(), value, new OffsetContext() {
+
+            @Override
+            public Map<String, ?> getPartition() {
+                return record.sourcePartition();
+            }
+
+            @Override
+            public Map<String, ?> getOffset() {
+                return record.sourceOffset();
+            }
+
+            @Override
+            public Schema getSourceInfoSchema() {
+                return value.getStruct("source").schema();
+            }
+
+            @Override
+            public Struct getSourceInfo() {
+                return value.getStruct("source");
+            }
+
+            @Override
+            public boolean isSnapshotRunning() {
+                return false;
+            }
+
+            @Override
+            public void markLastSnapshotRecord() {
+            }
+
+            @Override
+            public void preSnapshotStart() {
+            }
+
+            @Override
+            public void preSnapshotCompletion() {
+            }
+
+            @Override
+            public void postSnapshotCompletion() {
+            }
+
+            @Override
+            public void event(DataCollectionId collectionId, Instant timestamp) {
+            }
+
+            @Override
+            public TransactionContext getTransactionContext() {
+                // TODO Remove with RecordMakers rewrite
+                return null;
+            }
+        }, (ConnectHeaders) record.headers());
+    }
+
+    @Override
+    public OffsetContext getOffset() {
+        return offset;
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnection.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnection.java
@@ -14,7 +14,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.OptionalLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -406,7 +406,7 @@ public class MySqlConnection extends JdbcConnection {
         }
     }
 
-    public Optional<Long> getEstimatedTableSize(TableId tableId) {
+    public OptionalLong getEstimatedTableSize(TableId tableId) {
         try {
             // Choose how we create statements based on the # of rows.
             // This is approximate and less accurate then COUNT(*),
@@ -414,15 +414,15 @@ public class MySqlConnection extends JdbcConnection {
             execute("USE `" + tableId.catalog() + "`;");
             return queryAndMap("SHOW TABLE STATUS LIKE '" + tableId.table() + "';", rs -> {
                 if (rs.next()) {
-                    return Optional.of((rs.getLong(5)));
+                    return OptionalLong.of((rs.getLong(5)));
                 }
-                return Optional.empty();
+                return OptionalLong.empty();
             });
         }
         catch (SQLException e) {
             LOGGER.debug("Error while getting number of rows in table {}: {}", tableId, e.getMessage(), e);
         }
-        return Optional.empty();
+        return OptionalLong.empty();
     }
 
     /**

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnection.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnection.java
@@ -1,0 +1,551 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.mysql;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.CommonConnectorConfig.EventProcessingFailureHandlingMode;
+import io.debezium.config.Configuration;
+import io.debezium.config.Configuration.Builder;
+import io.debezium.config.Field;
+import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
+import io.debezium.connector.mysql.legacy.MySqlJdbcContext.DatabaseLocales;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.DatabaseHistory;
+import io.debezium.util.Strings;
+
+/**
+ * {@link JdbcConnection} extension to be used with MySQL Server
+ *
+ * @author Jiri Pechanec, Randall Hauch
+ *
+ */
+public class MySqlConnection extends JdbcConnection {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(MySqlConnection.class);
+
+    private static final String SQL_SHOW_SYSTEM_VARIABLES = "SHOW VARIABLES";
+    private static final String SQL_SHOW_SYSTEM_VARIABLES_CHARACTER_SET = "SHOW VARIABLES WHERE Variable_name IN ('character_set_server','collation_server')";
+    private static final String SQL_SHOW_SESSION_VARIABLE_SSL_VERSION = "SHOW SESSION STATUS LIKE 'Ssl_version'";
+
+    protected static final String URL_PATTERN = "jdbc:mysql://${hostname}:${port}/?useInformationSchema=true&nullCatalogMeansCurrent=false&useSSL=${useSSL}&useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8&zeroDateTimeBehavior=CONVERT_TO_NULL&connectTimeout=${connectTimeout}";
+
+    private final Map<String, String> originalSystemProperties = new HashMap<>();
+    private final MySqlConnectionConfiguration connectionConfig;
+
+    /**
+     * Creates a new connection using the supplied configuration.
+     *
+     * @param config {@link Configuration} instance, may not be null.
+     * @param sourceTimestampMode strategy for populating {@code source.ts_ms}.
+     * @param config
+     *            {@link Configuration} instance, may not be null.
+     * @param valueConverters
+     *            {@link SqlServerValueConverters} instance
+     */
+    public MySqlConnection(MySqlConnectionConfiguration connectionConfig) {
+        super(connectionConfig.config(), connectionConfig.factory());
+        this.connectionConfig = connectionConfig;
+    }
+
+    @Override
+    public synchronized Connection connection(boolean executeOnConnect) throws SQLException {
+        if (!isConnected() && connectionConfig.sslModeEnabled()) {
+            originalSystemProperties.clear();
+            // Set the System properties for SSL for the MySQL driver ...
+            setSystemProperty("javax.net.ssl.keyStore", MySqlConnectorConfig.SSL_KEYSTORE, true);
+            setSystemProperty("javax.net.ssl.keyStorePassword", MySqlConnectorConfig.SSL_KEYSTORE_PASSWORD, false);
+            setSystemProperty("javax.net.ssl.trustStore", MySqlConnectorConfig.SSL_TRUSTSTORE, true);
+            setSystemProperty("javax.net.ssl.trustStorePassword", MySqlConnectorConfig.SSL_TRUSTSTORE_PASSWORD, false);
+        }
+        return super.connection(executeOnConnect);
+    }
+
+    @Override
+    public void close() throws SQLException {
+        try {
+            super.close();
+        }
+        finally {
+            // Reset the system properties to their original value ...
+            originalSystemProperties.forEach((name, value) -> {
+                if (value != null) {
+                    System.setProperty(name, value);
+                }
+                else {
+                    System.clearProperty(name);
+                }
+            });
+        }
+    }
+
+    /**
+     * Read the MySQL charset-related system variables.
+     *
+     * @return the system variables that are related to server character sets; never null
+     */
+    protected Map<String, String> readMySqlCharsetSystemVariables() {
+        // Read the system variables from the MySQL instance and get the current database name ...
+        LOGGER.debug("Reading MySQL charset-related system variables before parsing DDL history.");
+        return querySystemVariables(SQL_SHOW_SYSTEM_VARIABLES_CHARACTER_SET);
+    }
+
+    /**
+     * Read the MySQL system variables.
+     *
+     * @return the system variables that are related to server character sets; never null
+     */
+    protected Map<String, String> readMySqlSystemVariables() {
+        // Read the system variables from the MySQL instance and get the current database name ...
+        LOGGER.debug("Reading MySQL system variables");
+        return querySystemVariables(SQL_SHOW_SYSTEM_VARIABLES);
+    }
+
+    private Map<String, String> querySystemVariables(String statement) {
+        final Map<String, String> variables = new HashMap<>();
+        try {
+            query(statement, rs -> {
+                while (rs.next()) {
+                    String varName = rs.getString(1);
+                    String value = rs.getString(2);
+                    if (varName != null && value != null) {
+                        variables.put(varName, value);
+                        LOGGER.debug("\t{} = {}",
+                                Strings.pad(varName, 45, ' '),
+                                Strings.pad(value, 45, ' '));
+                    }
+                }
+            });
+        }
+        catch (SQLException e) {
+            throw new DebeziumException("Error reading MySQL variables: " + e.getMessage(), e);
+        }
+
+        return variables;
+    }
+
+    protected String setStatementFor(Map<String, String> variables) {
+        StringBuilder sb = new StringBuilder("SET ");
+        boolean first = true;
+        List<String> varNames = new ArrayList<>(variables.keySet());
+        Collections.sort(varNames);
+        for (String varName : varNames) {
+            if (first) {
+                first = false;
+            }
+            else {
+                sb.append(", ");
+            }
+            sb.append(varName).append("=");
+            String value = variables.get(varName);
+            if (value == null) {
+                value = "";
+            }
+            if (value.contains(",") || value.contains(";")) {
+                value = "'" + value + "'";
+            }
+            sb.append(value);
+        }
+        return sb.append(";").toString();
+    }
+
+    protected void setSystemProperty(String property, Field field, boolean showValueInError) {
+        String value = connectionConfig.config().getString(field);
+        if (value != null) {
+            value = value.trim();
+            String existingValue = System.getProperty(property);
+            if (existingValue == null) {
+                // There was no existing property ...
+                String existing = System.setProperty(property, value);
+                originalSystemProperties.put(property, existing); // the existing value may be null
+            }
+            else {
+                existingValue = existingValue.trim();
+                if (!existingValue.equalsIgnoreCase(value)) {
+                    // There was an existing property, and the value is different ...
+                    String msg = "System or JVM property '" + property + "' is already defined, but the configuration property '"
+                            + field.name()
+                            + "' defines a different value";
+                    if (showValueInError) {
+                        msg = "System or JVM property '" + property + "' is already defined as " + existingValue
+                                + ", but the configuration property '" + field.name() + "' defines a different value '" + value + "'";
+                    }
+                    throw new DebeziumException(msg);
+                }
+                // Otherwise, there was an existing property, and the value is exactly the same (so do nothing!)
+            }
+        }
+    }
+
+    /**
+     * Read the Ssl Version session variable.
+     *
+     * @return the session variables that are related to sessions ssl version
+     */
+    protected String getSessionVariableForSslVersion() {
+        final String SSL_VERSION = "Ssl_version";
+        LOGGER.debug("Reading MySQL Session variable for Ssl Version");
+        Map<String, String> sessionVariables = querySystemVariables(SQL_SHOW_SESSION_VARIABLE_SSL_VERSION);
+        if (!sessionVariables.isEmpty() && sessionVariables.containsKey(SSL_VERSION)) {
+            return sessionVariables.get(SSL_VERSION);
+        }
+        return null;
+    }
+
+    /**
+     * Determine whether the MySQL server has GTIDs enabled.
+     *
+     * @return {@code false} if the server's {@code gtid_mode} is set and is {@code OFF}, or {@code true} otherwise
+     */
+    public boolean isGtidModeEnabled() {
+        try {
+            return queryAndMap("SHOW GLOBAL VARIABLES LIKE 'GTID_MODE'", rs -> {
+                if (rs.next()) {
+                    return !"OFF".equalsIgnoreCase(rs.getString(2));
+                }
+                return false;
+            });
+        }
+        catch (SQLException e) {
+            throw new DebeziumException("Unexpected error while connecting to MySQL and looking at GTID mode: ", e);
+        }
+    }
+
+    /**
+     * Determine the executed GTID set for MySQL.
+     *
+     * @return the string representation of MySQL's GTID sets; never null but an empty string if the server does not use GTIDs
+     */
+    public String knownGtidSet() {
+        try {
+            return queryAndMap("SHOW MASTER STATUS", rs -> {
+                if (rs.next() && rs.getMetaData().getColumnCount() > 4) {
+                    return rs.getString(5); // GTID set, may be null, blank, or contain a GTID set
+                }
+                return "";
+            });
+        }
+        catch (SQLException e) {
+            throw new DebeziumException("Unexpected error while connecting to MySQL and looking at GTID mode: ", e);
+        }
+    }
+
+    /**
+     * Determine the difference between two sets.
+     *
+     * @return a subtraction of two GTID sets; never null
+     */
+    public GtidSet subtractGtidSet(GtidSet set1, GtidSet set2) {
+        try {
+            return prepareQueryAndMap("SELECT GTID_SUBTRACT(?, ?)",
+                    ps -> {
+                        ps.setString(1, set1.toString());
+                        ps.setString(2, set2.toString());
+                    },
+                    rs -> {
+                        if (rs.next()) {
+                            return new GtidSet(rs.getString(1));
+                        }
+                        return new GtidSet("");
+                    });
+        }
+        catch (SQLException e) {
+            throw new DebeziumException("Unexpected error while connecting to MySQL and looking at GTID mode: ", e);
+        }
+    }
+
+    /**
+     * Get the purged GTID values from MySQL (gtid_purged value)
+     *
+     * @return A GTID set; may be empty if not using GTIDs or none have been purged yet
+     */
+    public GtidSet purgedGtidSet() {
+        try {
+            return queryAndMap("SELECT @@global.gtid_purged", rs -> {
+                if (rs.next() && rs.getMetaData().getColumnCount() > 0) {
+                    return new GtidSet(rs.getString(1)); // GTID set, may be null, blank, or contain a GTID set
+                }
+                return new GtidSet("");
+            });
+        }
+        catch (SQLException e) {
+            throw new DebeziumException("Unexpected error while connecting to MySQL and looking at gtid_purged variable: ", e);
+        }
+    }
+
+    /**
+     * Determine if the current user has the named privilege. Note that if the user has the "ALL" privilege this method
+     * returns {@code true}.
+     *
+     * @param grantName the name of the MySQL privilege; may not be null
+     * @return {@code true} if the user has the named privilege, or {@code false} otherwise
+     */
+    public boolean userHasPrivileges(String grantName) {
+        try {
+            return queryAndMap("SHOW GRANTS FOR CURRENT_USER", rs -> {
+                while (rs.next()) {
+                    String grants = rs.getString(1);
+                    LOGGER.debug(grants);
+                    if (grants == null) {
+                        return false;
+                    }
+                    grants = grants.toUpperCase();
+                    if (grants.contains("ALL") || grants.contains(grantName.toUpperCase())) {
+                        return true;
+                    }
+                }
+                return false;
+            });
+        }
+        catch (SQLException e) {
+            throw new DebeziumException("Unexpected error while connecting to MySQL and looking at privileges for current user: ", e);
+        }
+    }
+
+    /**
+     * Determine the earliest binlog filename that is still available in the server.
+     *
+     * @return the name of the earliest binlog filename, or null if there are none.
+     */
+    public String earliestBinlogFilename() {
+        // Accumulate the available binlog filenames ...
+        List<String> logNames = new ArrayList<>();
+        try {
+            LOGGER.info("Checking all known binlogs from MySQL");
+            query("SHOW BINARY LOGS", rs -> {
+                while (rs.next()) {
+                    logNames.add(rs.getString(1));
+                }
+            });
+        }
+        catch (SQLException e) {
+            throw new DebeziumException("Unexpected error while connecting to MySQL and looking for binary logs: ", e);
+        }
+
+        if (logNames.isEmpty()) {
+            return null;
+        }
+        return logNames.get(0);
+    }
+
+    /**
+     * Determine whether the MySQL server has the binlog_row_image set to 'FULL'.
+     *
+     * @return {@code true} if the server's {@code binlog_row_image} is set to {@code FULL}, or {@code false} otherwise
+     */
+    protected boolean isBinlogRowImageFull() {
+        try {
+            final String rowImage = queryAndMap("SHOW GLOBAL VARIABLES LIKE 'binlog_row_image'", rs -> {
+                if (rs.next()) {
+                    return rs.getString(2);
+                }
+                // This setting was introduced in MySQL 5.6+ with default of 'FULL'.
+                // For older versions, assume 'FULL'.
+                return "FULL";
+            });
+            LOGGER.debug("binlog_row_image={}", rowImage);
+            return "FULL".equalsIgnoreCase(rowImage);
+        }
+        catch (SQLException e) {
+            throw new DebeziumException("Unexpected error while connecting to MySQL and looking at BINLOG_ROW_IMAGE mode: ", e);
+        }
+    }
+
+    /**
+     * Determine whether the MySQL server has the row-level binlog enabled.
+     *
+     * @return {@code true} if the server's {@code binlog_format} is set to {@code ROW}, or {@code false} otherwise
+     */
+    protected boolean isBinlogFormatRow() {
+        try {
+            final String mode = queryAndMap("SHOW GLOBAL VARIABLES LIKE 'binlog_format'", rs -> rs.next() ? rs.getString(2) : "");
+            LOGGER.debug("binlog_format={}", mode);
+            return "ROW".equalsIgnoreCase(mode);
+        }
+        catch (SQLException e) {
+            throw new DebeziumException("Unexpected error while connecting to MySQL and looking at BINLOG_FORMAT mode: ", e);
+        }
+    }
+
+    /**
+     * Query the database server to get the list of the binlog files availble.
+     *
+     * @return list of the binlog files
+     */
+    public List<String> availableBinlogFiles() {
+        List<String> logNames = new ArrayList<>();
+        try {
+            LOGGER.info("Get all known binlogs from MySQL");
+            query("SHOW BINARY LOGS", rs -> {
+                while (rs.next()) {
+                    logNames.add(rs.getString(1));
+                }
+            });
+            return logNames;
+        }
+        catch (SQLException e) {
+            throw new DebeziumException("Unexpected error while connecting to MySQL and looking for binary logs: ", e);
+        }
+    }
+
+    public Optional<Long> getEstimatedTableSize(TableId tableId) {
+        try {
+            // Choose how we create statements based on the # of rows.
+            // This is approximate and less accurate then COUNT(*),
+            // but far more efficient for large InnoDB tables.
+            execute("USE `" + tableId.catalog() + "`;");
+            return queryAndMap("SHOW TABLE STATUS LIKE '" + tableId.table() + "';", rs -> {
+                if (rs.next()) {
+                    return Optional.of((rs.getLong(5)));
+                }
+                return Optional.empty();
+            });
+        }
+        catch (SQLException e) {
+            LOGGER.debug("Error while getting number of rows in table {}: {}", tableId, e.getMessage(), e);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Read the MySQL default character sets for exisiting databases.
+     *
+     * @return the map of database names with their default character sets; never null
+     */
+    protected Map<String, DatabaseLocales> readDatabaseCollations() {
+        LOGGER.debug("Reading default database charsets");
+        try {
+            return queryAndMap("SELECT schema_name, default_character_set_name, default_collation_name FROM information_schema.schemata", rs -> {
+                final Map<String, DatabaseLocales> charsets = new HashMap<>();
+                while (rs.next()) {
+                    String dbName = rs.getString(1);
+                    String charset = rs.getString(2);
+                    String collation = rs.getString(3);
+                    if (dbName != null && (charset != null || collation != null)) {
+                        charsets.put(dbName, new DatabaseLocales(charset, collation));
+                        LOGGER.debug("\t{} = {}, {}",
+                                Strings.pad(dbName, 45, ' '),
+                                Strings.pad(charset, 45, ' '),
+                                Strings.pad(collation, 45, ' '));
+                    }
+                }
+                return charsets;
+            });
+        }
+        catch (SQLException e) {
+            throw new DebeziumException("Error reading default database charsets: " + e.getMessage(), e);
+        }
+    }
+
+    public String connectionString() {
+        return connectionString(URL_PATTERN);
+    }
+
+    public static class MySqlConnectionConfiguration {
+
+        protected static final String JDBC_PROPERTY_LEGACY_DATETIME = "useLegacyDatetimeCode";
+
+        private final Configuration jdbcConfig;
+        private final ConnectionFactory factory;
+        private final Configuration config;
+
+        public MySqlConnectionConfiguration(Configuration config) {
+            // Set up the JDBC connection without actually connecting, with extra MySQL-specific properties
+            // to give us better JDBC database metadata behavior, including using UTF-8 for the client-side character encoding
+            // per https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-charsets.html
+            this.config = config;
+            final boolean useSSL = sslModeEnabled();
+            final Configuration dbConfig = config
+                    .filter(x -> !(x.startsWith(DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING) || x.equals(MySqlConnectorConfig.DATABASE_HISTORY.name())))
+                    .edit()
+                    .withDefault(MySqlConnectorConfig.PORT, MySqlConnectorConfig.PORT.defaultValue())
+                    .build()
+                    .subset("database.", true);
+
+            final Builder jdbcConfigBuilder = dbConfig
+                    .edit()
+                    .with("connectTimeout", Long.toString(getConnectionTimeout().toMillis()))
+                    .with("useSSL", Boolean.toString(useSSL));
+
+            final String legacyDateTime = dbConfig.getString(JDBC_PROPERTY_LEGACY_DATETIME);
+            if (legacyDateTime == null) {
+                jdbcConfigBuilder.with(JDBC_PROPERTY_LEGACY_DATETIME, "false");
+            }
+            else if ("true".equals(legacyDateTime)) {
+                LOGGER.warn("'{}' is set to 'true'. This setting is not recommended and can result in timezone issues.", JDBC_PROPERTY_LEGACY_DATETIME);
+            }
+
+            this.jdbcConfig = jdbcConfigBuilder.build();
+            String driverClassName = this.jdbcConfig.getString(MySqlConnectorConfig.JDBC_DRIVER);
+            factory = JdbcConnection.patternBasedFactory(MySqlConnection.URL_PATTERN, driverClassName, getClass().getClassLoader());
+        }
+
+        public Configuration config() {
+            return jdbcConfig;
+        }
+
+        public ConnectionFactory factory() {
+            return factory;
+        }
+
+        public String username() {
+            return config.getString(MySqlConnectorConfig.USER);
+        }
+
+        public String password() {
+            return config.getString(MySqlConnectorConfig.PASSWORD);
+        }
+
+        public String hostname() {
+            return config.getString(MySqlConnectorConfig.HOSTNAME);
+        }
+
+        public int port() {
+            return config.getInteger(MySqlConnectorConfig.PORT);
+        }
+
+        public SecureConnectionMode sslMode() {
+            String mode = config.getString(MySqlConnectorConfig.SSL_MODE);
+            return SecureConnectionMode.parse(mode);
+        }
+
+        public boolean sslModeEnabled() {
+            return sslMode() != SecureConnectionMode.DISABLED;
+        }
+
+        public Duration getConnectionTimeout() {
+            return Duration.ofMillis(config.getLong(MySqlConnectorConfig.CONNECTION_TIMEOUT_MS));
+        }
+
+        public EventProcessingFailureHandlingMode eventProcessingFailureHandlingMode() {
+            String mode = config.getString(CommonConnectorConfig.EVENT_PROCESSING_FAILURE_HANDLING_MODE);
+            if (mode == null) {
+                mode = config.getString(MySqlConnectorConfig.EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE);
+            }
+            return EventProcessingFailureHandlingMode.parse(mode);
+        }
+
+        public EventProcessingFailureHandlingMode inconsistentSchemaHandlingMode() {
+            String mode = config.getString(MySqlConnectorConfig.INCONSISTENT_SCHEMA_HANDLING_MODE);
+            return EventProcessingFailureHandlingMode.parse(mode);
+        }
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -565,11 +565,6 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
 
     protected static final int DEFAULT_PORT = 3306;
 
-    private static final String DATABASE_WHITELIST_NAME = "database.whitelist";
-    private static final String DATABASE_INCLUDE_LIST_NAME = "database.include.list";
-    private static final String DATABASE_BLACKLIST_NAME = "database.blacklist";
-    private static final String DATABASE_EXCLUDE_LIST_NAME = "database.exclude.list";
-
     /**
      * Default size of the binlog buffer used for examining transactions and
      * deciding whether to propagate them or not. A size of 0 disables the buffer,

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -6,55 +6,50 @@
 package io.debezium.connector.mysql;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.debezium.annotation.NotThreadSafe;
+import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
+import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.connector.common.BaseSourceTask;
+import io.debezium.connector.mysql.MySqlConnection.MySqlConnectionConfiguration;
+import io.debezium.connector.mysql.MySqlConnectorConfig.BigIntUnsignedHandlingMode;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
+import io.debezium.jdbc.JdbcValueConverters.BigIntUnsignedMode;
+import io.debezium.jdbc.JdbcValueConverters.DecimalMode;
+import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.pipeline.ChangeEventSourceCoordinator;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.relational.TableId;
 import io.debezium.schema.TopicSelector;
-import io.debezium.util.Collect;
-import io.debezium.util.LoggingContext;
-import io.debezium.util.LoggingContext.PreviousContext;
+import io.debezium.util.Clock;
+import io.debezium.util.SchemaNameAdjuster;
 
 /**
- * A Kafka Connect source task reads the MySQL binary log and generate the corresponding data change events.
+ * The main task executing streaming from MySQL.
+ * Responsible for lifecycle management of the streaming code.
  *
- * @see MySqlConnector
- * @author Randall Hauch
+ * @author Jiri Pechanec
+ *
  */
-@NotThreadSafe
-public final class MySqlConnectorTask extends BaseSourceTask {
+public class MySqlConnectorTask extends BaseSourceTask {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(MySqlConnectorTask.class);
+    private static final String CONTEXT_NAME = "mysql-connector-task";
+
     private volatile MySqlTaskContext taskContext;
-    private volatile MySqlJdbcContext connectionContext;
-    private volatile ChainedReader readers;
-
-    /**
-     * Create an instance of the log reader that uses Kafka to store database schema history and the
-     * {@link TopicSelector#defaultSelector(String) default topic selector} of "{@code <serverName>.<databaseName>.<tableName>}"
-     * for
-     * data and "{@code <serverName>}" for metadata.
-     */
-    public MySqlConnectorTask() {
-    }
+    private volatile ChangeEventQueue<DataChangeEvent> queue;
+    private volatile MySqlConnection connection;
+    private volatile ErrorHandler errorHandler;
+    private volatile MySqlDatabaseSchema schema;
 
     @Override
     public String version() {
@@ -63,409 +58,123 @@ public final class MySqlConnectorTask extends BaseSourceTask {
 
     @Override
     public ChangeEventSourceCoordinator start(Configuration config) {
-        final String serverName = config.getString(MySqlConnectorConfig.SERVER_NAME);
-        PreviousContext prevLoggingContext = LoggingContext.forConnector(Module.contextName(), serverName, "task");
+        final Clock clock = Clock.system();
+        final MySqlConnectorConfig connectorConfig = new MySqlConnectorConfig(config);
+        final TopicSelector<TableId> topicSelector = MySqlTopicSelector.defaultSelector(connectorConfig);
+        final SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create(LOGGER);
+        final MySqlValueConverters valueConverters = getValueConverters(connectorConfig);
 
+        // By default do not load whole result sets into memory
+        config = config.edit()
+                .withDefault("database.responseBuffering", "adaptive")
+                .withDefault("database.fetchSize", 10_000)
+                .build();
+
+        connection = new MySqlConnection(new MySqlConnectionConfiguration(config));
         try {
-            // Get the offsets for our partition ...
-            boolean startWithSnapshot = false;
-            boolean snapshotEventsAsInserts = config.getBoolean(MySqlConnectorConfig.SNAPSHOT_EVENTS_AS_INSERTS);
-            Map<String, String> partition = Collect.hashMapOf(SourceInfo.SERVER_PARTITION_KEY, serverName);
-            Map<String, ?> offsets = getRestartOffset(context.offsetStorageReader().offset(partition));
-            final SourceInfo source;
-            if (offsets != null) {
-                Filters filters = SourceInfo.offsetsHaveFilterInfo(offsets) ? getOldFilters(offsets, config) : getAllFilters(config);
-                this.taskContext = createAndStartTaskContext(config, filters);
-                this.connectionContext = taskContext.getConnectionContext();
-                source = taskContext.source();
-                // Set the position in our source info ...
-                source.setOffset(offsets);
-                logger.info("Found existing offset: {}", offsets);
-
-                // First check if db history is available
-                if (!taskContext.historyExists()) {
-                    if (taskContext.isSchemaOnlyRecoverySnapshot()) {
-                        startWithSnapshot = true;
-
-                        // But check to see if the server still has those binlog coordinates ...
-                        if (!isBinlogAvailable()) {
-                            String msg = "The connector is trying to read binlog starting at " + source + ", but this is no longer "
-                                    + "available on the server. Reconfigure the connector to use a snapshot when needed.";
-                            throw new ConnectException(msg);
-                        }
-                        logger.info("The db-history topic is missing but we are in {} snapshot mode. " +
-                                "Attempting to snapshot the current schema and then begin reading the binlog from the last recorded offset.",
-                                SnapshotMode.SCHEMA_ONLY_RECOVERY);
-                    }
-                    else {
-                        String msg = "The db history topic is missing. You may attempt to recover it by reconfiguring the connector to "
-                                + SnapshotMode.SCHEMA_ONLY_RECOVERY;
-                        throw new ConnectException(msg);
-                    }
-                    taskContext.initializeHistoryStorage();
-                }
-                else {
-
-                    // Before anything else, recover the database history to the specified binlog coordinates ...
-                    taskContext.loadHistory(source);
-
-                    if (source.isSnapshotInEffect()) {
-                        // The last offset was an incomplete snapshot that we cannot recover from...
-                        if (taskContext.isSnapshotNeverAllowed()) {
-                            // No snapshots are allowed
-                            String msg = "The connector previously stopped while taking a snapshot, but now the connector is configured "
-                                    + "to never allow snapshots. Reconfigure the connector to use snapshots initially or when needed.";
-                            throw new ConnectException(msg);
-                        }
-                        // Otherwise, restart a new snapshot ...
-                        startWithSnapshot = true;
-                        logger.info("Prior execution was an incomplete snapshot, so starting new snapshot");
-                    }
-                    else {
-                        // No snapshot was in effect, so we should just start reading from the binlog ...
-                        startWithSnapshot = false;
-
-                        // But check to see if the server still has those binlog coordinates ...
-                        if (!isBinlogAvailable()) {
-                            if (!taskContext.isSnapshotAllowedWhenNeeded()) {
-                                String msg = "The connector is trying to read binlog starting at " + source + ", but this is no longer "
-                                        + "available on the server. Reconfigure the connector to use a snapshot when needed.";
-                                throw new ConnectException(msg);
-                            }
-                            startWithSnapshot = true;
-                        }
-                    }
-                }
-
-            }
-            else {
-                // We have no recorded offsets ...
-                this.taskContext = createAndStartTaskContext(config, getAllFilters(config));
-                taskContext.initializeHistoryStorage();
-                this.connectionContext = taskContext.getConnectionContext();
-                source = taskContext.source();
-
-                if (taskContext.isSnapshotNeverAllowed()) {
-                    // We're not allowed to take a snapshot, so instead we have to assume that the binlog contains the
-                    // full history of the database.
-                    logger.info("Found no existing offset and snapshots disallowed, so starting at beginning of binlog");
-                    source.setBinlogStartPoint("", 0L); // start from the beginning of the binlog
-                    taskContext.initializeHistory();
-
-                    // Look to see what the first available binlog file is called, and whether it looks like binlog files have
-                    // been purged. If so, then output a warning ...
-                    String earliestBinlogFilename = earliestBinlogFilename();
-                    if (earliestBinlogFilename == null) {
-                        logger.warn("No binlog appears to be available. Ensure that the MySQL row-level binlog is enabled.");
-                    }
-                    else if (!earliestBinlogFilename.endsWith("00001")) {
-                        logger.warn("It is possible the server has purged some binlogs. If this is the case, then using snapshot mode may be required.");
-                    }
-                }
-                else {
-                    // We are allowed to use snapshots, and that is the best way to start ...
-                    startWithSnapshot = true;
-                    // The snapshot will determine if GTIDs are set
-                    logger.info("Found no existing offset, so preparing to perform a snapshot");
-                    // The snapshot will also initialize history ...
-                }
-            }
-
-            if (!startWithSnapshot && source.gtidSet() == null && connectionContext.isGtidModeEnabled()) {
-                // The snapshot will properly determine the GTID set, but we're not starting with a snapshot and GTIDs were not
-                // previously used but the MySQL server has them enabled ...
-                source.setCompletedGtidSet("");
-            }
-
-            // Check whether the row-level binlog is enabled ...
-            final boolean binlogFormatRow = isBinlogFormatRow();
-            final boolean binlogRowImageFull = isBinlogRowImageFull();
-            final boolean rowBinlogEnabled = binlogFormatRow && binlogRowImageFull;
-
-            ChainedReader.Builder chainedReaderBuilder = new ChainedReader.Builder();
-
-            // Set up the readers, with a callback to `completeReaders` so that we know when it is finished ...
-            if (startWithSnapshot) {
-                // We're supposed to start with a snapshot, so set that up ...
-                SnapshotReader snapshotReader = new SnapshotReader("snapshot", taskContext);
-                if (snapshotEventsAsInserts) {
-                    snapshotReader.generateInsertEvents();
-                }
-
-                if (!taskContext.getConnectorConfig().getSnapshotDelay().isZero()) {
-                    // Adding a timed blocking reader to delay the snapshot, can help to avoid initial rebalancing interruptions
-                    chainedReaderBuilder.addReader(new TimedBlockingReader("timed-blocker", taskContext.getConnectorConfig().getSnapshotDelay()));
-                }
-                chainedReaderBuilder.addReader(snapshotReader);
-
-                if (taskContext.isInitialSnapshotOnly()) {
-                    logger.warn("This connector will only perform a snapshot, and will stop after that completes.");
-                    chainedReaderBuilder.addReader(new BlockingReader("blocker",
-                            "Connector has completed all of its work but will continue in the running state. It can be shut down at any time."));
-                    chainedReaderBuilder
-                            .completionMessage("Connector configured to only perform snapshot, and snapshot completed successfully. Connector will terminate.");
-                }
-                else {
-                    if (!rowBinlogEnabled) {
-                        if (!binlogFormatRow) {
-                            throw new ConnectException("The MySQL server is not configured to use a ROW binlog_format, which is "
-                                    + "required for this connector to work properly. Change the MySQL configuration to use a "
-                                    + "binlog_format=ROW and restart the connector.");
-                        }
-                        else {
-                            throw new ConnectException("The MySQL server is not configured to use a FULL binlog_row_image, which is "
-                                    + "required for this connector to work properly. Change the MySQL configuration to use a "
-                                    + "binlog_row_image=FULL and restart the connector.");
-                        }
-                    }
-                    BinlogReader binlogReader = new BinlogReader("binlog", taskContext, null);
-                    chainedReaderBuilder.addReader(binlogReader);
-                }
-            }
-            else {
-                source.maybeSetFilterDataFromConfig(config);
-                if (!rowBinlogEnabled) {
-                    throw new ConnectException(
-                            "The MySQL server does not appear to be using a full row-level binlog, which is required for this connector to work properly. Enable this mode and restart the connector.");
-                }
-
-                // if there are new tables
-                if (newTablesInConfig()) {
-                    // and we are configured to run a parallel snapshot
-                    if (taskContext.getConnectorConfig().getSnapshotNewTables() == MySqlConnectorConfig.SnapshotNewTables.PARALLEL) {
-                        ServerIdGenerator serverIdGenerator = new ServerIdGenerator(config.getLong(MySqlConnectorConfig.SERVER_ID),
-                                config.getLong(MySqlConnectorConfig.SERVER_ID_OFFSET));
-                        ParallelSnapshotReader parallelSnapshotReader = new ParallelSnapshotReader(config,
-                                taskContext,
-                                getNewFilters(offsets, config),
-                                serverIdGenerator);
-
-                        MySqlTaskContext unifiedTaskContext = createAndStartTaskContext(config, getAllFilters(config));
-                        // we aren't completing a snapshot, but we need to make sure the "snapshot" flag is false for this new context.
-                        unifiedTaskContext.source().completeSnapshot();
-                        BinlogReader unifiedBinlogReader = new BinlogReader("binlog",
-                                unifiedTaskContext,
-                                null,
-                                serverIdGenerator.getConfiguredServerId());
-                        ReconcilingBinlogReader reconcilingBinlogReader = parallelSnapshotReader.createReconcilingBinlogReader(unifiedBinlogReader);
-
-                        chainedReaderBuilder.addReader(parallelSnapshotReader);
-                        chainedReaderBuilder.addReader(reconcilingBinlogReader);
-                        chainedReaderBuilder.addReader(unifiedBinlogReader);
-
-                        unifiedBinlogReader.uponCompletion(unifiedTaskContext::shutdown);
-                    }
-                }
-                else {
-                    // We're going to start by reading the binlog ...
-                    BinlogReader binlogReader = new BinlogReader("binlog", taskContext, null);
-                    chainedReaderBuilder.addReader(binlogReader);
-                }
-
-            }
-
-            readers = chainedReaderBuilder.build();
-            readers.uponCompletion(this::completeReaders);
-
-            // And finally initialize and start the chain of readers ...
-            this.readers.initialize();
-            this.readers.start();
+            connection.setAutoCommit(false);
         }
-        catch (Throwable e) {
-            // If we don't complete startup, then Kafka Connect will not attempt to stop the connector. So if we
-            // run into a problem, we have to stop ourselves ...
-            try {
-                stop();
-            }
-            catch (Throwable s) {
-                // Log, but don't propagate ...
-                logger.error("Failed to start the connector (see other exception), but got this error while cleaning up", s);
-            }
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-                throw new ConnectException("Interrupted while starting the connector", e);
-            }
-            if (e instanceof ConnectException) {
-                throw (ConnectException) e;
-            }
-            throw new ConnectException(e);
-        }
-        finally {
-            prevLoggingContext.restore();
+        catch (SQLException e) {
+            throw new DebeziumException(e);
         }
 
-        return null;
+        validateBinlogConfiguration(connectorConfig);
+
+        final MySqlOffsetContext previousOffset = (MySqlOffsetContext) getPreviousOffset(new MySqlOffsetContext.Loader(connectorConfig));
+        if (previousOffset == null) {
+            LOGGER.info("No previous offset found");
+        }
+
+        final boolean tableIdCaseInsensitive = !"0".equals(connection.readMySqlSystemVariables().get(MySqlSystemVariables.LOWER_CASE_TABLE_NAMES));
+
+        this.schema = new MySqlDatabaseSchema(connectorConfig, valueConverters, topicSelector, schemaNameAdjuster, tableIdCaseInsensitive);
+
+        validateAndLoadDatabaseHistory(connectorConfig, previousOffset, schema);
+        validateSnapshotFeasibility(connectorConfig, previousOffset);
+
+        taskContext = new MySqlTaskContext(connectorConfig, schema);
+
+        // Set up the task record queue ...
+        this.queue = new ChangeEventQueue.Builder<DataChangeEvent>()
+                .pollInterval(connectorConfig.getPollInterval())
+                .maxBatchSize(connectorConfig.getMaxBatchSize())
+                .maxQueueSize(connectorConfig.getMaxQueueSize())
+                .maxQueueSizeInBytes(connectorConfig.getMaxQueueSizeInBytes())
+                .loggingContextSupplier(() -> taskContext.configureLoggingContext(CONTEXT_NAME))
+                .build();
+
+        errorHandler = new MySqlErrorHandler(connectorConfig.getLogicalName(), queue);
+
+        final MySqlEventMetadataProvider metadataProvider = new MySqlEventMetadataProvider();
+
+        final EventDispatcher<TableId> dispatcher = new EventDispatcher<>(
+                connectorConfig,
+                topicSelector,
+                schema,
+                queue,
+                connectorConfig.getTableFilters().dataCollectionFilter(),
+                DataChangeEvent::new,
+                metadataProvider,
+                schemaNameAdjuster);
+
+        final MySqlStreamingChangeEventSourceMetrics streamingMetrics = new MySqlStreamingChangeEventSourceMetrics(taskContext, queue, metadataProvider);
+
+        ChangeEventSourceCoordinator coordinator = new ChangeEventSourceCoordinator(
+                previousOffset,
+                errorHandler,
+                MySqlConnector.class,
+                connectorConfig,
+                new MySqlChangeEventSourceFactory(connectorConfig, connection, errorHandler, dispatcher, clock, schema, taskContext, streamingMetrics),
+                new MySqlChangeEventSourceMetricsFactory(streamingMetrics),
+                dispatcher,
+                schema);
+
+        coordinator.start(taskContext, this.queue, metadataProvider);
+
+        return coordinator;
     }
 
-    public class ServerIdGenerator {
+    private MySqlValueConverters getValueConverters(MySqlConnectorConfig configuration) {
+        // Use MySQL-specific converters and schemas for values ...
 
-        private final long configuredServerId;
-        private final long offset;
-        private int counter;
+        TemporalPrecisionMode timePrecisionMode = configuration.getTemporalPrecisionMode();
 
-        private ServerIdGenerator(long configuredServerId, long configuredOffset) {
-            this.configuredServerId = configuredServerId;
-            this.offset = configuredOffset;
-            this.counter = 0;
-        }
+        DecimalMode decimalMode = configuration.getDecimalMode();
 
-        public long getNextServerId() {
-            counter++;
-            return configuredServerId + (counter * offset);
-        }
+        String bigIntUnsignedHandlingModeStr = configuration.getConfig().getString(MySqlConnectorConfig.BIGINT_UNSIGNED_HANDLING_MODE);
+        BigIntUnsignedHandlingMode bigIntUnsignedHandlingMode = BigIntUnsignedHandlingMode.parse(bigIntUnsignedHandlingModeStr);
+        BigIntUnsignedMode bigIntUnsignedMode = bigIntUnsignedHandlingMode.asBigIntUnsignedMode();
 
-        public long getConfiguredServerId() {
-            return configuredServerId;
-        }
-    }
-
-    /**
-     * Get the offset to restart the connector from. Normally, this is just the stored offset.
-     *
-     * However, if we were doing a parallel load with new tables, it's possible that the last
-     * committed offset is from reading the new tables, which could be beyond where we want to
-     * restart from (and restarting there could cause skipped events). To fix this, the new
-     * tables binlog reader records extra information in its offset to tell the connector where
-     * to restart from. If this extra information is present in the stored offset, that is the
-     * offset that is returned.
-     * @param storedOffset the stored offset.
-     * @return the offset to restart from.
-     * @see RecordMakers#RecordMakers(MySqlSchema, SourceInfo, TopicSelector, boolean, Map)
-     */
-    private Map<String, ?> getRestartOffset(Map<String, ?> storedOffset) {
-        Map<String, Object> restartOffset = new HashMap<>();
-        if (storedOffset != null) {
-            for (Entry<String, ?> entry : storedOffset.entrySet()) {
-                if (entry.getKey().startsWith(SourceInfo.RESTART_PREFIX)) {
-                    String newKey = entry.getKey().substring(SourceInfo.RESTART_PREFIX.length());
-                    restartOffset.put(newKey, entry.getValue());
-                }
-            }
-        }
-        return restartOffset.isEmpty() ? storedOffset : restartOffset;
-    }
-
-    private static MySqlTaskContext createAndStartTaskContext(Configuration config,
-                                                              Filters filters) {
-        MySqlTaskContext taskContext = new MySqlTaskContext(config, filters);
-        taskContext.start();
-        return taskContext;
-    }
-
-    /**
-     * @return true if new tables appear to have been added to the config, and false otherwise.
-     */
-    private boolean newTablesInConfig() {
-        final String elementSep = "/s*,/s*";
-
-        // take in two stringified lists, and return true if the first list contains elements that are not in the second list
-        BiFunction<String, String, Boolean> hasExclusiveElements = (String a, String b) -> {
-            if (a == null || a.isEmpty()) {
-                return false;
-            }
-            else if (b == null || b.isEmpty()) {
-                return true;
-            }
-            Set<String> bSet = Stream.of(b.split(elementSep)).collect(Collectors.toSet());
-            return !Stream.of(a.split(elementSep)).filter((x) -> !bSet.contains(x)).collect(Collectors.toSet()).isEmpty();
-        };
-
-        final SourceInfo sourceInfo = taskContext.source();
-        final Configuration config = taskContext.config();
-        if (!sourceInfo.hasFilterInfo()) {
-            // if there was previously no filter info, then we either can't evaluate if there are new tables,
-            // or there aren't any new tables because we previously used no filter.
-            return false;
-        }
-        // otherwise, we have filter info
-        // if either include lists has been added to, then we may have new tables
-
-        if (hasExclusiveElements.apply(
-                config.getFallbackStringProperty(MySqlConnectorConfig.DATABASE_INCLUDE_LIST, MySqlConnectorConfig.DATABASE_WHITELIST),
-                sourceInfo.getDatabaseIncludeList())) {
-            return true;
-        }
-        if (hasExclusiveElements.apply(
-                config.getFallbackStringProperty(MySqlConnectorConfig.TABLE_INCLUDE_LIST, MySqlConnectorConfig.TABLE_WHITELIST),
-                sourceInfo.getTableIncludeList())) {
-            return true;
-        }
-        // if either blacklist has been removed from, then we may have new tables
-        if (hasExclusiveElements.apply(sourceInfo.getDatabaseExcludeList(),
-                config.getFallbackStringProperty(MySqlConnectorConfig.DATABASE_EXCLUDE_LIST, MySqlConnectorConfig.DATABASE_BLACKLIST))) {
-            return true;
-        }
-        if (hasExclusiveElements.apply(sourceInfo.getTableExcludeList(),
-                config.getFallbackStringProperty(MySqlConnectorConfig.TABLE_EXCLUDE_LIST, MySqlConnectorConfig.TABLE_BLACKLIST))) {
-            return true;
-        }
-        // otherwise, false.
-        return false;
-    }
-
-    /**
-     * Get the filters representing the tables that have been newly added to the config, but
-     * not those that previously existed in the config.
-     * @return {@link Filters}
-     */
-    private static Filters getNewFilters(Map<String, ?> offsets, Configuration config) {
-        Filters oldFilters = getOldFilters(offsets, config);
-        return new Filters.Builder(config).excludeAllTables(oldFilters).build();
-    }
-
-    /**
-     * Get the filters representing those tables that previously existed in the config, but
-     * not those newly added to the config.
-     * @return {@link Filters}
-     */
-    private static Filters getOldFilters(Map<String, ?> offsets, Configuration config) {
-        return new Filters.Builder(config).setFiltersFromOffsets(offsets).build();
-    }
-
-    /**
-     * Get the filters representing all tables represented by the config.
-     * @return {@link Filters}
-     */
-    private static Filters getAllFilters(Configuration config) {
-        return new Filters.Builder(config).build();
+        final boolean timeAdjusterEnabled = configuration.getConfig().getBoolean(MySqlConnectorConfig.ENABLE_TIME_ADJUSTER);
+        return new MySqlValueConverters(decimalMode, timePrecisionMode, bigIntUnsignedMode,
+                configuration.binaryHandlingMode(), timeAdjusterEnabled ? MySqlValueConverters::adjustTemporal : x -> x,
+                MySqlValueConverters::defaultParsingErrorHandler);
     }
 
     @Override
     public List<SourceRecord> doPoll() throws InterruptedException {
-        Reader currentReader = readers;
-        if (currentReader == null) {
-            return null;
-        }
-        PreviousContext prevLoggingContext = this.taskContext.configureLoggingContext("task");
-        try {
-            logger.trace("Polling for events");
-            return currentReader.poll();
-        }
-        finally {
-            prevLoggingContext.restore();
-        }
+        final List<DataChangeEvent> records = queue.poll();
+
+        final List<SourceRecord> sourceRecords = records.stream()
+                .map(DataChangeEvent::getRecord)
+                .collect(Collectors.toList());
+
+        return sourceRecords;
     }
 
     @Override
     protected void doStop() {
-        if (context != null) {
-            PreviousContext prevLoggingContext = null;
-            if (this.taskContext != null) {
-                prevLoggingContext = this.taskContext.configureLoggingContext("task");
+        try {
+            if (connection != null) {
+                connection.close();
             }
-            try {
-                logger.info("Stopping MySQL connector task");
+        }
+        catch (SQLException e) {
+            LOGGER.error("Exception while closing JDBC connection", e);
+        }
 
-                if (readers != null) {
-                    readers.stop();
-                    readers.destroy();
-                }
-            }
-            finally {
-                if (prevLoggingContext != null) {
-                    prevLoggingContext.restore();
-                }
-            }
+        if (schema != null) {
+            schema.close();
         }
     }
 
@@ -474,26 +183,25 @@ public final class MySqlConnectorTask extends BaseSourceTask {
         return MySqlConnectorConfig.ALL_FIELDS;
     }
 
-    /**
-     * When the task is {@link #stop() stopped}, the readers may have additional work to perform before they actually
-     * stop and before all their records have been consumed via the {@link #poll()} method. This method signals that
-     * all of this has completed.
-     */
-    protected void completeReaders() {
-        PreviousContext prevLoggingContext = this.taskContext.configureLoggingContext("task");
-        try {
-            // Flush and stop database history, close all JDBC connections ...
-            if (this.taskContext != null) {
-                taskContext.shutdown();
+    private void validateBinlogConfiguration(MySqlConnectorConfig config) {
+        if (config.getSnapshotMode().shouldStream()) {
+            // Check whether the row-level binlog is enabled ...
+            final boolean binlogFormatRow = connection.isBinlogFormatRow();
+            final boolean binlogRowImageFull = connection.isBinlogRowImageFull();
+            final boolean rowBinlogEnabled = binlogFormatRow && binlogRowImageFull;
+
+            if (!rowBinlogEnabled) {
+                if (!binlogFormatRow) {
+                    throw new DebeziumException("The MySQL server is not configured to use a ROW binlog_format, which is "
+                            + "required for this connector to work properly. Change the MySQL configuration to use a "
+                            + "binlog_format=ROW and restart the connector.");
+                }
+                else {
+                    throw new DebeziumException("The MySQL server is not configured to use a FULL binlog_row_image, which is "
+                            + "required for this connector to work properly. Change the MySQL configuration to use a "
+                            + "binlog_row_image=FULL and restart the connector.");
+                }
             }
-        }
-        catch (Throwable e) {
-            logger.error("Unexpected error shutting down the database history and/or closing JDBC connections", e);
-        }
-        finally {
-            context = null;
-            logger.info("Connector task finished all work and is now shutdown");
-            prevLoggingContext.restore();
         }
     }
 
@@ -503,40 +211,40 @@ public final class MySqlConnectorTask extends BaseSourceTask {
      *
      * @return {@code true} if the server has the binlog coordinates, or {@code false} otherwise
      */
-    protected boolean isBinlogAvailable() {
-        String gtidStr = taskContext.source().gtidSet();
+    protected boolean isBinlogAvailable(MySqlConnectorConfig config, MySqlOffsetContext offset) {
+        String gtidStr = offset.getSource().gtidSet();
         if (gtidStr != null) {
             if (gtidStr.trim().isEmpty()) {
                 return true; // start at beginning ...
             }
-            String availableGtidStr = connectionContext.knownGtidSet();
+            String availableGtidStr = connection.knownGtidSet();
             if (availableGtidStr == null || availableGtidStr.trim().isEmpty()) {
                 // Last offsets had GTIDs but the server does not use them ...
-                logger.info("Connector used GTIDs previously, but MySQL does not know of any GTIDs or they are not enabled");
+                LOGGER.info("Connector used GTIDs previously, but MySQL does not know of any GTIDs or they are not enabled");
                 return false;
             }
             // GTIDs are enabled, and we used them previously, but retain only those GTID ranges for the allowed source UUIDs ...
-            GtidSet gtidSet = new GtidSet(gtidStr).retainAll(taskContext.gtidSourceFilter());
+            GtidSet gtidSet = new GtidSet(gtidStr).retainAll(config.gtidSourceFilter());
             // Get the GTID set that is available in the server ...
             GtidSet availableGtidSet = new GtidSet(availableGtidStr);
             if (gtidSet.isContainedWithin(availableGtidSet)) {
-                logger.info("MySQL current GTID set {} does contain the GTID set required by the connector {}", availableGtidSet, gtidSet);
-                final GtidSet knownServerSet = availableGtidSet.retainAll(taskContext.gtidSourceFilter());
-                final GtidSet gtidSetToReplicate = connectionContext.subtractGtidSet(knownServerSet, gtidSet);
-                final GtidSet purgedGtidSet = connectionContext.purgedGtidSet();
-                final GtidSet nonPurgedGtidSetToReplicate = connectionContext.subtractGtidSet(gtidSetToReplicate, purgedGtidSet);
-                logger.info("GTIDs known by the server but not processed yet {}, for replication are available only {}", gtidSetToReplicate, nonPurgedGtidSetToReplicate);
+                LOGGER.info("MySQL current GTID set {} does contain the GTID set required by the connector {}", availableGtidSet, gtidSet);
+                final GtidSet knownServerSet = availableGtidSet.retainAll(config.gtidSourceFilter());
+                final GtidSet gtidSetToReplicate = connection.subtractGtidSet(knownServerSet, gtidSet);
+                final GtidSet purgedGtidSet = connection.purgedGtidSet();
+                final GtidSet nonPurgedGtidSetToReplicate = connection.subtractGtidSet(gtidSetToReplicate, purgedGtidSet);
+                LOGGER.info("GTIDs known by the server but not processed yet {}, for replication are available only {}", gtidSetToReplicate, nonPurgedGtidSetToReplicate);
                 if (!gtidSetToReplicate.equals(nonPurgedGtidSetToReplicate)) {
-                    logger.info("Some of the GTIDs needed to replicate have been already purged");
+                    LOGGER.info("Some of the GTIDs needed to replicate have been already purged");
                     return false;
                 }
                 return true;
             }
-            logger.info("Connector last known GTIDs are {}, but MySQL has {}", gtidSet, availableGtidSet);
+            LOGGER.info("Connector last known GTIDs are {}, but MySQL has {}", gtidSet, availableGtidSet);
             return false;
         }
 
-        String binlogFilename = taskContext.source().binlogFilename();
+        String binlogFilename = offset.getSource().binlogFilename();
         if (binlogFilename == null) {
             return true; // start at current position
         }
@@ -545,107 +253,87 @@ public final class MySqlConnectorTask extends BaseSourceTask {
         }
 
         // Accumulate the available binlog filenames ...
-        List<String> logNames = new ArrayList<>();
-        try {
-            logger.info("Step 0: Get all known binlogs from MySQL");
-            connectionContext.jdbc().query("SHOW BINARY LOGS", rs -> {
-                while (rs.next()) {
-                    logNames.add(rs.getString(1));
-                }
-            });
-        }
-        catch (SQLException e) {
-            throw new ConnectException("Unexpected error while connecting to MySQL and looking for binary logs: ", e);
-        }
+        List<String> logNames = connection.availableBinlogFiles();
 
         // And compare with the one we're supposed to use ...
         boolean found = logNames.stream().anyMatch(binlogFilename::equals);
         if (!found) {
-            if (logger.isInfoEnabled()) {
-                logger.info("Connector requires binlog file '{}', but MySQL only has {}", binlogFilename, String.join(", ", logNames));
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.info("Connector requires binlog file '{}', but MySQL only has {}", binlogFilename, String.join(", ", logNames));
             }
         }
         else {
-            logger.info("MySQL has the binlog file '{}' required by the connector", binlogFilename);
+            LOGGER.info("MySQL has the binlog file '{}' required by the connector", binlogFilename);
         }
 
         return found;
     }
 
-    /**
-     * Determine the earliest binlog filename that is still available in the server.
-     *
-     * @return the name of the earliest binlog filename, or null if there are none.
-     */
-    protected String earliestBinlogFilename() {
-        // Accumulate the available binlog filenames ...
-        List<String> logNames = new ArrayList<>();
-        try {
-            logger.info("Checking all known binlogs from MySQL");
-            connectionContext.jdbc().query("SHOW BINARY LOGS", rs -> {
-                while (rs.next()) {
-                    logNames.add(rs.getString(1));
-                }
-            });
-        }
-        catch (SQLException e) {
-            throw new ConnectException("Unexpected error while connecting to MySQL and looking for binary logs: ", e);
-        }
-
-        if (logNames.isEmpty()) {
-            return null;
-        }
-        return logNames.get(0);
+    private MySqlOffsetContext initialOffsetContext(MySqlConnectorConfig config) {
+        return new MySqlOffsetContext(config, false, false, new SourceInfo(config));
     }
 
-    /**
-     * Determine whether the MySQL server has the binlog_row_image set to 'FULL'.
-     *
-     * @return {@code true} if the server's {@code binlog_row_image} is set to {@code FULL}, or {@code false} otherwise
-     */
-    protected boolean isBinlogRowImageFull() {
-        AtomicReference<String> rowImage = new AtomicReference<String>("");
-        try {
-            connectionContext.jdbc().query("SHOW GLOBAL VARIABLES LIKE 'binlog_row_image'", rs -> {
-                if (rs.next()) {
-                    rowImage.set(rs.getString(2));
-                }
-                else {
-                    // This setting was introduced in MySQL 5.6+ with default of 'FULL'.
-                    // For older versions, assume 'FULL'.
-                    rowImage.set("FULL");
-                }
-            });
+    private boolean validateAndLoadDatabaseHistory(MySqlConnectorConfig config, MySqlOffsetContext offset, MySqlDatabaseSchema schema) {
+        if (offset == null) {
+            LOGGER.info("Connector started for the first time, database history recovery will not be executed");
+            schema.initializeStorage();
+            return false;
         }
-        catch (SQLException e) {
-            throw new ConnectException("Unexpected error while connecting to MySQL and looking at BINLOG_ROW_IMAGE mode: ", e);
+        if (!schema.historyExists()) {
+            LOGGER.warn("Database history was not found but was expected");
+            if (config.getSnapshotMode().shouldSnapshotOnSchemaError()) {
+                // But check to see if the server still has those binlog coordinates ...
+                if (!isBinlogAvailable(config, offset)) {
+                    throw new DebeziumException("The connector is trying to read binlog starting at " + offset.getSource() + ", but this is no longer "
+                            + "available on the server. Reconfigure the connector to use a snapshot when needed.");
+                }
+                LOGGER.info("The db-history topic is missing but we are in {} snapshot mode. " +
+                        "Attempting to snapshot the current schema and then begin reading the binlog from the last recorded offset.",
+                        SnapshotMode.SCHEMA_ONLY_RECOVERY);
+            }
+            else {
+                throw new DebeziumException("The db history topic is missing. You may attempt to recover it by reconfiguring the connector to "
+                        + SnapshotMode.SCHEMA_ONLY_RECOVERY);
+            }
+            schema.initializeStorage();
+            return true;
         }
-
-        logger.debug("binlog_row_image={}", rowImage.get());
-
-        return "FULL".equalsIgnoreCase(rowImage.get());
+        schema.recover(offset);
+        return false;
     }
 
-    /**
-     * Determine whether the MySQL server has the row-level binlog enabled.
-     *
-     * @return {@code true} if the server's {@code binlog_format} is set to {@code ROW}, or {@code false} otherwise
-     */
-    protected boolean isBinlogFormatRow() {
-        AtomicReference<String> mode = new AtomicReference<String>("");
-        try {
-            connectionContext.jdbc().query("SHOW GLOBAL VARIABLES LIKE 'binlog_format'", rs -> {
-                if (rs.next()) {
-                    mode.set(rs.getString(2));
+    private void validateSnapshotFeasibility(MySqlConnectorConfig config, MySqlOffsetContext offset) {
+        if (offset != null) {
+            if (offset.isSnapshotRunning()) {
+                // The last offset was an incomplete snapshot and now the snapshot was disabled
+                if (!config.getSnapshotMode().shouldSnapshot()) {
+                    // No snapshots are allowed
+                    throw new DebeziumException("The connector previously stopped while taking a snapshot, but now the connector is configured "
+                            + "to never allow snapshots. Reconfigure the connector to use snapshots initially or when needed.");
                 }
-            });
+            }
+            else {
+                // But check to see if the server still has those binlog coordinates ...
+                if (!isBinlogAvailable(config, offset)) {
+                    if (!config.getSnapshotMode().shouldSnapshotOnDataError()) {
+                        throw new DebeziumException("The connector is trying to read binlog starting at " + offset.getSource() + ", but this is no longer "
+                                + "available on the server. Reconfigure the connector to use a snapshot when needed.");
+                    }
+                }
+            }
         }
-        catch (SQLException e) {
-            throw new ConnectException("Unexpected error while connecting to MySQL and looking at BINLOG_FORMAT mode: ", e);
+        else {
+            if (!config.getSnapshotMode().shouldSnapshot()) {
+                // Look to see what the first available binlog file is called, and whether it looks like binlog files have
+                // been purged. If so, then output a warning ...
+                String earliestBinlogFilename = connection.earliestBinlogFilename();
+                if (earliestBinlogFilename == null) {
+                    LOGGER.warn("No binlog appears to be available. Ensure that the MySQL row-level binlog is enabled.");
+                }
+                else if (!earliestBinlogFilename.endsWith("00001")) {
+                    LOGGER.warn("It is possible the server has purged some binlogs. If this is the case, then using snapshot mode may be required.");
+                }
+            }
         }
-
-        logger.debug("binlog_format={}", mode.get());
-
-        return "ROW".equalsIgnoreCase(mode.get());
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDatabaseSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDatabaseSchema.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.annotation.NotThreadSafe;
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.connector.mysql.MySqlSystemVariables.MySqlScope;
+import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
+import io.debezium.relational.HistorizedRelationalDatabaseSchema;
+import io.debezium.relational.RelationalTableFilters;
+import io.debezium.relational.SystemVariables;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.TableSchemaBuilder;
+import io.debezium.relational.Tables;
+import io.debezium.relational.ddl.DdlChanges;
+import io.debezium.relational.ddl.DdlChanges.DatabaseStatementStringConsumer;
+import io.debezium.relational.ddl.DdlParser;
+import io.debezium.relational.ddl.DdlParserListener.Event;
+import io.debezium.relational.ddl.DdlParserListener.TableEvent;
+import io.debezium.relational.ddl.DdlParserListener.TableIndexEvent;
+import io.debezium.relational.history.DatabaseHistory;
+import io.debezium.relational.history.TableChanges;
+import io.debezium.schema.SchemaChangeEvent;
+import io.debezium.schema.SchemaChangeEvent.SchemaChangeEventType;
+import io.debezium.schema.TopicSelector;
+import io.debezium.text.MultipleParsingExceptions;
+import io.debezium.text.ParsingException;
+import io.debezium.util.Collect;
+import io.debezium.util.SchemaNameAdjuster;
+
+/**
+ * Component that records the schema history for databases hosted by a MySQL database server. The schema information includes
+ * the {@link Tables table definitions} and the Kafka Connect {@link #schemaFor(TableId) Schema}s for each table, where the
+ * {@link Schema} excludes any columns that have been {@link MySqlConnectorConfig#COLUMN_EXCLUDE_LIST specified} in the
+ * configuration.
+ * <p>
+ * The history is changed by {@link #applyDdl(SourceInfo, String, String, DatabaseStatementStringConsumer) applying DDL
+ * statements}, and every change is {@link DatabaseHistory persisted} as defined in the supplied {@link MySqlConnectorConfig MySQL
+ * connector configuration}. This component can be reconstructed (e.g., on connector restart) and the history
+ * {@link #loadHistory(SourceInfo) loaded} from persisted storage.
+ * <p>
+ * Note that when {@link #applyDdl(SourceInfo, String, String, DatabaseStatementStringConsumer) applying DDL statements}, the
+ * caller is able to supply a {@link DatabaseStatementStringConsumer consumer function} that will be called with the DDL
+ * statements and the database to which they apply, grouped by database names. However, these will only be called based when the
+ * databases are included by the database filters defined in the {@link MySqlConnectorConfig MySQL connector configuration}.
+ *
+ * @author Randall Hauch
+ */
+@NotThreadSafe
+public class MySqlDatabaseSchema extends HistorizedRelationalDatabaseSchema {
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(MySqlDatabaseSchema.class);
+
+    private final Set<String> ignoredQueryStatements = Collect.unmodifiableSet("BEGIN", "END", "FLUSH PRIVILEGES");
+    private final DdlParser ddlParser;
+    private final RelationalTableFilters filters;
+    private final DdlChanges ddlChanges;
+
+    /**
+     * Create a schema component given the supplied {@link MySqlConnectorConfig MySQL connector configuration}.
+     * The DDL statements passed to the schema are parsed and a logical model of the database schema is created.
+     *
+     */
+    public MySqlDatabaseSchema(MySqlConnectorConfig connectorConfig, MySqlValueConverters valueConverter, TopicSelector<TableId> topicSelector,
+                               SchemaNameAdjuster schemaNameAdjuster, boolean tableIdCaseInsensitive) {
+        super(connectorConfig, topicSelector, connectorConfig.getTableFilters().dataCollectionFilter(), connectorConfig.getColumnFilter(),
+                new TableSchemaBuilder(
+                        valueConverter,
+                        schemaNameAdjuster,
+                        connectorConfig.customConverterRegistry(),
+                        connectorConfig.getSourceInfoStructMaker().schema(),
+                        connectorConfig.getSanitizeFieldNames()),
+                tableIdCaseInsensitive, connectorConfig.getKeyMapper());
+
+        this.ddlParser = new MySqlAntlrDdlParser(valueConverter, getTableFilter());
+        this.ddlChanges = this.ddlParser.getDdlChanges();
+        filters = connectorConfig.getTableFilters();
+    }
+
+    /**
+     * Get all table names for all databases that are monitored whose events are captured by Debezium
+     *
+     * @return the array with the table names
+     */
+    public String[] monitoredTablesAsStringArray() {
+        final Collection<TableId> tables = tableIds();
+        String[] ret = new String[tables.size()];
+        int i = 0;
+        for (TableId table : tables) {
+            ret[i++] = table.toString();
+        }
+        return ret;
+    }
+
+    /**
+     * Set the system variables on the DDL parser.
+     *
+     * @param variables the system variables; may not be null but may be empty
+     */
+    public void setSystemVariables(Map<String, String> variables) {
+        variables.forEach((varName, value) -> {
+            ddlParser.systemVariables().setVariable(MySqlScope.SESSION, varName, value);
+        });
+    }
+
+    /**
+     * Get the system variables as known by the DDL parser.
+     *
+     * @return the system variables; never null
+     */
+    public SystemVariables systemVariables() {
+        return ddlParser.systemVariables();
+    }
+
+    protected void appendDropTableStatement(StringBuilder sb, TableId tableId) {
+        sb.append("DROP TABLE ").append(tableId).append(" IF EXISTS;").append(System.lineSeparator());
+    }
+
+    protected void appendCreateTableStatement(StringBuilder sb, Table table) {
+        sb.append("CREATE TABLE ").append(table.id()).append(';').append(System.lineSeparator());
+    }
+
+    /**
+     * Discard any currently-cached schemas and rebuild them using the filters.
+     */
+    protected void refreshSchemas() {
+        clearSchemas();
+        // Create TableSchema instances for any existing table ...
+        this.tableIds().forEach(id -> {
+            Table table = this.tableFor(id);
+            buildAndRegisterSchema(table);
+        });
+    }
+
+    public boolean isGlobalSetVariableStatement(String ddl, String databaseName) {
+        return (databaseName == null || databaseName.isEmpty()) && ddl != null && ddl.toUpperCase().startsWith("SET ");
+    }
+
+    @Override
+    public void applySchemaChange(SchemaChangeEvent schemaChange) {
+        applySchemaChange(schemaChange, SchemaChangeEventConsumer.NOOP);
+    }
+
+    public void applySchemaChange(SchemaChangeEvent schemaChange, SchemaChangeEventConsumer schemaEventConsumer) {
+        LOGGER.debug("Applying schema change event {}", schemaChange);
+
+        if (schemaChange.getType() != SchemaChangeEventType.RAW) {
+            LOGGER.debug("Schema change already processed by the database schema");
+            return;
+        }
+
+        final String ddlStatements = schemaChange.getDdl();
+        final String databaseName = schemaChange.getDatabase();
+
+        if (ignoredQueryStatements.contains(ddlStatements)) {
+            return;
+        }
+
+        try {
+            this.ddlChanges.reset();
+            this.ddlParser.setCurrentSchema(databaseName);
+            this.ddlParser.parse(ddlStatements, tables());
+        }
+        catch (ParsingException | MultipleParsingExceptions e) {
+            if (databaseHistory.skipUnparseableDdlStatements()) {
+                LOGGER.warn("Ignoring unparseable DDL statement '{}': {}", ddlStatements, e);
+            }
+            else {
+                throw e;
+            }
+        }
+        final Set<TableId> changes = tables().drainChanges();
+        // No need to send schema events or store DDL if no table has changed
+        if (!databaseHistory.storeOnlyMonitoredTables() || isGlobalSetVariableStatement(ddlStatements, databaseName) || ddlChanges.anyMatch(filters)) {
+            if (schemaEventConsumer != null) {
+
+                // We are supposed to _also_ record the schema changes as SourceRecords, but these need to be filtered
+                // by database. Unfortunately, the databaseName on the event might not be the same database as that
+                // being modified by the DDL statements (since the DDL statements can have fully-qualified names).
+                // Therefore, we have to look at each statement to figure out which database it applies and then
+                // record the DDL statements (still in the same order) to those databases.
+
+                if (!ddlChanges.isEmpty()) {
+                    // We understood at least some of the DDL statements and can figure out to which database they apply.
+                    // They also apply to more databases than 'databaseName', so we need to apply the DDL statements in
+                    // the same order they were read for each _affected_ database, grouped together if multiple apply
+                    // to the same _affected_ database...
+                    ddlChanges.getEventsByDatabase((String dbName, List<Event> events) -> {
+                        if (acceptableDatabase(dbName)) {
+                            final String sanitizedDbName = (dbName == null) ? "" : dbName;
+                            final Set<TableId> tableIds = new HashSet<>();
+                            events.forEach(event -> {
+                                final TableId tableId = getTableId(event);
+                                if (tableId != null) {
+                                    tableIds.add(tableId);
+                                }
+                            });
+                            final Struct source = schemaChange.getSource();
+                            source.put(AbstractSourceInfo.DATABASE_NAME_KEY, sanitizedDbName);
+                            final String tableNamesStr = tableIds.stream().map(TableId::table).collect(Collectors.joining(","));
+                            if (!tableNamesStr.isEmpty()) {
+                                source.put(AbstractSourceInfo.TABLE_NAME_KEY, tableNamesStr);
+                            }
+                            schemaEventConsumer.consume(new SchemaChangeEvent(schemaChange.getPartition(),
+                                    schemaChange.getOffset(), schemaChange.getSource(), sanitizedDbName,
+                                    schemaChange.getSchema(), schemaChange.getDdl(), Collections.emptySet(), SchemaChangeEventType.DATABASE,
+                                    schemaChange.isFromSnapshot()),
+                                    tableIds);
+                        }
+                    });
+                }
+                else if (acceptableDatabase(databaseName)) {
+                    schemaEventConsumer.consume(schemaChange, null);
+                }
+            }
+            // Record the DDL statement so that we can later recover them if needed. We do this _after_ writing the
+            // schema change records so that failure recovery (which is based on of the history) won't lose
+            // schema change records.
+            // We are storing either
+            // - all DDLs if configured
+            // - or global SET variables
+            // - or DDLs for monitored objects
+            if (!databaseHistory.storeOnlyMonitoredTables() || isGlobalSetVariableStatement(ddlStatements, databaseName)
+                    || changes.stream().anyMatch(filters.dataCollectionFilter()::isIncluded)) {
+                LOGGER.debug("Recorded DDL statements for database '{}': {}", databaseName, ddlStatements);
+                record(schemaChange, schemaChange.getTableChanges());
+            }
+        }
+        else {
+            LOGGER.debug("Changes for DDL '{}' were filtered and not recorded in database history", ddlStatements);
+        }
+
+        // Figure out what changed ...
+        TableChanges tableChanges = new TableChanges();
+        changes.forEach(tableId -> {
+            Table table = tableFor(tableId);
+            if (table == null) { // removed
+                removeSchema(tableId);
+            }
+            else {
+                buildAndRegisterSchema(table);
+                tableChanges.create(table);
+            }
+        });
+    }
+
+    private boolean acceptableDatabase(final String databaseName) {
+        return filters.databaseFilter().test(databaseName) || databaseName == null || databaseName.isEmpty();
+    }
+
+    private TableId getTableId(Event event) {
+        if (event instanceof TableEvent) {
+            return ((TableEvent) event).tableId();
+        }
+        else if (event instanceof TableIndexEvent) {
+            return ((TableIndexEvent) event).tableId();
+        }
+        return null;
+    }
+
+    @Override
+    protected DdlParser getDdlParser() {
+        return ddlParser;
+    }
+
+    /**
+     * Return true if the database history entity exists
+     */
+    public boolean historyExists() {
+        return databaseHistory.exists();
+    }
+
+    @Override
+    public boolean storeOnlyMonitoredTables() {
+        return databaseHistory.storeOnlyMonitoredTables();
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlErrorHandler.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlErrorHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.pipeline.ErrorHandler;
+
+/**
+ * Error handler for SQL Server.
+ *
+ * @author Chris Cranford
+ */
+public class MySqlErrorHandler extends ErrorHandler {
+
+    public MySqlErrorHandler(String logicalName, ChangeEventQueue<?> queue) {
+        super(MySqlConnector.class, logicalName, queue);
+    }
+
+    @Override
+    protected boolean isRetriable(Throwable throwable) {
+        return false;
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlEventMetadataProvider.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlEventMetadataProvider.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.data.Envelope;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.schema.DataCollectionId;
+import io.debezium.util.Collect;
+
+class MySqlEventMetadataProvider implements EventMetadataProvider {
+
+    @Override
+    public Instant getEventTimestamp(DataCollectionId source, OffsetContext offset, Object key, Struct value) {
+        if (value == null) {
+            return null;
+        }
+        final Struct sourceInfo = value.getStruct(Envelope.FieldName.SOURCE);
+        if (source == null) {
+            return null;
+        }
+        final Long timestamp = sourceInfo.getInt64(AbstractSourceInfo.TIMESTAMP_KEY);
+        return timestamp == null ? null : Instant.ofEpochMilli(timestamp);
+    }
+
+    @Override
+    public Map<String, String> getEventSourcePosition(DataCollectionId source, OffsetContext offset, Object key,
+                                                      Struct value) {
+        if (value == null) {
+            return null;
+        }
+        final Struct sourceInfo = value.getStruct(Envelope.FieldName.SOURCE);
+        if (source == null) {
+            return null;
+        }
+        return Collect.hashMapOf(SourceInfo.BINLOG_FILENAME_OFFSET_KEY,
+                sourceInfo.getString(SourceInfo.BINLOG_FILENAME_OFFSET_KEY), SourceInfo.BINLOG_POSITION_OFFSET_KEY,
+                Long.toString(sourceInfo.getInt64(SourceInfo.BINLOG_POSITION_OFFSET_KEY)),
+                SourceInfo.BINLOG_ROW_IN_EVENT_OFFSET_KEY,
+                Integer.toString(sourceInfo.getInt32(SourceInfo.BINLOG_ROW_IN_EVENT_OFFSET_KEY)));
+    }
+
+    @Override
+    public String getTransactionId(DataCollectionId source, OffsetContext offset, Object key, Struct value) {
+        if (value == null) {
+            return null;
+        }
+        final Struct sourceInfo = value.getStruct(Envelope.FieldName.SOURCE);
+        if (source == null) {
+            return null;
+        }
+        return sourceInfo.getString(SourceInfo.GTID_KEY);
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlOffsetContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlOffsetContext.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.connector.SnapshotRecord;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.txmetadata.TransactionContext;
+import io.debezium.relational.TableId;
+import io.debezium.schema.DataCollectionId;
+
+public class MySqlOffsetContext implements OffsetContext {
+
+    private static final String SERVER_PARTITION_KEY = "server";
+    private static final String SNAPSHOT_COMPLETED_KEY = "snapshot_completed";
+
+    private final Schema sourceInfoSchema;
+    private final SourceInfo sourceInfo;
+    private final Map<String, String> partition;
+    private boolean snapshotCompleted;
+    private final TransactionContext transactionContext;
+    private final MySqlConnectorConfig connectorConfig;
+
+    public MySqlOffsetContext(MySqlConnectorConfig connectorConfig, boolean snapshot, boolean snapshotCompleted,
+                              TransactionContext transactionContext, SourceInfo sourceInfo) {
+        this.connectorConfig = connectorConfig;
+        partition = Collections.singletonMap(SERVER_PARTITION_KEY, connectorConfig.getLogicalName());
+        this.sourceInfo = sourceInfo;
+        sourceInfoSchema = sourceInfo.schema();
+
+        this.snapshotCompleted = snapshotCompleted;
+        if (this.snapshotCompleted) {
+            postSnapshotCompletion();
+        }
+        else {
+            sourceInfo.setSnapshot(snapshot ? SnapshotRecord.TRUE : SnapshotRecord.FALSE);
+        }
+        this.transactionContext = transactionContext;
+    }
+
+    public MySqlOffsetContext(MySqlConnectorConfig connectorConfig, boolean snapshot, boolean snapshotCompleted, SourceInfo sourceInfo) {
+        this(connectorConfig, snapshot, snapshotCompleted, new TransactionContext(), sourceInfo);
+    }
+
+    @Override
+    public Map<String, ?> getPartition() {
+        return partition;
+    }
+
+    @Override
+    public Map<String, ?> getOffset() {
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> offset = (Map<String, Object>) sourceInfo.offset();
+        if (sourceInfo.isSnapshot()) {
+            // TODO Added when responsibilites will split between StourceInfo and OffsetContext
+            // offset.put(SourceInfo.SNAPSHOT_KEY, true);
+        }
+        else {
+            return transactionContext.store(offset);
+        }
+        return offset;
+    }
+
+    @Override
+    public Schema getSourceInfoSchema() {
+        return sourceInfoSchema;
+    }
+
+    @Override
+    public Struct getSourceInfo() {
+        return sourceInfo.struct();
+    }
+
+    @Override
+    public boolean isSnapshotRunning() {
+        return sourceInfo.isSnapshot() && !snapshotCompleted;
+    }
+
+    public boolean isSnapshotCompleted() {
+        return snapshotCompleted;
+    }
+
+    @Override
+    public void preSnapshotStart() {
+        sourceInfo.setSnapshot(SnapshotRecord.TRUE);
+        snapshotCompleted = false;
+        sourceInfo.startSnapshot();
+    }
+
+    @Override
+    public void preSnapshotCompletion() {
+        snapshotCompleted = true;
+        sourceInfo.markLastSnapshot(connectorConfig.getConfig());
+    }
+
+    @Override
+    public void postSnapshotCompletion() {
+        sourceInfo.setSnapshot(SnapshotRecord.FALSE);
+    }
+
+    public static MySqlOffsetContext initial(MySqlConnectorConfig config) {
+        final MySqlOffsetContext offset = new MySqlOffsetContext(config, false, false, new SourceInfo(config));
+        offset.getSource().setBinlogStartPoint("", 0L); // start from the beginning of the binlog
+        return offset;
+    }
+
+    public static class Loader implements OffsetContext.Loader {
+
+        private final MySqlConnectorConfig connectorConfig;
+
+        public Loader(MySqlConnectorConfig connectorConfig) {
+            this.connectorConfig = connectorConfig;
+        }
+
+        @Override
+        public Map<String, ?> getPartition() {
+            return Collections.singletonMap(SERVER_PARTITION_KEY, connectorConfig.getLogicalName());
+        }
+
+        @Override
+        public OffsetContext load(Map<String, ?> offset) {
+            boolean snapshot = Boolean.TRUE.equals(offset.get(SourceInfo.SNAPSHOT_KEY));
+            boolean snapshotCompleted = Boolean.TRUE.equals(offset.get(SNAPSHOT_COMPLETED_KEY));
+
+            final SourceInfo sourceInfo = new SourceInfo(connectorConfig);
+            final MySqlOffsetContext offsetContext = new MySqlOffsetContext(connectorConfig, snapshot, snapshotCompleted,
+                    TransactionContext.load(offset), sourceInfo);
+            sourceInfo.setOffset(offset);
+            return offsetContext;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return super.toString();
+    }
+
+    @Override
+    public void markLastSnapshotRecord() {
+        sourceInfo.setSnapshot(SnapshotRecord.LAST);
+    }
+
+    @Override
+    public void event(DataCollectionId tableId, Instant timestamp) {
+        sourceInfo.setSourceTime(timestamp);
+        sourceInfo.tableEvent((TableId) tableId);
+    }
+
+    @Override
+    public TransactionContext getTransactionContext() {
+        return transactionContext;
+    }
+
+    public SourceInfo getSource() {
+        return sourceInfo;
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -440,14 +441,14 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
     }
 
     @Override
-    protected Optional<Long> rowCountForTable(TableId tableId) {
+    protected OptionalLong rowCountForTable(TableId tableId) {
         return connection.getEstimatedTableSize(tableId);
     }
 
     @Override
-    protected Statement readTableStatement(Optional<Long> rowCount) throws SQLException {
+    protected Statement readTableStatement(OptionalLong rowCount) throws SQLException {
         final long largeTableRowCount = connectorConfig.rowCountForLargeTable();
-        if (!rowCount.isPresent() || largeTableRowCount == 0 || rowCount.get() <= largeTableRowCount) {
+        if (!rowCount.isPresent() || largeTableRowCount == 0 || rowCount.getAsLong() <= largeTableRowCount) {
             return super.readTableStatement(rowCount);
         }
         return createStatementWithLargeResultSet();

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
@@ -1,0 +1,490 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import java.io.UnsupportedEncodingException;
+import java.sql.Blob;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotLockingMode;
+import io.debezium.connector.mysql.legacy.MySqlJdbcContext.DatabaseLocales;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.relational.Column;
+import io.debezium.relational.RelationalSnapshotChangeEventSource;
+import io.debezium.relational.RelationalTableFilters;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.schema.SchemaChangeEvent;
+import io.debezium.schema.SchemaChangeEvent.SchemaChangeEventType;
+import io.debezium.util.Clock;
+import io.debezium.util.Strings;
+
+public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEventSource {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MySqlSnapshotChangeEventSource.class);
+
+    private final MySqlConnectorConfig connectorConfig;
+    private final MySqlConnection connection;
+    private long globalLockAcquiredAt = -1;
+    private final RelationalTableFilters filters;
+    private final MySqlSnapshotChangeEventSourceMetrics metrics;
+    private final MySqlOffsetContext previousOffset;
+    private final MySqlDatabaseSchema databaseSchema;
+
+    public MySqlSnapshotChangeEventSource(MySqlConnectorConfig connectorConfig, MySqlOffsetContext previousOffset, MySqlConnection connection,
+                                          MySqlDatabaseSchema schema, EventDispatcher<TableId> dispatcher, Clock clock,
+                                          MySqlSnapshotChangeEventSourceMetrics metrics) {
+        super(connectorConfig, previousOffset, connection, schema, dispatcher, clock, metrics);
+        this.connectorConfig = connectorConfig;
+        this.connection = connection;
+        this.filters = connectorConfig.getTableFilters();
+        this.metrics = metrics;
+        this.previousOffset = previousOffset;
+        this.databaseSchema = schema;
+    }
+
+    @Override
+    protected SnapshottingTask getSnapshottingTask(OffsetContext previousOffset) {
+        boolean snapshotSchema = true;
+        boolean snapshotData = true;
+
+        // found a previous offset and the earlier snapshot has completed
+        if (previousOffset != null && !previousOffset.isSnapshotRunning()) {
+            LOGGER.info("A previous offset indicating a completed snapshot has been found. Neither schema nor data will be snapshotted.");
+            snapshotSchema = false;
+            snapshotData = false;
+        }
+        else {
+            LOGGER.info("No previous offset has been found");
+            if (connectorConfig.getSnapshotMode().includeData()) {
+                LOGGER.info("According to the connector configuration both schema and data will be snapshotted");
+            }
+            else {
+                LOGGER.info("According to the connector configuration only schema will be snapshotted");
+            }
+            snapshotData = connectorConfig.getSnapshotMode().includeData();
+            snapshotSchema = connectorConfig.getSnapshotMode().includeSchema();
+        }
+
+        return new SnapshottingTask(snapshotSchema, snapshotData);
+    }
+
+    @Override
+    protected SnapshotContext prepare(ChangeEventSourceContext context) throws Exception {
+        return new MySqlSnapshotContext();
+    }
+
+    @Override
+    protected void connectionCreated(RelationalSnapshotContext snapshotContext) throws Exception {
+    }
+
+    @Override
+    protected Set<TableId> getAllTableIds(RelationalSnapshotContext ctx) throws Exception {
+        // -------------------
+        // READ DATABASE NAMES
+        // -------------------
+        // Get the list of databases ...
+        LOGGER.info("Read list of available databases");
+        final List<String> databaseNames = new ArrayList<>();
+        connection.query("SHOW DATABASES", rs -> {
+            while (rs.next()) {
+                databaseNames.add(rs.getString(1));
+            }
+        });
+        LOGGER.info("\t list of available databases is: {}", databaseNames);
+
+        // ----------------
+        // READ TABLE NAMES
+        // ----------------
+        // Get the list of table IDs for each database. We can't use a prepared statement with MySQL, so we have to
+        // build the SQL statement each time. Although in other cases this might lead to SQL injection, in our case
+        // we are reading the database names from the database and not taking them from the user ...
+        LOGGER.info("Read list of available tables in each database");
+        final Set<TableId> tableIds = new HashSet<>();
+        final Set<String> readableDatabaseNames = new HashSet<>();
+        for (String dbName : databaseNames) {
+            try {
+                // MySQL sometimes considers some local files as databases (see DBZ-164),
+                // so we will simply try each one and ignore the problematic ones ...
+                connection.query("SHOW FULL TABLES IN " + quote(dbName) + " where Table_Type = 'BASE TABLE'", rs -> {
+                    while (rs.next()) {
+                        TableId id = new TableId(dbName, null, rs.getString(1));
+                        tableIds.add(id);
+                    }
+                });
+                readableDatabaseNames.add(dbName);
+            }
+            catch (SQLException e) {
+                // We were unable to execute the query or process the results, so skip this ...
+                LOGGER.warn("\t skipping database '{}' due to error reading tables: {}", dbName, e.getMessage());
+            }
+        }
+        final Set<String> includedDatabaseNames = readableDatabaseNames.stream().filter(filters.databaseFilter()).collect(Collectors.toSet());
+        LOGGER.info("\tsnapshot continuing with database(s): {}", includedDatabaseNames);
+        return tableIds;
+    }
+
+    @Override
+    protected void lockTablesForSchemaSnapshot(ChangeEventSourceContext sourceContext, RelationalSnapshotContext snapshotContext)
+            throws SQLException, InterruptedException {
+        // Set the transaction isolation level to REPEATABLE READ. This is the default, but the default can be changed
+        // which is why we explicitly set it here.
+        //
+        // With REPEATABLE READ, all SELECT queries within the scope of a transaction (which we don't yet have) will read
+        // from the same MVCC snapshot. Thus each plain (non-locking) SELECT statements within the same transaction are
+        // consistent also with respect to each other.
+        //
+        // See: https://dev.mysql.com/doc/refman/5.7/en/set-transaction.html
+        // See: https://dev.mysql.com/doc/refman/5.7/en/innodb-transaction-isolation-levels.html
+        // See: https://dev.mysql.com/doc/refman/5.7/en/innodb-consistent-read.html
+        connection.connection().setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
+        connection.executeWithoutCommitting("SET SESSION lock_wait_timeout=" + connectorConfig.snapshotLockTimeout().getSeconds());
+        try {
+            connection.executeWithoutCommitting("SET SESSION innodb_lock_wait_timeout=" + connectorConfig.snapshotLockTimeout().getSeconds());
+        }
+        catch (SQLException e) {
+            LOGGER.warn("Unable to set innodb_lock_wait_timeout", e);
+        }
+
+        // ------------------------------------
+        // LOCK TABLES
+        // ------------------------------------
+        // Obtain read lock on all tables. This statement closes all open tables and locks all tables
+        // for all databases with a global read lock, and it prevents ALL updates while we have this lock.
+        // It also ensures that everything we do while we have this lock will be consistent.
+        if (connectorConfig.getSnapshotLockingMode() != MySqlConnectorConfig.SnapshotLockingMode.NONE) {
+            try {
+                globalLock();
+                metrics.globalLockAcquired();
+            }
+            catch (SQLException e) {
+                LOGGER.info("Unable to flush and acquire global read lock, will use table read locks after reading table names");
+                // Continue anyway, since RDS (among others) don't allow setting a global lock
+                assert !isGloballyLocked();
+            }
+            // FLUSH TABLES resets TX and isolation level
+            connection.executeWithoutCommitting("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ");
+        }
+    }
+
+    @Override
+    protected void releaseSchemaSnapshotLocks(RelationalSnapshotContext snapshotContext) throws SQLException {
+        if (connectorConfig.getSnapshotLockingMode() == SnapshotLockingMode.MINIMAL) {
+            if (isGloballyLocked()) {
+                globalUnlock();
+            }
+        }
+    }
+
+    @Override
+    protected void determineSnapshotOffset(RelationalSnapshotContext ctx) throws Exception {
+        // TODO forced snapshot
+        if (previousOffset != null) {
+            ctx.offset = previousOffset;
+            tryStartingSnapshot(ctx);
+            return;
+        }
+        final MySqlOffsetContext offsetContext = MySqlOffsetContext.initial(connectorConfig);
+        ctx.offset = offsetContext;
+        LOGGER.info("Read binlog position of MySQL primary server");
+        final String showMasterStmt = "SHOW MASTER STATUS";
+        connection.query(showMasterStmt, rs -> {
+            if (rs.next()) {
+                final String binlogFilename = rs.getString(1);
+                final long binlogPosition = rs.getLong(2);
+                offsetContext.getSource().setBinlogStartPoint(binlogFilename, binlogPosition);
+                if (rs.getMetaData().getColumnCount() > 4) {
+                    // This column exists only in MySQL 5.6.5 or later ...
+                    final String gtidSet = rs.getString(5); // GTID set, may be null, blank, or contain a GTID set
+                    offsetContext.getSource().setCompletedGtidSet(gtidSet);
+                    LOGGER.info("\t using binlog '{}' at position '{}' and gtid '{}'", binlogFilename, binlogPosition,
+                            gtidSet);
+                }
+                else {
+                    LOGGER.info("\t using binlog '{}' at position '{}'", binlogFilename, binlogPosition);
+                }
+            }
+            else {
+                throw new DebeziumException("Cannot read the binlog filename and position via '" + showMasterStmt
+                        + "'. Make sure your server is correctly configured");
+            }
+        });
+        tryStartingSnapshot(ctx);
+    }
+
+    private void addRawSchemaEvent(RelationalSnapshotContext snapshotContext, String database, String ddl) {
+        addRawSchemaChangeEvent(new SchemaChangeEvent(snapshotContext.offset.getPartition(),
+                snapshotContext.offset.getOffset(), snapshotContext.offset.getSourceInfo(), database, null, ddl, true));
+    }
+
+    @Override
+    protected void readTableStructure(ChangeEventSourceContext sourceContext, RelationalSnapshotContext snapshotContext) throws SQLException, InterruptedException {
+        Set<TableId> capturedSchemaTables;
+        if (databaseSchema.storeOnlyMonitoredTables()) {
+            capturedSchemaTables = snapshotContext.capturedTables;
+            LOGGER.info("Only monitored tables schema should be captured, capturing: {}", capturedSchemaTables);
+        }
+        else {
+            capturedSchemaTables = snapshotContext.capturedSchemaTables;
+            LOGGER.info("All eligible tables schema should be captured, capturing: {}", capturedSchemaTables);
+        }
+        final Map<String, List<TableId>> tablesToRead = capturedSchemaTables.stream()
+                .collect(Collectors.groupingBy(TableId::catalog, LinkedHashMap::new, Collectors.toList()));
+        final Set<String> databases = tablesToRead.keySet();
+
+        // Record default charset
+        addRawSchemaEvent(snapshotContext, "", connection.setStatementFor(connection.readMySqlCharsetSystemVariables()));
+
+        for (TableId tableId : capturedSchemaTables) {
+            if (!sourceContext.isRunning()) {
+                throw new InterruptedException("Interrupted while emitting initial DROP TABLE events");
+            }
+            addRawSchemaEvent(snapshotContext, tableId.catalog(), "DROP TABLE IF EXISTS " + quote(tableId));
+        }
+
+        final Map<String, DatabaseLocales> databaseCharsets = connection.readDatabaseCollations();
+        for (String database : databases) {
+            if (!sourceContext.isRunning()) {
+                throw new InterruptedException("Interrupted while reading structure of schema " + databases);
+            }
+
+            LOGGER.info("Reading structure of database '{}'", database);
+            addRawSchemaEvent(snapshotContext, database, "DROP DATABASE IF EXISTS " + quote(database));
+            final StringBuilder createDatabaseDddl = new StringBuilder("CREATE DATABASE " + quote(database));
+            final DatabaseLocales defaultDatabaseLocales = databaseCharsets.get(database);
+            if (defaultDatabaseLocales != null) {
+                defaultDatabaseLocales.appendToDdlStatement(database, createDatabaseDddl);
+            }
+            addRawSchemaEvent(snapshotContext, database, createDatabaseDddl.toString());
+            addRawSchemaEvent(snapshotContext, database, "USE " + quote(database));
+
+            for (TableId tableId : tablesToRead.get(database)) {
+                connection.query("SHOW CREATE TABLE " + quote(tableId), rs -> {
+                    if (rs.next()) {
+                        addRawSchemaEvent(snapshotContext, database, rs.getString(2));
+                    }
+                });
+            }
+        }
+    }
+
+    @Override
+    protected SchemaChangeEvent getCreateTableEvent(RelationalSnapshotContext snapshotContext, Table table) throws SQLException {
+        return new SchemaChangeEvent(
+                snapshotContext.offset.getPartition(),
+                snapshotContext.offset.getOffset(),
+                snapshotContext.offset.getSourceInfo(),
+                snapshotContext.catalogName,
+                table.id().schema(),
+                null,
+                table,
+                SchemaChangeEventType.CREATE,
+                true);
+    }
+
+    @Override
+    protected void complete(SnapshotContext snapshotContext) {
+    }
+
+    /**
+     * Generate a valid sqlserver query string for the specified table
+     *
+     * @param tableId the table to generate a query for
+     * @return a valid query string
+     */
+    @Override
+    protected Optional<String> getSnapshotSelect(RelationalSnapshotContext snapshotContext, TableId tableId) {
+        return Optional.of(String.format("SELECT * FROM `%s`.`%s`", tableId.catalog(), tableId.table()));
+    }
+
+    @Override
+    protected Object getColumnValue(ResultSet rs, int columnIndex, Column column, Table table) throws SQLException {
+        if (column.jdbcType() == Types.TIME) {
+            return readTimeField(rs, columnIndex);
+        }
+        else if (column.jdbcType() == Types.DATE) {
+            return readDateField(rs, columnIndex, column, table);
+        }
+        // This is for DATETIME columns (a logical date + time without time zone)
+        // by reading them with a calendar based on the default time zone, we make sure that the value
+        // is constructed correctly using the database's (or connection's) time zone
+        else if (column.jdbcType() == Types.TIMESTAMP) {
+            return readTimestampField(rs, columnIndex, column, table);
+        }
+        // JDBC's rs.GetObject() will return a Boolean for all TINYINT(1) columns.
+        // TINYINT columns are reported as SMALLINT by JDBC driver
+        else if (column.jdbcType() == Types.TINYINT || column.jdbcType() == Types.SMALLINT) {
+            // It seems that rs.wasNull() returns false when default value is set and NULL is inserted
+            // We thus need to use getObject() to identify if the value was provided and if yes then
+            // read it again to get correct scale
+            return rs.getObject(columnIndex) == null ? null : rs.getInt(columnIndex);
+        }
+        // DBZ-2673
+        // It is necessary to check the type names as types like ENUM and SET are
+        // also reported as JDBC type char
+        else if ("CHAR".equals(column.typeName()) ||
+                "VARCHAR".equals(column.typeName()) ||
+                "TEXT".equals(column.typeName())) {
+            return rs.getBytes(columnIndex);
+        }
+        else {
+            return rs.getObject(columnIndex);
+        }
+    }
+
+    /**
+     * As MySQL connector/J implementation is broken for MySQL type "TIME" we have to use a binary-ish workaround
+     *
+     * @see https://issues.jboss.org/browse/DBZ-342
+     */
+    private Object readTimeField(ResultSet rs, int fieldNo) throws SQLException {
+        Blob b = rs.getBlob(fieldNo);
+        if (b == null) {
+            return null; // Don't continue parsing time field if it is null
+        }
+
+        try {
+            return MySqlValueConverters.stringToDuration(new String(b.getBytes(1, (int) (b.length())), "UTF-8"));
+        }
+        catch (UnsupportedEncodingException e) {
+            LOGGER.error("Could not read MySQL TIME value as UTF-8");
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * In non-string mode the date field can contain zero in any of the date part which we need to handle as all-zero
+     *
+     */
+    private Object readDateField(ResultSet rs, int fieldNo, Column column, Table table) throws SQLException {
+        Blob b = rs.getBlob(fieldNo);
+        if (b == null) {
+            return null; // Don't continue parsing date field if it is null
+        }
+
+        try {
+            return MySqlValueConverters.stringToLocalDate(new String(b.getBytes(1, (int) (b.length())), "UTF-8"), column, table);
+        }
+        catch (UnsupportedEncodingException e) {
+            LOGGER.error("Could not read MySQL TIME value as UTF-8");
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * In non-string mode the time field can contain zero in any of the date part which we need to handle as all-zero
+     *
+     */
+    private Object readTimestampField(ResultSet rs, int fieldNo, Column column, Table table) throws SQLException {
+        Blob b = rs.getBlob(fieldNo);
+        if (b == null) {
+            return null; // Don't continue parsing timestamp field if it is null
+        }
+
+        try {
+            return MySqlValueConverters.containsZeroValuesInDatePart((new String(b.getBytes(1, (int) (b.length())), "UTF-8")), column, table) ? null
+                    : rs.getTimestamp(fieldNo, Calendar.getInstance());
+        }
+        catch (UnsupportedEncodingException e) {
+            LOGGER.error("Could not read MySQL TIME value as UTF-8");
+            throw new RuntimeException(e);
+        }
+    }
+
+    private boolean isGloballyLocked() {
+        return globalLockAcquiredAt != -1;
+    }
+
+    private void globalUnlock() throws SQLException {
+        LOGGER.info("Releasing global read lock to enable MySQL writes");
+        connection.executeWithoutCommitting("UNLOCK TABLES");
+        long lockReleased = clock.currentTimeInMillis();
+        metrics.globalLockReleased();
+        LOGGER.info("Writes to MySQL tables prevented for a total of {}", Strings.duration(lockReleased - globalLockAcquiredAt));
+        globalLockAcquiredAt = -1;
+    }
+
+    private void globalLock() throws SQLException {
+        LOGGER.info("Flush and obtain global read lock to prevent writes to database");
+        connection.executeWithoutCommitting("FLUSH TABLES WITH READ LOCK");
+        globalLockAcquiredAt = clock.currentTimeInMillis();
+    }
+
+    private String quote(String dbOrTableName) {
+        return "`" + dbOrTableName + "`";
+    }
+
+    private String quote(TableId id) {
+        return quote(id.catalog()) + "." + quote(id.table());
+    }
+
+    @Override
+    protected Optional<Long> rowCountForTable(TableId tableId) {
+        return connection.getEstimatedTableSize(tableId);
+    }
+
+    @Override
+    protected Statement readTableStatement(Optional<Long> rowCount) throws SQLException {
+        final long largeTableRowCount = connectorConfig.rowCountForLargeTable();
+        if (!rowCount.isPresent() || largeTableRowCount == 0 || rowCount.get() <= largeTableRowCount) {
+            return super.readTableStatement(rowCount);
+        }
+        return createStatementWithLargeResultSet();
+    }
+
+    /**
+     * Create a JDBC statement that can be used for large result sets.
+     * <p>
+     * By default, the MySQL Connector/J driver retrieves all rows for ResultSets and stores them in memory. In most cases this
+     * is the most efficient way to operate and, due to the design of the MySQL network protocol, is easier to implement.
+     * However, when ResultSets that have a large number of rows or large values, the driver may not be able to allocate
+     * heap space in the JVM and may result in an {@link OutOfMemoryError}. See
+     * <a href="https://issues.jboss.org/browse/DBZ-94">DBZ-94</a> for details.
+     * <p>
+     * This method handles such cases using the
+     * <a href="https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-implementation-notes.html">recommended
+     * technique</a> for MySQL by creating the JDBC {@link Statement} with {@link ResultSet#TYPE_FORWARD_ONLY forward-only} cursor
+     * and {@link ResultSet#CONCUR_READ_ONLY read-only concurrency} flags, and with a {@link Integer#MIN_VALUE minimum value}
+     * {@link Statement#setFetchSize(int) fetch size hint}.
+     *
+     * @return the statement; never null
+     * @throws SQLException if there is a problem creating the statement
+     */
+    private Statement createStatementWithLargeResultSet() throws SQLException {
+        int fetchSize = connectorConfig.getSnapshotFetchSize();
+        Statement stmt = connection.connection().createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+        stmt.setFetchSize(fetchSize);
+        return stmt;
+    }
+
+    /**
+     * Mutable context which is populated in the course of snapshotting.
+     */
+    private static class MySqlSnapshotContext extends RelationalSnapshotContext {
+
+        public MySqlSnapshotContext() throws SQLException {
+            super("");
+        }
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
@@ -200,7 +200,6 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
 
     @Override
     protected void determineSnapshotOffset(RelationalSnapshotContext ctx) throws Exception {
-        // TODO forced snapshot
         if (previousOffset != null) {
             ctx.offset = previousOffset;
             tryStartingSnapshot(ctx);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSourceMetrics.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSourceMetrics.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.debezium.connector.base.ChangeEventQueueMetrics;
+import io.debezium.pipeline.metrics.SnapshotChangeEventSourceMetrics;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+
+/**
+ * @author Randall Hauch
+ *
+ */
+class MySqlSnapshotChangeEventSourceMetrics extends SnapshotChangeEventSourceMetrics implements MySqlSnapshotChangeEventSourceMetricsMXBean {
+
+    private final AtomicBoolean holdingGlobalLock = new AtomicBoolean();
+
+    private final MySqlDatabaseSchema schema;
+
+    public MySqlSnapshotChangeEventSourceMetrics(MySqlTaskContext taskContext, ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                 EventMetadataProvider eventMetadataProvider) {
+        super(taskContext, changeEventQueueMetrics, eventMetadataProvider);
+        this.schema = taskContext.getSchema();
+    }
+
+    @Override
+    public boolean getHoldingGlobalLock() {
+        return holdingGlobalLock.get();
+    }
+
+    public void globalLockAcquired() {
+        holdingGlobalLock.set(true);
+    }
+
+    public void globalLockReleased() {
+        holdingGlobalLock.set(false);
+    }
+
+    @Override
+    public String[] getMonitoredTables() {
+        return schema.monitoredTablesAsStringArray();
+    }
+
+    @Override
+    public long getTotalNumberOfEventsSeen() {
+        return getRowsScanned().values().stream()
+                .mapToLong((x) -> x)
+                .sum();
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSourceMetricsMXBean.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSourceMetricsMXBean.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import io.debezium.pipeline.metrics.SnapshotChangeEventSourceMetricsMXBean;
+
+/**
+ * @author Randall Hauch
+ */
+public interface MySqlSnapshotChangeEventSourceMetricsMXBean extends SnapshotChangeEventSourceMetricsMXBean {
+
+    boolean getHoldingGlobalLock();
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -1,0 +1,1285 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import static io.debezium.util.Strings.isNullOrEmpty;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.BitSet;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import com.github.shyiko.mysql.binlog.BinaryLogClient.LifecycleListener;
+import com.github.shyiko.mysql.binlog.event.DeleteRowsEventData;
+import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.EventData;
+import com.github.shyiko.mysql.binlog.event.EventHeader;
+import com.github.shyiko.mysql.binlog.event.EventHeaderV4;
+import com.github.shyiko.mysql.binlog.event.EventType;
+import com.github.shyiko.mysql.binlog.event.GtidEventData;
+import com.github.shyiko.mysql.binlog.event.QueryEventData;
+import com.github.shyiko.mysql.binlog.event.RotateEventData;
+import com.github.shyiko.mysql.binlog.event.RowsQueryEventData;
+import com.github.shyiko.mysql.binlog.event.TableMapEventData;
+import com.github.shyiko.mysql.binlog.event.UpdateRowsEventData;
+import com.github.shyiko.mysql.binlog.event.WriteRowsEventData;
+import com.github.shyiko.mysql.binlog.event.deserialization.EventDataDeserializationException;
+import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
+import com.github.shyiko.mysql.binlog.event.deserialization.GtidEventDataDeserializer;
+import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
+import com.github.shyiko.mysql.binlog.network.AuthenticationException;
+import com.github.shyiko.mysql.binlog.network.DefaultSSLSocketFactory;
+import com.github.shyiko.mysql.binlog.network.SSLMode;
+import com.github.shyiko.mysql.binlog.network.SSLSocketFactory;
+import com.github.shyiko.mysql.binlog.network.ServerException;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.CommonConnectorConfig.EventProcessingFailureHandlingMode;
+import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig.GtidNewChannelPosition;
+import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
+import io.debezium.connector.mysql.RecordMakers.RecordsForTable;
+import io.debezium.data.Envelope.Operation;
+import io.debezium.function.BlockingConsumer;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
+import io.debezium.relational.TableId;
+import io.debezium.schema.SchemaChangeEvent;
+import io.debezium.util.Clock;
+import io.debezium.util.ElapsedTimeStrategy;
+import io.debezium.util.Metronome;
+import io.debezium.util.Strings;
+import io.debezium.util.Threads;
+
+/**
+ *
+ * @author Jiri Pechanec
+ */
+public class MySqlStreamingChangeEventSource implements StreamingChangeEventSource {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MySqlStreamingChangeEventSource.class);
+
+    private static final long INITIAL_POLL_PERIOD_IN_MILLIS = TimeUnit.SECONDS.toMillis(5);
+    private static final long MAX_POLL_PERIOD_IN_MILLIS = TimeUnit.HOURS.toMillis(1);
+    private static final String KEEPALIVE_THREAD_NAME = "blc-keepalive";
+
+    private final boolean recordSchemaChangesInSourceRecords;
+    private final RecordMakers recordMakers;
+    private final SourceInfo source;
+    private final EnumMap<EventType, BlockingConsumer<Event>> eventHandlers = new EnumMap<>(EventType.class);
+    private final BinaryLogClient client;
+    private final MySqlStreamingChangeEventSourceMetrics metrics;
+    private final Clock clock;
+    private final ElapsedTimeStrategy pollOutputDelay;
+    private final EventProcessingFailureHandlingMode eventDeserializationFailureHandlingMode;
+    private final EventProcessingFailureHandlingMode inconsistentSchemaHandlingMode;
+
+    private int startingRowNumber = 0;
+    private long recordCounter = 0L;
+    private long previousOutputMillis = 0L;
+    private long initialEventsToSkip = 0L;
+    private boolean skipEvent = false;
+    private boolean ignoreDmlEventByGtidSource = false;
+    private final Predicate<String> gtidDmlSourceFilter;
+    private final AtomicLong totalRecordCounter = new AtomicLong();
+    private volatile Map<String, ?> lastOffset = null;
+    private com.github.shyiko.mysql.binlog.GtidSet gtidSet;
+    private final float heartbeatIntervalFactor = 0.8f;
+    private final Map<String, Thread> binaryLogClientThreads = new ConcurrentHashMap<>(4);
+    private final MySqlTaskContext taskContext;
+    private final MySqlConnectorConfig connectorConfig;
+    private final MySqlConnection connection;
+    private final EventDispatcher<TableId> eventDispatcher;
+    private final MySqlOffsetContext offsetContext;
+    private final ErrorHandler errorHandler;
+
+    public static class BinlogPosition {
+        final String filename;
+        final long position;
+
+        public BinlogPosition(String filename, long position) {
+            assert filename != null;
+
+            this.filename = filename;
+            this.position = position;
+        }
+
+        public String getFilename() {
+            return filename;
+        }
+
+        public long getPosition() {
+            return position;
+        }
+
+        @Override
+        public String toString() {
+            return filename + "/" + position;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + filename.hashCode();
+            result = prime * result + (int) (position ^ (position >>> 32));
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            BinlogPosition other = (BinlogPosition) obj;
+            if (!filename.equals(other.filename)) {
+                return false;
+            }
+            if (position != other.position) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    public MySqlStreamingChangeEventSource(MySqlConnectorConfig connectorConfig, MySqlOffsetContext offsetContext, MySqlConnection connection,
+                                           EventDispatcher<TableId> dispatcher, ErrorHandler errorHandler, Clock clock,
+                                           MySqlTaskContext taskContext, MySqlStreamingChangeEventSourceMetrics metrics) {
+
+        this.taskContext = taskContext;
+        this.connectorConfig = connectorConfig;
+        this.connection = connection;
+        this.clock = clock;
+        this.eventDispatcher = dispatcher;
+        this.errorHandler = errorHandler;
+        // With snapshot mode NEVER the initial context is not created by snapshot
+        this.offsetContext = (offsetContext == null) ? MySqlOffsetContext.initial(connectorConfig) : offsetContext;
+        this.metrics = metrics;
+
+        source = this.offsetContext.getSource();
+        recordMakers = new RecordMakers(taskContext.getSchema(), source, taskContext.getTopicSelector(), connectorConfig.isEmitTombstoneOnDelete(), null);
+        recordSchemaChangesInSourceRecords = connectorConfig.includeSchemaChangeRecords();
+        eventDeserializationFailureHandlingMode = connectorConfig.getEventProcessingFailureHandlingMode();
+        inconsistentSchemaHandlingMode = connectorConfig.inconsistentSchemaFailureHandlingMode();
+
+        // Use exponential delay to log the progress frequently at first, but the quickly tapering off to once an hour...
+        pollOutputDelay = ElapsedTimeStrategy.exponential(clock, INITIAL_POLL_PERIOD_IN_MILLIS, MAX_POLL_PERIOD_IN_MILLIS);
+
+        // Set up the log reader ...
+        client = taskContext.getBinaryLogClient();
+        // BinaryLogClient will overwrite thread names later
+        client.setThreadFactory(
+                Threads.threadFactory(MySqlConnector.class, connectorConfig.getLogicalName(), "binlog-client", false, false,
+                        x -> binaryLogClientThreads.put(x.getName(), x)));
+        client.setServerId(connectorConfig.serverId());
+        client.setSSLMode(sslModeFor(connectorConfig.sslMode()));
+        if (connectorConfig.sslModeEnabled()) {
+            SSLSocketFactory sslSocketFactory = getBinlogSslSocketFactory(connectorConfig, connection);
+            if (sslSocketFactory != null) {
+                client.setSslSocketFactory(sslSocketFactory);
+            }
+        }
+        Configuration configuration = connectorConfig.getConfig();
+        client.setKeepAlive(configuration.getBoolean(MySqlConnectorConfig.KEEP_ALIVE));
+        final long keepAliveInterval = configuration.getLong(MySqlConnectorConfig.KEEP_ALIVE_INTERVAL_MS);
+        client.setKeepAliveInterval(keepAliveInterval);
+        // Considering heartbeatInterval should be less than keepAliveInterval, we use the heartbeatIntervalFactor
+        // multiply by keepAliveInterval and set the result value to heartbeatInterval.The default value of heartbeatIntervalFactor
+        // is 0.8, and we believe the left time (0.2 * keepAliveInterval) is enough to process the packet received from the MySQL server.
+        client.setHeartbeatInterval((long) (keepAliveInterval * heartbeatIntervalFactor));
+
+        boolean filterDmlEventsByGtidSource = configuration.getBoolean(MySqlConnectorConfig.GTID_SOURCE_FILTER_DML_EVENTS);
+        gtidDmlSourceFilter = filterDmlEventsByGtidSource ? connectorConfig.gtidSourceFilter() : null;
+
+        // Set up the event deserializer with additional type(s) ...
+        final Map<Long, TableMapEventData> tableMapEventByTableId = new HashMap<Long, TableMapEventData>();
+        EventDeserializer eventDeserializer = new EventDeserializer() {
+            @Override
+            public Event nextEvent(ByteArrayInputStream inputStream) throws IOException {
+                try {
+                    // Delegate to the superclass ...
+                    Event event = super.nextEvent(inputStream);
+
+                    // We have to record the most recent TableMapEventData for each table number for our custom deserializers ...
+                    if (event.getHeader().getEventType() == EventType.TABLE_MAP) {
+                        TableMapEventData tableMapEvent = event.getData();
+                        tableMapEventByTableId.put(tableMapEvent.getTableId(), tableMapEvent);
+                    }
+                    return event;
+                }
+                // DBZ-217 In case an event couldn't be read we create a pseudo-event for the sake of logging
+                catch (EventDataDeserializationException edde) {
+                    EventHeaderV4 header = new EventHeaderV4();
+                    header.setEventType(EventType.INCIDENT);
+                    header.setTimestamp(edde.getEventHeader().getTimestamp());
+                    header.setServerId(edde.getEventHeader().getServerId());
+
+                    if (edde.getEventHeader() instanceof EventHeaderV4) {
+                        header.setEventLength(((EventHeaderV4) edde.getEventHeader()).getEventLength());
+                        header.setNextPosition(((EventHeaderV4) edde.getEventHeader()).getNextPosition());
+                        header.setFlags(((EventHeaderV4) edde.getEventHeader()).getFlags());
+                    }
+
+                    EventData data = new EventDataDeserializationExceptionData(edde);
+                    return new Event(header, data);
+                }
+            }
+        };
+
+        // Add our custom deserializers ...
+        eventDeserializer.setEventDataDeserializer(EventType.STOP, new StopEventDataDeserializer());
+        eventDeserializer.setEventDataDeserializer(EventType.GTID, new GtidEventDataDeserializer());
+        eventDeserializer.setEventDataDeserializer(EventType.WRITE_ROWS,
+                new RowDeserializers.WriteRowsDeserializer(tableMapEventByTableId));
+        eventDeserializer.setEventDataDeserializer(EventType.UPDATE_ROWS,
+                new RowDeserializers.UpdateRowsDeserializer(tableMapEventByTableId));
+        eventDeserializer.setEventDataDeserializer(EventType.DELETE_ROWS,
+                new RowDeserializers.DeleteRowsDeserializer(tableMapEventByTableId));
+        eventDeserializer.setEventDataDeserializer(EventType.EXT_WRITE_ROWS,
+                new RowDeserializers.WriteRowsDeserializer(
+                        tableMapEventByTableId).setMayContainExtraInformation(true));
+        eventDeserializer.setEventDataDeserializer(EventType.EXT_UPDATE_ROWS,
+                new RowDeserializers.UpdateRowsDeserializer(
+                        tableMapEventByTableId).setMayContainExtraInformation(true));
+        eventDeserializer.setEventDataDeserializer(EventType.EXT_DELETE_ROWS,
+                new RowDeserializers.DeleteRowsDeserializer(
+                        tableMapEventByTableId).setMayContainExtraInformation(true));
+        client.setEventDeserializer(eventDeserializer);
+    }
+
+    protected void onEvent(Event event) {
+        long ts = 0;
+
+        if (event.getHeader().getEventType() == EventType.HEARTBEAT) {
+            // HEARTBEAT events have no timestamp but are fired only when
+            // there is no traffic on the connection which means we are caught-up
+            // https://dev.mysql.com/doc/internals/en/heartbeat-event.html
+            metrics.setMilliSecondsBehindSource(ts);
+            return;
+        }
+
+        // MySQL has seconds resolution but mysql-binlog-connector-java returns
+        // a value in milliseconds
+        long eventTs = event.getHeader().getTimestamp();
+
+        if (eventTs == 0) {
+            LOGGER.trace("Received unexpected event with 0 timestamp: {}", event);
+            return;
+        }
+
+        ts = clock.currentTimeInMillis() - eventTs;
+        LOGGER.trace("Current milliseconds behind source: {} ms", ts);
+        metrics.setMilliSecondsBehindSource(ts);
+    }
+
+    protected void ignoreEvent(Event event) {
+        LOGGER.trace("Ignoring event due to missing handler: {}", event);
+    }
+
+    protected void handleEvent(Event event) {
+        if (event == null) {
+            return;
+        }
+
+        // Update the source offset info. Note that the client returns the value in *milliseconds*, even though the binlog
+        // contains only *seconds* precision ...
+        EventHeader eventHeader = event.getHeader();
+        if (!eventHeader.getEventType().equals(EventType.HEARTBEAT)) {
+            // HEARTBEAT events have no timestamp; only set the timestamp if the event is not a HEARTBEAT
+            source.setBinlogTimestampSeconds(eventHeader.getTimestamp() / 1000L); // client returns milliseconds,
+                                                                                  // but only second precision
+        }
+
+        source.setBinlogServerId(eventHeader.getServerId());
+        EventType eventType = eventHeader.getEventType();
+        if (eventType == EventType.ROTATE) {
+            EventData eventData = event.getData();
+            RotateEventData rotateEventData;
+            if (eventData instanceof EventDeserializer.EventDataWrapper) {
+                rotateEventData = (RotateEventData) ((EventDeserializer.EventDataWrapper) eventData).getInternal();
+            }
+            else {
+                rotateEventData = (RotateEventData) eventData;
+            }
+            source.setBinlogStartPoint(rotateEventData.getBinlogFilename(), rotateEventData.getBinlogPosition());
+        }
+        else if (eventHeader instanceof EventHeaderV4) {
+            EventHeaderV4 trackableEventHeader = (EventHeaderV4) eventHeader;
+            source.setEventPosition(trackableEventHeader.getPosition(), trackableEventHeader.getEventLength());
+        }
+
+        // If there is a handler for this event, forward the event to it ...
+        try {
+            // Forward the event to the handler ...
+            eventHandlers.getOrDefault(eventType, this::ignoreEvent).accept(event);
+
+            // Generate heartbeat message if the time is right
+            eventDispatcher.dispatchHeartbeatEvent(offsetContext);
+
+            // Capture that we've completed another event ...
+            source.completeEvent();
+
+            if (skipEvent) {
+                // We're in the mode of skipping events and we just skipped this one, so decrement our skip count ...
+                --initialEventsToSkip;
+                skipEvent = initialEventsToSkip > 0;
+            }
+        }
+        catch (RuntimeException e) {
+            // There was an error in the event handler, so propagate the failure to Kafka Connect ...
+            logStreamingSourceState();
+            errorHandler.setProducerThrowable(new DebeziumException("Error processing binlog event", e));
+            // Do not stop the client, since Kafka Connect should stop the connector on it's own
+            // (and doing it here may cause problems the second time it is stopped).
+            // We can clear the listeners though so that we ignore all future events ...
+            eventHandlers.clear();
+            LOGGER.info(
+                    "Error processing binlog event, and propagating to Kafka Connect so it stops this connector. Future binlog events read before connector is shutdown will be ignored.");
+        }
+        catch (InterruptedException e) {
+            // Most likely because this reader was stopped and our thread was interrupted ...
+            Thread.currentThread().interrupt();
+            eventHandlers.clear();
+            LOGGER.info("Stopped processing binlog events due to thread interruption");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T extends EventData> T unwrapData(Event event) {
+        EventData eventData = event.getData();
+        if (eventData instanceof EventDeserializer.EventDataWrapper) {
+            eventData = ((EventDeserializer.EventDataWrapper) eventData).getInternal();
+        }
+        return (T) eventData;
+    }
+
+    /**
+     * Handle the supplied event that signals that mysqld has stopped.
+     *
+     * @param event the server stopped event to be processed; may not be null
+     */
+    protected void handleServerStop(Event event) {
+        LOGGER.debug("Server stopped: {}", event);
+    }
+
+    /**
+     * Handle the supplied event that is sent by a primary to a replica to let the replica know that the primary is still alive. Not
+     * written to a binary log.
+     *
+     * @param event the server stopped event to be processed; may not be null
+     */
+    protected void handleServerHeartbeat(Event event) {
+        LOGGER.trace("Server heartbeat: {}", event);
+    }
+
+    /**
+     * Handle the supplied event that signals that an out of the ordinary event that occurred on the master. It notifies the replica
+     * that something happened on the primary that might cause data to be in an inconsistent state.
+     *
+     * @param event the server stopped event to be processed; may not be null
+     */
+    protected void handleServerIncident(Event event) {
+        if (event.getData() instanceof EventDataDeserializationExceptionData) {
+            metrics.onErroneousEvent("source = " + event.toString());
+            EventDataDeserializationExceptionData data = event.getData();
+
+            EventHeaderV4 eventHeader = (EventHeaderV4) data.getCause().getEventHeader(); // safe cast, instantiated that ourselves
+
+            // logging some additional context but not the exception itself, this will happen in handleEvent()
+            if (eventDeserializationFailureHandlingMode == EventProcessingFailureHandlingMode.FAIL) {
+                LOGGER.error(
+                        "Error while deserializing binlog event at offset {}.{}" +
+                                "Use the mysqlbinlog tool to view the problematic event: mysqlbinlog --start-position={} --stop-position={} --verbose {}",
+                        source.offset(),
+                        System.lineSeparator(),
+                        eventHeader.getPosition(),
+                        eventHeader.getNextPosition(),
+                        source.binlogFilename());
+
+                throw new RuntimeException(data.getCause());
+            }
+            else if (eventDeserializationFailureHandlingMode == EventProcessingFailureHandlingMode.WARN) {
+                LOGGER.warn(
+                        "Error while deserializing binlog event at offset {}.{}" +
+                                "This exception will be ignored and the event be skipped.{}" +
+                                "Use the mysqlbinlog tool to view the problematic event: mysqlbinlog --start-position={} --stop-position={} --verbose {}",
+                        source.offset(),
+                        System.lineSeparator(),
+                        System.lineSeparator(),
+                        eventHeader.getPosition(),
+                        eventHeader.getNextPosition(),
+                        source.binlogFilename(),
+                        data.getCause());
+            }
+        }
+        else {
+            LOGGER.error("Server incident: {}", event);
+        }
+    }
+
+    /**
+     * Handle the supplied event with a {@link RotateEventData} that signals the logs are being rotated. This means that either
+     * the server was restarted, or the binlog has transitioned to a new file. In either case, subsequent table numbers will be
+     * different than those seen to this point, so we need to {@link RecordMakers#clear() discard the cache of record makers}.
+     *
+     * @param event the database change data event to be processed; may not be null
+     */
+    protected void handleRotateLogsEvent(Event event) {
+        LOGGER.debug("Rotating logs: {}", event);
+        RotateEventData command = unwrapData(event);
+        assert command != null;
+        recordMakers.clear();
+    }
+
+    /**
+     * Handle the supplied event with a {@link GtidEventData} that signals the beginning of a GTID transaction.
+     * We don't yet know whether this transaction contains any events we're interested in, but we have to record
+     * it so that we know the position of this event and know we've processed the binlog to this point.
+     * <p>
+     * Note that this captures the current GTID and complete GTID set, regardless of whether the connector is
+     * {@link MySqlTaskContext#gtidSourceFilter() filtering} the GTID set upon connection. We do this because
+     * we actually want to capture all GTID set values found in the binlog, whether or not we process them.
+     * However, only when we connect do we actually want to pass to MySQL only those GTID ranges that are applicable
+     * per the configuration.
+     *
+     * @param event the GTID event to be processed; may not be null
+     */
+    protected void handleGtidEvent(Event event) {
+        LOGGER.debug("GTID transaction: {}", event);
+        GtidEventData gtidEvent = unwrapData(event);
+        String gtid = gtidEvent.getGtid();
+        gtidSet.add(gtid);
+        source.startGtid(gtid, gtidSet.toString()); // rather than use the client's GTID set
+        ignoreDmlEventByGtidSource = false;
+        if (gtidDmlSourceFilter != null && gtid != null) {
+            String uuid = gtid.trim().substring(0, gtid.indexOf(":"));
+            if (!gtidDmlSourceFilter.test(uuid)) {
+                ignoreDmlEventByGtidSource = true;
+            }
+        }
+        metrics.onGtidChange(gtid);
+    }
+
+    /**
+     * Handle the supplied event with an {@link RowsQueryEventData} by recording the original SQL query
+     * that generated the event.
+     *
+     * @param event the database change data event to be processed; may not be null
+     */
+    protected void handleRowsQuery(Event event) {
+        // Unwrap the RowsQueryEvent
+        final RowsQueryEventData lastRowsQueryEventData = unwrapData(event);
+
+        // Set the query on the source
+        source.setQuery(lastRowsQueryEventData.getQuery());
+    }
+
+    /**
+     * Handle the supplied event with an {@link QueryEventData} by possibly recording the DDL statements as changes in the
+     * MySQL schemas.
+     *
+     * @param event the database change data event to be processed; may not be null
+     * @throws InterruptedException if this thread is interrupted while recording the DDL statements
+     */
+    protected void handleQueryEvent(Event event) throws InterruptedException {
+        QueryEventData command = unwrapData(event);
+        LOGGER.debug("Received query command: {}", event);
+        String sql = command.getSql().trim();
+        if (sql.equalsIgnoreCase("BEGIN")) {
+            // We are starting a new transaction ...
+            source.startNextTransaction();
+            source.setBinlogThread(command.getThreadId());
+            if (initialEventsToSkip != 0) {
+                LOGGER.debug("Restarting partially-processed transaction; change events will not be created for the first {} events plus {} more rows in the next event",
+                        initialEventsToSkip, startingRowNumber);
+                // We are restarting, so we need to skip the events in this transaction that we processed previously...
+                skipEvent = true;
+            }
+            return;
+        }
+        if (sql.equalsIgnoreCase("COMMIT")) {
+            handleTransactionCompletion(event);
+            return;
+        }
+
+        String upperCasedStatementBegin = Strings.getBegin(sql, 7).toUpperCase();
+
+        if (upperCasedStatementBegin.startsWith("XA ")) {
+            // This is an XA transaction, and we currently ignore these and do nothing ...
+            return;
+        }
+        if (connectorConfig.getDdlFilter().test(sql)) {
+            LOGGER.debug("DDL '{}' was filtered out of processing", sql);
+            return;
+        }
+        if (upperCasedStatementBegin.equals("INSERT ") || upperCasedStatementBegin.equals("UPDATE ") || upperCasedStatementBegin.equals("DELETE ")) {
+            if (eventDeserializationFailureHandlingMode == EventProcessingFailureHandlingMode.FAIL) {
+                throw new DebeziumException(
+                        "Received DML '" + sql + "' for processing, binlog probably contains events generated with statement or mixed based replication format");
+            }
+            else if (eventDeserializationFailureHandlingMode == EventProcessingFailureHandlingMode.WARN) {
+                LOGGER.warn("Warning only: Received DML '" + sql
+                        + "' for processing, binlog probably contains events generated with statement or mixed based replication format");
+                return;
+            }
+            else {
+                return;
+            }
+        }
+        if (sql.equalsIgnoreCase("ROLLBACK")) {
+            // We have hit a ROLLBACK which is not supported
+            LOGGER.warn("Rollback statements cannot be handled without binlog buffering, the connector will fail. Please check '{}' to see how to enable buffering",
+                    MySqlConnectorConfig.BUFFER_SIZE_FOR_BINLOG_READER.name());
+        }
+
+        final SchemaChangeEvent schemaChangeEvent = new SchemaChangeEvent(offsetContext.getPartition(),
+                offsetContext.getOffset(), source.struct(), command.getDatabase(), null, command.getSql(), false);
+        taskContext.getSchema().applySchemaChange(schemaChangeEvent, (newEvent, tableId) -> {
+            if (recordSchemaChangesInSourceRecords) {
+                try {
+                    eventDispatcher.dispatchSchemaChangeEvent(tableId, (receiver) -> {
+                        try {
+                            receiver.schemaChangeEvent(newEvent);
+                        }
+                        catch (Exception e) {
+                            throw new DebeziumException(e);
+                        }
+                    });
+                }
+                catch (InterruptedException e) {
+                    LOGGER.info("Processing interrupted");
+                }
+            }
+        });
+    }
+
+    private void handleTransactionCompletion(Event event) {
+        // We are completing the transaction ...
+        source.commitTransaction();
+        source.setBinlogThread(-1L);
+        skipEvent = false;
+        ignoreDmlEventByGtidSource = false;
+    }
+
+    /**
+     * Handle a change in the table metadata.
+     * <p>
+     * This method should be called whenever we consume a TABLE_MAP event, and every transaction in the log should include one
+     * of these for each table affected by the transaction. Each table map event includes a monotonically-increasing numeric
+     * identifier, and this identifier is used within subsequent events within the same transaction. This table identifier can
+     * change when:
+     * <ol>
+     * <li>the table structure is modified (e.g., via an {@code ALTER TABLE ...} command); or</li>
+     * <li>MySQL rotates to a new binary log file, even if the table structure does not change.</li>
+     * </ol>
+     *
+     * @param event the update event; never null
+     */
+    protected void handleUpdateTableMetadata(Event event) {
+        TableMapEventData metadata = unwrapData(event);
+        long tableNumber = metadata.getTableId();
+        String databaseName = metadata.getDatabase();
+        String tableName = metadata.getTable();
+        TableId tableId = new TableId(databaseName, null, tableName);
+        if (recordMakers.assign(tableNumber, tableId)) {
+            LOGGER.debug("Received update table metadata event: {}", event);
+        }
+        else {
+            informAboutUnknownTableIfRequired(event, tableId, "update table metadata");
+        }
+    }
+
+    /**
+     * If we receive an event for a table that is monitored but whose metadata we
+     * don't know, either ignore that event or raise a warning or error as per the
+     * {@link MySqlConnectorConfig#INCONSISTENT_SCHEMA_HANDLING_MODE} configuration.
+     */
+    private void informAboutUnknownTableIfRequired(Event event, TableId tableId, String typeToLog) {
+        if (tableId != null && connectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId)) {
+            metrics.onErroneousEvent("source = " + tableId + ", event " + event);
+            EventHeaderV4 eventHeader = event.getHeader();
+
+            if (inconsistentSchemaHandlingMode == EventProcessingFailureHandlingMode.FAIL) {
+                LOGGER.error(
+                        "Encountered change event '{}' at offset {} for table {} whose schema isn't known to this connector. One possible cause is an incomplete database history topic. Take a new snapshot in this case.{}"
+                                + "Use the mysqlbinlog tool to view the problematic event: mysqlbinlog --start-position={} --stop-position={} --verbose {}",
+                        event, source.offset(), tableId, System.lineSeparator(), eventHeader.getPosition(),
+                        eventHeader.getNextPosition(), source.binlogFilename());
+                throw new DebeziumException("Encountered change event for table " + tableId
+                        + " whose schema isn't known to this connector");
+            }
+            else if (inconsistentSchemaHandlingMode == EventProcessingFailureHandlingMode.WARN) {
+                LOGGER.warn(
+                        "Encountered change event '{}' at offset {} for table {} whose schema isn't known to this connector. One possible cause is an incomplete database history topic. Take a new snapshot in this case.{}"
+                                + "The event will be ignored.{}"
+                                + "Use the mysqlbinlog tool to view the problematic event: mysqlbinlog --start-position={} --stop-position={} --verbose {}",
+                        event, source.offset(), tableId, System.lineSeparator(), System.lineSeparator(),
+                        eventHeader.getPosition(), eventHeader.getNextPosition(), source.binlogFilename());
+            }
+            else {
+                LOGGER.debug(
+                        "Encountered change event '{}' at offset {} for table {} whose schema isn't known to this connector. One possible cause is an incomplete database history topic. Take a new snapshot in this case.{}"
+                                + "The event will be ignored.{}"
+                                + "Use the mysqlbinlog tool to view the problematic event: mysqlbinlog --start-position={} --stop-position={} --verbose {}",
+                        event, source.offset(), tableId, System.lineSeparator(), System.lineSeparator(),
+                        eventHeader.getPosition(), eventHeader.getNextPosition(), source.binlogFilename());
+            }
+        }
+        else {
+            LOGGER.debug("Filtering {} event: {} for non-monitored table {}", typeToLog, event, tableId);
+            metrics.onFilteredEvent("source = " + tableId);
+        }
+    }
+
+    /**
+     * Generate source records for the supplied event with an {@link WriteRowsEventData}.
+     *
+     * @param event the database change data event to be processed; may not be null
+     * @throws InterruptedException if this thread is interrupted while blocking
+     */
+    protected void handleInsert(Event event) throws InterruptedException {
+        if (skipEvent) {
+            // We can skip this because we should already be at least this far ...
+            LOGGER.info("Skipping previously processed row event: {}", event);
+            return;
+        }
+        if (ignoreDmlEventByGtidSource) {
+            LOGGER.debug("Skipping DML event because this GTID source is filtered: {}", event);
+            return;
+        }
+        WriteRowsEventData write = unwrapData(event);
+        long tableNumber = write.getTableId();
+        BitSet includedColumns = write.getIncludedColumns();
+        RecordsForTable recordMaker = recordMakers.forTable(tableNumber, includedColumns, record -> eventDispatcher
+                .dispatchDataChangeEvent(recordMakers.getTableIdFromTableNumber(tableNumber), new MySqlChangeRecordEmitter(offsetContext, Operation.CREATE, record)));
+        if (recordMaker != null) {
+            List<Serializable[]> rows = write.getRows();
+            final Instant ts = clock.currentTimeAsInstant();
+            int count = 0;
+            int numRows = rows.size();
+            if (startingRowNumber < numRows) {
+                for (int row = startingRowNumber; row != numRows; ++row) {
+                    count += recordMaker.create(rows.get(row), ts, row, numRows);
+                }
+                if (LOGGER.isDebugEnabled()) {
+                    if (startingRowNumber != 0) {
+                        LOGGER.debug("Recorded {} insert record(s) for last {} row(s) in event: {}",
+                                count, numRows - startingRowNumber, event);
+                    }
+                    else {
+                        LOGGER.debug("Recorded {} insert record(s) for event: {}", count, event);
+                    }
+                }
+            }
+            else {
+                // All rows were previously processed ...
+                LOGGER.debug("Skipping previously processed insert event: {}", event);
+            }
+        }
+        else {
+            informAboutUnknownTableIfRequired(event, recordMakers.getTableIdFromTableNumber(tableNumber), "insert row");
+        }
+        startingRowNumber = 0;
+    }
+
+    /**
+     * Generate source records for the supplied event with an {@link UpdateRowsEventData}.
+     *
+     * @param event the database change data event to be processed; may not be null
+     * @throws InterruptedException if this thread is interrupted while blocking
+     */
+    protected void handleUpdate(Event event) throws InterruptedException {
+        if (skipEvent) {
+            // We can skip this because we should already be at least this far ...
+            LOGGER.debug("Skipping previously processed row event: {}", event);
+            return;
+        }
+        if (ignoreDmlEventByGtidSource) {
+            LOGGER.debug("Skipping DML event because this GTID source is filtered: {}", event);
+            return;
+        }
+        UpdateRowsEventData update = unwrapData(event);
+        long tableNumber = update.getTableId();
+        BitSet includedColumns = update.getIncludedColumns();
+        RecordsForTable recordMaker = recordMakers.forTable(tableNumber, includedColumns,
+                record -> eventDispatcher.dispatchDataChangeEvent(recordMakers.getTableIdFromTableNumber(tableNumber),
+                        new MySqlChangeRecordEmitter(offsetContext, Operation.UPDATE, record)));
+        if (recordMaker != null) {
+            List<Entry<Serializable[], Serializable[]>> rows = update.getRows();
+            final Instant ts = clock.currentTimeAsInstant();
+            int count = 0;
+            int numRows = rows.size();
+            if (startingRowNumber < numRows) {
+                for (int row = startingRowNumber; row != numRows; ++row) {
+                    Map.Entry<Serializable[], Serializable[]> changes = rows.get(row);
+                    Serializable[] before = changes.getKey();
+                    Serializable[] after = changes.getValue();
+                    count += recordMaker.update(before, after, ts, row, numRows);
+                }
+                if (LOGGER.isDebugEnabled()) {
+                    if (startingRowNumber != 0) {
+                        LOGGER.debug("Recorded {} update record(s) for last {} row(s) in event: {}",
+                                count, numRows - startingRowNumber, event);
+                    }
+                    else {
+                        LOGGER.debug("Recorded {} update record(s) for event: {}", count, event);
+                    }
+                }
+            }
+            else {
+                // All rows were previously processed ...
+                LOGGER.debug("Skipping previously processed update event: {}", event);
+            }
+        }
+        else {
+            informAboutUnknownTableIfRequired(event, recordMakers.getTableIdFromTableNumber(tableNumber), "update row");
+        }
+        startingRowNumber = 0;
+    }
+
+    /**
+     * Generate source records for the supplied event with an {@link DeleteRowsEventData}.
+     *
+     * @param event the database change data event to be processed; may not be null
+     * @throws InterruptedException if this thread is interrupted while blocking
+     */
+    protected void handleDelete(Event event) throws InterruptedException {
+        if (skipEvent) {
+            // We can skip this because we should already be at least this far ...
+            LOGGER.debug("Skipping previously processed row event: {}", event);
+            return;
+        }
+        if (ignoreDmlEventByGtidSource) {
+            LOGGER.debug("Skipping DML event because this GTID source is filtered: {}", event);
+            return;
+        }
+        DeleteRowsEventData deleted = unwrapData(event);
+        long tableNumber = deleted.getTableId();
+        BitSet includedColumns = deleted.getIncludedColumns();
+        RecordsForTable recordMaker = recordMakers.forTable(tableNumber, includedColumns,
+                record -> eventDispatcher.dispatchDataChangeEvent(recordMakers.getTableIdFromTableNumber(tableNumber),
+                        new MySqlChangeRecordEmitter(offsetContext, Operation.DELETE, record)));
+        if (recordMaker != null) {
+            List<Serializable[]> rows = deleted.getRows();
+            final Instant ts = clock.currentTimeAsInstant();
+            int count = 0;
+            int numRows = rows.size();
+            if (startingRowNumber < numRows) {
+                for (int row = startingRowNumber; row != numRows; ++row) {
+                    count += recordMaker.delete(rows.get(row), ts, row, numRows);
+                }
+                if (LOGGER.isDebugEnabled()) {
+                    if (startingRowNumber != 0) {
+                        LOGGER.debug("Recorded {} delete record(s) for last {} row(s) in event: {}",
+                                count, numRows - startingRowNumber, event);
+                    }
+                    else {
+                        LOGGER.debug("Recorded {} delete record(s) for event: {}", count, event);
+                    }
+                }
+            }
+            else {
+                // All rows were previously processed ...
+                LOGGER.debug("Skipping previously processed delete event: {}", event);
+            }
+        }
+        else {
+            informAboutUnknownTableIfRequired(event, recordMakers.getTableIdFromTableNumber(tableNumber), "delete row");
+        }
+        startingRowNumber = 0;
+    }
+
+    /**
+     * Handle a {@link EventType#VIEW_CHANGE} event.
+     *
+     * @param event the database change data event to be processed; may not be null
+     * @throws InterruptedException if this thread is interrupted while blocking
+     */
+    protected void viewChange(Event event) throws InterruptedException {
+        LOGGER.debug("View Change event: {}", event);
+        // do nothing
+    }
+
+    /**
+     * Handle a {@link EventType#XA_PREPARE} event.
+     *
+     * @param event the database change data event to be processed; may not be null
+     * @throws InterruptedException if this thread is interrupted while blocking
+     */
+    protected void prepareTransaction(Event event) throws InterruptedException {
+        LOGGER.debug("XA Prepare event: {}", event);
+        // do nothing
+    }
+
+    private SSLMode sslModeFor(SecureConnectionMode mode) {
+        switch (mode) {
+            case DISABLED:
+                return SSLMode.DISABLED;
+            case PREFERRED:
+                return SSLMode.PREFERRED;
+            case REQUIRED:
+                return SSLMode.REQUIRED;
+            case VERIFY_CA:
+                return SSLMode.VERIFY_CA;
+            case VERIFY_IDENTITY:
+                return SSLMode.VERIFY_IDENTITY;
+        }
+        return null;
+    }
+
+    @Override
+    public void execute(ChangeEventSourceContext context) throws InterruptedException {
+        if (!connectorConfig.getSnapshotMode().shouldStream()) {
+            LOGGER.info("Streaming is disabled for snapshot mode {}", connectorConfig.getSnapshotMode());
+            return;
+        }
+        taskContext.getSchema().assureNonEmptySchema();
+        final Set<Operation> skippedOperations = connectorConfig.getSkippedOps();
+
+        // Register our event handlers ...
+        eventHandlers.put(EventType.STOP, this::handleServerStop);
+        eventHandlers.put(EventType.HEARTBEAT, this::handleServerHeartbeat);
+        eventHandlers.put(EventType.INCIDENT, this::handleServerIncident);
+        eventHandlers.put(EventType.ROTATE, this::handleRotateLogsEvent);
+        eventHandlers.put(EventType.TABLE_MAP, this::handleUpdateTableMetadata);
+        eventHandlers.put(EventType.QUERY, this::handleQueryEvent);
+
+        if (!skippedOperations.contains(Operation.CREATE)) {
+            eventHandlers.put(EventType.WRITE_ROWS, this::handleInsert);
+            eventHandlers.put(EventType.EXT_WRITE_ROWS, this::handleInsert);
+        }
+
+        if (!skippedOperations.contains(Operation.UPDATE)) {
+            eventHandlers.put(EventType.UPDATE_ROWS, this::handleUpdate);
+            eventHandlers.put(EventType.EXT_UPDATE_ROWS, this::handleUpdate);
+        }
+
+        if (!skippedOperations.contains(Operation.DELETE)) {
+            eventHandlers.put(EventType.DELETE_ROWS, this::handleDelete);
+            eventHandlers.put(EventType.EXT_DELETE_ROWS, this::handleDelete);
+        }
+
+        eventHandlers.put(EventType.VIEW_CHANGE, this::viewChange);
+        eventHandlers.put(EventType.XA_PREPARE, this::prepareTransaction);
+        eventHandlers.put(EventType.XID, this::handleTransactionCompletion);
+
+        // Conditionally register ROWS_QUERY handler to parse SQL statements.
+        if (connectorConfig.includeSqlQuery()) {
+            eventHandlers.put(EventType.ROWS_QUERY, this::handleRowsQuery);
+        }
+
+        client.registerEventListener(connectorConfig.bufferSizeForStreamingChangeEventSource() == 0
+                ? this::handleEvent
+                : (new EventBuffer(connectorConfig.bufferSizeForStreamingChangeEventSource(), this, context))::add);
+
+        client.registerLifecycleListener(new ReaderThreadLifecycleListener());
+        client.registerEventListener(this::onEvent);
+        if (LOGGER.isDebugEnabled()) {
+            client.registerEventListener(this::logEvent);
+        }
+
+        final boolean isGtidModeEnabled = connection.isGtidModeEnabled();
+        metrics.setIsGtidModeEnabled(isGtidModeEnabled);
+
+        // Get the current GtidSet from MySQL so we can get a filtered/merged GtidSet based off of the last Debezium checkpoint.
+        String availableServerGtidStr = connection.knownGtidSet();
+        if (isGtidModeEnabled) {
+            // The server is using GTIDs, so enable the handler ...
+            eventHandlers.put(EventType.GTID, this::handleGtidEvent);
+
+            // Now look at the GTID set from the server and what we've previously seen ...
+            GtidSet availableServerGtidSet = new GtidSet(availableServerGtidStr);
+
+            // also take into account purged GTID logs
+            GtidSet purgedServerGtidSet = connection.purgedGtidSet();
+            LOGGER.info("GTID set purged on server: {}", purgedServerGtidSet);
+
+            GtidSet filteredGtidSet = filterGtidSet(availableServerGtidSet, purgedServerGtidSet);
+            if (filteredGtidSet != null) {
+                // We've seen at least some GTIDs, so start reading from the filtered GTID set ...
+                LOGGER.info("Registering binlog reader with GTID set: {}", filteredGtidSet);
+                String filteredGtidSetStr = filteredGtidSet.toString();
+                client.setGtidSet(filteredGtidSetStr);
+                source.setCompletedGtidSet(filteredGtidSetStr);
+                gtidSet = new com.github.shyiko.mysql.binlog.GtidSet(filteredGtidSetStr);
+            }
+            else {
+                // We've not yet seen any GTIDs, so that means we have to start reading the binlog from the beginning ...
+                client.setBinlogFilename(source.binlogFilename());
+                client.setBinlogPosition(source.binlogPosition());
+                gtidSet = new com.github.shyiko.mysql.binlog.GtidSet("");
+            }
+        }
+        else {
+            // The server is not using GTIDs, so start reading the binlog based upon where we last left off ...
+            client.setBinlogFilename(source.binlogFilename());
+            client.setBinlogPosition(source.binlogPosition());
+        }
+
+        // We may be restarting in the middle of a transaction, so see how far into the transaction we have already processed...
+        initialEventsToSkip = source.eventsToSkipUponRestart();
+        LOGGER.info("Skip {} events on streaming start", initialEventsToSkip);
+
+        // Set the starting row number, which is the next row number to be read ...
+        startingRowNumber = source.rowsToSkipUponRestart();
+        LOGGER.info("Skip {} rows on streaming start", startingRowNumber);
+
+        // Only when we reach the first BEGIN event will we start to skip events ...
+        skipEvent = false;
+
+        // Initial our poll output delay logic ...
+        pollOutputDelay.hasElapsed();
+        previousOutputMillis = clock.currentTimeInMillis();
+
+        try {
+            // Start the log reader, which starts background threads ...
+            if (context.isRunning()) {
+                long timeout = connectorConfig.getConnectionTimeout().toMillis();
+                long started = clock.currentTimeInMillis();
+                try {
+                    LOGGER.debug("Attempting to establish binlog reader connection with timeout of {} ms", timeout);
+                    client.connect(timeout);
+                    // Need to wait for keepalive thread to be running, otherwise it can be left orphaned
+                    // The problem is with timing. When the close is called too early after connect then
+                    // the keepalive thread is not terminated
+                    if (client.isKeepAlive()) {
+                        LOGGER.info("Waiting for keepalive thread to start");
+                        final Metronome metronome = Metronome.parker(Duration.ofMillis(100), clock);
+                        int waitAttempts = 50;
+                        boolean keepAliveThreadRunning = false;
+                        while (!keepAliveThreadRunning && waitAttempts-- > 0) {
+                            for (Thread t : binaryLogClientThreads.values()) {
+                                if (t.getName().startsWith(KEEPALIVE_THREAD_NAME) && t.isAlive()) {
+                                    LOGGER.info("Keepalive thread is running");
+                                    keepAliveThreadRunning = true;
+                                }
+                            }
+                            metronome.pause();
+                        }
+                    }
+                }
+                catch (TimeoutException e) {
+                    // If the client thread is interrupted *before* the client could connect, the client throws a timeout exception
+                    // The only way we can distinguish this is if we get the timeout exception before the specified timeout has
+                    // elapsed, so we simply check this (within 10%) ...
+                    long duration = clock.currentTimeInMillis() - started;
+                    if (duration > (0.9 * timeout)) {
+                        double actualSeconds = TimeUnit.MILLISECONDS.toSeconds(duration);
+                        throw new DebeziumException("Timed out after " + actualSeconds + " seconds while waiting to connect to MySQL at " +
+                                connectorConfig.hostname() + ":" + connectorConfig.port() + " with user '" + connectorConfig.username() + "'", e);
+                    }
+                    // Otherwise, we were told to shutdown, so we don't care about the timeout exception
+                }
+                catch (AuthenticationException e) {
+                    throw new DebeziumException("Failed to authenticate to the MySQL database at " +
+                            connectorConfig.hostname() + ":" + connectorConfig.port() + " with user '" + connectorConfig.username() + "'", e);
+                }
+                catch (Throwable e) {
+                    throw new DebeziumException("Unable to connect to the MySQL database at " +
+                            connectorConfig.hostname() + ":" + connectorConfig.port() + " with user '" + connectorConfig.username() + "': " + e.getMessage(), e);
+                }
+            }
+            while (context.isRunning()) {
+                Thread.sleep(100);
+            }
+        }
+        finally {
+            try {
+                client.disconnect();
+            }
+            catch (Exception e) {
+                LOGGER.info("Exception while stopping binary log client", e);
+            }
+        }
+    }
+
+    private SSLSocketFactory getBinlogSslSocketFactory(MySqlConnectorConfig connectorConfig, MySqlConnection connection) {
+        String acceptedTlsVersion = connection.getSessionVariableForSslVersion();
+        if (!isNullOrEmpty(acceptedTlsVersion)) {
+            SSLMode sslMode = sslModeFor(connectorConfig.sslMode());
+
+            // Keystore settings can be passed via system properties too so we need to read them
+            final String password = System.getProperty("javax.net.ssl.keyStorePassword");
+            final String keyFilename = System.getProperty("javax.net.ssl.keyStore");
+            KeyManager[] keyManagers = null;
+            if (keyFilename != null) {
+                final char[] passwordArray = (password == null) ? null : password.toCharArray();
+                try {
+                    KeyStore ks = KeyStore.getInstance("JKS");
+                    ks.load(new FileInputStream(keyFilename), passwordArray);
+
+                    KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509");
+                    kmf.init(ks, passwordArray);
+
+                    keyManagers = kmf.getKeyManagers();
+                }
+                catch (KeyStoreException | IOException | CertificateException | NoSuchAlgorithmException | UnrecoverableKeyException e) {
+                    throw new DebeziumException("Could not load keystore", e);
+                }
+            }
+
+            // DBZ-1208 Resembles the logic from the upstream BinaryLogClient, only that
+            // the accepted TLS version is passed to the constructed factory
+            if (sslMode == SSLMode.PREFERRED || sslMode == SSLMode.REQUIRED) {
+                final KeyManager[] finalKMS = keyManagers;
+                return new DefaultSSLSocketFactory(acceptedTlsVersion) {
+
+                    @Override
+                    protected void initSSLContext(SSLContext sc)
+                            throws GeneralSecurityException {
+                        sc.init(finalKMS, new TrustManager[]{
+                                new X509TrustManager() {
+
+                                    @Override
+                                    public void checkClientTrusted(
+                                                                   X509Certificate[] x509Certificates,
+                                                                   String s)
+                                            throws CertificateException {
+                                    }
+
+                                    @Override
+                                    public void checkServerTrusted(
+                                                                   X509Certificate[] x509Certificates,
+                                                                   String s)
+                                            throws CertificateException {
+                                    }
+
+                                    @Override
+                                    public X509Certificate[] getAcceptedIssuers() {
+                                        return new X509Certificate[0];
+                                    }
+                                }
+                        }, null);
+                    }
+                };
+            }
+            else {
+                return new DefaultSSLSocketFactory(acceptedTlsVersion);
+            }
+        }
+
+        return null;
+    }
+
+    private void logStreamingSourceState() {
+        logStreamingSourceState(Level.ERROR);
+    }
+
+    protected void logEvent(Event event) {
+        LOGGER.trace("Received event: {}", event);
+    }
+
+    private void logStreamingSourceState(Level severity) {
+        final Object position = client == null ? "N/A" : client.getBinlogFilename() + "/" + client.getBinlogPosition();
+        final String message = "Error during binlog processing. Last offset stored = {}, binlog reader near position = {}";
+        switch (severity) {
+            case WARN:
+                LOGGER.warn(message, lastOffset, position);
+                break;
+            case DEBUG:
+                LOGGER.debug(message, lastOffset, position);
+                break;
+            default:
+                LOGGER.error(message, lastOffset, position);
+        }
+    }
+
+    /**
+     * Apply the include/exclude GTID source filters to the current {@link #source() GTID set} and merge them onto the
+     * currently available GTID set from a MySQL server.
+     *
+     * The merging behavior of this method might seem a bit strange at first. It's required in order for Debezium to consume a
+     * MySQL binlog that has multi-source replication enabled, if a failover has to occur. In such a case, the server that
+     * Debezium is failed over to might have a different set of sources, but still include the sources required for Debezium
+     * to continue to function. MySQL does not allow downstream replicas to connect if the GTID set does not contain GTIDs for
+     * all channels that the server is replicating from, even if the server does have the data needed by the client. To get
+     * around this, we can have Debezium merge its GTID set with whatever is on the server, so that MySQL will allow it to
+     * connect. See <a href="https://issues.jboss.org/browse/DBZ-143">DBZ-143</a> for details.
+     *
+     * This method does not mutate any state in the context.
+     *
+     * @param availableServerGtidSet the GTID set currently available in the MySQL server
+     * @param purgedServerGtid the GTID set already purged by the MySQL server
+     * @return A GTID set meant for consuming from a MySQL binlog; may return null if the SourceInfo has no GTIDs and therefore
+     *         none were filtered
+     */
+    public GtidSet filterGtidSet(GtidSet availableServerGtidSet, GtidSet purgedServerGtid) {
+        String gtidStr = source.gtidSet();
+        if (gtidStr == null) {
+            return null;
+        }
+        LOGGER.info("Attempting to generate a filtered GTID set");
+        LOGGER.info("GTID set from previous recorded offset: {}", gtidStr);
+        GtidSet filteredGtidSet = new GtidSet(gtidStr);
+        Predicate<String> gtidSourceFilter = connectorConfig.gtidSourceFilter();
+        if (gtidSourceFilter != null) {
+            filteredGtidSet = filteredGtidSet.retainAll(gtidSourceFilter);
+            LOGGER.info("GTID set after applying GTID source includes/excludes to previous recorded offset: {}", filteredGtidSet);
+        }
+        LOGGER.info("GTID set available on server: {}", availableServerGtidSet);
+
+        GtidSet mergedGtidSet;
+
+        if (connectorConfig.gtidNewChannelPosition() == GtidNewChannelPosition.EARLIEST) {
+            final GtidSet knownGtidSet = filteredGtidSet;
+            LOGGER.info("Using first available positions for new GTID channels");
+            final GtidSet relevantAvailableServerGtidSet = (gtidSourceFilter != null) ? availableServerGtidSet.retainAll(gtidSourceFilter) : availableServerGtidSet;
+            LOGGER.info("Relevant GTID set available on server: {}", relevantAvailableServerGtidSet);
+
+            mergedGtidSet = relevantAvailableServerGtidSet
+                    .retainAll(uuid -> knownGtidSet.forServerWithId(uuid) != null)
+                    .with(purgedServerGtid)
+                    .with(filteredGtidSet);
+        }
+        else {
+            mergedGtidSet = availableServerGtidSet.with(filteredGtidSet);
+        }
+
+        LOGGER.info("Final merged GTID set to use when connecting to MySQL: {}", mergedGtidSet);
+        return mergedGtidSet;
+    }
+
+    MySqlStreamingChangeEventSourceMetrics getMetrics() {
+        return metrics;
+    }
+
+    void rewindBinaryLogClient(ChangeEventSourceContext context, BinlogPosition position) {
+        try {
+            if (context.isRunning()) {
+                LOGGER.debug("Rewinding binlog to position {}", position);
+                client.disconnect();
+                client.setBinlogFilename(position.getFilename());
+                client.setBinlogPosition(position.getPosition());
+                client.connect();
+            }
+        }
+        catch (IOException e) {
+            LOGGER.error("Unexpected error when re-connecting to the MySQL binary log reader", e);
+        }
+    }
+
+    BinlogPosition getCurrentBinlogPosition() {
+        return new BinlogPosition(client.getBinlogFilename(), client.getBinlogPosition());
+    }
+
+    /**
+     * Wraps the specified exception in a {@link DebeziumException}, ensuring that all useful state is captured inside
+     * the new exception's message.
+     *
+     * @param error the exception; may not be null
+     * @return the wrapped Kafka Connect exception
+     */
+    protected DebeziumException wrap(Throwable error) {
+        assert error != null;
+        String msg = error.getMessage();
+        if (error instanceof ServerException) {
+            ServerException e = (ServerException) error;
+            msg = msg + " Error code: " + e.getErrorCode() + "; SQLSTATE: " + e.getSqlState() + ".";
+        }
+        else if (error instanceof SQLException) {
+            SQLException e = (SQLException) error;
+            msg = e.getMessage() + " Error code: " + e.getErrorCode() + "; SQLSTATE: " + e.getSQLState() + ".";
+        }
+        return new DebeziumException(msg, error);
+    }
+
+    protected final class ReaderThreadLifecycleListener implements LifecycleListener {
+        @Override
+        public void onDisconnect(BinaryLogClient client) {
+            if (LOGGER.isInfoEnabled()) {
+                taskContext.temporaryLoggingContext(connectorConfig, "binlog", () -> {
+                    Map<String, ?> offset = lastOffset;
+                    if (offset != null) {
+                        LOGGER.info("Stopped reading binlog after {} events, last recorded offset: {}", totalRecordCounter, offset);
+                    }
+                    else {
+                        LOGGER.info("Stopped reading binlog after {} events, no new offset was recorded", totalRecordCounter);
+                    }
+                });
+            }
+        }
+
+        @Override
+        public void onConnect(BinaryLogClient client) {
+            // Set up the MDC logging context for this thread ...
+            taskContext.configureLoggingContext("binlog");
+
+            // The event row number will be used when processing the first event ...
+            LOGGER.info("Connected to MySQL binlog at {}:{}, starting at {}", connectorConfig.hostname(), connectorConfig.port(), source);
+        }
+
+        @Override
+        public void onCommunicationFailure(BinaryLogClient client, Exception ex) {
+            LOGGER.debug("A communication failure event arrived", ex);
+            logStreamingSourceState();
+            try {
+                // Stop BinaryLogClient background threads
+                client.disconnect();
+            }
+            catch (final Exception e) {
+                LOGGER.debug("Exception while closing client", e);
+            }
+            errorHandler.setProducerThrowable(wrap(ex));
+        }
+
+        @Override
+        public void onEventDeserializationFailure(BinaryLogClient client, Exception ex) {
+            if (eventDeserializationFailureHandlingMode == EventProcessingFailureHandlingMode.FAIL) {
+                LOGGER.debug("A deserialization failure event arrived", ex);
+                logStreamingSourceState();
+                errorHandler.setProducerThrowable(wrap(ex));
+            }
+            else if (eventDeserializationFailureHandlingMode == EventProcessingFailureHandlingMode.WARN) {
+                LOGGER.warn("A deserialization failure event arrived", ex);
+                logStreamingSourceState(Level.WARN);
+            }
+            else {
+                LOGGER.debug("A deserialization failure event arrived", ex);
+                logStreamingSourceState(Level.DEBUG);
+            }
+        }
+    }
+
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSourceMetrics.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSourceMetrics.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import com.github.shyiko.mysql.binlog.jmx.BinaryLogClientStatistics;
+
+import io.debezium.connector.base.ChangeEventQueueMetrics;
+import io.debezium.pipeline.metrics.StreamingChangeEventSourceMetrics;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.util.Collect;
+
+/**
+ * @author Randall Hauch
+ */
+public class MySqlStreamingChangeEventSourceMetrics extends StreamingChangeEventSourceMetrics implements MySqlStreamingChangeEventSourceMetricsMXBean {
+
+    private final BinaryLogClient client;
+    private final BinaryLogClientStatistics stats;
+    private final MySqlDatabaseSchema schema;
+
+    private final AtomicLong numberOfCommittedTransactions = new AtomicLong();
+    private final AtomicLong numberOfRolledBackTransactions = new AtomicLong();
+    private final AtomicLong numberOfNotWellFormedTransactions = new AtomicLong();
+    private final AtomicLong numberOfLargeTransactions = new AtomicLong();
+    private final AtomicBoolean isGtidModeEnabled = new AtomicBoolean(false);
+    private final AtomicLong milliSecondsBehindMaster = new AtomicLong();
+    private final AtomicReference<String> lastTransactionId = new AtomicReference<>();
+
+    public MySqlStreamingChangeEventSourceMetrics(MySqlTaskContext taskContext, ChangeEventQueueMetrics changeEventQueueMetrics, EventMetadataProvider metadataProvider) {
+        super(taskContext, changeEventQueueMetrics, metadataProvider);
+        this.client = taskContext.getBinaryLogClient();
+        this.stats = new BinaryLogClientStatistics(client);
+        this.schema = taskContext.getSchema();
+        this.milliSecondsBehindMaster.set(-1);
+    }
+
+    @Override
+    public boolean isConnected() {
+        return this.client.isConnected();
+    }
+
+    @Override
+    public String getBinlogFilename() {
+        return this.client.getBinlogFilename();
+    }
+
+    @Override
+    public long getBinlogPosition() {
+        return this.client.getBinlogPosition();
+    }
+
+    @Override
+    public String getGtidSet() {
+        return this.client.getGtidSet();
+    }
+
+    @Override
+    public boolean getIsGtidModeEnabled() {
+        return isGtidModeEnabled.get();
+    }
+
+    @Override
+    public String getLastEvent() {
+        return this.stats.getLastEvent();
+    }
+
+    @Override
+    public long getMilliSecondsSinceLastEvent() {
+        return this.stats.getSecondsSinceLastEvent() * 1000;
+    }
+
+    @Override
+    public long getTotalNumberOfEventsSeen() {
+        return this.stats.getTotalNumberOfEventsSeen();
+    }
+
+    @Override
+    public long getNumberOfSkippedEvents() {
+        return this.stats.getNumberOfSkippedEvents();
+    }
+
+    @Override
+    public long getNumberOfDisconnects() {
+        return this.stats.getNumberOfDisconnects();
+    }
+
+    @Override
+    public void reset() {
+        this.stats.reset();
+        numberOfCommittedTransactions.set(0);
+        numberOfRolledBackTransactions.set(0);
+        numberOfNotWellFormedTransactions.set(0);
+        numberOfLargeTransactions.set(0);
+        lastTransactionId.set(null);
+        isGtidModeEnabled.set(false);
+    }
+
+    @Override
+    public long getNumberOfCommittedTransactions() {
+        return numberOfCommittedTransactions.get();
+    }
+
+    @Override
+    public long getNumberOfRolledBackTransactions() {
+        return numberOfRolledBackTransactions.get();
+    }
+
+    @Override
+    public long getNumberOfNotWellFormedTransactions() {
+        return numberOfNotWellFormedTransactions.get();
+    }
+
+    @Override
+    public long getNumberOfLargeTransactions() {
+        return numberOfLargeTransactions.get();
+    }
+
+    public void onCommittedTransaction() {
+        numberOfCommittedTransactions.incrementAndGet();
+    }
+
+    public void onRolledBackTransaction() {
+        numberOfRolledBackTransactions.incrementAndGet();
+    }
+
+    public void onNotWellFormedTransaction() {
+        numberOfNotWellFormedTransactions.incrementAndGet();
+    }
+
+    public void onLargeTransaction() {
+        numberOfLargeTransactions.incrementAndGet();
+    }
+
+    public void onGtidChange(String gtid) {
+        lastTransactionId.set(gtid);
+    }
+
+    public void setIsGtidModeEnabled(final boolean enabled) {
+        isGtidModeEnabled.set(enabled);
+    }
+
+    public void setMilliSecondsBehindSource(long value) {
+        milliSecondsBehindMaster.set(value);
+    }
+
+    @Override
+    public String[] getMonitoredTables() {
+        return schema.monitoredTablesAsStringArray();
+    }
+
+    @Override
+    public long getMilliSecondsBehindSource() {
+        return milliSecondsBehindMaster.get();
+    }
+
+    @Override
+    public Map<String, String> getSourceEventPosition() {
+        return Collect.hashMapOf(
+                "filename", getBinlogFilename(),
+                "position", Long.toString(getBinlogPosition()),
+                "gtid", getGtidSet());
+    }
+
+    @Override
+    public String getLastTransactionId() {
+        return lastTransactionId.get();
+    }
+
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSourceMetricsMXBean.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSourceMetricsMXBean.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import io.debezium.pipeline.metrics.StreamingChangeEventSourceMetricsMXBean;
+
+/**
+ * @author Randall Hauch
+ *
+ */
+public interface MySqlStreamingChangeEventSourceMetricsMXBean extends StreamingChangeEventSourceMetricsMXBean {
+
+    /**
+     * Name of the current MySQL binlog file being read by underlying mysql-binlog-client.
+     */
+    String getBinlogFilename();
+
+    /**
+     * Current MySQL binlog offset position being read by underlying mysql-binlog-client.
+     */
+    long getBinlogPosition();
+
+    /**
+     * Current MySQL Gtid being read by underlying mysql-binlog-client.
+     */
+    String getGtidSet();
+
+    /**
+     * Tracks the number of events skipped by underlying mysql-binlog-client, generally due to the client
+     * being unable to properly deserialize the event.
+     */
+    long getNumberOfSkippedEvents();
+
+    /**
+     * Tracks the number of times the underlying mysql-binlog-client has been disconnected from MySQL.
+     */
+    long getNumberOfDisconnects();
+
+    /**
+     * Tracks the number of committed transactions.
+     */
+    long getNumberOfCommittedTransactions();
+
+    /**
+     * Tracks the number of rolled back transactions.
+     */
+    long getNumberOfRolledBackTransactions();
+
+    /**
+     * Tracks the number of transactions which are not well-formed.
+     * Example - The connector sees a commit TX event without a matched begin TX event.
+     */
+    long getNumberOfNotWellFormedTransactions();
+
+    /**
+     * Tracks the number of transaction which contains events that contained more entries than could be contained
+     * within the connectors {@see io.debezium.connector.mysql.EventBuffer} instance.
+     */
+    long getNumberOfLargeTransactions();
+
+    /**
+     * Tracks if the connector is running using Gtids to track current offset.
+     * @return true if using Gtids, false if not.
+     */
+    boolean getIsGtidModeEnabled();
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTaskContext.java
@@ -5,339 +5,40 @@
  */
 package io.debezium.connector.mysql;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.function.Predicate;
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import io.debezium.config.Configuration;
 import io.debezium.connector.common.CdcSourceTaskContext;
-import io.debezium.connector.mysql.MySqlConnectorConfig.GtidNewChannelPosition;
-import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
-import io.debezium.function.Predicates;
 import io.debezium.relational.TableId;
-import io.debezium.relational.history.DatabaseHistory;
 import io.debezium.schema.TopicSelector;
-import io.debezium.util.LoggingContext;
-import io.debezium.util.Strings;
 
 /**
- * A Kafka Connect source task reads the MySQL binary log and generate the corresponding data change events.
+ * A state (context) associated with a MySQL task
  *
- * @see MySqlConnector
- * @author Randall Hauch
+ * @author Jiri Pechanec
+ *
  */
-public final class MySqlTaskContext extends CdcSourceTaskContext {
+public class MySqlTaskContext extends CdcSourceTaskContext {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MySqlTaskContext.class);
-
-    private final MySqlJdbcContext connectionContext;
-    private final Configuration config;
-    private final MySqlConnectorConfig connectorConfig;
-    private final SourceInfo source;
-    private final MySqlSchema dbSchema;
+    private final MySqlDatabaseSchema schema;
+    private final BinaryLogClient binaryLogClient;
     private final TopicSelector<TableId> topicSelector;
-    private final RecordMakers recordProcessor;
-    private final Predicate<String> gtidSourceFilter;
-    private final Predicate<String> ddlFilter;
 
-    /**
-     * Whether table ids are compared ignoring letter casing.
-     */
-    private final boolean tableIdCaseInsensitive;
-
-    public MySqlTaskContext(Configuration config, Filters filters) {
-        this(config, filters, null, null);
+    public MySqlTaskContext(MySqlConnectorConfig config, MySqlDatabaseSchema schema) {
+        super(config.getContextName(), config.getLogicalName(), schema::tableIds);
+        this.schema = schema;
+        this.binaryLogClient = new BinaryLogClient(config.hostname(), config.port(), config.username(), config.password());
+        topicSelector = MySqlTopicSelector.defaultSelector(config);
     }
 
-    public MySqlTaskContext(Configuration config, Filters filters, Map<String, ?> restartOffset) {
-        this(config, filters, null, restartOffset);
+    public MySqlDatabaseSchema getSchema() {
+        return schema;
     }
 
-    public MySqlTaskContext(Configuration config, Filters filters, Boolean tableIdCaseInsensitive, Map<String, ?> restartOffset) {
-        super(Module.contextName(), config.getString(MySqlConnectorConfig.SERVER_NAME), Collections::emptyList);
-
-        this.config = config;
-        this.connectorConfig = new MySqlConnectorConfig(config);
-        this.connectionContext = new MySqlJdbcContext(connectorConfig);
-
-        // Set up the topic selector ...
-        this.topicSelector = MySqlTopicSelector.defaultSelector(connectorConfig.getLogicalName(), connectorConfig.getHeartbeatTopicsPrefix());
-
-        // Set up the source information ...
-        this.source = new SourceInfo(connectorConfig);
-
-        // Set up the GTID filter ...
-        String gtidSetIncludes = config.getString(MySqlConnectorConfig.GTID_SOURCE_INCLUDES);
-        String gtidSetExcludes = config.getString(MySqlConnectorConfig.GTID_SOURCE_EXCLUDES);
-        this.gtidSourceFilter = gtidSetIncludes != null ? Predicates.includesUuids(gtidSetIncludes)
-                : (gtidSetExcludes != null ? Predicates.excludesUuids(gtidSetExcludes) : null);
-
-        if (tableIdCaseInsensitive == null) {
-            this.tableIdCaseInsensitive = !"0".equals(connectionContext.readMySqlSystemVariables().get(MySqlSystemVariables.LOWER_CASE_TABLE_NAMES));
-        }
-        else {
-            this.tableIdCaseInsensitive = tableIdCaseInsensitive;
-        }
-
-        // Set up the MySQL schema ...
-        this.dbSchema = new MySqlSchema(connectorConfig, this.gtidSourceFilter, this.tableIdCaseInsensitive, topicSelector, filters);
-
-        // Set up the record processor ...
-        this.recordProcessor = new RecordMakers(dbSchema, source, topicSelector, connectorConfig.isEmitTombstoneOnDelete(), restartOffset);
-
-        // Set up the DDL filter
-        final String ddlFilter = config.getString(DatabaseHistory.DDL_FILTER);
-        this.ddlFilter = (ddlFilter != null) ? Predicates.includes(ddlFilter) : (x -> false);
+    public BinaryLogClient getBinaryLogClient() {
+        return binaryLogClient;
     }
 
-    public Configuration config() {
-        return config;
-    }
-
-    public MySqlConnectorConfig getConnectorConfig() {
-        return this.connectorConfig;
-    }
-
-    public MySqlJdbcContext getConnectionContext() {
-        return connectionContext;
-    }
-
-    public String connectorName() {
-        return config.getString("name");
-    }
-
-    public TopicSelector<TableId> topicSelector() {
+    public TopicSelector<TableId> getTopicSelector() {
         return topicSelector;
-    }
-
-    public SourceInfo source() {
-        return source;
-    }
-
-    public MySqlSchema dbSchema() {
-        return dbSchema;
-    }
-
-    public RecordMakers makeRecord() {
-        return recordProcessor;
-    }
-
-    /**
-     * Get the predicate function that will return {@code true} if a GTID source is to be included, or {@code false} if
-     * a GTID source is to be excluded.
-     *
-     * @return the GTID source predicate function; never null
-     */
-    public Predicate<String> gtidSourceFilter() {
-        return gtidSourceFilter;
-    }
-
-    /**
-     * Initialize the database history with any server-specific information. This should be done only upon connector startup
-     * when the connector has no prior history.
-     */
-    public void initializeHistory() {
-        // Read the system variables from the MySQL instance and get the current database name ...
-        Map<String, String> variables = connectionContext.readMySqlCharsetSystemVariables();
-        String ddlStatement = connectionContext.setStatementFor(variables);
-
-        // And write them into the database history ...
-        dbSchema.applyDdl(source, "", ddlStatement, null);
-    }
-
-    /**
-     * Load the database schema information using the previously-recorded history, and stop reading the history when the
-     * the history reaches the supplied starting point.
-     *
-     * @param startingPoint the source information with the current {@link SourceInfo#partition()} and {@link SourceInfo#offset()
-     *            offset} at which the database schemas are to reflect; may not be null
-     */
-    public void loadHistory(SourceInfo startingPoint) {
-        // Read the system variables from the MySQL instance and load them into the DDL parser as defaults ...
-        Map<String, String> variables = connectionContext.readMySqlCharsetSystemVariables();
-        dbSchema.setSystemVariables(variables);
-
-        // And then load the history ...
-        dbSchema.loadHistory(startingPoint);
-
-        // The server's default character set may have changed since we last recorded it in the history,
-        // so we need to see if the history's state does not match ...
-        String systemCharsetName = variables.get(MySqlSystemVariables.CHARSET_NAME_SERVER);
-        String systemCharsetNameFromHistory = dbSchema.systemVariables().getVariable(MySqlSystemVariables.CHARSET_NAME_SERVER);
-        if (!Strings.equalsIgnoreCase(systemCharsetName, systemCharsetNameFromHistory)) {
-            // The history's server character set is NOT the same as the server's current default,
-            // so record the change in the history ...
-            String ddlStatement = connectionContext.setStatementFor(variables);
-            dbSchema.applyDdl(source, "", ddlStatement, null);
-        }
-        recordProcessor.regenerate();
-    }
-
-    /**
-     * Return true if the database history entity exists
-     */
-    public boolean historyExists() {
-        // Read the system variables from the MySQL instance and load them into the DDL parser as defaults ...
-        Map<String, String> variables = connectionContext.readMySqlCharsetSystemVariables();
-        dbSchema.setSystemVariables(variables);
-
-        // And then load the history ...
-        return dbSchema.historyExists();
-    }
-
-    /**
-     * Initialize permanent storage for database history
-     */
-    public void initializeHistoryStorage() {
-        dbSchema.intializeHistoryStorage();
-    }
-
-    public long serverId() {
-        return config.getLong(MySqlConnectorConfig.SERVER_ID);
-    }
-
-    public long rowCountForLargeTable() {
-        return config.getLong(MySqlConnectorConfig.ROW_COUNT_FOR_STREAMING_RESULT_SETS);
-    }
-
-    public int bufferSizeForBinlogReader() {
-        return config.getInteger(MySqlConnectorConfig.BUFFER_SIZE_FOR_BINLOG_READER);
-    }
-
-    public boolean includeSchemaChangeRecords() {
-        return config.getBoolean(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES);
-    }
-
-    public boolean includeSqlQuery() {
-        return config.getBoolean(MySqlConnectorConfig.INCLUDE_SQL_QUERY);
-    }
-
-    public boolean isSnapshotAllowedWhenNeeded() {
-        return snapshotMode() == SnapshotMode.WHEN_NEEDED;
-    }
-
-    public boolean isSnapshotNeverAllowed() {
-        return snapshotMode() == SnapshotMode.NEVER;
-    }
-
-    public boolean isInitialSnapshotOnly() {
-        return snapshotMode() == SnapshotMode.INITIAL_ONLY;
-    }
-
-    public boolean isSchemaOnlySnapshot() {
-        return snapshotMode() == SnapshotMode.SCHEMA_ONLY;
-    }
-
-    public boolean isSchemaOnlyRecoverySnapshot() {
-        return snapshotMode() == SnapshotMode.SCHEMA_ONLY_RECOVERY;
-    }
-
-    protected SnapshotMode snapshotMode() {
-        String value = config.getString(MySqlConnectorConfig.SNAPSHOT_MODE);
-        return SnapshotMode.parse(value, MySqlConnectorConfig.SNAPSHOT_MODE.defaultValueAsString());
-    }
-
-    public void start() {
-        connectionContext.start();
-        // Start the MySQL database history, which simply starts up resources but does not recover the history to a specific point
-        dbSchema().start();
-    }
-
-    public void shutdown() {
-        try {
-            // Flush and stop the database history ...
-            LOGGER.debug("Stopping database history");
-            dbSchema.shutdown();
-        }
-        catch (Throwable e) {
-            LOGGER.error("Unexpected error shutting down the database history", e);
-        }
-        finally {
-            connectionContext.shutdown();
-        }
-    }
-
-    /**
-     * Run the supplied function in the temporary connector MDC context, and when complete always return the MDC context to its
-     * state before this method was called.
-     *
-     * @param contextName the name of the context; may not be null
-     * @param operation the function to run in the new MDC context; may not be null
-     * @throws IllegalArgumentException if any of the parameters are null
-     */
-    public void temporaryLoggingContext(String contextName, Runnable operation) {
-        LoggingContext.temporarilyForConnector("MySQL", connectorConfig.getLogicalName(), contextName, operation);
-    }
-
-    /**
-     * Apply the include/exclude GTID source filters to the current {@link #source() GTID set} and merge them onto the
-     * currently available GTID set from a MySQL server.
-     *
-     * The merging behavior of this method might seem a bit strange at first. It's required in order for Debezium to consume a
-     * MySQL binlog that has multi-source replication enabled, if a failover has to occur. In such a case, the server that
-     * Debezium is failed over to might have a different set of sources, but still include the sources required for Debezium
-     * to continue to function. MySQL does not allow downstream replicas to connect if the GTID set does not contain GTIDs for
-     * all channels that the server is replicating from, even if the server does have the data needed by the client. To get
-     * around this, we can have Debezium merge its GTID set with whatever is on the server, so that MySQL will allow it to
-     * connect. See <a href="https://issues.jboss.org/browse/DBZ-143">DBZ-143</a> for details.
-     *
-     * This method does not mutate any state in the context.
-     *
-     * @param availableServerGtidSet the GTID set currently available in the MySQL server
-     * @param purgedServerGtid the GTID set already purged by the MySQL server
-     * @return A GTID set meant for consuming from a MySQL binlog; may return null if the SourceInfo has no GTIDs and therefore
-     *         none were filtered
-     */
-    public GtidSet filterGtidSet(GtidSet availableServerGtidSet, GtidSet purgedServerGtid) {
-        String gtidStr = source.gtidSet();
-        if (gtidStr == null) {
-            return null;
-        }
-        LOGGER.info("Attempting to generate a filtered GTID set");
-        LOGGER.info("GTID set from previous recorded offset: {}", gtidStr);
-        GtidSet filteredGtidSet = new GtidSet(gtidStr);
-        Predicate<String> gtidSourceFilter = gtidSourceFilter();
-        if (gtidSourceFilter != null) {
-            filteredGtidSet = filteredGtidSet.retainAll(gtidSourceFilter);
-            LOGGER.info("GTID set after applying GTID source includes/excludes to previous recorded offset: {}", filteredGtidSet);
-        }
-        LOGGER.info("GTID set available on server: {}", availableServerGtidSet);
-
-        GtidSet mergedGtidSet;
-
-        if (connectorConfig.gtidNewChannelPosition() == GtidNewChannelPosition.EARLIEST) {
-            final GtidSet knownGtidSet = filteredGtidSet;
-            LOGGER.info("Using first available positions for new GTID channels");
-            final GtidSet relevantAvailableServerGtidSet = (gtidSourceFilter != null) ? availableServerGtidSet.retainAll(gtidSourceFilter) : availableServerGtidSet;
-            LOGGER.info("Relevant GTID set available on server: {}", relevantAvailableServerGtidSet);
-
-            mergedGtidSet = relevantAvailableServerGtidSet
-                    .retainAll(uuid -> knownGtidSet.forServerWithId(uuid) != null)
-                    .with(purgedServerGtid)
-                    .with(filteredGtidSet);
-        }
-        else {
-            mergedGtidSet = availableServerGtidSet.with(filteredGtidSet);
-        }
-
-        LOGGER.info("Final merged GTID set to use when connecting to MySQL: {}", mergedGtidSet);
-        return mergedGtidSet;
-    }
-
-    /**
-     * Get the predicate function that will return {@code true} if a DDL has to be skipped over and left out of the schema history
-     * or {@code false} when it should be processed.
-     *
-     * @return the DDL predicate function; never null
-     */
-    public Predicate<String> ddlFilter() {
-        return ddlFilter;
-    }
-
-    public boolean isTableIdCaseInsensitive() {
-        return tableIdCaseInsensitive;
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTopicSelector.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlTopicSelector.java
@@ -26,8 +26,14 @@ public class MySqlTopicSelector {
      *            {@code delimiter}
      * @return the topic selector; never null
      */
-    static TopicSelector<TableId> defaultSelector(String prefix, String heartbeatPrefix) {
+    @Deprecated
+    public static TopicSelector<TableId> defaultSelector(String prefix, String heartbeatPrefix) {
         return TopicSelector.defaultSelector(prefix, heartbeatPrefix, ".",
                 (t, pref, delimiter) -> String.join(delimiter, pref, t.catalog(), t.table()));
+    }
+
+    public static TopicSelector<TableId> defaultSelector(MySqlConnectorConfig connectorConfig) {
+        return TopicSelector.defaultSelector(connectorConfig,
+                (tableId, prefix, delimiter) -> String.join(delimiter, prefix, tableId.catalog(), tableId.table()));
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlValueConverters.java
@@ -103,7 +103,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
      * @param temporal the temporal instance to adjust; may not be null
      * @return the possibly adjusted temporal instance; never null
      */
-    protected static Temporal adjustTemporal(Temporal temporal) {
+    public static Temporal adjustTemporal(Temporal temporal) {
         if (temporal.isSupported(ChronoField.YEAR)) {
             int year = temporal.get(ChronoField.YEAR);
             if (0 <= year && year <= 69) {
@@ -132,9 +132,7 @@ public class MySqlValueConverters extends JdbcValueConverters {
      */
     public MySqlValueConverters(DecimalMode decimalMode, TemporalPrecisionMode temporalPrecisionMode, BigIntUnsignedMode bigIntUnsignedMode,
                                 BinaryHandlingMode binaryMode) {
-        this(decimalMode, temporalPrecisionMode, bigIntUnsignedMode, binaryMode, x -> x, (message, exception) -> {
-            throw new DebeziumException(message, exception);
-        });
+        this(decimalMode, temporalPrecisionMode, bigIntUnsignedMode, binaryMode, x -> x, MySqlValueConverters::defaultParsingErrorHandler);
     }
 
     /**
@@ -860,5 +858,9 @@ public class MySqlValueConverters extends JdbcValueConverters {
             return true;
         }
         return false;
+    }
+
+    public static void defaultParsingErrorHandler(String message, Exception exception) {
+        throw new DebeziumException(message, exception);
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RecordMakers.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RecordMakers.java
@@ -41,7 +41,7 @@ import io.debezium.util.SchemaNameAdjuster;
 public class RecordMakers {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final MySqlSchema schema;
+    private final MySqlDatabaseSchema schema;
     private final SourceInfo source;
     private final TopicSelector<TableId> topicSelector;
     private final boolean emitTombstoneOnDelete;
@@ -67,7 +67,7 @@ public class RecordMakers {
      *                      from the base offset.
      * @see MySqlConnectorTask#getRestartOffset(Map)
      */
-    public RecordMakers(MySqlSchema schema, SourceInfo source, TopicSelector<TableId> topicSelector,
+    public RecordMakers(MySqlDatabaseSchema schema, SourceInfo source, TopicSelector<TableId> topicSelector,
                         boolean emitTombstoneOnDelete, Map<String, ?> restartOffset) {
         this.schema = schema;
         this.source = source;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RowDeserializers.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/RowDeserializers.java
@@ -45,7 +45,7 @@ import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
  *
  * @author Randall Hauch
  */
-class RowDeserializers {
+public class RowDeserializers {
 
     /**
      * A specialization of {@link DeleteRowsEventDataDeserializer} that converts MySQL {@code DATE}, {@code TIME},

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/AbstractReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/AbstractReader.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import java.sql.SQLException;
 import java.time.Duration;
@@ -23,6 +23,7 @@ import com.github.shyiko.mysql.binlog.network.ServerException;
 
 import io.debezium.config.ConfigurationDefaults;
 import io.debezium.connector.base.ChangeEventQueueMetrics;
+import io.debezium.connector.mysql.HaltingPredicate;
 import io.debezium.time.Temporals;
 import io.debezium.util.Clock;
 import io.debezium.util.Metronome;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/BinlogReader.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import static io.debezium.util.Strings.isNullOrEmpty;
 
@@ -69,8 +69,16 @@ import com.github.shyiko.mysql.binlog.network.SSLSocketFactory;
 
 import io.debezium.config.CommonConnectorConfig.EventProcessingFailureHandlingMode;
 import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.EventDataDeserializationExceptionData;
+import io.debezium.connector.mysql.GtidSet;
+import io.debezium.connector.mysql.HaltingPredicate;
+import io.debezium.connector.mysql.MySqlConnector;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
-import io.debezium.connector.mysql.RecordMakers.RecordsForTable;
+import io.debezium.connector.mysql.RowDeserializers;
+import io.debezium.connector.mysql.SourceInfo;
+import io.debezium.connector.mysql.StopEventDataDeserializer;
+import io.debezium.connector.mysql.legacy.RecordMakers.RecordsForTable;
 import io.debezium.data.Envelope.Operation;
 import io.debezium.function.BlockingConsumer;
 import io.debezium.heartbeat.Heartbeat;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/BinlogReaderMetrics.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/BinlogReaderMetrics.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -20,7 +20,7 @@ import io.debezium.util.Collect;
 /**
  * @author Randall Hauch
  */
-class BinlogReaderMetrics extends PipelineMetrics implements BinlogReaderMetricsMXBean {
+public class BinlogReaderMetrics extends PipelineMetrics implements BinlogReaderMetricsMXBean {
 
     private final BinaryLogClient client;
     private final BinaryLogClientStatistics stats;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/BinlogReaderMetricsMXBean.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/BinlogReaderMetricsMXBean.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import io.debezium.pipeline.metrics.StreamingChangeEventSourceMetricsMXBean;
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/BlockingReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/BlockingReader.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/ChainedReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/ChainedReader.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/EventBuffer.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/EventBuffer.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.legacy;
+
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.EventType;
+import com.github.shyiko.mysql.binlog.event.QueryEventData;
+
+import io.debezium.connector.mysql.legacy.BinlogReader.BinlogPosition;
+
+/**
+ * This class represents a look-ahead buffer that allows Debezium to accumulate binlog events and decide
+ * if the last event in transaction is either {@code ROLLBACK} or {@code COMMIT}. The incoming events are either
+ * supposed to be in transaction or out-of-transaction. When out-of-transaction they are sent directly into
+ * the destination handler. When in transaction the event goes through the buffering.
+ * <p>
+ * The reason for the buffering is that the binlog contains rolled back transactions in some cases. E.g. that's
+ * the case when a temporary table is dropped (see DBZ-390). For rolled back transactions we may not propagate
+ * any of the contained events, hence the buffering is applied.
+ * <p>
+ * The transaction start is identified by a {@code BEGIN} event. Transaction is ended either by {@code COMMIT}
+ * event or by {@code XID} an event.
+ * <p>
+ * If there are more events that can fit to the buffer then:
+ * <ul>
+ *     <li>Binlog position is recorded for the first event not fitting into the buffer</li>
+ *     <li>Binlog position is recorded for the commit event</li>
+ *     <li>Buffer content is sent to the final handler</li>
+ *     <li>Binlog position is rewound and all events between the above recorded positions are sent to the final handler</li>
+ * </ul>
+ *
+ * @author Jiri Pechanec
+ *
+ */
+class EventBuffer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventBuffer.class);
+
+    private final int capacity;
+    private final Queue<Event> buffer;
+    private final BinlogReader reader;
+    private boolean txStarted = false;
+
+    /**
+     * Contains the position of the first event that has not fit into the buffer.
+     */
+    private BinlogPosition largeTxNotBufferedPosition;
+
+    /**
+     * Contains the position of the last event belonging to the transaction that has not fit into
+     * the buffer.
+     */
+    private BinlogPosition forwardTillPosition;
+
+    public EventBuffer(int capacity, BinlogReader reader) {
+        this.capacity = capacity;
+        this.buffer = new ArrayBlockingQueue<>(capacity);
+        this.reader = reader;
+    }
+
+    /**
+     * An entry point to the buffer that should be used by BinlogReader to push events.
+     * @param event to be stored in the buffer
+     */
+    public void add(Event event) {
+        if (event == null) {
+            return;
+        }
+
+        // we're reprocessing events of the current TX between the position where the
+        // buffer was full and the end of the TX; in this case there's nothing to do
+        // besides directly emitting the events
+        if (isReplayingEventsBeyondBufferCapacity()) {
+            reader.handleEvent(event);
+            return;
+        }
+
+        if (event.getHeader().getEventType() == EventType.QUERY) {
+            QueryEventData command = reader.unwrapData(event);
+            LOGGER.debug("Received query command: {}", event);
+            String sql = command.getSql().trim();
+            if (sql.equalsIgnoreCase("BEGIN")) {
+                beginTransaction(event);
+            }
+            else if (sql.equalsIgnoreCase("COMMIT")) {
+                completeTransaction(true, event);
+            }
+            else if (sql.equalsIgnoreCase("ROLLBACK")) {
+                rollbackTransaction();
+            }
+            else {
+                consumeEvent(event);
+            }
+        }
+        else if (event.getHeader().getEventType() == EventType.XID) {
+            completeTransaction(true, event);
+        }
+        else {
+            consumeEvent(event);
+        }
+    }
+
+    /**
+     * Whether we are replaying TX events from binlog that have not fit into the buffer before
+     */
+    private boolean isReplayingEventsBeyondBufferCapacity() {
+        if (forwardTillPosition != null) {
+            if (forwardTillPosition.equals(reader.getCurrentBinlogPosition())) {
+                forwardTillPosition = null;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Adds an event to the buffer if there is a space available. Records binlog position for the first
+     * event that does not fit for later replay.
+     *
+     * @param event
+     */
+    private void addToBuffer(Event event) {
+        if (isInBufferFullMode()) {
+            return;
+        }
+        if (buffer.size() == capacity) {
+            switchToBufferFullMode();
+        }
+        else {
+            buffer.add(event);
+        }
+    }
+
+    private void switchToBufferFullMode() {
+        largeTxNotBufferedPosition = reader.getCurrentBinlogPosition();
+        LOGGER.info("Buffer full, will need to re-read part of the transaction from binlog from {}", largeTxNotBufferedPosition);
+        reader.getMetrics().onLargeTransaction();
+        // Position for TABLE_MAP is not stored by com.github.shyiko.mysql.binlog.BinaryLogClient.updateClientBinlogFilenameAndPosition(Event)
+        if (buffer.peek().getHeader().getEventType() == EventType.TABLE_MAP) {
+            buffer.remove();
+        }
+    }
+
+    private boolean isInBufferFullMode() {
+        return largeTxNotBufferedPosition != null;
+    }
+
+    private void consumeEvent(Event event) {
+        if (txStarted) {
+            addToBuffer(event);
+        }
+        else {
+            reader.handleEvent(event);
+        }
+    }
+
+    private void beginTransaction(Event event) {
+        if (txStarted) {
+            LOGGER.warn("New transaction started but the previous was not completed, processing the buffer");
+            completeTransaction(false, null);
+        }
+        else {
+            txStarted = true;
+        }
+        addToBuffer(event);
+    }
+
+    /**
+     * Sends all events from the buffer int a final handler. For large transactions it executes rewind
+     * of binlog reader back to the first event that was not stored in the buffer.
+     *
+     * @param wellFormed
+     * @param event
+     */
+    private void completeTransaction(boolean wellFormed, Event event) {
+        LOGGER.debug("Committing transaction");
+        if (event != null) {
+            addToBuffer(event);
+        }
+        if (!txStarted) {
+            LOGGER.warn("Commit requested but TX was not started before");
+            wellFormed = false;
+        }
+        LOGGER.debug("Executing events from buffer");
+        for (Event e : buffer) {
+            reader.handleEvent(e);
+        }
+        LOGGER.debug("Executing events from binlog that have not fit into buffer");
+        if (isInBufferFullMode()) {
+            forwardTillPosition = reader.getCurrentBinlogPosition();
+            reader.rewindBinaryLogClient(largeTxNotBufferedPosition);
+        }
+        reader.getMetrics().onCommittedTransaction();
+        if (!wellFormed) {
+            reader.getMetrics().onNotWellFormedTransaction();
+        }
+        clear();
+    }
+
+    private void rollbackTransaction() {
+        LOGGER.debug("Rolling back transaction");
+        boolean wellFormed = true;
+        if (!txStarted) {
+            LOGGER.warn("Rollback requested but TX was not started before");
+            wellFormed = false;
+        }
+        reader.getMetrics().onRolledBackTransaction();
+        if (!wellFormed) {
+            reader.getMetrics().onNotWellFormedTransaction();
+        }
+        clear();
+    }
+
+    /**
+     * Cleans-up the buffer after the transaction is either thrown away or streamed into a Kafka topic
+     */
+    private void clear() {
+        buffer.clear();
+        largeTxNotBufferedPosition = null;
+        txStarted = false;
+    }
+
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/Filters.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/Filters.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import java.util.Map;
 import java.util.Set;
@@ -11,6 +11,8 @@ import java.util.function.Predicate;
 
 import io.debezium.annotation.Immutable;
 import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.SourceInfo;
 import io.debezium.relational.Selectors;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables.ColumnNameFilter;
@@ -40,7 +42,7 @@ public class Filters {
             "mysql.rds_replication_status",
             "mysql.rds_sysinfo");
 
-    protected static boolean isBuiltInDatabase(String databaseName) {
+    public static boolean isBuiltInDatabase(String databaseName) {
         if (databaseName == null) {
             return false;
         }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/MySqlConnectorTask.java
@@ -1,0 +1,657 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.legacy;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.annotation.NotThreadSafe;
+import io.debezium.config.Configuration;
+import io.debezium.config.Field;
+import io.debezium.connector.common.BaseSourceTask;
+import io.debezium.connector.mysql.GtidSet;
+import io.debezium.connector.mysql.Module;
+import io.debezium.connector.mysql.MySqlConnector;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
+import io.debezium.connector.mysql.RecordMakers;
+import io.debezium.connector.mysql.SourceInfo;
+import io.debezium.pipeline.ChangeEventSourceCoordinator;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.Collect;
+import io.debezium.util.LoggingContext;
+import io.debezium.util.LoggingContext.PreviousContext;
+
+/**
+ * A Kafka Connect source task reads the MySQL binary log and generate the corresponding data change events.
+ *
+ * @see MySqlConnector
+ * @author Randall Hauch
+ */
+@NotThreadSafe
+public final class MySqlConnectorTask extends BaseSourceTask {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private volatile MySqlTaskContext taskContext;
+    private volatile MySqlJdbcContext connectionContext;
+    private volatile ChainedReader readers;
+
+    /**
+     * Create an instance of the log reader that uses Kafka to store database schema history and the
+     * {@link TopicSelector#defaultSelector(String) default topic selector} of "{@code <serverName>.<databaseName>.<tableName>}"
+     * for
+     * data and "{@code <serverName>}" for metadata.
+     */
+    public MySqlConnectorTask() {
+    }
+
+    @Override
+    public String version() {
+        return Module.version();
+    }
+
+    @Override
+    public ChangeEventSourceCoordinator start(Configuration config) {
+        final String serverName = config.getString(MySqlConnectorConfig.SERVER_NAME);
+        PreviousContext prevLoggingContext = LoggingContext.forConnector(Module.contextName(), serverName, "task");
+
+        try {
+            // Get the offsets for our partition ...
+            boolean startWithSnapshot = false;
+            boolean snapshotEventsAsInserts = config.getBoolean(MySqlConnectorConfig.SNAPSHOT_EVENTS_AS_INSERTS);
+            Map<String, String> partition = Collect.hashMapOf(SourceInfo.SERVER_PARTITION_KEY, serverName);
+            Map<String, ?> offsets = getRestartOffset(context.offsetStorageReader().offset(partition));
+            final SourceInfo source;
+            if (offsets != null) {
+                Filters filters = SourceInfo.offsetsHaveFilterInfo(offsets) ? getOldFilters(offsets, config) : getAllFilters(config);
+                this.taskContext = createAndStartTaskContext(config, filters);
+                this.connectionContext = taskContext.getConnectionContext();
+                source = taskContext.source();
+                // Set the position in our source info ...
+                source.setOffset(offsets);
+                logger.info("Found existing offset: {}", offsets);
+
+                // First check if db history is available
+                if (!taskContext.historyExists()) {
+                    if (taskContext.isSchemaOnlyRecoverySnapshot()) {
+                        startWithSnapshot = true;
+
+                        // But check to see if the server still has those binlog coordinates ...
+                        if (!isBinlogAvailable()) {
+                            String msg = "The connector is trying to read binlog starting at " + source + ", but this is no longer "
+                                    + "available on the server. Reconfigure the connector to use a snapshot when needed.";
+                            throw new ConnectException(msg);
+                        }
+                        logger.info("The db-history topic is missing but we are in {} snapshot mode. " +
+                                "Attempting to snapshot the current schema and then begin reading the binlog from the last recorded offset.",
+                                SnapshotMode.SCHEMA_ONLY_RECOVERY);
+                    }
+                    else {
+                        String msg = "The db history topic is missing. You may attempt to recover it by reconfiguring the connector to "
+                                + SnapshotMode.SCHEMA_ONLY_RECOVERY;
+                        throw new ConnectException(msg);
+                    }
+                    taskContext.initializeHistoryStorage();
+                }
+                else {
+
+                    // Before anything else, recover the database history to the specified binlog coordinates ...
+                    taskContext.loadHistory(source);
+
+                    if (source.isSnapshotInEffect()) {
+                        // The last offset was an incomplete snapshot that we cannot recover from...
+                        if (taskContext.isSnapshotNeverAllowed()) {
+                            // No snapshots are allowed
+                            String msg = "The connector previously stopped while taking a snapshot, but now the connector is configured "
+                                    + "to never allow snapshots. Reconfigure the connector to use snapshots initially or when needed.";
+                            throw new ConnectException(msg);
+                        }
+                        // Otherwise, restart a new snapshot ...
+                        startWithSnapshot = true;
+                        logger.info("Prior execution was an incomplete snapshot, so starting new snapshot");
+                    }
+                    else {
+                        // No snapshot was in effect, so we should just start reading from the binlog ...
+                        startWithSnapshot = false;
+
+                        // But check to see if the server still has those binlog coordinates ...
+                        if (!isBinlogAvailable()) {
+                            if (!taskContext.isSnapshotAllowedWhenNeeded()) {
+                                String msg = "The connector is trying to read binlog starting at " + source + ", but this is no longer "
+                                        + "available on the server. Reconfigure the connector to use a snapshot when needed.";
+                                throw new ConnectException(msg);
+                            }
+                            startWithSnapshot = true;
+                        }
+                    }
+                }
+
+            }
+            else {
+                // We have no recorded offsets ...
+                this.taskContext = createAndStartTaskContext(config, getAllFilters(config));
+                taskContext.initializeHistoryStorage();
+                this.connectionContext = taskContext.getConnectionContext();
+                source = taskContext.source();
+
+                if (taskContext.isSnapshotNeverAllowed()) {
+                    // We're not allowed to take a snapshot, so instead we have to assume that the binlog contains the
+                    // full history of the database.
+                    logger.info("Found no existing offset and snapshots disallowed, so starting at beginning of binlog");
+                    source.setBinlogStartPoint("", 0L); // start from the beginning of the binlog
+                    taskContext.initializeHistory();
+
+                    // Look to see what the first available binlog file is called, and whether it looks like binlog files have
+                    // been purged. If so, then output a warning ...
+                    String earliestBinlogFilename = earliestBinlogFilename();
+                    if (earliestBinlogFilename == null) {
+                        logger.warn("No binlog appears to be available. Ensure that the MySQL row-level binlog is enabled.");
+                    }
+                    else if (!earliestBinlogFilename.endsWith("00001")) {
+                        logger.warn("It is possible the server has purged some binlogs. If this is the case, then using snapshot mode may be required.");
+                    }
+                }
+                else {
+                    // We are allowed to use snapshots, and that is the best way to start ...
+                    startWithSnapshot = true;
+                    // The snapshot will determine if GTIDs are set
+                    logger.info("Found no existing offset, so preparing to perform a snapshot");
+                    // The snapshot will also initialize history ...
+                }
+            }
+
+            if (!startWithSnapshot && source.gtidSet() == null && connectionContext.isGtidModeEnabled()) {
+                // The snapshot will properly determine the GTID set, but we're not starting with a snapshot and GTIDs were not
+                // previously used but the MySQL server has them enabled ...
+                source.setCompletedGtidSet("");
+            }
+
+            // Check whether the row-level binlog is enabled ...
+            final boolean binlogFormatRow = isBinlogFormatRow();
+            final boolean binlogRowImageFull = isBinlogRowImageFull();
+            final boolean rowBinlogEnabled = binlogFormatRow && binlogRowImageFull;
+
+            ChainedReader.Builder chainedReaderBuilder = new ChainedReader.Builder();
+
+            // Set up the readers, with a callback to `completeReaders` so that we know when it is finished ...
+            if (startWithSnapshot) {
+                // We're supposed to start with a snapshot, so set that up ...
+                SnapshotReader snapshotReader = new SnapshotReader("snapshot", taskContext);
+                if (snapshotEventsAsInserts) {
+                    snapshotReader.generateInsertEvents();
+                }
+
+                if (!taskContext.getConnectorConfig().getSnapshotDelay().isZero()) {
+                    // Adding a timed blocking reader to delay the snapshot, can help to avoid initial rebalancing interruptions
+                    chainedReaderBuilder.addReader(new TimedBlockingReader("timed-blocker", taskContext.getConnectorConfig().getSnapshotDelay()));
+                }
+                chainedReaderBuilder.addReader(snapshotReader);
+
+                if (taskContext.isInitialSnapshotOnly()) {
+                    logger.warn("This connector will only perform a snapshot, and will stop after that completes.");
+                    chainedReaderBuilder.addReader(new BlockingReader("blocker",
+                            "Connector has completed all of its work but will continue in the running state. It can be shut down at any time."));
+                    chainedReaderBuilder
+                            .completionMessage("Connector configured to only perform snapshot, and snapshot completed successfully. Connector will terminate.");
+                }
+                else {
+                    if (!rowBinlogEnabled) {
+                        if (!binlogFormatRow) {
+                            throw new ConnectException("The MySQL server is not configured to use a ROW binlog_format, which is "
+                                    + "required for this connector to work properly. Change the MySQL configuration to use a "
+                                    + "binlog_format=ROW and restart the connector.");
+                        }
+                        else {
+                            throw new ConnectException("The MySQL server is not configured to use a FULL binlog_row_image, which is "
+                                    + "required for this connector to work properly. Change the MySQL configuration to use a "
+                                    + "binlog_row_image=FULL and restart the connector.");
+                        }
+                    }
+                    BinlogReader binlogReader = new BinlogReader("binlog", taskContext, null);
+                    chainedReaderBuilder.addReader(binlogReader);
+                }
+            }
+            else {
+                source.maybeSetFilterDataFromConfig(config);
+                if (!rowBinlogEnabled) {
+                    throw new ConnectException(
+                            "The MySQL server does not appear to be using a full row-level binlog, which is required for this connector to work properly. Enable this mode and restart the connector.");
+                }
+
+                // if there are new tables
+                if (newTablesInConfig()) {
+                    // and we are configured to run a parallel snapshot
+                    if (taskContext.getConnectorConfig().getSnapshotNewTables() == MySqlConnectorConfig.SnapshotNewTables.PARALLEL) {
+                        ServerIdGenerator serverIdGenerator = new ServerIdGenerator(config.getLong(MySqlConnectorConfig.SERVER_ID),
+                                config.getLong(MySqlConnectorConfig.SERVER_ID_OFFSET));
+                        ParallelSnapshotReader parallelSnapshotReader = new ParallelSnapshotReader(config,
+                                taskContext,
+                                getNewFilters(offsets, config),
+                                serverIdGenerator);
+
+                        MySqlTaskContext unifiedTaskContext = createAndStartTaskContext(config, getAllFilters(config));
+                        // we aren't completing a snapshot, but we need to make sure the "snapshot" flag is false for this new context.
+                        unifiedTaskContext.source().completeSnapshot();
+                        BinlogReader unifiedBinlogReader = new BinlogReader("binlog",
+                                unifiedTaskContext,
+                                null,
+                                serverIdGenerator.getConfiguredServerId());
+                        ReconcilingBinlogReader reconcilingBinlogReader = parallelSnapshotReader.createReconcilingBinlogReader(unifiedBinlogReader);
+
+                        chainedReaderBuilder.addReader(parallelSnapshotReader);
+                        chainedReaderBuilder.addReader(reconcilingBinlogReader);
+                        chainedReaderBuilder.addReader(unifiedBinlogReader);
+
+                        unifiedBinlogReader.uponCompletion(unifiedTaskContext::shutdown);
+                    }
+                }
+                else {
+                    // We're going to start by reading the binlog ...
+                    BinlogReader binlogReader = new BinlogReader("binlog", taskContext, null);
+                    chainedReaderBuilder.addReader(binlogReader);
+                }
+
+            }
+
+            readers = chainedReaderBuilder.build();
+            readers.uponCompletion(this::completeReaders);
+
+            // And finally initialize and start the chain of readers ...
+            this.readers.initialize();
+            this.readers.start();
+        }
+        catch (Throwable e) {
+            // If we don't complete startup, then Kafka Connect will not attempt to stop the connector. So if we
+            // run into a problem, we have to stop ourselves ...
+            try {
+                stop();
+            }
+            catch (Throwable s) {
+                // Log, but don't propagate ...
+                logger.error("Failed to start the connector (see other exception), but got this error while cleaning up", s);
+            }
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+                throw new ConnectException("Interrupted while starting the connector", e);
+            }
+            if (e instanceof ConnectException) {
+                throw (ConnectException) e;
+            }
+            throw new ConnectException(e);
+        }
+        finally {
+            prevLoggingContext.restore();
+        }
+
+        return null;
+    }
+
+    public class ServerIdGenerator {
+
+        private final long configuredServerId;
+        private final long offset;
+        private int counter;
+
+        private ServerIdGenerator(long configuredServerId, long configuredOffset) {
+            this.configuredServerId = configuredServerId;
+            this.offset = configuredOffset;
+            this.counter = 0;
+        }
+
+        public long getNextServerId() {
+            counter++;
+            return configuredServerId + (counter * offset);
+        }
+
+        public long getConfiguredServerId() {
+            return configuredServerId;
+        }
+    }
+
+    /**
+     * Get the offset to restart the connector from. Normally, this is just the stored offset.
+     *
+     * However, if we were doing a parallel load with new tables, it's possible that the last
+     * committed offset is from reading the new tables, which could be beyond where we want to
+     * restart from (and restarting there could cause skipped events). To fix this, the new
+     * tables binlog reader records extra information in its offset to tell the connector where
+     * to restart from. If this extra information is present in the stored offset, that is the
+     * offset that is returned.
+     * @param storedOffset the stored offset.
+     * @return the offset to restart from.
+     * @see RecordMakers#RecordMakers(MySqlSchema, SourceInfo, TopicSelector, boolean, Map)
+     */
+    private Map<String, ?> getRestartOffset(Map<String, ?> storedOffset) {
+        Map<String, Object> restartOffset = new HashMap<>();
+        if (storedOffset != null) {
+            for (Entry<String, ?> entry : storedOffset.entrySet()) {
+                if (entry.getKey().startsWith(SourceInfo.RESTART_PREFIX)) {
+                    String newKey = entry.getKey().substring(SourceInfo.RESTART_PREFIX.length());
+                    restartOffset.put(newKey, entry.getValue());
+                }
+            }
+        }
+        return restartOffset.isEmpty() ? storedOffset : restartOffset;
+    }
+
+    private static MySqlTaskContext createAndStartTaskContext(Configuration config,
+                                                              Filters filters) {
+        MySqlTaskContext taskContext = new MySqlTaskContext(config, filters);
+        taskContext.start();
+        return taskContext;
+    }
+
+    /**
+     * @return true if new tables appear to have been added to the config, and false otherwise.
+     */
+    private boolean newTablesInConfig() {
+        final String elementSep = "/s*,/s*";
+
+        // take in two stringified lists, and return true if the first list contains elements that are not in the second list
+        BiFunction<String, String, Boolean> hasExclusiveElements = (String a, String b) -> {
+            if (a == null || a.isEmpty()) {
+                return false;
+            }
+            else if (b == null || b.isEmpty()) {
+                return true;
+            }
+            Set<String> bSet = Stream.of(b.split(elementSep)).collect(Collectors.toSet());
+            return !Stream.of(a.split(elementSep)).filter((x) -> !bSet.contains(x)).collect(Collectors.toSet()).isEmpty();
+        };
+
+        final SourceInfo sourceInfo = taskContext.source();
+        final Configuration config = taskContext.config();
+        if (!sourceInfo.hasFilterInfo()) {
+            // if there was previously no filter info, then we either can't evaluate if there are new tables,
+            // or there aren't any new tables because we previously used no filter.
+            return false;
+        }
+        // otherwise, we have filter info
+        // if either include lists has been added to, then we may have new tables
+
+        if (hasExclusiveElements.apply(
+                config.getFallbackStringProperty(MySqlConnectorConfig.DATABASE_INCLUDE_LIST, MySqlConnectorConfig.DATABASE_WHITELIST),
+                sourceInfo.getDatabaseIncludeList())) {
+            return true;
+        }
+        if (hasExclusiveElements.apply(
+                config.getFallbackStringProperty(MySqlConnectorConfig.TABLE_INCLUDE_LIST, MySqlConnectorConfig.TABLE_WHITELIST),
+                sourceInfo.getTableIncludeList())) {
+            return true;
+        }
+        // if either blacklist has been removed from, then we may have new tables
+        if (hasExclusiveElements.apply(sourceInfo.getDatabaseExcludeList(),
+                config.getFallbackStringProperty(MySqlConnectorConfig.DATABASE_EXCLUDE_LIST, MySqlConnectorConfig.DATABASE_BLACKLIST))) {
+            return true;
+        }
+        if (hasExclusiveElements.apply(sourceInfo.getTableExcludeList(),
+                config.getFallbackStringProperty(MySqlConnectorConfig.TABLE_EXCLUDE_LIST, MySqlConnectorConfig.TABLE_BLACKLIST))) {
+            return true;
+        }
+        // otherwise, false.
+        return false;
+    }
+
+    /**
+     * Get the filters representing the tables that have been newly added to the config, but
+     * not those that previously existed in the config.
+     * @return {@link Filters}
+     */
+    private static Filters getNewFilters(Map<String, ?> offsets, Configuration config) {
+        Filters oldFilters = getOldFilters(offsets, config);
+        return new Filters.Builder(config).excludeAllTables(oldFilters).build();
+    }
+
+    /**
+     * Get the filters representing those tables that previously existed in the config, but
+     * not those newly added to the config.
+     * @return {@link Filters}
+     */
+    private static Filters getOldFilters(Map<String, ?> offsets, Configuration config) {
+        return new Filters.Builder(config).setFiltersFromOffsets(offsets).build();
+    }
+
+    /**
+     * Get the filters representing all tables represented by the config.
+     * @return {@link Filters}
+     */
+    private static Filters getAllFilters(Configuration config) {
+        return new Filters.Builder(config).build();
+    }
+
+    @Override
+    public List<SourceRecord> doPoll() throws InterruptedException {
+        Reader currentReader = readers;
+        if (currentReader == null) {
+            return null;
+        }
+        PreviousContext prevLoggingContext = this.taskContext.configureLoggingContext("task");
+        try {
+            logger.trace("Polling for events");
+            return currentReader.poll();
+        }
+        finally {
+            prevLoggingContext.restore();
+        }
+    }
+
+    @Override
+    protected void doStop() {
+        if (context != null) {
+            PreviousContext prevLoggingContext = null;
+            if (this.taskContext != null) {
+                prevLoggingContext = this.taskContext.configureLoggingContext("task");
+            }
+            try {
+                logger.info("Stopping MySQL connector task");
+
+                if (readers != null) {
+                    readers.stop();
+                    readers.destroy();
+                }
+            }
+            finally {
+                if (prevLoggingContext != null) {
+                    prevLoggingContext.restore();
+                }
+            }
+        }
+    }
+
+    @Override
+    protected Iterable<Field> getAllConfigurationFields() {
+        return MySqlConnectorConfig.ALL_FIELDS;
+    }
+
+    /**
+     * When the task is {@link #stop() stopped}, the readers may have additional work to perform before they actually
+     * stop and before all their records have been consumed via the {@link #poll()} method. This method signals that
+     * all of this has completed.
+     */
+    protected void completeReaders() {
+        PreviousContext prevLoggingContext = this.taskContext.configureLoggingContext("task");
+        try {
+            // Flush and stop database history, close all JDBC connections ...
+            if (this.taskContext != null) {
+                taskContext.shutdown();
+            }
+        }
+        catch (Throwable e) {
+            logger.error("Unexpected error shutting down the database history and/or closing JDBC connections", e);
+        }
+        finally {
+            context = null;
+            logger.info("Connector task finished all work and is now shutdown");
+            prevLoggingContext.restore();
+        }
+    }
+
+    /**
+     * Determine whether the binlog position as set on the {@link MySqlTaskContext#source() SourceInfo} is available in the
+     * server.
+     *
+     * @return {@code true} if the server has the binlog coordinates, or {@code false} otherwise
+     */
+    protected boolean isBinlogAvailable() {
+        String gtidStr = taskContext.source().gtidSet();
+        if (gtidStr != null) {
+            if (gtidStr.trim().isEmpty()) {
+                return true; // start at beginning ...
+            }
+            String availableGtidStr = connectionContext.knownGtidSet();
+            if (availableGtidStr == null || availableGtidStr.trim().isEmpty()) {
+                // Last offsets had GTIDs but the server does not use them ...
+                logger.info("Connector used GTIDs previously, but MySQL does not know of any GTIDs or they are not enabled");
+                return false;
+            }
+            // GTIDs are enabled, and we used them previously, but retain only those GTID ranges for the allowed source UUIDs ...
+            GtidSet gtidSet = new GtidSet(gtidStr).retainAll(taskContext.gtidSourceFilter());
+            // Get the GTID set that is available in the server ...
+            GtidSet availableGtidSet = new GtidSet(availableGtidStr);
+            if (gtidSet.isContainedWithin(availableGtidSet)) {
+                logger.info("MySQL current GTID set {} does contain the GTID set required by the connector {}", availableGtidSet, gtidSet);
+                final GtidSet knownServerSet = availableGtidSet.retainAll(taskContext.gtidSourceFilter());
+                final GtidSet gtidSetToReplicate = connectionContext.subtractGtidSet(knownServerSet, gtidSet);
+                final GtidSet purgedGtidSet = connectionContext.purgedGtidSet();
+                final GtidSet nonPurgedGtidSetToReplicate = connectionContext.subtractGtidSet(gtidSetToReplicate, purgedGtidSet);
+                logger.info("GTIDs known by the server but not processed yet {}, for replication are available only {}", gtidSetToReplicate, nonPurgedGtidSetToReplicate);
+                if (!gtidSetToReplicate.equals(nonPurgedGtidSetToReplicate)) {
+                    logger.info("Some of the GTIDs needed to replicate have been already purged");
+                    return false;
+                }
+                return true;
+            }
+            logger.info("Connector last known GTIDs are {}, but MySQL has {}", gtidSet, availableGtidSet);
+            return false;
+        }
+
+        String binlogFilename = taskContext.source().binlogFilename();
+        if (binlogFilename == null) {
+            return true; // start at current position
+        }
+        if (binlogFilename.equals("")) {
+            return true; // start at beginning
+        }
+
+        // Accumulate the available binlog filenames ...
+        List<String> logNames = new ArrayList<>();
+        try {
+            logger.info("Step 0: Get all known binlogs from MySQL");
+            connectionContext.jdbc().query("SHOW BINARY LOGS", rs -> {
+                while (rs.next()) {
+                    logNames.add(rs.getString(1));
+                }
+            });
+        }
+        catch (SQLException e) {
+            throw new ConnectException("Unexpected error while connecting to MySQL and looking for binary logs: ", e);
+        }
+
+        // And compare with the one we're supposed to use ...
+        boolean found = logNames.stream().anyMatch(binlogFilename::equals);
+        if (!found) {
+            if (logger.isInfoEnabled()) {
+                logger.info("Connector requires binlog file '{}', but MySQL only has {}", binlogFilename, String.join(", ", logNames));
+            }
+        }
+        else {
+            logger.info("MySQL has the binlog file '{}' required by the connector", binlogFilename);
+        }
+
+        return found;
+    }
+
+    /**
+     * Determine the earliest binlog filename that is still available in the server.
+     *
+     * @return the name of the earliest binlog filename, or null if there are none.
+     */
+    protected String earliestBinlogFilename() {
+        // Accumulate the available binlog filenames ...
+        List<String> logNames = new ArrayList<>();
+        try {
+            logger.info("Checking all known binlogs from MySQL");
+            connectionContext.jdbc().query("SHOW BINARY LOGS", rs -> {
+                while (rs.next()) {
+                    logNames.add(rs.getString(1));
+                }
+            });
+        }
+        catch (SQLException e) {
+            throw new ConnectException("Unexpected error while connecting to MySQL and looking for binary logs: ", e);
+        }
+
+        if (logNames.isEmpty()) {
+            return null;
+        }
+        return logNames.get(0);
+    }
+
+    /**
+     * Determine whether the MySQL server has the binlog_row_image set to 'FULL'.
+     *
+     * @return {@code true} if the server's {@code binlog_row_image} is set to {@code FULL}, or {@code false} otherwise
+     */
+    protected boolean isBinlogRowImageFull() {
+        AtomicReference<String> rowImage = new AtomicReference<String>("");
+        try {
+            connectionContext.jdbc().query("SHOW GLOBAL VARIABLES LIKE 'binlog_row_image'", rs -> {
+                if (rs.next()) {
+                    rowImage.set(rs.getString(2));
+                }
+                else {
+                    // This setting was introduced in MySQL 5.6+ with default of 'FULL'.
+                    // For older versions, assume 'FULL'.
+                    rowImage.set("FULL");
+                }
+            });
+        }
+        catch (SQLException e) {
+            throw new ConnectException("Unexpected error while connecting to MySQL and looking at BINLOG_ROW_IMAGE mode: ", e);
+        }
+
+        logger.debug("binlog_row_image={}", rowImage.get());
+
+        return "FULL".equalsIgnoreCase(rowImage.get());
+    }
+
+    /**
+     * Determine whether the MySQL server has the row-level binlog enabled.
+     *
+     * @return {@code true} if the server's {@code binlog_format} is set to {@code ROW}, or {@code false} otherwise
+     */
+    protected boolean isBinlogFormatRow() {
+        AtomicReference<String> mode = new AtomicReference<String>("");
+        try {
+            connectionContext.jdbc().query("SHOW GLOBAL VARIABLES LIKE 'binlog_format'", rs -> {
+                if (rs.next()) {
+                    mode.set(rs.getString(2));
+                }
+            });
+        }
+        catch (SQLException e) {
+            throw new ConnectException("Unexpected error while connecting to MySQL and looking at BINLOG_FORMAT mode: ", e);
+        }
+
+        logger.debug("binlog_format={}", mode.get());
+
+        return "ROW".equalsIgnoreCase(mode.get());
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/MySqlJdbcContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/MySqlJdbcContext.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -24,6 +24,8 @@ import io.debezium.config.CommonConnectorConfig.EventProcessingFailureHandlingMo
 import io.debezium.config.Configuration;
 import io.debezium.config.Configuration.Builder;
 import io.debezium.config.Field;
+import io.debezium.connector.mysql.GtidSet;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
@@ -295,7 +297,7 @@ public class MySqlJdbcContext implements AutoCloseable {
         return result.get();
     }
 
-    protected String connectionString() {
+    public String connectionString() {
         return jdbc.connectionString(MYSQL_CONNECTION_URL);
     }
 
@@ -315,7 +317,7 @@ public class MySqlJdbcContext implements AutoCloseable {
      *
      * @return the system variables that are related to server character sets; never null
      */
-    protected Map<String, String> readMySqlSystemVariables() {
+    public Map<String, String> readMySqlSystemVariables() {
         // Read the system variables from the MySQL instance and get the current database name ...
         logger.debug("Reading MySQL system variables");
         return querySystemVariables(SQL_SHOW_SYSTEM_VARIABLES);
@@ -434,7 +436,7 @@ public class MySqlJdbcContext implements AutoCloseable {
      *
      * @return the session variables that are related to sessions ssl version
      */
-    protected String getSessionVariableForSslVersion() {
+    public String getSessionVariableForSslVersion() {
         final String SSL_VERSION = "Ssl_version";
         logger.debug("Reading MySQL Session variable for Ssl Version");
         Map<String, String> sessionVariables = querySystemVariables(SQL_SHOW_SESSION_VARIABLE_SSL_VERSION);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/MySqlSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/MySqlSchema.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import java.util.Collection;
 import java.util.Map;
@@ -19,8 +19,12 @@ import io.debezium.DebeziumException;
 import io.debezium.annotation.NotThreadSafe;
 import io.debezium.config.CommonConnectorConfig.EventProcessingFailureHandlingMode;
 import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnector;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.connector.mysql.MySqlConnectorConfig.BigIntUnsignedHandlingMode;
 import io.debezium.connector.mysql.MySqlSystemVariables.MySqlScope;
+import io.debezium.connector.mysql.MySqlValueConverters;
+import io.debezium.connector.mysql.SourceInfo;
 import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
 import io.debezium.document.Document;
 import io.debezium.jdbc.JdbcValueConverters.BigIntUnsignedMode;
@@ -167,7 +171,7 @@ public class MySqlSchema extends RelationalDatabaseSchema {
                 });
     }
 
-    protected HistoryRecordComparator historyComparator() {
+    public HistoryRecordComparator historyComparator() {
         return this.historyComparator;
     }
 
@@ -289,7 +293,7 @@ public class MySqlSchema extends RelationalDatabaseSchema {
     /**
      * Discard any currently-cached schemas and rebuild them using the filters.
      */
-    protected void refreshSchemas() {
+    public void refreshSchemas() {
         clearSchemas();
         // Create TableSchema instances for any existing table ...
         this.tableIds().forEach(id -> {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/MySqlTaskContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/MySqlTaskContext.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.legacy;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.mysql.GtidSet;
+import io.debezium.connector.mysql.Module;
+import io.debezium.connector.mysql.MySqlConnector;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.MySqlConnectorConfig.GtidNewChannelPosition;
+import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
+import io.debezium.connector.mysql.MySqlSystemVariables;
+import io.debezium.connector.mysql.MySqlTopicSelector;
+import io.debezium.connector.mysql.SourceInfo;
+import io.debezium.function.Predicates;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.DatabaseHistory;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.LoggingContext;
+import io.debezium.util.Strings;
+
+/**
+ * A Kafka Connect source task reads the MySQL binary log and generate the corresponding data change events.
+ *
+ * @see MySqlConnector
+ * @author Randall Hauch
+ */
+public final class MySqlTaskContext extends CdcSourceTaskContext {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MySqlTaskContext.class);
+
+    private final MySqlJdbcContext connectionContext;
+    private final Configuration config;
+    private final MySqlConnectorConfig connectorConfig;
+    private final SourceInfo source;
+    private final MySqlSchema dbSchema;
+    private final TopicSelector<TableId> topicSelector;
+    private final RecordMakers recordProcessor;
+    private final Predicate<String> gtidSourceFilter;
+    private final Predicate<String> ddlFilter;
+
+    /**
+     * Whether table ids are compared ignoring letter casing.
+     */
+    private final boolean tableIdCaseInsensitive;
+
+    public MySqlTaskContext(Configuration config, Filters filters) {
+        this(config, filters, null, null);
+    }
+
+    public MySqlTaskContext(Configuration config, Filters filters, Map<String, ?> restartOffset) {
+        this(config, filters, null, restartOffset);
+    }
+
+    public MySqlTaskContext(Configuration config, Filters filters, Boolean tableIdCaseInsensitive, Map<String, ?> restartOffset) {
+        super(Module.contextName(), config.getString(MySqlConnectorConfig.SERVER_NAME), Collections::emptyList);
+
+        this.config = config;
+        this.connectorConfig = new MySqlConnectorConfig(config);
+        this.connectionContext = new MySqlJdbcContext(connectorConfig);
+
+        // Set up the topic selector ...
+        this.topicSelector = MySqlTopicSelector.defaultSelector(connectorConfig.getLogicalName(), connectorConfig.getHeartbeatTopicsPrefix());
+
+        // Set up the source information ...
+        this.source = new SourceInfo(connectorConfig);
+
+        // Set up the GTID filter ...
+        String gtidSetIncludes = config.getString(MySqlConnectorConfig.GTID_SOURCE_INCLUDES);
+        String gtidSetExcludes = config.getString(MySqlConnectorConfig.GTID_SOURCE_EXCLUDES);
+        this.gtidSourceFilter = gtidSetIncludes != null ? Predicates.includesUuids(gtidSetIncludes)
+                : (gtidSetExcludes != null ? Predicates.excludesUuids(gtidSetExcludes) : null);
+
+        if (tableIdCaseInsensitive == null) {
+            this.tableIdCaseInsensitive = !"0".equals(connectionContext.readMySqlSystemVariables().get(MySqlSystemVariables.LOWER_CASE_TABLE_NAMES));
+        }
+        else {
+            this.tableIdCaseInsensitive = tableIdCaseInsensitive;
+        }
+
+        // Set up the MySQL schema ...
+        this.dbSchema = new MySqlSchema(connectorConfig, this.gtidSourceFilter, this.tableIdCaseInsensitive, topicSelector, filters);
+
+        // Set up the record processor ...
+        this.recordProcessor = new RecordMakers(dbSchema, source, topicSelector, connectorConfig.isEmitTombstoneOnDelete(), restartOffset);
+
+        // Set up the DDL filter
+        final String ddlFilter = config.getString(DatabaseHistory.DDL_FILTER);
+        this.ddlFilter = (ddlFilter != null) ? Predicates.includes(ddlFilter) : (x -> false);
+    }
+
+    public Configuration config() {
+        return config;
+    }
+
+    public MySqlConnectorConfig getConnectorConfig() {
+        return this.connectorConfig;
+    }
+
+    public MySqlJdbcContext getConnectionContext() {
+        return connectionContext;
+    }
+
+    public String connectorName() {
+        return config.getString("name");
+    }
+
+    public TopicSelector<TableId> topicSelector() {
+        return topicSelector;
+    }
+
+    public SourceInfo source() {
+        return source;
+    }
+
+    public MySqlSchema dbSchema() {
+        return dbSchema;
+    }
+
+    public RecordMakers makeRecord() {
+        return recordProcessor;
+    }
+
+    /**
+     * Get the predicate function that will return {@code true} if a GTID source is to be included, or {@code false} if
+     * a GTID source is to be excluded.
+     *
+     * @return the GTID source predicate function; never null
+     */
+    public Predicate<String> gtidSourceFilter() {
+        return gtidSourceFilter;
+    }
+
+    /**
+     * Initialize the database history with any server-specific information. This should be done only upon connector startup
+     * when the connector has no prior history.
+     */
+    public void initializeHistory() {
+        // Read the system variables from the MySQL instance and get the current database name ...
+        Map<String, String> variables = connectionContext.readMySqlCharsetSystemVariables();
+        String ddlStatement = connectionContext.setStatementFor(variables);
+
+        // And write them into the database history ...
+        dbSchema.applyDdl(source, "", ddlStatement, null);
+    }
+
+    /**
+     * Load the database schema information using the previously-recorded history, and stop reading the history when the
+     * the history reaches the supplied starting point.
+     *
+     * @param startingPoint the source information with the current {@link SourceInfo#partition()} and {@link SourceInfo#offset()
+     *            offset} at which the database schemas are to reflect; may not be null
+     */
+    public void loadHistory(SourceInfo startingPoint) {
+        // Read the system variables from the MySQL instance and load them into the DDL parser as defaults ...
+        Map<String, String> variables = connectionContext.readMySqlCharsetSystemVariables();
+        dbSchema.setSystemVariables(variables);
+
+        // And then load the history ...
+        dbSchema.loadHistory(startingPoint);
+
+        // The server's default character set may have changed since we last recorded it in the history,
+        // so we need to see if the history's state does not match ...
+        String systemCharsetName = variables.get(MySqlSystemVariables.CHARSET_NAME_SERVER);
+        String systemCharsetNameFromHistory = dbSchema.systemVariables().getVariable(MySqlSystemVariables.CHARSET_NAME_SERVER);
+        if (!Strings.equalsIgnoreCase(systemCharsetName, systemCharsetNameFromHistory)) {
+            // The history's server character set is NOT the same as the server's current default,
+            // so record the change in the history ...
+            String ddlStatement = connectionContext.setStatementFor(variables);
+            dbSchema.applyDdl(source, "", ddlStatement, null);
+        }
+        recordProcessor.regenerate();
+    }
+
+    /**
+     * Return true if the database history entity exists
+     */
+    public boolean historyExists() {
+        // Read the system variables from the MySQL instance and load them into the DDL parser as defaults ...
+        Map<String, String> variables = connectionContext.readMySqlCharsetSystemVariables();
+        dbSchema.setSystemVariables(variables);
+
+        // And then load the history ...
+        return dbSchema.historyExists();
+    }
+
+    /**
+     * Initialize permanent storage for database history
+     */
+    public void initializeHistoryStorage() {
+        dbSchema.intializeHistoryStorage();
+    }
+
+    public long serverId() {
+        return config.getLong(MySqlConnectorConfig.SERVER_ID);
+    }
+
+    public long rowCountForLargeTable() {
+        return config.getLong(MySqlConnectorConfig.ROW_COUNT_FOR_STREAMING_RESULT_SETS);
+    }
+
+    public int bufferSizeForBinlogReader() {
+        return config.getInteger(MySqlConnectorConfig.BUFFER_SIZE_FOR_BINLOG_READER);
+    }
+
+    public boolean includeSchemaChangeRecords() {
+        return config.getBoolean(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES);
+    }
+
+    public boolean includeSqlQuery() {
+        return config.getBoolean(MySqlConnectorConfig.INCLUDE_SQL_QUERY);
+    }
+
+    public boolean isSnapshotAllowedWhenNeeded() {
+        return snapshotMode() == SnapshotMode.WHEN_NEEDED;
+    }
+
+    public boolean isSnapshotNeverAllowed() {
+        return snapshotMode() == SnapshotMode.NEVER;
+    }
+
+    public boolean isInitialSnapshotOnly() {
+        return snapshotMode() == SnapshotMode.INITIAL_ONLY;
+    }
+
+    public boolean isSchemaOnlySnapshot() {
+        return snapshotMode() == SnapshotMode.SCHEMA_ONLY;
+    }
+
+    public boolean isSchemaOnlyRecoverySnapshot() {
+        return snapshotMode() == SnapshotMode.SCHEMA_ONLY_RECOVERY;
+    }
+
+    protected SnapshotMode snapshotMode() {
+        String value = config.getString(MySqlConnectorConfig.SNAPSHOT_MODE);
+        return SnapshotMode.parse(value, MySqlConnectorConfig.SNAPSHOT_MODE.defaultValueAsString());
+    }
+
+    public void start() {
+        connectionContext.start();
+        // Start the MySQL database history, which simply starts up resources but does not recover the history to a specific point
+        dbSchema().start();
+    }
+
+    public void shutdown() {
+        try {
+            // Flush and stop the database history ...
+            LOGGER.debug("Stopping database history");
+            dbSchema.shutdown();
+        }
+        catch (Throwable e) {
+            LOGGER.error("Unexpected error shutting down the database history", e);
+        }
+        finally {
+            connectionContext.shutdown();
+        }
+    }
+
+    /**
+     * Run the supplied function in the temporary connector MDC context, and when complete always return the MDC context to its
+     * state before this method was called.
+     *
+     * @param contextName the name of the context; may not be null
+     * @param operation the function to run in the new MDC context; may not be null
+     * @throws IllegalArgumentException if any of the parameters are null
+     */
+    public void temporaryLoggingContext(String contextName, Runnable operation) {
+        LoggingContext.temporarilyForConnector("MySQL", connectorConfig.getLogicalName(), contextName, operation);
+    }
+
+    /**
+     * Apply the include/exclude GTID source filters to the current {@link #source() GTID set} and merge them onto the
+     * currently available GTID set from a MySQL server.
+     *
+     * The merging behavior of this method might seem a bit strange at first. It's required in order for Debezium to consume a
+     * MySQL binlog that has multi-source replication enabled, if a failover has to occur. In such a case, the server that
+     * Debezium is failed over to might have a different set of sources, but still include the sources required for Debezium
+     * to continue to function. MySQL does not allow downstream replicas to connect if the GTID set does not contain GTIDs for
+     * all channels that the server is replicating from, even if the server does have the data needed by the client. To get
+     * around this, we can have Debezium merge its GTID set with whatever is on the server, so that MySQL will allow it to
+     * connect. See <a href="https://issues.jboss.org/browse/DBZ-143">DBZ-143</a> for details.
+     *
+     * This method does not mutate any state in the context.
+     *
+     * @param availableServerGtidSet the GTID set currently available in the MySQL server
+     * @param purgedServerGtid the GTID set already purged by the MySQL server
+     * @return A GTID set meant for consuming from a MySQL binlog; may return null if the SourceInfo has no GTIDs and therefore
+     *         none were filtered
+     */
+    public GtidSet filterGtidSet(GtidSet availableServerGtidSet, GtidSet purgedServerGtid) {
+        String gtidStr = source.gtidSet();
+        if (gtidStr == null) {
+            return null;
+        }
+        LOGGER.info("Attempting to generate a filtered GTID set");
+        LOGGER.info("GTID set from previous recorded offset: {}", gtidStr);
+        GtidSet filteredGtidSet = new GtidSet(gtidStr);
+        Predicate<String> gtidSourceFilter = gtidSourceFilter();
+        if (gtidSourceFilter != null) {
+            filteredGtidSet = filteredGtidSet.retainAll(gtidSourceFilter);
+            LOGGER.info("GTID set after applying GTID source includes/excludes to previous recorded offset: {}", filteredGtidSet);
+        }
+        LOGGER.info("GTID set available on server: {}", availableServerGtidSet);
+
+        GtidSet mergedGtidSet;
+
+        if (connectorConfig.gtidNewChannelPosition() == GtidNewChannelPosition.EARLIEST) {
+            final GtidSet knownGtidSet = filteredGtidSet;
+            LOGGER.info("Using first available positions for new GTID channels");
+            final GtidSet relevantAvailableServerGtidSet = (gtidSourceFilter != null) ? availableServerGtidSet.retainAll(gtidSourceFilter) : availableServerGtidSet;
+            LOGGER.info("Relevant GTID set available on server: {}", relevantAvailableServerGtidSet);
+
+            mergedGtidSet = relevantAvailableServerGtidSet
+                    .retainAll(uuid -> knownGtidSet.forServerWithId(uuid) != null)
+                    .with(purgedServerGtid)
+                    .with(filteredGtidSet);
+        }
+        else {
+            mergedGtidSet = availableServerGtidSet.with(filteredGtidSet);
+        }
+
+        LOGGER.info("Final merged GTID set to use when connecting to MySQL: {}", mergedGtidSet);
+        return mergedGtidSet;
+    }
+
+    /**
+     * Get the predicate function that will return {@code true} if a DDL has to be skipped over and left out of the schema history
+     * or {@code false} when it should be processed.
+     *
+     * @return the DDL predicate function; never null
+     */
+    public Predicate<String> ddlFilter() {
+        return ddlFilter;
+    }
+
+    public boolean isTableIdCaseInsensitive() {
+        return tableIdCaseInsensitive;
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/ParallelSnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/ParallelSnapshotReader.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -16,6 +16,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.HaltingPredicate;
+import io.debezium.connector.mysql.SourceInfo;
 
 /**
  * A reader that runs a {@link ChainedReader} consisting of a {@link SnapshotReader} and a {@link BinlogReader}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/Reader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/Reader.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import java.util.List;
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/ReaderMetricsMXBean.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/ReaderMetricsMXBean.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 /**
  * Metrics that are common for both snapshot and binlog readers

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/ReconcilingBinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/ReconcilingBinlogReader.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import static io.debezium.connector.mysql.SourceInfo.BINLOG_FILENAME_OFFSET_KEY;
 import static io.debezium.connector.mysql.SourceInfo.BINLOG_POSITION_OFFSET_KEY;
@@ -19,6 +19,8 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.connector.mysql.HaltingPredicate;
+import io.debezium.connector.mysql.SourceInfo;
 import io.debezium.document.Document;
 
 /**

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/RecordMakers.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/RecordMakers.java
@@ -1,0 +1,554 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.legacy;
+
+import java.time.Instant;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.connector.mysql.SourceInfo;
+import io.debezium.data.Envelope;
+import io.debezium.function.BlockingConsumer;
+import io.debezium.relational.RelationalChangeRecordEmitter;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.TableSchema;
+import io.debezium.relational.history.HistoryRecord.Fields;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.SchemaNameAdjuster;
+
+/**
+ * A component that makes {@link SourceRecord}s for tables.
+ *
+ * @author Randall Hauch
+ */
+public class RecordMakers {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final MySqlSchema schema;
+    private final SourceInfo source;
+    private final TopicSelector<TableId> topicSelector;
+    private final boolean emitTombstoneOnDelete;
+    private final Map<Long, Converter> convertersByTableNumber = new HashMap<>();
+    private final Map<TableId, Long> tableNumbersByTableId = new HashMap<>();
+    private final Map<Long, TableId> tableIdsByTableNumber = new HashMap<>();
+    private final Schema schemaChangeKeySchema;
+    private final Schema schemaChangeValueSchema;
+    private final SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create(logger);
+    private final Map<String, ?> restartOffset;
+
+    /**
+     * Create the record makers using the supplied components.
+     *
+     * @param schema the schema information about the MySQL server databases; may not be null
+     * @param source the connector's source information; may not be null
+     * @param topicSelector the selector for topic names; may not be null
+     * @param emitTombstoneOnDelete whether to emit a tombstone message upon DELETE events or not
+     * @param restartOffset the offset to publish with the {@link SourceInfo#RESTART_PREFIX} prefix
+     *                      as additional information in the offset. If the connector attempts to
+     *                      restart from an offset with information with this prefix it will
+     *                      create an offset from the prefixed information rather than restarting
+     *                      from the base offset.
+     * @see MySqlConnectorTask#getRestartOffset(Map)
+     */
+    public RecordMakers(MySqlSchema schema, SourceInfo source, TopicSelector<TableId> topicSelector,
+                        boolean emitTombstoneOnDelete, Map<String, ?> restartOffset) {
+        this.schema = schema;
+        this.source = source;
+        this.topicSelector = topicSelector;
+        this.emitTombstoneOnDelete = emitTombstoneOnDelete;
+        this.restartOffset = restartOffset;
+        this.schemaChangeKeySchema = SchemaBuilder.struct()
+                .name(schemaNameAdjuster.adjust("io.debezium.connector.mysql.SchemaChangeKey"))
+                .field(Fields.DATABASE_NAME, Schema.STRING_SCHEMA)
+                .build();
+        this.schemaChangeValueSchema = SchemaBuilder.struct()
+                .name(schemaNameAdjuster.adjust("io.debezium.connector.mysql.SchemaChangeValue"))
+                .field(Fields.SOURCE, source.schema())
+                .field(Fields.DATABASE_NAME, Schema.STRING_SCHEMA)
+                .field(Fields.DDL_STATEMENTS, Schema.STRING_SCHEMA)
+                .build();
+    }
+
+    /**
+     * Obtain the record maker for the given table, using the specified columns and sending records to the given consumer.
+     *
+     * @param tableId the identifier of the table for which records are to be produced
+     * @param includedColumns the set of columns that will be included in each row; may be null if all columns are included
+     * @param consumer the consumer for all produced records; may not be null
+     * @return the table-specific record maker; may be null if the table is not included in the connector
+     */
+    public RecordsForTable forTable(TableId tableId, BitSet includedColumns, BlockingConsumer<SourceRecord> consumer) {
+        Long tableNumber = tableNumbersByTableId.get(tableId);
+        return tableNumber != null ? forTable(tableNumber, includedColumns, consumer) : null;
+    }
+
+    /**
+     * Determine if there is a record maker for the given table.
+     *
+     * @param tableId the identifier of the table
+     * @return {@code true} if there is a {@link #forTable(TableId, BitSet, BlockingConsumer) record maker}, or {@code false}
+     * if there is none
+     */
+    public boolean hasTable(TableId tableId) {
+        Long tableNumber = tableNumbersByTableId.get(tableId);
+        if (tableNumber == null) {
+            return false;
+        }
+        Converter converter = convertersByTableNumber.get(tableNumber);
+        return converter != null;
+    }
+
+    /**
+     * Obtain the record maker for the given table, using the specified columns and sending records to the given consumer.
+     *
+     * @param tableNumber the {@link #assign(long, TableId) assigned table number} for which records are to be produced
+     * @param includedColumns the set of columns that will be included in each row; may be null if all columns are included
+     * @param consumer the consumer for all produced records; may not be null
+     * @return the table-specific record maker; may be null if the table is not included in the connector
+     */
+    public RecordsForTable forTable(long tableNumber, BitSet includedColumns, BlockingConsumer<SourceRecord> consumer) {
+        Converter converter = convertersByTableNumber.get(tableNumber);
+        if (converter == null) {
+            return null;
+        }
+        return new RecordsForTable(converter, includedColumns, consumer);
+    }
+
+    /**
+     * Produce a schema change record for the given DDL statements.
+     *
+     * @param databaseName the name of the database that is affected by the DDL statements; may not be null
+     * @param tables the list of tables affected by the DDL statements
+     * @param ddlStatements the DDL statements; may not be null
+     * @param consumer the consumer for all produced records; may not be null
+     * @return the number of records produced; will be 0 or more
+     */
+    public int schemaChanges(String databaseName, Set<TableId> tables, String ddlStatements, BlockingConsumer<SourceRecord> consumer) {
+        String topicName = topicSelector.getPrimaryTopic();
+        Integer partition = 0;
+        Struct key = schemaChangeRecordKey(databaseName);
+        Struct value = schemaChangeRecordValue(databaseName, tables, ddlStatements);
+        SourceRecord record = new SourceRecord(source.partition(), source.offset(),
+                topicName, partition, schemaChangeKeySchema, key, schemaChangeValueSchema, value);
+        try {
+            consumer.accept(record);
+            return 1;
+        }
+        catch (InterruptedException e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Clear all of the cached record makers. This should be done when the logs are rotated, since in that a different table
+     * numbering scheme will be used by all subsequent TABLE_MAP binlog events.
+     */
+    public void clear() {
+        logger.debug("Clearing table converters");
+        convertersByTableNumber.clear();
+        tableNumbersByTableId.clear();
+        tableIdsByTableNumber.clear();
+    }
+
+    /**
+     * Clear all of the cached record makers and generate new ones. This should be done when the schema changes for reasons other
+     * than reading DDL from the binlog.
+     */
+    public void regenerate() {
+        clear();
+        AtomicInteger nextTableNumber = new AtomicInteger(0);
+        Set<TableId> tableIds = schema.tableIds();
+        logger.debug("Regenerating converters for {} tables", tableIds.size());
+        tableIds.forEach(id -> {
+            assign(nextTableNumber.incrementAndGet(), id);
+        });
+    }
+
+    private Map<String, ?> getSourceRecordOffset(Map<String, Object> sourceOffset) {
+        if (restartOffset == null) {
+            return sourceOffset;
+        }
+        else {
+            for (Entry<String, ?> restartOffsetEntry : restartOffset.entrySet()) {
+                sourceOffset.put(SourceInfo.RESTART_PREFIX + restartOffsetEntry.getKey(), restartOffsetEntry.getValue());
+            }
+
+            return sourceOffset;
+        }
+    }
+
+    /**
+     * Assign the given table number to the table with the specified {@link TableId table ID}.
+     *
+     * @param tableNumber the table number found in binlog events
+     * @param id the identifier for the corresponding table
+     * @return {@code true} if the assignment was successful, or {@code false} if the table is currently excluded in the
+     *         connector's configuration
+     */
+    public boolean assign(long tableNumber, TableId id) {
+        Long existingTableNumber = tableNumbersByTableId.get(id);
+        if (existingTableNumber != null && existingTableNumber.longValue() == tableNumber
+                && convertersByTableNumber.containsKey(tableNumber)) {
+            // This is the exact same table number for the same table, so do nothing ...
+            return true;
+        }
+        TableSchema tableSchema = schema.schemaFor(id);
+        if (tableSchema == null) {
+            return false;
+        }
+
+        String topicName = topicSelector.topicNameFor(id);
+        Envelope envelope = tableSchema.getEnvelopeSchema();
+
+        // Generate this table's insert, update, and delete converters ...
+        Integer partitionNum = null;
+        Converter converter = new Converter() {
+
+            @Override
+            public int read(SourceInfo source, Object[] row, int rowNumber, int numberOfRows, BitSet includedColumns, Instant ts,
+                            BlockingConsumer<SourceRecord> consumer)
+                    throws InterruptedException {
+                Struct key = tableSchema.keyFromColumnData(row);
+                Struct value = tableSchema.valueFromColumnData(row);
+                if (value != null || key != null) {
+                    Schema keySchema = tableSchema.keySchema();
+                    Map<String, ?> partition = source.partition();
+                    Map<String, Object> offset = source.offsetForRow(rowNumber, numberOfRows);
+                    source.tableEvent(id);
+                    Struct origin = source.struct();
+                    SourceRecord record = new SourceRecord(partition, getSourceRecordOffset(offset), topicName, partitionNum,
+                            keySchema, key, envelope.schema(), envelope.read(value, origin, ts));
+                    consumer.accept(record);
+                    return 1;
+                }
+                return 0;
+            }
+
+            @Override
+            public int insert(SourceInfo source, Object[] row, int rowNumber, int numberOfRows, BitSet includedColumns, Instant ts,
+                              BlockingConsumer<SourceRecord> consumer)
+                    throws InterruptedException {
+                validateColumnCount(tableSchema, row);
+                Struct key = tableSchema.keyFromColumnData(row);
+                Struct value = tableSchema.valueFromColumnData(row);
+                if (value != null || key != null) {
+                    Schema keySchema = tableSchema.keySchema();
+                    Map<String, ?> partition = source.partition();
+                    Map<String, Object> offset = source.offsetForRow(rowNumber, numberOfRows);
+                    source.tableEvent(id);
+                    Struct origin = source.struct();
+                    SourceRecord record = new SourceRecord(partition, getSourceRecordOffset(offset), topicName, partitionNum,
+                            keySchema, key, envelope.schema(), envelope.create(value, origin, ts));
+                    consumer.accept(record);
+                    return 1;
+                }
+                return 0;
+            }
+
+            @Override
+            public int update(SourceInfo source, Object[] before, Object[] after, int rowNumber, int numberOfRows, BitSet includedColumns,
+                              Instant ts,
+                              BlockingConsumer<SourceRecord> consumer)
+                    throws InterruptedException {
+                int count = 0;
+                validateColumnCount(tableSchema, after);
+                Struct newkey = tableSchema.keyFromColumnData(after);
+                Struct valueAfter = tableSchema.valueFromColumnData(after);
+                if (valueAfter != null || newkey != null) {
+                    Object oldKey = tableSchema.keyFromColumnData(before);
+                    Struct valueBefore = tableSchema.valueFromColumnData(before);
+                    Schema keySchema = tableSchema.keySchema();
+                    Map<String, ?> partition = source.partition();
+                    Map<String, Object> offset = source.offsetForRow(rowNumber, numberOfRows);
+                    source.tableEvent(id);
+                    Struct origin = source.struct();
+                    if (newkey != null && !Objects.equals(newkey, oldKey)) {
+                        // The key has changed, so we need to deal with both the new key and old key.
+                        // Consumers may push the events into a system that won't allow both records to exist at the same time,
+                        // so we first want to send the delete event for the old key...
+
+                        ConnectHeaders headers = new ConnectHeaders();
+                        headers.add(RelationalChangeRecordEmitter.PK_UPDATE_NEWKEY_FIELD, newkey, keySchema);
+
+                        SourceRecord record = new SourceRecord(partition, getSourceRecordOffset(offset), topicName, partitionNum,
+                                keySchema, oldKey, envelope.schema(), envelope.delete(valueBefore, origin, ts), null, headers);
+                        consumer.accept(record);
+                        ++count;
+
+                        if (emitTombstoneOnDelete) {
+                            // Next send a tombstone event for the old key ...
+                            record = new SourceRecord(partition, getSourceRecordOffset(offset), topicName, partitionNum, keySchema, oldKey, null, null);
+                            consumer.accept(record);
+                            ++count;
+                        }
+
+                        headers = new ConnectHeaders();
+                        headers.add(RelationalChangeRecordEmitter.PK_UPDATE_OLDKEY_FIELD, oldKey, keySchema);
+
+                        // And finally send the create event ...
+                        record = new SourceRecord(partition, getSourceRecordOffset(offset), topicName, partitionNum,
+                                keySchema, newkey, envelope.schema(), envelope.create(valueAfter, origin, ts), null, headers);
+                        consumer.accept(record);
+                        ++count;
+                    }
+                    else {
+                        // The key has not changed, so a simple update is fine ...
+                        SourceRecord record = new SourceRecord(partition, getSourceRecordOffset(offset), topicName, partitionNum,
+                                keySchema, newkey, envelope.schema(), envelope.update(valueBefore, valueAfter, origin, ts));
+                        consumer.accept(record);
+                        ++count;
+                    }
+                }
+                return count;
+            }
+
+            @Override
+            public int delete(SourceInfo source, Object[] row, int rowNumber, int numberOfRows, BitSet includedColumns, Instant ts,
+                              BlockingConsumer<SourceRecord> consumer)
+                    throws InterruptedException {
+                int count = 0;
+                validateColumnCount(tableSchema, row);
+                Struct key = tableSchema.keyFromColumnData(row);
+                Struct value = tableSchema.valueFromColumnData(row);
+                if (value != null || key != null) {
+                    Schema keySchema = tableSchema.keySchema();
+                    Map<String, ?> partition = source.partition();
+                    Map<String, Object> offset = source.offsetForRow(rowNumber, numberOfRows);
+                    source.tableEvent(id);
+                    Struct origin = source.struct();
+                    // Send a delete message ...
+                    SourceRecord record = new SourceRecord(partition, getSourceRecordOffset(offset), topicName, partitionNum,
+                            keySchema, key, envelope.schema(), envelope.delete(value, origin, ts));
+                    consumer.accept(record);
+                    ++count;
+
+                    // And send a tombstone ...
+                    if (emitTombstoneOnDelete) {
+                        record = new SourceRecord(partition, getSourceRecordOffset(offset), topicName, partitionNum,
+                                keySchema, key, null, null);
+                        consumer.accept(record);
+                        ++count;
+                    }
+                }
+                return count;
+            }
+
+            @Override
+            public String toString() {
+                return "RecordMaker.Converter(" + id + ")";
+            }
+
+            private void validateColumnCount(TableSchema tableSchema, Object[] row) {
+                final int expectedColumnsCount = schema.tableFor(tableSchema.id()).columns().size();
+                if (expectedColumnsCount != row.length) {
+                    logger.error("Invalid number of columns, expected '{}' arrived '{}'", expectedColumnsCount, row.length);
+                    throw new ConnectException(
+                            "The binlog event does not contain expected number of columns; the internal schema representation is probably out of sync with the real database schema, or the binlog contains events recorded with binlog_row_image other than FULL or the table in question is an NDB table");
+                }
+            }
+        };
+
+        convertersByTableNumber.put(tableNumber, converter);
+        Long previousTableNumber = tableNumbersByTableId.put(id, tableNumber);
+        tableIdsByTableNumber.put(tableNumber, id);
+        if (previousTableNumber != null) {
+            assert previousTableNumber.longValue() != tableNumber;
+            convertersByTableNumber.remove(previousTableNumber);
+        }
+        return true;
+    }
+
+    protected Struct schemaChangeRecordKey(String databaseName) {
+        Struct result = new Struct(schemaChangeKeySchema);
+        result.put(Fields.DATABASE_NAME, databaseName);
+        return result;
+    }
+
+    protected Struct schemaChangeRecordValue(String databaseName, Set<TableId> tables, String ddlStatements) {
+        source.databaseEvent(databaseName);
+        source.tableEvent(tables);
+        Struct result = new Struct(schemaChangeValueSchema);
+        result.put(Fields.SOURCE, source.struct());
+        result.put(Fields.DATABASE_NAME, databaseName);
+        result.put(Fields.DDL_STATEMENTS, ddlStatements);
+        return result;
+    }
+
+    protected static interface Converter {
+        int read(SourceInfo source, Object[] row, int rowNumber, int numberOfRows, BitSet includedColumns, Instant ts,
+                 BlockingConsumer<SourceRecord> consumer)
+                throws InterruptedException;
+
+        int insert(SourceInfo source, Object[] row, int rowNumber, int numberOfRows, BitSet includedColumns, Instant ts,
+                   BlockingConsumer<SourceRecord> consumer)
+                throws InterruptedException;
+
+        int update(SourceInfo source, Object[] before, Object[] after, int rowNumber, int numberOfRows, BitSet includedColumns, Instant ts,
+                   BlockingConsumer<SourceRecord> consumer)
+                throws InterruptedException;
+
+        int delete(SourceInfo source, Object[] row, int rowNumber, int numberOfRows, BitSet includedColumns, Instant ts,
+                   BlockingConsumer<SourceRecord> consumer)
+                throws InterruptedException;
+
+    }
+
+    /**
+     * A {@link SourceRecord} factory for a specific table and consumer.
+     */
+    public final class RecordsForTable {
+        private final BitSet includedColumns;
+        private final Converter converter;
+        private final BlockingConsumer<SourceRecord> consumer;
+
+        protected RecordsForTable(Converter converter, BitSet includedColumns, BlockingConsumer<SourceRecord> consumer) {
+            this.converter = converter;
+            this.includedColumns = includedColumns;
+            this.consumer = consumer;
+        }
+
+        /**
+         * Produce a {@link io.debezium.data.Envelope.Operation#READ read} record for the row.
+         *
+         * @param row the values of the row, in the same order as the columns in the {@link Table} definition in the
+         *            {@link MySqlSchema}.
+         * @param ts the timestamp for this row
+         * @return the number of records produced; will be 0 or more
+         * @throws InterruptedException if this thread is interrupted while waiting to give a source record to the consumer
+         */
+        public int read(Object[] row, Instant ts) throws InterruptedException {
+            return read(row, ts, 0, 1);
+        }
+
+        /**
+         * Produce a {@link io.debezium.data.Envelope.Operation#READ read} record for the row.
+         *
+         * @param row the values of the row, in the same order as the columns in the {@link Table} definition in the
+         *            {@link MySqlSchema}.
+         * @param ts the timestamp for this row
+         * @param rowNumber the number of this row; must be 0 or more
+         * @param numberOfRows the total number of rows to be read; must be 1 or more
+         * @return the number of records produced; will be 0 or more
+         * @throws InterruptedException if this thread is interrupted while waiting to give a source record to the consumer
+         */
+        public int read(Object[] row, Instant ts, int rowNumber, int numberOfRows) throws InterruptedException {
+            return converter.read(source, row, rowNumber, numberOfRows, includedColumns, ts, consumer);
+        }
+
+        /**
+         * Produce a {@link io.debezium.data.Envelope.Operation#CREATE create} record for the row.
+         *
+         * @param row the values of the row, in the same order as the columns in the {@link Table} definition in the
+         *            {@link MySqlSchema}.
+         * @param ts the timestamp for this row
+         * @return the number of records produced; will be 0 or more
+         * @throws InterruptedException if this thread is interrupted while waiting to give a source record to the consumer
+         */
+        public int create(Object[] row, Instant ts) throws InterruptedException {
+            return create(row, ts, 0, 1);
+        }
+
+        /**
+         * Produce a {@link io.debezium.data.Envelope.Operation#CREATE create} record for the row.
+         *
+         * @param row the values of the row, in the same order as the columns in the {@link Table} definition in the
+         *            {@link MySqlSchema}.
+         * @param ts the timestamp for this row
+         * @param rowNumber the number of this row; must be 0 or more
+         * @param numberOfRows the total number of rows to be read; must be 1 or more
+         * @return the number of records produced; will be 0 or more
+         * @throws InterruptedException if this thread is interrupted while waiting to give a source record to the consumer
+         */
+        public int create(Object[] row, Instant ts, int rowNumber, int numberOfRows) throws InterruptedException {
+            return converter.insert(source, row, rowNumber, numberOfRows, includedColumns, ts, consumer);
+        }
+
+        /**
+         * Produce an {@link io.debezium.data.Envelope.Operation#UPDATE update} record for the row.
+         *
+         * @param before the values of the row <i>before</i> the update, in the same order as the columns in the {@link Table}
+         *            definition in the {@link MySqlSchema}
+         * @param after the values of the row <i>after</i> the update, in the same order as the columns in the {@link Table}
+         *            definition in the {@link MySqlSchema}
+         * @param ts the timestamp for this row
+         * @return the number of records produced; will be 0 or more
+         * @throws InterruptedException if this thread is interrupted while waiting to give a source record to the consumer
+         */
+        public int update(Object[] before, Object[] after, Instant ts) throws InterruptedException {
+            return update(before, after, ts, 0, 1);
+        }
+
+        /**
+         * Produce an {@link io.debezium.data.Envelope.Operation#UPDATE update} record for the row.
+         *
+         * @param before the values of the row <i>before</i> the update, in the same order as the columns in the {@link Table}
+         *            definition in the {@link MySqlSchema}
+         * @param after the values of the row <i>after</i> the update, in the same order as the columns in the {@link Table}
+         *            definition in the {@link MySqlSchema}
+         * @param ts the timestamp for this row
+         * @param rowNumber the number of this row; must be 0 or more
+         * @param numberOfRows the total number of rows to be read; must be 1 or more
+         * @return the number of records produced; will be 0 or more
+         * @throws InterruptedException if this thread is interrupted while waiting to give a source record to the consumer
+         */
+        public int update(Object[] before, Object[] after, Instant ts, int rowNumber, int numberOfRows) throws InterruptedException {
+            return converter.update(source, before, after, rowNumber, numberOfRows, includedColumns, ts, consumer);
+        }
+
+        /**
+         * Produce a {@link io.debezium.data.Envelope.Operation#DELETE delete} record for the row.
+         *
+         * @param row the values of the row, in the same order as the columns in the {@link Table} definition in the
+         *            {@link MySqlSchema}.
+         * @param ts the timestamp for this row
+         * @return the number of records produced; will be 0 or more
+         * @throws InterruptedException if this thread is interrupted while waiting to give a source record to the consumer
+         */
+        public int delete(Object[] row, Instant ts) throws InterruptedException {
+            return delete(row, ts, 0, 1);
+        }
+
+        /**
+         * Produce a {@link io.debezium.data.Envelope.Operation#DELETE delete} record for the row.
+         *
+         * @param row the values of the row, in the same order as the columns in the {@link Table} definition in the
+         *            {@link MySqlSchema}.
+         * @param ts the timestamp for this row
+         * @param rowNumber the number of this row; must be 0 or more
+         * @param numberOfRows the total number of rows to be read; must be 1 or more
+         * @return the number of records produced; will be 0 or more
+         * @throws InterruptedException if this thread is interrupted while waiting to give a source record to the consumer
+         */
+        public int delete(Object[] row, Instant ts, int rowNumber, int numberOfRows) throws InterruptedException {
+            return converter.delete(source, row, rowNumber, numberOfRows, includedColumns, ts, consumer);
+        }
+    }
+
+    /**
+     * Converts table number back to table id
+     *
+     * @param tableNumber
+     * @return the table id or null for unknown tables
+     */
+    public TableId getTableIdFromTableNumber(long tableNumber) {
+        return tableIdsByTableNumber.get(tableNumber);
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SnapshotReader.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import java.io.UnsupportedEncodingException;
 import java.sql.Blob;
@@ -38,8 +38,12 @@ import org.apache.kafka.connect.source.SourceRecord;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.SnapshotRecord;
-import io.debezium.connector.mysql.MySqlJdbcContext.DatabaseLocales;
-import io.debezium.connector.mysql.RecordMakers.RecordsForTable;
+import io.debezium.connector.mysql.MySqlConnector;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.MySqlValueConverters;
+import io.debezium.connector.mysql.SourceInfo;
+import io.debezium.connector.mysql.legacy.MySqlJdbcContext.DatabaseLocales;
+import io.debezium.connector.mysql.legacy.RecordMakers.RecordsForTable;
 import io.debezium.data.Envelope;
 import io.debezium.function.BufferedBlockingConsumer;
 import io.debezium.function.Predicates;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SnapshotReaderMetrics.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SnapshotReaderMetrics.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SnapshotReaderMetricsMXBean.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SnapshotReaderMetricsMXBean.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import io.debezium.pipeline.metrics.SnapshotChangeEventSourceMetricsMXBean;
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/TimedBlockingReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/TimedBlockingReader.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import java.time.Duration;
 import java.util.List;

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/AbstractMySqlConnectorOutputTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/AbstractMySqlConnectorOutputTest.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.GtidSet.UUIDSet;
+import io.debezium.connector.mysql.legacy.MySqlJdbcContext;
 import io.debezium.data.VerifyRecord.RecordValueComparator;
 import io.debezium.embedded.ConnectorOutputTest;
 import io.debezium.util.Stopwatch;

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -40,6 +40,7 @@ import io.debezium.connector.mysql.MySQLConnection.MySqlVersion;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotLockingMode;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
+import io.debezium.connector.mysql.legacy.Filters;
 import io.debezium.converters.CloudEventsConverterTest;
 import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
@@ -455,6 +456,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
             }
         }
 
+        // Testing.Print.enable();
         // And consume the one insert ...
         records = consumeRecordsByTopic(1);
         assertThat(records.recordsForTopic(DATABASE.topicForTable("products")).size()).isEqualTo(1);
@@ -462,7 +464,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         inserts = records.recordsForTopic(DATABASE.topicForTable("products"));
         assertInsert(inserts.get(0), "id", 1001);
 
-        // Testing.print("*** Done with simple insert");
+        Testing.print("*** Done with simple insert");
 
         // ---------------------------------------------------------------------------------------------------------------
         // Changing the primary key of a row should result in 3 events: INSERT, DELETE, and TOMBSTONE
@@ -955,7 +957,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
             }
         }
 
-        SourceRecords records = consumeRecordsByTopic(16);
+        SourceRecords records = consumeRecordsByTopic(15);
         final List<SourceRecord> migrationTestRecords = records.recordsForTopic(DATABASE.topicForTable("migration_test"));
         assertThat(migrationTestRecords.size()).isEqualTo(1);
         final SourceRecord record = migrationTestRecords.get(0);
@@ -1495,6 +1497,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         // Start the connector ...
         start(MySqlConnector.class, config);
 
+        // Testing.Print.enable();
         // ---------------------------------------------------------------------------------------------------------------
         // Consume all of the events due to startup and initialization of the database
         // ---------------------------------------------------------------------------------------------------------------
@@ -2222,7 +2225,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
     }
 
     private void waitForStreamingRunning(String serverName) throws InterruptedException {
-        waitForStreamingRunning("mysql", serverName, "binlog");
+        waitForStreamingRunning("mysql", serverName, "streaming");
     }
 
     private List<SourceRecord> recordsForTopicForRoProductsTable(SourceRecords records) {
@@ -2243,6 +2246,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         // ---------------------------------------------------------------------------------------------------------------
         // Consume all of the events due to startup and initialization of the database
         // ---------------------------------------------------------------------------------------------------------------
+        // Testing.Print.enable();
         SourceRecords records = consumeRecordsByTopic(INITIAL_EVENT_COUNT); // 6 DDL changes
         assertThat(records.recordsForTopic(DATABASE.topicForTable("orders")).size()).isEqualTo(5);
 
@@ -2270,7 +2274,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
                 connection.execute("UPDATE orders SET quantity=5 WHERE order_number=10004");
             }
         }
-        records = consumeRecordsByTopic(5);
+        records = consumeRecordsByTopic(1);
         updates = records.recordsForTopic(DATABASE.topicForTable("orders"));
         assertThat(updates.size()).isEqualTo(1);
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorRegressionIT.java
@@ -88,7 +88,7 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 .build();
         // Start the connector ...
         start(MySqlConnector.class, config);
-        waitForStreamingRunning("mysql", DATABASE.getServerName(), "binlog");
+        waitForStreamingRunning("mysql", DATABASE.getServerName(), "streaming");
 
         // ---------------------------------------------------------------------------------------------------------------
         // Consume all of the events due to startup and initialization of the database
@@ -934,7 +934,7 @@ public class MySqlConnectorRegressionIT extends AbstractConnectorTest {
                 .build();
         // Start the connector ...
         start(MySqlConnector.class, config);
-        waitForStreamingRunning("mysql", DATABASE.getServerName(), "binlog");
+        waitForStreamingRunning("mysql", DATABASE.getServerName(), "streaming");
 
         // ---------------------------------------------------------------------------------------------------------------
         // Consume all of the events due to startup and initialization of the database

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlMetricsIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlMetricsIT.java
@@ -122,7 +122,7 @@ public class MySqlMetricsIT extends AbstractConnectorTest {
                         .build());
 
         assertSnapshotMetrics();
-        assertNoStreamingMetricsExist();
+        assertStreamingMetricsExist();
     }
 
     @Test
@@ -189,6 +189,16 @@ public class MySqlMetricsIT extends AbstractConnectorTest {
         }
     }
 
+    private void assertStreamingMetricsExist() throws Exception {
+        final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+        try {
+            mBeanServer.getAttribute(getStreamingMetricsObjectName(), "TotalNumberOfEventsSeen");
+        }
+        catch (InstanceNotFoundException e) {
+            Assert.fail("Streaming Metrics should exist");
+        }
+    }
+
     private void assertSnapshotMetrics() throws Exception {
         final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
 
@@ -245,7 +255,7 @@ public class MySqlMetricsIT extends AbstractConnectorTest {
     }
 
     private ObjectName getStreamingMetricsObjectName() throws MalformedObjectNameException {
-        return getStreamingMetricsObjectName("mysql", SERVER_NAME, "binlog");
+        return getStreamingMetricsObjectName("mysql", SERVER_NAME, "streaming");
     }
 
     private void waitForSnapshotToBeCompleted() throws InterruptedException {
@@ -253,6 +263,6 @@ public class MySqlMetricsIT extends AbstractConnectorTest {
     }
 
     private void waitForStreamingToStart() throws InterruptedException {
-        waitForStreamingRunning("mysql", SERVER_NAME, "binlog");
+        waitForStreamingRunning("mysql", SERVER_NAME, "streaming");
     }
 }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSourceTypeInSchemaIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSourceTypeInSchemaIT.java
@@ -168,7 +168,7 @@ public class MySqlSourceTypeInSchemaIT extends AbstractConnectorTest {
 
         // Start the connector ...
         start(MySqlConnector.class, config);
-        waitForStreamingRunning("mysql", DATABASE.getServerName(), "binlog");
+        waitForStreamingRunning("mysql", DATABASE.getServerName(), "streaming");
 
         // ---------------------------------------------------------------------------------------------------------------
         // Consume all of the events due to startup and initialization of the database

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MysqlDefaultDatabaseCharsetIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MysqlDefaultDatabaseCharsetIT.java
@@ -55,7 +55,7 @@ public class MysqlDefaultDatabaseCharsetIT extends AbstractConnectorTest {
                 .build();
         start(MySqlConnector.class, config);
 
-        // Testing.Print.enable();
+        Testing.Print.enable();
 
         AbstractConnectorTest.SourceRecords records = consumeRecordsByTopic(7);
         final SourceRecord record = records.recordsForTopic(DATABASE.topicForTable("DATA")).get(0);

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MysqlDefaultValueIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MysqlDefaultValueIT.java
@@ -54,8 +54,8 @@ import io.debezium.util.Testing;
 @SkipWhenDatabaseVersion(check = LESS_THAN, major = 5, minor = 6, reason = "DDL uses fractional second data types, not supported until MySQL 5.6")
 public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
-    // 4 meta events (set character_set etc.) and then 15 tables with 3 events each (drop DDL, create DDL, insert)
-    private static final int EVENT_COUNT = 4 + 15 * 3;
+    // 4 meta events (set character_set etc.) and then 14 tables with 3 events each (drop DDL, create DDL, insert)
+    private static final int EVENT_COUNT = 4 + 14 * 3;
 
     private static final Path DB_HISTORY_PATH = Testing.Files.createTestingPath("file-db-history-connect.txt").toAbsolutePath();
     private final UniqueDatabase DATABASE = new UniqueDatabase("myServer1", "default_value")

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/UniqueDatabase.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/UniqueDatabase.java
@@ -123,7 +123,7 @@ public class UniqueDatabase {
         return String.format("%s.%s", databaseName, tableName);
     }
 
-    protected String getServerName() {
+    public String getServerName() {
         return serverName;
     }
 
@@ -202,7 +202,8 @@ public class UniqueDatabase {
                 .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MySqlConnectorConfig.DATABASE_INCLUDE_LIST, getDatabaseName())
                 .with(MySqlConnectorConfig.DATABASE_HISTORY, FileDatabaseHistory.class)
-                .with(MySqlConnectorConfig.BUFFER_SIZE_FOR_BINLOG_READER, 10_000);
+                .with(MySqlConnectorConfig.BUFFER_SIZE_FOR_BINLOG_READER, 10_000)
+                .with("internal.implementation", "new");
 
         if (dbHistoryPath != null) {
             builder.with(FileDatabaseHistory.FILE_PATH, dbHistoryPath);

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/ZZZGtidSetIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/ZZZGtidSetIT.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
+import io.debezium.connector.mysql.legacy.BinlogReaderIT;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.jdbc.JdbcConnection;

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/BinlogReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/BinlogReaderIT.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import static io.debezium.junit.EqualityCheck.LESS_THAN;
 import static io.debezium.junit.EqualityCheck.LESS_THAN_OR_EQUAL;
@@ -35,8 +35,11 @@ import org.junit.Test;
 
 import io.debezium.config.CommonConnectorConfig.EventProcessingFailureHandlingMode;
 import io.debezium.config.Configuration;
-import io.debezium.connector.mysql.AbstractReader.AcceptAllPredicate;
+import io.debezium.connector.mysql.MySQLConnection;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
+import io.debezium.connector.mysql.UniqueDatabase;
+import io.debezium.connector.mysql.legacy.AbstractReader.AcceptAllPredicate;
 import io.debezium.data.Envelope;
 import io.debezium.data.KeyValueStore;
 import io.debezium.data.KeyValueStore.Collection;

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/ChainedReaderTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/ChainedReaderTest.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -18,7 +18,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import io.debezium.config.ConfigurationDefaults;
-import io.debezium.connector.mysql.Reader.State;
+import io.debezium.connector.mysql.legacy.Reader.State;
 import io.debezium.util.Clock;
 import io.debezium.util.Collect;
 import io.debezium.util.Threads;

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/Configurator.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/Configurator.java
@@ -3,12 +3,14 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import java.nio.file.Path;
 
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.MySqlTopicSelector;
 import io.debezium.relational.history.FileDatabaseHistory;
 import io.debezium.util.Testing;
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/FiltersTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/FiltersTest.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import static org.fest.assertions.Assertions.assertThat;
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/MySqlSchemaTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/MySqlSchemaTest.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -18,6 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.MySqlSystemVariables;
+import io.debezium.connector.mysql.SourceInfo;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchema;

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/MySqlTaskContextIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/MySqlTaskContextIT.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -11,6 +11,8 @@ import java.sql.SQLException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
+
+import io.debezium.connector.mysql.MySqlConnectorConfig;
 
 /**
  * @author Randall Hauch

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/MySqlTaskContextTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/MySqlTaskContextTest.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -17,9 +17,12 @@ import org.junit.Test;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.connector.mysql.GtidSet;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.connector.mysql.MySqlConnectorConfig.GtidNewChannelPosition;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
+import io.debezium.connector.mysql.SourceInfo;
 import io.debezium.doc.FixFor;
 import io.debezium.document.Document;
 import io.debezium.relational.history.FileDatabaseHistory;

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/ParallelSnapshotReaderTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/ParallelSnapshotReaderTest.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -21,7 +21,8 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Assert;
 import org.junit.Test;
 
-import io.debezium.connector.mysql.ParallelSnapshotReader.ParallelHaltingPredicate;
+import io.debezium.connector.mysql.SourceInfo;
+import io.debezium.connector.mysql.legacy.ParallelSnapshotReader.ParallelHaltingPredicate;
 
 /**
  * @author Moira Tagle

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/ReconcilingBinlogReaderTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/ReconcilingBinlogReaderTest.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -13,6 +13,8 @@ import java.util.Map;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.Assert;
 import org.junit.Test;
+
+import io.debezium.connector.mysql.SourceInfo;
 
 /**
  * @author Moira Tagle

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/SnapshotReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/SnapshotReaderIT.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.mysql;
+package io.debezium.connector.mysql.legacy;
 
 import static io.debezium.junit.EqualityCheck.LESS_THAN;
 import static org.fest.assertions.Assertions.assertThat;
@@ -32,6 +32,9 @@ import org.junit.Test;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.config.Configuration.Builder;
+import io.debezium.connector.mysql.MySQLConnection;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.UniqueDatabase;
 import io.debezium.data.KeyValueStore;
 import io.debezium.data.KeyValueStore.Collection;
 import io.debezium.data.SchemaChangeHistory;

--- a/debezium-connector-mysql/src/test/resources/log4j.properties
+++ b/debezium-connector-mysql/src/test/resources/log4j.properties
@@ -8,7 +8,7 @@ log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p  %X{dbz.connecto
 log4j.rootLogger=WARN, stdout
 
 # Set up the default logging to be INFO level, then override specific units
-log4j.logger.io.debezium=WARN
+log4j.logger.io.debezium=INFO
 log4j.logger.io.debezium.embedded.EmbeddedEngine$EmbeddedConfig=WARN
 #log4j.logger.io.debezium.connector.mysql.BinlogReader=DEBUG
 #log4j.logger.io.debezium.connector.mysql.SnapshotReader=DEBUG

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -2513,5 +2513,15 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         public void initializeStorage() {
             delegate.initializeStorage();
         }
+
+        @Override
+        public boolean storeOnlyMonitoredTables() {
+            return false;
+        }
+
+        @Override
+        public boolean skipUnparseableDdlStatements() {
+            return false;
+        }
     }
 }

--- a/debezium-core/src/main/java/io/debezium/connector/common/CdcSourceTaskContext.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/CdcSourceTaskContext.java
@@ -11,6 +11,7 @@ import java.util.function.Supplier;
 
 import org.apache.kafka.connect.source.SourceTask;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.schema.DataCollectionId;
 import io.debezium.util.Clock;
 import io.debezium.util.LoggingContext;
@@ -48,6 +49,19 @@ public class CdcSourceTaskContext {
      */
     public LoggingContext.PreviousContext configureLoggingContext(String contextName) {
         return LoggingContext.forConnector(connectorType, connectorName, contextName);
+    }
+
+    /**
+     * Run the supplied function in the temporary connector MDC context, and when complete always return the MDC context to its
+     * state before this method was called.
+     *
+     * @param connectorConfig the configuration of the connector; may not be null
+     * @param contextName the name of the context; may not be null
+     * @param operation the function to run in the new MDC context; may not be null
+     * @throws IllegalArgumentException if any of the parameters are null
+     */
+    public void temporaryLoggingContext(CommonConnectorConfig connectorConfig, String contextName, Runnable operation) {
+        LoggingContext.temporarilyForConnector("MySQL", connectorConfig.getLogicalName(), contextName, operation);
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/spi/ChangeEventSourceMetricsFactory.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/spi/ChangeEventSourceMetricsFactory.java
@@ -47,4 +47,8 @@ public interface ChangeEventSourceMetricsFactory {
      */
     <T extends CdcSourceTaskContext> StreamingChangeEventSourceMetrics getStreamingMetrics(T taskContext, ChangeEventQueueMetrics changeEventQueueMetrics,
                                                                                            EventMetadataProvider eventMetadataProvider);
+
+    default boolean connectionMetricHandledByCoordinator() {
+        return true;
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseSchema.java
+++ b/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseSchema.java
@@ -28,7 +28,7 @@ import io.debezium.schema.TopicSelector;
 public abstract class HistorizedRelationalDatabaseSchema extends RelationalDatabaseSchema
         implements HistorizedDatabaseSchema<TableId> {
 
-    private final DatabaseHistory databaseHistory;
+    protected final DatabaseHistory databaseHistory;
     private boolean recoveredTables;
 
     protected HistorizedRelationalDatabaseSchema(HistorizedRelationalDatabaseConnectorConfig config, TopicSelector<TableId> topicSelector,
@@ -92,5 +92,9 @@ public abstract class HistorizedRelationalDatabaseSchema extends RelationalDatab
     @Override
     public boolean tableInformationComplete() {
         return recoveredTables;
+    }
+
+    public boolean storeOnlyMonitoredTables() {
+        return databaseHistory.storeOnlyMonitoredTables();
     }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -14,6 +14,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -379,7 +380,7 @@ public abstract class RelationalSnapshotChangeEventSource extends AbstractSnapsh
             return;
         }
         LOGGER.info("\t For table '{}' using select statement: '{}'", table.id(), selectStatement.get());
-        final Optional<Long> rowCount = rowCountForTable(table.id());
+        final OptionalLong rowCount = rowCountForTable(table.id());
 
         try (Statement statement = readTableStatement(rowCount);
                 ResultSet rs = statement.executeQuery(selectStatement.get())) {
@@ -405,7 +406,7 @@ public abstract class RelationalSnapshotChangeEventSource extends AbstractSnapsh
                     if (logTimer.expired()) {
                         long stop = clock.currentTimeInMillis();
                         if (rowCount.isPresent()) {
-                            LOGGER.info("\t Exported {} of {} records for table '{}' after {}", rows, rowCount.get(),
+                            LOGGER.info("\t Exported {} of {} records for table '{}' after {}", rows, rowCount.getAsLong(),
                                     table.id(), Strings.duration(stop - exportStart));
                         }
                         else {
@@ -439,8 +440,8 @@ public abstract class RelationalSnapshotChangeEventSource extends AbstractSnapsh
     /**
      * If connector is able to provide statistics-based number of records per table.
      */
-    protected Optional<Long> rowCountForTable(TableId tableId) {
-        return Optional.empty();
+    protected OptionalLong rowCountForTable(TableId tableId) {
+        return OptionalLong.empty();
     }
 
     private Timer getTableScanLogTimer() {
@@ -504,7 +505,7 @@ public abstract class RelationalSnapshotChangeEventSource extends AbstractSnapsh
     /**
      * Allow per-connector query creation to override for best database performance depending on the table size.
      */
-    protected Statement readTableStatement(Optional<Long> tableSize) throws SQLException {
+    protected Statement readTableStatement(OptionalLong tableSize) throws SQLException {
         int fetchSize = connectorConfig.getSnapshotFetchSize();
         Statement statement = jdbcConnection.connection().createStatement(); // the default cursor is FORWARD_ONLY
         statement.setFetchSize(fetchSize);

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalTableFilters.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalTableFilters.java
@@ -12,17 +12,31 @@ import java.util.function.Predicate;
 
 import io.debezium.config.Configuration;
 import io.debezium.relational.Selectors.TableIdToStringMapper;
+import io.debezium.relational.Selectors.TableSelectionPredicateBuilder;
 import io.debezium.relational.Tables.TableFilter;
 import io.debezium.schema.DataCollectionFilters;
 
 public class RelationalTableFilters implements DataCollectionFilters {
 
+    // Filter that filters tables based only on datbase/schema/system table filters but not table filters
+    // Represents the list of tables whose schema needs to be captured
+    private final TableFilter eligibleTableFilter;
+    // Filter that filters tables based on table filters
     private final TableFilter tableFilter;
+    private final Predicate<String> databaseFilter;
     private final String excludeColumns;
 
     public RelationalTableFilters(Configuration config, TableFilter systemTablesFilter, TableIdToStringMapper tableIdMapper) {
-        // Define the filter using the include and exclude lists for tables and database names ...
-        Predicate<TableId> predicate = Selectors.tableSelector()
+        // Define the filter that provides the list of tables that could be captured if configured
+        final TableSelectionPredicateBuilder eligibleTables = Selectors.tableSelector()
+                .includeDatabases(
+                        config.getFallbackStringProperty(
+                                RelationalDatabaseConnectorConfig.DATABASE_INCLUDE_LIST,
+                                RelationalDatabaseConnectorConfig.DATABASE_WHITELIST))
+                .excludeDatabases(
+                        config.getFallbackStringProperty(
+                                RelationalDatabaseConnectorConfig.DATABASE_EXCLUDE_LIST,
+                                RelationalDatabaseConnectorConfig.DATABASE_BLACKLIST))
                 .includeSchemas(
                         config.getFallbackStringProperty(
                                 RelationalDatabaseConnectorConfig.SCHEMA_INCLUDE_LIST,
@@ -30,7 +44,17 @@ public class RelationalTableFilters implements DataCollectionFilters {
                 .excludeSchemas(
                         config.getFallbackStringProperty(
                                 RelationalDatabaseConnectorConfig.SCHEMA_EXCLUDE_LIST,
-                                RelationalDatabaseConnectorConfig.SCHEMA_BLACKLIST))
+                                RelationalDatabaseConnectorConfig.SCHEMA_BLACKLIST));
+        final Predicate<TableId> eligibleTablePredicate = eligibleTables.build();
+
+        Predicate<TableId> finalEligibleTablePredicate = config.getBoolean(RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN)
+                ? eligibleTablePredicate.and(systemTablesFilter::isIncluded)
+                : eligibleTablePredicate;
+
+        this.eligibleTableFilter = finalEligibleTablePredicate::test;
+
+        // Define the filter using the include and exclude lists for tables and database names ...
+        Predicate<TableId> tablePredicate = eligibleTables
                 .includeTables(
                         config.getFallbackStringProperty(
                                 RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST,
@@ -43,17 +67,38 @@ public class RelationalTableFilters implements DataCollectionFilters {
                         tableIdMapper)
                 .build();
 
-        Predicate<TableId> finalPredicate = config.getBoolean(RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN)
-                ? predicate.and(systemTablesFilter::isIncluded)
-                : predicate;
+        Predicate<TableId> finalTablePredicate = config.getBoolean(RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN)
+                ? tablePredicate.and(systemTablesFilter::isIncluded)
+                : tablePredicate;
 
-        this.tableFilter = finalPredicate::test;
+        this.tableFilter = finalTablePredicate::test;
+
+        // Define the database filter using the include and exclude lists for database names ...
+        this.databaseFilter = Selectors.databaseSelector()
+                .includeDatabases(
+                        config.getFallbackStringProperty(
+                                RelationalDatabaseConnectorConfig.DATABASE_INCLUDE_LIST,
+                                RelationalDatabaseConnectorConfig.DATABASE_WHITELIST))
+                .excludeDatabases(
+                        config.getFallbackStringProperty(
+                                RelationalDatabaseConnectorConfig.DATABASE_EXCLUDE_LIST,
+                                RelationalDatabaseConnectorConfig.DATABASE_BLACKLIST))
+                .build();
+
         this.excludeColumns = config.getFallbackStringProperty(COLUMN_EXCLUDE_LIST, COLUMN_BLACKLIST);
     }
 
     @Override
     public TableFilter dataCollectionFilter() {
         return tableFilter;
+    }
+
+    public TableFilter eligibleDataCollectionFilter() {
+        return eligibleTableFilter;
+    }
+
+    public Predicate<String> databaseFilter() {
+        return databaseFilter;
     }
 
     public String getExcludeColumns() {

--- a/debezium-core/src/main/java/io/debezium/relational/ddl/DdlChanges.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ddl/DdlChanges.java
@@ -12,7 +12,9 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import io.debezium.annotation.NotThreadSafe;
+import io.debezium.relational.RelationalTableFilters;
 import io.debezium.relational.TableId;
+import io.debezium.relational.Tables.TableFilter;
 
 /**
  * A {@link DdlParserListener} that accumulates changes, allowing them to be consumed in the same order by database.
@@ -129,6 +131,36 @@ public class DdlChanges implements DdlParserListener {
         }
     }
 
+    /**
+     * Consume the events in the same order they were {@link #handle(io.debezium.relational.ddl.DdlParserListener.Event) recorded},
+     * but grouped by database name. Multiple sequential statements that were applied to the same database are grouped together.
+     * @param consumer the consumer
+     */
+    public void getEventsByDatabase(DatabaseEventConsumer consumer) {
+        if (isEmpty()) {
+            return;
+        }
+        if (databaseNames.size() <= 1) {
+            consumer.consume(databaseNames.iterator().next(), events);
+            return;
+        }
+        List<Event> dbEvents = new ArrayList<>();
+        String currentDatabase = null;
+        for (Event event : events) {
+            String dbName = getDatabase(event);
+            if (currentDatabase == null || dbName.equals(currentDatabase)) {
+                currentDatabase = dbName;
+                // Accumulate the statement ...
+                dbEvents.add(event);
+            }
+            else {
+                // Submit the statements ...
+                consumer.consume(currentDatabase, dbEvents);
+                dbEvents = new ArrayList<>();
+            }
+        }
+    }
+
     protected String getDatabase(Event event) {
         switch (event.type()) {
             case CREATE_TABLE:
@@ -188,10 +220,30 @@ public class DdlChanges implements DdlParserListener {
      * <li>events that set a variable and either affects included database or is a system-wide variable</li>
      * <ul>
      */
+    @Deprecated
     public boolean anyMatch(Predicate<String> databaseFilter, Predicate<TableId> tableFilter) {
         return events.stream().anyMatch(event -> (event instanceof DatabaseEvent) && databaseFilter.test(((DatabaseEvent) event).databaseName())
                 || (event instanceof TableEvent) && tableFilter.test(((TableEvent) event).tableId())
                 || (event instanceof SetVariableEvent) && (!((SetVariableEvent) event).databaseName().isPresent()
                         || databaseFilter.test(((SetVariableEvent) event).databaseName().get())));
     }
+
+    /**
+     * @return true if any event stored is one of
+     * <ul>
+     * <li>database-wide events and affects included/excluded database</li>
+     * <li>table related events and the table is included</li>
+     * <li>events that set a variable and either affects included database or is a system-wide variable</li>
+     * <ul>
+     */
+    // TODO javadoc
+    public boolean anyMatch(RelationalTableFilters filters) {
+        Predicate<String> databaseFilter = filters.databaseFilter();
+        TableFilter tableFilter = filters.dataCollectionFilter();
+        return events.stream().anyMatch(event -> (event instanceof DatabaseEvent) && databaseFilter.test(((DatabaseEvent) event).databaseName())
+                || (event instanceof TableEvent) && tableFilter.isIncluded(((TableEvent) event).tableId())
+                || (event instanceof SetVariableEvent) && (!((SetVariableEvent) event).databaseName().isPresent()
+                        || databaseFilter.test(((SetVariableEvent) event).databaseName().get())));
+    }
+
 }

--- a/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
@@ -145,4 +145,8 @@ public interface DatabaseHistory {
      * Called to initialize permanent storage of the history.
      */
     void initializeStorage();
+
+    boolean storeOnlyMonitoredTables();
+
+    boolean skipUnparseableDdlStatements();
 }

--- a/debezium-core/src/main/java/io/debezium/schema/HistorizedDatabaseSchema.java
+++ b/debezium-core/src/main/java/io/debezium/schema/HistorizedDatabaseSchema.java
@@ -5,7 +5,10 @@
  */
 package io.debezium.schema;
 
+import java.util.Collection;
+
 import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.relational.TableId;
 
 /**
  * A database schema that is historized, i.e. it undergoes schema changes and can be recovered from a persistent schema
@@ -18,9 +21,26 @@ import io.debezium.pipeline.spi.OffsetContext;
  */
 public interface HistorizedDatabaseSchema<I extends DataCollectionId> extends DatabaseSchema<I> {
 
+    @FunctionalInterface
+    public static interface SchemaChangeEventConsumer {
+
+        void consume(SchemaChangeEvent event, Collection<TableId> tableIds);
+
+        static SchemaChangeEventConsumer NOOP = (x, y) -> {
+        };
+    }
+
     void applySchemaChange(SchemaChangeEvent schemaChange);
+
+    default void applySchemaChange(SchemaChangeEvent schemaChange, SchemaChangeEventConsumer schemaEventConsumer) {
+        applySchemaChange(schemaChange);
+    }
 
     void recover(OffsetContext offset);
 
     void initializeStorage();
+
+    default boolean storeOnlyMonitoredTables() {
+        return false;
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/schema/SchemaChangeEvent.java
+++ b/debezium-core/src/main/java/io/debezium/schema/SchemaChangeEvent.java
@@ -119,6 +119,12 @@ public class SchemaChangeEvent {
                 + ", type=" + type + "]";
     }
 
+    /**
+     * Type describing the content of the event.
+     * CREATE, ALTER, DROP - corresponds to table operations
+     * DATABASE - an event common to the database, like CREATE/DROP DATABASE or SET...
+     * RAW - the event that contains only raw SQL statement not processed by the parser
+     */
     public static enum SchemaChangeEventType {
         CREATE,
         ALTER,

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -16,6 +16,15 @@ toc::[]
 
 endif::community[]
 
+[WARNING]
+====
+The MySQL connector has been rewritten (link:https://issues.redhat.com/browse/DBZ-1865[DBZ-1865]) to the standard framework starting with *1.5.0.Alpha* release.
+The connector behaviour is almost in parity with the original one.
+The only feature that was dropped (and will be re-introduced later in a different form) is the *experimental* parallel snapshotting (link:https://issues.redhat.com/browse/DBZ-175[DBZ-175]).
+
+If you depend on a missing feature or you hit another difference in behaviour (please log a link:https://issues.redhat.com/browse/DBZ[Jira issue]) then you can use the legacy implementation by setting `internal.implementation=legacy` config option.
+====
+
 MySQL has a binary log (binlog) that records all operations in the order in which they are committed to the database. This includes changes to table schemas as well as changes to the data in tables. MySQL uses the binlog for replication and recovery.
 
 The {prodname} MySQL connector reads the binlog, produces change events for row-level `INSERT`, `UPDATE`, and `DELETE` operations, and emits the change events to Kafka topics. Client applications read those Kafka topics.

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -16,13 +16,14 @@ toc::[]
 
 endif::community[]
 
-[WARNING]
+[NOTE]
 ====
-The MySQL connector has been rewritten (link:https://issues.redhat.com/browse/DBZ-1865[DBZ-1865]) to the standard framework starting with *1.5.0.Alpha* release.
-The connector behaviour is almost in parity with the original one.
-The only feature that was dropped (and will be re-introduced later in a different form) is the *experimental* parallel snapshotting (link:https://issues.redhat.com/browse/DBZ-175[DBZ-175]).
+A new capturing implementation for the Debezium MySQL connector has been created as of the starting with *1.5.0.Alpha* release (link:https://issues.redhat.com/browse/DBZ-1865[DBZ-1865]),
+based on the common connector framework used by all the other Kafka Connect connectors of Debezium. 
+The connector behaviour is almost in parity with previous implementation,
+with the exception of the *experimental* parallel snapshotting feature (link:https://issues.redhat.com/browse/DBZ-175[DBZ-175]), which isn't available with the new implementation yet and which is planned to be re-introduced later in a different form.
 
-If you depend on a missing feature or you hit another difference in behaviour (please log a link:https://issues.redhat.com/browse/DBZ[Jira issue]) then you can use the legacy implementation by setting `internal.implementation=legacy` config option.
+If you encounter any issues with the new MySQL connector implementation, please log a link:https://issues.redhat.com/browse/DBZ[Jira issue]; in this case, you can use the legacy implementation by setting the `internal.implementation=legacy` connector configuration option.
 ====
 
 MySQL has a binary log (binlog) that records all operations in the order in which they are committed to the database. This includes changes to table schemas as well as changes to the data in tables. MySQL uses the binlog for replication and recovery.


### PR DESCRIPTION
The things to be implemented after the first alpha

 - RecordMakers removal so it is fully replaced witch change event emitter instead of indirect calls
 - further separation between `SourceInfo` and `OffsetContext`
 - rewrtte BinlReader and SnapshotReader legacy tests to run with new connector
 - two phase database schema contract to better conform to DDL processing model
 - transaction metadata support
 - provide support for `when_needed` snapshot mode