### PR TITLE
DBZ-2911 Add additional LSN information to PostgreSQL sources

### DIFF
--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/SourceInfoTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/SourceInfoTest.java
@@ -259,6 +259,7 @@ public class SourceInfoTest {
                 .field("ts_ms", Schema.INT64_SCHEMA)
                 .field("snapshot", AbstractSourceInfoStructMaker.SNAPSHOT_RECORD_SCHEMA)
                 .field("db", Schema.STRING_SCHEMA)
+                .field("sequence", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("rs", Schema.STRING_SCHEMA)
                 .field("collection", Schema.STRING_SCHEMA)
                 .field("ord", Schema.INT32_SCHEMA)

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
@@ -620,6 +620,7 @@ public class SourceInfoTest {
                 .field("ts_ms", Schema.INT64_SCHEMA)
                 .field("snapshot", AbstractSourceInfoStructMaker.SNAPSHOT_RECORD_SCHEMA)
                 .field("db", Schema.STRING_SCHEMA)
+                .field("sequence", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("table", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("server_id", Schema.INT64_SCHEMA)
                 .field("gtid", Schema.OPTIONAL_STRING_SCHEMA)

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/SourceInfoTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/SourceInfoTest.java
@@ -720,6 +720,7 @@ public class SourceInfoTest {
                 .field("ts_ms", Schema.INT64_SCHEMA)
                 .field("snapshot", AbstractSourceInfoStructMaker.SNAPSHOT_RECORD_SCHEMA)
                 .field("db", Schema.STRING_SCHEMA)
+                .field("sequence", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("table", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("server_id", Schema.INT64_SCHEMA)
                 .field("gtid", Schema.OPTIONAL_STRING_SCHEMA)

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
@@ -52,7 +52,7 @@ public class PostgresOffsetContext implements OffsetContext {
 
         this.lastCompletelyProcessedLsn = lastCompletelyProcessedLsn;
         this.lastCommitLsn = lastCommitLsn;
-        sourceInfo.update(lsn, time, txId, null, sourceInfo.xmin());
+        sourceInfo.update(lsn, time, txId, null, sourceInfo.xmin(), lastCommitLsn);
         sourceInfoSchema = sourceInfo.schema();
 
         this.lastSnapshotRecord = lastSnapshotRecord;
@@ -141,7 +141,7 @@ public class PostgresOffsetContext implements OffsetContext {
     public void updateCommitPosition(Lsn lsn, Lsn lastCompletelyProcessedLsn, Instant commitTime, Long txId, TableId tableId, Long xmin) {
         this.lastCompletelyProcessedLsn = lastCompletelyProcessedLsn;
         this.lastCommitLsn = lastCompletelyProcessedLsn;
-        sourceInfo.update(lsn, commitTime, txId, tableId, xmin);
+        sourceInfo.update(lsn, commitTime, txId, tableId, xmin, lastCompletelyProcessedLsn);
     }
 
     boolean hasLastKnownPosition() {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SourceInfoTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SourceInfoTest.java
@@ -68,6 +68,7 @@ public class SourceInfoTest {
                 .field("ts_ms", Schema.INT64_SCHEMA)
                 .field("snapshot", AbstractSourceInfoStructMaker.SNAPSHOT_RECORD_SCHEMA)
                 .field("db", Schema.STRING_SCHEMA)
+                .field("sequence", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("schema", Schema.STRING_SCHEMA)
                 .field("table", Schema.STRING_SCHEMA)
                 .field("txId", Schema.OPTIONAL_INT64_SCHEMA)

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SourceInfoTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SourceInfoTest.java
@@ -95,6 +95,7 @@ public class SourceInfoTest {
                 .field("ts_ms", Schema.INT64_SCHEMA)
                 .field("snapshot", AbstractSourceInfoStructMaker.SNAPSHOT_RECORD_SCHEMA)
                 .field("db", Schema.STRING_SCHEMA)
+                .field("sequence", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("schema", Schema.STRING_SCHEMA)
                 .field("table", Schema.STRING_SCHEMA)
                 .field("change_lsn", Schema.OPTIONAL_STRING_SCHEMA)

--- a/debezium-core/src/main/java/io/debezium/connector/AbstractSourceInfo.java
+++ b/debezium-core/src/main/java/io/debezium/connector/AbstractSourceInfo.java
@@ -28,6 +28,7 @@ public abstract class AbstractSourceInfo {
     public static final String SCHEMA_NAME_KEY = "schema";
     public static final String TABLE_NAME_KEY = "table";
     public static final String COLLECTION_NAME_KEY = "collection";
+    public static final String SEQUENCE_KEY = "sequence";
 
     private final CommonConnectorConfig config;
 
@@ -75,4 +76,18 @@ public abstract class AbstractSourceInfo {
     public Struct struct() {
         return structMaker().struct(this);
     }
+
+    /**
+     * Returns extra sequencing metadata about a change event formatted
+     * as a stringified JSON array. The metadata contained in a sequence must be
+     * ordered sequentially in order to be understood and compared.
+     *
+     * Note: if a source's sequence metadata contains any string values, those
+     * strings must be correctly escaped before being included in the stringified
+     * JSON array.
+     */
+    protected String sequence() {
+        return null;
+    };
+
 }

--- a/debezium-core/src/main/java/io/debezium/connector/AbstractSourceInfoStructMaker.java
+++ b/debezium-core/src/main/java/io/debezium/connector/AbstractSourceInfoStructMaker.java
@@ -43,18 +43,21 @@ public abstract class AbstractSourceInfoStructMaker<T extends AbstractSourceInfo
                 .field(AbstractSourceInfo.SERVER_NAME_KEY, Schema.STRING_SCHEMA)
                 .field(AbstractSourceInfo.TIMESTAMP_KEY, Schema.INT64_SCHEMA)
                 .field(AbstractSourceInfo.SNAPSHOT_KEY, SNAPSHOT_RECORD_SCHEMA)
-                .field(AbstractSourceInfo.DATABASE_NAME_KEY, Schema.STRING_SCHEMA);
+                .field(AbstractSourceInfo.DATABASE_NAME_KEY, Schema.STRING_SCHEMA)
+                .field(AbstractSourceInfo.SEQUENCE_KEY, Schema.OPTIONAL_STRING_SCHEMA);
     }
 
     protected Struct commonStruct(T sourceInfo) {
         final Instant timestamp = sourceInfo.timestamp() == null ? Instant.now() : sourceInfo.timestamp();
         final String database = sourceInfo.database() == null ? "" : sourceInfo.database();
+        final String sequence = sourceInfo.sequence() == null ? "" : sourceInfo.sequence();
         Struct ret = new Struct(schema())
                 .put(AbstractSourceInfo.DEBEZIUM_VERSION_KEY, version)
                 .put(AbstractSourceInfo.DEBEZIUM_CONNECTOR_KEY, connector)
                 .put(AbstractSourceInfo.SERVER_NAME_KEY, serverName)
                 .put(AbstractSourceInfo.TIMESTAMP_KEY, timestamp.toEpochMilli())
-                .put(AbstractSourceInfo.DATABASE_NAME_KEY, database);
+                .put(AbstractSourceInfo.DATABASE_NAME_KEY, database)
+                .put(AbstractSourceInfo.SEQUENCE_KEY, sequence);
         final SnapshotRecord snapshot = sourceInfo.snapshot();
         if (snapshot != null) {
             snapshot.toSource(ret);

--- a/debezium-core/src/main/java/io/debezium/connector/AbstractSourceInfoStructMaker.java
+++ b/debezium-core/src/main/java/io/debezium/connector/AbstractSourceInfoStructMaker.java
@@ -50,14 +50,16 @@ public abstract class AbstractSourceInfoStructMaker<T extends AbstractSourceInfo
     protected Struct commonStruct(T sourceInfo) {
         final Instant timestamp = sourceInfo.timestamp() == null ? Instant.now() : sourceInfo.timestamp();
         final String database = sourceInfo.database() == null ? "" : sourceInfo.database();
-        final String sequence = sourceInfo.sequence() == null ? "" : sourceInfo.sequence();
         Struct ret = new Struct(schema())
                 .put(AbstractSourceInfo.DEBEZIUM_VERSION_KEY, version)
                 .put(AbstractSourceInfo.DEBEZIUM_CONNECTOR_KEY, connector)
                 .put(AbstractSourceInfo.SERVER_NAME_KEY, serverName)
                 .put(AbstractSourceInfo.TIMESTAMP_KEY, timestamp.toEpochMilli())
-                .put(AbstractSourceInfo.DATABASE_NAME_KEY, database)
-                .put(AbstractSourceInfo.SEQUENCE_KEY, sequence);
+                .put(AbstractSourceInfo.DATABASE_NAME_KEY, database);
+        final String sequence = sourceInfo.sequence();
+        if (sequence != null) {
+            ret.put(AbstractSourceInfo.SEQUENCE_KEY, sequence);
+        }
         final SnapshotRecord snapshot = sourceInfo.snapshot();
         if (snapshot != null) {
             snapshot.toSource(ret);

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -825,6 +825,7 @@ The following example shows the value portion of a change event that the connect
             "ts_ms": 1559033904863,
             "snapshot": true,
             "db": "postgres",
+            "sequence": "[24023119,24023128]"
             "schema": "public",
             "table": "customers",
             "txId": 555,
@@ -890,6 +891,7 @@ a|Mandatory field that describes the source metadata for the event. This field c
 * {prodname} version
 * Connector type and name
 * Database and table that contains the new row
+* Stringified JSON array of additional offset information. The first value is always the last committed LSN, the second value is always the current LSN. Either value may be `null`.
 * Schema name
 * If the event was part of a snapshot
 * ID of the transaction in which the operation was performed

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -825,7 +825,7 @@ The following example shows the value portion of a change event that the connect
             "ts_ms": 1559033904863,
             "snapshot": true,
             "db": "postgres",
-            "sequence": "[24023119,24023128]"
+            "sequence": "[\"24023119\",\"24023128\"]"
             "schema": "public",
             "table": "customers",
             "txId": 555,


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2911

Adds a new "sequence" field to PostgresSQL sources to allow downstream
systems to deduplicate PostgreSQL records in O(1) time. The sequence
field is a stringified list, containing the last committed LSN and the
current LSN. A new integration test was added.

Note: I ended up adding this field as a string because I was unable to add it
as a struct or array. I tried doing so first, but found that adding non-scalar types
to the source object caused the `CloudEvents` tests to fail. It looks like
`CloudEvents` [only support scalar types](https://github.com/cloudevents/spec/blob/v1.0.1/spec.md#type-system). Since no other type of source performs a
struct -> string conversion for `CloudEvents`, it seemed safer just to make it
a string.
