### PR TITLE
DBZ-3097 Remove parenthetical ref to Db2 connector being `Incubating`

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/index.adoc
+++ b/documentation/modules/ROOT/pages/connectors/index.adoc
@@ -1,6 +1,6 @@
 = Connectors
 
-{prodname}'s goal is to build up a library of connectors that capture changes from a variety of DBMSes and produce events with very similar structures, making it far easier for your applications to consume and respond to the events regardless of where the changes originated.
+{prodname}'s goal is to build up a library of connectors that capture changes from a variety of database management systems and produce events with very similar structures, making it far easier for your applications to consume and respond to the events regardless of where the changes originated.
 
 We currently have the following connectors:
 
@@ -9,7 +9,7 @@ We currently have the following connectors:
 * xref:connectors/postgresql.adoc[PostgreSQL]
 * xref:connectors/sqlserver.adoc[SQL Server]
 * xref:connectors/oracle.adoc[Oracle] (Incubating)
-* xref:connectors/db2.adoc[Db2] (Incubating)
+* xref:connectors/db2.adoc[Db2]
 * xref:connectors/cassandra.adoc[Cassandra] (Incubating)
 * xref:connectors/vitess.adoc[Vitess] (Incubating)
 


### PR DESCRIPTION
Jira issue [DBZ-3097](https://issues.redhat.com/browse/DBZ-3097?filter=-2)

This change is a followup to [DBZ-2814 _IBM Db2 Connector promoted to GA_](https://issues.redhat.com/browse/DBZ-2814). It removes the string `(Incubating)` from the Db2 connector item in the list of connectors in the Connectors **Overview** topic (`connectors/index.adoc`).