### PR TITLE
DBZ-3087 Remove zero-width spaces from prop names subject to copying

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -13,6 +13,7 @@ ifdef::community[]
 :source-highlighter: highlight.js
 
 toc::[]
+endif::community[]
 
 {prodname}'s Db2 connector can capture row-level changes in the tables of a Db2 database. This connector is strongly inspired by the {prodname} implementation of SQL Server, which uses a SQL-based polling model that puts tables into "capture mode". When a table is in capture mode, the {prodname} Db2 connector generates and streams a change event for each row-level update to that table.
 
@@ -1706,65 +1707,65 @@ The following configuration properties are _required_ unless a default value is 
 |===
 |Property |Default |Description
 
-|[[db2-property-name]]<<db2-property-name, `name`>>
+|[[db2-property-name]]<<db2-property-name, `+name+`>>
 |
 |Unique name for the connector. Attempting to register again with the same name will fail. This property is required by all Kafka Connect connectors.
 
-|[[db2-property-connector-class]]<<db2-property-connector-class, `connector.class`>>
+|[[db2-property-connector-class]]<<db2-property-connector-class, `+connector.class+`>>
 |
 |The name of the Java class for the connector. Always use a value of `io.debezium.connector.db2.Db2Connector` for the Db2 connector.
 
-|[[db2-property-tasks-max]]<<db2-property-tasks-max, `tasks.max`>>
+|[[db2-property-tasks-max]]<<db2-property-tasks-max, `+tasks.max+`>>
 |`1`
 |The maximum number of tasks that should be created for this connector. The Db2 connector always uses a single task and therefore does not use this value, so the default is always acceptable.
 
-|[[db2-property-database-hostname]]<<db2-property-database-hostname, `database.hostname`>>
+|[[db2-property-database-hostname]]<<db2-property-database-hostname, `+database.hostname+`>>
 |
 |IP address or hostname of the Db2 database server.
 
-|[[db2-property-database-port]]<<db2-property-database-port, `database.port`>>
+|[[db2-property-database-port]]<<db2-property-database-port, `+database.port+`>>
 |`50000`
 |Integer port number of the Db2 database server.
 
-|[[db2-property-database-user]]<<db2-property-database-user, `database.user`>>
+|[[db2-property-database-user]]<<db2-property-database-user, `+database.user+`>>
 |
 |Name of the Db2 database user for connecting to the Db2 database server.
 
-|[[db2-property-database-password]]<<db2-property-database-password, `database.password`>>
+|[[db2-property-database-password]]<<db2-property-database-password, `+database.password+`>>
 |
 |Password to use when connecting to the Db2 database server.
 
-|[[db2-property-database-dbname]]<<db2-property-database-dbname, `database.dbname`>>
+|[[db2-property-database-dbname]]<<db2-property-database-dbname, `+database.dbname+`>>
 |
 |The name of the Db2 database from which to stream the changes
 
-|[[db2-property-database-server-name]]<<db2-property-database-server-name, `database.server{zwsp}.name`>>
+|[[db2-property-database-server-name]]<<db2-property-database-server-name, `+database.server.name+`>>
 |
 |Logical name that identifies and provides a namespace for the particular Db2 database server that hosts the database for which {prodname} is capturing changes. Only alphanumeric characters and underscores should be used in the database server logical name. The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
 
-|[[db2-property-database-history-kafka-topic]]<<db2-property-database-history-kafka-topic, `database.history{zwsp}.kafka.topic`>>
+|[[db2-property-database-history-kafka-topic]]<<db2-property-database-history-kafka-topic, `+database.history.kafka.topic+`>>
 |
 |The full name of the Kafka topic where the connector stores the database schema history.
 
-|[[db2-property-database-history-kafka-bootstrap-servers]]<<db2-property-database-history-kafka-bootstrap-servers, `database.history{zwsp}.kafka.bootstrap{zwsp}.servers`>>
+|[[db2-property-database-history-kafka-bootstrap-servers]]<<db2-property-database-history-kafka-bootstrap-servers, `+database.history.kafka.bootstrap.servers+`>>
 |
 |A list of host/port pairs that the connector uses to establish an initial connection to the Kafka cluster. This connection is used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. Each pair should point to the same Kafka cluster used by the {prodname} Kafka Connect process.
 
-|[[db2-property-table-include-list]]<<db2-property-table-include-list, `table.include.list`>>
+|[[db2-property-table-include-list]]<<db2-property-table-include-list, `+table.include.list+`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you want the connector to capture. Any table not included in the include list does not have its changes captured. Each identifier is of the form _schemaName_._tableName_. By default, the connector captures changes in every non-system table. Do not also set the `table.exclude.list` property.
 
-|[[db2-property-table-exclude-list]]<<db2-property-table-exclude-list, `table.exclude.list`>>
+|[[db2-property-table-exclude-list]]<<db2-property-table-exclude-list, `+table.exclude.list+`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you do not want the connector to capture. The connector captures changes in each non-system table that is not included in the exclude list. Each identifier is of the form _schemaName_._tableName_. Do not also set the `table.include.list` property.
 
-|[[db2-property-column-exclude-list]]<<db2-property-column-exclude-list, `column.exclude.list`>>
+|[[db2-property-column-exclude-list]]<<db2-property-column-exclude-list, `+column.exclude.list+`>>
 |_empty string_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to exclude from change event values.
 Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 Primary key columns are always included in the event's key, even if they are excluded from the value.
 
-|[[db2-property-column-mask-hash]]<<db2-property-column-mask-hash, `column.mask{zwsp}.hash._hashAlgorithm_{zwsp}.with.salt._salt_`>>
+|[[db2-property-column-mask-hash]]<<db2-property-column-mask-hash, `+column.mask.hash._hashAlgorithm_.with.salt._salt_+`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be pseudonyms in change event values. A pseudonym is a field value that  consists of the hashed value obtained by applying the `_hashAlgorithm_` algorithm and the `_salt_` salt that you specify in the property name. +
  +
@@ -1779,7 +1780,7 @@ where `CzQMA0cB5K` is a randomly selected salt.
  +
 Depending on the `_hashAlgorithm_` used, the `_salt_` selected, and the actual data set, the field value may not be completely masked.
 
-|[[db2-property-time-precision-mode]]<<db2-property-time-precision-mode, `time.precision.mode`>>
+|[[db2-property-time-precision-mode]]<<db2-property-time-precision-mode, `+time.precision.mode+`>>
 |`adaptive`
 | Time, date, and timestamps can be represented with different kinds of precision: +
  +
@@ -1787,7 +1788,7 @@ Depending on the `_hashAlgorithm_` used, the `_salt_` selected, and the actual d
  +
 `connect` always represents time and timestamp values by using Kafka Connect's built-in representations for `Time`, `Date`, and `Timestamp`, which uses millisecond precision regardless of the database columns' precision. See {link-prefix}:{link-db2-connector}#db2-temporal-values[temporal values].
 
-|[[db2-property-tombstones-on-delete]]<<db2-property-tombstones-on-delete, `tombstones.on{zwsp}.delete`>>
+|[[db2-property-tombstones-on-delete]]<<db2-property-tombstones-on-delete, `+tombstones.on.delete+`>>
 |`true`
 | Controls whether a tombstone event should be generated after a _delete_ event. +
  +
@@ -1797,19 +1798,19 @@ Depending on the `_hashAlgorithm_` used, the `_salt_` selected, and the actual d
  +
 After a _delete_ operation, emitting a tombstone event enables Kafka to delete all change event records that have the same key as the deleted row.
 
-|[[db2-property-include-schema-changes]]<<db2-property-include-schema-changes, `include.schema{zwsp}.changes`>>
+|[[db2-property-include-schema-changes]]<<db2-property-include-schema-changes, `+include.schema.changes+`>>
 |`true`
 |Boolean value that specifies whether the connector should publish changes in the database schema to a Kafka topic with the same name as the database server ID. Each schema change is recorded with a key that contains the database name and a value that is a JSON structure that describes the schema update. This is independent of how the connector internally records database history.
 
-|[[db2-property-column-truncate-to-length-chars]]<<db2-property-column-truncate-to-length-chars, `column.truncate.to.{zwsp}_length_.chars`>>
+|[[db2-property-column-truncate-to-length-chars]]<<db2-property-column-truncate-to-length-chars, `+column.truncate.to._length_.chars+`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event records, values in these columns are truncated if they are longer than the number of characters specified by _length_ in the property name. You can specify multiple properties with different lengths in a single configuration. Length must be a positive integer, for example, `column.truncate.to.20.chars`.
 
-|[[db2-property-column-mask-with-length-chars]]<<db2-property-column-mask-with-length-chars, `column.mask{zwsp}.with._length_.chars`>>
+|[[db2-property-column-mask-with-length-chars]]<<db2-property-column-mask-with-length-chars, `+column.mask.with._length_.chars+`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event values, the values in the specified table columns are replaced with _length_ number of asterisk (`*`) characters. You can specify multiple properties with different lengths in a single configuration. Length must be a positive integer or zero. When you specify zero, the connector replaces a value with an empty string.
 
-|[[db2-property-column-propagate-source-type]]<<db2-property-column-propagate-source-type, `column.propagate{zwsp}.source.type`>>
+|[[db2-property-column-propagate-source-type]]<<db2-property-column-propagate-source-type, `+column.propagate.source.type+`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns. Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_. +
  +
@@ -1819,7 +1820,7 @@ For each specified column, the connector adds the column's original type and ori
  +
 This property is useful for properly sizing corresponding columns in sink databases.
 
-|[[db2-property-datatype-propagate-source-type]]<<db2-property-datatype-propagate-source-type, `datatype.propagate{zwsp}.source.type`>>
+|[[db2-property-datatype-propagate-source-type]]<<db2-property-datatype-propagate-source-type, `+datatype.propagate.source.type+`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the database-specific data type name for some columns. Fully-qualified data type names are of the form _databaseName_._tableName_._typeName_, or _databaseName_._schemaName_._tableName_._typeName_. +
  +
@@ -1831,7 +1832,7 @@ These parameters propagate a column's original type name and length, for variabl
  +
 See {link-prefix}:{link-db2-connector}#db2-data-types[Db2 data types] for the list of Db2-specific data type names.
 
-|[[db2-property-message-key-columns]]<<db2-property-message-key-columns, `message.key{zwsp}.columns`>>
+|[[db2-property-message-key-columns]]<<db2-property-message-key-columns, `+message.key.columns+`>>
 |_empty string_
 |A semicolon separated list of tables with regular expressions that match table column names. The connector maps values in matching columns to key fields in change event records that it sends to Kafka topics. This is useful when a table does not have a primary key, or when you want to order change event records in a Kafka topic according to a field that is not a primary key. +
  +
@@ -1855,7 +1856,7 @@ The following _advanced_ configuration properties have defaults that work in mos
 |===
 |Property |Default |Description
 
-|[[db2-property-snapshot-mode]]<<db2-property-snapshot-mode, `snapshot.mode`>>
+|[[db2-property-snapshot-mode]]<<db2-property-snapshot-mode, `+snapshot.mode+`>>
 |`initial`
 |Specifies the criteria for performing a snapshot when the connector starts: +
  +
@@ -1863,7 +1864,7 @@ The following _advanced_ configuration properties have defaults that work in mos
  +
 `schema_only` - For tables in capture mode, the connector takes a snapshot of only the schema for the table. This is useful when only the changes that are happening from now on need to be emitted to Kafka topics. After the snapshot is complete, the connector continues by reading change events from the database's redo logs.
 
-|[[db2-property-snapshot-isolation-mode]]<<db2-property-snapshot-isolation-mode, `snapshot.isolation{zwsp}.mode`>>
+|[[db2-property-snapshot-isolation-mode]]<<db2-property-snapshot-isolation-mode, `+snapshot.isolation.mode+`>>
 |`repeatable_read`
 |During a snapshot, controls the transaction isolation level and how long the connector locks the tables that are in capture mode. The possible values are: +
  +
@@ -1875,7 +1876,7 @@ The following _advanced_ configuration properties have defaults that work in mos
  +
 `exclusive` - Uses repeatable read isolation level but takes an  exclusive lock for all tables to be read. This mode prevents other transactions from updating table rows during an initial snapshot. Only `exclusive` mode guarantees full consistency; the initial snapshot and streaming logs constitute a linear history.
 
-|[[db2-property-event-processing-failure-handling-mode]]<<db2-property-event-processing-failure-handling-mode, `event.processing{zwsp}.failure.handling{zwsp}.mode`>>
+|[[db2-property-event-processing-failure-handling-mode]]<<db2-property-event-processing-failure-handling-mode, `+event.processing.failure.handling.mode+`>>
 |`fail`
 |Specifies how the connector handles exceptions during processing of events. The possible values are: +
  +
@@ -1885,23 +1886,23 @@ The following _advanced_ configuration properties have defaults that work in mos
  +
 `skip` - The connector skips the problematic event and continues processing with the next event.
 
-|[[db2-property-poll-interval-ms]]<<db2-property-poll-interval-ms, `poll.interval.ms`>>
+|[[db2-property-poll-interval-ms]]<<db2-property-poll-interval-ms, `+poll.interval.ms+`>>
 |`1000`
 |Positive integer value that specifies the number of milliseconds the connector should wait for new change events to appear before it starts processing a batch of events. Defaults to 1000 milliseconds, or 1 second.
 
-|[[db2-property-max-queue-size]]<<db2-property-max-queue-size, `max.queue.size`>>
+|[[db2-property-max-queue-size]]<<db2-property-max-queue-size, `+max.queue.size+`>>
 |`8192`
 |Positive integer value for the maximum size of the blocking queue. The connector places change events that it reads from the database log into the blocking queue before writing them to Kafka. This queue can provide backpressure for reading change-data tables when, for example, writing records to Kafka is slower than it should be or Kafka is not available. Events that appear in the queue are not included in the offsets that are  periodically recorded by the connector. The `max.queue.size` value should always be larger than the value of the `max.batch.size` connector  configuration property.
 
-|[[db2-property-max-batch-size]]<<db2-property-max-batch-size, `max.batch.size`>>
+|[[db2-property-max-batch-size]]<<db2-property-max-batch-size, `+max.batch.size+`>>
 |`2048`
 |Positive integer value that specifies the maximum size of each batch of events that the connector processes.
 
-|[[db2-property-max-queue-size-in-bytes]]<<db2-property-max-queue-size-in-bytes, `max.queue.size.in.bytes`>>
+|[[db2-property-max-queue-size-in-bytes]]<<db2-property-max-queue-size-in-bytes, `+max.queue.size.in.bytes+`>>
 |`0`
 |Long value for the maximum size in bytes of the blocking queue. The feature is disabled by default, it will be active if it's set with a positive long value.
 
-|[[db2-property-heartbeat-interval-ms]]<<db2-property-heartbeat-interval-ms, `heartbeat.interval{zwsp}.ms`>>
+|[[db2-property-heartbeat-interval-ms]]<<db2-property-heartbeat-interval-ms, `+heartbeat.interval.ms+`>>
 |`0`
 |Controls how frequently the connector sends heartbeat messages to a Kafka topic. The default behavior is that the connector does not send heartbeat messages. +
  +
@@ -1909,19 +1910,19 @@ Heartbeat messages are useful for monitoring whether the connector is receiving 
  +
 Heartbeat messages are useful when there are many updates in a database that is being tracked but only a tiny number of updates are in tables that are in capture mode. In this situation, the connector reads from the database transaction log as usual but rarely emits change records to Kafka. This means that the connector has few opportunities to send the latest offset to Kafka. Sending heartbeat messages enables the connector to send the latest offset to Kafka.
 
-|[[db2-property-heartbeat-topics-prefix]]<<db2-property-heartbeat-topics-prefix, `heartbeat.topics{zwsp}.prefix`>>
+|[[db2-property-heartbeat-topics-prefix]]<<db2-property-heartbeat-topics-prefix, `+heartbeat.topics.prefix+`>>
 |`__debezium-heartbeat`
 |Specifies the prefix for the name of the topic to which the connector sends heartbeat messages. The format for this topic name is  `<heartbeat.topics.prefix>.<server.name>`.
 
-|[[db2-property-snapshot-delay-ms]]<<db2-property-snapshot-delay-ms, `snapshot.delay.ms`>>
+|[[db2-property-snapshot-delay-ms]]<<db2-property-snapshot-delay-ms, `+snapshot.delay.ms+`>>
 |
 |An interval in milliseconds that the connector should wait before performing a snapshot when the connector starts. If you are starting multiple connectors in a cluster, this property is useful for avoiding snapshot interruptions, which might cause re-balancing of connectors.
 
-|[[db2-property-snapshot-fetch-size]]<<db2-property-snapshot-fetch-size, `snapshot.fetch.size`>>
+|[[db2-property-snapshot-fetch-size]]<<db2-property-snapshot-fetch-size, `+snapshot.fetch.size+`>>
 |`2000`
 |During a snapshot, the connector reads table content in batches of rows. This property specifies the maximum number of rows in a batch.
 
-|[[db2-property-snapshot-lock-timeout-ms]]<<db2-property-snapshot-lock-timeout-ms, `snapshot.lock{zwsp}.timeout.ms`>>
+|[[db2-property-snapshot-lock-timeout-ms]]<<db2-property-snapshot-lock-timeout-ms, `+snapshot.lock.timeout.ms+`>>
 |`10000`
 |Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this interval, the snapshot fails. {link-prefix}:{link-db2-connector}#db2-snapshots[How the connector performs snapshots] provides details. Other possible settings are: +
  +
@@ -1929,7 +1930,7 @@ Heartbeat messages are useful when there are many updates in a database that is 
  +
 `-1` - The connector waits infinitely.
 
-|[[db2-property-snapshot-select-statement-overrides]]<<db2-property-snapshot-select-statement-overrides, `snapshot.select{zwsp}.statement{zwsp}.overrides`>>
+|[[db2-property-snapshot-select-statement-overrides]]<<db2-property-snapshot-select-statement-overrides, `+snapshot.select.statement.overrides+`>>
 |
 |Controls which table rows are included in snapshots. This property affects snapshots only. It does not affect events that the connector reads from the log. Specify a comma-separated list of fully-qualified table names in the form _schemaName.tableName_. +
  +
@@ -1937,13 +1938,13 @@ For each table that you specify, also specify another configuration property: `s
  +
 A possible use case for setting these properties is large, append-only tables. You can specify a `SELECT` statement that sets a specific point for where to start a snapshot, or where to resume a snapshot if a previous snapshot was interrupted.
 
-|[[db2-property-sanitize-field-names]]<<db2-property-sanitize-field-names, `sanitize.field{zwsp}.names`>>
+|[[db2-property-sanitize-field-names]]<<db2-property-sanitize-field-names, `+sanitize.field.names+`>>
 |`true` if connector configuration sets the `key.converter` or `value.converter` property to the Avro converter.
 
 `false` if not.
 |Indicates whether field names are sanitized to adhere to {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming requirements].
 
-|[[db2-property-provide-transaction-metadata]]<<db2-property-provide-transaction-metadata, `provide.transaction{zwsp}.metadata`>>
+|[[db2-property-provide-transaction-metadata]]<<db2-property-provide-transaction-metadata, `+provide.transaction.metadata+`>>
 |`false`
 |Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See  {link-prefix}:{link-db2-connector}#db2-transaction-metadata[Transaction metadata] for details.
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -311,7 +311,7 @@ Every change event that captures a change to the `customers` collection has the 
 |The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion.
 
 |2
-|`fulfillment{zwsp}.inventory{zwsp}.customers{zwsp}.Key`
+|`fulfillment.inventory.customers.Key`
 a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the key for the document that was changed. Key schema names have the format _connector-name_._database-name_._collection-name_.`Key`. In this example: +
 
 * `fulfillment` is the name of the connector that generated this event. +
@@ -1072,99 +1072,99 @@ The following configuration properties are _required_ unless a default value is 
 |===
 |Property |Default |Description
 
-|[[mongodb-property-name]]<<mongodb-property-name, `name`>>
+|[[mongodb-property-name]]<<mongodb-property-name, `+name+`>>
 |
 |Unique name for the connector. Attempting to register again with the same name will fail. (This property is required by all Kafka Connect connectors.)
 
-|[[mongodb-property-connector-class]]<<mongodb-property-connector-class, `connector.class`>>
+|[[mongodb-property-connector-class]]<<mongodb-property-connector-class, `+connector.class+`>>
 |
 |The name of the Java class for the connector. Always use a value of `io.debezium.connector.mongodb.MongoDbConnector` for the MongoDB connector.
 
-|[[mongodb-property-mongodb-hosts]]<<mongodb-property-mongodb-hosts, `mongodb.hosts`>>
+|[[mongodb-property-mongodb-hosts]]<<mongodb-property-mongodb-hosts, `+mongodb.hosts+`>>
 |
 |The comma-separated list of hostname and port pairs (in the form 'host' or 'host:port') of the MongoDB servers in the replica set. The list can contain a single hostname and port pair. If `mongodb.members.auto.discover` is set to `false`, then the host and port pair should be prefixed with the replica set name (e.g., `rs0/localhost:27017`).
 
-|[[mongodb-property-mongodb-name]]<<mongodb-property-mongodb-name, `mongodb.name`>>
+|[[mongodb-property-mongodb-name]]<<mongodb-property-mongodb-name, `+mongodb.name+`>>
 |
 |A unique name that identifies the connector and/or MongoDB replica set or sharded cluster that this connector monitors. Each server should be monitored by at most one {prodname} connector, since this server name prefixes all persisted Kafka topics emanating from the MongoDB replica set or cluster.
 Only alphanumeric characters and underscores should be used.
 
-|[[mongodb-property-mongodb-user]]<<mongodb-property-mongodb-user, `mongodb.user`>>
+|[[mongodb-property-mongodb-user]]<<mongodb-property-mongodb-user, `+mongodb.user+`>>
 |
 |Name of the database user to be used when connecting to MongoDB. This is required only when MongoDB is configured to use authentication.
 
-|[[mongodb-property-mongodb-password]]<<mongodb-property-mongodb-password, `mongodb.password`>>
+|[[mongodb-property-mongodb-password]]<<mongodb-property-mongodb-password, `+mongodb.password+`>>
 |
 |Password to be used when connecting to MongoDB. This is required only when MongoDB is configured to use authentication.
 
-|[[mongodb-property-mongodb-authsource]]<<mongodb-property-mongodb-authsource, `mongodb.authsource`>>
+|[[mongodb-property-mongodb-authsource]]<<mongodb-property-mongodb-authsource, `+mongodb.authsource+`>>
 |`admin`
 |Database (authentication source) containing MongoDB credentials. This is required only when MongoDB is configured to use authentication with another authentication database than `admin`.
 
-|[[mongodb-property-mongodb-ssl-enabled]]<<mongodb-property-mongodb-ssl-enabled, `mongodb.ssl.enabled`>>
+|[[mongodb-property-mongodb-ssl-enabled]]<<mongodb-property-mongodb-ssl-enabled, `+mongodb.ssl.enabled+`>>
 |`false`
 |Connector will use SSL to connect to MongoDB instances.
 
-|[[mongodb-property-mongodb-ssl-invalid-hostname-allowed]]<<mongodb-property-mongodb-ssl-invalid-hostname-allowed, `mongodb.ssl.invalid{zwsp}.hostname.allowed`>>
+|[[mongodb-property-mongodb-ssl-invalid-hostname-allowed]]<<mongodb-property-mongodb-ssl-invalid-hostname-allowed, `+mongodb.ssl.invalid.hostname.allowed+`>>
 |`false`
 |When SSL is enabled this setting controls whether strict hostname checking is disabled during connection phase. If `true` the connection will not prevent man-in-the-middle attacks.
 
-|[[mongodb-property-database-include-list]]<<mongodb-property-database-include-list, `database.include{zwsp}.list`>>
+|[[mongodb-property-database-include-list]]<<mongodb-property-database-include-list, `+database.include.list+`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match database names to be monitored; any database name not included in `database.include.list` is excluded from monitoring. By default all databases are monitored.
 Must not be used with `database.exclude.list`.
 
-|[[mongodb-property-database-exclude-list]]<<mongodb-property-database-exclude-list, `database.exclude{zwsp}.list`>>
+|[[mongodb-property-database-exclude-list]]<<mongodb-property-database-exclude-list, `+database.exclude.list+`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match database names to be excluded from monitoring; any database name not included in `database.exclude.list` is monitored.
 Must not be used with `database.include.list`.
 
-|[[mongodb-property-collection-include-list]]<<mongodb-property-collection-include-list, `collection{zwsp}.include.list`>>
+|[[mongodb-property-collection-include-list]]<<mongodb-property-collection-include-list, `+collection.include.list+`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified namespaces for MongoDB collections to be monitored; any collection not included in `collection.include.list` is excluded from monitoring. Each identifier is of the form _databaseName_._collectionName_. By default the connector will monitor all collections except those in the `local` and `admin` databases.
 Must not be used with `collection.exclude.list`.
 
-|[[mongodb-property-collection-exclude-list]]<<mongodb-property-collection-exclude-list, `collection{zwsp}.exclude.list`>>
+|[[mongodb-property-collection-exclude-list]]<<mongodb-property-collection-exclude-list, `+collection.exclude.list+`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified namespaces for MongoDB collections to be excluded from monitoring; any collection not included in `collection.exclude.list` is monitored. Each identifier is of the form _databaseName_._collectionName_.
 Must not be used with `collection.include.list`.
 
-|[[mongodb-property-snapshot-mode]]<<mongodb-property-snapshot-mode, `snapshot.mode`>>
+|[[mongodb-property-snapshot-mode]]<<mongodb-property-snapshot-mode, `+snapshot.mode+`>>
 |`initial`
 |Specifies the criteria for running a snapshot upon startup of the connector. The default is *initial*, and specifies the connector reads a snapshot when either no offset is found or if the oplog no longer contains the previous offset. The *never* option specifies that the connector should never use snapshots, instead the connector should proceed to tail the log.
 
-|[[mongodb-property-snapshot-include-collection-list]]<<mongodb-property-snapshot-include-collection-list, `snapshot.include.collection.list`>>
+|[[mongodb-property-snapshot-include-collection-list]]<<mongodb-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>
 | All collections specified in `collection.include.list`
 |An optional, comma-separated list of regular expressions that match names of schemas specified in `collection.include.list` for which you *want* to take the snapshot.
 
-|[[mongodb-property-field-exclude-list]]<<mongodb-property-field-exclude-list, `field.exclude{zwsp}.list`>>
+|[[mongodb-property-field-exclude-list]]<<mongodb-property-field-exclude-list, `+field.exclude.list+`>>
 |_empty string_
 |An optional comma-separated list of the fully-qualified names of fields that should be excluded from change event message values. Fully-qualified names for fields are of the form _databaseName_._collectionName_._fieldName_._nestedFieldName_, where _databaseName_ and _collectionName_ may contain the wildcard (*) which matches any characters.
 
-|[[mongodb-property-field-renames]]<<mongodb-property-field-renames, `field.renames`>>
+|[[mongodb-property-field-renames]]<<mongodb-property-field-renames, `+field.renames+`>>
 |_empty string_
 |An optional comma-separated list of the fully-qualified replacements of fields that should be used to rename fields in change event message values. Fully-qualified replacements for fields are of the form _databaseName_._collectionName_._fieldName_._nestedFieldName_:__newNestedFieldName__, where _databaseName_ and _collectionName_ may contain the wildcard (*) which matches any characters, the colon character (:) is used to determine rename mapping of field. The next field replacement is applied to the result of the previous field replacement in the list, so keep this in mind when renaming multiple fields that are in the same path.
 
-|[[mongodb-property-tasks-max]]<<mongodb-property-tasks-max, `tasks.max`>>
+|[[mongodb-property-tasks-max]]<<mongodb-property-tasks-max, `+tasks.max+`>>
 |`1`
 |The maximum number of tasks that should be created for this connector. The MongoDB connector will attempt to use a separate task for each replica set, so the default is acceptable when using the connector with a single MongoDB replica set. When using the connector with a MongoDB sharded cluster, we recommend specifying a value that is equal to or more than the number of shards in the cluster, so that the work for each replica set can be distributed by Kafka Connect.
 
-|[[mongodb-property-snapshot-max-threads]]<<mongodb-property-snapshot-max-threads, `snapshot{zwsp}.max.threads`>>
+|[[mongodb-property-snapshot-max-threads]]<<mongodb-property-snapshot-max-threads, `+snapshot.max.threads+`>>
 |`1`
 |Positive integer value that specifies the maximum number of threads used to perform an intial sync of the collections in a replica set. Defaults to 1.
 
-|[[mongodb-property-tombstones-on-delete]]<<mongodb-property-tombstones-on-delete, `tombstones.on{zwsp}.delete`>>
+|[[mongodb-property-tombstones-on-delete]]<<mongodb-property-tombstones-on-delete, `+tombstones.on.delete+`>>
 |`true`
 | Controls whether a tombstone event should be generated after a delete event. +
 When `true` the delete operations are represented by a delete event and a subsequent tombstone event. When `false` only a delete event is sent. +
 Emitting the tombstone event (the default behavior) allows Kafka to completely delete all events pertaining to the given key once the source record got deleted.
 
-|[[mongodb-property-snapshot-delay-ms]]<<mongodb-property-snapshot-delay-ms, `snapshot.delay.ms`>>
+|[[mongodb-property-snapshot-delay-ms]]<<mongodb-property-snapshot-delay-ms, `+snapshot.delay.ms+`>>
 |
 |An interval in milliseconds that the connector should wait before taking a snapshot after starting up; +
 Can be used to avoid snapshot interruptions when starting multiple connectors in a cluster, which may cause re-balancing of connectors.
 
-|[[mongodb-property-snapshot-fetch-size]]<<mongodb-property-snapshot-fetch-size, `snapshot.fetch.size`>>
+|[[mongodb-property-snapshot-fetch-size]]<<mongodb-property-snapshot-fetch-size, `+snapshot.fetch.size+`>>
 |`0`
 |Specifies the maximum number of documents that should be read in one go from each collection while taking a snapshot.
 The connector will read the collection contents in multiple batches of this size. +
@@ -1181,40 +1181,40 @@ The following _advanced_ configuration properties have good defaults that will w
 |Default
 |Description
 
-|[[mongodb-property-max-queue-size]]<<mongodb-property-max-queue-size, `max.queue.size`>>
+|[[mongodb-property-max-queue-size]]<<mongodb-property-max-queue-size, `+max.queue.size+`>>
 |`8192`
 |Positive integer value that specifies the maximum size of the blocking queue into which change events read from the database log are placed before they are written to Kafka. This queue can provide backpressure to the oplog reader when, for example, writes to Kafka are slower or if Kafka is not available. Events that appear in the queue are not included in the offsets periodically recorded by this connector. Defaults to 8192, and should always be larger than the maximum batch size specified in the `max.batch.size` property.
 
-|[[mongodb-property-max-batch-size]]<<mongodb-property-max-batch-size, `max.batch.size`>>
+|[[mongodb-property-max-batch-size]]<<mongodb-property-max-batch-size, `+max.batch.size+`>>
 |`2048`
 |Positive integer value that specifies the maximum size of each batch of events that should be processed during each iteration of this connector. Defaults to 2048.
 
-|[[mongodb-property-max-queue-size-in-bytes]]<<mongodb-property-max-queue-size-in-bytes, `max.queue.size.in.bytes`>>
+|[[mongodb-property-max-queue-size-in-bytes]]<<mongodb-property-max-queue-size-in-bytes, `+max.queue.size.in.bytes+`>>
 |`0`
 |Long value for the maximum size in bytes of the blocking queue. The feature is disabled by default, it will be active if it's set with a positive long value.
 
-|[[mongodb-property-poll-interval-ms]]<<mongodb-property-poll-interval-ms, `poll.interval.ms`>>
+|[[mongodb-property-poll-interval-ms]]<<mongodb-property-poll-interval-ms, `+poll.interval.ms+`>>
 |`1000`
 |Positive integer value that specifies the number of milliseconds the connector should wait during each iteration for new change events to appear. Defaults to 1000 milliseconds, or 1 second.
 
-|[[mongodb-property-connect-backoff-initial-delay-ms]]<<mongodb-property-connect-backoff-initial-delay-ms, `connect.backoff{zwsp}.initial.delay.ms`>>
+|[[mongodb-property-connect-backoff-initial-delay-ms]]<<mongodb-property-connect-backoff-initial-delay-ms, `+connect.backoff.initial.delay.ms+`>>
 |`1000`
 |Positive integer value that specifies the initial delay when trying to reconnect to a primary after the first failed connection attempt or when no primary is available. Defaults to 1 second (1000 ms).
 
-|[[mongodb-property-connect-backoff-max-delay-ms]]<<mongodb-property-connect-backoff-max-delay-ms, `connect.backoff{zwsp}.max.delay.ms`>>
+|[[mongodb-property-connect-backoff-max-delay-ms]]<<mongodb-property-connect-backoff-max-delay-ms, `+connect.backoff.max.delay.ms+`>>
 |`1000`
 |Positive integer value that specifies the maximum delay when trying to reconnect to a primary after repeated failed connection attempts or when no primary is available. Defaults to 120 seconds (120,000 ms).
 
-|[[mongodb-property-connect-max-attempts]]<<mongodb-property-connect-max-attempts, `connect.max{zwsp}.attempts`>>
+|[[mongodb-property-connect-max-attempts]]<<mongodb-property-connect-max-attempts, `+connect.max.attempts+`>>
 |`16`
 |Positive integer value that specifies the maximum number of failed connection attempts to a replica set primary before an exception occurs and task is aborted. Defaults to 16, which with the defaults for `connect.backoff.initial.delay.ms` and `connect.backoff.max.delay.ms` results in just over 20 minutes of attempts before failing.
 
-|[[mongodb-property-mongodb-members-auto-discover]]<<mongodb-property-mongodb-members-auto-discover, `mongodb.members{zwsp}.auto.discover`>>
+|[[mongodb-property-mongodb-members-auto-discover]]<<mongodb-property-mongodb-members-auto-discover, `+mongodb.members.auto.discover+`>>
 |`true`
 |Boolean value that specifies whether the addresses in 'mongodb.hosts' are seeds that should be used to discover all members of the cluster or replica set (`true`), or whether the address(es) in `mongodb.hosts` should be used as is (`false`). The default is `true` and should be used in all cases except where MongoDB is {link-prefix}:{link-mongodb-connector}#mongodb-replicaset[fronted by a proxy].
 
 ifdef::community[]
-|[[mongodb-property-source-struct-version]]<<mongodb-property-source-struct-version, `source.struct{zwsp}.version`>>
+|[[mongodb-property-source-struct-version]]<<mongodb-property-source-struct-version, `+source.struct.version+`>>
 |v2
 |Schema version for the `source` block in CDC events. {prodname} 0.10 introduced a few breaking +
 changes to the structure of the `source` block in order to unify the exposed structure across
@@ -1223,7 +1223,7 @@ By setting this option to `v1` the structure used in earlier versions can be pro
 Note that this setting is not recommended and is planned for removal in a future {prodname} version.
 endif::community[]
 
-|[[mongodb-property-heartbeat-interval-ms]]<<mongodb-property-heartbeat-interval-ms, `heartbeat.interval{zwsp}.ms`>>
+|[[mongodb-property-heartbeat-interval-ms]]<<mongodb-property-heartbeat-interval-ms, `+heartbeat.interval.ms+`>>
 |`0`
 |Controls how frequently heartbeat messages are sent. +
 This property contains an interval in milliseconds that defines how frequently the connector sends messages into a heartbeat topic.
@@ -1236,55 +1236,55 @@ This will cause the oplog files to be rotated out but connector will not notice 
 Set this parameter to `0` to not send heartbeat messages at all. +
 Disabled by default.
 
-|[[mongodb-property-heartbeat-topics-prefix]]<<mongodb-property-heartbeat-topics-prefix, `heartbeat.topics{zwsp}.prefix`>>
+|[[mongodb-property-heartbeat-topics-prefix]]<<mongodb-property-heartbeat-topics-prefix, `+heartbeat.topics.prefix+`>>
 |`__debezium-heartbeat`
 |Controls the naming of the topic to which heartbeat messages are sent. +
 The topic is named according to the pattern `<heartbeat.topics.prefix>.<server.name>`.
 
-|[[mongodb-property-sanitize-field-names]]<<mongodb-property-sanitize-field-names, `sanitize.field{zwsp}.names`>>
+|[[mongodb-property-sanitize-field-names]]<<mongodb-property-sanitize-field-names, `+sanitize.field.names+`>>
 |`true` when connector configuration explicitly specifies the `key.converter` or `value.converter` parameters to use Avro, otherwise defaults to `false`.
 |Whether field names are sanitized to adhere to Avro naming requirements.
 ifdef::community[]
 See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 endif::community[]
 
-|[[mongodb-property-skipped-operations]]<<mongodb-property-skipped-operations, `skipped.operations`>>
+|[[mongodb-property-skipped-operations]]<<mongodb-property-skipped-operations, `+skipped.operations+`>>
 |
 | comma-separated list of oplog operations that will be skipped during streaming.
 The operations include: `c` for inserts/create, `u` for updates, and `d` for deletes.
 By default, no operations are skipped.
 
-|[[mongodb-property-snapshot-collection-filter-overrides]]<<mongodb-property-snapshot-collection-filter-overrides, `snapshot.collection.filter.overrides`>>
+|[[mongodb-property-snapshot-collection-filter-overrides]]<<mongodb-property-snapshot-collection-filter-overrides, `+snapshot.collection.filter.overrides+`>>
 |
-| Controls which collection items are included in snapshot. This property affects snapshots only. Specify a comma-separated list of collection names in the form _databaseName{zwsp}.collectionName_.
+| Controls which collection items are included in snapshot. This property affects snapshots only. Specify a comma-separated list of collection names in the form _databaseName.collectionName_.
 
-For each collection that you specify, also specify another configuration property: `snapshot{zwsp}.collection{zwsp}.filter{zwsp}.overrides{zwsp}._databaseName_._collectionName_`. For example, the name of the other configuration property might be: `snapshot{zwsp}.collection{zwsp}.filter{zwsp}.overrides{zwsp}.customers{zwsp}.orders`. Set this property to a valid filter expression that retrieves only the items that you want in the snapshot. When the connector performs a snapshot, it retrieves only the items that matches the filter expression.
+For each collection that you specify, also specify another configuration property: `snapshot.collection.filter.overrides._databaseName_._collectionName_`. For example, the name of the other configuration property might be: `snapshot.collection.filter.overrides.customers.orders`. Set this property to a valid filter expression that retrieves only the items that you want in the snapshot. When the connector performs a snapshot, it retrieves only the items that matches the filter expression.
 
 
-|[[mongodb-property-provide-transaction-metadata]]<<mongodb-property-provide-transaction-metadata, `provide.transaction{zwsp}.metadata`>>
+|[[mongodb-property-provide-transaction-metadata]]<<mongodb-property-provide-transaction-metadata, `+provide.transaction.metadata+`>>
 |`false`
 |When set to `true` {prodname} generates events with transaction boundaries and enriches data events envelope with transaction metadata.
 
 See {link-prefix}:{link-mongodb-connector}#mongodb-transaction-metadata[Transaction Metadata] for additional details.
 
-|[[mongodb-property-retriable-restart-connector-wait-ms]]<<mongodb-property-retriable-restart-connector-wait-ms, `retriable.restart{zwsp}.connector.wait.ms`>>
+|[[mongodb-property-retriable-restart-connector-wait-ms]]<<mongodb-property-retriable-restart-connector-wait-ms, `+retriable.restart.connector.wait.ms+`>>
 |10000 (10 seconds)
 |The number of milliseconds to wait before restarting a connector after a retriable error occurs.
 
-|[[mongodb-property-mongodb-poll-interval-ms]]<<mongodb-property-mongodb-poll-interval-ms, `mongodb.poll{zwsp}.interval.ms`>>
+|[[mongodb-property-mongodb-poll-interval-ms]]<<mongodb-property-mongodb-poll-interval-ms, `+mongodb.poll.interval.ms+`>>
 |`30000`
 |The interval in which the connector polls for new, removed, or changed replica sets.
 
-|[[mongodb-property-mongodb-connect-timeout-ms]]<<mongodb-property-mongodb-connect-timeout-ms, `mongodb.connect{zwsp}.timeout.ms`>>
+|[[mongodb-property-mongodb-connect-timeout-ms]]<<mongodb-property-mongodb-connect-timeout-ms, `+mongodb.connect.timeout.ms+`>>
 |10000 (10 seconds)
 |The number of milliseconds the driver will wait before a new connection attempt is aborted.
 
-|[[mongodb-property-mongodb-socket-timeout-ms]]<<mongodb-property-mongodb-socket-timeout-ms, `mongodb.socket{zwsp}.timeout.ms`>>
+|[[mongodb-property-mongodb-socket-timeout-ms]]<<mongodb-property-mongodb-socket-timeout-ms, `+mongodb.socket.timeout.ms+`>>
 |0
 |The number of milliseconds before a send/receive on the socket can take before a timeout occurs.
 A value of `0` disables this behavior.
 
-|[[mongodb-property-mongodb-server-selection-timeout-ms]]<<mongodb-property-mongodb-server-selection-timeout-ms, `mongodb.server{zwsp}.selection{zwsp}.timeout.ms`>>
+|[[mongodb-property-mongodb-server-selection-timeout-ms]]<<mongodb-property-mongodb-server-selection-timeout-ms, `+mongodb.server.selection.timeout.ms+`>>
 |30000 (30 seconds)
 |The number of milliseconds the driver will wait to select a server before it times out and throws an error.
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -1968,88 +1968,88 @@ The following configuration properties are _required_ unless a default value is 
 |===
 |Property |Default |Description
 
-|[[mysql-property-name]]<<mysql-property-name, `name`>>
+|[[mysql-property-name]]<<mysql-property-name, `+name+`>>
 |
 |Unique name for the connector. Attempting to register again with the same name fails. This property is required by all Kafka Connect connectors.
 
-|[[mysql-property-connector-class]]<<mysql-property-connector-class, `connector.class`>>
+|[[mysql-property-connector-class]]<<mysql-property-connector-class, `+connector.class+`>>
 |
-|The name of the Java class for the connector. Always specify  `io.debezium{zwsp}.connector.mysql.MySqlConnector` for the MySQL connector.
+|The name of the Java class for the connector. Always specify  `io.debezium.connector.mysql.MySqlConnector` for the MySQL connector.
 
-|[[mysql-property-tasks-max]]<<mysql-property-tasks-max, `tasks.max`>>
+|[[mysql-property-tasks-max]]<<mysql-property-tasks-max, `+tasks.max+`>>
 |`1`
 |The maximum number of tasks that should be created for this connector. The MySQL connector always uses a single task and therefore does not use this value, so the default is always acceptable.
 
-|[[mysql-property-database-hostname]]<<mysql-property-database-hostname, `database.hostname`>>
+|[[mysql-property-database-hostname]]<<mysql-property-database-hostname, `+database.hostname+`>>
 |
 |IP address or host name of the MySQL database server.
 
-|[[mysql-property-database-port]]<<mysql-property-database-port, `database.port`>>
+|[[mysql-property-database-port]]<<mysql-property-database-port, `+database.port+`>>
 |`3306`
 |Integer port number of the MySQL database server.
 
-|[[mysql-property-database-user]]<<mysql-property-database-user, `database.user`>>
+|[[mysql-property-database-user]]<<mysql-property-database-user, `+database.user+`>>
 |
 |Name of the MySQL user to use when connecting to the MySQL database server.
 
-|[[mysql-property-database-password]]<<mysql-property-database-password, `database.password`>>
+|[[mysql-property-database-password]]<<mysql-property-database-password, `+database.password+`>>
 |
 |Password to use when connecting to the MySQL database server.
 
-|[[mysql-property-database-server-name]]<<mysql-property-database-server-name, `database.server.name`>>
+|[[mysql-property-database-server-name]]<<mysql-property-database-server-name, `+database.server.name+`>>
 |
 |Logical name that identifies and provides a namespace for the particular MySQL database server/cluster in which {prodname} is capturing changes. The logical name should be unique across all other connectors, since it is used as a prefix for all Kafka topic names that receive events emitted by this connector.
 Only alphanumeric characters and underscores are allowed in this name.
 
-|[[mysql-property-database-server-id]]<<mysql-property-database-server-id, `database.server.id`>>
+|[[mysql-property-database-server-id]]<<mysql-property-database-server-id, `+database.server.id+`>>
 |_random_
 |A numeric ID of this database client, which must be unique across all currently-running database processes in the MySQL cluster. This connector joins the MySQL database cluster as another server (with this unique ID) so it can read the binlog. By default, a random number between 5400 and 6400 is generated, though the recommendation is to explicitly set a value.
 
-|[[mysql-property-database-history-kafka-topic]]<<mysql-property-database-history-kafka-topic, `database.history.kafka{zwsp}.topic`>>
+|[[mysql-property-database-history-kafka-topic]]<<mysql-property-database-history-kafka-topic, `+database.history.kafka.topic+`>>
 |
 |The full name of the Kafka topic where the connector stores the database schema history.
 
-|[[mysql-property-database-history-kafka-bootstrap-servers]]<<mysql-property-database-history-kafka-bootstrap-servers, `database.history{zwsp}.kafka.bootstrap{zwsp}.servers`>>
+|[[mysql-property-database-history-kafka-bootstrap-servers]]<<mysql-property-database-history-kafka-bootstrap-servers, `+database.history.kafka.bootstrap.servers+`>>
 |
 |A list of host/port pairs that the connector uses for establishing an initial connection to the Kafka cluster. This connection is used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. Each pair should point to the same Kafka cluster used by the Kafka Connect process.
 
-|[[mysql-property-database-include-list]]<<mysql-property-database-include-list, `database.include.list`>>
+|[[mysql-property-database-include-list]]<<mysql-property-database-include-list, `+database.include.list+`>>
 |_empty string_
 |An optional, comma-separated list of regular expressions that match the names of the databases for which to capture changes. The connector does not capture changes in any database whose name is not in `database.include.list`. By default, the connector captures changes in all databases.
 Do not also set the `database.exclude.list` connector confiuration property.
 
-|[[mysql-property-database-exclude-list]]<<mysql-property-database-exclude-list, `database.exclude.list`>>
+|[[mysql-property-database-exclude-list]]<<mysql-property-database-exclude-list, `+database.exclude.list+`>>
 |_empty string_
 |An optional, comma-separated list of regular expressions that match the names of databases for which you do not want to capture changes. The connector captures changes in any database whose name is not in the `database.exclude.list`.
 Do not also set the `database.include.list` connector configuration property.
 
-|[[mysql-property-table-include-list]]<<mysql-property-table-include-list, `table.include.list`>>
+|[[mysql-property-table-include-list]]<<mysql-property-table-include-list, `+table.include.list+`>>
 |_empty string_
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers of tables whose changes you want to capture. The connector does not capture changes in any table not included in `table.include.list`. Each identifier is of the form _databaseName_._tableName_. By default, the connector captures changes in every non-system table in each database whose changes are being captured.
 Do not also specify the `table.exclude.list` connector configuration property.
 
-|[[mysql-property-table-exclude-list]]<<mysql-property-table-exclude-list, `table.exclude.list`>>
+|[[mysql-property-table-exclude-list]]<<mysql-property-table-exclude-list, `+table.exclude.list+`>>
 |_empty string_
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you do not want to capture. The connector captures changes in any table not included in `table.exclude.list`. Each identifier is of the form _databaseName_._tableName_.
 Do not also specify the `table.include.list` connector configuration property.
 
-|[[mysql-property-column-exclude-list]]<<mysql-property-column-exclude-list, `column.exclude.list`>>
+|[[mysql-property-column-exclude-list]]<<mysql-property-column-exclude-list, `+column.exclude.list+`>>
 |_empty string_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to exclude from change event record values. Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_.
 
-|[[mysql-property-column-include-list]]<<mysql-property-column-include-list, `column.include.list`>>
+|[[mysql-property-column-include-list]]<<mysql-property-column-include-list, `+column.include.list+`>>
 |_empty string_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns to include in change event record values. Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_.
 
-|[[mysql-property-column-truncate-to-length-chars]]<<mysql-property-column-truncate-to-length-chars, `column.truncate.to{zwsp}._length_.chars`>>
+|[[mysql-property-column-truncate-to-length-chars]]<<mysql-property-column-truncate-to-length-chars, `+column.truncate.to._length_.chars+`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be truncated in the change event record values if the field values are longer than the specified number of characters. You can configure multiple properties with different lengths in a single configuration. The length must be a positive integer. Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_.
 
-|[[mysql-property-column-mask-with-length-chars]]<<mysql-property-column-mask-with-length-chars, `column.mask.with{zwsp}._length_.chars`>>
+|[[mysql-property-column-mask-with-length-chars]]<<mysql-property-column-mask-with-length-chars, `+column.mask.with._length_.chars+`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be replaced in the change event message values with a field value consisting of the specified number of asterisk (`*`) characters. You can configure multiple properties with different lengths in a single configuration. Each length must be a positive integer or zero. Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_.
 
-|[[mysql-property-column-mask-hash]]<<mysql-property-column-mask-hash, `column.mask{zwsp}.hash._hashAlgorithm_{zwsp}.with.salt._salt_`>>
+|[[mysql-property-column-mask-hash]]<<mysql-property-column-mask-hash, `+column.mask.hash._hashAlgorithm_.with.salt._salt_+`>>
 |_n/a_
 a|An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be pseudonyms in the change event record values. Pseudonyms consist of the hashed value obtained by applying the algorithm `_hashAlgorithm_` and salt `_salt_`. +
  +
@@ -2064,7 +2064,7 @@ You can configure multiple properties with different lengths in a single configu
  +
 Depending on the configured `_hashAlgorithm_`, the selected `_salt_`, and the actual data set, the resulting masked data set might not be completely anonymized.
 
-|[[mysql-property-column-propagate-source-type]]<<mysql-property-column-propagate-source-type, `column.propagate{zwsp}.source.type`>>
+|[[mysql-property-column-propagate-source-type]]<<mysql-property-column-propagate-source-type, `+column.propagate.source.type+`>>
 |_n/a_
 a|An optional, comma-separated list of regular expressions that match the fully-qualified names of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change event records. These schema parameters:
 
@@ -2080,7 +2080,7 @@ _databaseName_._tableName_._columnName_
 
 _databaseName_._schemaName_._tableName_._columnName_
 
-|[[mysql-property-datatype-propagate-source-type]]<<mysql-property-datatype-propagate-source-type, `datatype.propagate{zwsp}.source.type`>>
+|[[mysql-property-datatype-propagate-source-type]]<<mysql-property-datatype-propagate-source-type, `+datatype.propagate.source.type+`>>
 |_n/a_
 a|An optional, comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change event records. These schema parameters:
 
@@ -2098,8 +2098,8 @@ _databaseName_._schemaName_._tableName_._typeName_
 
 See {link-prefix}:{link-mysql-connector}#mysql-data-types[how MySQL connectors map data types] for the list of MySQL-specific data type names.
 
-|[[mysql-property-time-precision-mode]]<<mysql-property-time-precision-mode, `time.precision.mode`>>
-|`adaptive_time{zwsp}_microseconds`
+|[[mysql-property-time-precision-mode]]<<mysql-property-time-precision-mode, `+time.precision.mode+`>>
+|`adaptive_time_microseconds`
 |Time, date, and timestamps can be represented with different kinds of precision, including: +
  +
 `adaptive_time_microseconds` (the default) captures the date, datetime and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type, with the exception of TIME type fields, which are always captured as microseconds. +
@@ -2110,7 +2110,7 @@ endif::community[]
  +
 `connect` always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which use millisecond precision regardless of the database columns' precision.
 
-|[[mysql-property-decimal-handling-mode]]<<mysql-property-decimal-handling-mode,`decimal.handling.mode`>>
+|[[mysql-property-decimal-handling-mode]]<<mysql-property-decimal-handling-mode,`decimal.handling.mode+`>>
 |`precise`
 |Specifies how the connector should handle values for `DECIMAL` and `NUMERIC` columns: +
  +
@@ -2120,7 +2120,7 @@ endif::community[]
  +
 `string` encodes values as formatted strings, which is easy to consume but  semantic information about the real type is lost.
 
-|[[mysql-property-bigint-unsigned-handling-mode]]<<mysql-property-bigint-unsigned-handling-mode, `bigint.unsigned{zwsp}.handling.mode`>>
+|[[mysql-property-bigint-unsigned-handling-mode]]<<mysql-property-bigint-unsigned-handling-mode, `+bigint.unsigned.handling.mode+`>>
 |`long`
 |Specifies how BIGINT UNSIGNED columns should be represented in change events. Possible settings are: +
  +
@@ -2128,11 +2128,11 @@ endif::community[]
  +
 `precise` uses `java.math.BigDecimal` to represent values, which are encoded in the change events by using a binary representation and Kafka Connect's `org.apache.kafka.connect.data.Decimal` type. Use this setting when working with values larger than 2^63, because these values cannot be conveyed by using `long`.
 
-|[[mysql-property-include-schema-changes]]<<mysql-property-include-schema-changes, `include.schema{zwsp}.changes`>>
+|[[mysql-property-include-schema-changes]]<<mysql-property-include-schema-changes, `+include.schema.changes+`>>
 |`true`
 |Boolean value that specifies whether the connector should publish changes in the database schema to a Kafka topic with the same name as the database server ID. Each schema change is recorded by using a key that contains the database name and whose value includes the DDL statement(s). This is independent of how the connector internally records database history.
 
-|[[mysql-property-include-query]]<<mysql-property-include-query, `include.query`>>
+|[[mysql-property-include-query]]<<mysql-property-include-query, `+include.query+`>>
 |`false`
 |Boolean value that specifies whether the connector should include the original SQL query that generated the change event. +
  +
@@ -2140,7 +2140,7 @@ If you set this option to `true` then you must also configure MySQL with the `bi
  +
 Setting `include.query`to `true` might expose tables or fields explicitly excluded or masked by including the original SQL statement in the change event. For this reason, the default setting is `false`.
 
-|[[mysql-property-event-processing-failure-handling-mode]]<<mysql-property-event-processing-failure-handling-mode, `event.processing{zwsp}.failure.handling.mode`>>
+|[[mysql-property-event-processing-failure-handling-mode]]<<mysql-property-event-processing-failure-handling-mode, `+event.processing.failure.handling.mode+`>>
 |`fail`
 |Specifies how the connector should react to exceptions during deserialization of binlog events. +
  +
@@ -2150,7 +2150,7 @@ Setting `include.query`to `true` might expose tables or fields explicitly exclud
  +
 `skip` passes over the problematic event and does not log anything.
 
-|[[mysql-property-inconsistent-schema-handling-mode]]<<mysql-property-inconsistent-schema-handling-mode, `inconsistent.schema{zwsp}.handling.mode`>>
+|[[mysql-property-inconsistent-schema-handling-mode]]<<mysql-property-inconsistent-schema-handling-mode, `+inconsistent.schema.handling.mode+`>>
 |`fail`
 |Specifies how the connector should react to binlog events that relate to tables that are not present in internal schema representation. That is, the internal representation is not consistent with the database. +
  +
@@ -2160,43 +2160,43 @@ Setting `include.query`to `true` might expose tables or fields explicitly exclud
  +
 `skip` passes over the problematic event and does not log anything.
 
-|[[mysql-property-max-queue-size]]<<mysql-property-max-queue-size, `max.queue.size`>>
+|[[mysql-property-max-queue-size]]<<mysql-property-max-queue-size, `+max.queue.size+`>>
 |`8192`
 |Positive integer value that specifies the maximum size of the blocking queue into which change events read from the database log are placed before they are written to Kafka. This queue can provide backpressure to the binlog reader when, for example, writes to Kafka are slow or if Kafka is not available. Events that appear in the queue are not included in the offsets periodically recorded by this connector. Defaults to 8192, and should always be larger than the maximum batch size specified by the `max.batch.size` property.
 
-|[[mysql-property-max-batch-size]]<<mysql-property-max-batch-size, `max.batch.size`>>
+|[[mysql-property-max-batch-size]]<<mysql-property-max-batch-size, `+max.batch.size+`>>
 |`2048`
 |Positive integer value that specifies the maximum size of each batch of events that should be processed during each iteration of this connector. Defaults to 2048.
 
-|[[mysql-property-max-queue-size-in-bytes]]<<mysql-property-max-queue-size-in-bytes, `max.queue.size.in.bytes`>>
+|[[mysql-property-max-queue-size-in-bytes]]<<mysql-property-max-queue-size-in-bytes, `+max.queue.size.in.bytes+`>>
 |`0`
 |Long value for the maximum size in bytes of the blocking queue. The feature is disabled by default, it will be active if it's set with a positive long value.
 
-|[[mysql-property-poll-interval-ms]]<<mysql-property-poll-interval-ms, `poll.interval.ms`>>
+|[[mysql-property-poll-interval-ms]]<<mysql-property-poll-interval-ms, `+poll.interval.ms+`>>
 |`1000`
 |Positive integer value that specifies the number of milliseconds the connector should wait for new change events to appear before it starts processing a batch of events. Defaults to 1000 milliseconds, or 1 second.
 
-|[[mysql-property-connect-timeout-ms]]<<mysql-property-connect-timeout-ms, `connect.timeout.ms`>>
+|[[mysql-property-connect-timeout-ms]]<<mysql-property-connect-timeout-ms, `+connect.timeout.ms+`>>
 |`30000`
 |A positive integer value that specifies the maximum time in milliseconds this connector should wait after trying to connect to the MySQL database server before timing out. Defaults to 30 seconds.
 
-|[[mysql-property-gtid-source-includes]]<<mysql-property-gtid-source-includes, `gtid.source.includes`>>
+|[[mysql-property-gtid-source-includes]]<<mysql-property-gtid-source-includes, `+gtid.source.includes+`>>
 |
 |A comma-separated list of regular expressions that match source UUIDs in the GTID set used to find the binlog position in the MySQL server. Only the GTID ranges that have sources that match one of these include patterns are used.
 Do not also specify a setting for `gtid.source.excludes`.
 
-|[[mysql-property-gtid-source-excludes]]<<mysql-property-gtid-source-excludes, `gtid.source.excludes`>>
+|[[mysql-property-gtid-source-excludes]]<<mysql-property-gtid-source-excludes, `+gtid.source.excludes+`>>
 |
 |A comma-separated list of regular expressions that match source UUIDs in the GTID set used to find the binlog position in the MySQL server. Only the GTID ranges that have sources that do not match any of these exclude patterns are used. Do not also specify a value for `gtid.source.includes`.
 
 ifdef::community[]
-|[[mysql-property-gtid-new-channel-position]]<<mysql-property-gtid-new-channel-position, `gtid.new.channel.position`>> +
+|[[mysql-property-gtid-new-channel-position]]<<mysql-property-gtid-new-channel-position, `+gtid.new.channel.position+`>> +
 _deprecated and scheduled for removal_
 |`earliest`
 |When set to `latest`, when the connector sees a new GTID channel, it starts consuming from the last executed transaction in that GTID channel. If set to `earliest` (default), the connector starts reading that channel from the first available (not purged) GTID position. `earliest` is useful when you have an active-passive MySQL setup where {prodname} is connected to the primary server. In this case, during failover, the replica with the new UUID (and GTID channel) starts receiving writes before {prodname} is connected. These writes would be lost when using `latest`.
 endif::community[]
 
-|[[mysql-property-tombstones-on-delete]]<<mysql-property-tombstones-on-delete, `tombstones.on.delete`>>
+|[[mysql-property-tombstones-on-delete]]<<mysql-property-tombstones-on-delete, `+tombstones.on.delete+`>>
 |`true`
 |Controls whether a delete event is followed by a tombstone event. +
  +
@@ -2206,7 +2206,7 @@ endif::community[]
  +
 After a source record is deleted, emitting a tombstone event (the default behavior) allows Kafka to completely delete all events that pertain to the key of the deleted row.
 
-|[[mysql-property-message-key-columns]]<<mysql-property-message-key-columns, `message.key.columns`>>
+|[[mysql-property-message-key-columns]]<<mysql-property-message-key-columns, `+message.key.columns+`>>
 |_n/a_
 |A semicolon separated list of tables with regular expressions that match table column names. The connector maps values in matching columns to key fields in change event records that it sends to Kafka topics. This is useful when a table does not have a primary key, or when you want to order change event records in a Kafka topic according to a field that is not a primary key. +
  +
@@ -2220,7 +2220,7 @@ For example: +
  +
 If `table_a` has an `id` column, and `regex_1` is `^i` (matches any column that starts with `i`), the connector maps the value in the `id` column of `table_a` to a key field in change events that the connector sends to Kafka.
 
-|[[mysql-property-binary-handling-mode]]<<mysql-property-binary-handling-mode,`binary.handling.mode`>>
+|[[mysql-property-binary-handling-mode]]<<mysql-property-binary-handling-mode,`+binary.handling.mode+`>>
 |bytes
 |Specifies how binary columns, for example, `blob`, `binary`, `varbinary`, should be represented in change events. Possible settings:  +
  +
@@ -2242,29 +2242,29 @@ The following table describes {link-prefix}:{link-mysql-connector}#mysql-advance
 |===
 |Property |Default |Description
 
-|[[mysql-property-connect-keep-alive]]<<mysql-property-connect-keep-alive, `connect.keep.alive`>>
+|[[mysql-property-connect-keep-alive]]<<mysql-property-connect-keep-alive, `+connect.keep.alive+`>>
 |`true`
 |A Boolean value that specifies whether a separate thread should be used to ensure that the connection to the MySQL server/cluster is kept alive.
 
-|[[mysql-property-table-ignore-builtin]]<<mysql-property-table-ignore-builtin, `table.ignore{zwsp}.builtin`>>
+|[[mysql-property-table-ignore-builtin]]<<mysql-property-table-ignore-builtin, `+table.ignore.builtin+`>>
 |`true`
 |A Boolean value that specifies whether built-in system tables should be ignored. This applies regardless of the table include and exclude lists. By default, system tables are excluded from having their changes captured, and no events are generated when changes are made to any system tables.
 
-|[[mysql-property-database-history-kafka-recovery-poll-interval-ms]]<<mysql-property-database-history-kafka-recovery-poll-interval-ms, `database.history{zwsp}.kafka.recovery{zwsp}.poll.interval.ms`>>
+|[[mysql-property-database-history-kafka-recovery-poll-interval-ms]]<<mysql-property-database-history-kafka-recovery-poll-interval-ms, `+database.history.kafka.recovery.poll.interval.ms+`>>
 |`100`
 |An integer value that specifies the maximum number of milliseconds the connector should wait during startup/recovery while polling for persisted data. The default is 100ms.
 
-|[[mysql-property-database-history-kafka-recovery-attempts]]<<mysql-property-database-history-kafka-recovery-attempts, `database.history{zwsp}.kafka.recovery{zwsp}.attempts`>>
+|[[mysql-property-database-history-kafka-recovery-attempts]]<<mysql-property-database-history-kafka-recovery-attempts, `+database.history.kafka.recovery.attempts+`>>
 |`4`
 |The maximum number of times that the connector should try to read persisted history data before the connector recovery fails with an error. The maximum amount of time to wait after receiving no data is `recovery.attempts` x `recovery.poll.interval.ms`.
 
-|[[mysql-property-database-history-skip-unparseable-ddl]]<<mysql-property-database-history-skip-unparseable-ddl, `database.history{zwsp}.skip.unparseable{zwsp}.ddl`>>
+|[[mysql-property-database-history-skip-unparseable-ddl]]<<mysql-property-database-history-skip-unparseable-ddl, `+database.history.skip.unparseable.ddl+`>>
 |`false`
 |A Boolean value that specifies whether the connector should ignore malformed or unknown database statements or stop processing so a human can fix the issue.
 The safe default is `false`.
 Skipping should be used only with care as it can lead to data loss or mangling when the binlog is being processed.
 
-|[[mysql-property-database-history-store-only-monitored-tables-ddl]]<<mysql-property-database-history-store-only-monitored-tables-ddl, `database.history{zwsp}.store.only{zwsp}.monitored.tables{zwsp}.ddl`>>
+|[[mysql-property-database-history-store-only-monitored-tables-ddl]]<<mysql-property-database-history-store-only-monitored-tables-ddl, `+database.history.store.only.monitored.tables.ddl+`>>
 |`false`
 |A Boolean value that specifies whether the connector should record all DDL statements  +
  +
@@ -2272,7 +2272,7 @@ Skipping should be used only with care as it can lead to data loss or mangling w
  +
 The safe default is `false`.
 
-|[[mysql-property-database-ssl-mode]]<<mysql-property-database-ssl-mode, `database.ssl.mode`>>
+|[[mysql-property-database-ssl-mode]]<<mysql-property-database-ssl-mode, `+database.ssl.mode+`>>
 |`disabled`
 |Specifies whether to use an encrypted connection. Possible settings are: +
  +
@@ -2286,7 +2286,7 @@ The safe default is `false`.
  +
 `verify_identity` behaves like `verify_ca` but additionally verifies that the server certificate matches the host of the remote connection.
 
-|[[mysql-property-binlog-buffer-size]]<<mysql-property-binlog-buffer-size, `binlog.buffer.size`>>
+|[[mysql-property-binlog-buffer-size]]<<mysql-property-binlog-buffer-size, `+binlog.buffer.size+`>>
 |0
 |The size of a look-ahead buffer used by the binlog reader. The default setting of `0` disables buffering. +
  +
@@ -2299,7 +2299,7 @@ If the size of the transaction is larger than the buffer then {prodname} must re
  +
 NOTE: This feature is incubating. Feedback is encouraged. It is expected that this feature is not completely polished.
 
-|[[mysql-property-snapshot-mode]]<<mysql-property-snapshot-mode, `snapshot.mode`>>
+|[[mysql-property-snapshot-mode]]<<mysql-property-snapshot-mode, `+snapshot.mode+`>>
 |`initial`
 |Specifies the criteria for running a snapshot when the connector starts. Possible settings are: +
  +
@@ -2313,7 +2313,7 @@ NOTE: This feature is incubating. Feedback is encouraged. It is expected that th
  +
 `schema_only_recovery` - this is a recovery setting for a connector that has already been capturing changes. When you restart the connector, this setting enables recovery of a corrupted or lost database history topic. You might set it periodically to "clean up" a database history topic that has been growing unexpectedly. Database history topics require infinite retention.
 
-|[[mysql-property-snapshot-locking-mode]]<<mysql-property-snapshot-locking-mode, `snapshot.locking{zwsp}.mode`>>
+|[[mysql-property-snapshot-locking-mode]]<<mysql-property-snapshot-locking-mode, `+snapshot.locking.mode+`>>
 |`minimal`
 a|Controls whether and how long the connector holds the global MySQL read lock, which prevents any updates to the database, while the connector is performing a snapshot. Possible settings are: +
  +
@@ -2325,35 +2325,35 @@ a|Controls whether and how long the connector holds the global MySQL read lock, 
  +
 `none` - prevents the connector from acquiring any table locks during the snapshot. While this setting is allowed with all snapshot modes, it is safe to use if and _only_ if no schema changes are happening while the snapshot is running. For tables defined with MyISAM engine, the tables would still be locked despite this property being set as MyISAM acquires a table lock. This behavior is unlike InnoDB engine, which acquires row level locks.
 
-|[[mysql-property-snapshot-include-collection-list]]<<mysql-property-snapshot-include-collection-list, `snapshot.include.collection.list`>>
+|[[mysql-property-snapshot-include-collection-list]]<<mysql-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>
 | All tables specified in `table.include.list`
 |An optional, comma-separated list of regular expressions that match names of schemas specified in `table.include.list` for which you *want* to take the snapshot.
 
-|[[mysql-property-snapshot-select-statement-overrides]]<<mysql-property-snapshot-select-statement-overrides, `snapshot.select{zwsp}.statement{zwsp}.overrides`>>
+|[[mysql-property-snapshot-select-statement-overrides]]<<mysql-property-snapshot-select-statement-overrides, `+snapshot.select.statement.overrides+`>>
 |
-|Controls which table rows are included in snapshots. This property affects snapshots only. It does not affect events captured from the binlog. Specify a comma-separated list of fully-qualified table names in the form _databaseName{zwsp}.tableName_. +
+|Controls which table rows are included in snapshots. This property affects snapshots only. It does not affect events captured from the binlog. Specify a comma-separated list of fully-qualified table names in the form _databaseName.tableName_. +
  +
-For each table that you specify, also specify another configuration property: `snapshot{zwsp}.select{zwsp}.statement{zwsp}.overrides{zwsp}._DB_NAME_._TABLE_NAME_`. For example, the name of the other configuration property might be:  `snapshot{zwsp}.select{zwsp}.statement{zwsp}.overrides{zwsp}.customers{zwsp}.orders`. Set this property to a `SELECT` statement that obtains only the rows that you want in the snapshot. When the connector performs a snapshot, it executes this `SELECT` statement to retrieve data from that table. +
+For each table that you specify, also specify another configuration property: `snapshot.select.statement.overrides._DB_NAME_._TABLE_NAME_`. For example, the name of the other configuration property might be:  `snapshot.select.statement.overrides.customers.orders`. Set this property to a `SELECT` statement that obtains only the rows that you want in the snapshot. When the connector performs a snapshot, it executes this `SELECT` statement to retrieve data from that table. +
  +
 A possible use case for setting these properties is large, append-only tables. You can specify a `SELECT` statement that sets a specific point for where to start a snapshot, or where to resume a snapshot if a previous snapshot was interrupted.
 
-|[[mysql-property-snapshot-events-as-inserts]]<<mysql-property-snapshot-events-as-inserts, `snapshot.events{zwsp}.as{zwsp}.inserts`>>
+|[[mysql-property-snapshot-events-as-inserts]]<<mysql-property-snapshot-events-as-inserts, `+snapshot.events.as.inserts+`>>
 |`true`
 |Controls whether or not to mark snapshot events as insert events (`"op": "c"`). If disabled, the Debezium default of marking snapshot events as reads (`"op": "r"`) will be used.
 
-|[[mysql-property-min-row-count-to-stream-results]]<<mysql-property-min-row-count-to-stream-results, `min.row.count.to{zwsp}.stream.results`>>
+|[[mysql-property-min-row-count-to-stream-results]]<<mysql-property-min-row-count-to-stream-results, `+min.row.count.to.stream.results+`>>
 |`1000`
 |During a snapshot, the connector queries each table for which the connector is configured to capture changes. The connector uses each query result to produce a read event that contains data for all rows in that table. This property determines whether the MySQL connector puts results for a table into memory, which is fast but requires large amounts of memory, or streams the results, which can be slower but work for very large tables. The setting of this property specifies the minimum number of rows a table must contain before the connector streams results. +
  +
 To skip all table size checks and always stream all results during a snapshot, set this property to `0`.
 
-|[[mysql-property-heartbeat-interval-ms]]<<mysql-property-heartbeat-interval-ms, `heartbeat.interval{zwsp}.ms`>>
+|[[mysql-property-heartbeat-interval-ms]]<<mysql-property-heartbeat-interval-ms, `+heartbeat.interval.ms+`>>
 |`0`
 |Controls how frequently the connector sends heartbeat messages to a Kafka topic. The default behavior is that the connector does not send heartbeat messages. +
  +
 Heartbeat messages are useful for monitoring whether the connector is receiving change events from the database. Heartbeat messages might help decrease the number of change events that need to be re-sent when a connector restarts. To send heartbeat messages, set this property to a positive integer, which indicates the number of milliseconds between heartbeat messages.
 
-|[[mysql-property-heartbeat-topics-prefix]]<<mysql-property-heartbeat-topics-prefix, `heartbeat.topics{zwsp}.prefix`>>
+|[[mysql-property-heartbeat-topics-prefix]]<<mysql-property-heartbeat-topics-prefix, `+heartbeat.topics.prefix+`>>
 |`__debezium-heartbeat`
 |Controls the name of the topic to which the connector sends heartbeat messages. The topic name has this pattern: +
  +
@@ -2361,45 +2361,45 @@ _heartbeat.topics.prefix_._server.name_ +
  +
 For example, if the database server name is `fulfillment`, the default topic name is `__debezium-heartbeat.fulfillment`.
 
-|[[mysql-property-database-initial-statements]]<<mysql-property-database-initial-statements, `database.initial{zwsp}.statements`>>
+|[[mysql-property-database-initial-statements]]<<mysql-property-database-initial-statements, `+database.initial.statements+`>>
 |
 |A semicolon separated list of SQL statements to be executed when a JDBC connection, not the connection that is reading the transaction log, to the database is established.
 To specify a semicolon as a character in a SQ statement and not as a delimiter, use two semicolons, (`;;`). +
  +
 The connector might establish JDBC connections at its own discretion, so this property is ony for configuring session parameters. It is not for executing DML statements.
 
-|[[mysql-property-snapshot-delay-ms]]<<mysql-property-snapshot-delay-ms, `snapshot.delay.ms`>>
+|[[mysql-property-snapshot-delay-ms]]<<mysql-property-snapshot-delay-ms, `+snapshot.delay.ms+`>>
 |
 |An interval in milliseconds that the connector should wait before performing a snapshot when the connector starts. If you are starting multiple connectors in a cluster, this property is useful for avoiding snapshot interruptions, which might cause re-balancing of connectors.
 
-|[[mysql-property-snapshot-fetch-size]]<<mysql-property-snapshot-fetch-size, `snapshot.fetch.size`>>
+|[[mysql-property-snapshot-fetch-size]]<<mysql-property-snapshot-fetch-size, `+snapshot.fetch.size+`>>
 |
 |During a snapshot, the connector reads table content in batches of rows. This property specifies the maximum number of rows in a batch.
 
-|[[mysql-property-snapshot-lock-timeout-ms]]<<mysql-property-snapshot-lock-timeout-ms, `snapshot.lock{zwsp}.timeout.ms`>>
+|[[mysql-property-snapshot-lock-timeout-ms]]<<mysql-property-snapshot-lock-timeout-ms, `+snapshot.lock.timeout.ms+`>>
 |`10000`
 |Positive integer that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. See {link-prefix}:{link-mysql-connector}#mysql-snapshots[how MySQL connectors perform database snapshots].
 
-|[[mysql-property-enable-time-adjuster]]<<mysql-property-enable-time-adjuster, `enable.time{zwsp}.adjuster`>>
+|[[mysql-property-enable-time-adjuster]]<<mysql-property-enable-time-adjuster, `+enable.time.adjuster+`>>
 |`true`
 |Boolean value that indicates whether the connector converts a 2-digit year specification to 4 digits. Set to `false` when conversion is fully delegated to the database. +
  +
 MySQL allows users to insert year values with either 2-digits or 4-digits. For 2-digit values, the value gets mapped to a year in the range 1970 - 2069. The default behavior is that the connector does the conversion.
 
 ifdef::community[]
-|[[mysql-property-source-struct-version]]<<mysql-property-source-struct-version, `source.struct{zwsp}.version`>>
+|[[mysql-property-source-struct-version]]<<mysql-property-source-struct-version, `+source.struct.version+`>>
 |`v2`
 |Schema version for the `source` block in {prodname} events.  {prodname} 0.10 introduced a few breaking changes to the structure of the `source` block in order to unify the exposed structure across all the connectors. +
  +
 By setting this option to `v1`, the structure used in earlier versions can be produced. However, this setting is not recommended and is planned for removal in a future {prodname} version.
 endif::community[]
 
-|[[mysql-property-sanitize-field-names]]<<mysql-property-sanitize-field-names, `sanitize.field{zwsp}.names`>>
-|`true` if connector configuration sets the `key{zwsp}.converter` or `value{zwsp}.converter` property to the Avro converter. +
+|[[mysql-property-sanitize-field-names]]<<mysql-property-sanitize-field-names, `+sanitize.field.names+`>>
+|`true` if connector configuration sets the `key.converter` or `value.converter` property to the Avro converter. +
 `false` if not.
 |Indicates whether field names are sanitized to adhere to {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming requirements].
 
-|[[mysql-property-skipped-operations]]<<mysql-property-skipped-operations, `skipped.operations`>>
+|[[mysql-property-skipped-operations]]<<mysql-property-skipped-operations, `+skipped.operations+`>>
 |
 |Comma-separated list of oplog operations to skip during streaming. Values that you can specify are: `c` for inserts/create, `u` for updates, `d` for deletes. By default, no operations are skipped.
 
@@ -2482,39 +2482,39 @@ The {prodname} MySQL connector also provides the following custom binlog metrics
 |===
 |Attribute |Type |Description
 
-|[[binlog-filename]]<<binlog-filename,`BinlogFilename`>>
+|[[binlog-filename]]<<binlog-filename,`+BinlogFilename+`>>
 |`string`
 |The name of the binlog file that the connector has most recently read.
 
-|[[binlog-position]]<<binlog-position,`BinlogPosition`>>
+|[[binlog-position]]<<binlog-position,`+BinlogPosition+`>>
 |`long`
 |The most recent position (in bytes) within the binlog that the connector has read.
 
-|[[is-gtid-mode-enabled]]<<is-gtid-mode-enabled,`IsGtidModeEnabled`>>
+|[[is-gtid-mode-enabled]]<<is-gtid-mode-enabled,`+IsGtidModeEnabled+`>>
 |`boolean`
 |Flag that denotes whether the connector is currently tracking GTIDs from MySQL server.
 
-|[[gtid-set]]<<gtid-set,`GtidSet`>>
+|[[gtid-set]]<<gtid-set,`+GtidSet+`>>
 |`string`
 |The string representation of the most recent GTID set processed by the connector when reading the binlog.
 
-|[[number-of-skipped-events]]<<number-of-skipped-events,`NumberOfSkipped{zwsp}Events`>>
+|[[number-of-skipped-events]]<<number-of-skipped-events,`+NumberOfSkippedEvents+`>>
 |`long`
 |The number of events that have been skipped by the MySQL connector. Typically events are skipped due to a malformed or unparseable event from MySQL's binlog.
 
-|[[number-of-disconnects]]<<number-of-disconnects,`NumberOfDisconnects`>>
+|[[number-of-disconnects]]<<number-of-disconnects,`+NumberOfDisconnects+`>>
 |`long`
 |The number of disconnects by the MySQL connector.
 
-|[[number-of-rolled-back-transactions]]<<number-of-rolled-back-transactions,`NumberOfRolledBack{zwsp}Transactions`>>
+|[[number-of-rolled-back-transactions]]<<number-of-rolled-back-transactions,`+NumberOfRolledBackTransactions+`>>
 |`long`
 |The number of processed transactions that were rolled back and not streamed.
 
-|[[number-of-not-well-formed-transactions]]<<number-of-not-well-formed-transactions,`NumberOfNotWell{zwsp}FormedTransactions`>>
+|[[number-of-not-well-formed-transactions]]<<number-of-not-well-formed-transactions,`+NumberOfNotWellFormedTransactions+`>>
 |`long`
 |The number of transactions that have not conformed to the expected protocol of `BEGIN` + `COMMIT`/`ROLLBACK`. This value should be `0` under normal conditions.
 
-|[[number-of-large-transactions]]<<number-of-large-transactions,`NumberOfLarge{zwsp}Transactions`>>
+|[[number-of-large-transactions]]<<number-of-large-transactions,`+NumberOfLargeTransactions+`>>
 |`long`
 |The number of transactions that have not fit into the look-ahead buffer. For optimal performance, this value should be significantly smaller than `NumberOfCommittedTransactions` and `NumberOfRolledBackTransactions`.
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2110,7 +2110,7 @@ endif::community[]
  +
 `connect` always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which use millisecond precision regardless of the database columns' precision.
 
-|[[mysql-property-decimal-handling-mode]]<<mysql-property-decimal-handling-mode,`decimal.handling.mode+`>>
+|[[mysql-property-decimal-handling-mode]]<<mysql-property-decimal-handling-mode,`+decimal.handling.mode+`>>
 |`precise`
 |Specifies how the connector should handle values for `DECIMAL` and `NUMERIC` columns: +
  +

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1016,7 +1016,7 @@ Please file a {jira-url}/browse/DBZ[JIRA issue] for any specific types you are m
 |n/a
 |`NUMBER` columns with a scale of 0 represent integer numbers; a negative scale indicates rounding in Oracle, e.g. a scale of -2 will cause rounding to hundreds. +
 Depending on the precision and scale, a matching Kafka Connect integer type will be chosen: `INT8` if P - S < 3, `INT16` if P - S < 5, `INT32` if P - S < 10 and `INT64` if P - S < 19. +
-If P - S >= 19, the column will be mapped to `BYTES` (`org.apache.kafka.connect{zwsp}.data.Decimal`).
+If P - S >= 19, the column will be mapped to `BYTES` (`org.apache.kafka.connect.data.Decimal`).
 
 |`SMALLINT`
 |`BYTES`
@@ -1250,55 +1250,55 @@ The *MBean* is `debezium.oracle:type=connector-metrics,context=log-miner,server=
 |===
 |Attributes |Type |Description
 
-|[[log-miner-metrics-currentscn]]<<log-miner-metrics-currentscn, `CurrentScn`>>
+|[[log-miner-metrics-currentscn]]<<log-miner-metrics-currentscn, `+CurrentScn+`>>
 |`long`
 |The most recent SCN has has been processed.
 
-|[[log-miner-metrics-captureddmlcount]]<<log-miner-metrics-captureddmlcount, `CapturedDmlCount`>>
+|[[log-miner-metrics-captureddmlcount]]<<log-miner-metrics-captureddmlcount, `+CapturedDmlCount+`>>
 |`int`
 |The number of DML operations observed.
 
-|[[log-miner-metrics-currentlogfilename]]<<log-miner-metrics-currentlogfilename, `CurrentLogFileName`>>
+|[[log-miner-metrics-currentlogfilename]]<<log-miner-metrics-currentlogfilename, `+CurrentLogFileName+`>>
 |`string[]`
 |The current redo log filename.
 
-|[[log-miner-metrics-redologstatus]]<<log-miner-metrics-redologstatus, `RedoLogStatus`>>
+|[[log-miner-metrics-redologstatus]]<<log-miner-metrics-redologstatus, `+RedoLogStatus+`>>
 |`string[]`
 |The current status of the redo logs.
 
-|[[log-miner-metrics-switchcounter]]<<log-miner-metrics-switchcounter, `SwitchCounter`>>
+|[[log-miner-metrics-switchcounter]]<<log-miner-metrics-switchcounter, `+SwitchCounter+`>>
 |`long`
 |The number of times the redo logs have switched.
 
-|[[log-miner-metrics-lastlogminerqueryduration]]<<log-miner-metrics-lastlogminerqueryduration, `LastLogMinerQueryDuration`>>
+|[[log-miner-metrics-lastlogminerqueryduration]]<<log-miner-metrics-lastlogminerqueryduration, `+LastLogMinerQueryDuration+`>>
 |`Duration`
 |The duration it took for the last log mining query to prepare results for processing.
 
-|[[log-miner-metrics-averagelogminerqueryduration]]<<log-miner-metrics-averagelogminerqueryduration, `AverageLogMinerQueryDuration`>>
+|[[log-miner-metrics-averagelogminerqueryduration]]<<log-miner-metrics-averagelogminerqueryduration, `+AverageLogMinerQueryDuration+`>>
 |`Duration`
 |The average duration it has taken for log mining queries to prepare results for processing.
 
-|[[log-miner-metrics-logminerquerycount]]<<log-miner-metrics-logminerquerycount, `LogMinerQueryCount`>>
+|[[log-miner-metrics-logminerquerycount]]<<log-miner-metrics-logminerquerycount, `+LogMinerQueryCount+`>>
 |`int`
 |The number of log mining queries executed.
 
-|[[log-miner-metrics-lastprocessedcapturedbatchduration]]<<log-miner-metrics-lastprocessedcapturedbatchduration, `LastProcessedCapturedBatchDuration`>>
+|[[log-miner-metrics-lastprocessedcapturedbatchduration]]<<log-miner-metrics-lastprocessedcapturedbatchduration, `+LastProcessedCapturedBatchDuration+`>>
 |`Duration`
 |The duration it took for the last log mining query results to be processed.
 
-|[[log-miner-metrics-averageprocessedcapturedbatchduration]]<<log-miner-metrics-averageprocessedcapturedbatchduration, `AverageProcessedCapturedBatchDuration`>>
+|[[log-miner-metrics-averageprocessedcapturedbatchduration]]<<log-miner-metrics-averageprocessedcapturedbatchduration, `+AverageProcessedCapturedBatchDuration+`>>
 |`Duration`
 |The average duration it has taken for the log mining query results to be processed.
 
-|[[log-miner-metrics-processedcapturebatchcount]]<<log-miner-metrics-processedcapturebatchcount, `ProcesssedCaptureBatchCount`>>
+|[[log-miner-metrics-processedcapturebatchcount]]<<log-miner-metrics-processedcapturebatchcount, `+ProcesssedCaptureBatchCount+`>>
 |`int`
 |The number of log mining query results processed.
 
-|[[log-miner-metrics-batchsize]]<<log-miner-metrics-batchsize, `BatchSize`>>
+|[[log-miner-metrics-batchsize]]<<log-miner-metrics-batchsize, `+BatchSize+`>>
 |`int`
 |The number of entries fetched by the log mining query per database round-trip.
 
-|[[log-miner-metrics-millisecondtosleepbetweenminingquery]]<<log-miner-metrics-millisecondtosleepbetweenminingquery, `MillisecondToSleepBetweenMiningQuery`>>
+|[[log-miner-metrics-millisecondtosleepbetweenminingquery]]<<log-miner-metrics-millisecondtosleepbetweenminingquery, `+MillisecondToSleepBetweenMiningQuery+`>>
 |`int`
 |The number of milliseconds the connector sleeps before fetching another batch of results from the log mining view.
 
@@ -1323,132 +1323,132 @@ The following configuration properties are _required_ unless a default value is 
 |Default
 |Description
 
-|[[oracle-property-name]]<<oracle-property-name, `name`>>
+|[[oracle-property-name]]<<oracle-property-name, `+name+`>>
 |
 |Unique name for the connector. Attempting to register again with the same name will fail. (This property is required by all Kafka Connect connectors.)
 
-|[[oracle-property-connector-class]]<<oracle-property-connector-class, `connector.class`>>
+|[[oracle-property-connector-class]]<<oracle-property-connector-class, `+connector.class+`>>
 |
-|The name of the Java class for the connector. Always use a value of `io.debezium{zwsp}.connector.oracle.OracleConnector` for the Oracle connector.
+|The name of the Java class for the connector. Always use a value of `io.debezium.connector.oracle.OracleConnector` for the Oracle connector.
 
-|[[oracle-property-tasks-max]]<<oracle-property-tasks-max, `tasks.max`>>
+|[[oracle-property-tasks-max]]<<oracle-property-tasks-max, `+tasks.max+`>>
 |`1`
 |The maximum number of tasks that should be created for this connector. The Oracle connector always uses a single task and therefore does not use this value, so the default is always acceptable.
 
-|[[oracle-property-database-hostname]]<<oracle-property-database-hostname, `database.hostname`>>
+|[[oracle-property-database-hostname]]<<oracle-property-database-hostname, `+database.hostname+`>>
 |
 |IP address or hostname of the Oracle database server.
 
-|[[oracle-property-database-port]]<<oracle-property-database-port, `database.port`>>
+|[[oracle-property-database-port]]<<oracle-property-database-port, `+database.port+`>>
 |
 |Integer port number of the Oracle database server.
 
-|[[oracle-property-database-user]]<<oracle-property-database-user, `database.user`>>
+|[[oracle-property-database-user]]<<oracle-property-database-user, `+database.user+`>>
 |
 |Name of the user to use when connecting to the Oracle database server.
 
-|[[oracle-property-database-password]]<<oracle-property-database-password, `database.password`>>
+|[[oracle-property-database-password]]<<oracle-property-database-password, `+database.password+`>>
 |
 |Password to use when connecting to the Oracle database server.
 
-|[[oracle-property-database-dbname]]<<oracle-property-database-dbname, `database.dbname`>>
+|[[oracle-property-database-dbname]]<<oracle-property-database-dbname, `+database.dbname+`>>
 |
 |Name of the database to connect to. Must be the CDB name when working with the CDB + PDB model.
 
-|[[oracle-property-database-url]]<<oracle-property-database-url, `database.url`>>
+|[[oracle-property-database-url]]<<oracle-property-database-url, `+database.url+`>>
 |
 |Raw database jdbc url. This property can be used when more flexibility is needed and can support raw TNS names or RAC connection strings.
 
-|[[oracle-property-database-tablename-case-insensitive]]<<oracle-property-database-tablename-case-insensitive, `database.tablename.case.insensitive`>>
+|[[oracle-property-database-tablename-case-insensitive]]<<oracle-property-database-tablename-case-insensitive, `+database.tablename.case.insensitive+`>>
 |`false`
 |Enable support for case insensitive table names; set to `true` for Oracle 11g.
 
-|[[oracle-property-database-oracle-version]]<<oracle-property-database-oracle-version, `database.oracle.version`>>
+|[[oracle-property-database-oracle-version]]<<oracle-property-database-oracle-version, `+database.oracle.version+`>>
 |`12+`
 |Specifies how to decode the Oracle SCN values.
 `11` should be used when connecting to Oracle 11 databases.
 `12+` (the default) should be used when connecting to Oracle 12 or later databases.
 This field is only applicable when using the Oracle XStreams connector adapter.
 
-|[[oracle-property-database-pdb-name]]<<oracle-property-database-pdb-name, `database.pdb.name`>>
+|[[oracle-property-database-pdb-name]]<<oracle-property-database-pdb-name, `+database.pdb.name+`>>
 |
 |Name of the PDB to connect to, when working with the CDB + PDB model.
 
-|[[oracle-property-database-out-server-name]]<<oracle-property-database-out-server-name, `database.out.server.name`>>
+|[[oracle-property-database-out-server-name]]<<oracle-property-database-out-server-name, `+database.out.server.name+`>>
 |
 |Name of the XStream outbound server configured in the database.
 
-|[[oracle-property-database-server-name]]<<oracle-property-database-server-name, `database.server.name`>>
+|[[oracle-property-database-server-name]]<<oracle-property-database-server-name, `+database.server.name+`>>
 |
 |Logical name that identifies and provides a namespace for the particular Oracle database server being monitored. The logical name should be unique across all other connectors, since it is used as a prefix for all Kafka topic names emanating from this connector.
 Only alphanumeric characters and underscores should be used.
 
-|[[oracle-property-database-connection-adapter]]<<oracle-database-connection-adapter, `database.connection.adapter`>>
+|[[oracle-property-database-connection-adapter]]<<oracle-database-connection-adapter, `+database.connection.adapter+`>>
 |`xstream`
 |The adapter implementation to use.
 `xstream` uses the Oracle XStreams API.
 `logminer` uses the native Oracle LogMiner API.
 
-|[[oracle-property-rac-nodes]]<<oracle-property-rac-nodes, `rac.nodes`>>
+|[[oracle-property-rac-nodes]]<<oracle-property-rac-nodes, `+rac.nodes+`>>
 |
 |A comma-separated list of RAC node host names or addresses.
 This field is required to enable Oracle RAC support.
 
-|[[oracle-property-database-history-kafka-topic]]<<oracle-property-database-history-kafka-topic, `database.history.kafka.topic`>>
+|[[oracle-property-database-history-kafka-topic]]<<oracle-property-database-history-kafka-topic, `+database.history.kafka.topic+`>>
 |
 |The full name of the Kafka topic where the connector will store the database schema history.
 
-|[[oracle-property-database-history-kafka-bootstrap-servers]]<<oracle-property-database-history-kafka-bootstrap-servers, `database.history{zwsp}.kafka.bootstrap.servers`>>
+|[[oracle-property-database-history-kafka-bootstrap-servers]]<<oracle-property-database-history-kafka-bootstrap-servers, `+database.history.kafka.bootstrap.servers+`>>
 |
 |A list of host/port pairs that the connector will use for establishing an initial connection to the Kafka cluster. This connection will be used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. This should point to the same Kafka cluster used by the Kafka Connect process.
 
-|[[oracle-property-snapshot-mode]]<<oracle-property-snapshot-mode, `snapshot.mode`>>
+|[[oracle-property-snapshot-mode]]<<oracle-property-snapshot-mode, `+snapshot.mode+`>>
 |_initial_
 |A mode for taking an initial snapshot of the structure and optionally data of captured tables. Supported values are _initial_ (will take a snapshot of structure and data of captured tables; useful if topics should be populated with a complete representation of the data from the captured tables) and _schema_only_ (will take a snapshot of the structure of captured tables only; useful if only changes happening from now onwards should be propagated to topics). Once the snapshot is complete, the connector will continue reading change events from the database's redo logs.
 
-|[[oracle-property-table-include-list]]<<oracle-property-table-include-list, `table.include.list`>>
+|[[oracle-property-table-include-list]]<<oracle-property-table-include-list, `+table.include.list+`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be monitored; any table not included in the include list will be excluded from monitoring. Each identifier is of the form _schemaName_._tableName_. By default the connector will monitor every non-system table in each monitored database. May not be used with `table.exclude.list`.
 
-|[[oracle-property-table-exclude-list]]<<oracle-property-table-exclude-list, `table.exclude.list`>>
+|[[oracle-property-table-exclude-list]]<<oracle-property-table-exclude-list, `+table.exclude.list+`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables to be excluded from monitoring; any table not included in the exclude list will be monitored. Each identifier is of the form _schemaName_._tableName_. May not be used with `table.include.list`.
 
-|[[oracle-property-column-mask-hash]]<<oracle-property-column-mask-hash, `column.mask.hash._hashAlgorithm_.with.salt._salt_`>>
+|[[oracle-property-column-mask-hash]]<<oracle-property-column-mask-hash, `+column.mask.hash._hashAlgorithm_.with.salt._salt_+`>>
 |_n/a_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be pseudonyms in the change event message values with a field value consisting of the hashed value using the algorithm `_hashAlgorithm_` and salt `_salt_`.
 Based on the used hash function referential integrity is kept while data is pseudonymized. Supported hash functions are described in the {link-java7-standard-names}[MessageDigest section] of the Java Cryptography Architecture Standard Algorithm Name Documentation.
 The hash is automatically shortened to the length of the column.
 
-|[[oracle-property-log-mining-batch-size-min]]<<oracle-property-log-mining-batch-size-min, `log.mining.batch.size.min`>>
+|[[oracle-property-log-mining-batch-size-min]]<<oracle-property-log-mining-batch-size-min, `+log.mining.batch.size.min+`>>
 |`1000`
 |The minimum SCN interval size that this connector will try to read from redo/archive logs. Active batch size will be also increased/decreased by this amount for tuning connector throughput when needed.
 
-|[[oracle-property-log-mining-batch-size-max]]<<oracle-property-log-mining-batch-size-max, `log.mining.batch.size.max`>>
+|[[oracle-property-log-mining-batch-size-max]]<<oracle-property-log-mining-batch-size-max, `+log.mining.batch.size.max+`>>
 |`100000`
 |The maximum SCN interval size that this connector will use when reading from redo/archive logs.
 
-|[[oracle-property-log-mining-batch-size-default]]<<oracle-property-log-mining-batch-size-default, `log.mining.batch.size.default`>>
+|[[oracle-property-log-mining-batch-size-default]]<<oracle-property-log-mining-batch-size-default, `+log.mining.batch.size.default+`>>
 |`20000`
 |The starting SCN interval size that the connector will use for reading data from redo/archive logs.
 
-|[[oracle-property-log-mining-sleep-time-min-ms]]<<oracle-property-log-mining-sleep-time-min-ms, `log.mining.sleep.time.min.ms`>>
+|[[oracle-property-log-mining-sleep-time-min-ms]]<<oracle-property-log-mining-sleep-time-min-ms, `+log.mining.sleep.time.min.ms+`>>
 |`0`
 |The minimum amount of time that the connector will sleep after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.
 
-|[[oracle-property-log-mining-sleep-time-max-ms]]<<oracle-property-log-mining-sleep-time-max-ms, `log.mining.sleep.time.max.ms`>>
+|[[oracle-property-log-mining-sleep-time-max-ms]]<<oracle-property-log-mining-sleep-time-max-ms, `+log.mining.sleep.time.max.ms+`>>
 |`3000`
 |The maximum amount of time that the connector will sleep after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.
 
-|[[oracle-property-log-mining-sleep-time-default-ms]]<<oracle-property-log-mining-sleep-time-default-ms, `log.mining.sleep.time.default.ms`>>
+|[[oracle-property-log-mining-sleep-time-default-ms]]<<oracle-property-log-mining-sleep-time-default-ms, `+log.mining.sleep.time.default.ms+`>>
 |`1000`
 |The starting amount of time that the connector will sleep after reading data from redo/archive logs and before starting reading data again. Value is in milliseconds.
 
-|[[oracle-property-log-mining-sleep-time-increment-ms]]<<oracle-property-log-mining-sleep-time-increment-ms, `log.mining.sleep.time.increment.ms`>>
+|[[oracle-property-log-mining-sleep-time-increment-ms]]<<oracle-property-log-mining-sleep-time-increment-ms, `+log.mining.sleep.time.increment.ms+`>>
 |`200`
 |The maximum amount of time up or down that the connector will use to tune the optimal sleep time when reading data from logminer. Value is in milliseconds.
 
-|[[oracle-property-log-mining-view-fetch-size]]<<oracle-property-log-mining-view-fetch-size, `log.mining.view.fetch.size`>>
+|[[oracle-property-log-mining-view-fetch-size]]<<oracle-property-log-mining-view-fetch-size, `+log.mining.view.fetch.size+`>>
 |`10000`
 |The number of content records that will be fetched from the log miner content view.
 
@@ -1463,61 +1463,61 @@ where `CzQMA0cB5K` is a randomly selected salt.
 
 Note: Depending on the `_hashAlgorithm_` used, the `_salt_` selected and the actual data set, the resulting masked data set may not be completely anonymized.
 
-|[[oracle-property-decimal-handling-mode]]<<oracle-property-decimal-handling-mode, `decimal.handling.mode`>>
+|[[oracle-property-decimal-handling-mode]]<<oracle-property-decimal-handling-mode, `+decimal.handling.mode+`>>
 |`precise`
 | Specifies how the connector should handle floating point values for `NUMBER`, `DECIMAL` and `NUMERIC` columns: `precise` (the default) represents them precisely using `java.math.BigDecimal` values represented in change events in a binary form; or `double` represents them using `double` values, which may result in a loss of precision but will be far easier to use. `string` option encodes values as formatted string which is easy to consume but a semantic information about the real type is lost. See <<decimal-values>>.
 
-|[[oracle-property-event-processing-failure-handling-mode]]<<oracle-property-event-processing-failure-handling-mode, `event.processing{zwsp}.failure.handling.mode`>>
+|[[oracle-property-event-processing-failure-handling-mode]]<<oracle-property-event-processing-failure-handling-mode, `+event.processing.failure.handling.mode+`>>
 |`fail`
 | Specifies how the connector should react to exceptions during processing of events.
 `fail` will propagate the exception (indicating the offset of the problematic event), causing the connector to stop. +
 `warn` will cause the problematic event to be skipped and the offset of the problematic event to be logged. +
 `skip` will cause the problematic event to be skipped.
 
-|[[oracle-property-max-queue-size]]<<oracle-property-max-queue-size, `max.queue.size`>>
+|[[oracle-property-max-queue-size]]<<oracle-property-max-queue-size, `+max.queue.size+`>>
 |`8192`
 |Positive integer value that specifies the maximum size of the blocking queue into which change events read from the database log are placed before they are written to Kafka. This queue can provide backpressure to the binlog reader when, for example, writes to Kafka are slower or if Kafka is not available. Events that appear in the queue are not included in the offsets periodically recorded by this connector. Defaults to 8192, and should always be larger than the maximum batch size specified in the `max.batch.size` property.
 
-|[[oracle-property-max-batch-size]]<<oracle-property-max-batch-size, `max.batch.size`>>
+|[[oracle-property-max-batch-size]]<<oracle-property-max-batch-size, `+max.batch.size+`>>
 |`2048`
 |Positive integer value that specifies the maximum size of each batch of events that should be processed during each iteration of this connector. Defaults to 2048.
 
-|[[oracle-property-max-queue-size-in-bytes]]<<oracle-property-max-queue-size-in-bytes, `max.queue.size.in.bytes`>>
+|[[oracle-property-max-queue-size-in-bytes]]<<oracle-property-max-queue-size-in-bytes, `+max.queue.size.in.bytes+`>>
 |`0`
 |Long value for the maximum size in bytes of the blocking queue. The feature is disabled by default, it will be active if it's set with a positive long value.
 
-|[[oracle-property-poll-interval-ms]]<<oracle-property-poll-interval-ms, `poll.interval.ms`>>
+|[[oracle-property-poll-interval-ms]]<<oracle-property-poll-interval-ms, `+poll.interval.ms+`>>
 |`1000`
 |Positive integer value that specifies the number of milliseconds the connector should wait during each iteration for new change events to appear. Defaults to 1000 milliseconds, or 1 second.
 
-|[[oracle-property-tombstones-on-delete]]<<oracle-property-tombstones-on-delete, `tombstones.on.delete`>>
+|[[oracle-property-tombstones-on-delete]]<<oracle-property-tombstones-on-delete, `+tombstones.on.delete+`>>
 |`true`
 | Controls whether a tombstone event should be generated after a delete event. +
 When `true` the delete operations are represented by a delete event and a subsequent tombstone event. When `false` only a delete event is sent. +
 Emitting the tombstone event (the default behavior) allows Kafka to completely delete all events pertaining to the given key once the source record got deleted.
 
-|[[oracle-property-message-key-columns]]<<oracle-property-message-key-columns, `message.key.columns`>>
+|[[oracle-property-message-key-columns]]<<oracle-property-message-key-columns, `+message.key.columns+`>>
 |_n/a_
 | A semi-colon list of regular expressions that match fully-qualified tables and columns to map a primary key. +
 Each item (regular expression) must match the `<fully-qualified table>:<a comma-separated list of columns>` representing the custom key. +
 Fully-qualified tables could be defined as _pdbName_._schemaName_._tableName_.
 
-|[[oracle-property-column-truncate-to-length-chars]]<<oracle-property-column-truncate-to-length-chars, `column.truncate.to._length_.chars`>>
+|[[oracle-property-column-truncate-to-length-chars]]<<oracle-property-column-truncate-to-length-chars, `+column.truncate.to._length_.chars+`>>
 |_n/a_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be truncated in the change event message values if the field values are longer than the specified number of characters. Multiple properties with different lengths can be used in a single configuration, although in each the length must be a positive integer. Fully-qualified names for columns are of the form _pdbName_._schemaName_._tableName_._columnName_.
 
-|[[oracle-property-column-mask-with-length-chars]]<<oracle-property-column-mask-with-length-chars, `column.mask.with._length_.chars`>>
+|[[oracle-property-column-mask-with-length-chars]]<<oracle-property-column-mask-with-length-chars, `+column.mask.with._length_.chars+`>>
 |_n/a_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be replaced in the change event message values with a field value consisting of the specified number of asterisk (`*`) characters. Multiple properties with different lengths can be used in a single configuration, although in each the length must be a positive integer or zero. Fully-qualified names for columns are of the form _pdbName_._schemaName_._tableName_._columnName_.
 
-|[[oracle-property-column-propagate-source-type]]<<oracle-property-column-propagate-source-type, `column.propagate.source.type`>>
+|[[oracle-property-column-propagate-source-type]]<<oracle-property-column-propagate-source-type, `+column.propagate.source.type+`>>
 |_n/a_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
 The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
 Useful to properly size corresponding columns in sink databases.
 Fully-qualified names for columns are of the form _tableName_._columnName_, or _schemaName_._tableName_._columnName_.
 
-|[[oracle-property-datatype-propagate-source-type]]<<oracle-property-datatype-propagate-source-type, `datatype.propagate.source.type`>>
+|[[oracle-property-datatype-propagate-source-type]]<<oracle-property-datatype-propagate-source-type, `+datatype.propagate.source.type+`>>
 |_n/a_
 |An optional comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
 The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
@@ -1525,7 +1525,7 @@ Useful to properly size corresponding columns in sink databases.
 Fully-qualified data type names are of the form _tableName_._typeName_, or _schemaName_._tableName_._typeName_.
 See the {link-prefix}:{link-oracle-connector}#oracle-data-types[list of Oracle-specific data type names].
 
-|[[oracle-property-heartbeat-interval-ms]]<<oracle-property-heartbeat-interval-ms, `heartbeat.interval.ms`>>
+|[[oracle-property-heartbeat-interval-ms]]<<oracle-property-heartbeat-interval-ms, `+heartbeat.interval.ms+`>>
 |`0`
 |Controls how frequently heartbeat messages are sent. +
 This property contains an interval in milli-seconds that defines how frequently the connector sends messages into a heartbeat topic.
@@ -1539,42 +1539,42 @@ and also may result in more change events to be re-sent after a connector restar
 Set this parameter to `0` to not send heartbeat messages at all. +
 Disabled by default.
 
-|[[oracle-property-heartbeat-topics-prefix]]<<oracle-property-heartbeat-topics-prefix, `heartbeat.topics.prefix`>>
+|[[oracle-property-heartbeat-topics-prefix]]<<oracle-property-heartbeat-topics-prefix, `+heartbeat.topics.prefix+`>>
 |`__debezium-heartbeat`
 |Controls the naming of the topic to which heartbeat messages are sent. +
 The topic is named according to the pattern `<heartbeat.topics.prefix>.<server.name>`.
 
-|[[oracle-property-snapshot-delay-ms]]<<oracle-property-snapshot-delay-ms, `snapshot.delay.ms`>>
+|[[oracle-property-snapshot-delay-ms]]<<oracle-property-snapshot-delay-ms, `+snapshot.delay.ms+`>>
 |
 |An interval in milli-seconds that the connector should wait before taking a snapshot after starting up; +
 Can be used to avoid snapshot interruptions when starting multiple connectors in a cluster, which may cause re-balancing of connectors.
 
-|[[oracle-property-snapshot-fetch-size]]<<oracle-property-snapshot-fetch-size, `snapshot.fetch.size`>>
+|[[oracle-property-snapshot-fetch-size]]<<oracle-property-snapshot-fetch-size, `+snapshot.fetch.size+`>>
 |`2000`
 |Specifies the maximum number of rows that should be read in one go from each table while taking a snapshot.
 The connector will read the table contents in multiple batches of this size. Defaults to 2000.
 
-|[[oracle-property-sanitize-field-names]]<<oracle-property-sanitize-field-names, `sanitize.field.names`>>
+|[[oracle-property-sanitize-field-names]]<<oracle-property-sanitize-field-names, `+sanitize.field.names+`>>
 |`true` when connector configuration explicitly specifies the `key.converter` or `value.converter` parameters to use Avro, otherwise defaults to `false`.
 |Whether field names will be sanitized to adhere to Avro naming requirements.
 See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 
-|[[oracle-property-provide-transaction-metadata]]<<oracle-property-provide-transaction-metadata, `provide.transaction.metadata`>>
+|[[oracle-property-provide-transaction-metadata]]<<oracle-property-provide-transaction-metadata, `+provide.transaction.metadata+`>>
 |`false`
 |When set to `true` {prodname} generates events with transaction boundaries and enriches data events envelope with transaction metadata.
 
 See {link-prefix}:{link-oracle-connector}#oracle-transaction-metadata[Transaction Metadata] for additional details.
 
-|[[oracle-property-log-mining-history-recorder-class]]<<oracle-property-log-mining-history-recorder-class, `log.mining.history.recorder.class`>>
+|[[oracle-property-log-mining-history-recorder-class]]<<oracle-property-log-mining-history-recorder-class, `+log.mining.history.recorder.class+`>>
 |
 |The fully qualified class name to an implementation of `HistoryReader` to be used during LogMining streaming.
 
-|[[oracle-property-log-mining-archive-log-hours]]<<oracle-property-log-mining-archive-log-hours, `log.mining.archive.log.hours`>>
+|[[oracle-property-log-mining-archive-log-hours]]<<oracle-property-log-mining-archive-log-hours, `+log.mining.archive.log.hours+`>>
 |`0`
 |The number of hours in the past from SYSDATE to mine archive logs.
 Using the default `0` will mine all archive logs.
 
-|[[oracle-property-database-history-retention-hours]]<<oracle-property-database-history-retention-hours, `database.history.retention.hours`>>
+|[[oracle-property-database-history-retention-hours]]<<oracle-property-database-history-retention-hours, `+database.history.retention.hours+`>>
 |`0`
 |The number of hours to retain entries in log mining history table.
 When set to `0`, log mining history is is disabled.

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -579,7 +579,7 @@ If the `database.server.name` connector configuration property has the value `Po
 |The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion.
 
 |2
-|`PostgreSQL_server{zwsp}.inventory.customers{zwsp}.Key`
+|`PostgreSQL_server.inventory.customers.Key`
 a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._database-name_._table-name_.`Key`. In this example: +
 
 * `PostgreSQL_server` is the name of the connector that generated this event. +
@@ -2298,24 +2298,24 @@ The following configuration properties are _required_ unless a default value is 
 |Default
 |Description
 
-|[[postgresql-property-name]]<<postgresql-property-name, `name`>>
+|[[postgresql-property-name]]<<postgresql-property-name, `+name+`>>
 |
 |Unique name for the connector. Attempting to register again with the same name will fail. This property is required by all Kafka Connect connectors.
 
-|[[postgresql-property-connector-class]]<<postgresql-property-connector-class, `connector.class`>>
+|[[postgresql-property-connector-class]]<<postgresql-property-connector-class, `+connector.class+`>>
 |
 |The name of the Java class for the connector. Always use a value of `io.debezium.connector.postgresql.PostgresConnector` for the PostgreSQL connector.
 
-|[[postgresql-property-tasks-max]]<<postgresql-property-tasks-max, `tasks.max`>>
+|[[postgresql-property-tasks-max]]<<postgresql-property-tasks-max, `+tasks.max+`>>
 |`1`
 |The maximum number of tasks that should be created for this connector. The PostgreSQL connector always uses a single task and therefore does not use this value, so the default is always acceptable.
 
-|[[postgresql-property-plugin-name]]<<postgresql-property-plugin-name, `plugin.name`>>
+|[[postgresql-property-plugin-name]]<<postgresql-property-plugin-name, `+plugin.name+`>>
 |`decoderbufs`
 |The name of the PostgreSQL {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed on the PostgreSQL server.
 
 ifdef::community[]
-Supported values are `decoderbufs`, `wal2json`, `wal2json_rds`, `wal2json_streaming`, `wal2json_rds_streaming` and `pgoutput`.
+Supported values are `decoderbufs`, `wal2json`, `+wal2json_rds+`, `+wal2json_streaming+`, `+wal2json_rds_streaming+` and `pgoutput`.
 
 If you are using a `wal2json` plug-in and transactions are very large, the JSON batch event that contains all transaction changes might not fit into the hard-coded memory buffer, which has a size of 1 GB. In such cases, switch to a streaming plug-in, by setting the `plugin-name` property to `wal2json_streaming` or  `wal2json_rds_streaming`. With a streaming plug-in, PostgreSQL sends the connector a separate message for each change in a transaction.
 
@@ -2324,20 +2324,20 @@ ifdef::product[]
 The only supported value is `pgoutput`. You must explicitly set `plugin.name` to `pgoutput`.
 endif::product[]
 
-|[[postgresql-property-slot-name]]<<postgresql-property-slot-name, `slot.name`>>
+|[[postgresql-property-slot-name]]<<postgresql-property-slot-name, `+slot.name+`>>
 |`debezium`
 |The name of the PostgreSQL logical decoding slot that was created for streaming changes from a particular plug-in for a particular database/schema. The server uses this slot to stream events to the {prodname} connector that you are configuring.
 
 Slot names must conform to link:https://www.postgresql.org/docs/current/static/warm-standby.html#STREAMING-REPLICATION-SLOTS-MANIPULATION[PostgreSQL replication slot naming rules], which state: _"Each replication slot has a name, which can contain lower-case letters, numbers, and the underscore character."_
 
-|[[postgresql-property-slot-drop-on-stop]]<<postgresql-property-slot-drop-on-stop, `slot.drop.on.stop`>>
+|[[postgresql-property-slot-drop-on-stop]]<<postgresql-property-slot-drop-on-stop, `+slot.drop.on.stop+`>>
 |`false`
 |Whether or not to delete the logical replication slot when the connector stops in a graceful, expected way. The default behavior is that the replication slot remains configured for the connector when the connector stops. When the connector restarts, having the same replication slot enables the connector to start processing where it left off.
 
 Set to `true` in only testing or development environments. Dropping the slot allows the database to discard WAL segments. When the connector restarts it performs a new snapshot or it can continue from a persistent offset in the Kafka Connect offsets topic.
 
-|[[postgresql-property-publication-name]]<<postgresql-property-publication-name, `publication.name`>>
-|`dbz_{zwsp}publication`
+|[[postgresql-property-publication-name]]<<postgresql-property-publication-name, `+publication.name+`>>
+|`dbz_publication`
 |The name of the PostgreSQL publication created for streaming changes when using `pgoutput`.
 
 This publication is created at start-up if it does not already exist and it includes _all tables_.
@@ -2347,55 +2347,55 @@ so it is usually preferable to create the publication before starting the connec
 
 If the publication already exists, either for all tables or configured with a subset of tables, {prodname} uses the publication as it is defined.
 
-|[[postgresql-property-database-hostname]]<<postgresql-property-database-hostname, `database.hostname`>>
+|[[postgresql-property-database-hostname]]<<postgresql-property-database-hostname, `+database.hostname+`>>
 |
 |IP address or hostname of the PostgreSQL database server.
 
-|[[postgresql-property-database-port]]<<postgresql-property-database-port, `database.port`>>
+|[[postgresql-property-database-port]]<<postgresql-property-database-port, `+database.port+`>>
 |`5432`
 |Integer port number of the PostgreSQL database server.
 
-|[[postgresql-property-database-user]]<<postgresql-property-database-user, `database.user`>>
+|[[postgresql-property-database-user]]<<postgresql-property-database-user, `+database.user+`>>
 |
 |Name of the PostgreSQL database user for connecting to the PostgreSQL database server.
 
-|[[postgresql-property-database-password]]<<postgresql-property-database-password, `database.password`>>
+|[[postgresql-property-database-password]]<<postgresql-property-database-password, `+database.password+`>>
 |
 |Password to use when connecting to the PostgreSQL database server.
 
-|[[postgresql-property-database-dbname]]<<postgresql-property-database-dbname, `database.dbname`>>
+|[[postgresql-property-database-dbname]]<<postgresql-property-database-dbname, `+database.dbname+`>>
 |
 |The name of the PostgreSQL database from which to stream the changes.
 
-|[[postgresql-property-database-server-name]]<<postgresql-property-database-server-name, `database.server{zwsp}.name`>>
+|[[postgresql-property-database-server-name]]<<postgresql-property-database-server-name, `+database.server.name+`>>
 |
 |Logical name that identifies and provides a namespace for the particular PostgreSQL database server or cluster in which {prodname} is capturing changes. Only alphanumeric characters and underscores should be used in the database server logical name. The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
 
-|[[postgresql-property-schema-include-list]]<<postgresql-property-schema-include-list, `schema.include{zwsp}.list`>>
+|[[postgresql-property-schema-include-list]]<<postgresql-property-schema-include-list, `+schema.include.list+`>>
 |
 |An optional, comma-separated list of regular expressions that match names of schemas for which you *want* to capture changes. Any schema name not included in `schema.include.list` is excluded from having its changes captured. By default, all non-system schemas have their changes captured. Do not also set the `schema.exclude.list` property.
 
-|[[postgresql-property-schema-exclude-list]]<<postgresql-property-schema-exclude-list, `schema.exclude{zwsp}.list`>>
+|[[postgresql-property-schema-exclude-list]]<<postgresql-property-schema-exclude-list, `+schema.exclude.list+`>>
 |
 |An optional, comma-separated list of regular expressions that match names of schemas for which you *do not* want to capture changes. Any schema whose name is not included in `schema.exclude.list` has its changes captured, with the exception of system schemas. Do not also set the `schema.include.list` property.
 
-|[[postgresql-property-table-include-list]]<<postgresql-property-table-include-list, `table.include{zwsp}.list`>>
+|[[postgresql-property-table-include-list]]<<postgresql-property-table-include-list, `+table.include.list+`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you want to capture. Any table not included in `table.include.list` does not have its changes captured. Each identifier is of the form _schemaName_._tableName_. By default, the connector captures changes in every non-system table in each schema whose changes are being captured. Do not also set the `table.exclude.list` property.
 
-|[[postgresql-property-table-exclude-list]]<<postgresql-property-table-exclude-list, `table.exclude{zwsp}.list`>>
+|[[postgresql-property-table-exclude-list]]<<postgresql-property-table-exclude-list, `+table.exclude.list+`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you *do not* want to capture. Any table not included in `table.exclude.list` has it changes captured. Each identifier is of the form _schemaName_._tableName_. Do not also set the `table.include.list` property.
 
-|[[postgresql-property-column-include-list]]<<postgresql-property-column-include-list, `column.include{zwsp}.list`>>
+|[[postgresql-property-column-include-list]]<<postgresql-property-column-include-list, `+column.include.list+`>>
 |
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in change event record values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. Do not also set the `column.exclude.list` property.
 
-|[[postgresql-property-column-exclude-list]]<<postgresql-property-column-exclude-list, `column.exclude{zwsp}.list`>>
+|[[postgresql-property-column-exclude-list]]<<postgresql-property-column-exclude-list, `+column.exclude.list+`>>
 |
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event record values. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. Do not also set the `column.include.list` property.
 
-|[[postgresql-property-time-precision-mode]]<<postgresql-property-time-precision-mode, `time.precision.mode`>>
+|[[postgresql-property-time-precision-mode]]<<postgresql-property-time-precision-mode, `+time.precision.mode+`>>
 |`adaptive`
 |Time, date, and timestamps can be represented with different kinds of precision: +
  +
@@ -2405,7 +2405,7 @@ If the publication already exists, either for all tables or configured with a su
  +
 `connect` always represents time and timestamp values by using Kafka Connect's built-in representations for `Time`, `Date`, and `Timestamp`, which use millisecond precision regardless of the database columns' precision. See {link-prefix}:{link-postgresql-connector}#postgresql-temporal-values[temporal values].
 
-|[[postgresql-property-decimal-handling-mode]]<<postgresql-property-decimal-handling-mode, `decimal.handling{zwsp}.mode`>>
+|[[postgresql-property-decimal-handling-mode]]<<postgresql-property-decimal-handling-mode, `+decimal.handling.mode+`>>
 |`precise`
 |Specifies how the connector should handle values for `DECIMAL` and `NUMERIC` columns: +
  +
@@ -2415,7 +2415,7 @@ If the publication already exists, either for all tables or configured with a su
  +
 `string` encodes values as formatted strings, which are easy to consume but semantic information about the real type is lost. See {link-prefix}:{link-postgresql-connector}#postgresql-decimal-types[Decimal types].
 
-|[[postgresql-property-hstore-handling-mode]]<<postgresql-property-hstore-handling-mode, `hstore.handling{zwsp}.mode`>>
+|[[postgresql-property-hstore-handling-mode]]<<postgresql-property-hstore-handling-mode, `+hstore.handling.mode+`>>
 |`map`
 | Specifies how the connector should handle values for `hstore` columns: +
  +
@@ -2423,7 +2423,7 @@ If the publication already exists, either for all tables or configured with a su
  +
 `json` represents values by using `json string`. This setting encodes values as formatted strings such as `{"key" : "val"}`. See {link-prefix}:{link-postgresql-connector}#postgresql-hstore-type[PostgreSQL `HSTORE` type].
 
-|[[postgresql-property-interval-handling-mode]]<<postgresql-property-interval-handling-mode, `interval.handling{zwsp}.mode`>>
+|[[postgresql-property-interval-handling-mode]]<<postgresql-property-interval-handling-mode, `+interval.handling.mode+`>>
 |`numeric`
 | Specifies how the connector should handle values for `interval` columns: +
  +
@@ -2431,7 +2431,7 @@ If the publication already exists, either for all tables or configured with a su
  +
 `string` represents intervals exactly by using the string pattern representation `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`. For example: `P1Y2M3DT4H5M6.78S`. See {link-prefix}:{link-postgresql-connector}#postgresql-basic-types[PostgreSQL basic types].
 
-|[[postgresql-property-database-sslmode]]<<postgresql-property-database-sslmode, `database.sslmode`>>
+|[[postgresql-property-database-sslmode]]<<postgresql-property-database-sslmode, `+database.sslmode+`>>
 |`disable`
 |Whether to use an encrypted connection to the PostgreSQL server. Options include: +
  +
@@ -2443,27 +2443,27 @@ If the publication already exists, either for all tables or configured with a su
  +
 `verify-full` behaves like `verify-ca` but also verifies that the server certificate matches the host to which the connector is trying to connect. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
-|[[postgresql-property-database-sslcert]]<<postgresql-property-database-sslcert, `database.sslcert`>>
+|[[postgresql-property-database-sslcert]]<<postgresql-property-database-sslcert, `+database.sslcert+`>>
 |
 |The path to the file that contains the SSL certificate for the client. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
-|[[postgresql-property-database-sslkey]]<<postgresql-property-database-sslkey, `database.sslkey`>>
+|[[postgresql-property-database-sslkey]]<<postgresql-property-database-sslkey, `+database.sslkey+`>>
 |
 |The path to the file that contains the SSL private key of the client. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
-|[[postgresql-property-database-sslpassword]]<<postgresql-property-database-sslpassword, `database{zwsp}.sslpassword`>>
+|[[postgresql-property-database-sslpassword]]<<postgresql-property-database-sslpassword, `+database.sslpassword+`>>
 |
 |The password to access the client private key from the file specified by `database.sslkey`. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
-|[[postgresql-property-database-sslrootcert]]<<postgresql-property-database-sslrootcert, `database{zwsp}.sslrootcert`>>
+|[[postgresql-property-database-sslrootcert]]<<postgresql-property-database-sslrootcert, `+database.sslrootcert+`>>
 |
 |The path to the file that contains the root certificate(s) against which the server is validated. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
-|[[postgresql-property-database-tcpkeepalive]]<<postgresql-property-database-tcpkeepalive, `database{zwsp}.tcpKeepAlive`>>
+|[[postgresql-property-database-tcpkeepalive]]<<postgresql-property-database-tcpkeepalive, `+database.tcpKeepAlive+`>>
 |`true`
 |Enable TCP keep-alive probe to verify that the database connection is still alive. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
 
-|[[postgresql-property-tombstones-on-delete]]<<postgresql-property-tombstones-on-delete, `tombstones.on{zwsp}.delete`>>
+|[[postgresql-property-tombstones-on-delete]]<<postgresql-property-tombstones-on-delete, `+tombstones.on.delete+`>>
 |`true`
 | Controls whether a tombstone event should be generated after a _delete_ event. +
  +
@@ -2473,15 +2473,15 @@ If the publication already exists, either for all tables or configured with a su
  +
 After a _delete_ operation, emitting a tombstone event enables Kafka to delete all change event records that have the same key as the deleted row.
 
-|[[postgresql-property-column-truncate-to-length-chars]]<<postgresql-property-column-truncate-to-length-chars, `column.truncate.to{zwsp}._length_.chars`>>
+|[[postgresql-property-column-truncate-to-length-chars]]<<postgresql-property-column-truncate-to-length-chars, `+column.truncate.to._length_.chars+`>>
 |_n/a_
-|An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event records, values in these columns are truncated if they are longer than the number of characters specified by _length_ in the property name. You can specify multiple properties with different lengths in a single configuration. Length must be a positive integer, for example, `column.truncate.to.20.chars`.
+|An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event records, values in these columns are truncated if they are longer than the number of characters specified by _length_ in the property name. You can specify multiple properties with different lengths in a single configuration. Length must be a positive integer, for example, `+column.truncate.to.20.chars`.
 
-|[[postgresql-property-column-mask-with-length-chars]]<<postgresql-property-column-mask-with-length-chars, `column.mask.with{zwsp}._length_.chars`>>
+|[[postgresql-property-column-mask-with-length-chars]]<<postgresql-property-column-mask-with-length-chars, `+column.mask.with._length_.chars+`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event values, the values in the specified table columns are replaced with _length_ number of asterisk (`*`) characters. You can specify multiple properties with different lengths in a single configuration. Length must be a positive integer or zero. When you specify zero, the connector replaces a value with an empty string.
 
-|[[postgresql-property-column-mask-hash]]<<postgresql-property-column-mask-hash, `column.mask{zwsp}.hash._hashAlgorithm_{zwsp}.with.salt._salt_`>>
+|[[postgresql-property-column-mask-hash]]<<postgresql-property-column-mask-hash, `+column.mask.hash._hashAlgorithm_.with.salt._salt_+`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_. In change event values, the values in the specified columns are replaced with pseudonyms. +
  +
@@ -2493,7 +2493,7 @@ If necessary, the pseudonym is automatically shortened to the length of the colu
  +
 Depending on the _hashAlgorithm_ used, the _salt_ selected, and the actual data set, the resulting masked data set might not be completely masked.
 
-|[[postgresql-property-column-propagate-source-type]]<<postgresql-property-column-propagate-source-type, `column.propagate{zwsp}.source.type`>>
+|[[postgresql-property-column-propagate-source-type]]<<postgresql-property-column-propagate-source-type, `+column.propagate.source.type+`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns. Fully-qualified names for columns are of the form _databaseName_._tableName_._columnName_, or _databaseName_._schemaName_._tableName_._columnName_. +
  +
@@ -2503,7 +2503,7 @@ For each specified column, the connector adds the column's original type and ori
  +
 This property is useful for properly sizing corresponding columns in sink databases.
 
-|[[postgresql-property-datatype-propagate-source-type]]<<postgresql-property-datatype-propagate-source-type, `datatype.propagate{zwsp}.source.type`>>
+|[[postgresql-property-datatype-propagate-source-type]]<<postgresql-property-datatype-propagate-source-type, `+datatype.propagate.source.type+`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the database-specific data type name for some columns. Fully-qualified data type names are of the form _databaseName_._tableName_._typeName_, or _databaseName_._schemaName_._tableName_._typeName_. +
  +
@@ -2515,7 +2515,7 @@ These parameters propagate a column's original type name and length, for variabl
  +
 See the {link-prefix}:{link-postgresql-connector}#postgresql-data-types[list of PostgreSQL-specific data type names].
 
-|[[postgresql-property-message-key-columns]]<<postgresql-property-message-key-columns, `message.key{zwsp}.columns`>>
+|[[postgresql-property-message-key-columns]]<<postgresql-property-message-key-columns, `+message.key.columns+`>>
 |_empty string_
 |A semicolon separated list of tables with regular expressions that match table column names. The connector maps values in matching columns to key fields in change event records that it sends to Kafka topics. This is useful when a table does not have a primary key, or when you want to order change event records in a Kafka topic according to a field that is not a primary key. +
  +
@@ -2529,7 +2529,7 @@ For example, +
  +
 If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column that starts with `i`), the connector maps the value in ``table_a``'s `id` column to a key field in change events that the connector sends to Kafka.
 
-|[[postgresql-publication-autocreate-mode]]<<postgresql-publication-autocreate-mode, `publication{zwsp}.autocreate.mode`>>
+|[[postgresql-publication-autocreate-mode]]<<postgresql-publication-autocreate-mode, `+publication.autocreate.mode+`>>
 |_all_tables_
 |Applies only when streaming changes by using link:https://www.postgresql.org/docs/current/sql-createpublication.html[the `pgoutput` plug-in]. The setting determines how creation of a link:https://www.postgresql.org/docs/current/logical-replication-publication.html[publication] should work. Possible settings are: +
  +
@@ -2539,7 +2539,7 @@ If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column tha
  +
 `filtered` - If a publication exists, the connector uses it. If no publication exists, the connector creates a new publication for tables that match the current filter configuration as specified by the `database.exclude.list`, `schema.include.list`, `schema.exclude.list`, and `table.include.list` connector configuration properties. For example: `CREATE PUBLICATION <publication_name> FOR TABLE <tbl1, tbl2, tbl3>`.
 
-|[[postgresql-property-binary-handling-mode]]<<postgresql-property-binary-handling-mode, `binary.handling{zwsp}.mode`>>
+|[[postgresql-property-binary-handling-mode]]<<postgresql-property-binary-handling-mode, `+binary.handling.mode+`>>
 |bytes
 |Specifies how binary (`bytea`) columns should be represented in change events: +
  +
@@ -2549,7 +2549,7 @@ If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column tha
  +
 `hex` represents binary data as hex-encoded (base16) strings.
 
-|[[postgresql-property-truncat-handling-mode]]<<postgresql-property-truncate-handling-mode, `truncate.handling{zwsp}.mode`>>
+|[[postgresql-property-truncat-handling-mode]]<<postgresql-property-truncate-handling-mode, `+truncate.handling.mode+`>>
 |bytes
 |Specifies how whether `TRUNCATE` events should be propagated or not (only available when using the `pgoutput` plug-in with Postgres 11 or later): +
  +
@@ -2571,7 +2571,7 @@ The following _advanced_ configuration properties have defaults that work in mos
 |Default
 |Description
 
-|[[postgresql-property-snapshot-mode]]<<postgresql-property-snapshot-mode, `snapshot.mode`>>
+|[[postgresql-property-snapshot-mode]]<<postgresql-property-snapshot-mode, `+snapshot.mode+`>>
 |`initial`
 |Specifies the criteria for performing a snapshot when the connector starts: +
  +
@@ -2592,26 +2592,26 @@ endif::community[]
 The{link-prefix}:{link-postgresql-connector}#snapshot-mode-settings[reference table for snapshot mode settings] has more details.
 
 ifdef::community[]
-|[[postgresql-property-snapshot-custom-class]]<<postgresql-property-snapshot-custom-class, `snapshot.custom.class`>>
+|[[postgresql-property-snapshot-custom-class]]<<postgresql-property-snapshot-custom-class, `+snapshot.custom.class+`>>
 |
 | A full Java class name that is an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. Required when the `snapshot.mode` property is set to `custom`. See {link-prefix}:{link-postgresql-connector}#postgresql-custom-snapshot[custom snapshotter SPI].
 endif::community[]
-|[[postgresql-property-snapshot-include-collection-list]]<<postgresql-property-snapshot-include-collection-list, `snapshot.include.collection.list`>>
+|[[postgresql-property-snapshot-include-collection-list]]<<postgresql-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>
 | All tables specified in `table.include.list`
 |An optional, comma-separated list of regular expressions that match names of schemas specified in `table.include.list` for which you *want* to take the snapshot when the `snapshot.mode` is not `never`
-|[[postgresql-property-snapshot-lock-timeout-ms]]<<postgresql-property-snapshot-lock-timeout-ms, `snapshot.lock{zwsp}.timeout.ms`>>
+|[[postgresql-property-snapshot-lock-timeout-ms]]<<postgresql-property-snapshot-lock-timeout-ms, `+snapshot.lock.timeout.ms+`>>
 |`10000`
 |Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. {link-prefix}:{link-postgresql-connector}#postgresql-snapshots[How the connector performs snapshots] provides details.
 
-|[[postgresql-property-snapshot-select-statement-overrides]]<<postgresql-property-snapshot-select-statement-overrides, `snapshot.select{zwsp}.statement{zwsp}.overrides`>>
+|[[postgresql-property-snapshot-select-statement-overrides]]<<postgresql-property-snapshot-select-statement-overrides, `+snapshot.select.statement.overrides+`>>
 |
 |Controls which table rows are included in snapshots. This property affects snapshots only. It does not affect events that are generated by the logical decoding plug-in. Specify a comma-separated list of fully-qualified table names in the form _databaseName.tableName_. +
  +
-For each table that you specify, also specify another configuration property: `snapshot.select.statement{zwsp}.overrides._DB_NAME_._TABLE_NAME_`, for example: `snapshot.select.statement{zwsp}.overrides.customers.orders`. Set this property to a `SELECT` statement that obtains only the rows that you want in the snapshot. When the connector performs a snapshot, it executes this `SELECT` statement to retrieve data from that table. +
+For each table that you specify, also specify another configuration property: `snapshot.select.statement.overrides._DB_NAME_._TABLE_NAME_`, for example: `snapshot.select.statement.overrides.customers.orders`. Set this property to a `SELECT` statement that obtains only the rows that you want in the snapshot. When the connector performs a snapshot, it executes this `SELECT` statement to retrieve data from that table. +
  +
 A possible use case for setting these properties is large, append-only tables. You can specify a `SELECT` statement that sets a specific point for where to start a snapshot, or where to resume a snapshot if a previous snapshot was interrupted.
 
-|[[postgresql-property-event-processing-failure-handling-mode]]<<postgresql-property-event-processing-failure-handling-mode, `event.processing{zwsp}.failure.handling{zwsp}.mode`>>
+|[[postgresql-property-event-processing-failure-handling-mode]]<<postgresql-property-event-processing-failure-handling-mode, `+event.processing.failure.handling.mode+`>>
 |`fail`
 | Specifies how the connector should react to exceptions during processing of events: +
  +
@@ -2621,23 +2621,23 @@ A possible use case for setting these properties is large, append-only tables. Y
  +
 `skip` skips the problematic event and continues processing.
 
-|[[postgresql-property-max-queue-size]]<<postgresql-property-max-queue-size, `max.queue.size`>>
+|[[postgresql-property-max-queue-size]]<<postgresql-property-max-queue-size, `+max.queue.size+`>>
 |`20240`
 |Positive integer value for the maximum size of the blocking queue. The connector places change events received from streaming replication in the blocking queue before writing them to Kafka. This queue can provide backpressure when, for example, writing records to Kafka is slower that it should be or Kafka is not available.
 
-|[[postgresql-property-max-batch-size]]<<postgresql-property-max-batch-size, `max.batch.size`>>
+|[[postgresql-property-max-batch-size]]<<postgresql-property-max-batch-size, `+max.batch.size+`>>
 |`10240`
 |Positive integer value that specifies the maximum size of each batch of events that the connector processes.
 
-|[[postgresql-property-max-queue-size-in-bytes]]<<postgresql-property-max-queue-size-in-bytes, `max.queue.size.in.bytes`>>
+|[[postgresql-property-max-queue-size-in-bytes]]<<postgresql-property-max-queue-size-in-bytes, `+max.queue.size.in.bytes+`>>
 |`0`
 |Long value for the maximum size in bytes of the blocking queue. The feature is disabled by default, it will be active if it's set with a positive long value.
 
-|[[postgresql-property-poll-interval-ms]]<<postgresql-property-poll-interval-ms, `poll.interval.ms`>>
+|[[postgresql-property-poll-interval-ms]]<<postgresql-property-poll-interval-ms, `+poll.interval.ms+`>>
 |`1000`
 |Positive integer value that specifies the number of milliseconds the connector should wait for new change events to appear before it starts processing a batch of events. Defaults to 1000 milliseconds, or 1 second.
 
-|[[postgresql-property-include-unknown-datatypes]]<<postgresql-property-include-unknown-datatypes, `include.unknown{zwsp}.datatypes`>>
+|[[postgresql-property-include-unknown-datatypes]]<<postgresql-property-include-unknown-datatypes, `+include.unknown.datatypes+`>>
 |`false`
 |Specifies connector behavior when the connector encounters a field whose data type is unknown. The default behavior is that the connector omits the field from the change event and logs a warning. +
  +
@@ -2645,7 +2645,7 @@ Set this property to `true` if you want the change event to contain an opaque bi
 
 NOTE: Consumers risk backward compatibility issues when `include.unknown.datatypes` is set to `true`. Not only may the database-specific binary representation change between releases, but if the data type is eventually supported by {prodname}, the data type will be sent downstream in a logical type, which would require adjustments by consumers. In general, when encountering unsupported data types, create a feature request so that support can be added.
 
-|[[postgresql-property-database-initial-statements]]<<postgresql-property-database-initial-statements, `database.initial{zwsp}.statements`>>
+|[[postgresql-property-database-initial-statements]]<<postgresql-property-database-initial-statements, `+database.initial.statements+`>>
 |
 |A semicolon separated list of SQL statements that the connector executes when it establishes a JDBC connection to the database. To use a semicolon as a character and not as a delimiter, specify two consecutive semicolons, `;;`. +
  +
@@ -2653,7 +2653,7 @@ The connector may establish JDBC connections at its own discretion. Consequently
  +
 The connector does not execute these statements when it creates a connection for reading the transaction log. +
 
-|[[postgresql-property-heartbeat-interval-ms]]<<postgresql-property-heartbeat-interval-ms, `heartbeat.interval{zwsp}.ms`>>
+|[[postgresql-property-heartbeat-interval-ms]]<<postgresql-property-heartbeat-interval-ms, `+heartbeat.interval.ms+`>>
 |`0`
 |Controls how frequently the connector sends heartbeat messages to a Kafka topic. The default behavior is that the connector does not send heartbeat messages. +
  +
@@ -2661,7 +2661,7 @@ Heartbeat messages are useful for monitoring whether the connector is receiving 
  +
 Heartbeat messages are needed when there are many updates in a database that is being tracked but only a tiny number of updates are related to the table(s) and schema(s) for which the connector is capturing changes. In this situation, the connector reads from the database transaction log as usual but rarely emits change records to Kafka. This means that no offset updates are committed to Kafka and the connector does not have an opportunity to send the latest retrieved LSN to the database. The database retains WAL files that contain events that have already been processed by the connector. Sending heartbeat messages enables the connector to send the latest retrieved LSN to the database, which allows the database to reclaim disk space being used by no longer needed WAL files.
 
-|[[postgresql-property-heartbeat-topics-prefix]]<<postgresql-property-heartbeat-topics-prefix, `heartbeat.topics{zwsp}.prefix`>>
+|[[postgresql-property-heartbeat-topics-prefix]]<<postgresql-property-heartbeat-topics-prefix, `+heartbeat.topics.prefix+`>>
 |`__debezium-heartbeat`
 |Controls the name of the topic to which the connector sends heartbeat messages. The topic name has this pattern: +
  +
@@ -2669,7 +2669,7 @@ _<heartbeat.topics.prefix>_._<server.name>_ +
  +
 For example, if the database server name is `fulfillment`, the default topic name is `__debezium-heartbeat.fulfillment`.
 
-|[[postgresql-property-heartbeat-action-query]]<<postgresql-property-heartbeat-action-query, `heartbeat.action{zwsp}.query`>>
+|[[postgresql-property-heartbeat-action-query]]<<postgresql-property-heartbeat-action-query, `+heartbeat.action.query+`>>
 |
 |Specifies a query that the connector executes on the source database when the connector sends a heartbeat message. +
  +
@@ -2679,7 +2679,7 @@ This is useful for resolving the situation described in {link-prefix}:{link-post
  +
 This allows the connector to receive changes from the low-traffic database and acknowledge their LSNs, which prevents unbounded WAL growth on the database host.
 
-|[[postgresql-property-schema-refresh-mode]]<<postgresql-property-schema-refresh-mode, `schema.refresh.mode`>>
+|[[postgresql-property-schema-refresh-mode]]<<postgresql-property-schema-refresh-mode, `+schema.refresh.mode+`>>
 |`columns_diff`
 |Specify the conditions that trigger a refresh of the in-memory schema for a table. +
  +
@@ -2690,15 +2690,15 @@ This allows the connector to receive changes from the low-traffic database and a
 This setting can significantly improve connector performance if there are frequently-updated tables that have TOASTed data that are rarely part of updates. However, it is possible for the in-memory schema to
 become outdated if TOASTable columns are dropped from the table.
 
-|[[postgresql-property-snapshot-delay-ms]]<<postgresql-property-snapshot-delay-ms, `snapshot.delay.ms`>>
+|[[postgresql-property-snapshot-delay-ms]]<<postgresql-property-snapshot-delay-ms, `+snapshot.delay.ms+`>>
 |
 |An interval in milliseconds that the connector should wait before performing a snapshot when the connector starts. If you are starting multiple connectors in a cluster, this property is useful for avoiding snapshot interruptions, which might cause re-balancing of connectors.
 
-|[[postgresql-property-snapshot-fetch-size]]<<postgresql-property-snapshot-fetch-size, `snapshot.fetch.size`>>
+|[[postgresql-property-snapshot-fetch-size]]<<postgresql-property-snapshot-fetch-size, `+snapshot.fetch.size+`>>
 |`10240`
 |During a snapshot, the connector reads table content in batches of rows. This property specifies the maximum number of rows in a batch.
 
-|[[postgresql-property-slot-stream-params]]<<postgresql-property-slot-stream-params, `slot.stream.params`>>
+|[[postgresql-property-slot-stream-params]]<<postgresql-property-slot-stream-params, `+slot.stream.params+`>>
 |
 |Semicolon separated list of parameters to pass to the configured logical decoding plug-in. For example, `add-tables=public.table,public.table2;include-lsn=true`.
 
@@ -2706,30 +2706,30 @@ ifdef::community[]
 If you are using the `wal2json` plug-in, this property is useful for enabling server-side table filtering. Allowed values depend on the configured plug-in.
 endif::community[]
 
-|[[postgresql-property-sanitize-field-names]]<<postgresql-property-sanitize-field-names, `sanitize.field{zwsp}.names`>>
+|[[postgresql-property-sanitize-field-names]]<<postgresql-property-sanitize-field-names, `+sanitize.field.names+`>>
 |`true` if connector configuration sets the `key.converter` or `value.converter` property to the Avro converter.
 
 `false` if not.
 |Indicates whether field names are sanitized to adhere to {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming requirements].
 
-|[[postgresql-property-slot-max-retries]]<<postgresql-property-slot-max-retries, `slot.max.retries`>>
+|[[postgresql-property-slot-max-retries]]<<postgresql-property-slot-max-retries, `+slot.max.retries+`>>
 |`6`
 |If connecting to a replication slot fails, this is the maximum number of consecutive attempts to connect.
 
-|[[postgresql-property-slot-retry-delay-ms]]<<postgresql-property-slot-retry-delay-ms, `slot.retry.delay.ms`>> +
+|[[postgresql-property-slot-retry-delay-ms]]<<postgresql-property-slot-retry-delay-ms, `+slot.retry.delay.ms+`>> +
 |`10000` (10 seconds)
 |The number of milliseconds to wait between retry attempts when the connector fails to connect to a replication slot.
 
-|[[postgresql-property-toasted-value-placeholder]]<<postgresql-property-toasted-value-placeholder, `toasted.value{zwsp}.placeholder`>>
+|[[postgresql-property-toasted-value-placeholder]]<<postgresql-property-toasted-value-placeholder, `+toasted.value.placeholder+`>>
 |`__debezium_unavailable_value`
 |Specifies the constant that the connector provides to indicate that the original value is a toasted value that is not provided by the database.
 If the setting of `toasted.value.placeholder` starts with the `hex:` prefix it is expected that the rest of the string represents hexadecimally encoded octets. See {link-prefix}:{link-postgresql-connector}#postgresql-toasted-values[toasted values] for additional details.
 
-|[[postgresql-property-provide-transaction-metadata]]<<postgresql-property-provide-transaction-metadata, `provide.transaction{zwsp}.metadata`>>
+|[[postgresql-property-provide-transaction-metadata]]<<postgresql-property-provide-transaction-metadata, `+provide.transaction.metadata+`>>
 |`false`
 |Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See {link-prefix}:{link-postgresql-connector}#postgresql-transaction-metadata[Transaction metadata] for details.
 
-|[[postgresql-property-retriable-restart-connector-wait-ms]]<<postgresql-property-retriable-restart-connector-wait-ms, `retriable.restart{zwsp}.connector.wait.ms`>> +
+|[[postgresql-property-retriable-restart-connector-wait-ms]]<<postgresql-property-retriable-restart-connector-wait-ms, `+retriable.restart.connector.wait.ms+`>> +
 |10000 (10 seconds)
 |The number of milliseconds to wait before restarting a connector after a retriable error occurs.
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -499,7 +499,7 @@ Every change event that captures a change to the `customers` table has the same 
 |Indicates whether the event key must contain a value in its `payload` field. In this example, a value in the key's payload is required. A value in the key's payload field is optional when a table does not have a primary key.
 
 |4
-|`server1.dbo{zwsp}.customers{zwsp}.Key`
+|`server1.dbo.customers.Key`
 a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._database-schema-name_._table-name_.`Key`. In this example: +
 
 * `server1` is the name of the connector that generated this event. +
@@ -1821,71 +1821,71 @@ The following configuration properties are _required_ unless a default value is 
 |Default
 |Description
 
-|[[sqlserver-property-name]]<<sqlserver-property-name, `name`>>
+|[[sqlserver-property-name]]<<sqlserver-property-name, `+name+`>>
 |
 |Unique name for the connector. Attempting to register again with the same name will fail. (This property is required by all Kafka Connect connectors.)
 
-|[[sqlserver-property-connector-class]]<<sqlserver-property-connector-class, `connector.class`>>
+|[[sqlserver-property-connector-class]]<<sqlserver-property-connector-class, `+connector.class+`>>
 |
 |The name of the Java class for the connector. Always use a value of `io.debezium.connector.sqlserver.SqlServerConnector` for the SQL Server connector.
 
-|[[sqlserver-property-tasks-max]]<<sqlserver-property-tasks-max, `tasks.max`>>
+|[[sqlserver-property-tasks-max]]<<sqlserver-property-tasks-max, `+tasks.max+`>>
 |`1`
 |The maximum number of tasks that should be created for this connector. The SQL Server connector always uses a single task and therefore does not use this value, so the default is always acceptable.
 
-|[[sqlserver-property-database-hostname]]<<sqlserver-property-database-hostname, `database.hostname`>>
+|[[sqlserver-property-database-hostname]]<<sqlserver-property-database-hostname, `+database.hostname+`>>
 |
 |IP address or hostname of the SQL Server database server.
 
-|[[sqlserver-property-database-port]]<<sqlserver-property-database-port, `database.port`>>
+|[[sqlserver-property-database-port]]<<sqlserver-property-database-port, `+database.port+`>>
 |`1433`
 |Integer port number of the SQL Server database server.
 
-|[[sqlserver-property-database-user]]<<sqlserver-property-database-user, `database.user`>>
+|[[sqlserver-property-database-user]]<<sqlserver-property-database-user, `+database.user+`>>
 |
 |Username to use when connecting to the SQL Server database server.
 
-|[[sqlserver-property-database-password]]<<sqlserver-property-database-password, `database.password`>>
+|[[sqlserver-property-database-password]]<<sqlserver-property-database-password, `+database.password+`>>
 |
 |Password to use when connecting to the SQL Server database server.
 
-|[[sqlserver-property-database-dbname]]<<sqlserver-property-database-dbname, `database.dbname`>>
+|[[sqlserver-property-database-dbname]]<<sqlserver-property-database-dbname, `+database.dbname+`>>
 |
 |The name of the SQL Server database from which to stream the changes
 
-|[[sqlserver-property-database-server-name]]<<sqlserver-property-database-server-name, `database.server{zwsp}.name`>>
+|[[sqlserver-property-database-server-name]]<<sqlserver-property-database-server-name, `+database.server.name+`>>
 |
 |Logical name that identifies and provides a namespace for the SQL Server database server that you want {prodname} to capture. The logical name should be unique across all other connectors, since it is used as a prefix for all Kafka topic names emanating from this connector.
 Only alphanumeric characters and underscores should be used.
 
-|[[sqlserver-property-database-history-kafka-topic]]<<sqlserver-property-database-history-kafka-topic, `database.history{zwsp}.kafka.topic`>>
+|[[sqlserver-property-database-history-kafka-topic]]<<sqlserver-property-database-history-kafka-topic, `+database.history.kafka.topic+`>>
 |
 |The full name of the Kafka topic where the connector will store the database schema history.
 
-|[[sqlserver-property-database-history-kafka-bootstrap-servers]]<<sqlserver-property-database-history-kafka-bootstrap-servers, `database.history{zwsp}.kafka.bootstrap{zwsp}.servers`>>
+|[[sqlserver-property-database-history-kafka-bootstrap-servers]]<<sqlserver-property-database-history-kafka-bootstrap-servers, `+database.history.kafka.bootstrap.servers+`>>
 |
 |A list of host and port pairs that the connector will use for establishing an initial connection to the Kafka cluster.
 This connection is used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. This should point to the same Kafka cluster used by the Kafka Connect process.
 
-|[[sqlserver-property-table-include-list]]<<sqlserver-property-table-include-list, `table.include.list`>>
+|[[sqlserver-property-table-include-list]]<<sqlserver-property-table-include-list, `+table.include.list+`>>
 |
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for tables that you want {prodname} to capture; any table that is not included in `table.include.list` is excluded from capture. Each identifier is of the form _schemaName_._tableName_.
 By default, the connector captures all non-system tables for the designated schemas.
 Must not be used with `table.exclude.list`.
 
-|[[sqlserver-property-table-exclude-list]]<<sqlserver-property-table-exclude-list, `table.exclude.list`>>
+|[[sqlserver-property-table-exclude-list]]<<sqlserver-property-table-exclude-list, `+table.exclude.list+`>>
 |
 |An optional comma-separated list of regular expressions that match fully-qualified table identifiers for the tables that you want to exclude from being captured; {prodname} captures all tables that are not included in `table.exclude.list`.
 Each identifier is of the form _schemaName_._tableName_. Must not be used with `table.include.list`.
 
-|[[sqlserver-property-column-include-list]]<<sqlserver-property-column-include-list, `column.include.list`>>
+|[[sqlserver-property-column-include-list]]<<sqlserver-property-column-include-list, `+column.include.list+`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in the change event message values.
 Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 Note that primary key columns are always included in the event's key, even if not included in the value.
 Do not also set the `column.exclude.list` property.
 
-|[[sqlserver-property-column-exclude-list]]<<sqlserver-property-column-exclude-list, `column.exclude.list`>>
+|[[sqlserver-property-column-exclude-list]]<<sqlserver-property-column-exclude-list, `+column.exclude.list+`>>
 |_empty string_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event message values.
 Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
@@ -1893,7 +1893,7 @@ Note that primary key columns are always included in the event's key, also if ex
 Do not also set the `column.include.list` property.
 
 
-|[[sqlserver-property-column-mask-hash]]<<sqlserver-property-column-mask-hash, `column.mask{zwsp}.hash._hashAlgorithm_{zwsp}.with.salt._salt_`>>
+|[[sqlserver-property-column-mask-hash]]<<sqlserver-property-column-mask-hash, `+column.mask.hash._hashAlgorithm_.with.salt._salt_+`>>
 |_n/a_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be pseudonyms in the change event message values with a field value consisting of the hashed value using the algorithm `_hashAlgorithm_` and salt `_salt_`.
 Based on the used hash function referential integrity is kept while data is pseudonymized. Supported hash functions are described in the {link-java7-standard-names}[MessageDigest section] of the Java Cryptography Architecture Standard Algorithm Name Documentation.
@@ -1909,36 +1909,36 @@ where `CzQMA0cB5K` is a randomly selected salt.
 
 Note: Depending on the `_hashAlgorithm_` used, the `_salt_` selected and the actual data set, the resulting masked data set may not be completely anonymized.
 
-|[[sqlserver-property-time-precision-mode]]<<sqlserver-property-time-precision-mode, `time.precision{zwsp}.mode`>>
+|[[sqlserver-property-time-precision-mode]]<<sqlserver-property-time-precision-mode, `+time.precision.mode+`>>
 |`adaptive`
 | Time, date, and timestamps can be represented with different kinds of precision, including: `adaptive` (the default) captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type; or `connect` always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which uses millisecond precision regardless of the database columns' precision. See {link-prefix}:{link-sqlserver-connector}#sqlserver-temporal-values[temporal values].
 
-|[[sqlserver-property-include-schema-changes]]<<sqlserver-property-include-schema-changes, `include.schema{zwsp}.changes`>>
+|[[sqlserver-property-include-schema-changes]]<<sqlserver-property-include-schema-changes, `+include.schema.changes+`>>
 |`true`
 |Boolean value that specifies whether the connector should publish changes in the database schema to a Kafka topic with the same name as the database server ID. Each schema change is recorded with a key that contains the database name and a value that is a JSON structure that describes the schema update. This is independent of how the connector internally records database history. The default is `true`.
 
-|[[sqlserver-property-tombstones-on-delete]]<<sqlserver-property-tombstones-on-delete, `tombstones.on{zwsp}.delete`>>
+|[[sqlserver-property-tombstones-on-delete]]<<sqlserver-property-tombstones-on-delete, `+tombstones.on.delete+`>>
 |`true`
 | Controls whether a tombstone event should be generated after a delete event. +
 When `true` the delete operations are represented by a delete event and a subsequent tombstone event. When `false` only a delete event is sent. +
 Emitting the tombstone event (the default behavior) allows Kafka to completely delete all events pertaining to the given key once the source record got deleted.
 
-|[[sqlserver-property-column-truncate-to-length-chars]]<<sqlserver-property-column-truncate-to-length-chars, `column.truncate.to{zwsp}._length_.chars`>>
+|[[sqlserver-property-column-truncate-to-length-chars]]<<sqlserver-property-column-truncate-to-length-chars, `+column.truncate.to._length_.chars+`>>
 |_n/a_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be truncated in the change event message values if the field values are longer than the specified number of characters. Multiple properties with different lengths can be used in a single configuration, although in each the length must be a positive integer. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 
-|[[sqlserver-property-column-mask-with-length-chars]]<<sqlserver-property-column-mask-with-length-chars, `column.mask.with{zwsp}._length_.chars`>>
+|[[sqlserver-property-column-mask-with-length-chars]]<<sqlserver-property-column-mask-with-length-chars, `+column.mask.with._length_.chars+`>>
 |_n/a_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of character-based columns whose values should be replaced in the change event message values with a field value consisting of the specified number of asterisk (`*`) characters. Multiple properties with different lengths can be used in a single configuration, although in each the length must be a positive integer or zero. Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 
-|[[sqlserver-property-column-propagate-source-type]]<<sqlserver-property-column-propagate-source-type, `column.propagate{zwsp}.source.type`>>
+|[[sqlserver-property-column-propagate-source-type]]<<sqlserver-property-column-propagate-source-type, `+column.propagate.source.type+`>>
 |_n/a_
 |An optional comma-separated list of regular expressions that match the fully-qualified names of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
 The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` is used to propagate the original type name and length (for variable-width types), respectively.
 Useful to properly size corresponding columns in sink databases.
 Fully-qualified names for columns are of the form _schemaName_._tableName_._columnName_.
 
-|[[sqlserver-property-datatype-propagate-source-type]]<<sqlserver-property-datatype-propagate-source-type,`datatype.propagate{zwsp}.source.type`>>
+|[[sqlserver-property-datatype-propagate-source-type]]<<sqlserver-property-datatype-propagate-source-type,`datatype.propagate.source.type+`>>
 |_n/a_
 |An optional comma-separated list of regular expressions that match the database-specific data type name of columns whose original type and length should be added as a parameter to the corresponding field schemas in the emitted change messages.
 The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
@@ -1946,13 +1946,13 @@ Useful to properly size corresponding columns in sink databases.
 Fully-qualified data type names are of the form _schemaName_._tableName_._typeName_.
 See {link-prefix}:{link-sqlserver-connector}#sqlserver-data-types[SQL Server data types] for the list of SQL Server-specific data type names.
 
-|[[sqlserver-property-message-key-columns]]<<sqlserver-property-message-key-columns, `message.key.columns`>>
+|[[sqlserver-property-message-key-columns]]<<sqlserver-property-message-key-columns, `+message.key.columns+`>>
 |_n/a_
 | A semi-colon list of regular expressions that match fully-qualified tables and columns to map a primary key. +
 Each item (regular expression) must match the fully-qualified `<fully-qualified table>:<a comma-separated list of columns>` representing the custom key. +
 Fully-qualified tables could be defined as _schemaName_._tableName_.
 
-|[[sqlserver-property-binary-handling-mode]]<<sqlserver-property-binary-handling-mode, `binary.handling.mode`>>
+|[[sqlserver-property-binary-handling-mode]]<<sqlserver-property-binary-handling-mode, `+binary.handling.mode+`>>
 |bytes
 |Specifies how binary (`binary`, `varbinary`) columns should be represented in change events, including: `bytes` represents binary data as byte array (default), `base64` represents binary data as base64-encoded String, `hex` represents binary data as hex-encoded (base16) String
 |===
@@ -1965,7 +1965,7 @@ The following _advanced_ configuration properties have good defaults that will w
 |Default
 |Description
 
-|[[sqlserver-property-snapshot-mode]]<<sqlserver-property-snapshot-mode, `snapshot.mode`>>
+|[[sqlserver-property-snapshot-mode]]<<sqlserver-property-snapshot-mode, `+snapshot.mode+`>>
 |_initial_
 |A mode for taking an initial snapshot of the structure and optionally data of captured tables.
 Once the snapshot is complete, the connector will continue reading change events from the database's redo logs.
@@ -1975,11 +1975,11 @@ The following values are supported:
 * `initial_only`: Takes a snapshot of structure and data like `initial` but instead does not transition into streaming changes once the snapshot has completed. +
 * `schema_only`: Takes a snapshot of the structure of captured tables only; useful if only changes happening from now onwards should be propagated to topics.
 
-|[[sqlserver-property-snapshot-include-collection-list]]<<sqlserver-property-snapshot-include-collection-list, `snapshot.include.collection.list`>>
+|[[sqlserver-property-snapshot-include-collection-list]]<<sqlserver-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>
 | All tables specified in `table.include.list`
 |An optional, comma-separated list of regular expressions that match names of schemas specified in `table.include.list` for which you *want* to take the snapshot.
 
-|[[sqlserver-property-snapshot-isolation-mode]]<<sqlserver-property-snapshot-isolation-mode, `snapshot.isolation{zwsp}.mode`>>
+|[[sqlserver-property-snapshot-isolation-mode]]<<sqlserver-property-snapshot-isolation-mode, `+snapshot.isolation.mode+`>>
 |_repeatable_read_
 |Mode to control which transaction isolation level is used and how long the connector locks tables that are designated for capture.
 The following values are supported:
@@ -2002,7 +2002,7 @@ twice - once in initial snapshot and once in streaming phase. Nonetheless, that 
 data mirroring.
 For `read_uncommitted` there are no data consistency guarantees at all (some data might be lost or corrupted).
 
-|[[sqlserver-property-source-timestamp-mode]]<<sqlserver-property-source-timestamp-mode, `source.timestamp{zwsp}.mode`>>
+|[[sqlserver-property-source-timestamp-mode]]<<sqlserver-property-source-timestamp-mode, `+source.timestamp.mode+`>>
 |_commit_
 a|String that represents the criteria of the attached timestamp within the source record (ts_ms).
 
@@ -2010,26 +2010,26 @@ a|String that represents the criteria of the attached timestamp within the sourc
 * `processing` sets the source timestamp to the time when {prodname} accesses the record in the change table.
 Use the `processing` option if you want {prodname] to set the top level `ts_ms` value, or if you want to avoid the additional cost of {prodname} querying the database to extract the LSN timestamps.
 
-|[[sqlserver-property-event-processing-failure-handling-mode]]<<sqlserver-property-event-processing-failure-handling-mode, `event.processing{zwsp}.failure.handling{zwsp}.mode`>>
+|[[sqlserver-property-event-processing-failure-handling-mode]]<<sqlserver-property-event-processing-failure-handling-mode, `+event.processing.failure.handling.mode+`>>
 |`fail`
 | Specifies how the connector should react to exceptions during processing of events.
 `fail` will propagate the exception (indicating the offset of the problematic event), causing the connector to stop. +
 `warn` will cause the problematic event to be skipped and the offset of the problematic event to be logged. +
 `skip` will cause the problematic event to be skipped.
 
-|[[sqlserver-property-poll-interval-ms]]<<sqlserver-property-poll-interval-ms, `poll.interval.ms`>>
+|[[sqlserver-property-poll-interval-ms]]<<sqlserver-property-poll-interval-ms, `+poll.interval.ms+`>>
 |`1000`
 |Positive integer value that specifies the number of milliseconds the connector should wait during each iteration for new change events to appear. Defaults to 1000 milliseconds, or 1 second.
 
-|[[sqlserver-property-max-queue-size]]<<sqlserver-property-max-queue-size, `max.queue.size`>>
+|[[sqlserver-property-max-queue-size]]<<sqlserver-property-max-queue-size, `+max.queue.size+`>>
 |`8192`
 |Positive integer value that specifies the maximum size of the blocking queue into which change events read from the database log are placed before they are written to Kafka. This queue can provide backpressure to the CDC table reader when, for example, writes to Kafka are slower or if Kafka is not available. Events that appear in the queue are not included in the offsets periodically recorded by this connector. Defaults to 8192, and should always be larger than the maximum batch size specified in the `max.batch.size` property.
 
-|[[sqlserver-property-max-batch-size]]<<sqlserver-property-max-batch-size, `max.batch.size`>>
+|[[sqlserver-property-max-batch-size]]<<sqlserver-property-max-batch-size, `+max.batch.size+`>>
 |`2048`
 |Positive integer value that specifies the maximum size of each batch of events that should be processed during each iteration of this connector. Defaults to 2048.
 
-|[[sqlserver-property-heartbeat-interval-ms]]<<sqlserver-property-heartbeat-interval-ms, `heartbeat.interval{zwsp}.ms`>>
+|[[sqlserver-property-heartbeat-interval-ms]]<<sqlserver-property-heartbeat-interval-ms, `+heartbeat.interval.ms+`>>
 |`0`
 |Controls how frequently heartbeat messages are sent. +
 This property contains an interval in milliseconds that defines how frequently the connector sends messages to a heartbeat topic.
@@ -2041,39 +2041,39 @@ This may result in more change events to be re-sent after a connector restart.
 Set this parameter to `0` to not send heartbeat messages at all. +
 Disabled by default.
 
-|[[sqlserver-property-heartbeat-topics-prefix]]<<sqlserver-property-heartbeat-topics-prefix, `heartbeat.topics{zwsp}.prefix`>>
+|[[sqlserver-property-heartbeat-topics-prefix]]<<sqlserver-property-heartbeat-topics-prefix, `+heartbeat.topics.prefix+`>>
 |`__debezium-heartbeat`
 |Controls the naming of the topic to which heartbeat messages are sent. +
 The topic is named according to the pattern `<heartbeat.topics.prefix>.<server.name>`.
 
-|[[sqlserver-property-snapshot-delay-ms]]<<sqlserver-property-snapshot-delay-ms, `snapshot.delay.ms`>>
+|[[sqlserver-property-snapshot-delay-ms]]<<sqlserver-property-snapshot-delay-ms, `+snapshot.delay.ms+`>>
 |
 |An interval in milli-seconds that the connector should wait before taking a snapshot after starting up; +
 Can be used to avoid snapshot interruptions when starting multiple connectors in a cluster, which may cause re-balancing of connectors.
 
-|[[sqlserver-property-snapshot-fetch-size]]<<sqlserver-property-snapshot-fetch-size, `snapshot.fetch.size`>>
+|[[sqlserver-property-snapshot-fetch-size]]<<sqlserver-property-snapshot-fetch-size, `+snapshot.fetch.size+`>>
 |`2000`
 |Specifies the maximum number of rows that should be read in one go from each table while taking a snapshot.
 The connector will read the table contents in multiple batches of this size. Defaults to 2000.
 
-|[[sqlserver-property-query-fetch-size]]<<sqlserver-property-query-fetch-size, `query.fetch.size`>>
+|[[sqlserver-property-query-fetch-size]]<<sqlserver-property-query-fetch-size, `+query.fetch.size+`>>
 |
 |Specifies the number of rows that will be fetched for each database round-trip of a given query.
 Defaults to the JDBC driver's default fetch size.
 
-|[[sqlserver-property-snapshot-lock-timeout-ms]]<<sqlserver-property-snapshot-lock-timeout-ms, `snapshot.lock{zwsp}.timeout.ms`>>
+|[[sqlserver-property-snapshot-lock-timeout-ms]]<<sqlserver-property-snapshot-lock-timeout-ms, `+snapshot.lock.timeout.ms+`>>
 |`10000`
 |An integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If table locks cannot be acquired in this time interval, the snapshot will fail (also see {link-prefix}:{link-sqlserver-connector}#sqlserver-snapshots[snapshots]). +
 When set to `0` the connector will fail immediately when it cannot obtain the lock. Value `-1` indicates infinite waiting.
 
-|[[sqlserver-property-snapshot-select-statement-overrides]]<<sqlserver-property-snapshot-select-statement-overrides, `snapshot.select{zwsp}.statement{zwsp}.overrides`>>
+|[[sqlserver-property-snapshot-select-statement-overrides]]<<sqlserver-property-snapshot-select-statement-overrides, `+snapshot.select.statement.overrides+`>>
 |
 |Controls which rows from tables are included in snapshot. +
 This property contains a comma-separated list of fully-qualified tables _(SCHEMA_NAME.TABLE_NAME)_. Select statements for the individual tables are specified in further configuration properties, one for each table, identified by the id `snapshot.select.statement.overrides.[SCHEMA_NAME].[TABLE_NAME]`. The value of those properties is the SELECT statement to use when retrieving data from the specific table during snapshotting. _A possible use case for large append-only tables is setting a specific point where to start (resume) snapshotting, in case a previous snapshotting was interrupted._ +
 *Note*: This setting has impact on snapshots only. Events captured during log reading are not affected by it.
 
 ifdef::community[]
-|[[sqlserver-property-source-struct-version]]<<sqlserver-property-source-struct-version, `source.struct.version`>>
+|[[sqlserver-property-source-struct-version]]<<sqlserver-property-source-struct-version, `+source.struct.version+`>>
 |v2
 |Schema version for the `source` block in CDC events; {prodname} 0.10 introduced a few breaking +
 changes to the structure of the `source` block in order to unify the exposed structure across
@@ -2082,14 +2082,14 @@ By setting this option to `v1` the structure used in earlier versions can be pro
 Note that this setting is not recommended and is planned for removal in a future {prodname} version.
 endif::community[]
 
-|[[sqlserver-property-sanitize-field-names]]<<sqlserver-property-sanitize-field-names, `sanitize.field{zwsp}.names`>>
+|[[sqlserver-property-sanitize-field-names]]<<sqlserver-property-sanitize-field-names, `+sanitize.field.names+`>>
 |`true` when connector configuration explicitly specifies the `key.converter` or `value.converter` parameters to use Avro, otherwise defaults to `false`.
 |Whether field names are sanitized to adhere to Avro naming requirements.
 ifdef::community[]
 See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 endif::community[]
 
-|[[sqlserver-property-database-server-timezone]]<<sqlserver-property-database-server-timezone, `database.server{zwsp}.timezone`>>
+|[[sqlserver-property-database-server-timezone]]<<sqlserver-property-database-server-timezone, `+database.server.timezone+`>>
 |
 | Timezone of the server.
 
@@ -2100,13 +2100,13 @@ Set a value for the property only when running on SQL Server 2014 or older, and 
 When unset, default behavior is to use the timezone of the VM running the {prodname} connector. In this case, when running on on SQL Server 2014 or older and using different timezones on server and the connector, incorrect ts_ms values may be produced. +
 Possible values include "Z", "UTC", offset values like "+02:00", short zone ids like "CET", and long zone ids like "Europe/Paris".
 
-|[[sqlserver-property-provide-transaction-metadata]]<<sqlserver-property-provide-transaction-metadata, `provide.transaction{zwsp}.metadata`>>
+|[[sqlserver-property-provide-transaction-metadata]]<<sqlserver-property-provide-transaction-metadata, `+provide.transaction.metadata+`>>
 |`false`
 |When set to `true` {prodname} generates events with transaction boundaries and enriches data events envelope with transaction metadata.
 
 See {link-prefix}:{link-sqlserver-connector}#sqlserver-transaction-metadata[Transaction Metadata] for additional details.
 
-|[[sqlserver-property-retriable-restart-connector-wait-ms]]<<sqlserver-property-retriable-restart-connector-wait-ms, `retriable.restart{zwsp}.connector.wait.ms`>> +
+|[[sqlserver-property-retriable-restart-connector-wait-ms]]<<sqlserver-property-retriable-restart-connector-wait-ms, `+retriable.restart.connector.wait.ms+`>> +
 |10000 (10 seconds)
 |The number of milli-seconds to wait before restarting a connector after a retriable error occurs.
 

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -213,7 +213,7 @@ If the `database.server.name` connector configuration property has the value `Vi
 |The schema portion of the key specifies a Kafka Connect schema that describes what is in the key's `payload` portion.
 
 |2
-|`Vitess_server{zwsp}.commerce.customers{zwsp}.Key`
+|`Vitess_server.commerce.customers.Key`
 a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._keyspace-name_._table-name_.`Key`. In this example: +
 
 * `Vitess_server` is the name of the connector that generated this event. +
@@ -958,44 +958,44 @@ The *MBean* is `debezium.vitess:type=connector-metrics,context=streaming,server=
 |===
 |Attributes |Type |Description
 
-|[[connectors-strm-metric-millisecondssincelastevent]]<<connectors-strm-metric-millisecondssincelastevent, `MilliSecondsSinceLastEvent`>>
+|[[connectors-strm-metric-millisecondssincelastevent]]<<connectors-strm-metric-millisecondssincelastevent, `+MilliSecondsSinceLastEvent+`>>
 |`long`
 |The number of milliseconds since the connector has read and processed the most recent event.
 
-|[[connectors-strm-metric-totalnumberofeventsseen]]<<connectors-strm-metric-totalnumberofeventsseen, `TotalNumberOfEventsSeen`>>
+|[[connectors-strm-metric-totalnumberofeventsseen]]<<connectors-strm-metric-totalnumberofeventsseen, `+TotalNumberOfEventsSeen+`>>
 |`long`
 |The total number of events that this connector has seen since last started or reset.
 
-|[[connectors-strm-metric-numberofeventsfiltered]]<<connectors-strm-metric-numberofeventsfiltered, `NumberOfEventsFiltered`>>
+|[[connectors-strm-metric-numberofeventsfiltered]]<<connectors-strm-metric-numberofeventsfiltered, `+NumberOfEventsFiltered+`>>
 |`long`
 |The number of events that have been filtered by include/exclude list filtering rules configured on the connector.
 
-|[[connectors-strm-metric-queuetotalcapacity]]<<connectors-strm-metric-queuetotalcapacity, `QueueTotalCapacity`>>
+|[[connectors-strm-metric-queuetotalcapacity]]<<connectors-strm-metric-queuetotalcapacity, `+QueueTotalCapacity+`>>
 |`int`
 |The length the queue used to pass events between the streamer and the main Kafka Connect loop.
 
-|[[connectors-strm-metric-queueremainingcapacity]]<<connectors-strm-metric-queueremainingcapacity, `QueueRemainingCapacity`>>
+|[[connectors-strm-metric-queueremainingcapacity]]<<connectors-strm-metric-queueremainingcapacity, `+QueueRemainingCapacity+`>>
 |`int`
 |The free capacity of the queue used to pass events between the streamer and the main Kafka Connect loop.
 
-|[[connectors-strm-metric-connected]]<<connectors-strm-metric-connected, `Connected`>>
+|[[connectors-strm-metric-connected]]<<connectors-strm-metric-connected, `+Connected+`>>
 |`boolean`
 |Flag that denotes whether the connector is currently connected to the database server.
 
-|[[connectors-strm-metric-millisecondsbehindsource]]<<connectors-strm-metric-millisecondsbehindsource, `MilliSecondsBehindSource`>>
+|[[connectors-strm-metric-millisecondsbehindsource]]<<connectors-strm-metric-millisecondsbehindsource, `+MilliSecondsBehindSource+`>>
 |`long`
 |The number of milliseconds between the last change event's timestamp and the connector processing it.
 The values will incoporate any differences between the clocks on the machines where the database server and the connector are running.
 
-|[[connectors-strm-metric-numberofcommittedtransactions]]<<connectors-strm-metric-numberofcommittedtransactions, `NumberOfCommittedTransactions`>>
+|[[connectors-strm-metric-numberofcommittedtransactions]]<<connectors-strm-metric-numberofcommittedtransactions, `+NumberOfCommittedTransactions+`>>
 |`long`
 |The number of processed transactions that were committed.
 
-|[[connectors-strm-metric-maxqueuesizeinbytes]]<<connectors-strm-metric-maxqueuesizeinbytes, `MaxQueueSizeInBytes`>>
+|[[connectors-strm-metric-maxqueuesizeinbytes]]<<connectors-strm-metric-maxqueuesizeinbytes, `+MaxQueueSizeInBytes+`>>
 |`long`
 |The maximum buffer of the queue in bytes used to pass events between the streamer and the main Kafka Connect loop.
 
-|[[connectors-strm-metric-currentqueuesizeinbytes]]<<connectors-strm-metric-currentqueuesizeinbytes, `CurrentQueueSizeInBytes`>>
+|[[connectors-strm-metric-currentqueuesizeinbytes]]<<connectors-strm-metric-currentqueuesizeinbytes, `+CurrentQueueSizeInBytes+`>>
 |`long`
 |The current buffer of the queue in bytes used to pass events between the streamer and the main Kafka Connect loop.
 
@@ -1024,59 +1024,59 @@ The following configuration properties are _required_ unless a default value is 
 |Default
 |Description
 
-|[[vitess-property-name]]<<vitess-property-name, `name`>>
+|[[vitess-property-name]]<<vitess-property-name, `+name+`>>
 |
 |Unique name for the connector. Attempting to register again with the same name will fail. This property is required by all Kafka Connect connectors.
 
-|[[vitess-property-connector-class]]<<vitess-property-connector-class, `connector.class`>>
+|[[vitess-property-connector-class]]<<vitess-property-connector-class, `+connector.class+`>>
 |
 |The name of the Java class for the connector. Always use a value of `io.debezium.connector.vitess.VitessConnector` for the Vitess connector.
 
-|[[vitess-property-tasks-max]]<<vitess-property-tasks-max, `tasks.max`>>
+|[[vitess-property-tasks-max]]<<vitess-property-tasks-max, `+tasks.max+`>>
 |`1`
 |The maximum number of tasks that should be created for this connector. The Vitess connector always uses a single task and therefore does not use this value, so the default is always acceptable.
 
-|[[vitess-property-database-hostname]]<<vitess-property-database-hostname, `database.hostname`>>
+|[[vitess-property-database-hostname]]<<vitess-property-database-hostname, `+database.hostname+`>>
 |
 |IP address or hostname of the Vitess database server (VTGate).
 
-|[[vitess-property-database-port]]<<vitess-property-database-port, `database.port`>>
+|[[vitess-property-database-port]]<<vitess-property-database-port, `+database.port+`>>
 |`15991`
 |Integer port number of the Vitess database server (VTGate).
 
-|[[vitess-property-keyspace]]<<vitess-property-keyspace, `vitess.keyspace`>>
+|[[vitess-property-keyspace]]<<vitess-property-keyspace, `+vitess.keyspace+`>>
 |
 |The name of the keyspace from which to stream the changes.
 
-|[[vitess-property-shard]]<<vitess-property-shard, `vitess.shard`>>
+|[[vitess-property-shard]]<<vitess-property-shard, `+vitess.shard+`>>
 |_n/a_
 |An optional name of the shard from which to stream the changes. If not configured, in case of unsharded keyspace, the connector streams changes from the only shard, in case of sharded keyspace, the connector streams changes from all shards in the keyspace. We recommend not configuring it in order to stream from all shards in the keyspace because it has better support for reshard operation. If configured, for example, `-80`, the connector will stream changes from the `-80` shard.
 
-|[[vitess-property-database-user]]<<vitess-property-database-user, `vitess.database.user`>>
+|[[vitess-property-database-user]]<<vitess-property-database-user, `+vitess.database.user+`>>
 |_n/a_
 |An optional username of the Vitess database server (VTGate). If not configured, unauthenticated VTGate gRPC is used.
 
-|[[vitess-property-database-password]]<<vitess-property-database-password, `vitess.database.password`>>
+|[[vitess-property-database-password]]<<vitess-property-database-password, `+vitess.database.password+`>>
 |_n/a_
 |An optional password of the Vitess database server (VTGate). If not configured, unauthenticated VTGate gRPC is used.
 
-|[[vitess-property-vtctld-host]]<<vitess-property-vtctld-host, `vitess.vtctld.host`>>
+|[[vitess-property-vtctld-host]]<<vitess-property-vtctld-host, `+vitess.vtctld.host+`>>
 |
 |IP address or hostname of the VTCtld server.
 
-|[[vitess-property-vtctld-port]]<<vitess-property-vtctld-port, `vitess.vtctld.port`>>
+|[[vitess-property-vtctld-port]]<<vitess-property-vtctld-port, `+vitess.vtctld.port+`>>
 |`15999`
 |Integer port number of the VTCtld server.
 
-|[[vitess-property-vtctld-user]]<<vitess-property-vtctld-user, `vitess.vtctld.user`>>
+|[[vitess-property-vtctld-user]]<<vitess-property-vtctld-user, `+vitess.vtctld.user+`>>
 |_n/a_
 |An optional username of the VTCtld server. If not configured, unauthenticated VTCtld gRPC is used.
 
-|[[vitess-property-vtctld-password]]<<vitess-property-vtctld-password, `vitess.vtctld.password`>>
+|[[vitess-property-vtctld-password]]<<vitess-property-vtctld-password, `+vitess.vtctld.password+`>>
 |_n/a_
 |An optional password of the VTCtld server. If not configured, unauthenticated VTCtld gRPC is used.
 
-|[[vitess-property-tablet-type]]<<vitess-property-tablet-type, `vitess.tablet.type`>>
+|[[vitess-property-tablet-type]]<<vitess-property-tablet-type, `+vitess.tablet.type+`>>
 |`MASTER`
 |The type of Tablet (hence MySQL) from which to stream the changes: +
  +
@@ -1086,27 +1086,27 @@ The following configuration properties are _required_ unless a default value is 
  +
 `RDONLY`  represents streaming from the read-only slave MySQL instance.
 
-|[[vitess-property-database-server-name]]<<vitess-property-database-server-name, `database.server{zwsp}.name`>>
+|[[vitess-property-database-server-name]]<<vitess-property-database-server-name, `+database.server.name+`>>
 |
 |Logical name that identifies and provides a namespace for the particular Vitess database server or cluster in which {prodname} is capturing changes. Only alphanumeric characters and underscores should be used in the database server logical name. The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
 
-|[[vitess-property-table-include-list]]<<vitess-property-table-include-list, `table.include{zwsp}.list`>>
+|[[vitess-property-table-include-list]]<<vitess-property-table-include-list, `+table.include.list+`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you want to capture. Any table not included in `table.include.list` does not have its changes captured. Each identifier is of the form _keyspace_._tableName_. By default, the connector captures changes in every non-system table in each schema whose changes are being captured. Do not also set the `table.exclude.list` property.
 
-|[[vitess-property-table-exclude.list]]<<vitess-property-table-exclude.list, `table.exclude{zwsp}.list`>>
+|[[vitess-property-table-exclude.list]]<<vitess-property-table-exclude.list, `+table.exclude.list+`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you *do not* want to capture. Any table not included in `table.exclude.list` has it changes captured. Each identifier is of the form _keyspace_._tableName_. Do not also set the `table.include.list` property.
 
-|[[vitess-property-column-include-list]]<<vitess-property-column-include-list, `column.include{zwsp}.list`>>
+|[[vitess-property-column-include-list]]<<vitess-property-column-include-list, `+column.include.list+`>>
 |
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in change event record values. Fully-qualified names for columns are of the form _keyspace_._tableName_._columnName_. Do not also set the `column.exclude.list` property.
 
-|[[vitess-property-column-exclude-list]]<<vitess-property-column-exclude-list, `column.exclude{zwsp}.list`>>
+|[[vitess-property-column-exclude-list]]<<vitess-property-column-exclude-list, `+column.exclude.list+`>>
 |
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event record values. Fully-qualified names for columns are of the form _keyspace_._tableName_._columnName_. Do not also set the `column.include.list` property.
 
-|[[vitess-property-tombstones-on-delete]]<<vitess-property-tombstones-on-delete, `tombstones.on{zwsp}.delete`>>
+|[[vitess-property-tombstones-on-delete]]<<vitess-property-tombstones-on-delete, `+tombstones.on.delete+`>>
 |`true`
 | Controls whether a tombstone event should be generated after a _delete_ event. +
  +
@@ -1116,7 +1116,7 @@ The following configuration properties are _required_ unless a default value is 
  +
 After a _delete_ operation, emitting a tombstone event enables Kafka to delete all change event records that have the same key as the deleted row.
 
-|[[vitess-property-message-key-columns]]<<vitess-property-message-key-columns, `message.key{zwsp}.columns`>>
+|[[vitess-property-message-key-columns]]<<vitess-property-message-key-columns, `+message.key.columns+`>>
 |_empty string_
 |A semicolon separated list of tables with regular expressions that match table column names. The connector maps values in matching columns to key fields in change event records that it sends to Kafka topics. This is useful when a table does not have a primary key, or when you want to order change event records in a Kafka topic according to a field that is not a primary key. +
  +
@@ -1141,7 +1141,7 @@ The following _advanced_ configuration properties have defaults that work in mos
 |Default
 |Description
 
-|[[vitess-property-event-processing-failure-handling-mode]]<<vitess-property-event-processing-failure-handling-mode, `event.processing{zwsp}.failure.handling{zwsp}.mode`>>
+|[[vitess-property-event-processing-failure-handling-mode]]<<vitess-property-event-processing-failure-handling-mode, `+event.processing.failure.handling.mode+`>>
 |`fail`
 | Specifies how the connector should react to exceptions during processing of events: +
  +
@@ -1151,23 +1151,23 @@ The following _advanced_ configuration properties have defaults that work in mos
  +
 `skip` skips the problematic event and continues processing.
 
-|[[vitess-property-max-queue-size]]<<vitess-property-max-queue-size, `max.queue.size`>>
+|[[vitess-property-max-queue-size]]<<vitess-property-max-queue-size, `+max.queue.size+`>>
 |`20240`
 |Positive integer value for the maximum size of the blocking queue. The connector places change events received from streaming replication in the blocking queue before writing them to Kafka. This queue can provide backpressure when, for example, writing records to Kafka is slower that it should be or Kafka is not available.
 
-|[[vitess-property-max-batch-size]]<<vitess-property-max-batch-size, `max.batch.size`>>
+|[[vitess-property-max-batch-size]]<<vitess-property-max-batch-size, `+max.batch.size+`>>
 |`10240`
 |Positive integer value that specifies the maximum size of each batch of events that the connector processes.
 
-|[[vitess-property-max-queue-size-in-bytes]]<<vitess-property-max-queue-size-in-bytes, `max.queue.size.in.bytes`>>
+|[[vitess-property-max-queue-size-in-bytes]]<<vitess-property-max-queue-size-in-bytes, `+max.queue.size.in.bytes+`>>
 |`0`
 |Long value for the maximum size in bytes of the blocking queue. The feature is disabled by default, it will be active if it's set with a positive long value.
 
-|[[vitess-property-poll-interval-ms]]<<vitess-property-poll-interval-ms, `poll.interval.ms`>>
+|[[vitess-property-poll-interval-ms]]<<vitess-property-poll-interval-ms, `+poll.interval.ms+`>>
 |`1000`
 |Positive integer value that specifies the number of milliseconds the connector should wait for new change events to appear before it starts processing a batch of events. Defaults to 1000 milliseconds, or 1 second.
 
-|[[vitess-property-sanitize-field-names]]<<vitess-property-sanitize-field-names, `sanitize.field.names`>>
+|[[vitess-property-sanitize-field-names]]<<vitess-property-sanitize-field-names, `+sanitize.field.names+`>>
 |`true` if connector configuration sets the `key.converter` or `value.converter` property to the Avro converter. +
 `false` if not.
 |Indicates whether field names are sanitized to adhere to {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming requirements].


### PR DESCRIPTION
Jira [DBZ-3087](https://issues.redhat.com/browse/DBZ-3087)

This change removes instances of {zwsp} from properties tables in the documentation for Debezium connectors and recodes strings that included the zero-width spaces as passthrough literal monospace by enclosing them in \`+ +\`.

I tested the change locally and found that all of the strings render correctly and the encoded self-referential links work as expected. However, there's a reversion to the past behavior of Firefox inserting hyphens when long property name strings break after the page width decreases below a certain threshold. For example:
![image](https://user-images.githubusercontent.com/23705736/108112745-86783f00-7064-11eb-973f-717c11e220d7.png)

In a local test of the downstream build, no hyphenation occurs. 
![image](https://user-images.githubusercontent.com/23705736/108122189-e45f5380-7071-11eb-9ece-7c5e3386ad26.png)

The hyphenation behavior is not evident in Chrome upstream or downstream.

I tested copy and paste from the FF tables to the command line to to vi and the hyphens do not seem to carry over. So although the display below a certain browser size is not ideal, I think that the change resolves the most crucial problem of customers being unable to paste names directly into their configurations. 