### PR TITLE
DBZ-3111 Remove dup anchors introduced into props tables in DBZ-2918.

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/cassandra.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cassandra.adoc
@@ -1004,8 +1004,7 @@ refreshing the cached Cassandra table schemas.
 |`false`
 |Whether deletion events should have a subsequent tombstone event (true) or not (false). It's important to note that in Cassandra, two events with the same key may be updating different columns of a given table. So this could potentially result in records being lost during compaction if they have not been consumed by the consumer yet. In other words, do NOT set this to true if you have Kafka compaction turned on.
 
-|[[cassandra-property-field-exclude-list]]
-[[cassandra-property-field-exclude-list]]<<cassandra-property-field-exclude-list, `field.exclude.list`>>
+|[[cassandra-property-field-exclude-list]]<<cassandra-property-field-exclude-list, `field.exclude.list`>>
 |
 |A comma-separated list of fully-qualified names of fields that should be excluded from change event message values. Fully-qualified names for fields are in the form keyspace_name>.<field_name>.<nested_field_name>.
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1027,8 +1027,8 @@ The following table describes how the connector maps each of the Db2 data types 
 .Mappings for Db2 basic data types
 [cols="25%a,20%a,55%a",options="header"]
 |===
-|Db2 data type 
-|Literal type (schema type) 
+|Db2 data type
+|Literal type (schema type)
 |Semantic type (schema name) and Notes
 
 |`BOOLEAN`
@@ -1557,7 +1557,7 @@ apiVersion: {KafkaConnectApiVersion}
 |The connector’s configuration.
 
 |4
-|The database host, which is the address of the Db2 instance. 
+|The database host, which is the address of the Db2 instance.
 
 |5
 |The logical name of the Db2 instance/cluster, which forms a namespace and is used in the names of the Kafka topics to which the connector writes, the names of Kafka Connect schemas, and the namespaces of the corresponding Avro schema when the {link-prefix}:{link-avro-serialization}[Avro Connector] is used.
@@ -1580,7 +1580,7 @@ You can send this configuration with a `POST` command to a running Kafka Connect
 === Adding connector configuration
 
 ifdef::community[]
-To start running a Db2 connector, create a connector configuration and add the configuration to your Kafka Connect cluster. 
+To start running a Db2 connector, create a connector configuration and add the configuration to your Kafka Connect cluster.
 
 .Prerequisites
 
@@ -1602,7 +1602,7 @@ You can use a provided {prodname} container to deploy a {prodname} Db2 connector
 .Prerequisites
 
 * Podman or Docker is installed and you have sufficient rights to create and manage containers.
-* You installed the {prodname} Db2 connector archive. 
+* You installed the {prodname} Db2 connector archive.
 
 .Procedure
 
@@ -1750,18 +1750,15 @@ The following configuration properties are _required_ unless a default value is 
 |
 |A list of host/port pairs that the connector uses to establish an initial connection to the Kafka cluster. This connection is used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. Each pair should point to the same Kafka cluster used by the {prodname} Kafka Connect process.
 
-|[[db2-property-table-include-list]]
-[[db2-property-table-include-list]]<<db2-property-table-include-list, `table.include.list`>>
+|[[db2-property-table-include-list]]<<db2-property-table-include-list, `table.include.list`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you want the connector to capture. Any table not included in the include list does not have its changes captured. Each identifier is of the form _schemaName_._tableName_. By default, the connector captures changes in every non-system table. Do not also set the `table.exclude.list` property.
 
-|[[db2-property-table-exclude-list]]
-[[db2-property-table-exclude-list]]<<db2-property-table-exclude-list, `table.exclude.list`>>
+|[[db2-property-table-exclude-list]]<<db2-property-table-exclude-list, `table.exclude.list`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you do not want the connector to capture. The connector captures changes in each non-system table that is not included in the exclude list. Each identifier is of the form _schemaName_._tableName_. Do not also set the `table.include.list` property.
 
-|[[db2-property-column-exclude-list]]
-[[db2-property-column-exclude-list]]<<db2-property-column-exclude-list, `column.exclude.list`>>
+|[[db2-property-column-exclude-list]]<<db2-property-column-exclude-list, `column.exclude.list`>>
 |_empty string_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to exclude from change event values.
 Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -154,7 +154,7 @@ Try to avoid task reassignment and reconfiguration while the connector is perfor
 === Streaming changes
 
 Once the connector task for a replica set has an offset, it uses the offset to determine the position in the oplog where it should start streaming changes.
-The task will then connect to the replica set's primary node and start streaming changes from that position, processing all of the create, insert, and delete operations and converting them into {prodname} {link-prefix}:{link-mongodb-connector}#mongodb-events[change events]. Each change event includes the position in the oplog where the operation was found, and the connector periodically records this as its most recent offset. The interval at which the offset is recorded is governed by link:https://kafka.apache.org/documentation/#offset.flush.interval.ms[`offset.flush.interval.ms`], which is a Kafka Connect worker configuration property. 
+The task will then connect to the replica set's primary node and start streaming changes from that position, processing all of the create, insert, and delete operations and converting them into {prodname} {link-prefix}:{link-mongodb-connector}#mongodb-events[change events]. Each change event includes the position in the oplog where the operation was found, and the connector periodically records this as its most recent offset. The interval at which the offset is recorded is governed by link:https://kafka.apache.org/documentation/#offset.flush.interval.ms[`offset.flush.interval.ms`], which is a Kafka Connect worker configuration property.
 
 
 When the connector is stopped gracefully, the last offset processed is recorded so that, upon restart, the connector will continue exactly where it left off.
@@ -202,11 +202,11 @@ Partitioning the events by key does mean that all events with the same key alway
 [[mongodb-events]]
 === Data change events
 
-The {prodname} MongoDB connector generates a data change event for each document-level operation that inserts, updates, or deletes data. Each event contains a key and a value. The structure of the key and the value depends on the collection that was changed. 
+The {prodname} MongoDB connector generates a data change event for each document-level operation that inserts, updates, or deletes data. Each event contains a key and a value. The structure of the key and the value depends on the collection that was changed.
 
-{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry. This makes each event self-contained. 
+{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry. This makes each event self-contained.
 
-The following skeleton JSON shows the basic four parts of a change event. However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of these four parts in change events. A `schema` field is in a change event only when you configure the converter to produce it. Likewise, the event key and event payload are in a change event only if you configure a converter to produce it. If you use the JSON converver and you configure it to produce all four basic change event parts, change events have this structure: 
+The following skeleton JSON shows the basic four parts of a change event. However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of these four parts in change events. A `schema` field is in a change event only when you configure the converter to produce it. Likewise, the event key and event payload are in a change event only if you configure a converter to produce it. If you use the JSON converver and you configure it to produce all four basic change event parts, change events have this structure:
 
 [source,json,index=0]
 ----
@@ -217,7 +217,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
  "payload": { // <2>
    ...
  },
- "schema": { // <3> 
+ "schema": { // <3>
    ...
  },
  "payload": { // <4>
@@ -233,15 +233,15 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 
 |1
 |`schema`
-|The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the key for the document that was changed. 
+|The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the key for the document that was changed.
 
 |2
 |`payload`
-|The first `payload` field is part of the event key. It has the structure described by the previous `schema` field and it contains the key for the document that was changed. 
+|The first `payload` field is part of the event key. It has the structure described by the previous `schema` field and it contains the key for the document that was changed.
 
 |3
 |`schema`
-|The second `schema` field is part of the event value. It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion. In other words, the second `schema` describes the structure of the document that was changed. Typically, this schema contains nested schemas. 
+|The second `schema` field is part of the event value. It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion. In other words, the second `schema` describes the structure of the document that was changed. Typically, this schema contains nested schemas.
 
 |4
 |`payload`
@@ -264,7 +264,7 @@ This can lead to unexpected conflicts if the logical server name, a database nam
 A change event's key contains the schema for the changed document's key and the changed document's actual key. For a given collection, both the schema and its corresponding payload contain a single `id` field.
 The value of this field is the document's identifier represented as a string that is derived from link:https://docs.mongodb.com/manual/reference/mongodb-extended-json/[MongoDB extended JSON serialization strict mode].
 
-Consider a connector with a logical name of `fulfillment`, a replica set containing an `inventory` database, and a `customers` collection that contains documents such as the following. 
+Consider a connector with a logical name of `fulfillment`, a replica set containing an `inventory` database, and a `customers` collection that contains documents such as the following.
 
 .Example document
 [source,json,indent=0]
@@ -308,13 +308,13 @@ Every change event that captures a change to the `customers` collection has the 
 
 |1
 |`schema`
-|The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion. 
+|The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion.
 
 |2
 |`fulfillment{zwsp}.inventory{zwsp}.customers{zwsp}.Key`
-a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the key for the document that was changed. Key schema names have the format _connector-name_._database-name_._collection-name_.`Key`. In this example: + 
+a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the key for the document that was changed. Key schema names have the format _connector-name_._database-name_._collection-name_.`Key`. In this example: +
 
-* `fulfillment` is the name of the connector that generated this event. + 
+* `fulfillment` is the name of the connector that generated this event. +
 * `inventory` is the database that contains the collection that was changed. +
 * `customers` is the collection that contains the document that was updated.
 
@@ -323,7 +323,7 @@ a|Name of the schema that defines the structure of the key's payload. This schem
 |Indicates whether the event key must contain a value in its `payload` field. In this example, a value in the key's payload is required. A value in the key's payload field is optional when a document does not have a key.
 
 |4
-|`fields` 
+|`fields`
 |Specifies each field that is expected in the `payload`, including each field's name, type, and whether it is required.
 
 |5
@@ -332,7 +332,7 @@ a|Name of the schema that defines the structure of the key's payload. This schem
 
 |===
 
-This example uses a document with an integer identifier, but any valid MongoDB document identifier works the same way, including a document identifier. For a document identifier, an event key's `payload.id` value is a string that represents the updated document's original `_id` field as a MongoDB extended JSON serialization that uses strict mode. The following table provides examples of how different types of `_id` fields are represented. 
+This example uses a document with an integer identifier, but any valid MongoDB document identifier works the same way, including a document identifier. For a document identifier, an event key's `payload.id` value is a string that represents the updated document's original `_id` field as a MongoDB extended JSON serialization that uses strict mode. The following table provides examples of how different types of `_id` fields are represented.
 
 .Examples of representing document `_id` fields in event key payloads
 [options="header",role="code-wordbreak-col2 code-wordbreak-col3"]
@@ -349,9 +349,9 @@ This example uses a document with an integer identifier, but any valid MongoDB d
 [[mongodb-change-events-value]]
 ==== Change event values
 
-The value in a change event is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. Change events for operations that create, update or delete data all have a value payload with an envelope structure. 
+The value in a change event is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. Change events for operations that create, update or delete data all have a value payload with an envelope structure.
 
-Consider the same sample document that was used to show an example of a change event key: 
+Consider the same sample document that was used to show an example of a change event key:
 
 
 .Example document
@@ -365,7 +365,7 @@ Consider the same sample document that was used to show an example of a change e
   }
 ----
 
-The value portion of a change event for a change to this document is described for each event type: 
+The value portion of a change event for a change to this document is described for each event type:
 
 * <<mongodb-create-events,_create_ events>>
 * <<mongodb-update-events,_update_ events>>
@@ -374,7 +374,7 @@ The value portion of a change event for a change to this document is described f
 [id="mongodb-create-events"]
 ==== _create_ events
 
-The following example shows the value portion of a change event that the connector generates for an operation that creates data in the `customers` collection: 
+The following example shows the value portion of a change event that the connector generates for an operation that creates data in the `customers` collection:
 
 [source,json,options="nowrap",indent=0,subs="+attributes"]
 ----
@@ -392,14 +392,14 @@ The following example shows the value portion of a change event that the connect
         {
           "type": "string",
           "optional": true,
-          "name": "io.debezium.data.Json", 
+          "name": "io.debezium.data.Json",
           "version": 1,
           "field": "patch"
         },
         {
           "type": "string",
           "optional": true,
-          "name": "io.debezium.data.Json", 
+          "name": "io.debezium.data.Json",
           "version": 1,
           "field": "filter"
         },
@@ -504,21 +504,21 @@ The following example shows the value portion of a change event that the connect
 
 |1
 |`schema`
-|The value's schema, which describes the structure of the value's payload. A change event's value schema is the same in every change event that the connector generates for a particular collection. 
+|The value's schema, which describes the structure of the value's payload. A change event's value schema is the same in every change event that the connector generates for a particular collection.
 
 |2
 |`name`
 a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. +
  +
-`io.debezium.data.Json` is the schema for the payload's `after`, `patch`, and `filter` fields. This schema is specific to the `customers` collection. A _create_ event is the only kind of event that contains an `after` field. An _update_ event contains a `filter` field and a `patch` field. A _delete_ event contains a `filter` field, but not an `after` field nor a `patch` field. 
+`io.debezium.data.Json` is the schema for the payload's `after`, `patch`, and `filter` fields. This schema is specific to the `customers` collection. A _create_ event is the only kind of event that contains an `after` field. An _update_ event contains a `filter` field and a `patch` field. A _delete_ event contains a `filter` field, but not an `after` field nor a `patch` field.
 
 |3
 |`name`
-a|`io.debezium.connector.mongo.Source` is the schema for the payload's `source` field. This schema is specific to the MongoDB connector. The connector uses it for all events that it generates. 
+a|`io.debezium.connector.mongo.Source` is the schema for the payload's `source` field. This schema is specific to the MongoDB connector. The connector uses it for all events that it generates.
 
 |4
 |`name`
-a|`dbserver1.inventory.customers.Envelope` is the schema for the overall structure of the payload, where `dbserver1` is the connector name, `inventory` is the database, and `customers` is the collection. This schema is specific to the collection. 
+a|`dbserver1.inventory.customers.Envelope` is the schema for the overall structure of the payload, where `dbserver1` is the connector name, `inventory` is the database, and `customers` is the collection. This schema is specific to the collection.
 
 |5
 |`payload`
@@ -533,7 +533,7 @@ However, by using the {link-prefix}:{link-avro-serialization}[Avro converter], y
 
 |7
 |`source`
-a|Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes: 
+a|Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes:
 
 * {prodname} version.
 * Name of the connector that generated the event.
@@ -545,7 +545,7 @@ a|Mandatory field that describes the source metadata for the event. This field c
 
 |8
 |`op`
-a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a document. Valid values are: 
+a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a document. Valid values are:
 
 * `c` = create
 * `u` = update
@@ -563,13 +563,13 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 [id="mongodb-update-events"]
 ==== _update_ events
 
-The value of a change event for an update in the sample `customers` collection has the same schema as a _create_ event for that collection. Likewise, the event value's payload has the same structure. However, the event value payload contains different values in an _update_ event. An _update_ event does not have an `after` value. Instead, it has these two fields:  
+The value of a change event for an update in the sample `customers` collection has the same schema as a _create_ event for that collection. Likewise, the event value's payload has the same structure. However, the event value payload contains different values in an _update_ event. An _update_ event does not have an `after` value. Instead, it has these two fields:
 
-* `patch` is a string field that contains the JSON representation of the idempotent update operation 
+* `patch` is a string field that contains the JSON representation of the idempotent update operation
 
-* `filter` is a string field that contains the JSON representation of the selection criteria for the update. The `filter` string can include multiple shard key fields for sharded collections. 
+* `filter` is a string field that contains the JSON representation of the selection criteria for the update. The `filter` string can include multiple shard key fields for sharded collections.
 
-Here is an example of a change event value in an event that the connector generates for an update in the `customers` collection: 
+Here is an example of a change event value in an event that the connector generates for an update in the `customers` collection:
 
 [source,json,indent=0,options="nowrap",subs="+attributes"]
 ----
@@ -603,7 +603,7 @@ Here is an example of a change event value in an event that the connector genera
 
 |1
 |`op`
-a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `u` indicates that the operation updated a document. 
+a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `u` indicates that the operation updated a document.
 
 |2
 |`ts_ms`
@@ -615,15 +615,15 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 |`patch`
 |Contains the JSON string representation of the actual MongoDB idempotent change to the document. In this example, the update changed the `first_name` field to a new value. +
  +
-An _update_ event value does not contain an `after` field. 
+An _update_ event value does not contain an `after` field.
 
 |4
 |`filter`
-|Contains the JSON string representation of the MongoDB selection criteria that was used to identify the document to be updated. 
+|Contains the JSON string representation of the MongoDB selection criteria that was used to identify the document to be updated.
 
 |5
 |`source`
-a|Mandatory field that describes the source metadata for the event. This field contains the same information as a _create_ event for the same collection, but the values are different since this event is from a different position in the oplog. The source metadata includes: 
+a|Mandatory field that describes the source metadata for the event. This field contains the same information as a _create_ event for the same collection, but the values are different since this event is from a different position in the oplog. The source metadata includes:
 
 * {prodname} version.
 * Name of the connector that generated the event.
@@ -642,13 +642,13 @@ In a {prodname} change event, MongoDB provides the content of the `patch` field.
 
 [NOTE]
 ====
-In MongoDB's oplog, _update_ events do not contain the _before_ or _after_ states of the changed document. Consequently, it is not possible for a {prodname} connector to provide this information. However, a {prodname} connector provides a document's starting state in _create_ and _read_ events. Downstream consumers of the stream can reconstruct document state by keeping the latest state for each document and comparing the state in a new event with the saved state. {prodname} connector's are not able to keep this state. 
+In MongoDB's oplog, _update_ events do not contain the _before_ or _after_ states of the changed document. Consequently, it is not possible for a {prodname} connector to provide this information. However, a {prodname} connector provides a document's starting state in _create_ and _read_ events. Downstream consumers of the stream can reconstruct document state by keeping the latest state for each document and comparing the state in a new event with the saved state. {prodname} connector's are not able to keep this state.
 ====
 
 [id="mongodb-delete-events"]
 ==== _delete_ events
 
-The value in a _delete_ change event has the same `schema` portion as _create_ and _update_ events for the same collection. The `payload` portion in a _delete_ event contains values that are different from _create_ and _update_ events for the same collection. In particular, a _delete_ event contains neither an `after` value nor a `patch` value. Here is an example of a _delete_ event for a document in the `customers` collection: 
+The value in a _delete_ change event has the same `schema` portion as _create_ and _update_ events for the same collection. The `payload` portion in a _delete_ event contains values that are different from _create_ and _update_ events for the same collection. In particular, a _delete_ event contains neither an `after` value nor a `patch` value. Here is an example of a _delete_ event for a document in the `customers` collection:
 
 [source,json,indent=0,subs="+attributes"]
 ----
@@ -691,11 +691,11 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 
 |3
 |`filter`
-|Contains the JSON string representation of the MongoDB selection criteria that was used to identify the document to be deleted.  
+|Contains the JSON string representation of the MongoDB selection criteria that was used to identify the document to be deleted.
 
 |4
 |`source`
-a|Mandatory field that describes the source metadata for the event. This field contains the same information as a _create_ or _update_ event for the same collection, but the values are different since this event is from a different position in the oplog. The source metadata includes: 
+a|Mandatory field that describes the source metadata for the event. This field contains the same information as a _create_ or _update_ event for the same collection, but the values are different since this event is from a different position in the oplog. The source metadata includes:
 
 * {prodname} version.
 * Name of the connector that generated the event.
@@ -765,7 +765,7 @@ This field provides information about every event in the form of a composite of 
 * `total_order` - the absolute position of the event among all events generated by the transaction
 * `data_collection_order` - the per-data collection position of the event among all events that were emitted by the transaction
 
-Following is an example of what a message looks like: 
+Following is an example of what a message looks like:
 
 [source,json,indent=0,subs="+attributes"]
 ----
@@ -792,7 +792,7 @@ Following is an example of what a message looks like:
 == Deploying the MongoDB connector
 
 ifdef::community[]
-With https://zookeeper.apache.org[Zookeeper], http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect] installed, the remaining tasks to deploy a {prodname} MongoDB connector are to 
+With https://zookeeper.apache.org[Zookeeper], http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect] installed, the remaining tasks to deploy a {prodname} MongoDB connector are to
 download the
 ifeval::['{page-version}' == 'master']
 {link-mongodb-plugin-snapshot}[connector's plug-in archive],
@@ -800,25 +800,25 @@ endif::[]
 ifeval::['{page-version}' != 'master']
 https://repo1.maven.org/maven2/io/debezium/debezium-connector-mongodb/{debezium-version}/debezium-connector-mongodb-{debezium-version}-plugin.tar.gz[connector's plug-in archive],
 endif::[]
-extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to  {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`]. You then need to 
+extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to  {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`]. You then need to
 restart your Kafka Connect process to pick up the new JAR files.
 
 If you are working with immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s Container images] for Zookeeper, Kafka, and Kafka Connect with the MongoDB connector already installed and ready to run. You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and OpenShift].
 
-The {prodname} xref:tutorial.adoc[tutorial] walks you through using these images, and this is a great way to learn about {prodname}. 
+The {prodname} xref:tutorial.adoc[tutorial] walks you through using these images, and this is a great way to learn about {prodname}.
 endif::community[]
 
 ifdef::product[]
-To deploy a {prodname} MongoDB connector, install the {prodname} MongoDB connector archive, configure the connector, and start the connector by adding its configuration to Kafka Connect. 
+To deploy a {prodname} MongoDB connector, install the {prodname} MongoDB connector archive, configure the connector, and start the connector by adding its configuration to Kafka Connect.
 
 To install the MongoDB connector, follow the procedures in {LinkDebeziumInstallOpenShift}[{NameDebeziumInstallOpenShift}]. The main steps are:
 
-. Use link:https://access.redhat.com/products/red-hat-amq#streams[Red Hat AMQ Streams] to set up Apache Kafka and Kafka Connect on OpenShift. AMQ Streams offers operators and images that bring Kafka to OpenShift. 
+. Use link:https://access.redhat.com/products/red-hat-amq#streams[Red Hat AMQ Streams] to set up Apache Kafka and Kafka Connect on OpenShift. AMQ Streams offers operators and images that bring Kafka to OpenShift.
 
 . Download the {prodname} link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions[MongoDB connector].
 
 . Extract the connector files into your Kafka Connect environment.
-. Add the connector plug-in's parent directory to your Kafka Connect `plugin.path`, for example: 
+. Add the connector plug-in's parent directory to your Kafka Connect `plugin.path`, for example:
 +
 [source]
 ----
@@ -884,7 +884,7 @@ apiVersion: {KafkaConnectApiVersion}
     labels: strimzi.io/cluster: my-connect-cluster
   spec:
     class: io.debezium.connector.mongodb.MongoDbConnector // <2>
-    config:  
+    config:
      mongodb.hosts: rs0/192.168.99.100:27017 // <3>
      mongodb.name: fulfillment // <4>
      collection.include.list: inventory[.]* // <5>
@@ -905,33 +905,33 @@ This configuration can be sent via POST to a running Kafka Connect service, whic
 === Adding connector configuration
 
 ifdef::community[]
-To run a {prodname} MongoDB connector, create a connector configuration and add the configuration to your Kafka Connect cluster. 
+To run a {prodname} MongoDB connector, create a connector configuration and add the configuration to your Kafka Connect cluster.
 
 .Prerequisites
 
 * MongoDB is set up to run a {prodname} connector.
 
-* A {prodname} MongoDB connector is installed. 
+* A {prodname} MongoDB connector is installed.
 
 .Procedure
 
 . Create a configuration for the MongoDB connector.
 
-. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster. 
+. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster.
 
 endif::community[]
 
 ifdef::product[]
-You can use a provided {prodname} container to deploy a {prodname} MongoDB connector. In this procedure, you build a custom Kafka Connect container image for {prodname}, configure the {prodname} connector as needed, and then add your connector configuration to your Kafka Connect environment. 
+You can use a provided {prodname} container to deploy a {prodname} MongoDB connector. In this procedure, you build a custom Kafka Connect container image for {prodname}, configure the {prodname} connector as needed, and then add your connector configuration to your Kafka Connect environment.
 
 .Prerequisites
 
 * Podman or Docker is installed and you have sufficient rights to create and manage containers.
-* You installed the {prodname} MongoDB connector archive. 
+* You installed the {prodname} MongoDB connector archive.
 
 .Procedure
 
-. Extract the {prodname} MongoDB connector archive to create a directory structure for the connector plug-in, for example: 
+. Extract the {prodname} MongoDB connector archive to create a directory structure for the connector plug-in, for example:
 +
 [subs="+macros,+attributes"]
 ----
@@ -982,7 +982,7 @@ spec:
 
 . Create a `KafkaConnector` custom resource that defines your {prodname} MongoDB connector instance. See {LinkDebeziumUserGuide}#mongodb-example-configuration[the connector configuration example].
 
-. Apply the connector instance, for example: 
+. Apply the connector instance, for example:
 +
 `oc apply -f inventory-connector.yaml`
 +
@@ -997,19 +997,19 @@ This registers `inventory-connector` and the connector starts to run against the
 oc logs $(oc get pods -o name -l strimzi.io/name=my-connect-cluster-connect)
 ----
 
-.. Review the log output to verify that the initial snapshot has been executed. You should see something like the following lines: 
+.. Review the log output to verify that the initial snapshot has been executed. You should see something like the following lines:
 +
 [source,shell,options="nowrap"]
 ----
 ... INFO Starting snapshot for ...
-... INFO Snapshot is using user 'debezium' ... 
+... INFO Snapshot is using user 'debezium' ...
 ----
 
 endif::product[]
 
 .Results
 
-When the connector starts, it {link-prefix}:{link-mongodb-connector}#mongodb-performing-a-snapshot[performs a consistent snapshot] of the MongoDB databases that the connector is configured for. The connector then starts generating data change events for document-level operations and streaming change event records to Kafka topics. 
+When the connector starts, it {link-prefix}:{link-mongodb-connector}#mongodb-performing-a-snapshot[performs a consistent snapshot] of the MongoDB databases that the connector is configured for. The connector then starts generating data change events for document-level operations and streaming change event records to Kafka topics.
 
 [[mongodb-monitoring]]
 === Monitoring
@@ -1109,26 +1109,22 @@ Only alphanumeric characters and underscores should be used.
 |`false`
 |When SSL is enabled this setting controls whether strict hostname checking is disabled during connection phase. If `true` the connection will not prevent man-in-the-middle attacks.
 
-|[[mongodb-property-database-include-list]]
-[[mongodb-property-database-include-list]]<<mongodb-property-database-include-list, `database.include{zwsp}.list`>>
+|[[mongodb-property-database-include-list]]<<mongodb-property-database-include-list, `database.include{zwsp}.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match database names to be monitored; any database name not included in `database.include.list` is excluded from monitoring. By default all databases are monitored.
 Must not be used with `database.exclude.list`.
 
-|[[mongodb-property-database-exclude-list]]
-[[mongodb-property-database-exclude-list]]<<mongodb-property-database-exclude-list, `database.exclude{zwsp}.list`>>
+|[[mongodb-property-database-exclude-list]]<<mongodb-property-database-exclude-list, `database.exclude{zwsp}.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match database names to be excluded from monitoring; any database name not included in `database.exclude.list` is monitored.
 Must not be used with `database.include.list`.
 
-|[[mongodb-property-collection-include-list]]
-[[mongodb-property-collection-include-list]]<<mongodb-property-collection-include-list, `collection{zwsp}.include.list`>>
+|[[mongodb-property-collection-include-list]]<<mongodb-property-collection-include-list, `collection{zwsp}.include.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified namespaces for MongoDB collections to be monitored; any collection not included in `collection.include.list` is excluded from monitoring. Each identifier is of the form _databaseName_._collectionName_. By default the connector will monitor all collections except those in the `local` and `admin` databases.
 Must not be used with `collection.exclude.list`.
 
-|[[mongodb-property-collection-exclude-list]]
-[[mongodb-property-collection-exclude-list]]<<mongodb-property-collection-exclude-list, `collection{zwsp}.exclude.list`>>
+|[[mongodb-property-collection-exclude-list]]<<mongodb-property-collection-exclude-list, `collection{zwsp}.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified namespaces for MongoDB collections to be excluded from monitoring; any collection not included in `collection.exclude.list` is monitored. Each identifier is of the form _databaseName_._collectionName_.
 Must not be used with `collection.include.list`.
@@ -1141,8 +1137,7 @@ Must not be used with `collection.include.list`.
 | All collections specified in `collection.include.list`
 |An optional, comma-separated list of regular expressions that match names of schemas specified in `collection.include.list` for which you *want* to take the snapshot.
 
-|[[mongodb-property-field-exclude-list]]
-[[mongodb-property-field-exclude-list]]<<mongodb-property-field-exclude-list, `field.exclude{zwsp}.list`>>
+|[[mongodb-property-field-exclude-list]]<<mongodb-property-field-exclude-list, `field.exclude{zwsp}.list`>>
 |_empty string_
 |An optional comma-separated list of the fully-qualified names of fields that should be excluded from change event message values. Fully-qualified names for fields are of the form _databaseName_._collectionName_._fieldName_._nestedFieldName_, where _databaseName_ and _collectionName_ may contain the wildcard (*) which matches any characters.
 
@@ -1272,24 +1267,24 @@ For each collection that you specify, also specify another configuration propert
 
 See {link-prefix}:{link-mongodb-connector}#mongodb-transaction-metadata[Transaction Metadata] for additional details.
 
-|[[mongodb-property-retriable-restart-connector-wait-ms]]<<mongodb-property-retriable-restart-connector-wait-ms, `retriable.restart{zwsp}.connector.wait.ms`>> 
+|[[mongodb-property-retriable-restart-connector-wait-ms]]<<mongodb-property-retriable-restart-connector-wait-ms, `retriable.restart{zwsp}.connector.wait.ms`>>
 |10000 (10 seconds)
 |The number of milliseconds to wait before restarting a connector after a retriable error occurs.
 
-|[[mongodb-property-mongodb-poll-interval-ms]]<<mongodb-property-mongodb-poll-interval-ms, `mongodb.poll{zwsp}.interval.ms`>> 
+|[[mongodb-property-mongodb-poll-interval-ms]]<<mongodb-property-mongodb-poll-interval-ms, `mongodb.poll{zwsp}.interval.ms`>>
 |`30000`
 |The interval in which the connector polls for new, removed, or changed replica sets.
 
-|[[mongodb-property-mongodb-connect-timeout-ms]]<<mongodb-property-mongodb-connect-timeout-ms, `mongodb.connect{zwsp}.timeout.ms`>> 
+|[[mongodb-property-mongodb-connect-timeout-ms]]<<mongodb-property-mongodb-connect-timeout-ms, `mongodb.connect{zwsp}.timeout.ms`>>
 |10000 (10 seconds)
 |The number of milliseconds the driver will wait before a new connection attempt is aborted.
 
-|[[mongodb-property-mongodb-socket-timeout-ms]]<<mongodb-property-mongodb-socket-timeout-ms, `mongodb.socket{zwsp}.timeout.ms`>> 
+|[[mongodb-property-mongodb-socket-timeout-ms]]<<mongodb-property-mongodb-socket-timeout-ms, `mongodb.socket{zwsp}.timeout.ms`>>
 |0
 |The number of milliseconds before a send/receive on the socket can take before a timeout occurs.
 A value of `0` disables this behavior.
 
-|[[mongodb-property-mongodb-server-selection-timeout-ms]]<<mongodb-property-mongodb-server-selection-timeout-ms, `mongodb.server{zwsp}.selection{zwsp}.timeout.ms`>> 
+|[[mongodb-property-mongodb-server-selection-timeout-ms]]<<mongodb-property-mongodb-server-selection-timeout-ms, `mongodb.server{zwsp}.selection{zwsp}.timeout.ms`>>
 |30000 (30 seconds)
 |The number of milliseconds the driver will wait to select a server before it times out and throws an error.
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -19,7 +19,7 @@ endif::community[]
 [NOTE]
 ====
 A new capturing implementation for the Debezium MySQL connector has been created as of the starting with *1.5.0.Alpha* release (link:https://issues.redhat.com/browse/DBZ-1865[DBZ-1865]),
-based on the common connector framework used by all the other Kafka Connect connectors of Debezium. 
+based on the common connector framework used by all the other Kafka Connect connectors of Debezium.
 The connector behaviour is almost in parity with previous implementation,
 with the exception of the *experimental* parallel snapshotting feature (link:https://issues.redhat.com/browse/DBZ-175[DBZ-175]), which isn't available with the new implementation yet and which is planned to be re-introduced later in a different form.
 
@@ -51,7 +51,7 @@ endif::product[]
 [[how-the-mysql-connector-works]]
 == How the connector works
 
-An overview of the MySQL topologies that the connector supports is useful for planning your application. To optimally configure and run a {prodname} MySQL connector, it is helpful to understand how the connector tracks the structure of tables, exposes schema changes, performs snapshots, and determines Kafka topic names. 
+An overview of the MySQL topologies that the connector supports is useful for planning your application. To optimally configure and run a {prodname} MySQL connector, it is helpful to understand how the connector tracks the structure of tables, exposes schema changes, performs snapshots, and determines Kafka topic names.
 
 ifdef::product[]
 Details are in the following topics:
@@ -100,7 +100,7 @@ Because these hosted options do not allow a global read lock, table-level locks 
 [[mysql-schema-history-topic]]
 === Schema history topic
 
-When a database client queries a database, the client uses the database’s current schema. However, the database schema can be changed at any time, which means that the connector must be able to identify what the schema was at the time each insert, update, or delete operation was recorded. Also, a connector cannot just use the current schema because the connector might be processing events that are relatively old and may have been recorded before the tables' schemas were changed. 
+When a database client queries a database, the client uses the database’s current schema. However, the database schema can be changed at any time, which means that the connector must be able to identify what the schema was at the time each insert, update, or delete operation was recorded. Also, a connector cannot just use the current schema because the connector might be processing events that are relatively old and may have been recorded before the tables' schemas were changed.
 
 To handle this, MySQL includes in the binlog not only the row-level changes to the data, but also the DDL statements that are applied to the database. As the connector reads the binlog and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema. The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event. In a separate database history Kafka topic, the connector records all DDL statements along with the position in the binlog where each DDL statement appeared.
 
@@ -120,11 +120,11 @@ See {link-prefix}:{link-mysql-connector}#mysql-topic-names[default names for top
 
 You can configure a {prodname} MySQL connector to produce schema change events that include all DDL statements applied to databases in the MySQL server. The connector emits these events to a Kafka topic named _serverName_ where _serverName_ is the name of the connector as specified by the `database.server.name` connector configuration property.
 
-If you choose to use _schema change events_, ensure that you consume records from the schema change topic. The database history topic is for connector use only. 
+If you choose to use _schema change events_, ensure that you consume records from the schema change topic. The database history topic is for connector use only.
 
 IMPORTANT: A global order for events emitted to the schema change topic is vital. Therefore, you must not partition the database history topic. This means that you must specify a partition count of `1` when creating the database history topic. When relying on auto topic creation, make sure that Kafka’s `num.partitions` configuration option, which specifies the default number of partitions, is set to `1`.
 
-Each record that the connector emits to the schema change topic contains a message key that includes the name of the connected database when the DDL statement was applied, for example: 
+Each record that the connector emits to the schema change topic contains a message key that includes the name of the connected database when the DDL statement was applied, for example:
 
 [source,json,subs="+attributes"]
 ----
@@ -147,7 +147,7 @@ Each record that the connector emits to the schema change topic contains a messa
 }
 ----
 
-The schema change event record value contains a structure that includes the DDL statements, the name of the database to which the statements were applied, and the position in the binlog where the statements appeared, for example: 
+The schema change event record value contains a structure that includes the DDL statements, the name of the database to which the statements were applied, and the position in the binlog where the statements appeared, for example:
 
 [source,json,subs="attributes"]
 ----
@@ -299,7 +299,7 @@ When a {prodname} MySQL connector is first started, it performs an initial _cons
 
 |1
 a| Grabs a global read lock that blocks _writes_ by other database clients. +
- + 
+ +
 The snapshot itself does not prevent other clients from applying DDL that might interfere with the connector's attempt to read the binlog position and table schemas. The connector keeps the global read lock while it reads the binlog position, and releases the lock as described in a later step.
 
 |2
@@ -315,7 +315,7 @@ a|Reads the schema of the databases and tables for which the connector is config
 a|Releases the global read lock. Other database clients can now write to the database.
 
 |6
-a|If applicable, writes the DDL changes to the schema change topic, including all necessary `DROP...` and `CREATE...` DDL statements. 
+a|If applicable, writes the DDL changes to the schema change topic, including all necessary `DROP...` and `CREATE...` DDL statements.
 
 |7
 a|Scans the database tables. For each row, the connector emits `CREATE` events to the relevant table-specific Kafka topics.
@@ -334,7 +334,7 @@ If the connector fails, stops, or is rebalanced while performing the _initial sn
 If the connector stops for long enough, MySQL could purge old binlog files and the connector's position would be lost. If the position is lost, the connector reverts to the _initial snapshot_ for its starting position. For more tips on troubleshooting the {prodname} MySQL connector, see {link-prefix}:{link-mysql-connector}#mysql-when-things-go-wrong[behavior when things go wrong].
 
 Global read locks not allowed::
-Some environments do not allow global read locks. If the {prodname} MySQL connector detects that global read locks are not permitted, the connector uses table-level locks instead and performs a snapshot with this method. This requires the database user for the {prodname} connector to have `LOCK TABLES` privileges. 
+Some environments do not allow global read locks. If the {prodname} MySQL connector detects that global read locks are not permitted, the connector uses table-level locks instead and performs a snapshot with this method. This requires the database user for the {prodname} connector to have `LOCK TABLES` privileges.
 +
 .Workflow for performing an initial snapshot with table-level locks
 [cols="1,9",options="header",subs="+attributes"]
@@ -342,7 +342,7 @@ Some environments do not allow global read locks. If the {prodname} MySQL connec
 |Step |Action
 
 |1
-|Obtains table-level locks. 
+|Obtains table-level locks.
 
 |2
 a|Starts a transaction with link:https://dev.mysql.com/doc/refman/{mysql-version}/en/innodb-consistent-read.html[repeatable read semantics] to ensure that all subsequent reads within the transaction are done against the _consistent snapshot_.
@@ -354,7 +354,7 @@ a|Starts a transaction with link:https://dev.mysql.com/doc/refman/{mysql-version
 a|Reads the current binlog position.
 
 |5
-a|Reads the schema of the databases and tables for which the connector is configured to capture changes. 
+a|Reads the schema of the databases and tables for which the connector is configured to capture changes.
 
 |6
 a|If applicable, writes the DDL changes to the schema change topic, including all necessary `DROP...` and `CREATE...` DDL statements.
@@ -397,11 +397,11 @@ fulfillment.inventory.products
 [[mysql-events]]
 == Data change events
 
-The {prodname} MySQL connector generates a data change event for each row-level `INSERT`, `UPDATE`, and `DELETE` operation. Each event contains a key and a value. The structure of the key and the value depends on the table that was changed. 
+The {prodname} MySQL connector generates a data change event for each row-level `INSERT`, `UPDATE`, and `DELETE` operation. Each event contains a key and a value. The structure of the key and the value depends on the table that was changed.
 
-{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry. This makes each event self-contained. 
+{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry. This makes each event self-contained.
 
-The following skeleton JSON shows the basic four parts of a change event. However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of these four parts in change events. A `schema` field is in a change event only when you configure the converter to produce it. Likewise, the event key and event payload are in a change event only if you configure a converter to produce it. If you use the JSON converver and you configure it to produce all four basic change event parts, change events have this structure: 
+The following skeleton JSON shows the basic four parts of a change event. However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of these four parts in change events. A `schema` field is in a change event only when you configure the converter to produce it. Likewise, the event key and event payload are in a change event only if you configure a converter to produce it. If you use the JSON converver and you configure it to produce all four basic change event parts, change events have this structure:
 
 [source,json,index=0]
 ----
@@ -412,7 +412,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
  "payload": { //<2>
    ...
  },
- "schema": { //<3> 
+ "schema": { //<3>
    ...
  },
  "payload": { //<4>
@@ -434,11 +434,11 @@ It is possible to override the table's primary key by setting the {link-prefix}:
 
 |2
 |`payload`
-|The first `payload` field is part of the event key. It has the structure described by the previous `schema` field and it contains the key for the row that was changed. 
+|The first `payload` field is part of the event key. It has the structure described by the previous `schema` field and it contains the key for the row that was changed.
 
 |3
 |`schema`
-|The second `schema` field is part of the event value. It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion. In other words, the second `schema` describes the structure of the row that was changed. Typically, this schema contains nested schemas. 
+|The second `schema` field is part of the event value. It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion. In other words, the second `schema` describes the structure of the row that was changed. Typically, this schema contains nested schemas.
 
 |4
 |`payload`
@@ -470,7 +470,7 @@ endif::product[]
 
 A change event's key contains the schema for the changed table's key and the changed row's actual key. Both the schema and its corresponding payload contain a field for each column in the changed table's `PRIMARY KEY` (or unique constraint) at the time the connector created the event.
 
-Consider the following `customers` table, which is followed by an example of a change event key for this table. 
+Consider the following `customers` table, which is followed by an example of a change event key for this table.
 
 [source,sql]
 ----
@@ -512,13 +512,13 @@ Every change event that captures a change to the `customers` table has the same 
 
 |1
 |`schema`
-|The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion. 
+|The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion.
 
 |2
 |`mysql-server-1.inventory.customers.Key`
-a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._database-name_._table-name_.`Key`. In this example: + 
+a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._database-name_._table-name_.`Key`. In this example: +
 
-* `mysql-server-1` is the name of the connector that generated this event. + 
+* `mysql-server-1` is the name of the connector that generated this event. +
 * `inventory` is the database that contains the table that was changed. +
 * `customers` is the table that was updated.
 
@@ -527,7 +527,7 @@ a|Name of the schema that defines the structure of the key's payload. This schem
 |Indicates whether the event key must contain a value in its `payload` field. In this example, a value in the key's payload is required. A value in the key's payload field is optional when a table does not have a primary key.
 
 |4
-|`fields` 
+|`fields`
 |Specifies each field that is expected in the `payload`, including each field's name, type, and whether it is required.
 
 |5
@@ -542,9 +542,9 @@ a|Name of the schema that defines the structure of the key's payload. This schem
 [[mysql-change-event-values]]
 === Change event values
 
-The value in a change event is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. Change events for operations that create, update or delete data all have a value payload with an envelope structure. 
+The value in a change event is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. Change events for operations that create, update or delete data all have a value payload with an envelope structure.
 
-Consider the same sample table that was used to show an example of a change event key: 
+Consider the same sample table that was used to show an example of a change event key:
 
 [source,sql]
 ----
@@ -556,7 +556,7 @@ CREATE TABLE customers (
 ) AUTO_INCREMENT=1001;
 ----
 
-The value portion of a change event for a change to this table is described for: 
+The value portion of a change event for a change to this table is described for:
 
 * <<mysql-create-events,_create_ events>>
 * <<mysql-update-events,_update_ events>>
@@ -568,7 +568,7 @@ The value portion of a change event for a change to this table is described for:
 [id="mysql-create-events"]
 === _create_ events
 
-The following example shows the value portion of a change event that the connector generates for an operation that creates data in the `customers` table: 
+The following example shows the value portion of a change event that the connector generates for an operation that creates data in the `customers` table:
 
 [source,json,options="nowrap",subs="+attributes"]
 ----
@@ -629,7 +629,7 @@ The following example shows the value portion of a change event that the connect
           }
         ],
         "optional": true,
-        "name": "mysql-server-1.inventory.customers.Value", 
+        "name": "mysql-server-1.inventory.customers.Value",
         "field": "after"
       },
       {
@@ -762,7 +762,7 @@ The following example shows the value portion of a change event that the connect
 
 |1
 |`schema`
-|The value's schema, which describes the structure of the value's payload. A change event's value schema is the same in every change event that the connector generates for a particular table. 
+|The value's schema, which describes the structure of the value's payload. A change event's value schema is the same in every change event that the connector generates for a particular table.
 
 |2
 |`name`
@@ -774,7 +774,7 @@ Names of schemas for `before` and `after` fields are of the form `_logicalName_.
 
 |3
 |`name`
-|`io.debezium.connector.mysql.Source` is the schema for the payload's `source` field. This schema is specific to the MySQL connector. The connector uses it for all events that it generates. 
+|`io.debezium.connector.mysql.Source` is the schema for the payload's `source` field. This schema is specific to the MySQL connector. The connector uses it for all events that it generates.
 
 |4
 |`name`
@@ -789,7 +789,7 @@ However, by using the {link-prefix}:{link-avro-serialization}[Avro converter], y
 
 |6
 |`op`
-a| Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are: 
+a| Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are:
 
 * `c` = create
 * `u` = update
@@ -804,7 +804,7 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 
 |8
 |`before`
-| An optional field that specifies the state of the row before the event occurred. When the `op` field is `c` for create, as it is in this example, the `before` field is `null` since this change event is for new content. 
+| An optional field that specifies the state of the row before the event occurred. When the `op` field is `c` for create, as it is in this example, the `before` field is `null` since this change event is for new content.
 
 |9
 |`after`
@@ -812,7 +812,7 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 
 |10
 |`source`
-a| Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes: 
+a| Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes:
 
 * {prodname} version
 * Connector name
@@ -833,7 +833,7 @@ If the {link-prefix}:{link-mysql-connector}#enable-query-log-events[`binlog_rows
 [id="mysql-update-events"]
 === _update_ events
 
-The value of a change event for an update in the sample `customers` table has the same schema as a _create_ event for that table. Likewise, the event value's payload has the same structure. However, the event value payload contains different values in an _update_ event. Here is an example of a change event value in an event that the connector generates for an update in the `customers` table: 
+The value of a change event for an update in the sample `customers` table has the same schema as a _create_ event for that table. Likewise, the event value's payload has the same structure. However, the event value payload contains different values in an _update_ event. Here is an example of a change event value in an event that the connector generates for an update in the `customers` table:
 
 [source,json,options="nowrap",subs="+attributes"]
 ----
@@ -886,11 +886,11 @@ The value of a change event for an update in the sample `customers` table has th
 
 |2
 |`after`
-| An optional field that specifies the state of the row after the event occurred. You can compare the `before` and `after` structures to determine what the update to this row was. In the example, the `first_name` value is now `Anne Marie`. 
+| An optional field that specifies the state of the row after the event occurred. You can compare the `before` and `after` structures to determine what the update to this row was. In the example, the `first_name` value is now `Anne Marie`.
 
 |3
 |`source`
-a|Mandatory field that describes the source metadata for the event. The `source` field structure has the same fields as in a _create_ event, but some values are different, for example, the sample _update_ event is from a different position in the binlog. The source metadata includes: 
+a|Mandatory field that describes the source metadata for the event. The `source` field structure has the same fields as in a _create_ event, but some values are different, for example, the sample _update_ event is from a different position in the binlog. The source metadata includes:
 
 * {prodname} version
 * Connector name
@@ -919,7 +919,7 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 
 [NOTE]
 ====
-Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a {link-prefix}:{link-mysql-connector}#mysql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row. Details are in the next section. 
+Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a {link-prefix}:{link-mysql-connector}#mysql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row. Details are in the next section.
 ====
 
 // Type: continue
@@ -927,7 +927,7 @@ Updating the columns for a row's primary/unique key changes the value of the row
 === Primary key updates
 
 An `UPDATE` operation that changes a row's primary key field(s) is known
-as a primary key change. For a primary key change, in place of an `UPDATE` event record, the connector emits a `DELETE` event record for the old key and a `CREATE` event record for the new (updated) key. These events have the usual structure and content, and in addition, each one has a message header related to the primary key change: 
+as a primary key change. For a primary key change, in place of an `UPDATE` event record, the connector emits a `DELETE` event record for the old key and a `CREATE` event record for the new (updated) key. These events have the usual structure and content, and in addition, each one has a message header related to the primary key change:
 
 * The `DELETE` event record has `__debezium.newkey` as a message header. The value of this header is the new primary key for the updated row.
 
@@ -937,7 +937,7 @@ as a primary key change. For a primary key change, in place of an `UPDATE` event
 [id="mysql-delete-events"]
 === _delete_ events
 
-The value in a _delete_ change event has the same `schema` portion as _create_ and _update_ events for the same table. The `payload` portion in a _delete_ event for the sample `customers` table looks like this:  
+The value in a _delete_ change event has the same `schema` portion as _create_ and _update_ events for the same table. The `payload` portion in a _delete_ event for the sample `customers` table looks like this:
 
 [source,json,options="nowrap",subs="+attributes"]
 ----
@@ -988,7 +988,7 @@ The value in a _delete_ change event has the same `schema` portion as _create_ a
 
 |3
 |`source`
-a|Mandatory field that describes the source metadata for the event. In a _delete_ event value, the `source` field structure is the same as for _create_ and _update_ events for the same table. Many `source` field values are also the same. In a _delete_ event value, the `ts_ms` and `pos` field values, as well as other values, might have changed. But the `source` field in a _delete_ event value provides the same metadata: 
+a|Mandatory field that describes the source metadata for the event. In a _delete_ event value, the `source` field structure is the same as for _create_ and _update_ events for the same table. Many `source` field values are also the same. In a _delete_ event value, the `ts_ms` and `pos` field values, as well as other values, might have changed. But the `source` field in a _delete_ event value provides the same metadata:
 
 * {prodname} version
 * Connector name
@@ -1032,7 +1032,7 @@ When a row is deleted, the _delete_ event value still works with log compaction,
 
 The {prodname} MySQL connector represents changes to rows with events that are structured like the table in which the row exists. The event contains a field for each column value. The MySQL data type of that column dictates how {prodname} represents the value in the event.
 
-Columns that store strings are defined in MySQL with a character set and collation. The MySQL connector uses the column's character set when reading the binary representation of the column values in the binlog events. 
+Columns that store strings are defined in MySQL with a character set and collation. The MySQL connector uses the column's character set when reading the binary representation of the column values in the binlog events.
 
 The connector can map MySQL data types to both _literal_ and _semantic_ types.
 
@@ -1189,7 +1189,7 @@ In link:https://www.iso.org/iso-8601-date-and-time-format.html[ISO 8601] format 
 [id="mysql-temporal-types"]
 === Temporal types
 
-Excluding the `TIMESTAMP` data type, MySQL temporal types depend on the value of the `time.precision.mode` connector configuration property. For `TIMESTAMP` columns whose default value is specified as `CURRENT_TIMESTAMP` or `NOW`, the value `1970-01-01 00:00:00` is used as the default value in the Kafka Connect schema. 
+Excluding the `TIMESTAMP` data type, MySQL temporal types depend on the value of the `time.precision.mode` connector configuration property. For `TIMESTAMP` columns whose default value is specified as `CURRENT_TIMESTAMP` or `NOW`, the value `1970-01-01 00:00:00` is used as the default value in the Kafka Connect schema.
 
 MySQL allows zero-values for `DATE`, `DATETIME`, and `TIMESTAMP` columns because zero-values are sometimes preferred over null values. The MySQL connector represents zero-values as null values when the column definition allows null values, or as the epoch day when the column does not allow null values.
 
@@ -1263,7 +1263,7 @@ Represents the number of milliseconds since the epoch, and does not include time
 [id="mysql-decimal-types"]
 === Decimal types
 
-{prodname} connectors handle decimals according to the setting of the {link-prefix}:{link-mysql-connector}#mysql-property-decimal-handling-mode[`decimal.handling.mode` connector configuration property]. 
+{prodname} connectors handle decimals according to the setting of the {link-prefix}:{link-mysql-connector}#mysql-property-decimal-handling-mode[`decimal.handling.mode` connector configuration property].
 
 decimal.handling.mode=precise::
 +
@@ -1370,7 +1370,7 @@ Contains a structure with two fields:
 [[setting-up-mysql]]
 == Set up
 
-Some MySQL setup tasks are required before you can install and run a {prodname} connector. 
+Some MySQL setup tasks are required before you can install and run a {prodname} connector.
 
 ifdef::product[]
 Details are in the following sections:
@@ -1387,7 +1387,7 @@ endif::product[]
 // ModuleID: creating-a-mysql-user-for-a-debezium-connector
 // Title: Creating a MySQL user for a {prodname} connector
 [[mysql-creating-user]]
-=== Creating a user 
+=== Creating a user
 
 A {prodname} MySQL connector requires a MySQL user account. This MySQL user must have appropriate permissions on all databases for which the {prodname} MySQL connector captures changes.
 
@@ -1412,7 +1412,7 @@ mysql> CREATE USER 'user'@'localhost' IDENTIFIED BY 'password';
 mysql> GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'user' IDENTIFIED BY 'password';
 ----
 +
-The table below describes the permissions. 
+The table below describes the permissions.
 +
 IMPORTANT: If using a hosted option such as Amazon RDS or Amazon Aurora that does not allow a global read lock, table-level locks are used to create the _consistent snapshot_. In this case, you need to also grant `LOCK TABLES` permissions to the user that you create. See {link-prefix}:{link-mysql-connector}#mysql-snapshots[snapshots] for more details.
 
@@ -1465,9 +1465,9 @@ The connector always requires this.
 // ModuleID: enabling-the-mysql-binlog-for-debezium
 // Title: Enabling the MySQL binlog for {prodname}
 [[enable-mysql-binlog]]
-=== Enabling the binlog 
+=== Enabling the binlog
 
-You must enable binary logging for MySQL replication. The binary logs record transaction updates for replication tools to propagate changes. 
+You must enable binary logging for MySQL replication. The binary logs record transaction updates for replication tools to propagate changes.
 
 .Prerequisites
 
@@ -1488,14 +1488,14 @@ FROM information_schema.global_variables WHERE variable_name='log_bin';
 +
 [source,properties]
 ----
-server-id         = 223344 
-log_bin           = mysql-bin 
-binlog_format     = ROW 
-binlog_row_image  = FULL 
-expire_logs_days  = 10 
+server-id         = 223344
+log_bin           = mysql-bin
+binlog_format     = ROW
+binlog_row_image  = FULL
+expire_logs_days  = 10
 ----
 
-. Confirm your changes by checking the binlog status once more: 
+. Confirm your changes by checking the binlog status once more:
 +
 [source,SQL]
 ----
@@ -1643,7 +1643,7 @@ a|The number of seconds the server waits for activity on a non-interactive conne
 // ModuleID: enabling-query-log-events-for-debezium-mysql-connectors
 // Title: Enabling query log events for {prodname} MySQL connectors
 [[enable-query-log-events]]
-=== Enabling query log events 
+=== Enabling query log events
 
 You might want to see the original `SQL` statement for each binlog event. Enabling the `binlog_rows_query_log_events` option in the MySQL configuration file allows you to do this.
 
@@ -1675,7 +1675,7 @@ mysql> binlog_rows_query_log_events=ON
 [[mysql-deploying-a-connector]]
 == Deployment
 
-To deploy a {prodname} MySQL connector, install the {prodname} MySQL connector archive, configure the connector, and start the connector by adding its configuration to Kafka Connect. 
+To deploy a {prodname} MySQL connector, install the {prodname} MySQL connector archive, configure the connector, and start the connector by adding its configuration to Kafka Connect.
 
 ifdef::product[]
 Details are in the following topics:
@@ -1763,13 +1763,13 @@ For details, see {link-prefix}:{link-mysql-connector}#mysql-connector-properties
 <8> Logical name of the MySQL server or cluster.
 <9> List of databases hosted by the specified server.
 <10> List of Kafka brokers that the connector uses to write and recover DDL statements to the database history topic.
-<11> Name of the database history topic. This topic is for internal use only and should not be used by consumers. 
-<12> Flag that specifies if the connector should generate events for DDL changes and emit them to the `fulfillment` schema change topic for use by consumers. 
+<11> Name of the database history topic. This topic is for internal use only and should not be used by consumers.
+<12> Flag that specifies if the connector should generate events for DDL changes and emit them to the `fulfillment` schema change topic for use by consumers.
 endif::community[]
 
 ifdef::product[]
 
-Typically, you configure a {prodname} MySQL connector in a `.yaml` file that sets connector configuration properties. Following is an example of the configuration for a MySQL connector that connects to a MySQL server on port 3306 and captures changes to the `inventory` database. 
+Typically, you configure a {prodname} MySQL connector in a `.yaml` file that sets connector configuration properties. Following is an example of the configuration for a MySQL connector that connects to a MySQL server on port 3306 and captures changes to the `inventory` database.
 For details, see {link-prefix}:{link-mysql-connector}#mysql-connector-properties[MySQL connector configuration properties].
 
 [source,yaml,options="nowrap"]
@@ -1838,37 +1838,37 @@ endif::product[]
 // ModuleID: adding-debezium-mysql-connector-configuration-to-kafka-connect
 // Title: Adding {prodname} MySQL connector configuration to Kafka Connect
 [[mysql-adding-configuration]]
-=== Adding connector configuration 
+=== Adding connector configuration
 ifdef::community[]
-To start running a MySQL connector, configure a connector and add the configuration to your Kafka Connect cluster. 
+To start running a MySQL connector, configure a connector and add the configuration to your Kafka Connect cluster.
 
 .Prerequisites
 
-* {link-prefix}:{link-mysql-connector}#setting-up-mysql[MySQL server] is 
+* {link-prefix}:{link-mysql-connector}#setting-up-mysql[MySQL server] is
 set up for a {prodname} connector.
 
-* {prodname} MySQL connector is installed. 
+* {prodname} MySQL connector is installed.
 
 .Procedure
 
 . Create a configuration for the MySQL connector.
 
-. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster. 
+. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster.
 
 endif::community[]
 
 ifdef::product[]
-You can use a provided {prodname} container to deploy a {prodname} MySQL connector. In this procedure, you build a custom Kafka Connect container image for {prodname}, configure the {prodname} connector as needed, and then add your connector configuration to your Kafka Connect environment. 
+You can use a provided {prodname} container to deploy a {prodname} MySQL connector. In this procedure, you build a custom Kafka Connect container image for {prodname}, configure the {prodname} connector as needed, and then add your connector configuration to your Kafka Connect environment.
 
 .Prerequisites
 
 * Podman or Docker is installed.
 * You have sufficient rights to create and manage containers.
-* You downloaded the {prodname} MySQL connector archive. 
+* You downloaded the {prodname} MySQL connector archive.
 
 .Procedure
 
-. Extract the {prodname} MySQL connector archive to create a directory structure for the connector plug-in, for example: 
+. Extract the {prodname} MySQL connector archive to create a directory structure for the connector plug-in, for example:
 +
 [subs="+macros"]
 ----
@@ -1919,7 +1919,7 @@ spec:
 
 . Create a `KafkaConnector` custom resource that defines your {prodname} MySQL connector instance. See {LinkDebeziumUserGuide}#mysql-example-configuration[the connector configuration example].
 
-. Apply the connector instance, for example: 
+. Apply the connector instance, for example:
 +
 `oc apply -f inventory-connector.yaml`
 +
@@ -1934,19 +1934,19 @@ This registers `inventory-connector` and the connector starts to run against the
 oc logs $(oc get pods -o name -l strimzi.io/name=my-connect-cluster-connect)
 ----
 
-.. Review the log output to verify that the initial snapshot has been executed. You should see something like the following lines: 
+.. Review the log output to verify that the initial snapshot has been executed. You should see something like the following lines:
 +
 [source,shell,options="nowrap"]
 ----
 ... INFO Starting snapshot for ...
-... INFO Snapshot is using user 'debezium' ... 
+... INFO Snapshot is using user 'debezium' ...
 ----
 
 endif::product[]
 
 .Results
 
-When the connector starts, it {link-prefix}:{link-mysql-connector}#mysql-snapshots[performs a consistent snapshot] of the MySQL databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics. 
+When the connector starts, it {link-prefix}:{link-mysql-connector}#mysql-snapshots[performs a consistent snapshot] of the MySQL databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
 
 // Type: reference
 // ModuleID: descriptions-of-debezium-mysql-connector-configuration-properties
@@ -2003,7 +2003,7 @@ Only alphanumeric characters and underscores are allowed in this name.
 
 |[[mysql-property-database-server-id]]<<mysql-property-database-server-id, `database.server.id`>>
 |_random_
-|A numeric ID of this database client, which must be unique across all currently-running database processes in the MySQL cluster. This connector joins the MySQL database cluster as another server (with this unique ID) so it can read the binlog. By default, a random number between 5400 and 6400 is generated, though the recommendation is to explicitly set a value.  
+|A numeric ID of this database client, which must be unique across all currently-running database processes in the MySQL cluster. This connector joins the MySQL database cluster as another server (with this unique ID) so it can read the binlog. By default, a random number between 5400 and 6400 is generated, though the recommendation is to explicitly set a value.
 
 |[[mysql-property-database-history-kafka-topic]]<<mysql-property-database-history-kafka-topic, `database.history.kafka{zwsp}.topic`>>
 |
@@ -2013,32 +2013,27 @@ Only alphanumeric characters and underscores are allowed in this name.
 |
 |A list of host/port pairs that the connector uses for establishing an initial connection to the Kafka cluster. This connection is used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. Each pair should point to the same Kafka cluster used by the Kafka Connect process.
 
-|[[mysql-property-database-include-list]]
-[[mysql-property-database-include-list]]<<mysql-property-database-include-list, `database.include.list`>>
+|[[mysql-property-database-include-list]]<<mysql-property-database-include-list, `database.include.list`>>
 |_empty string_
-|An optional, comma-separated list of regular expressions that match the names of the databases for which to capture changes. The connector does not capture changes in any database whose name is not in `database.include.list`. By default, the connector captures changes in all databases. 
+|An optional, comma-separated list of regular expressions that match the names of the databases for which to capture changes. The connector does not capture changes in any database whose name is not in `database.include.list`. By default, the connector captures changes in all databases.
 Do not also set the `database.exclude.list` connector confiuration property.
 
-|[[mysql-property-database-exclude-list]]
-[[mysql-property-database-exclude-list]]<<mysql-property-database-exclude-list, `database.exclude.list`>>
+|[[mysql-property-database-exclude-list]]<<mysql-property-database-exclude-list, `database.exclude.list`>>
 |_empty string_
-|An optional, comma-separated list of regular expressions that match the names of databases for which you do not want to capture changes. The connector captures changes in any database whose name is not in the `database.exclude.list`. 
+|An optional, comma-separated list of regular expressions that match the names of databases for which you do not want to capture changes. The connector captures changes in any database whose name is not in the `database.exclude.list`.
 Do not also set the `database.include.list` connector configuration property.
 
-|[[mysql-property-table-include-list]]
-[[mysql-property-table-include-list]]<<mysql-property-table-include-list, `table.include.list`>>
+|[[mysql-property-table-include-list]]<<mysql-property-table-include-list, `table.include.list`>>
 |_empty string_
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers of tables whose changes you want to capture. The connector does not capture changes in any table not included in `table.include.list`. Each identifier is of the form _databaseName_._tableName_. By default, the connector captures changes in every non-system table in each database whose changes are being captured.
 Do not also specify the `table.exclude.list` connector configuration property.
 
-|[[mysql-property-table-exclude-list]]
-[[mysql-property-table-exclude-list]]<<mysql-property-table-exclude-list, `table.exclude.list`>>
+|[[mysql-property-table-exclude-list]]<<mysql-property-table-exclude-list, `table.exclude.list`>>
 |_empty string_
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you do not want to capture. The connector captures changes in any table not included in `table.exclude.list`. Each identifier is of the form _databaseName_._tableName_.
 Do not also specify the `table.include.list` connector configuration property.
 
-|[[mysql-property-column-exclude-list]]
-[[mysql-property-column-exclude-list]]<<mysql-property-column-exclude-list, `column.exclude.list`>>
+|[[mysql-property-column-exclude-list]]<<mysql-property-column-exclude-list, `column.exclude.list`>>
 |_empty string_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to exclude from change event record values. Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_.
 
@@ -2071,36 +2066,36 @@ Depending on the configured `_hashAlgorithm_`, the selected `_salt_`, and the ac
 
 |[[mysql-property-column-propagate-source-type]]<<mysql-property-column-propagate-source-type, `column.propagate{zwsp}.source.type`>>
 |_n/a_
-a|An optional, comma-separated list of regular expressions that match the fully-qualified names of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change event records. These schema parameters: 
+a|An optional, comma-separated list of regular expressions that match the fully-qualified names of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change event records. These schema parameters:
 
-`pass:[_]pass:[_]{prodname}.source.column.type` 
+`pass:[_]pass:[_]{prodname}.source.column.type`
 
-`pass:[_]pass:[_]{prodname}.source.column.length` 
- 
-`pass:[_]pass:[_]{prodname}.source.column.scale` 
+`pass:[_]pass:[_]{prodname}.source.column.length`
 
-are used to propagate the original type name and length for variable-width types, respectively. This is useful to properly size corresponding columns in sink databases. Fully-qualified names for columns are of one of these forms: 
+`pass:[_]pass:[_]{prodname}.source.column.scale`
 
-_databaseName_._tableName_._columnName_ 
+are used to propagate the original type name and length for variable-width types, respectively. This is useful to properly size corresponding columns in sink databases. Fully-qualified names for columns are of one of these forms:
+
+_databaseName_._tableName_._columnName_
 
 _databaseName_._schemaName_._tableName_._columnName_
 
 |[[mysql-property-datatype-propagate-source-type]]<<mysql-property-datatype-propagate-source-type, `datatype.propagate{zwsp}.source.type`>>
 |_n/a_
-a|An optional, comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change event records. These schema parameters: 
- 
-`pass:[_]pass:[_]debezium.source.column.type`  
+a|An optional, comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change event records. These schema parameters:
+
+`pass:[_]pass:[_]debezium.source.column.type`
 
 `pass:[_]pass:[_]debezium.source.column.length`
 
-`pass:[_]pass:[_]debezium.source.column.scale`  
+`pass:[_]pass:[_]debezium.source.column.scale`
 
-are used to propagate the original type name and length for variable-width types, respectively. This is useful to properly size corresponding columns in sink databases. Fully-qualified data type names are of one of these forms: 
+are used to propagate the original type name and length for variable-width types, respectively. This is useful to properly size corresponding columns in sink databases. Fully-qualified data type names are of one of these forms:
 
-_databaseName_._tableName_._typeName_ 
+_databaseName_._tableName_._typeName_
 
-_databaseName_._schemaName_._tableName_._typeName_ 
- 
+_databaseName_._schemaName_._tableName_._typeName_
+
 See {link-prefix}:{link-mysql-connector}#mysql-data-types[how MySQL connectors map data types] for the list of MySQL-specific data type names.
 
 |[[mysql-property-time-precision-mode]]<<mysql-property-time-precision-mode, `time.precision.mode`>>
@@ -2135,7 +2130,7 @@ endif::community[]
 
 |[[mysql-property-include-schema-changes]]<<mysql-property-include-schema-changes, `include.schema{zwsp}.changes`>>
 |`true`
-|Boolean value that specifies whether the connector should publish changes in the database schema to a Kafka topic with the same name as the database server ID. Each schema change is recorded by using a key that contains the database name and whose value includes the DDL statement(s). This is independent of how the connector internally records database history. 
+|Boolean value that specifies whether the connector should publish changes in the database schema to a Kafka topic with the same name as the database server ID. Each schema change is recorded by using a key that contains the database name and whose value includes the DDL statement(s). This is independent of how the connector internally records database history.
 
 |[[mysql-property-include-query]]<<mysql-property-include-query, `include.query`>>
 |`false`
@@ -2209,7 +2204,7 @@ endif::community[]
  +
 `false` - only a delete event is emitted. +
  +
-After a source record is deleted, emitting a tombstone event (the default behavior) allows Kafka to completely delete all events that pertain to the key of the deleted row. 
+After a source record is deleted, emitting a tombstone event (the default behavior) allows Kafka to completely delete all events that pertain to the key of the deleted row.
 
 |[[mysql-property-message-key-columns]]<<mysql-property-message-key-columns, `message.key.columns`>>
 |_n/a_
@@ -2223,7 +2218,7 @@ For example: +
  +
 `dbA.table_a:regex_1;dbB.table_b:regex_2;dbC.table_c:regex_3` +
  +
-If `table_a` has an `id` column, and `regex_1` is `^i` (matches any column that starts with `i`), the connector maps the value in the `id` column of `table_a` to a key field in change events that the connector sends to Kafka. 
+If `table_a` has an `id` column, and `regex_1` is `^i` (matches any column that starts with `i`), the connector maps the value in the `id` column of `table_a` to a key field in change events that the connector sends to Kafka.
 
 |[[mysql-property-binary-handling-mode]]<<mysql-property-binary-handling-mode,`binary.handling.mode`>>
 |bytes
@@ -2356,7 +2351,7 @@ To skip all table size checks and always stream all results during a snapshot, s
 |`0`
 |Controls how frequently the connector sends heartbeat messages to a Kafka topic. The default behavior is that the connector does not send heartbeat messages. +
  +
-Heartbeat messages are useful for monitoring whether the connector is receiving change events from the database. Heartbeat messages might help decrease the number of change events that need to be re-sent when a connector restarts. To send heartbeat messages, set this property to a positive integer, which indicates the number of milliseconds between heartbeat messages. 
+Heartbeat messages are useful for monitoring whether the connector is receiving change events from the database. Heartbeat messages might help decrease the number of change events that need to be re-sent when a connector restarts. To send heartbeat messages, set this property to a positive integer, which indicates the number of milliseconds between heartbeat messages.
 
 |[[mysql-property-heartbeat-topics-prefix]]<<mysql-property-heartbeat-topics-prefix, `heartbeat.topics{zwsp}.prefix`>>
 |`__debezium-heartbeat`
@@ -2375,7 +2370,7 @@ The connector might establish JDBC connections at its own discretion, so this pr
 
 |[[mysql-property-snapshot-delay-ms]]<<mysql-property-snapshot-delay-ms, `snapshot.delay.ms`>>
 |
-|An interval in milliseconds that the connector should wait before performing a snapshot when the connector starts. If you are starting multiple connectors in a cluster, this property is useful for avoiding snapshot interruptions, which might cause re-balancing of connectors. 
+|An interval in milliseconds that the connector should wait before performing a snapshot when the connector starts. If you are starting multiple connectors in a cluster, this property is useful for avoiding snapshot interruptions, which might cause re-balancing of connectors.
 
 |[[mysql-property-snapshot-fetch-size]]<<mysql-property-snapshot-fetch-size, `snapshot.fetch.size`>>
 |
@@ -2389,7 +2384,7 @@ The connector might establish JDBC connections at its own discretion, so this pr
 |`true`
 |Boolean value that indicates whether the connector converts a 2-digit year specification to 4 digits. Set to `false` when conversion is fully delegated to the database. +
  +
-MySQL allows users to insert year values with either 2-digits or 4-digits. For 2-digit values, the value gets mapped to a year in the range 1970 - 2069. The default behavior is that the connector does the conversion. 
+MySQL allows users to insert year values with either 2-digits or 4-digits. For 2-digit values, the value gets mapped to a year in the range 1970 - 2069. The default behavior is that the connector does the conversion.
 
 ifdef::community[]
 |[[mysql-property-source-struct-version]]<<mysql-property-source-struct-version, `source.struct{zwsp}.version`>>
@@ -2413,8 +2408,8 @@ endif::community[]
 [id="mysql-pass-through-configuration-properties"]
 .Pass-through configuration properties
 
-The MySQL connector also supports pass-through configuration properties that are used when creating the Kafka producer and consumer. 
-Specifically, all connector configuration properties that begin with the `database.history.producer.` prefix are used (without the prefix) when creating the Kafka producer that writes to the database history. 
+The MySQL connector also supports pass-through configuration properties that are used when creating the Kafka producer and consumer.
+Specifically, all connector configuration properties that begin with the `database.history.producer.` prefix are used (without the prefix) when creating the Kafka producer that writes to the database history.
 All properties that begin with the prefix `database.history.consumer.` are used (without the prefix) when creating the Kafka consumer that reads the database history upon connector start-up.
 
 For example, the following connector configuration properties can be used to secure connections to the Kafka broker:
@@ -2466,7 +2461,7 @@ The *MBean* is `debezium.mysql:type=connector-metrics,context=snapshot,server=_<
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
-The {prodname} MySQL connector also provides the `HoldingGlobalLock` custom snapshot metric. This metric is set to a Boolean value that indicates whether the connector currently holds a global or table write lock. 
+The {prodname} MySQL connector also provides the `HoldingGlobalLock` custom snapshot metric. This metric is set to a Boolean value that indicates whether the connector currently holds a global or table write lock.
 
 // Type: reference
 // ModuleID: monitoring-debezium-mysql-connector-binlog-reading
@@ -2541,7 +2536,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-hi
 [[mysql-when-things-go-wrong]]
 == Behavior when things go wrong
 
-{prodname} is a distributed system that captures all changes in multiple upstream databases; it never misses or loses an event. When the system is operating normally or being managed carefully then {prodname} provides _exactly once_ delivery of every change event record. 
+{prodname} is a distributed system that captures all changes in multiple upstream databases; it never misses or loses an event. When the system is operating normally or being managed carefully then {prodname} provides _exactly once_ delivery of every change event record.
 
 If a fault does happen then the system does not lose any events. However, while it is recovering from the fault, it might repeat some change events. In these abnormal situations, {prodname}, like Kafka, provides _at least once_ delivery of change events.
 
@@ -2550,7 +2545,7 @@ The rest of this section describes how {prodname} handles various kinds of fault
 endif::community[]
 
 ifdef::product[]
-Details are in the following sections: 
+Details are in the following sections:
 
 * xref:debezium-mysql-connector-configuration-and-startup-errors[]
 * xref:mysql-becomes-unavailable-while-debezium-is-running[]
@@ -2591,7 +2586,7 @@ When Kafka Connect stops gracefully, there is a short delay while the {prodname}
 
 If Kafka Connect crashes, the process stops and any {prodname} MySQL connector tasks terminate without their most recently-processed offsets being recorded. In distributed mode, Kafka Connect restarts the connector tasks on other processes. However, the MySQL connector resumes from the last offset recorded by the earlier processes. This means that the replacement tasks might generate some of the same events processed prior to the crash, creating duplicate events.
 
-Each change event message includes source-specific information that you can use to identify duplicate events, for example: 
+Each change event message includes source-specific information that you can use to identify duplicate events, for example:
 
 * Event origin
 * MySQL server's event time

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1406,13 +1406,11 @@ This field is required to enable Oracle RAC support.
 |_initial_
 |A mode for taking an initial snapshot of the structure and optionally data of captured tables. Supported values are _initial_ (will take a snapshot of structure and data of captured tables; useful if topics should be populated with a complete representation of the data from the captured tables) and _schema_only_ (will take a snapshot of the structure of captured tables only; useful if only changes happening from now onwards should be propagated to topics). Once the snapshot is complete, the connector will continue reading change events from the database's redo logs.
 
-|[[oracle-property-table-include-list]]
-[[oracle-property-table-include-list]]<<oracle-property-table-include-list, `table.include.list`>>
+|[[oracle-property-table-include-list]]<<oracle-property-table-include-list, `table.include.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be monitored; any table not included in the include list will be excluded from monitoring. Each identifier is of the form _schemaName_._tableName_. By default the connector will monitor every non-system table in each monitored database. May not be used with `table.exclude.list`.
 
-|[[oracle-property-table-exclude-list]]
-[[oracle-property-table-exclude-list]]<<oracle-property-table-exclude-list, `table.exclude.list`>>
+|[[oracle-property-table-exclude-list]]<<oracle-property-table-exclude-list, `table.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be excluded from monitoring; any table not included in the exclude list will be monitored. Each identifier is of the form _schemaName_._tableName_. May not be used with `table.include.list`.
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -14,16 +14,16 @@ ifdef::community[]
 
 toc::[]
 
-{prodname}'s PostgreSQL connector captures row-level changes in the schemas of a PostgreSQL database. PostgreSQL versions 9.6, 10, 11, 12 and 13 are supported. 
+{prodname}'s PostgreSQL connector captures row-level changes in the schemas of a PostgreSQL database. PostgreSQL versions 9.6, 10, 11, 12 and 13 are supported.
 endif::community[]
 ifdef::product[]
-{prodname}'s PostgreSQL connector captures row-level changes in the schemas of a PostgreSQL database. PostgreSQL versions 10, 11, 12 and 13 are supported. 
+{prodname}'s PostgreSQL connector captures row-level changes in the schemas of a PostgreSQL database. PostgreSQL versions 10, 11, 12 and 13 are supported.
 endif::product[]
 
-The first time it connects to a PostgreSQL server or cluster, the connector takes a consistent snapshot of all schemas. After that snapshot is complete, the connector continuously captures row-level changes that insert, update, and delete database content and that were committed to a PostgreSQL database. The connector generates data change event records and streams them to Kafka topics. For each table, the default behavior is that the connector streams all generated events to a separate Kafka topic for that table. Applications and services consume data change event records from that topic. 
+The first time it connects to a PostgreSQL server or cluster, the connector takes a consistent snapshot of all schemas. After that snapshot is complete, the connector continuously captures row-level changes that insert, update, and delete database content and that were committed to a PostgreSQL database. The connector generates data change event records and streams them to Kafka topics. For each table, the default behavior is that the connector streams all generated events to a separate Kafka topic for that table. Applications and services consume data change event records from that topic.
 
 ifdef::product[]
-Information and procedures for using a {prodname} PostgreSQL connector is organized as follows: 
+Information and procedures for using a {prodname} PostgreSQL connector is organized as follows:
 
 * xref:overview-of-debezium-postgresql-connector[]
 * xref:how-debezium-postgresql-connectors-work[]
@@ -37,18 +37,18 @@ Information and procedures for using a {prodname} PostgreSQL connector is organi
 endif::product[]
 
 // Type: concept
-// Title: Overview of {prodname} PostgreSQL connector 
+// Title: Overview of {prodname} PostgreSQL connector
 // ModuleID: overview-of-debezium-postgresql-connector
 [[postgresql-overview]]
 == Overview
 
-PostgreSQL's link:https://www.postgresql.org/docs/current/static/logicaldecoding-explanation.html[_logical decoding_] feature was introduced in version 9.4. It is a mechanism that allows the extraction of the changes that were committed to the transaction log and the processing of these changes in a user-friendly manner with the help of an link:https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[_output plug-in_]. The output plug-in enables clients to consume the changes. 
+PostgreSQL's link:https://www.postgresql.org/docs/current/static/logicaldecoding-explanation.html[_logical decoding_] feature was introduced in version 9.4. It is a mechanism that allows the extraction of the changes that were committed to the transaction log and the processing of these changes in a user-friendly manner with the help of an link:https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[_output plug-in_]. The output plug-in enables clients to consume the changes.
 
 The PostgreSQL connector contains two main parts that work together to read and process database changes:
 
 [[postgresql-output-plugin]]
 ifdef::community[]
-* A logical decoding output plug-in. You might need to install the output plug-in that you choose to use. You must configure a replication slot that uses your chosen output plug-in before running the PostgreSQL server. The plug-in can be one of the following: 
+* A logical decoding output plug-in. You might need to install the output plug-in that you choose to use. You must configure a replication slot that uses your chosen output plug-in before running the PostgreSQL server. The plug-in can be one of the following:
 ** link:https://github.com/debezium/postgres-decoderbufs[`decoderbufs`] is based on Protobuf and maintained by the {prodname} community.
 ** link:https://github.com/eulerto/wal2json[`wal2json`] is based on JSON and maintained by the wal2json community.
 ** `pgoutput` is the standard logical decoding output plug-in in PostgreSQL 10+. It is maintained by the PostgreSQL community, and used by PostgreSQL itself for link:https://www.postgresql.org/docs/current/logical-replication-architecture.html[logical replication]. This plug-in is always present so no additional libraries need to be installed. The {prodname} connector interprets the raw replication event stream directly into change events.
@@ -66,7 +66,7 @@ The connector produces a _change event_ for every row-level insert, update, and 
 
 PostgreSQL normally purges write-ahead log (WAL) segments after some period of time. This means that the connector does not have the complete history of all changes that have been made to the database. Therefore, when the PostgreSQL connector first connects to a particular PostgreSQL database, it starts by performing a _consistent snapshot_ of each of the database schemas. After the connector completes the snapshot, it continues streaming changes from the exact point at which the snapshot was made. This way, the connector starts with a consistent view of all of the data, and does not omit any changes that were made while the snapshot was being taken.
 
-The connector is tolerant of failures. As the connector reads changes and produces events, it records the WAL position for each event. If the connector stops for any reason (including communication failures, network problems, or crashes), upon restart the connector continues reading the WAL where it last left off. This includes snapshots. If the connector stops during a snapshot, the connector begins a new snapshot when it restarts. 
+The connector is tolerant of failures. As the connector reads changes and produces events, it records the WAL position for each event. If the connector stops for any reason (including communication failures, network problems, or crashes), upon restart the connector continues reading the WAL where it last left off. This includes snapshots. If the connector stops during a snapshot, the connector begins a new snapshot when it restarts.
 
 [[postgresql-limitations]]
 [IMPORTANT]
@@ -74,9 +74,9 @@ The connector is tolerant of failures. As the connector reads changes and produc
 The connector relies on and reflects the PostgreSQL logical decoding feature, which has the following limitations:
 
 * Logical decoding does not support DDL changes. This means that the connector is unable to report DDL change events back to consumers.
-* Logical decoding replication slots are supported on only `primary` servers. When there is a cluster of PostgreSQL servers, the connector can run on only the active `primary` server. It cannot run on `hot` or `warm` standby replicas. If the `primary` server fails or is demoted, the connector stops. After the `primary` server has recovered, you can restart the connector. If a different PostgreSQL server has been promoted to `primary`, adjust the connector configuration before restarting the connector. 
+* Logical decoding replication slots are supported on only `primary` servers. When there is a cluster of PostgreSQL servers, the connector can run on only the active `primary` server. It cannot run on `hot` or `warm` standby replicas. If the `primary` server fails or is demoted, the connector stops. After the `primary` server has recovered, you can restart the connector. If a different PostgreSQL server has been promoted to `primary`, adjust the connector configuration before restarting the connector.
 
-{link-prefix}:{link-postgresql-connector}#postgresql-when-things-go-wrong[ Behavior when things go wrong] describes what the connector does when there is a problem. 
+{link-prefix}:{link-postgresql-connector}#postgresql-when-things-go-wrong[ Behavior when things go wrong] describes what the connector does when there is a problem.
 ====
 
 [IMPORTANT]
@@ -91,10 +91,10 @@ With a single byte character encoding, it is not possible to correctly process s
 [[how-the-postgresql-connector-works]]
 == How the connector works
 
-To optimally configure and run a {prodname} PostgreSQL connector, it is helpful to understand how the connector performs snapshots, streams change events, determines Kafka topic names, and uses metadata. 
+To optimally configure and run a {prodname} PostgreSQL connector, it is helpful to understand how the connector performs snapshots, streams change events, determines Kafka topic names, and uses metadata.
 
 ifdef::product[]
-Details are in the following topics: 
+Details are in the following topics:
 
 * xref:how-debezium-postgresql-connectors-perform-database-snapshots[]
 * xref:how-debezium-postgresql-connectors-stream-change-event-records[]
@@ -118,10 +118,10 @@ See the link:https://www.postgresql.org/docs/current/logical-replication-securit
 [[postgresql-snapshots]]
 === Snapshots
 
-Most PostgreSQL servers are configured to not retain the complete history of the database in the WAL segments. This means that the PostgreSQL connector would be unable to see the entire history of the database by reading only the WAL. Consequently, the first time that the connector starts, it performs an initial _consistent snapshot_ of the database. The default behavior for performing a snapshot consists of the following steps. You can change this behavior by setting the {link-prefix}:{link-postgresql-connector}#postgresql-property-snapshot-mode[`snapshot.mode` connector configuration property] to a value other than `initial`. 
+Most PostgreSQL servers are configured to not retain the complete history of the database in the WAL segments. This means that the PostgreSQL connector would be unable to see the entire history of the database by reading only the WAL. Consequently, the first time that the connector starts, it performs an initial _consistent snapshot_ of the database. The default behavior for performing a snapshot consists of the following steps. You can change this behavior by setting the {link-prefix}:{link-postgresql-connector}#postgresql-property-snapshot-mode[`snapshot.mode` connector configuration property] to a value other than `initial`.
 
 . Start a transaction with a link:https://www.postgresql.org/docs/current/static/sql-set-transaction.html[SERIALIZABLE, READ ONLY, DEFERRABLE] isolation level to ensure that subsequent reads in this transaction are against a single consistent version of the data. Any changes to the data due to subsequent `INSERT`, `UPDATE`, and `DELETE` operations by other clients are not visible to this transaction.
-. Obtain an `ACCESS SHARE MODE` lock on each of the tables being tracked to ensure that no structural changes can occur to any of the tables while the snapshot is taking place. These locks do not prevent table `INSERT`, `UPDATE` and `DELETE` operations from taking place during the snapshot. 
+. Obtain an `ACCESS SHARE MODE` lock on each of the tables being tracked to ensure that no structural changes can occur to any of the tables while the snapshot is taking place. These locks do not prevent table `INSERT`, `UPDATE` and `DELETE` operations from taking place during the snapshot.
 +
 _This step is omitted when `snapshot.mode` is set to `exported`, which allows the connector to perform a lock-free snapshot_.
 . Read the current position in the server's transaction log.
@@ -145,8 +145,8 @@ This is a known issue and the affected snapshot modes will be reworked to use `e
 |Description
 
 |`always`
-|The connector always performs a snapshot when it starts. After the snapshot completes, the connector continues streaming changes from step 3 in the above sequence. This mode is useful in these situations: + 
- 
+|The connector always performs a snapshot when it starts. After the snapshot completes, the connector continues streaming changes from step 3 in the above sequence. This mode is useful in these situations: +
+
 * It is known that some WAL segments have been deleted and are no longer available. +
 * After a cluster failure, a new primary has been promoted. The `always` snapshot mode ensures that the connector does not miss any changes that were made after the new primary had been promoted but before the connector was restarted on the new primary.
 
@@ -170,7 +170,7 @@ ifdef::community[]
 [[postgresql-custom-snapshot]]
 === Custom snapshotter SPI
 
-For more advanced uses, you can provide an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. This interface allows control of most of the aspects of how the connector performs snapshots. This includes whether or not to take a snapshot, the options for opening the snapshot transaction, and whether to take locks. 
+For more advanced uses, you can provide an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. This interface allows control of most of the aspects of how the connector performs snapshots. This includes whether or not to take a snapshot, the options for opening the snapshot transaction, and whether to take locks.
 
 Following is the full API for the interface. All built-in snapshot modes implement this interface.
 
@@ -284,15 +284,15 @@ The PostgreSQL connector typically spends the vast majority of its time streamin
 
 Whenever the server commits a transaction, a separate server process invokes a callback function from the {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in]. This function processes the changes from the transaction, converts them to a specific format (Protobuf or JSON in the case of {prodname} plug-in) and writes them on an output stream, which can then be consumed by clients.
 
-The {prodname} PostgreSQL connector acts as a PostgreSQL client. When the connector receives changes it transforms the events into {prodname} _create_, _update_, or _delete_ events that include the LSN of the event. The PostgreSQL connector forwards these change events in records to the Kafka Connect framework, which is running in the same process. The Kafka Connect process asynchronously writes the change event records in the same order in which they were generated to the appropriate Kafka topic. 
+The {prodname} PostgreSQL connector acts as a PostgreSQL client. When the connector receives changes it transforms the events into {prodname} _create_, _update_, or _delete_ events that include the LSN of the event. The PostgreSQL connector forwards these change events in records to the Kafka Connect framework, which is running in the same process. The Kafka Connect process asynchronously writes the change event records in the same order in which they were generated to the appropriate Kafka topic.
 
 Periodically, Kafka Connect records the most recent _offset_ in another Kafka topic. The offset indicates source-specific position information that {prodname} includes with each event. For the PostgreSQL connector, the LSN recorded in each change event is the offset.
 
-When Kafka Connect gracefully shuts down, it stops the connectors, flushes all event records to Kafka, and records the last offset received from each connector. When Kafka Connect restarts, it reads the last recorded offset for each connector, and starts each connector at its last recorded offset. When the connector restarts, it sends a request to the PostgreSQL server to send the events starting just after that position. 
+When Kafka Connect gracefully shuts down, it stops the connectors, flushes all event records to Kafka, and records the last offset received from each connector. When Kafka Connect restarts, it reads the last recorded offset for each connector, and starts each connector at its last recorded offset. When the connector restarts, it sends a request to the PostgreSQL server to send the events starting just after that position.
 
 [NOTE]
 ====
-The PostgreSQL connector retrieves schema information as part of the events sent by the logical decoding plug-in. However, the connector does not retrieve information about which columns compose the primary key. The connector obtains this information from the JDBC metadata (side channel). If the primary key definition of a table changes (by adding, removing or renaming primary key columns), there is a tiny period of time when the primary key information from JDBC is not synchronized with the change event that the logical decoding plug-in generates. During this tiny period, a message could be created with an inconsistent key structure. To prevent this inconsistency, update primary key structures as follows: 
+The PostgreSQL connector retrieves schema information as part of the events sent by the logical decoding plug-in. However, the connector does not retrieve information about which columns compose the primary key. The connector obtains this information from the JDBC metadata (side channel). If the primary key definition of a table changes (by adding, removing or renaming primary key columns), there is a tiny period of time when the primary key information from JDBC is not synchronized with the change event that the logical decoding plug-in generates. During this tiny period, a message could be created with an inconsistent key structure. To prevent this inconsistency, update primary key structures as follows:
 
 . Put the database or an application into a read-only mode.
 . Let {prodname} process all remaining events.
@@ -317,7 +317,7 @@ See {link-prefix}:{link-postgresql-connector}#setting-up-postgresql[Setting up P
 [[postgresql-topic-names]]
 === Topics names
 
-The PostgreSQL connector writes events for all insert, update, and delete operations on a single table to a single Kafka topic. By default, the Kafka topic name is _serverName_._schemaName_._tableName_ where: 
+The PostgreSQL connector writes events for all insert, update, and delete operations on a single table to a single Kafka topic. By default, the Kafka topic name is _serverName_._schemaName_._tableName_ where:
 
 * _serverName_ is the logical name of the connector as specified with the `database.server.name` connector configuration property.
 * _schemaName_ is the name of the database schema where the operation occurred.
@@ -343,7 +343,7 @@ Now suppose that the tables are not part of a specific schema but were created i
 [[postgresql-meta-information]]
 === Meta information
 
-In addition to a {link-prefix}:{link-postgresql-connector}#postgresql-events[_database change event_], each record produced by a PostgreSQL connector contains some metadata. Metadata includes where the event occurred on the server, the name of the source partition and the name of the Kafka topic and partition where the event should go, for example: 
+In addition to a {link-prefix}:{link-postgresql-connector}#postgresql-events[_database change event_], each record produced by a PostgreSQL connector contains some metadata. Metadata includes where the event occurred on the server, the name of the source partition and the name of the Kafka topic and partition where the event should go, for example:
 
 [source,json,indent=0]
 ----
@@ -358,14 +358,14 @@ In addition to a {link-prefix}:{link-postgresql-connector}#postgresql-events[_da
     "kafkaPartition": null
 ----
 
-* `sourcePartition` always defaults to the setting of the `database.server.name` connector configuration property. 
+* `sourcePartition` always defaults to the setting of the `database.server.name` connector configuration property.
 
 * `sourceOffset` contains information about the location of the server where the event occurred:
 
 ** `lsn` represents the PostgreSQL https://www.postgresql.org/docs/current/static/datatype-pg-lsn.html[Log Sequence Number] or `offset` in the transaction log.
 ** `txId` represents the identifier of the server transaction that caused the event.
-** `ts_ms` represents the server time at which the transaction was committed in the form of the number of milliseconds since the epoch. 
-* `kafkaPartition` with a setting of `null` means that the connector does not use a specific Kafka partition. The PostgreSQL connector uses only one Kafka Connect partition and it places the generated events into one Kafka partition. 
+** `ts_ms` represents the server time at which the transaction was committed in the form of the number of milliseconds since the epoch.
+* `kafkaPartition` with a setting of `null` means that the connector does not use a specific Kafka partition. The PostgreSQL connector uses only one Kafka Connect partition and it places the generated events into one Kafka partition.
 
 // Type: concept
 // ModuleID: debezium-postgresql-connector-generated-events-that-represent-transaction-boundaries
@@ -373,7 +373,7 @@ In addition to a {link-prefix}:{link-postgresql-connector}#postgresql-events[_da
 [[postgresql-transaction-metadata]]
 === Transaction metadata
 
-{prodname} can generate events that represent transaction boundaries and that enrich data change event messages. For every transaction `BEGIN` and `END`, {prodname} generates an event that contains the following fields: 
+{prodname} can generate events that represent transaction boundaries and that enrich data change event messages. For every transaction `BEGIN` and `END`, {prodname} generates an event that contains the following fields:
 
 * `status` - `BEGIN` or `END`
 * `id` - string representation of unique transaction identifier
@@ -448,11 +448,11 @@ Following is an example of a message:
 [[postgresql-events]]
 == Data change events
 
-The {prodname} PostgreSQL connector generates a data change event for each row-level `INSERT`, `UPDATE`, and `DELETE` operation. Each event contains a key and a value. The structure of the key and the value depends on the table that was changed. 
+The {prodname} PostgreSQL connector generates a data change event for each row-level `INSERT`, `UPDATE`, and `DELETE` operation. Each event contains a key and a value. The structure of the key and the value depends on the table that was changed.
 
-{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry. This makes each event self-contained. 
+{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry. This makes each event self-contained.
 
-The following skeleton JSON shows the basic four parts of a change event. However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of these four parts in change events. A `schema` field is in a change event only when you configure the converter to produce it. Likewise, the event key and event payload are in a change event only if you configure a converter to produce it. If you use the JSON converter and you configure it to produce all four basic change event parts, change events have this structure: 
+The following skeleton JSON shows the basic four parts of a change event. However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of these four parts in change events. A `schema` field is in a change event only when you configure the converter to produce it. Likewise, the event key and event payload are in a change event only if you configure a converter to produce it. If you use the JSON converter and you configure it to produce all four basic change event parts, change events have this structure:
 
 [source,json,index=0]
 ----
@@ -463,7 +463,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
  "payload": { // <2>
    ...
  },
- "schema": { // <3> 
+ "schema": { // <3>
    ...
  },
  "payload": { // <4>
@@ -485,11 +485,11 @@ It is possible to override the table's primary key by setting the {link-prefix}:
 
 |2
 |`payload`
-|The first `payload` field is part of the event key. It has the structure described by the previous `schema` field and it contains the key for the row that was changed. 
+|The first `payload` field is part of the event key. It has the structure described by the previous `schema` field and it contains the key for the row that was changed.
 
 |3
 |`schema`
-|The second `schema` field is part of the event value. It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion. In other words, the second `schema` describes the structure of the row that was changed. Typically, this schema contains nested schemas. 
+|The second `schema` field is part of the event value. It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion. In other words, the second `schema` describes the structure of the row that was changed. Typically, this schema contains nested schemas.
 
 |4
 |`payload`
@@ -526,7 +526,7 @@ endif::product[]
 [[postgresql-change-events-key]]
 === Change event keys
 
-For a given table, the change event's key has a structure that contains a field for each column in the primary key of the table at the time the event was created. Alternatively, if the table has `REPLICA IDENTITY` set to `FULL` or `USING INDEX` there is a field for each unique key constraint. 
+For a given table, the change event's key has a structure that contains a field for each column in the primary key of the table at the time the event was created. Alternatively, if the table has `REPLICA IDENTITY` set to `FULL` or `USING INDEX` there is a field for each unique key constraint.
 
 Consider a `customers` table defined in the `public` database schema and the example of a change event key for that table.
 
@@ -576,13 +576,13 @@ If the `database.server.name` connector configuration property has the value `Po
 
 |1
 |`schema`
-|The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion. 
+|The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion.
 
 |2
 |`PostgreSQL_server{zwsp}.inventory.customers{zwsp}.Key`
-a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._database-name_._table-name_.`Key`. In this example: + 
+a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._database-name_._table-name_.`Key`. In this example: +
 
-* `PostgreSQL_server` is the name of the connector that generated this event. + 
+* `PostgreSQL_server` is the name of the connector that generated this event. +
 * `inventory` is the database that contains the table that was changed. +
 * `customers` is the table that was updated.
 
@@ -591,7 +591,7 @@ a|Name of the schema that defines the structure of the key's payload. This schem
 |Indicates whether the event key must contain a value in its `payload` field. In this example, a value in the key's payload is required. A value in the key's payload field is optional when a table does not have a primary key.
 
 |4
-|`fields` 
+|`fields`
 |Specifies each field that is expected in the `payload`, including each field's name, index, and schema.
 
 |5
@@ -616,9 +616,9 @@ If the table does not have a primary or unique key, then the change event's key 
 [[postgresql-change-events-value]]
 === Change event values
 
-The value in a change event is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. Change events for operations that create, update or delete data all have a value payload with an envelope structure. 
+The value in a change event is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. Change events for operations that create, update or delete data all have a value payload with an envelope structure.
 
-Consider the same sample table that was used to show an example of a change event key: 
+Consider the same sample table that was used to show an example of a change event key:
 
 [source,sql,indent=0]
 ----
@@ -631,10 +631,10 @@ CREATE TABLE customers (
 );
 ----
 
-The value portion of a change event for a change to this table varies according to the `REPLICA IDENTITY` setting and the operation that the event is for. 
+The value portion of a change event for a change to this table varies according to the `REPLICA IDENTITY` setting and the operation that the event is for.
 
 ifdef::product[]
-Details follow in these sections: 
+Details follow in these sections:
 
 * <<postgresql-replica-identity, Replica identity>>
 * <<postgresql-create-events,_create_ events>>
@@ -654,7 +654,7 @@ There are 4 possible values for `REPLICA IDENTITY`:
 
 * `DEFAULT` - The default behavior is that `UPDATE` and `DELETE` events contain the previous values for the primary key columns of a table if that table has a primary key. For an `UPDATE` event, only the primary key columns with changed values are present.
 +
-If a table does not have a primary key, the connector does not emit `UPDATE` or `DELETE` events for that table. For a table without a primary key, the connector emits only _create_ events. Typically, a table without a primary key is used for appending messages to the end of the table, which means that `UPDATE` and `DELETE` events are not useful. 
+If a table does not have a primary key, the connector does not emit `UPDATE` or `DELETE` events for that table. For a table without a primary key, the connector emits only _create_ events. Typically, a table without a primary key is used for appending messages to the end of the table, which means that `UPDATE` and `DELETE` events are not useful.
 * `NOTHING` - Emitted events for `UPDATE` and `DELETE` operations do not contain any information about the previous value of any table column.
 * `FULL` - Emitted events for `UPDATE` and `DELETE` operations contain the previous values of all columns in the table.
 * `INDEX` _index-name_ - Emitted events for `UPDATE` and `DELETE` operations contain the previous values of the columns contained in the specified index. `UPDATE` events also contain the indexed columns with the updated values.
@@ -663,7 +663,7 @@ If a table does not have a primary key, the connector does not emit `UPDATE` or 
 [[postgresql-create-events]]
 === _create_ events
 
-The following example shows the value portion of a change event that the connector generates for an operation that creates data in the `customers` table: 
+The following example shows the value portion of a change event that the connector generates for an operation that creates data in the `customers` table:
 
 [source,json,options="nowrap",indent=0,subs="+attributes"]
 ----
@@ -724,7 +724,7 @@ The following example shows the value portion of a change event that the connect
                     }
                 ],
                 "optional": true,
-                "name": "PostgreSQL_server.inventory.customers.Value", 
+                "name": "PostgreSQL_server.inventory.customers.Value",
                 "field": "after"
             },
             {
@@ -840,7 +840,7 @@ The following example shows the value portion of a change event that the connect
 
 |1
 |`schema`
-|The value's schema, which describes the structure of the value's payload. A change event's value schema is the same in every change event that the connector generates for a particular table. 
+|The value's schema, which describes the structure of the value's payload. A change event's value schema is the same in every change event that the connector generates for a particular table.
 
 |2
 |`name`
@@ -852,7 +852,7 @@ Names of schemas for `before` and `after` fields are of the form `_logicalName_.
 
 |3
 |`name`
-a|`io.debezium.connector.postgresql.Source` is the schema for the payload's `source` field. This schema is specific to the PostgreSQL connector. The connector uses it for all events that it generates. 
+a|`io.debezium.connector.postgresql.Source` is the schema for the payload's `source` field. This schema is specific to the PostgreSQL connector. The connector uses it for all events that it generates.
 
 |4
 |`name`
@@ -880,7 +880,7 @@ Whether or not this field is available is dependent on the {link-prefix}:{link-p
 
 |8
 |`source`
-a|Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes: 
+a|Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes:
 
 * {prodname} version
 * Connector type and name
@@ -893,7 +893,7 @@ a|Mandatory field that describes the source metadata for the event. This field c
 
 |9
 |`op`
-a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are: 
+a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are:
 
 * `c` = create
 * `u` = update
@@ -912,7 +912,7 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 [[postgresql-update-events]]
 === _update_ events
 
-The value of a change event for an update in the sample `customers` table has the same schema as a _create_ event for that table. Likewise, the event value's payload has the same structure. However, the event value payload contains different values in an _update_ event. Here is an example of a change event value in an event that the connector generates for an update in the `customers` table: 
+The value of a change event for an update in the sample `customers` table has the same schema as a _create_ event for that table. Likewise, the event value's payload has the same structure. However, the event value payload contains different values in an _update_ event. Here is an example of a change event value in an event that the connector generates for an update in the `customers` table:
 
 [source,json,indent=0,options="nowrap",subs="+attributes"]
 ----
@@ -960,11 +960,11 @@ For an _update_ event to contain the previous values of all columns in the row, 
 
 |2
 |`after`
-|An optional field that specifies the state of the row after the event occurred. In this example, the `first_name` value is now `Anne Marie`. 
+|An optional field that specifies the state of the row after the event occurred. In this example, the `first_name` value is now `Anne Marie`.
 
 |3
 |`source`
-a|Mandatory field that describes the source metadata for the event. The `source` field structure has the same fields as in a _create_ event, but some values are different. The source metadata includes: 
+a|Mandatory field that describes the source metadata for the event. The `source` field structure has the same fields as in a _create_ event, but some values are different. The source metadata includes:
 
 * {prodname} version
 * Connector type and name
@@ -989,7 +989,7 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 
 [NOTE]
 ====
-Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a {link-prefix}:{link-postgresql-connector}#postgresql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row. Details are in the next section. 
+Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a {link-prefix}:{link-postgresql-connector}#postgresql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row. Details are in the next section.
 ====
 
 // Type: continue
@@ -997,7 +997,7 @@ Updating the columns for a row's primary/unique key changes the value of the row
 === Primary key updates
 
 An `UPDATE` operation that changes a row's primary key field(s) is known
-as a primary key change. For a primary key change, in place of sending an `UPDATE` event record, the connector sends a `DELETE` event record for the old key and a `CREATE` event record for the new (updated) key. These events have the usual structure and content, and in addition, each one has a message header related to the primary key change: 
+as a primary key change. For a primary key change, in place of sending an `UPDATE` event record, the connector sends a `DELETE` event record for the old key and a `CREATE` event record for the new (updated) key. These events have the usual structure and content, and in addition, each one has a message header related to the primary key change:
 
 * The `DELETE` event record has `__debezium.newkey` as a message header. The value of this header is the new primary key for the updated row.
 
@@ -1054,7 +1054,7 @@ In this example, the `before` field contains only the primary key column because
 
 |3
 |`source`
-a|Mandatory field that describes the source metadata for the event. In a _delete_ event value, the `source` field structure is the same as for _create_ and _update_ events for the same table. Many `source` field values are also the same. In a _delete_ event value, the `ts_ms` and `lsn` field values, as well as other values, might have changed. But the `source` field in a _delete_ event value provides the same metadata: 
+a|Mandatory field that describes the source metadata for the event. In a _delete_ event value, the `source` field structure is the same as for _create_ and _update_ events for the same table. Many `source` field values are also the same. In a _delete_ event value, the `ts_ms` and `lsn` field values, as well as other values, might have changed. But the `source` field in a _delete_ event value provides the same metadata:
 
 * {prodname} version
 * Connector type and name
@@ -1077,7 +1077,7 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 
 |===
 
-A _delete_ change event record provides a consumer with the information it needs to process the removal of this row. 
+A _delete_ change event record provides a consumer with the information it needs to process the removal of this row.
 
 [WARNING]
 ====
@@ -1129,7 +1129,7 @@ The message key is `null` in this case, the message value looks like this:
 
 |1
 |`source`
-a|Mandatory field that describes the source metadata for the event. In a _truncate_ event value, the `source` field structure is the same as for _create_, _update_, and _delete_ events for the same table, provides this metadata: 
+a|Mandatory field that describes the source metadata for the event. In a _truncate_ event value, the `source` field structure is the same as for _create_, _update_, and _delete_ events for the same table, provides this metadata:
 
 * {prodname} version
 * Connector type and name
@@ -1174,7 +1174,7 @@ The PostgreSQL connector represents changes to rows with events that are structu
 * _semantic type_ describes how the Kafka Connect schema captures the _meaning_ of the field using the name of the Kafka Connect schema for the field.
 
 ifdef::product[]
-Details are in the following sections: 
+Details are in the following sections:
 
 * xref:postgresql-basic-types[]
 * xref:postgresql-temporal-types[]
@@ -1373,7 +1373,7 @@ Contains the string representation of the PostgreSQL `ENUM` value. The set of al
 [id="postgresql-temporal-types"]
 === Temporal types
 
-Other than PostgreSQL's `TIMESTAMPTZ` and `TIMETZ` data types, which contain time zone information, how temporal types are mapped depends on the value of the `time.precision.mode` connector configuration property. The following sections describe these mappings: 
+Other than PostgreSQL's `TIMESTAMPTZ` and `TIMETZ` data types, which contain time zone information, how temporal types are mapped depends on the value of the `time.precision.mode` connector configuration property. The following sections describe these mappings:
 
 * xref:postgresql-time-precision-mode-adaptive[`time.precision.mode=adaptive`]
 * xref:postgresql-time-precision-mode-adaptive-time-microseconds[`time.precision.mode=adaptive_time_microseconds`]
@@ -1381,7 +1381,7 @@ Other than PostgreSQL's `TIMESTAMPTZ` and `TIMETZ` data types, which contain tim
 
 [[postgresql-time-precision-mode-adaptive]]
 .`time.precision.mode=adaptive`
-When the `time.precision.mode` property is set to `adaptive`, the default, the connector determines the literal type and semantic type based on the column's data type definition. This ensures that events _exactly_ represent the values in the database. 
+When the `time.precision.mode` property is set to `adaptive`, the default, the connector determines the literal type and semantic type based on the column's data type definition. This ensures that events _exactly_ represent the values in the database.
 
 .Mappings when `time.precision.mode` is `adaptive`
 [cols="25%a,20%a,55%a",options="header"]
@@ -1501,7 +1501,7 @@ The timezone of the JVM running Kafka Connect and {prodname} does not affect thi
 [id="postgresql-decimal-types"]
 === Decimal types
 
-The setting of the PostgreSQL connector configuration property, `decimal.handling.mode` determines how the connector maps decimal types. 
+The setting of the PostgreSQL connector configuration property, `decimal.handling.mode` determines how the connector maps decimal types.
 
 When the `decimal.handling.mode` property is set to `precise`, the connector uses the Kafka Connect `org.apache.kafka.connect.data.Decimal` logical type for all `DECIMAL` and `NUMERIC` columns. This is the default mode.
 
@@ -1569,7 +1569,7 @@ When the `decimal.handling.mode` property is set to `double`, the connector repr
 
 |===
 
-The last possible setting for the `decimal.handling.mode` configuration property is `string`. In this case, the connector represents `DECIMAL` and `NUMERIC` values as their formatted string representation, and encodes them as shown in the following table. 
+The last possible setting for the `decimal.handling.mode` configuration property is `string`. In this case, the connector represents `DECIMAL` and `NUMERIC` values as their formatted string representation, and encodes them as shown in the following table.
 
 .Mappings when `decimal.handling.mode` is `string`
 [cols="30%a,30%a,40%a",options="header"]
@@ -1593,7 +1593,7 @@ PostgreSQL supports `NaN` (not a number) as a special value to be stored in `DEC
 [id="postgresql-hstore-type"]
 === HSTORE type
 
-When the `hstore.handling.mode` connector configuration property is set to `json` (the default), the connector represents `HSTORE` values as string representations of JSON values and encodes them as shown in the following table. When the `hstore.handling.mode` property is set to `map`, the connector uses the `MAP` schema type for `HSTORE` values. 
+When the `hstore.handling.mode` connector configuration property is set to `json` (the default), the connector represents `HSTORE` values as string representations of JSON values and encodes them as shown in the following table. When the `hstore.handling.mode` property is set to `map`, the connector uses the `MAP` schema type for `HSTORE` values.
 
 .Mappings for `HSTORE` data type
 [cols="25%a,20%a,55%a",options="header"]
@@ -1680,7 +1680,7 @@ The PostgreSQL connector supports all link:http://postgis.net[PostGIS data types
 
 |`GEOMETRY` +
 (planar)
-|`STRUCT` 
+|`STRUCT`
 a|`io.debezium.data.geometry.Geometry` +
  +
 Contains a structure with two fields: +
@@ -1712,17 +1712,17 @@ This impacts replication messages that are coming from the database. Values that
 There is no safe way for {prodname} to read the missing value out-of-bands directly from the database, as this would potentially lead to race conditions. Consequently, {prodname} follows these rules to handle toasted values:
 
 * Tables with `REPLICA IDENTITY FULL` - TOAST column values are part of the `before` and `after` fields in change events just like any other column.
-* Tables with `REPLICA IDENTITY DEFAULT` - When receiving an `UPDATE` event from the database, any unchanged TOAST column value that is not part of the replica identity is not contained in the event. 
+* Tables with `REPLICA IDENTITY DEFAULT` - When receiving an `UPDATE` event from the database, any unchanged TOAST column value that is not part of the replica identity is not contained in the event.
 Similarly, when receiving a `DELETE` event, no TOAST columns, if any, are  in the `before` field.
 As {prodname} cannot safely provide the column value in this case, the connector returns a placeholder value as defined by the connector configuration property, `toasted.value.placeholder`.
 
 ifdef::community[]
 [IMPORTANT]
 ====
-There is a problem related to Amazon RDS instances. The `wal2json` plug-in has evolved over the time and there were releases that provided out-of-band toasted values. Amazon supports different versions of the plug-in for different PostgreSQL versions. See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html[Amazon's documentation] to obtain version to version mapping. For consistent toasted values handling: 
+There is a problem related to Amazon RDS instances. The `wal2json` plug-in has evolved over the time and there were releases that provided out-of-band toasted values. Amazon supports different versions of the plug-in for different PostgreSQL versions. See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html[Amazon's documentation] to obtain version to version mapping. For consistent toasted values handling:
 
 * Use the `pgoutput` plug-in for PostgreSQL 10+ instances.
-* Set `include-unchanged-toast=0` for older versions of the `wal2json` plug-in by using the `slot.stream.params` configuration option. 
+* Set `include-unchanged-toast=0` for older versions of the `wal2json` plug-in by using the `slot.stream.params` configuration option.
 ====
 endif::community[]
 
@@ -1742,7 +1742,7 @@ endif::community[]
 ifdef::product[]
 This release of {prodname} supports only the native `pgoutput` logical replication stream. To set up PostgreSQL so that it uses the `pgoutput` plug-in, you must enable a replication slot, and configure a user with sufficient privileges to perform the replication.
 
-Details are in the following topics: 
+Details are in the following topics:
 
 * xref:configuring-a-replication-slot-for-the-debezium-pgoutput-plug-in[]
 * xref:setting-up-postgresql-permissions-required-by-debezium-connectors[]
@@ -1757,7 +1757,7 @@ ifdef::product[]
 // Title: Configuring a replication slot for the {prodname} `pgoutput` plug-in
 === Configuring replication slot
 
-PostgreSQL's logical decoding uses replication slots. To configure a replication slot, specify the following in the `postgresql.conf` file: 
+PostgreSQL's logical decoding uses replication slots. To configure a replication slot, specify the following in the `postgresql.conf` file:
 
 [source]
 ----
@@ -1766,7 +1766,7 @@ max_wal_senders=1
 max_replication_slots=1
 ----
 
-These settings instruct the PostgreSQL server as follows: 
+These settings instruct the PostgreSQL server as follows:
 
 * `wal_level` - Use logical decoding with the write-ahead log.
 * `max_wal_senders` - Use a maximum of one separate process for processing WAL changes.
@@ -1781,7 +1781,7 @@ For more information, see the link:https://www.postgresql.org/docs/current/warm-
 
 [NOTE]
 ====
-Familiarity with the mechanics and link:https://www.postgresql.org/docs/current/static/wal-configuration.html[configuration of the PostgreSQL write-ahead log] is helpful for using the {prodname} PostgreSQL connector. 
+Familiarity with the mechanics and link:https://www.postgresql.org/docs/current/static/wal-configuration.html[configuration of the PostgreSQL write-ahead log] is helpful for using the {prodname} PostgreSQL connector.
 ====
 endif::product[]
 
@@ -1804,7 +1804,7 @@ If the `wal_level` is not `logical` after the change above, it is probably becau
 [IMPORTANT]
 ====
 Ensure that you use the latest versions of PostgreSQL 9.6, 10 or 11 on Amazon RDS.
-Otherwise, older versions of the `wal2json` plug-in might be installed. 
+Otherwise, older versions of the `wal2json` plug-in might be installed.
 See https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html[the official documentation] for the exact `wal2json` versions installed on Amazon RDS.
 In the case of an older version, replication messages received from the database might not contain complete information about type constraints such as length or scale or `NULL`/`NOT NULL`. This might cause creation of messages with an inconsistent schema for a short period of time when there are changes to a column's definition.
 
@@ -1855,7 +1855,7 @@ This means that a logical decoding output plug-in is no longer necessary and cha
 As of PostgreSQL 9.4, the only way to read changes to the write-ahead-log is to install a logical decoding output plug-in. Plug-ins are written in C, compiled, and installed on the machine that runs the PostgreSQL server. Plug-ins use  a number of PostgreSQL specific APIs, as described by the link:https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[PostgreSQL documentation].
 
 The PostgreSQL connector works with one of {prodname}'s supported logical decoding plug-ins to encode the changes in either link:https://github.com/google/protobuf[Protobuf format] or link:http://www.json.org/[JSON] format.
-See the documentation for your chosen plug-in to learn more about the plug-in's requirements, limitations, and how to compile it. 
+See the documentation for your chosen plug-in to learn more about the plug-in's requirements, limitations, and how to compile it.
 
 * link:https://github.com/debezium/postgres-decoderbufs/blob/master/README.md[`protobuf`]
 * link:https://github.com/eulerto/wal2json/blob/master/README.md[`wal2json`]
@@ -1887,7 +1887,7 @@ All up-to-date differences are tracked in a test suite link:https://github.com/d
 [[postgresql-server-configuration]]
 === Configuring the PostgreSQL server
 
-If you are using one of the supported {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-ins], that is, not `pgoutput`, and it has been installed, configure the PostgreSQL server as follows:  
+If you are using one of the supported {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-ins], that is, not `pgoutput`, and it has been installed, configure the PostgreSQL server as follows:
 
 . To load the plug-in at startup, add the following to the `postgresql.conf` file::
 +
@@ -1896,9 +1896,9 @@ If you are using one of the supported {link-prefix}:{link-postgresql-connector}#
 # MODULES
 shared_preload_libraries = 'decoderbufs,wal2json' // <1>
 ----
-<1> Instructs the server to load the `decoderbufs` and `wal2json` logical decoding plug-ins at startup. The names of the plug-ins are set in the link:https://github.com/debezium/postgres-decoderbufs/blob/v0.3.0/Makefile[`Protobuf`] and link:https://github.com/eulerto/wal2json/blob/master/Makefile[`wal2json`] make files. 
+<1> Instructs the server to load the `decoderbufs` and `wal2json` logical decoding plug-ins at startup. The names of the plug-ins are set in the link:https://github.com/debezium/postgres-decoderbufs/blob/v0.3.0/Makefile[`Protobuf`] and link:https://github.com/eulerto/wal2json/blob/master/Makefile[`wal2json`] make files.
 
-. To configure the replication slot regardless of the decoder being used, specify the following in the `postgresql.conf` file: 
+. To configure the replication slot regardless of the decoder being used, specify the following in the `postgresql.conf` file:
 +
 [source,properties]
 ----
@@ -1931,11 +1931,11 @@ endif::community[]
 [[postgresql-permissions]]
 === Setting up permissions
 
-Setting up a PostgreSQL server to run a {prodname} connector requires a database user who can perform replications. Replication can be performed only by a database user who has appropriate permissions and only for a configured number of hosts. Also, you must configure the PostgreSQL server to allow replication to take place between the server machine and the host on which the PostgreSQL connector is running. 
+Setting up a PostgreSQL server to run a {prodname} connector requires a database user who can perform replications. Replication can be performed only by a database user who has appropriate permissions and only for a configured number of hosts. Also, you must configure the PostgreSQL server to allow replication to take place between the server machine and the host on which the PostgreSQL connector is running.
 
 .Prerequisites
 
-* PostgreSQL administrative permissions. 
+* PostgreSQL administrative permissions.
 
 .Procedure
 
@@ -1951,7 +1951,7 @@ CREATE ROLE name REPLICATION LOGIN;
 By default, superusers have both of the above roles.
 ====
 
-. Configure the PostgreSQL server to allow replication to take place between the server machine and the host on which the PostgreSQL connector is running. 
+. Configure the PostgreSQL server to allow replication to take place between the server machine and the host on which the PostgreSQL connector is running.
 +
 .`pg_hba.conf` file example:
 [source]
@@ -1986,7 +1986,7 @@ endif::community[]
 In certain cases, it is possible for PostgreSQL disk space consumed by WAL files to spike or increase out of usual proportions.
 There are several possible reasons for this situation:
 
-* The LSN up to which the connector has received data is available in the `confirmed_flush_lsn` column of the server's `pg_replication_slots` view. Data that is older than this LSN is no longer available, and the database is responsible for reclaiming the disk space. 
+* The LSN up to which the connector has received data is available in the `confirmed_flush_lsn` column of the server's `pg_replication_slots` view. Data that is older than this LSN is no longer available, and the database is responsible for reclaiming the disk space.
 +
 Also in the `pg_replication_slots` view, the `restart_lsn` column contains the LSN of the oldest WAL that the connector might require. If the value for `confirmed_flush_lsn` is regularly increasing and the value of  `restart_lsn` lags then the database needs to reclaim the space.
 +
@@ -2030,7 +2030,7 @@ If you are working with immutable containers, see link:https://hub.docker.com/r/
 endif::community[]
 
 ifdef::product[]
-To deploy a {prodname} PostgreSQL connector, add the connector files to Kafka Connect, create a custom container to run the connector, and add connector configuration to your container. Details are in the following topics: 
+To deploy a {prodname} PostgreSQL connector, add the connector files to Kafka Connect, create a custom container to run the connector, and add connector configuration to your container. Details are in the following topics:
 
 * xref:deploying-debezium-postgresql-connectors[]
 * xref:descriptions-of-debezium-postgresql-connector-configuration-properties[]
@@ -2043,26 +2043,26 @@ To deploy a {prodname} PostgreSQL connector, add the connector files to Kafka Co
 
 To deploy a {prodname} PostgreSQL connector, you need to build a custom Kafka Connect container image that contains the {prodname} connector archive and push this container image to a container registry.You then need to create two custom resources (CRs):
 
-* A `KafkaConnect` CR that configures your Kafka Connector and that specifies the name of the image that you created to run your {prodname} connector. You apply this CR to the OpenShift Kafka instance. 
+* A `KafkaConnect` CR that configures your Kafka Connector and that specifies the name of the image that you created to run your {prodname} connector. You apply this CR to the OpenShift Kafka instance.
 
-* A `KafkaConnector` CR that configures your {prodname} PostgreSQL connector. You apply this CR to the OpenShift instance where Red Hat AMQ Streams is deployed. 
+* A `KafkaConnector` CR that configures your {prodname} PostgreSQL connector. You apply this CR to the OpenShift instance where Red Hat AMQ Streams is deployed.
 
 .Prerequisites
 
 * PostgreSQL is running and you performed the steps to {LinkDebeziumUserGuide}#setting-up-postgresql-to-run-a-debezium-connector[set up PostgreSQL to run a {prodname} connector].
 
-* link:https://access.redhat.com/products/red-hat-amq#streams[Red Hat AMQ Streams] was used to set up and start running Apache Kafka and Kafka Connect on OpenShift. AMQ Streams offers operators and images that bring Kafka to OpenShift. 
+* link:https://access.redhat.com/products/red-hat-amq#streams[Red Hat AMQ Streams] was used to set up and start running Apache Kafka and Kafka Connect on OpenShift. AMQ Streams offers operators and images that bring Kafka to OpenShift.
 
 * Podman or Docker is installed.
 
-* You have an account and permissions to create and manage containers in the container registry (such as `quay.io` or `docker.io`) to which you plan to add the container that will run your Debezium connector. 
+* You have an account and permissions to create and manage containers in the container registry (such as `quay.io` or `docker.io`) to which you plan to add the container that will run your Debezium connector.
 
 .Procedure
 
-. Create the {prodname} PostgreSQL container for Kafka Connect: 
+. Create the {prodname} PostgreSQL container for Kafka Connect:
 .. Download the {prodname} link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions[PostgreSQL connector archive].
 
-.. Extract the {prodname} PostgreSQL connector archive to create a directory structure for the connector plug-in, for example: 
+.. Extract the {prodname} PostgreSQL connector archive to create a directory structure for the connector plug-in, for example:
 +
 [subs="+macros"]
 ----
@@ -2071,7 +2071,7 @@ To deploy a {prodname} PostgreSQL connector, you need to build a custom Kafka Co
 │   ├── ...
 ----
 
-.. Create a Docker file that uses `{DockerKafkaConnect}` as the base image. 
+.. Create a Docker file that uses `{DockerKafkaConnect}` as the base image.
 For example, from a terminal window, enter the following:
 +
 [subs="+macros,+attributes"]
@@ -2095,7 +2095,7 @@ The command creates a Docker file with the name `debezium-container-for-postgres
 podman build -t debezium-container-for-postgresql:latest .
 ----
 +
-This command builds a container image with the name `debezium-container-for-postgresql`. 
+This command builds a container image with the name `debezium-container-for-postgresql`.
 
 .. Push your custom image to a container registry such as `quay.io` or any internal container registry. Ensure that this registry is reachable from your OpenShift instance. For example:
 +
@@ -2128,11 +2128,11 @@ oc create -f dbz-connect.yaml
 +
 This updates your Kafka Connect environment in OpenShift to add a Kafka Connector instance that specifies the name of the image that you created to run your {prodname} connector.
 
-. Create a `KafkaConnector` custom resource that configures your {prodname} PostgreSQL connector instance. 
+. Create a `KafkaConnector` custom resource that configures your {prodname} PostgreSQL connector instance.
 +
 You configure a {prodname} PostgreSQL connector in a `.yaml` file that sets connector configuration properties. A connector configuration might instruct {prodname} to produce events for a subset of the schemas and tables, or it might set properties so that {prodname} ignores, masks, or truncates values in specified columns that are sensitive, too large, or not needed. See the {link-prefix}:{link-postgresql-connector}#postgresql-connector-properties[complete list of PostgreSQL connector properties] that can be specified in these configurations.
 +
-The following example configures a {prodname} connector that connects to a PostgreSQL server host, `192.168.99.100`, on port `5432`. This host has a database named `sampledb`, a schema named `public`, and `fulfillment` is the server's logical name. 
+The following example configures a {prodname} connector that connects to a PostgreSQL server host, `192.168.99.100`, on port `5432`. This host has a database named `sampledb`, a schema named `public`, and `fulfillment` is the server's logical name.
 +
 .`fulfillment-connector.yaml`
 [source,yaml,options="nowrap",subs="+attributes"]
@@ -2141,7 +2141,7 @@ apiVersion: {KafkaConnectorApiVersion}
   kind: KafkaConnector
   metadata:
     name: fulfillment-connector  // <1>
-    labels: 
+    labels:
       strimzi.io/cluster: my-connect-cluster
   spec:
     class: io.debezium.connector.postgresql.PostgresConnector
@@ -2151,7 +2151,7 @@ apiVersion: {KafkaConnectorApiVersion}
       database.port: 5432
       database.user: debezium
       database.password: dbz
-      database.dbname: sampledb  
+      database.dbname: sampledb
       database.server.name: fulfillment   // <5>
       schema.include.list: public   // <6>
       plugin.name: pgoutput    // <7>
@@ -2172,7 +2172,7 @@ This name is used as the prefix for all Kafka topics that receive change event r
 <6> The connector captures changes in only the `public` schema. It is possible to configure the connector to capture changes in only the tables that you choose. See {link-prefix}:{link-postgresql-connector}#postgresql-property-table-include-list[`table.include.list` connector configuration property].
 <7> The name of the PostgreSQL {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed on the PostgreSQL server. While the only supported value for PostgreSQL 10 and later is `pgoutput`, you must explicitly set `plugin.name` to `pgoutput`.
 
-. Create your connector instance with Kafka Connect. For example, if you saved your `KafkaConnector` resource in the `fulfillment-connector.yaml` file, you would run the following command: 
+. Create your connector instance with Kafka Connect. For example, if you saved your `KafkaConnector` resource in the `fulfillment-connector.yaml` file, you would run the following command:
 +
 [source,shell,options="nowrap"]
 ----
@@ -2181,7 +2181,7 @@ oc apply -f fulfillment-connector.yaml
 +
 This registers `fulfillment-connector` and the connector starts to run against the `sampledb` database as defined in the `KafkaConnector` CR.
 
-. Verify that the connector was created and has started: 
+. Verify that the connector was created and has started:
 .. Display the Kafka Connect log output to verify that the connector was created and has started to capture changes in the specified database:
 +
 [source,shell,options="nowrap"]
@@ -2189,15 +2189,15 @@ This registers `fulfillment-connector` and the connector starts to run against t
 oc logs $(oc get pods -o name -l strimzi.io/cluster=my-connect-cluster)
 ----
 
-.. Review the log output to verify that the initial snapshot has been executed. You should see something like this: 
+.. Review the log output to verify that the initial snapshot has been executed. You should see something like this:
 +
 [source,shell,options="nowrap"]
 ----
 ... INFO Starting snapshot for ...
-... INFO Snapshot is using user 'debezium' ... 
+... INFO Snapshot is using user 'debezium' ...
 ----
 +
-If the connector starts correctly without errors, it creates a topic for each table whose changes the connector is capturing. For the example CR, there would be a topic for each table in the `public` schema. Downstream applications can subscribe to these topics. 
+If the connector starts correctly without errors, it creates a topic for each table whose changes the connector is capturing. For the example CR, there would be a topic for each table in the `public` schema. Downstream applications can subscribe to these topics.
 
 .. Verify that the connector created the topics by running the following command:
 +
@@ -2208,7 +2208,7 @@ oc get kafkatopics
 
 .Results
 
-When the connector starts, it {link-prefix}:{link-postgresql-connector}#postgresql-snapshots[performs a consistent snapshot] of the PostgreSQL server databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics. 
+When the connector starts, it {link-prefix}:{link-postgresql-connector}#postgresql-snapshots[performs a consistent snapshot] of the PostgreSQL server databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
 
 endif::product[]
 
@@ -2258,7 +2258,7 @@ You can send this configuration with a `POST` command to a running Kafka Connect
 [[postgresql-adding-connector-configuration]]
 === Adding connector configuration
 
-To start running a PostgreSQL connector, create a connector configuration and add the configuration to your Kafka Connect cluster. 
+To start running a PostgreSQL connector, create a connector configuration and add the configuration to your Kafka Connect cluster.
 
 .Prerequisites
 
@@ -2266,13 +2266,13 @@ To start running a PostgreSQL connector, create a connector configuration and ad
 
 * The {link-prefix}:{link-postgresql-connector}#installing-postgresql-output-plugin[logical decoding plug-in] is installed.
 
-* The PostgreSQL connector is installed. 
+* The PostgreSQL connector is installed.
 
 .Procedure
 
 . Create a configuration for the PostgreSQL connector.
 
-. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster. 
+. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster.
 
 endif::community[]
 
@@ -2282,7 +2282,7 @@ endif::community[]
 [[postgresql-connector-properties]]
 === Connector configuration properties
 
-The {prodname} PostgreSQL connector has many configuration properties that you can use to achieve the right connector behavior for your application. Many properties have default values. Information about the properties is organized as follows: 
+The {prodname} PostgreSQL connector has many configuration properties that you can use to achieve the right connector behavior for your application. Many properties have default values. Information about the properties is organized as follows:
 
 * xref:postgresql-required-configuration-properties[Required configuration properties]
 * xref:postgresql-advanced-configuration-properties[Advanced configuration properties]
@@ -2326,15 +2326,15 @@ endif::product[]
 
 |[[postgresql-property-slot-name]]<<postgresql-property-slot-name, `slot.name`>>
 |`debezium`
-|The name of the PostgreSQL logical decoding slot that was created for streaming changes from a particular plug-in for a particular database/schema. The server uses this slot to stream events to the {prodname} connector that you are configuring. 
+|The name of the PostgreSQL logical decoding slot that was created for streaming changes from a particular plug-in for a particular database/schema. The server uses this slot to stream events to the {prodname} connector that you are configuring.
 
 Slot names must conform to link:https://www.postgresql.org/docs/current/static/warm-standby.html#STREAMING-REPLICATION-SLOTS-MANIPULATION[PostgreSQL replication slot naming rules], which state: _"Each replication slot has a name, which can contain lower-case letters, numbers, and the underscore character."_
 
 |[[postgresql-property-slot-drop-on-stop]]<<postgresql-property-slot-drop-on-stop, `slot.drop.on.stop`>>
 |`false`
-|Whether or not to delete the logical replication slot when the connector stops in a graceful, expected way. The default behavior is that the replication slot remains configured for the connector when the connector stops. When the connector restarts, having the same replication slot enables the connector to start processing where it left off. 
+|Whether or not to delete the logical replication slot when the connector stops in a graceful, expected way. The default behavior is that the replication slot remains configured for the connector when the connector stops. When the connector restarts, having the same replication slot enables the connector to start processing where it left off.
 
-Set to `true` in only testing or development environments. Dropping the slot allows the database to discard WAL segments. When the connector restarts it performs a new snapshot or it can continue from a persistent offset in the Kafka Connect offsets topic. 
+Set to `true` in only testing or development environments. Dropping the slot allows the database to discard WAL segments. When the connector restarts it performs a new snapshot or it can continue from a persistent offset in the Kafka Connect offsets topic.
 
 |[[postgresql-property-publication-name]]<<postgresql-property-publication-name, `publication.name`>>
 |`dbz_{zwsp}publication`
@@ -2371,33 +2371,27 @@ If the publication already exists, either for all tables or configured with a su
 |
 |Logical name that identifies and provides a namespace for the particular PostgreSQL database server or cluster in which {prodname} is capturing changes. Only alphanumeric characters and underscores should be used in the database server logical name. The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
 
-|[[postgresql-property-schema-include-list]]
-[[postgresql-property-schema-include-list]]<<postgresql-property-schema-include-list, `schema.include{zwsp}.list`>>
+|[[postgresql-property-schema-include-list]]<<postgresql-property-schema-include-list, `schema.include{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match names of schemas for which you *want* to capture changes. Any schema name not included in `schema.include.list` is excluded from having its changes captured. By default, all non-system schemas have their changes captured. Do not also set the `schema.exclude.list` property.
 
-|[[postgresql-property-schema-exclude-list]]
-[[postgresql-property-schema-exclude-list]]<<postgresql-property-schema-exclude-list, `schema.exclude{zwsp}.list`>>
+|[[postgresql-property-schema-exclude-list]]<<postgresql-property-schema-exclude-list, `schema.exclude{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match names of schemas for which you *do not* want to capture changes. Any schema whose name is not included in `schema.exclude.list` has its changes captured, with the exception of system schemas. Do not also set the `schema.include.list` property.
 
-|[[postgresql-property-table-include-list]]
-[[postgresql-property-table-include-list]]<<postgresql-property-table-include-list, `table.include{zwsp}.list`>>
+|[[postgresql-property-table-include-list]]<<postgresql-property-table-include-list, `table.include{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you want to capture. Any table not included in `table.include.list` does not have its changes captured. Each identifier is of the form _schemaName_._tableName_. By default, the connector captures changes in every non-system table in each schema whose changes are being captured. Do not also set the `table.exclude.list` property.
 
-|[[postgresql-property-table-exclude-list]]
-[[postgresql-property-table-exclude-list]]<<postgresql-property-table-exclude-list, `table.exclude{zwsp}.list`>>
+|[[postgresql-property-table-exclude-list]]<<postgresql-property-table-exclude-list, `table.exclude{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you *do not* want to capture. Any table not included in `table.exclude.list` has it changes captured. Each identifier is of the form _schemaName_._tableName_. Do not also set the `table.include.list` property.
 
-|[[postgresql-property-column-include-list]]
-[[postgresql-property-column-include-list]]<<postgresql-property-column-include-list, `column.include{zwsp}.list`>>
+|[[postgresql-property-column-include-list]]<<postgresql-property-column-include-list, `column.include{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in change event record values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. Do not also set the `column.exclude.list` property.
 
-|[[postgresql-property-column-exclude-list]]
-[[postgresql-property-column-exclude-list]]<<postgresql-property-column-exclude-list, `column.exclude{zwsp}.list`>>
+|[[postgresql-property-column-exclude-list]]<<postgresql-property-column-exclude-list, `column.exclude{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event record values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. Do not also set the `column.include.list` property.
 
@@ -2477,15 +2471,15 @@ If the publication already exists, either for all tables or configured with a su
  +
 `false` - only a _delete_ event is sent. +
  +
-After a _delete_ operation, emitting a tombstone event enables Kafka to delete all change event records that have the same key as the deleted row. 
+After a _delete_ operation, emitting a tombstone event enables Kafka to delete all change event records that have the same key as the deleted row.
 
 |[[postgresql-property-column-truncate-to-length-chars]]<<postgresql-property-column-truncate-to-length-chars, `column.truncate.to{zwsp}._length_.chars`>>
 |_n/a_
-|An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event records, values in these columns are truncated if they are longer than the number of characters specified by _length_ in the property name. You can specify multiple properties with different lengths in a single configuration. Length must be a positive integer, for example, `column.truncate.to.20.chars`. 
+|An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event records, values in these columns are truncated if they are longer than the number of characters specified by _length_ in the property name. You can specify multiple properties with different lengths in a single configuration. Length must be a positive integer, for example, `column.truncate.to.20.chars`.
 
 |[[postgresql-property-column-mask-with-length-chars]]<<postgresql-property-column-mask-with-length-chars, `column.mask.with{zwsp}._length_.chars`>>
 |_n/a_
-|An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event values, the values in the specified table columns are replaced with _length_ number of asterisk (`*`) characters. You can specify multiple properties with different lengths in a single configuration. Length must be a positive integer or zero. When you specify zero, the connector replaces a value with an empty string.  
+|An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event values, the values in the specified table columns are replaced with _length_ number of asterisk (`*`) characters. You can specify multiple properties with different lengths in a single configuration. Length must be a positive integer or zero. When you specify zero, the connector replaces a value with an empty string.
 
 |[[postgresql-property-column-mask-hash]]<<postgresql-property-column-mask-hash, `column.mask{zwsp}.hash._hashAlgorithm_{zwsp}.with.salt._salt_`>>
 |_n/a_
@@ -2533,7 +2527,7 @@ For example, +
  +
 `schemaA.table_a:regex_1;schemaB.table_b:regex_2;schemaC.table_c:regex_3` +
  +
-If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column that starts with `i`), the connector maps the value in ``table_a``'s `id` column to a key field in change events that the connector sends to Kafka. 
+If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column that starts with `i`), the connector maps the value in ``table_a``'s `id` column to a key field in change events that the connector sends to Kafka.
 
 |[[postgresql-publication-autocreate-mode]]<<postgresql-publication-autocreate-mode, `publication{zwsp}.autocreate.mode`>>
 |_all_tables_
@@ -2607,7 +2601,7 @@ endif::community[]
 |An optional, comma-separated list of regular expressions that match names of schemas specified in `table.include.list` for which you *want* to take the snapshot when the `snapshot.mode` is not `never`
 |[[postgresql-property-snapshot-lock-timeout-ms]]<<postgresql-property-snapshot-lock-timeout-ms, `snapshot.lock{zwsp}.timeout.ms`>>
 |`10000`
-|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. {link-prefix}:{link-postgresql-connector}#postgresql-snapshots[How the connector performs snapshots] provides details. 
+|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. {link-prefix}:{link-postgresql-connector}#postgresql-snapshots[How the connector performs snapshots] provides details.
 
 |[[postgresql-property-snapshot-select-statement-overrides]]<<postgresql-property-snapshot-select-statement-overrides, `snapshot.select{zwsp}.statement{zwsp}.overrides`>>
 |
@@ -2647,7 +2641,7 @@ A possible use case for setting these properties is large, append-only tables. Y
 |`false`
 |Specifies connector behavior when the connector encounters a field whose data type is unknown. The default behavior is that the connector omits the field from the change event and logs a warning. +
  +
-Set this property to `true` if you want the change event to contain an opaque binary representation of the field. This lets consumers decode the field. You can control the exact representation by setting the {link-prefix}:{link-postgresql-connector}#postgresql-property-binary-handling-mode[`binary handling mode`] property. 
+Set this property to `true` if you want the change event to contain an opaque binary representation of the field. This lets consumers decode the field. You can control the exact representation by setting the {link-prefix}:{link-postgresql-connector}#postgresql-property-binary-handling-mode[`binary handling mode`] property.
 
 NOTE: Consumers risk backward compatibility issues when `include.unknown.datatypes` is set to `true`. Not only may the database-specific binary representation change between releases, but if the data type is eventually supported by {prodname}, the data type will be sent downstream in a logical type, which would require adjustments by consumers. In general, when encountering unsupported data types, create a feature request so that support can be added.
 
@@ -2665,7 +2659,7 @@ The connector does not execute these statements when it creates a connection for
  +
 Heartbeat messages are useful for monitoring whether the connector is receiving change events from the database. Heartbeat messages might help decrease the number of change events that need to be re-sent when a connector restarts. To send heartbeat messages, set this property to a positive integer, which indicates the number of milliseconds between heartbeat messages. +
  +
-Heartbeat messages are needed when there are many updates in a database that is being tracked but only a tiny number of updates are related to the table(s) and schema(s) for which the connector is capturing changes. In this situation, the connector reads from the database transaction log as usual but rarely emits change records to Kafka. This means that no offset updates are committed to Kafka and the connector does not have an opportunity to send the latest retrieved LSN to the database. The database retains WAL files that contain events that have already been processed by the connector. Sending heartbeat messages enables the connector to send the latest retrieved LSN to the database, which allows the database to reclaim disk space being used by no longer needed WAL files. 
+Heartbeat messages are needed when there are many updates in a database that is being tracked but only a tiny number of updates are related to the table(s) and schema(s) for which the connector is capturing changes. In this situation, the connector reads from the database transaction log as usual but rarely emits change records to Kafka. This means that no offset updates are committed to Kafka and the connector does not have an opportunity to send the latest retrieved LSN to the database. The database retains WAL files that contain events that have already been processed by the connector. Sending heartbeat messages enables the connector to send the latest retrieved LSN to the database, which allows the database to reclaim disk space being used by no longer needed WAL files.
 
 |[[postgresql-property-heartbeat-topics-prefix]]<<postgresql-property-heartbeat-topics-prefix, `heartbeat.topics{zwsp}.prefix`>>
 |`__debezium-heartbeat`
@@ -2683,7 +2677,7 @@ This is useful for resolving the situation described in {link-prefix}:{link-post
  +
 `INSERT INTO test_heartbeat_table (text) VALUES ('test_heartbeat')` +
  +
-This allows the connector to receive changes from the low-traffic database and acknowledge their LSNs, which prevents unbounded WAL growth on the database host. 
+This allows the connector to receive changes from the low-traffic database and acknowledge their LSNs, which prevents unbounded WAL growth on the database host.
 
 |[[postgresql-property-schema-refresh-mode]]<<postgresql-property-schema-refresh-mode, `schema.refresh.mode`>>
 |`columns_diff`
@@ -2698,11 +2692,11 @@ become outdated if TOASTable columns are dropped from the table.
 
 |[[postgresql-property-snapshot-delay-ms]]<<postgresql-property-snapshot-delay-ms, `snapshot.delay.ms`>>
 |
-|An interval in milliseconds that the connector should wait before performing a snapshot when the connector starts. If you are starting multiple connectors in a cluster, this property is useful for avoiding snapshot interruptions, which might cause re-balancing of connectors. 
+|An interval in milliseconds that the connector should wait before performing a snapshot when the connector starts. If you are starting multiple connectors in a cluster, this property is useful for avoiding snapshot interruptions, which might cause re-balancing of connectors.
 
 |[[postgresql-property-snapshot-fetch-size]]<<postgresql-property-snapshot-fetch-size, `snapshot.fetch.size`>>
 |`10240`
-|During a snapshot, the connector reads table content in batches of rows. This property specifies the maximum number of rows in a batch. 
+|During a snapshot, the connector reads table content in batches of rows. This property specifies the maximum number of rows in a batch.
 
 |[[postgresql-property-slot-stream-params]]<<postgresql-property-slot-stream-params, `slot.stream.params`>>
 |
@@ -2713,7 +2707,7 @@ If you are using the `wal2json` plug-in, this property is useful for enabling se
 endif::community[]
 
 |[[postgresql-property-sanitize-field-names]]<<postgresql-property-sanitize-field-names, `sanitize.field{zwsp}.names`>>
-|`true` if connector configuration sets the `key.converter` or `value.converter` property to the Avro converter. 
+|`true` if connector configuration sets the `key.converter` or `value.converter` property to the Avro converter.
 
 `false` if not.
 |Indicates whether field names are sanitized to adhere to {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming requirements].
@@ -2756,8 +2750,8 @@ Be sure to consult the {link-kafka-docs}.html[Kafka documentation] for all of th
 
 The {prodname} PostgreSQL connector provides two types of metrics that are in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect provide.
 
-* {link-prefix}:{link-postgresql-connector}#postgresql-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot. 
-* {link-prefix}:{link-postgresql-connector}#postgresql-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records. 
+* {link-prefix}:{link-postgresql-connector}#postgresql-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
+* {link-prefix}:{link-postgresql-connector}#postgresql-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
 
 {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
 
@@ -2789,7 +2783,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming
 [[postgresql-when-things-go-wrong]]
 == Behavior when things go wrong
 
-{prodname} is a distributed system that captures all changes in multiple upstream databases; it never misses or loses an event. When the system is operating normally or being managed carefully then {prodname} provides _exactly once_ delivery of every change event record. 
+{prodname} is a distributed system that captures all changes in multiple upstream databases; it never misses or loses an event. When the system is operating normally or being managed carefully then {prodname} provides _exactly once_ delivery of every change event record.
 
 If a fault does happen then the system does not lose any events. However, while it is recovering from the fault, it might repeat some change events. In these abnormal situations, {prodname}, like Kafka, provides _at least once_ delivery of change events.
 
@@ -2798,7 +2792,7 @@ The rest of this section describes how {prodname} handles various kinds of fault
 endif::community[]
 
 ifdef::product[]
-Details are in the following sections: 
+Details are in the following sections:
 
 * xref:postgresql-connector-configuration-and-startup-errors[]
 * xref:postgresql-becomes-unavailable[]
@@ -2814,7 +2808,7 @@ endif::product[]
 
 In the following situations, the connector fails when trying to start, reports an error/exception in the log, and stops running:
 
-* The connector's configuration is invalid. 
+* The connector's configuration is invalid.
 * The connector cannot successfully connect to PostgreSQL by using the specified connection parameters.
 * The connector is restarting from a previously-recorded position in the PostgreSQL WAL (by using the LSN) and PostgreSQL no longer has that history available.
 
@@ -2832,23 +2826,23 @@ The PostgreSQL connector externally stores the last processed offset in the form
 
 As of release 12, PostgreSQL allows logical replication slots _only on primary servers_. This means that you can point a {prodname} PostgreSQL connector to only the active primary server of a database cluster.
 Also, replication slots themselves are not propagated to replicas.
-If the primary server goes down, a new primary must be promoted. 
+If the primary server goes down, a new primary must be promoted.
 
 ifdef::community[]
-The new primary must have the {link-prefix}:{link-postgresql-connector}#installing-postgresql-output-plugin[logical decoding plug-in] installed and a replication slot that is configured for use by the plug-in and the database for which you want to capture changes. Only then can you point the connector to the new server and restart the connector. 
+The new primary must have the {link-prefix}:{link-postgresql-connector}#installing-postgresql-output-plugin[logical decoding plug-in] installed and a replication slot that is configured for use by the plug-in and the database for which you want to capture changes. Only then can you point the connector to the new server and restart the connector.
 endif::community[]
 
 ifdef::product[]
-The new primary must have a replication slot that is configured for use by the `pgoutput` plug-in and the database in which you want to capture changes. Only then can you point the connector to the new server and restart the connector. 
+The new primary must have a replication slot that is configured for use by the `pgoutput` plug-in and the database in which you want to capture changes. Only then can you point the connector to the new server and restart the connector.
 endif::product[]
 
-There are important caveats when failovers occur and you should pause {prodname} until you can verify that you have an intact replication slot that has not lost data. After a failover: 
+There are important caveats when failovers occur and you should pause {prodname} until you can verify that you have an intact replication slot that has not lost data. After a failover:
 
-* There must be a process that re-creates the {prodname} replication slot before allowing the application to write to the *new* primary. This is crucial. Without this process, your application can miss change events. 
+* There must be a process that re-creates the {prodname} replication slot before allowing the application to write to the *new* primary. This is crucial. Without this process, your application can miss change events.
 
 * You might need to verify that {prodname} was able to read all changes in the slot **before the old primary failed**.
 
-One reliable method of recovering and verifying whether any changes were lost is to recover a backup of the failed primary to the point immediately before it failed. While this can be administratively difficult, it allows you to inspect the replication slot for any unconsumed changes. 
+One reliable method of recovering and verifying whether any changes were lost is to recover a backup of the failed primary to the point immediately before it failed. While this can be administratively difficult, it allows you to inspect the replication slot for any unconsumed changes.
 
 ifdef::community[]
 
@@ -2872,7 +2866,7 @@ If the Kafka Connector process stops unexpectedly, any connector tasks it was ru
 
 Because there is a chance that some events might be duplicated during a recovery from failure, consumers should always anticipate some duplicate events. {prodname} changes are idempotent, so a sequence of events always results in the same state.
 
-In each change event record, {prodname} connectors insert source-specific information about the origin of the event, including the PostgreSQL server's time of the event, the ID of the server transaction, and the position in the write-ahead log where the transaction changes were written. Consumers can keep track of this information, especially the LSN, to determine whether an event is a duplicate. 
+In each change event record, {prodname} connectors insert source-specific information about the origin of the event, including the PostgreSQL server's time of the event, the ID of the server transaction, and the position in the write-ahead log where the transaction changes were written. Consumers can keep track of this information, especially the LSN, to determine whether an event is a duplicate.
 
 [id="postgresql-kafka-becomes-unavailable"]
 === Kafka becomes unavailable

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -25,7 +25,7 @@ The {prodname} SQL Server connector captures row-level changes that occur in the
 
 ifdef::product[]
 
-For details about the {prodname} SQL Server connector and its use, see following topics: 
+For details about the {prodname} SQL Server connector and its use, see following topics:
 
 * xref:overview-of-debezium-sql-server-connector[]
 * xref:how-debezium-sql-server-connectors-work[]
@@ -38,26 +38,26 @@ For details about the {prodname} SQL Server connector and its use, see following
 endif::product[]
 
 The first time that the {prodname} SQL Server connector connects to a SQL Server database or cluster, it takes a consistent snapshot of the schemas in the database.
-After the initial snapshot is complete, the connector continuously captures row-level changes for `INSERT`, `UPDATE`, or `DELETE` operations that are committed to the SQL Server databases that are enabled for CDC. 
-The connector produces events for each data change operation, and streams them to Kafka topics. 
+After the initial snapshot is complete, the connector continuously captures row-level changes for `INSERT`, `UPDATE`, or `DELETE` operations that are committed to the SQL Server databases that are enabled for CDC.
+The connector produces events for each data change operation, and streams them to Kafka topics.
 The connector streams all of the events for a table to a dedicated Kafka topic.
 Applications and services can then consume data change event records from that topic.
 
 
 // Type: concept
-// Title: Overview of {prodname} SQL Server connector 
+// Title: Overview of {prodname} SQL Server connector
 // ModuleID: overview-of-debezium-sql-server-connector
 [[sqlserver-overview]]
 == Overview
 
-The {prodname} SQL Server connector is based on the https://docs.microsoft.com/en-us/sql/relational-databases/track-changes/about-change-data-capture-sql-server?view=sql-server-2017[change data capture] 
+The {prodname} SQL Server connector is based on the https://docs.microsoft.com/en-us/sql/relational-databases/track-changes/about-change-data-capture-sql-server?view=sql-server-2017[change data capture]
 feature that is available in https://blogs.msdn.microsoft.com/sqlreleaseservices/sql-server-2016-service-pack-1-sp1-released/[SQL Server 2016 Service Pack 1 (SP1) and later] Standard edition or Enterprise edition.
 The SQL Server capture process monitors designated databases and tables, and stores the changes into specifically created _change tables_ that have stored procedure facades.
 
-To enable the {prodname} SQL Server connector to capture change event records for database operations, 
-you must first enable change data capture on the SQL Server database. 
+To enable the {prodname} SQL Server connector to capture change event records for database operations,
+you must first enable change data capture on the SQL Server database.
 CDC must be enabled on both the database and on each table that you want to capture.
-After you set up CDC on the source database, the connector can capture row-level `INSERT`, `UPDATE`, and `DELETE` operations  
+After you set up CDC on the source database, the connector can capture row-level `INSERT`, `UPDATE`, and `DELETE` operations
 that occur in the database.
 The connector writes event records for each source table to a Kafka topic especially dedicated to that table.
 One topic exists for each captured table.
@@ -72,11 +72,11 @@ The {prodname} SQL Server connector is tolerant of failures.
 As the connector reads changes and produces events, it periodically records the position of events in the database log (_LSN / Log Sequence Number_).
 If the connector stops for any reason (including communication failures, network problems, or crashes), after a restart the connector resumes reading the SQL Server _CDC_ tables from the last point that it read.
 
-NOTE: Offsets are committed periodically. 
-They are not committed at the time that a change event occurs. 
+NOTE: Offsets are committed periodically.
+They are not committed at the time that a change event occurs.
 As a result, following an outage, duplicate events might be generated.
 
-Fault tolerance also applies to snapshots. 
+Fault tolerance also applies to snapshots.
 That is, if the connector stops during a snapshot, the connector begins a new snapshot when it restarts.
 
 // Type: assembly
@@ -85,11 +85,11 @@ That is, if the connector stops during a snapshot, the connector begins a new sn
 [[how-the-sqlserver-connector-works]]
 == How the SQL Server connector works
 
-To optimally configure and run a {prodname} SQL Server connector, it is helpful to understand how the connector performs snapshots, streams change events, determines Kafka topic names, and uses metadata. 
+To optimally configure and run a {prodname} SQL Server connector, it is helpful to understand how the connector performs snapshots, streams change events, determines Kafka topic names, and uses metadata.
 
 ifdef::product[]
 
-For details about how the connector works, see the following sections: 
+For details about how the connector works, see the following sections:
 
 * xref:how-debezium-sql-server-connectors-perform-database-snapshots[]
 * xref:how-the-debezium-sql-server-connector-reads-change-data-tables[]
@@ -107,11 +107,11 @@ endif::product[]
 === Snapshots
 
 SQL Server CDC is not designed to store a complete history of database changes.
-For the {prodname} SQL Server connector to establish a baseline for the current state of the database, 
+For the {prodname} SQL Server connector to establish a baseline for the current state of the database,
 it uses a process called _snapshotting_.
 
 You can configure how the connector creates snapshots.
-By default, the connector's snapshot mode is set to `initial`. 
+By default, the connector's snapshot mode is set to `initial`.
 Based on this `initial` snapshot mode, the first time that the connector starts, it performs an initial _consistent snapshot_ of the database.
 This initial snapshot captures the structure and data for any tables that match the criteria defined by the `include` and `exclude` properties that are configured for the connector (for example, `table.include.list`, `column.include.list`, `table.exclude.list`, and so forth).
 
@@ -127,7 +127,7 @@ The level of the lock is determined by `snapshot.isolation.mode` configuration o
 7. Records the successful completion of the snapshot in the connector offsets.
 
 The resulting initial snapshot captures the current state of each row in the tables that are enabled for CDC.
-From this baseline state, the connector captures subsequent changes as they occur. 
+From this baseline state, the connector captures subsequent changes as they occur.
 
 // Type: concept
 // ModuleID: how-the-debezium-sql-server-connector-reads-change-data-tables
@@ -154,17 +154,17 @@ The connector is able to detect whether CDC is enabled or disabled for included 
 [[sqlserver-topic-names]]
 === Topic names
 
-The SQL Server connector writes events for all `INSERT`, `UPDATE`, and `DELETE` operations for a specific table to a single Kafka topic. 
+The SQL Server connector writes events for all `INSERT`, `UPDATE`, and `DELETE` operations for a specific table to a single Kafka topic.
 By default, the Kafka topic name takes the form _serverName_._schemaName_._tableName_.
-The following list provides definitions for the components of the default name: 
+The following list provides definitions for the components of the default name:
 
 _serverName_:: The logical name of the connector, as specified by the `database.server.name` configuration property.
 _schemaName_:: The name of the database schema in which the change event occurred.
 _tableName_:: The name of the database table in which the change event occurred.
 
 For example, suppose that `fulfillment` is the logical server name in the configuration for a connector that is capturing changes in a SQL Server installation.
-The server has an `inventory` database with the schema name `dbo`, and the database contains tables with the names `products`, `products_on_hand`, `customers`, and `orders`. 
-The connector would stream records to the following Kafka topics: 
+The server has an `inventory` database with the schema name `dbo`, and the database contains tables with the names `products`, `products_on_hand`, `customers`, and `orders`.
+The connector would stream records to the following Kafka topics:
 
 * `fulfillment.dbo.products`
 * `fulfillment.dbo.products_on_hand`
@@ -172,19 +172,19 @@ The connector would stream records to the following Kafka topics:
 * `fulfillment.dbo.orders`
 
 If the default topic name do not meet your requirements, you can configure custom topic names.
-To configure custom topic names, you specify regular expressions in the logical topic routing SMT. 
-For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].  
+To configure custom topic names, you specify regular expressions in the logical topic routing SMT.
+For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].
 
- 
+
 // Type: concept
 // ModuleID: how-the-debezium-sql-server-connector-uses-the-schema-change-topic
 // Title: How the {prodname} SQL Server connector uses the schema change topic
 === Schema change topic
 
-For each table for which CDC is enabled, the {prodname} SQL Server connector stores a history of schema changes in a database history topic. 
-This topic reflects an internal connector state and you should not use it directly. 
-Application that require notifications about schema changes, should obtain the information from the public schema change topic. 
-The connector writes all of these events to a Kafka topic named `<serverName>`, where `serverName` is the name of the connector that is specified in the database.server.name configuration property. 
+For each table for which CDC is enabled, the {prodname} SQL Server connector stores a history of schema changes in a database history topic.
+This topic reflects an internal connector state and you should not use it directly.
+Application that require notifications about schema changes, should obtain the information from the public schema change topic.
+The connector writes all of these events to a Kafka topic named `<serverName>`, where `serverName` is the name of the connector that is specified in the database.server.name configuration property.
 
 [WARNING]
 ====
@@ -193,11 +193,11 @@ The format of the messages that a connector emits to its schema change topic is 
 
 {prodname} emits a message to the schema change topic when the following events occur:
 
-* You enable CDC for a table. 
+* You enable CDC for a table.
 * You disable CDC for a table.
 * You alter the structure of a table for which CDC is enabled by following the {link-prefix}:{link-sqlserver-connector}#sqlserver-schema-evolution[schema evolution procedure].
 
-A message to the schema change topic contains a logical representation of the table schema, for example: 
+A message to the schema change topic contains a logical representation of the table schema, for example:
 
 [source,json,indent=0,subs="+attributes"]
 ----
@@ -303,20 +303,20 @@ A message to the schema change topic contains a logical representation of the ta
 
 |1
 |`databaseName` +
-`schemaName` 
-|Identifies the database and the schema that contain the change.  
+`schemaName`
+|Identifies the database and the schema that contain the change.
 
 |2
 |`ddl`
-|Always `null` for the SQL Server connector. For other connectors, this field contains the DDL responsible for the schema change. This DDL is not available to SQL Server connectors. 
+|Always `null` for the SQL Server connector. For other connectors, this field contains the DDL responsible for the schema change. This DDL is not available to SQL Server connectors.
 
 |3
 |`tableChanges`
 |An array of one or more items that contain the schema changes generated by a DDL command.
 
 |4
-|`type` 
-a|Describes the kind of change. The value is one of the following: 
+|`type`
+a|Describes the kind of change. The value is one of the following:
 
 * `CREATE` - table created
 * `ALTER` - table modified
@@ -327,20 +327,20 @@ a|Describes the kind of change. The value is one of the following:
 |Full identifier of the table that was created, altered, or dropped.
 
 |6
-|`table` 
+|`table`
 |Represents table metadata after the applied change.
 
 |7
-|`primaryKeyColumnNames` 
+|`primaryKeyColumnNames`
 |List of columns that compose the table's primary key.
 
 |8
 |`columns`
-|Metadata for each column in the changed table. 
+|Metadata for each column in the changed table.
 
 |===
 
-In messages that the connector sends to the schema change topic, the key is the name of the database that contains the schema change. 
+In messages that the connector sends to the schema change topic, the key is the name of the database that contains the schema change.
 In the following example, the `payload` field contains the key:
 
 [source,json,indent=0,subs="+attributes"]
@@ -369,11 +369,11 @@ In the following example, the `payload` field contains the key:
 // Title: Descriptions of {prodname} SQL Server connector data change events
 === Data change events
 
-The {prodname} SQL Server connector generates a data change event for each row-level `INSERT`, `UPDATE`, and `DELETE` operation. Each event contains a key and a value. The structure of the key and the value depends on the table that was changed. 
+The {prodname} SQL Server connector generates a data change event for each row-level `INSERT`, `UPDATE`, and `DELETE` operation. Each event contains a key and a value. The structure of the key and the value depends on the table that was changed.
 
-{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry. This makes each event self-contained. 
+{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry. This makes each event self-contained.
 
-The following skeleton JSON shows the basic four parts of a change event. However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of these four parts in change events. A `schema` field is in a change event only when you configure the converter to produce it. Likewise, the event key and event payload are in a change event only if you configure a converter to produce it. If you use the JSON converver and you configure it to produce all four basic change event parts, change events have this structure: 
+The following skeleton JSON shows the basic four parts of a change event. However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of these four parts in change events. A `schema` field is in a change event only when you configure the converter to produce it. Likewise, the event key and event payload are in a change event only if you configure a converter to produce it. If you use the JSON converver and you configure it to produce all four basic change event parts, change events have this structure:
 
 [source,json,index=0]
 ----
@@ -384,7 +384,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
  "payload": { // <2>
    ...
  },
- "schema": { // <3> 
+ "schema": { // <3>
    ...
  },
  "payload": { // <4>
@@ -406,11 +406,11 @@ It is possible to override the table's primary key by setting the {link-prefix}:
 
 |2
 |`payload`
-|The first `payload` field is part of the event key. It has the structure described by the previous `schema` field and it contains the key for the row that was changed. 
+|The first `payload` field is part of the event key. It has the structure described by the previous `schema` field and it contains the key for the row that was changed.
 
 |3
 |`schema`
-|The second `schema` field is part of the event value. It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion. In other words, the second `schema` describes the structure of the row that was changed. Typically, this schema contains nested schemas. 
+|The second `schema` field is part of the event value. It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion. In other words, the second `schema` describes the structure of the row that was changed. Typically, this schema contains nested schemas.
 
 |4
 |`payload`
@@ -432,7 +432,7 @@ ifdef::product[]
 For details about change events, see the following topics:
 
 * xref:about-keys-in-debezium-sql-server-change-events[]
-* xref:about-values-in-debezium-sql-server-change-events[] 
+* xref:about-values-in-debezium-sql-server-change-events[]
 
 endif::product[]
 
@@ -444,7 +444,7 @@ endif::product[]
 
 A change event's key contains the schema for the changed table's key and the changed row's actual key. Both the schema and its corresponding payload contain a field for each column in the changed table's primary key (or unique key constraint) at the time the connector created the event.
 
-Consider the following `customers` table, which is followed by an example of a change event key for this table. 
+Consider the following `customers` table, which is followed by an example of a change event key for this table.
 
 .Example table
 [source,sql,indent=0]
@@ -488,10 +488,10 @@ Every change event that captures a change to the `customers` table has the same 
 
 |1
 |`schema`
-|The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion. 
+|The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion.
 
 |2
-|`fields` 
+|`fields`
 |Specifies each field that is expected in the `payload`, including each field's name, type, and whether it is required. In this example, there is one required field named `id` of type `int32`.
 
 |3
@@ -500,9 +500,9 @@ Every change event that captures a change to the `customers` table has the same 
 
 |4
 |`server1.dbo{zwsp}.customers{zwsp}.Key`
-a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._database-schema-name_._table-name_.`Key`. In this example: + 
+a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._database-schema-name_._table-name_.`Key`. In this example: +
 
-* `server1` is the name of the connector that generated this event. + 
+* `server1` is the name of the connector that generated this event. +
 * `dbo` is the database schema for the table that was changed. +
 * `customers` is the table that was updated.
 
@@ -531,9 +531,9 @@ endif::community[]
 [[sqlserver-change-event-values]]
 ==== Change event values
 
-The value in a change event is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. Change events for operations that create, update or delete data all have a value payload with an envelope structure. 
+The value in a change event is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. Change events for operations that create, update or delete data all have a value payload with an envelope structure.
 
-Consider the same sample table that was used to show an example of a change event key: 
+Consider the same sample table that was used to show an example of a change event key:
 
 [source,sql,indent=0]
 ----
@@ -545,7 +545,7 @@ CREATE TABLE customers (
 );
 ----
 
-The value portion of a change event for a change to this table is described for each event type. 
+The value portion of a change event for a change to this table is described for each event type.
 
 ifdef::product[]
 
@@ -558,7 +558,7 @@ endif::product[]
 [[sqlserver-create-events]]
 ===== _create_ events
 
-The following example shows the value portion of a change event that the connector generates for an operation that creates data in the `customers` table: 
+The following example shows the value portion of a change event that the connector generates for an operation that creates data in the `customers` table:
 
 [source,json,indent=0,subs="+attributes"]
 ----
@@ -619,7 +619,7 @@ The following example shows the value portion of a change event that the connect
           }
         ],
         "optional": true,
-        "name": "server1.dbo.customers.Value", 
+        "name": "server1.dbo.customers.Value",
         "field": "after"
       },
       {
@@ -735,7 +735,7 @@ The following example shows the value portion of a change event that the connect
 
 |1
 |`schema`
-|The value's schema, which describes the structure of the value's payload. A change event's value schema is the same in every change event that the connector generates for a particular table. 
+|The value's schema, which describes the structure of the value's payload. A change event's value schema is the same in every change event that the connector generates for a particular table.
 
 |2
 |`name`
@@ -747,7 +747,7 @@ a|In the `schema` section, each `name` field specifies the schema for a field in
 
 |3
 |`name`
-a|`io.debezium.connector.sqlserver.Source` is the schema for the payload's `source` field. This schema is specific to the SQL Server connector. The connector uses it for all events that it generates. 
+a|`io.debezium.connector.sqlserver.Source` is the schema for the payload's `source` field. This schema is specific to the SQL Server connector. The connector uses it for all events that it generates.
 
 |4
 |`name`
@@ -762,7 +762,7 @@ However, by using the {link-prefix}:{link-avro-serialization}[Avro converter], y
 
 |6
 |`before`
-|An optional field that specifies the state of the row before the event occurred. When the `op` field is `c` for create, as it is in this example, the `before` field is `null` since this change event is for new content. 
+|An optional field that specifies the state of the row before the event occurred. When the `op` field is `c` for create, as it is in this example, the `before` field is `null` since this change event is for new content.
 
 |7
 |`after`
@@ -770,7 +770,7 @@ However, by using the {link-prefix}:{link-avro-serialization}[Avro converter], y
 
 |8
 |`source`
-a|Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes: 
+a|Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes:
 
 * {prodname} version
 * Connector type and name
@@ -782,7 +782,7 @@ a|Mandatory field that describes the source metadata for the event. This field c
 
 |9
 |`op`
-a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are: 
+a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are:
 
 * `c` = create
 * `u` = update
@@ -791,10 +791,10 @@ a|Mandatory string that describes the type of operation that caused the connecto
 
 |10
 |`ts_ms`
-a| Optional field that displays the time at which the connector processed the event. 
+a| Optional field that displays the time at which the connector processed the event.
 In the event message envelope, the time is based on the system clock in the JVM running the Kafka Connect task. +
  +
-In the `source` object, `ts_ms` indicates the time when a change was committed in the database. 
+In the `source` object, `ts_ms` indicates the time when a change was committed in the database.
 By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
@@ -802,7 +802,7 @@ By comparing the value for `payload.source.ts_ms` with the value for `payload.ts
 [[sqlserver-update-events]]
 ===== _update_ events
 
-The value of a change event for an update in the sample `customers` table has the same schema as a _create_ event for that table. Likewise, the event value's payload has the same structure. However, the event value payload contains different values in an _update_ event. Here is an example of a change event value in an event that the connector generates for an update in the `customers` table: 
+The value of a change event for an update in the sample `customers` table has the same schema as a _create_ event for that table. Likewise, the event value's payload has the same structure. However, the event value payload contains different values in an _update_ event. Here is an example of a change event value in an event that the connector generates for an update in the `customers` table:
 
 [source,json,indent=0,subs="+attributes"]
 ----
@@ -852,11 +852,11 @@ The value of a change event for an update in the sample `customers` table has th
 
 |2
 |`after`
-| An optional field that specifies the state of the row after the event occurred. You can compare the `before` and `after` structures to determine what the update to this row was. In the example, the `email` value is now `noreply@example.org`. 
+| An optional field that specifies the state of the row after the event occurred. You can compare the `before` and `after` structures to determine what the update to this row was. In the example, the `email` value is now `noreply@example.org`.
 
 |3
 |`source`
-a|Mandatory field that describes the source metadata for the event. The `source` field structure has the same fields as in a _create_ event, but some values are different, for example, the sample _update_ event has a different offset. The source metadata includes: 
+a|Mandatory field that describes the source metadata for the event. The `source` field structure has the same fields as in a _create_ event, but some values are different, for example, the sample _update_ event has a different offset. The source metadata includes:
 
 * {prodname} version
 * Connector type and name
@@ -868,10 +868,10 @@ a|Mandatory field that describes the source metadata for the event. The `source`
 
 The `event_serial_no` field differentiates events that have the same commit and change LSN. Typical situations for when this field has a value other than `1`:
 
-* _update_ events have the value set to `2` because the update generates two events in the CDC change table of SQL Server (link:https://docs.microsoft.com/en-us/sql/relational-databases/system-tables/cdc-capture-instance-ct-transact-sql?view=sql-server-2017[see the source documentation for details]). The first event contains the old values and the second contains contains new values. The connector uses values in the first event to create the second event. The connector drops the first event. 
+* _update_ events have the value set to `2` because the update generates two events in the CDC change table of SQL Server (link:https://docs.microsoft.com/en-us/sql/relational-databases/system-tables/cdc-capture-instance-ct-transact-sql?view=sql-server-2017[see the source documentation for details]). The first event contains the old values and the second contains contains new values. The connector uses values in the first event to create the second event. The connector drops the first event.
 
 * When a primary key is updated SQL Server emits two evemts. A _delete_ event for the removal of the record with the old primary key value and a _create_ event for the addition of the record with the new primary key.
-Both operations share the same commit and change LSN and their event numbers are `1` and `2`, respectively. 
+Both operations share the same commit and change LSN and their event numbers are `1` and `2`, respectively.
 
 |4
 |`op`
@@ -879,10 +879,10 @@ a|Mandatory string that describes the type of operation. In an _update_ event va
 
 |5
 |`ts_ms`
-a| Optional field that displays the time at which the connector processed the event. 
+a| Optional field that displays the time at which the connector processed the event.
 In the event message envelope, the time is based on the system clock in the JVM running the Kafka Connect task. +
  +
-In the `source` object, `ts_ms` indicates the time when the change was committed to the database. 
+In the `source` object, `ts_ms` indicates the time when the change was committed to the database.
 By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
@@ -895,7 +895,7 @@ Updating the columns for a row's primary/unique key changes the value of the row
 [[sqlserver-delete-events]]
 ===== _delete_ events
 
-The value in a _delete_ change event has the same `schema` portion as _create_ and _update_ events for the same table. The `payload` portion in a _delete_ event for the sample `customers` table looks like this:  
+The value in a _delete_ change event has the same `schema` portion as _create_ and _update_ events for the same table. The `payload` portion in a _delete_ event for the sample `customers` table looks like this:
 
 [source,json,indent=0,subs="+attributes"]
 ----
@@ -944,7 +944,7 @@ The value in a _delete_ change event has the same `schema` portion as _create_ a
 
 |3
 |`source`
-a|Mandatory field that describes the source metadata for the event. In a _delete_ event value, the `source` field structure is the same as for _create_ and _update_ events for the same table. Many `source` field values are also the same. In a _delete_ event value, the `ts_ms` and `pos` field values, as well as other values, might have changed. But the `source` field in a _delete_ event value provides the same metadata: 
+a|Mandatory field that describes the source metadata for the event. In a _delete_ event value, the `source` field structure is the same as for _create_ and _update_ events for the same table. Many `source` field values are also the same. In a _delete_ event value, the `ts_ms` and `pos` field values, as well as other values, might have changed. But the `source` field in a _delete_ event value provides the same metadata:
 
 * {prodname} version
 * Connector type and name
@@ -960,10 +960,10 @@ a|Mandatory string that describes the type of operation. The `op` field value is
 
 |5
 |`ts_ms`
-a| Optional field that displays the time at which the connector processed the event. 
+a| Optional field that displays the time at which the connector processed the event.
 In the event message envelope, the time is based on the system clock in the JVM running the Kafka Connect task. +
  +
-In the `source` object, `ts_ms` indicates the time that the change was made in the database. 
+In the `source` object, `ts_ms` indicates the time that the change was made in the database.
 By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
 
 |===
@@ -980,11 +980,11 @@ When a row is deleted, the _delete_ event value still works with log compaction,
 [[sqlserver-transaction-metadata]]
 === Transaction metadata
 
-{prodname} can generate events that represent transaction boundaries and that enrich data change event messages. 
+{prodname} can generate events that represent transaction boundaries and that enrich data change event messages.
 
-Database transactions are represented by a statement block that is enclosed between the `BEGIN` and `END` keywords. 
-{prodname} generates transaction boundary events for the `BEGIN` and `END` delimiters in every transaction. 
-Transaction boundary events contain the following fields: 
+Database transactions are represented by a statement block that is enclosed between the `BEGIN` and `END` keywords.
+{prodname} generates transaction boundary events for the `BEGIN` and `END` delimiters in every transaction.
+Transaction boundary events contain the following fields:
 
 `status`:: `BEGIN` or `END`
 `id`:: String representation of unique transaction identifier.
@@ -1063,9 +1063,9 @@ The following example shows what a typical message looks like:
 === Data type mappings
 
 The {prodname} SQL Server connector represents changes to table row data by producing events that are structured like the table in which the row exists.
-Each event contains fields to represent the column values for the row. 
-The way in which an event represents the column values for an operation depends on the SQL data type of the column. 
-In the event, the connector maps the fields for each SQL Server data type to both a _literal type_ and a _semantic type_. 
+Each event contains fields to represent the column values for the row.
+The way in which an event represents the column values for an operation depends on the SQL data type of the column.
+In the event, the connector maps the fields for each SQL Server data type to both a _literal type_ and a _semantic type_.
 
 The connector can map SQL Server data types to both _literal_ and _semantic_ types.
 
@@ -1088,7 +1088,7 @@ endif::product[]
 
 The following table shows how the connector maps basic SQL Server data types.
 
-.Data type mappings used by the SQL Server connector 
+.Data type mappings used by the SQL Server connector
 [cols="30%a,25%a,45%a",options="header"]
 |===
 |SQL Server data type
@@ -1297,11 +1297,11 @@ Note that the timezone of the JVM running Kafka Connect and {prodname} does not 
 
 |`NUMERIC[(P[,S])]`
 |`BYTES`
-|`org.apache.kafka.connect.data.Decimal` 
+|`org.apache.kafka.connect.data.Decimal`
 
 |`DECIMAL[(P[,S])]`
 |`BYTES`
-|`org.apache.kafka.connect.data.Decimal` 
+|`org.apache.kafka.connect.data.Decimal`
 
 |`SMALLMONEY`
 |`BYTES`
@@ -1322,8 +1322,8 @@ The `connect.decimal.precision` schema parameter contains an integer that repres
 [[setting-up-sqlserver]]
 == Setting up SQL Server
 
-For {prodname} to capture change events from SQL Server tables, a SQL Server administrator with the necessary privileges must first run a query to enable CDC on the database. 
-The administrator must then enable CDC for each table that you want Debezium to capture.   
+For {prodname} to capture change events from SQL Server tables, a SQL Server administrator with the necessary privileges must first run a query to enable CDC on the database.
+The administrator must then enable CDC for each table that you want Debezium to capture.
 
 ifdef::product[]
 
@@ -1344,13 +1344,13 @@ The {prodname} connector can then capture these events and emit them to Kafka to
 === Enabling CDC on the SQL Server database
 
 Before you can enable CDC for a table, you must enable it for the SQL Server database.
-A SQL Server administrator enables CDC by running a system stored procedure. 
+A SQL Server administrator enables CDC by running a system stored procedure.
 System stored procedures can be run by using SQL Server Management Studio, or by using Transact-SQL.
 
 .Prerequisites
 * You are a member of the _sysadmin_ fixed server role for the SQL Server.
-* You are a db_owner of the database. 
-* The SQL Server Agent is running.  
+* You are a db_owner of the database.
+* The SQL Server Agent is running.
 
 NOTE: The SQL Server CDC feature processes changes that occur in user-created tables only. You cannot enable CDC on the SQL Server `master` database.
 
@@ -1358,7 +1358,7 @@ NOTE: The SQL Server CDC feature processes changes that occur in user-created ta
 
 . From the *View* menu in SQL Server Management Studio, click *Template Explorer*.
 . In the *Template Browser*, expand *SQL Server Templates*.
-. Expand *Change Data Capture > Configuration* and then click *Enable Database for CDC*.  
+. Expand *Change Data Capture > Configuration* and then click *Enable Database for CDC*.
 . In the template, replace the database name in the `USE` statement with the name of the database that you want to enable for CDC.
 . Run the stored procedure `sys.sp_cdc_enable_db` to enable the database for CDC.
 +
@@ -1383,20 +1383,20 @@ A SQL Server administrator must enable change data capture on the source tables 
 The database must already be enabled for CDC.
 To enable CDC on a table, a SQL Server administrator runs the stored procedure `sys.sp_cdc_enable_table` for the table.
 The stored procedures can be run by using SQL Server Management Studio, or by using Transact-SQL.
-SQL Server CDC must be enabled for every table that you want to capture. 
+SQL Server CDC must be enabled for every table that you want to capture.
 
 .Prerequisites
 * CDC is enabled on the SQL Server database.
-* The SQL Server Agent is running.  
-* You are a member of the `db_owner` fixed database role for the database. 
+* The SQL Server Agent is running.
+* You are a member of the `db_owner` fixed database role for the database.
 
 .Procedure
 . From the *View* menu in SQL Server Management Studio, click *Template Explorer*.
 . In the *Template Browser*, expand *SQL Server Templates*.
-. Expand *Change Data Capture > Configuration*, and then click *Enable Table Specifying Filegroup Option*.  
+. Expand *Change Data Capture > Configuration*, and then click *Enable Table Specifying Filegroup Option*.
 . In the template, replace the table name in the `USE` statement with the name of the table that you want to capture.
 . Run the stored procedure `sys.sp_cdc_enable_table`.
-+ 
++
 The following example shows how to enable CDC for the table `MyTable`:
 +
 .Example: Enabling CDC for a SQL Server table
@@ -1414,10 +1414,10 @@ EXEC sys.sp_cdc_enable_table
 GO
 ----
 <.> Specifies the name of the table that you want to capture.
-<.> Specifies a role `MyRole` to which you can add users to whom you want to grant `SELECT` permission on the captured columns of the source table. 
+<.> Specifies a role `MyRole` to which you can add users to whom you want to grant `SELECT` permission on the captured columns of the source table.
 Users in the `sysadmin` or `db_owner` role also have access to the specified change tables. Set the value of `@role_name` to `NULL`, to allow only members in the `sysadmin` or `db_owner` to have full access to captured information.
-<.> Specifies the `filegroup` where SQL Server places the change table for the captured table. 
-The named `filegroup` must already exist. 
+<.> Specifies the `filegroup` where SQL Server places the change table for the captured table.
+The named `filegroup` must already exist.
 It is best not to locate change tables in the same `filegroup` that you use for source tables.
 
 
@@ -1429,14 +1429,14 @@ A SQL Server administrator can run a system stored procedure to query a database
 The stored procedures can be run by using SQL Server Management Studio, or by using Transact-SQL.
 
 .Prerequisites
-* You have `SELECT` permission on all of the captured columns of the capture instance. 
+* You have `SELECT` permission on all of the captured columns of the capture instance.
 Members of the `db_owner` database role can view information for all of the defined capture instances.
-* You have membership in any gating roles that are defined for the table information that the query includes. 
+* You have membership in any gating roles that are defined for the table information that the query includes.
 
 .Procedure
 
 . From the *View* menu in SQL Server Management Studio, click *Object Explorer*.
-. From the Object Explorer, expand *Databases*, and then expand your database object, for example, *MyDB*. 
+. From the Object Explorer, expand *Databases*, and then expand your database object, for example, *MyDB*.
 . Expand *Programmability > Stored Procedures > System Stored Procedures*.
 . Run the `sys.sp_cdc_help_change_data_capture` stored procedure to query the table.
 +
@@ -1525,7 +1525,7 @@ For details about deploying the {prodname} SQL Server connector, see the followi
 * xref:adding-sql-server-connector-configuration-to-kafka-connect[]
 * xref:descriptions-of-debezium-sql-server-connector-configuration-properties[]
 
-To deploy a {prodname} SQL Server connector, install the {prodname} SQL Server connector archive, configure the connector, and start the connector by adding its configuration to Kafka Connect. 
+To deploy a {prodname} SQL Server connector, install the {prodname} SQL Server connector archive, configure the connector, and start the connector by adding its configuration to Kafka Connect.
 
 endif::product[]
 
@@ -1537,13 +1537,13 @@ ifdef::product[]
 
 To install the SQL Server connector, follow the procedures in {LinkDebeziumInstallOpenShift}[{NameDebeziumInstallOpenShift}]. The main steps are:
 
-. Use link:https://access.redhat.com/products/red-hat-amq#streams[Red Hat AMQ Streams] to set up Apache Kafka and Kafka Connect on OpenShift. AMQ Streams offers operators and images that bring Kafka to OpenShift. 
+. Use link:https://access.redhat.com/products/red-hat-amq#streams[Red Hat AMQ Streams] to set up Apache Kafka and Kafka Connect on OpenShift. AMQ Streams offers operators and images that bring Kafka to OpenShift.
 
-. From a browser, open the link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions[Software Downloads page on the Red Hat Customer Portal], 
+. From a browser, open the link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions[Software Downloads page on the Red Hat Customer Portal],
 and download the {prodname} SQL Server connector.
 
 . Extract the connector files into your Kafka Connect environment.
-. Add the connector plug-in's parent directory to your Kafka Connect `plugin.path`, for example: 
+. Add the connector plug-in's parent directory to your Kafka Connect `plugin.path`, for example:
 +
 [source]
 ----
@@ -1624,14 +1624,14 @@ Typically, you configure the {prodname} SQL Server connector in a `.yaml` file i
 
 [source,yaml,options="nowrap"]
 ----
-apiVersion: kafka.strimzi.io/v1beta1 
+apiVersion: kafka.strimzi.io/v1beta1
   kind: KafkaConnector
   metadata:
     name: inventory-connector // <1>
     labels: strimzi.io/cluster: my-connect-cluster
   spec:
     class: io.debezium.connector.sqlserver.SqlServerConnector // <2>
-    config:  
+    config:
       database.hostname: 192.168.99.100 // <3>
       database.port: 1433 // <4>
       database.user: debezium // <5>
@@ -1639,7 +1639,7 @@ apiVersion: kafka.strimzi.io/v1beta1
       database.dbname: testDB // <7>
       database.server.name: fullfullment // <8>
       database.include.list: dbo.customers // <9>
-      database.history.kafka.bootstrap.servers: my-cluster-kafka-bootstrap:9092 // <10> 
+      database.history.kafka.bootstrap.servers: my-cluster-kafka-bootstrap:9092 // <10>
       database.history.kafka.topic: dbhistory.fullfillment // <11>
 
 ----
@@ -1697,36 +1697,36 @@ This configuration can be sent via POST to a running Kafka Connect service, whic
 ==== Adding connector configuration
 
 ifdef::community[]
-To run a {prodname} SQL Server connector, create a connector configuration and add the configuration to your Kafka Connect cluster. 
+To run a {prodname} SQL Server connector, create a connector configuration and add the configuration to your Kafka Connect cluster.
 
 .Prerequisites
 
 * SQL Server is set up to run a {prodname} connector.
 
-* A {prodname} SQL Server connector is installed. 
+* A {prodname} SQL Server connector is installed.
 
 .Procedure
 
 . Create a configuration for the SQL Server connector.
 
-. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster. 
+. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster.
 
 endif::community[]
 
 ifdef::product[]
 
-You can use a provided {prodname} container to deploy a {prodname} SQL Server connector. 
-In this procedure, you build a custom Kafka Connect container image for {prodname}, configure the {prodname} connector as needed, 
-and then add your connector configuration to your Kafka Connect environment. 
+You can use a provided {prodname} container to deploy a {prodname} SQL Server connector.
+In this procedure, you build a custom Kafka Connect container image for {prodname}, configure the {prodname} connector as needed,
+and then add your connector configuration to your Kafka Connect environment.
 
 .Prerequisites
 
 * Podman or Docker is installed and you have sufficient rights to create and manage containers.
-* You installed the {prodname} SQL Server connector archive. 
+* You installed the {prodname} SQL Server connector archive.
 
 .Procedure
 
-. Extract the {prodname} SQL Server connector archive to create a directory structure for the connector plug-in, for example: 
+. Extract the {prodname} SQL Server connector archive to create a directory structure for the connector plug-in, for example:
 +
 [subs=+macros]
 ----
@@ -1777,7 +1777,7 @@ spec:
 
 . Create a `KafkaConnector` custom resource that defines your {prodname} SQL Server connector instance. See {LinkDebeziumUserGuide}#sqlserver-example-configuration[the connector configuration example].
 
-. Apply the connector instance, for example: 
+. Apply the connector instance, for example:
 +
 `oc apply -f inventory-connector.yaml`
 +
@@ -1792,19 +1792,19 @@ This registers `inventory-connector` and the connector starts to run against the
 oc logs $(oc get pods -o name -l strimzi.io/name=my-connect-cluster-connect)
 ----
 
-.. Review the log output to verify that the initial snapshot has been executed. You should see something like the following lines: 
+.. Review the log output to verify that the initial snapshot has been executed. You should see something like the following lines:
 +
 [source,shell,options="nowrap"]
 ----
 ... INFO Starting snapshot for ...
-... INFO Snapshot is using user 'debezium' ... 
+... INFO Snapshot is using user 'debezium' ...
 ----
 
 endif::product[]
 
 .Results
 
-When the connector starts, it {link-prefix}:{link-sqlserver-connector}#sqlserver-snapshots[performs a consistent snapshot] of the SQL Server databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics. 
+When the connector starts, it {link-prefix}:{link-sqlserver-connector}#sqlserver-snapshots[performs a consistent snapshot] of the SQL Server databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
 
 
 // Type: reference
@@ -1867,29 +1867,25 @@ Only alphanumeric characters and underscores should be used.
 |A list of host and port pairs that the connector will use for establishing an initial connection to the Kafka cluster.
 This connection is used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. This should point to the same Kafka cluster used by the Kafka Connect process.
 
-|[[sqlserver-property-table-include-list]]
-[[sqlserver-property-table-include-list]]<<sqlserver-property-table-include-list, `table.include.list`>>
+|[[sqlserver-property-table-include-list]]<<sqlserver-property-table-include-list, `table.include.list`>>
 |
-|An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables that you want {prodname} to capture; any table that is not included in `table.include.list` is excluded from capture. Each identifier is of the form _schemaName_._tableName_. 
+|An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables that you want {prodname} to capture; any table that is not included in `table.include.list` is excluded from capture. Each identifier is of the form _schemaName_._tableName_.
 By default, the connector captures all non-system tables for the designated schemas.
 Must not be used with `table.exclude.list`.
 
-|[[sqlserver-property-table-exclude-list]]
-[[sqlserver-property-table-exclude-list]]<<sqlserver-property-table-exclude-list, `table.exclude.list`>>
+|[[sqlserver-property-table-exclude-list]]<<sqlserver-property-table-exclude-list, `table.exclude.list`>>
 |
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for the tables that you want to exclude from being captured; {prodname} captures all tables that are not included in `table.exclude.list`.
 Each identifier is of the form _schemaName_._tableName_. Must not be used with `table.include.list`.
 
-|[[sqlserver-property-column-include-list]]
-[[sqlserver-property-column-include-list]]<<sqlserver-property-column-include-list, `column.include.list`>>
+|[[sqlserver-property-column-include-list]]<<sqlserver-property-column-include-list, `column.include.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in the change event message values.
 Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 Note that primary key columns are always included in the event's key, even if not included in the value.
 Do not also set the `column.exclude.list` property.
 
-|[[sqlserver-property-column-exclude-list]]
-[[sqlserver-property-column-exclude-list]]<<sqlserver-property-column-exclude-list, `column.exclude.list`>>
+|[[sqlserver-property-column-exclude-list]]<<sqlserver-property-column-exclude-list, `column.exclude.list`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event message values.
 Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
@@ -1972,8 +1968,8 @@ The following _advanced_ configuration properties have good defaults that will w
 |[[sqlserver-property-snapshot-mode]]<<sqlserver-property-snapshot-mode, `snapshot.mode`>>
 |_initial_
 |A mode for taking an initial snapshot of the structure and optionally data of captured tables.
-Once the snapshot is complete, the connector will continue reading change events from the database's redo logs. 
-The following values are supported: 
+Once the snapshot is complete, the connector will continue reading change events from the database's redo logs.
+The following values are supported:
 
 * `initial`: Takes a snapshot of structure and data of captured tables; useful if topics should be populated with a complete representation of the data from the captured tables. +
 * `initial_only`: Takes a snapshot of structure and data like `initial` but instead does not transition into streaming changes once the snapshot has completed. +
@@ -1996,7 +1992,7 @@ The following values are supported:
 to be read). +
 
 The `snapshot`, `read_committed` and `read_uncommitted` modes do not prevent other
-transactions from updating table rows during initial snapshot. 
+transactions from updating table rows during initial snapshot.
 The `exclusive` and `repeatable_read` modes do prevent concurrent updates. +
 
 Mode choice also affects data consistency. Only `exclusive` and `snapshot` modes guarantee full consistency, that is, initial
@@ -2011,7 +2007,7 @@ For `read_uncommitted` there are no data consistency guarantees at all (some dat
 a|String that represents the criteria of the attached timestamp within the source record (ts_ms).
 
 * `commit` (default) sets the source timestamp to the time when the record was committed to the database.
-* `processing` sets the source timestamp to the time when {prodname} accesses the record in the change table. 
+* `processing` sets the source timestamp to the time when {prodname} accesses the record in the change table.
 Use the `processing` option if you want {prodname] to set the top level `ts_ms` value, or if you want to avoid the additional cost of {prodname} querying the database to extract the LSN timestamps.
 
 |[[sqlserver-property-event-processing-failure-handling-mode]]<<sqlserver-property-event-processing-failure-handling-mode, `event.processing{zwsp}.failure.handling{zwsp}.mode`>>
@@ -2097,9 +2093,9 @@ endif::community[]
 |
 | Timezone of the server.
 
-This property defines the timezone of the transaction timestamp (`ts_ms`) that is retrieved from the server (which is actually not zoned). 
-By default, the value is unset. 
-Set a value for the property only when running on SQL Server 2014 or older, and the database server and the JVM running the {prodname} connector use different timezones. 
+This property defines the timezone of the transaction timestamp (`ts_ms`) that is retrieved from the server (which is actually not zoned).
+By default, the value is unset.
+Set a value for the property only when running on SQL Server 2014 or older, and the database server and the JVM running the {prodname} connector use different timezones.
 
 When unset, default behavior is to use the timezone of the VM running the {prodname} connector. In this case, when running on on SQL Server 2014 or older and using different timezones on server and the connector, incorrect ts_ms values may be produced. +
 Possible values include "Z", "UTC", offset values like "+02:00", short zone ids like "CET", and long zone ids like "Europe/Paris".
@@ -2143,18 +2139,18 @@ Be sure to consult the {link-kafka-docs}.html[Kafka documentation] for all of th
 
 // Type: assembly
 // ModuleID: refreshing-capture-tables-after-a-schema-change
-// Title: Refreshing capture tables after a schema change 
+// Title: Refreshing capture tables after a schema change
 [[sqlserver-schema-evolution]]
 === Database schema evolution
 
 When change data capture is enabled for a SQL Server table, as changes occur in the table, event records are persisted to a capture table on the server.
 If you introduce a change in the structure of the source table change, for example, by adding a new column, that change is not dynamically reflected in the change table.
 For as long as the capture table continues to use the outdated schema, the {prodname} connector is unable to emit data change events for the table correctly.
-You must intervene to refresh the capture table to enable the connector to resume processing change events.   
- 
+You must intervene to refresh the capture table to enable the connector to resume processing change events.
+
 Because of the way that CDC is implemented in SQL Server, you cannot use {prodname} to update capture tables.
 To refresh capture tables, one must be a SQL Server database operator with elevated privileges.
-As a {prodname} user, you must coordinate tasks with the SQL Server database operator to complete the schema refresh and restore streaming to Kafka topics.    
+As a {prodname} user, you must coordinate tasks with the SQL Server database operator to complete the schema refresh and restore streaming to Kafka topics.
 
 You can use one of the following methods to update capture tables after a schema change:
 
@@ -2179,17 +2175,17 @@ For example, if CDC is enabled on a table, SQL Server does not allow you to chan
 ====
 After you change a column in a source table from `NULL` to `NOT NULL` or vice versa, the SQL Server connector cannot correctly capture the changed information until after you create a new capture instance.
 If you do not create a new capture table after a change to the column designation, change event records that the connector emits do not correctly indicate whether the column is optional.
-That is, columns that were previously defined as optional (or `NULL`) continue to be, despite now being defined as `NOT NULL`. 
+That is, columns that were previously defined as optional (or `NULL`) continue to be, despite now being defined as `NOT NULL`.
 Similarly, columns that had been defined as required (`NOT NULL`), retain that designation, although they are now defined as `NULL`.
 ====
 
 // Type: procedure
 // ModuleID: debezium-sql-server-connector-running-an-offline-update-after-a-schema-change
-// Title: Running an offline update after a schema change 
+// Title: Running an offline update after a schema change
 [id="offline-schema-updates"]
 ==== Offline schema updates
 
-Offline schema updates provide the safest method for updating capture tables. 
+Offline schema updates provide the safest method for updating capture tables.
 However, offline updates might not be feasible for use with applications that require high-availability.
 
 .Prerequisites
@@ -2209,13 +2205,13 @@ However, offline updates might not be feasible for use with applications that re
 
 // Type: procedure
 // ModuleID: debezium-sql-server-connector-running-an-online-update-after-a-schema-change
-// Title: Running an online update after a schema change 
+// Title: Running an online update after a schema change
 [id="online-schema-updates"]
 ==== Online schema updates
 
-The procedure for completing an online schema updates is simpler than the procedure for running an offline schema update, 
+The procedure for completing an online schema updates is simpler than the procedure for running an offline schema update,
 and you can complete it without requiring any downtime in application and data processing.
-However, with online schema updates, a potential processing gap can occur after you update the schema in the source database, 
+However, with online schema updates, a potential processing gap can occur after you update the schema in the source database,
 but before you create the new capture instance.
 During that interval, change events continue to be captured by the old instance of the change table, Q
 and the change data that is saved to the old table retains the structure of the earlier schema.
@@ -2232,7 +2228,7 @@ If your application does not tolerate such a transition period, it is best to us
 3. When {prodname} starts streaming from the new capture table, you can drop the old capture table by running the `sys.sp_cdc_disable_table` stored procedure with the parameter `@capture_instance` set to the old capture instance name.
 
 
-.Example: Running an online schema update after a database schema change 
+.Example: Running an online schema update after a database schema change
 ifdef::community[]
 Let's deploy the SQL Server based https://github.com/debezium/debezium-examples/tree/master/tutorial#using-sql-server[{prodname} tutorial] to demonstrate the online schema update.
 
@@ -2304,7 +2300,7 @@ Eventually, the `phone_number` field is added to the schema and its value appear
     },
 ----
 
-. Drop the old capture instance by running the `sys.sp_cdc_disable_table` stored procedure. 
+. Drop the old capture instance by running the `sys.sp_cdc_disable_table` stored procedure.
 +
 [source,sql]
 ----
@@ -2320,7 +2316,7 @@ GO
 
 The {prodname} SQL Server connector provides three types of metrics that are in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect provide.
 The connector provides the following metrics:
- 
+
 * <<sqlserver-snapshot-metrics, snapshot metrics>>; for monitoring the connector when performing snapshots.
 * <<sqlserver-streaming-metrics, streaming metrics>>; for monitoring the connector when reading CDC table data.
 * <<sqlserver-schema-history-metrics, schema history metrics>>; for monitoring the status of the connector's schema history.

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -87,9 +87,9 @@ For example, suppose that `fulfillment` is the logical server name in the config
 
 The {prodname} Vitess connector generates a data change event for each row-level `INSERT`, `UPDATE`, and `DELETE` operation. Each event contains a key and a value. The structure of the key and the value depends on the table that was changed.
 
-{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry. This makes each event self-contained. 
+{prodname} and Kafka Connect are designed around _continuous streams of event messages_. However, the structure of these events may change over time, which can be difficult for consumers to handle. To address this, each event contains the schema for its content or, if you are using a schema registry, a schema ID that a consumer can use to obtain the schema from the registry. This makes each event self-contained.
 
-The following skeleton JSON shows the basic four parts of a change event. However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of these four parts in change events. A `schema` field is in a change event only when you configure the converter to produce it. Likewise, the event key and event payload are in a change event only if you configure a converter to produce it. If you use the JSON converter and you configure it to produce all four basic change event parts, change events have this structure: 
+The following skeleton JSON shows the basic four parts of a change event. However, how you configure the Kafka Connect converter that you choose to use in your application determines the representation of these four parts in change events. A `schema` field is in a change event only when you configure the converter to produce it. Likewise, the event key and event payload are in a change event only if you configure a converter to produce it. If you use the JSON converter and you configure it to produce all four basic change event parts, change events have this structure:
 
 [source,json,index=0]
 ----
@@ -100,7 +100,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
  "payload": { // <2>
    ...
  },
- "schema": { // <3> 
+ "schema": { // <3>
    ...
  },
  "payload": { // <4>
@@ -126,7 +126,7 @@ It is possible to override the table's primary key by setting the {link-prefix}:
 
 |3
 |`schema`
-|The second `schema` field is part of the event value. It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion. In other words, the second `schema` describes the structure of the row that was changed. Typically, this schema contains nested schemas. 
+|The second `schema` field is part of the event value. It specifies the Kafka Connect schema that describes what is in the event value's `payload` portion. In other words, the second `schema` describes the structure of the row that was changed. Typically, this schema contains nested schemas.
 
 |4
 |`payload`
@@ -210,7 +210,7 @@ If the `database.server.name` connector configuration property has the value `Vi
 
 |1
 |`schema`
-|The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion. 
+|The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion.
 
 |2
 |`Vitess_server{zwsp}.commerce.customers{zwsp}.Key`
@@ -225,7 +225,7 @@ a|Name of the schema that defines the structure of the key's payload. This schem
 |Indicates whether the event key must contain a value in its `payload` field. In this example, a value in the key's payload is required. A value in the key's payload field is optional when a table does not have a primary key.
 
 |4
-|`fields` 
+|`fields`
 |Specifies each field that is expected in the `payload`, including each field's name, index, and schema.
 
 |5
@@ -250,9 +250,9 @@ If the table does not have a primary, then the change event's key is null. The r
 [[vitess-change-events-value]]
 === Change event values
 
-The value in a change event is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. Change events for operations that create, update or delete data all have a value payload with an envelope structure. 
+The value in a change event is a bit more complicated than the key. Like the key, the value has a `schema` section and a `payload` section. The `schema` section contains the schema that describes the `Envelope` structure of the `payload` section, including its nested fields. Change events for operations that create, update or delete data all have a value payload with an envelope structure.
 
-Consider the same sample table that was used to show an example of a change event key: 
+Consider the same sample table that was used to show an example of a change event key:
 
 [source,sql,indent=0]
 ----
@@ -271,7 +271,7 @@ The emitted events for `UPDATE` and `DELETE` oeprations contain the previous val
 [[vitess-create-events]]
 === _create_ events
 
-The following example shows the value portion of a change event that the connector generates for an operation that creates data in the `customers` table: 
+The following example shows the value portion of a change event that the connector generates for an operation that creates data in the `customers` table:
 
 [source,json,options="nowrap",indent=0,subs="+attributes"]
 ----
@@ -436,7 +436,7 @@ The following example shows the value portion of a change event that the connect
 
 |1
 |`schema`
-|The value's schema, which describes the structure of the value's payload. A change event's value schema is the same in every change event that the connector generates for a particular table. 
+|The value's schema, which describes the structure of the value's payload. A change event's value schema is the same in every change event that the connector generates for a particular table.
 
 |2
 |`name`
@@ -471,7 +471,7 @@ a|An optional field that specifies the state of the row before the event occurre
 
 |8
 |`source`
-a|Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes: 
+a|Mandatory field that describes the source metadata for the event. This field contains information that you can use to compare this event with other events, with regard to the origin of the events, the order in which the events occurred, and whether events were part of the same transaction. The source metadata includes:
 
 * {prodname} version
 * Connector type and name
@@ -482,7 +482,7 @@ a|Mandatory field that describes the source metadata for the event. This field c
 
 |9
 |`op`
-a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are: 
+a|Mandatory string that describes the type of operation that caused the connector to generate the event. In this example, `c` indicates that the operation created a row. Valid values are:
 
 * `c` = create
 * `u` = update
@@ -500,7 +500,7 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 [[vitess-update-events]]
 === _update_ events
 
-The value of a change event for an update in the sample `customers` table has the same schema as a _create_ event for that table. Likewise, the event value's payload has the same structure. However, the event value payload contains different values in an _update_ event. Here is an example of a change event value in an event that the connector generates for an update in the `customers` table: 
+The value of a change event for an update in the sample `customers` table has the same schema as a _create_ event for that table. Likewise, the event value's payload has the same structure. However, the event value payload contains different values in an _update_ event. Here is an example of a change event value in an event that the connector generates for an update in the `customers` table:
 
 [source,json,indent=0,options="nowrap",subs="+attributes"]
 ----
@@ -547,11 +547,11 @@ The value of a change event for an update in the sample `customers` table has th
 
 |2
 |`after`
-|An optional field that specifies the state of the row after the event occurred. In this example, the `first_name` value is now `Anne Marie`. 
+|An optional field that specifies the state of the row after the event occurred. In this example, the `first_name` value is now `Anne Marie`.
 
 |3
 |`source`
-a|Mandatory field that describes the source metadata for the event. The `source` field structure has the same fields as in a _create_ event, but some values are different. The source metadata includes: 
+a|Mandatory field that describes the source metadata for the event. The `source` field structure has the same fields as in a _create_ event, but some values are different. The source metadata includes:
 
 * {prodname} version
 * Connector type and name
@@ -580,7 +580,7 @@ Updating the columns for a row's primary key changes the value of the row's key.
 [[vitess-delete-events]]
 === _delete_ events
 
-The value in a _delete_ change event has the same `schema` portion as _create_ and _update_ events for the same table. The `payload` portion in a _delete_ event for the sample `customers` table looks like this:  
+The value in a _delete_ change event has the same `schema` portion as _create_ and _update_ events for the same table. The `payload` portion in a _delete_ event for the sample `customers` table looks like this:
 
 [source,json,indent=0,subs="+attributes"]
 ----
@@ -626,7 +626,7 @@ The value in a _delete_ change event has the same `schema` portion as _create_ a
 
 |3
 |`source`
-a|Mandatory field that describes the source metadata for the event. In a _delete_ event value, the `source` field structure is the same as for _create_ and _update_ events for the same table. Many `source` field values are also the same. In a _delete_ event value, the `ts_ms` and `lsn` field values, as well as other values, might have changed. But the `source` field in a _delete_ event value provides the same metadata: 
+a|Mandatory field that describes the source metadata for the event. In a _delete_ event value, the `source` field structure is the same as for _create_ and _update_ events for the same table. Many `source` field values are also the same. In a _delete_ event value, the `ts_ms` and `lsn` field values, as well as other values, might have changed. But the `source` field in a _delete_ event value provides the same metadata:
 
 * {prodname} version
 * Connector type and name
@@ -1089,23 +1089,19 @@ The following configuration properties are _required_ unless a default value is 
 |
 |Logical name that identifies and provides a namespace for the particular Vitess database server or cluster in which {prodname} is capturing changes. Only alphanumeric characters and underscores should be used in the database server logical name. The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
 
-|[[vitess-property-table-include-list]]
-[[vitess-property-table-include-list]]<<vitess-property-table-include-list, `table.include{zwsp}.list`>>
+|[[vitess-property-table-include-list]]<<vitess-property-table-include-list, `table.include{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you want to capture. Any table not included in `table.include.list` does not have its changes captured. Each identifier is of the form _keyspace_._tableName_. By default, the connector captures changes in every non-system table in each schema whose changes are being captured. Do not also set the `table.exclude.list` property.
 
-|[[vitess-property-table-exclude-list]]
-[[vitess-property-table-exclude.list]]<<vitess-property-table-exclude.list, `table.exclude{zwsp}.list`>>
+|[[vitess-property-table-exclude.list]]<<vitess-property-table-exclude.list, `table.exclude{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you *do not* want to capture. Any table not included in `table.exclude.list` has it changes captured. Each identifier is of the form _keyspace_._tableName_. Do not also set the `table.include.list` property.
 
-|[[vitess-property-column-include-list]]
-[[vitess-property-column-include-list]]<<vitess-property-column-include-list, `column.include{zwsp}.list`>>
+|[[vitess-property-column-include-list]]<<vitess-property-column-include-list, `column.include{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in change event record values. Fully-qualified names for columns are of the form _keyspace_._tableName_._columnName_. Do not also set the `column.exclude.list` property.
 
-|[[vitess-property-column-exclude-list]]
-[[vitess-property-column-exclude-list]]<<vitess-property-column-exclude-list, `column.exclude{zwsp}.list`>>
+|[[vitess-property-column-exclude-list]]<<vitess-property-column-exclude-list, `column.exclude{zwsp}.list`>>
 |
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event record values. Fully-qualified names for columns are of the form _keyspace_._tableName_._columnName_. Do not also set the `column.include.list` property.
 
@@ -1117,7 +1113,7 @@ The following configuration properties are _required_ unless a default value is 
  +
 `false` - only a _delete_ event is sent. +
  +
-After a _delete_ operation, emitting a tombstone event enables Kafka to delete all change event records that have the same key as the deleted row. 
+After a _delete_ operation, emitting a tombstone event enables Kafka to delete all change event records that have the same key as the deleted row.
 
 |[[vitess-property-message-key-columns]]<<vitess-property-message-key-columns, `message.key{zwsp}.columns`>>
 |_empty string_
@@ -1189,7 +1185,7 @@ Be sure to consult the {link-kafka-docs}.html[Kafka documentation] for all of th
 [[vitess-when-things-go-wrong]]
 == Behavior when things go wrong
 
-{prodname} is a distributed system that captures all changes in multiple upstream databases; it never misses or loses an event. When the system is operating normally or being managed carefully then {prodname} provides _exactly once_ delivery of every change event record. 
+{prodname} is a distributed system that captures all changes in multiple upstream databases; it never misses or loses an event. When the system is operating normally or being managed carefully then {prodname} provides _exactly once_ delivery of every change event record.
 
 If a fault does happen then the system does not lose any events. However, while it is recovering from the fault, it might repeat some change events. In these abnormal situations, {prodname}, like Kafka, provides _at least once_ delivery of change events.
 
@@ -1200,7 +1196,7 @@ The rest of this section describes how {prodname} handles various kinds of fault
 
 In the following situations, the connector fails when trying to start, reports an error/exception in the log, and stops running:
 
-* The connector's configuration is invalid. 
+* The connector's configuration is invalid.
 * The connector cannot successfully connect to Vitess by using the specified connection parameters.
 
 In these cases, the error message has details about the problem and possibly a suggested workaround. After you correct the configuration or address the Vitess problem, restart the connector.


### PR DESCRIPTION
Jira [DBZ-3111](https://issues.redhat.com/browse/DBZ-3111)

This change removes redundant anchors that I erroneously inserted into the tables for the `*include-` and `*exclude-` .list properties for all of the connectors when I updated terminology in [DBZ-2918](https://issues.redhat.com/browse/DBZ-2918). The duplicates generated build warnings that prevented Antora from building the documentation.

Verified in a local Antora build that the build now completes successfully, that the property names render correctly, and that the links work as expected. 