### PR TITLE
DBZ-3190 Deprecate database.tablename.case.insensitive option

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -322,6 +323,22 @@ public class OracleConnection extends JdbcConnection {
             }
         }
         tables.overwriteTable(editor.create());
+    }
+
+    /**
+     * Resolve the table name case insensitivity used by the schema based on the following rules:
+     *
+     * <ul>
+     *     <li>If option is provided in connector configuration, it will be used.</li>
+     *     <li>Otherwise resolved by database version where Oracle 11 will be {@code true}; otherwise {@code false}.</li>
+     * </ul>
+     *
+     * @param connectorConfig the connector configuration
+     * @return whether table name case insensitivity is used
+     */
+    public boolean getTablenameCaseInsensitivity(OracleConnectorConfig connectorConfig) {
+        Optional<Boolean> configValue = connectorConfig.getTablenameCaseInsensitive();
+        return configValue.orElse(getOracleVersion().getMajor() == 11);
     }
 
     public OracleConnection executeLegacy(String... sqlStatements) throws SQLException {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseSchema.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseSchema.java
@@ -39,7 +39,7 @@ public class OracleDatabaseSchema extends HistorizedRelationalDatabaseSchema {
                         connectorConfig.customConverterRegistry(),
                         connectorConfig.getSourceInfoStructMaker().schema(),
                         connectorConfig.getSanitizeFieldNames()),
-                connectorConfig.getTablenameCaseInsensitive(),
+                connection.getTablenameCaseInsensitivity(connectorConfig),
                 connectorConfig.getKeyMapper());
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.Optional;
 
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -20,11 +21,15 @@ import org.slf4j.LoggerFactory;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.doc.FixFor;
+import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.relational.history.KafkaDatabaseHistory;
 
 public class OracleConnectorConfigTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OracleConnectorConfigTest.class);
+
+    private static final String TABLENAME_CASE_INSENSITIVE_WARNING = "The option '" + OracleConnectorConfig.TABLENAME_CASE_INSENSITIVE
+            + "' is deprecated and will be removed in the future.";
 
     @Test
     public void validXtreamNoUrl() throws Exception {
@@ -178,5 +183,38 @@ public class OracleConnectorConfigTest {
 
         config = Configuration.create().with(transactionRetentionField, 0).build();
         assertThat(config.validateAndRecord(Collections.singletonList(transactionRetentionField), LOGGER::error)).isFalse();
+    }
+
+    @Test
+    @FixFor("DBZ-3190")
+    public void shouldLogDeprecationWarningForTablenameCaseInsensitiveTrue() throws Exception {
+        final LogInterceptor logInterceptor = new LogInterceptor();
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                Configuration.create().with(OracleConnectorConfig.TABLENAME_CASE_INSENSITIVE, true).build());
+
+        assertThat(connectorConfig.getTablenameCaseInsensitive()).isEqualTo(Optional.of(true));
+        assertThat(logInterceptor.containsMessage(TABLENAME_CASE_INSENSITIVE_WARNING)).isTrue();
+    }
+
+    @Test
+    @FixFor("DBZ-3190")
+    public void shouldLogDeprecationWarningForTablenameCaseInsensitiveFalse() throws Exception {
+        final LogInterceptor logInterceptor = new LogInterceptor();
+
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
+                Configuration.create().with(OracleConnectorConfig.TABLENAME_CASE_INSENSITIVE, false).build());
+
+        assertThat(connectorConfig.getTablenameCaseInsensitive()).isEqualTo(Optional.of(false));
+        assertThat(logInterceptor.containsMessage(TABLENAME_CASE_INSENSITIVE_WARNING)).isTrue();
+    }
+
+    @Test
+    @FixFor("DBZ-3190")
+    public void shouldNotBePresentWhenTablenameCaseInsensitiveNotSupplied() throws Exception {
+        final LogInterceptor logInterceptor = new LogInterceptor();
+        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(Configuration.create().build());
+        assertThat(connectorConfig.getTablenameCaseInsensitive()).isEqualTo(Optional.empty());
+        assertThat(logInterceptor.containsMessage(TABLENAME_CASE_INSENSITIVE_WARNING)).isFalse();
     }
 }

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1365,9 +1365,10 @@ The following configuration properties are _required_ unless a default value is 
 |
 |Raw database jdbc url. This property can be used when more flexibility is needed and can support raw TNS names or RAC connection strings.
 
-|[[oracle-property-database-tablename-case-insensitive]]<<oracle-property-database-tablename-case-insensitive, `+database.tablename.case.insensitive+`>>
+|[[oracle-property-database-tablename-case-insensitive]]<<oracle-property-database-tablename-case-insensitive, `+database.tablename.case.insensitive+`>> +
+_deprecated and scheduled for removal_
 |`false`
-|Enable support for case insensitive table names; set to `true` for Oracle 11g.
+|Enable support for case insensitive table names; *only* set to `true` for Oracle 11g.
 
 |[[oracle-property-database-oracle-version]]<<oracle-property-database-oracle-version, `+database.oracle.version+`>>
 |`12+`

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1365,11 +1365,6 @@ The following configuration properties are _required_ unless a default value is 
 |
 |Raw database jdbc url. This property can be used when more flexibility is needed and can support raw TNS names or RAC connection strings.
 
-|[[oracle-property-database-tablename-case-insensitive]]<<oracle-property-database-tablename-case-insensitive, `+database.tablename.case.insensitive+`>> +
-_deprecated and scheduled for removal_
-|`false`
-|Enable support for case insensitive table names; *only* set to `true` for Oracle 11g.
-
 |[[oracle-property-database-oracle-version]]<<oracle-property-database-oracle-version, `+database.oracle.version+`>>
 |`12+`
 |Specifies how to decode the Oracle SCN values.


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3190

* Option deprecated
* If provided, value continues to be used with warning logged
* If not provided, value will be resolved by database version