### PR TITLE
DBZ-3074 PgOutputMessageDecoder - Fix unordered keys

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputRelationMetaData.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputRelationMetaData.java
@@ -21,6 +21,7 @@ public class PgOutputRelationMetaData {
     private final String schema;
     private final String name;
     private final List<ColumnMetaData> columns;
+    private final List<String> primaryKeyNames;
 
     /**
      * Construct a pgoutput relation metadata object representing a relational table.
@@ -29,12 +30,14 @@ public class PgOutputRelationMetaData {
      * @param schema the schema the table exists within; should never be null
      * @param name the name of the table; should never be null
      * @param columns list of column metadata instances describing the state of each column
+     * @param primaryKeyNames ordered list of primary key column names
      */
-    PgOutputRelationMetaData(int relationId, String schema, String name, List<ColumnMetaData> columns) {
+    PgOutputRelationMetaData(int relationId, String schema, String name, List<ColumnMetaData> columns, List<String> primaryKeyNames) {
         this.relationId = relationId;
         this.schema = schema;
         this.name = name;
         this.columns = columns;
+        this.primaryKeyNames = primaryKeyNames;
     }
 
     public int getRelationId() {
@@ -51,6 +54,10 @@ public class PgOutputRelationMetaData {
 
     public List<ColumnMetaData> getColumns() {
         return columns;
+    }
+
+    public List<String> getPrimaryKeyNames() {
+        return primaryKeyNames;
     }
 
     public TableId getTableId() {

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -1276,7 +1276,7 @@ public class JdbcConnection implements AutoCloseable {
         return Optional.empty();
     }
 
-    protected List<String> readPrimaryKeyNames(DatabaseMetaData metadata, TableId id) throws SQLException {
+    public List<String> readPrimaryKeyNames(DatabaseMetaData metadata, TableId id) throws SQLException {
         final List<String> pkColumnNames = new ArrayList<>();
         try (ResultSet rs = metadata.getPrimaryKeys(id.catalog(), id.schema(), id.table())) {
             while (rs.next()) {


### PR DESCRIPTION
Fix issue where `PgOutputMessageDecoder` does not define primary key metadata in key-order.

`PgOutputMessageDecoder.getTablePrimaryKeyColumnNamesFromDatabase()` returns a `Set`, leading to unordered
primary keys in the metadata. Switch the logic to call `JdbcConnection.readPrimaryKeyNames()` which
_does_ correctly return an ordered primary key list.