### PR TITLE
DBZ-3075 Close Kafka Database History producer with a timeout of 30s.

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
@@ -455,7 +455,7 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
                     this.producer.flush();
                 }
                 finally {
-                    this.producer.close();
+                    this.producer.close(Duration.ofSeconds(30));
                 }
             }
         }


### PR DESCRIPTION
The KafkaProducer in KafkaDatabaseHistory is not closed with a  timeout This can cause the producer to wait indefinitely and still produce logs after connector/task is deleted.
This change closes producer with a timeout of 30s.