### PR TITLE
DBZ-3197 Describe how to grant replication role to non-master account.

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1806,11 +1806,18 @@ ifdef::community[]
 It is possible to capture changes in a PostgreSQL database that is running in link:https://aws.amazon.com/rds/[Amazon RDS]. To do this:
 
 * Set the instance parameter `rds.logical_replication` to `1`.
-* Verify that the `wal_level` parameter is set to `logical` by running the query `SHOW wal_level` as the database RDS master user. This might not be the case in multi-zone replication setups.
-You cannot set this option manually. It is link:https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html[automatically changed] when the `rds.logical_replication` parameter is set to `1`.
-If the `wal_level` is not `logical` after the change above, it is probably because the instance has to be restarted due to the parameter group change. This happens according to your maintenance window or you can do it manually.
+* Verify that the `wal_level` parameter is set to `logical` by running the query `SHOW wal_level` as the database RDS master user.
+  This might not be the case in multi-zone replication setups.
+  You cannot set this option manually.
+  It is link:https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html[automatically changed] when the `rds.logical_replication` parameter is set to `1`.
+  If the `wal_level` is not set to `logical` after you make the preceding change, it is probably because the instance has to be restarted after the parameter group change.
+  Restarts occur during your maintenance window, or you can initiate a restart manually.
 * Set the  {prodname} `plugin.name` parameter to `wal2json`. You can skip this on PostgreSQL 10+ if you plan to use `pgoutput` logical replication stream support.
-* Use the RDS master account for replication as RDS currently does not support setting of `REPLICATION` privilege for another account.
+* Initiate logical replication from an AWS account that has the `rds_replication` role.
+  The role grants permissions to manage logical slots and to stream data using logical slots.
+  By default, only the master user account on AWS has the `rds_replication` role on Amazon RDS.
+  To initiate logical replication from a user account other than the master account, grant the account the `rds_replication` role.
+  For example, `grant rds_replication to _<my_user>_`
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Per the [DBZ-3197](https://issues.redhat.com/browse/DBZ-3197) enhancement request, this change adds information about how to use non-master accounts for PG logical replication by granting them the replication role.

Tested change via local Antora build.