### PR TITLE
DBZ-3157 Add event_serial_no to CloudEvent Id

### DIFF
--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
@@ -34,6 +34,7 @@ import io.debezium.connector.sqlserver.SqlServerConnectorConfig.SnapshotIsolatio
 import io.debezium.connector.sqlserver.SqlServerConnectorConfig.SnapshotMode;
 import io.debezium.connector.sqlserver.util.TestHelper;
 import io.debezium.converters.CloudEventsConverterTest;
+import io.debezium.converters.CloudEventsMaker;
 import io.debezium.data.SchemaAndValueField;
 import io.debezium.data.SourceRecordAssert;
 import io.debezium.doc.FixFor;
@@ -588,7 +589,7 @@ public class SnapshotIT extends AbstractConnectorTest {
     }
 
     @Test
-    @FixFor("DBZ-1292")
+    @FixFor({ "DBZ-1292", "DBZ-3157" })
     public void shouldOutputRecordsInCloudEventsFormat() throws Exception {
         final Configuration config = TestHelper.defaultConfig().build();
 
@@ -620,7 +621,8 @@ public class SnapshotIT extends AbstractConnectorTest {
 
         // test streaming
         for (SourceRecord sourceRecord : streamingTable1) {
-            CloudEventsConverterTest.shouldConvertToCloudEventsInJson(sourceRecord, false);
+            CloudEventsConverterTest.shouldConvertToCloudEventsInJson(sourceRecord, false,
+                    jsonNode -> { assertThat(jsonNode.get(CloudEventsMaker.FieldName.ID).asText()).contains("event_serial_no:1"); });
             CloudEventsConverterTest.shouldConvertToCloudEventsInJsonWithDataAsAvro(sourceRecord, false);
             CloudEventsConverterTest.shouldConvertToCloudEventsInAvro(sourceRecord, "sqlserver", "server1", false);
         }

--- a/debezium-core/src/main/java/io/debezium/converters/CloudEventsMaker.java
+++ b/debezium-core/src/main/java/io/debezium/converters/CloudEventsMaker.java
@@ -271,7 +271,8 @@ public abstract class CloudEventsMaker {
         public String ceId() {
             return "name:" + recordParser.getMetadata(AbstractSourceInfo.SERVER_NAME_KEY)
                     + ";change_lsn:" + recordParser.getMetadata(RecordParser.SqlserverRecordParser.CHANGE_LSN_KEY)
-                    + ";commit_lsn:" + recordParser.getMetadata(RecordParser.SqlserverRecordParser.COMMIT_LSN_KEY);
+                    + ";commit_lsn:" + recordParser.getMetadata(RecordParser.SqlserverRecordParser.COMMIT_LSN_KEY)
+                    + ";event_serial_no:" + recordParser.getMetadata(RecordParser.SqlserverRecordParser.EVENT_SERIAL_NO_KEY);
         }
     }
 }

--- a/debezium-core/src/test/java/io/debezium/converters/CloudEventsConverterTest.java
+++ b/debezium-core/src/test/java/io/debezium/converters/CloudEventsConverterTest.java
@@ -12,6 +12,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
@@ -32,6 +33,10 @@ import io.debezium.util.Testing;
 public class CloudEventsConverterTest {
 
     public static void shouldConvertToCloudEventsInJson(SourceRecord record, boolean hasTransaction) {
+        shouldConvertToCloudEventsInJson(record, hasTransaction, valueJson -> {});
+    }
+
+    public static void shouldConvertToCloudEventsInJson(SourceRecord record, boolean hasTransaction, Consumer<JsonNode> furtherAssertions) {
         Map<String, Object> config = new HashMap<>();
         config.put("serializer.type", "json");
         config.put("data.serializer.type", "json");
@@ -104,6 +109,8 @@ public class CloudEventsConverterTest {
             assertThat(dataJson.get(CloudEventsMaker.FieldName.PAYLOAD_FIELD_NAME)).isNotNull();
             // before field may be null
             assertThat(dataJson.get(CloudEventsMaker.FieldName.PAYLOAD_FIELD_NAME).get(Envelope.FieldName.AFTER)).isNotNull();
+
+            furtherAssertions.accept(valueJson);
         }
         catch (Throwable t) {
             Testing.Print.enable();


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3157

Added `event_serial_no` to CloudEvents `Id` field for SQLServer to make it unique in case of the key field update of the source table.