### PR TITLE
DBZ-3011 Add git repository suffix to repo URLs

### DIFF
--- a/jenkins-jobs/job-dsl/release_deploy_snapshots.groovy
+++ b/jenkins-jobs/job-dsl/release_deploy_snapshots.groovy
@@ -20,7 +20,7 @@ pipelineJob('release-deploy-snapshots') {
         stringParam('DEBEZIUM_BRANCH', 'master', 'A branch from which Debezium is built')
         stringParam(
                 'DEBEZIUM_ADDITIONAL_REPOSITORIES',
-                'incubator#github.com/debezium/debezium-incubator.git#master db2#github.com/debezium/debezium-connector-db2#main vitess#github.com/debezium/debezium-connector-vitess#master cassandra#github.com/debezium/debezium-connector-cassandra#main',
+                'incubator#github.com/debezium/debezium-incubator.git#master db2#github.com/debezium/debezium-connector-db2.git#main vitess#github.com/debezium/debezium-connector-vitess.git#master cassandra#github.com/debezium/debezium-connector-cassandra.git#main',
                 'A space separated list of additional repositories from which Debezium incubating components are built (id#repo#branch)'
         )
     }

--- a/jenkins-jobs/job-dsl/release_upstream.groovy
+++ b/jenkins-jobs/job-dsl/release_upstream.groovy
@@ -17,7 +17,7 @@ pipelineJob('release-debezium-upstream') {
         stringParam('DEBEZIUM_BRANCH', 'master', 'A branch from which Debezium is built')
         stringParam(
                 'DEBEZIUM_ADDITIONAL_REPOSITORIES',
-                'incubator#github.com/debezium/debezium-incubator.git#master db2#github.com/debezium/debezium-connector-db2#main vitess#github.com/debezium/debezium-connector-vitess#master cassandra#github.com/debezium/debezium-connector-cassandra#main',
+                'incubator#github.com/debezium/debezium-incubator.git#master db2#github.com/debezium/debezium-connector-db2.git#main vitess#github.com/debezium/debezium-connector-vitess.git#master cassandra#github.com/debezium/debezium-connector-cassandra.git#main',
                 'A space separated list of additional repositories from which Debezium incubating components are built (id#repo#branch)'
         )
         stringParam('IMAGES_REPOSITORY', 'github.com/debezium/docker-images.git', 'Repository from which Debezium images are built')


### PR DESCRIPTION
I don't know if this is an issue as long as git access is with a proper user agent and github redirects to the correct URL, but it won't hurt anyways?

FYI @jpechane 

closes https://issues.redhat.com/browse/DBZ-3011