### PR TITLE
DBZ-3024 Migrate DebeziumContainer enhancements for DBZ-2950 and DBZ-2952 into main repository

### DIFF
--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/DebeziumContainerTest.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/DebeziumContainerTest.java
@@ -79,7 +79,7 @@ public class DebeziumContainerTest {
                 .atMost(Duration.ofSeconds(30))
                 .untilAsserted(
                         () -> {
-                            String status = executeHttpRequest(debeziumContainer.getConnectorStatusURI("my-connector-1"));
+                            String status = executeHttpRequest(debeziumContainer.getConnectorStatusUri("my-connector-1"));
 
                             assertThat(JsonPath.<String> read(status, "$.name")).isEqualTo("my-connector-1");
                             assertThat(JsonPath.<String> read(status, "$.connector.state")).isEqualTo("RUNNING");


### PR DESCRIPTION
DBZ-2950 and DBZ-3002 need some enhancements to DebeziumContainer. In order to have SNAPSHOT packages in the Sonatype repository and new code in nightly builds of debezium/connect containers I need to have this migrated to the main repo in order to continue with DBZ-2950 (add MySQL connector to UI backend) prior finishing DBZ-3002 (re-add Postgress replication slot validation).

closes https://issues.redhat.com/browse/DBZ-3024