### PR TITLE
DBZ-3242 Disable log.mining.transaction.retention.hours by default

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -67,8 +67,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     protected final static Duration MIN_SLEEP_TIME = Duration.ZERO;
     protected final static Duration SLEEP_TIME_INCREMENT = Duration.ofMillis(200);
 
-    protected final static Duration DEFAULT_TRANSACTION_RETENTION = Duration.ofHours(4);
-
     public static final Field PORT = RelationalDatabaseConnectorConfig.PORT
             .withDefault(DEFAULT_PORT);
 
@@ -171,9 +169,9 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withType(Type.LONG)
             .withWidth(Width.SHORT)
             .withImportance(Importance.MEDIUM)
-            .withDefault(DEFAULT_TRANSACTION_RETENTION.toHours())
-            .withValidation(OracleConnectorConfig::isPositiveNonZeroInteger)
-            .withDescription("Hours to keep long running transactions in transaction buffer between log mining sessions.");
+            .withDefault(0)
+            .withValidation(Field::isNonNegativeInteger)
+            .withDescription("Hours to keep long running transactions in transaction buffer between log mining sessions.  By default, all transactions are retained.");
 
     public static final Field RAC_SYSTEM = Field.create("database.rac")
             .withDisplayName("Oracle RAC")
@@ -964,15 +962,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             return Field.isRequired(config, field, problems);
         }
         return 0;
-    }
-
-    public static int isPositiveNonZeroInteger(Configuration config, Field field, ValidationOutput problems) {
-        Integer value = config.getInteger(field);
-        if (value == 0) {
-            problems.accept(field, value, "The value must be non-zero.");
-            return 1;
-        }
-        return Field.isPositiveInteger(config, field, problems);
     }
 
     private static Boolean resolveTableNameCaseInsensitivity(Configuration config) {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
@@ -167,7 +167,7 @@ public class OracleConnectorConfigTest {
     public void validTransactionRetentionDefaults() throws Exception {
         final Configuration config = Configuration.create().build();
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
-        assertThat(connectorConfig.getLogMiningTransactionRetention()).isEqualTo(OracleConnectorConfig.DEFAULT_TRANSACTION_RETENTION);
+        assertThat(connectorConfig.getLogMiningTransactionRetention()).isEqualTo(Duration.ZERO);
     }
 
     @Test
@@ -182,6 +182,9 @@ public class OracleConnectorConfigTest {
         assertThat(connectorConfig.getLogMiningTransactionRetention()).isEqualTo(Duration.ofHours(3));
 
         config = Configuration.create().with(transactionRetentionField, 0).build();
+        assertThat(config.validateAndRecord(Collections.singletonList(transactionRetentionField), LOGGER::error)).isTrue();
+
+        config = Configuration.create().with(transactionRetentionField, -1).build();
         assertThat(config.validateAndRecord(Collections.singletonList(transactionRetentionField), LOGGER::error)).isFalse();
     }
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1604,8 +1604,9 @@ Using the default `0` will mine all archive logs.
 When set to `0`, log mining history is is disabled.
 
 |[[oracle-property-log-mining-transaction-retention-hours]]<<oracle-property-log-mining-transaction-retention-hours, `log.mining.transaction.retention.hours`>>
-|`4`
+|`0`
 |Positive integer value that specifies the number of hours to retain long running transactions between redo log switches.
+When set to `0`, transactions are retained until a commit or rollback is detected.
 
 The LogMiner adapter maintains an in-memory buffer of all running transactions.
 As all DML operations that are part of a transaction will be buffered until a commit or rollback is detected,


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3242

* Default value `0` disables the check
* Any negative value will show a configuration problem
* Any positive value over `0` will enable the retention check