### PR TITLE
DBZ-3195 Correct typo in anchor id for entry in PG properties table

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2634,7 +2634,7 @@ If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column tha
  +
 `hex` represents binary data as hex-encoded (base16) strings.
 
-|[[postgresql-property-truncat-handling-mode]]<<postgresql-property-truncate-handling-mode, `+truncate.handling.mode+`>>
+|[[postgresql-property-truncate-handling-mode]]<<postgresql-property-truncate-handling-mode, `+truncate.handling.mode+`>>
 |bytes
 |Specifies how whether `TRUNCATE` events should be propagated or not (only available when using the `pgoutput` plug-in with Postgres 11 or later): +
  +


### PR DESCRIPTION
Jira [DBZ-3195](https://issues.redhat.com/browse/DBZ-3195)

Added a missing `e` to the anchor id for the `truncate.handling.mode` property entry in the _Required connector configuration properties_ table in the PostgreSQL connector doc. The typo caused the downstream build to fail.

**Anchor string**: postgresql-property-**truncat**-handling-mode Missing an `e`.
**Link string**: postgresql-property-truncate-handling-mode
