### PR TITLE
Log database connection validation failures at ERROR level with exception

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnector.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnector.java
@@ -100,7 +100,7 @@ public class MySqlConnector extends RelationalBaseSourceConnector {
                 LOGGER.info("Successfully tested connection for {} with user '{}'", connection.connectionString(), connectionConfig.username());
             }
             catch (SQLException e) {
-                LOGGER.info("Failed testing connection for {} with user '{}'", connection.connectionString(), connectionConfig.username());
+                LOGGER.error("Failed testing connection for {} with user '{}'", connection.connectionString(), connectionConfig.username(), e);
                 hostnameValue.addErrorMessage("Unable to connect: " + e.getMessage());
             }
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
@@ -128,8 +128,8 @@ public class PostgresConnector extends RelationalBaseSourceConnector {
                 }
             }
             catch (SQLException e) {
-                LOGGER.error("Failed testing connection for {} with user '{}': {}", connection.connectionString(),
-                        connection.username(), e.getMessage());
+                LOGGER.error("Failed testing connection for {} with user '{}'", connection.connectionString(),
+                        connection.username(), e);
                 hostnameValue.addErrorMessage("Error while validating connector config: " + e.getMessage());
             }
         }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
@@ -84,8 +84,8 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
                     connection.username());
         }
         catch (Exception e) {
-            LOGGER.debug("Failed testing connection for {} with user '{}'", config.withMaskedPasswords(),
-                    userValue);
+            LOGGER.error("Failed testing connection for {} with user '{}'", config.withMaskedPasswords(),
+                    userValue, e);
             hostnameValue.addErrorMessage("Unable to connect. Check this and other connection properties. Error: "
                     + e.getMessage());
         }


### PR DESCRIPTION
In case of database connection validation failures, the logged message is at the  `INFO` level, without the stack trace or root cause in place.

```
2021-02-19 10:04:31,757 INFO  || Failed testing connection for
jdbc:mysql://xxxxx:3306/?useInformationSchema=true&nullCatalogMeansCurrent=false&useSSL=false&useUnicode=true&characterEncoding=UTF-8&characterSetResults=UTF-8&zeroDateTimeBehavior=convertToNull
with user 'migration-user'  [io.debezium.connector.mysql.MySqlConnector]
```

This message is not useful in understanding or rectifying the issue.
Therefore, suggesting to log at the `ERROR` level along with the thrown
exception.