### PR TITLE
DBZ-3257 Revert Clob behavior for Oracle LogMiner to avoid null values

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
@@ -240,7 +240,13 @@ public class OracleValueConverters extends JdbcValueConverters {
             return ((CHAR) data).stringValue();
         }
         if (data instanceof Clob) {
-            return ((Clob) data).toString();
+            try {
+                Clob clob = (Clob) data;
+                return clob.getSubString(1, (int) clob.length());
+            }
+            catch (SQLException e) {
+                throw new RuntimeException("Couldn't convert value for column " + column.name(), e);
+            }
         }
         if (data instanceof String) {
             String s = (String) data;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
@@ -26,6 +26,7 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 
+import io.debezium.DebeziumException;
 import io.debezium.config.CommonConnectorConfig.BinaryHandlingMode;
 import io.debezium.data.SpecialValueDecimal;
 import io.debezium.data.VariableScaleDecimal;
@@ -242,10 +243,13 @@ public class OracleValueConverters extends JdbcValueConverters {
         if (data instanceof Clob) {
             try {
                 Clob clob = (Clob) data;
+                // Note that java.sql.Clob specifies that the first character starts at 1
+                // and that length must be greater-than or equal to 0.  So for an empty
+                // clob field, a call to getSubString(1, 0) is perfectly valid.
                 return clob.getSubString(1, (int) clob.length());
             }
             catch (SQLException e) {
-                throw new RuntimeException("Couldn't convert value for column " + column.name(), e);
+                throw new DebeziumException("Couldn't convert value for column " + column.name(), e);
             }
         }
         if (data instanceof String) {
@@ -292,7 +296,7 @@ public class OracleValueConverters extends JdbcValueConverters {
                 return blob.getBytes(0, Long.valueOf(blob.length()).intValue());
             }
             catch (SQLException e) {
-                throw new RuntimeException("Couldn't convert value for column " + column.name(), e);
+                throw new DebeziumException("Couldn't convert value for column " + column.name(), e);
             }
         }
         return super.convertBinary(column, fieldDefn, data, mode);
@@ -305,7 +309,7 @@ public class OracleValueConverters extends JdbcValueConverters {
                 data = ((NUMBER) data).intValue();
             }
             catch (SQLException e) {
-                throw new RuntimeException("Couldn't convert value for column " + column.name(), e);
+                throw new DebeziumException("Couldn't convert value for column " + column.name(), e);
             }
         }
 
@@ -325,7 +329,7 @@ public class OracleValueConverters extends JdbcValueConverters {
                 return ((BINARY_FLOAT) data).floatValue();
             }
             catch (SQLException e) {
-                throw new RuntimeException("Couldn't convert value for column " + column.name(), e);
+                throw new DebeziumException("Couldn't convert value for column " + column.name(), e);
             }
         }
         else if (data instanceof String) {
@@ -342,7 +346,7 @@ public class OracleValueConverters extends JdbcValueConverters {
                 return ((BINARY_DOUBLE) data).doubleValue();
             }
             catch (SQLException e) {
-                throw new RuntimeException("Couldn't convert value for column " + column.name(), e);
+                throw new DebeziumException("Couldn't convert value for column " + column.name(), e);
             }
         }
         else if (data instanceof String) {
@@ -359,7 +363,7 @@ public class OracleValueConverters extends JdbcValueConverters {
                 data = ((NUMBER) data).bigDecimalValue();
             }
             catch (SQLException e) {
-                throw new RuntimeException("Couldn't convert value for column " + column.name(), e);
+                throw new DebeziumException("Couldn't convert value for column " + column.name(), e);
             }
         }
 
@@ -397,7 +401,7 @@ public class OracleValueConverters extends JdbcValueConverters {
                 data = ((NUMBER) data).byteValue();
             }
             catch (SQLException e) {
-                throw new RuntimeException("Couldn't convert value for column " + column.name(), e);
+                throw new DebeziumException("Couldn't convert value for column " + column.name(), e);
             }
         }
 
@@ -410,7 +414,7 @@ public class OracleValueConverters extends JdbcValueConverters {
                 data = ((NUMBER) data).shortValue();
             }
             catch (SQLException e) {
-                throw new RuntimeException("Couldn't convert value for column " + column.name(), e);
+                throw new DebeziumException("Couldn't convert value for column " + column.name(), e);
             }
         }
 
@@ -423,7 +427,7 @@ public class OracleValueConverters extends JdbcValueConverters {
                 data = ((NUMBER) data).intValue();
             }
             catch (SQLException e) {
-                throw new RuntimeException("Couldn't convert value for column " + column.name(), e);
+                throw new DebeziumException("Couldn't convert value for column " + column.name(), e);
             }
         }
 
@@ -436,7 +440,7 @@ public class OracleValueConverters extends JdbcValueConverters {
                 data = ((NUMBER) data).longValue();
             }
             catch (SQLException e) {
-                throw new RuntimeException("Couldn't convert value for column " + column.name(), e);
+                throw new DebeziumException("Couldn't convert value for column " + column.name(), e);
             }
         }
 
@@ -465,7 +469,7 @@ public class OracleValueConverters extends JdbcValueConverters {
                 return ((NUMBER) data).intValue() == 0 ? Boolean.FALSE : Boolean.TRUE;
             }
             catch (SQLException e) {
-                throw new RuntimeException("Couldn't convert value for column " + column.name(), e);
+                throw new DebeziumException("Couldn't convert value for column " + column.name(), e);
             }
         }
         return super.convertBoolean(column, fieldDefn, data);
@@ -531,7 +535,7 @@ public class OracleValueConverters extends JdbcValueConverters {
             }
         }
         catch (SQLException e) {
-            throw new RuntimeException("Couldn't convert value for column " + column.name(), e);
+            throw new DebeziumException("Couldn't convert value for column " + column.name(), e);
         }
         return data;
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
@@ -197,7 +197,13 @@ class LogMinerQueryResultProcessor {
                         break;
                 }
 
-                final LogMinerDmlEntry dmlEntry = parse(redoSql, schema, tableId, txId);
+                final Table table = schema.tableFor(tableId);
+                if (table == null) {
+                    LogMinerHelper.logWarn(transactionalBufferMetrics, "DML for table '{}' that is not known to this connector, skipping.", tableId);
+                    continue;
+                }
+
+                final LogMinerDmlEntry dmlEntry = parse(redoSql, table, txId);
                 dmlEntry.setObjectOwner(segOwner);
                 dmlEntry.setSourceTime(changeTime);
                 dmlEntry.setTransactionId(txId);
@@ -217,11 +223,10 @@ class LogMinerQueryResultProcessor {
                         if (counter == 0) {
                             offsetContext.setCommitScn(commitScn.longValue());
                         }
-                        Table table = schema.tableFor(tableId);
                         LOGGER.trace("Processing DML event {} scn {}", dmlEntry.toString(), scn);
 
                         dispatcher.dispatchDataChangeEvent(tableId,
-                                new LogMinerChangeRecordEmitter(offsetContext, dmlEntry, table, clock));
+                                new LogMinerChangeRecordEmitter(offsetContext, dmlEntry, schema.tableFor(tableId), clock));
                     });
 
                 }
@@ -277,11 +282,11 @@ class LogMinerQueryResultProcessor {
         }
     }
 
-    private LogMinerDmlEntry parse(String redoSql, OracleDatabaseSchema schema, TableId tableId, String txId) {
+    private LogMinerDmlEntry parse(String redoSql, Table table, String txId) {
         LogMinerDmlEntry dmlEntry;
         try {
             Instant parseStart = Instant.now();
-            dmlEntry = dmlParser.parse(redoSql, schema.getTables(), tableId, txId);
+            dmlEntry = dmlParser.parse(redoSql, table, txId);
             metrics.addCurrentParseTime(Duration.between(parseStart, Instant.now()));
         }
         catch (DmlParserException e) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/DmlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/DmlParser.java
@@ -6,8 +6,7 @@
 package io.debezium.connector.oracle.logminer.parser;
 
 import io.debezium.connector.oracle.logminer.valueholder.LogMinerDmlEntry;
-import io.debezium.relational.TableId;
-import io.debezium.relational.Tables;
+import io.debezium.relational.Table;
 
 /**
  * Contract for a DML parser for LogMiner.
@@ -19,11 +18,10 @@ public interface DmlParser {
      * Parse a DML SQL string from the LogMiner event stream.
      *
      * @param sql the sql statement
-     * @param tables collection of known tables.
-     * @param tableId the table identifier
+     * @param table the table the sql statement is for
      * @param txId the current transaction id the sql is part of.
      * @return the parsed sql as a DML entry or {@code null} if the SQL couldn't be parsed.
      * @throws DmlParserException thrown if a parse exception is detected.
      */
-    LogMinerDmlEntry parse(String sql, Tables tables, TableId tableId, String txId);
+    LogMinerDmlEntry parse(String sql, Table table, String txId);
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/SimpleDmlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/SimpleDmlParser.java
@@ -25,8 +25,6 @@ import io.debezium.connector.oracle.logminer.valueholder.LogMinerDmlEntryImpl;
 import io.debezium.data.Envelope;
 import io.debezium.relational.Column;
 import io.debezium.relational.Table;
-import io.debezium.relational.TableId;
-import io.debezium.relational.Tables;
 import io.debezium.text.ParsingException;
 
 import net.sf.jsqlparser.JSQLParserException;
@@ -74,11 +72,10 @@ public class SimpleDmlParser implements DmlParser {
     /**
      * This parses a DML
      * @param dmlContent DML
-     * @param tables debezium Tables
-     * @param tableId the TableId for the log miner contents view row
+     * @param table the table
      * @return parsed value holder class
      */
-    public LogMinerDmlEntry parse(String dmlContent, Tables tables, TableId tableId, String txId) {
+    public LogMinerDmlEntry parse(String dmlContent, Table table, String txId) {
         try {
 
             // If a table contains Spatial data type, DML input generates two entries in REDO LOG.
@@ -102,7 +99,7 @@ public class SimpleDmlParser implements DmlParser {
 
             Statement st = pm.parse(new StringReader(dmlContent));
             if (st instanceof Update) {
-                parseUpdate(tables, tableId, (Update) st);
+                parseUpdate(table, (Update) st);
                 List<LogMinerColumnValue> actualNewValues = newColumnValues.values().stream()
                         .filter(LogMinerColumnValueWrapper::isProcessed).map(LogMinerColumnValueWrapper::getColumnValue).collect(Collectors.toList());
                 List<LogMinerColumnValue> actualOldValues = oldColumnValues.values().stream()
@@ -111,14 +108,14 @@ public class SimpleDmlParser implements DmlParser {
 
             }
             else if (st instanceof Insert) {
-                parseInsert(tables, tableId, (Insert) st);
+                parseInsert(table, (Insert) st);
                 List<LogMinerColumnValue> actualNewValues = newColumnValues.values()
                         .stream().map(LogMinerColumnValueWrapper::getColumnValue).collect(Collectors.toList());
                 return new LogMinerDmlEntryImpl(Envelope.Operation.CREATE, actualNewValues, Collections.emptyList());
 
             }
             else if (st instanceof Delete) {
-                parseDelete(tables, tableId, (Delete) st);
+                parseDelete(table, (Delete) st);
                 List<LogMinerColumnValue> actualOldValues = oldColumnValues.values()
                         .stream().map(LogMinerColumnValueWrapper::getColumnValue).collect(Collectors.toList());
                 return new LogMinerDmlEntryImpl(Envelope.Operation.DELETE, Collections.emptyList(), actualOldValues);
@@ -133,14 +130,11 @@ public class SimpleDmlParser implements DmlParser {
         }
     }
 
-    private void initColumns(Tables tables, TableId tableId, String tableName) {
-        if (!tableId.table().equals(tableName)) {
-            throw new ParsingException(null, "Resolved TableId expected table name '" + tableId.table() + "' but is '" + tableName + "'");
+    private void initColumns(Table table, String tableName) {
+        if (!table.id().table().equals(tableName)) {
+            throw new ParsingException(null, "Resolved TableId expected table name '" + table.id().table() + "' but is '" + tableName + "'");
         }
-        table = tables.forTable(tableId);
-        if (table == null) {
-            throw new ParsingException(null, "Trying to parse a table '" + tableId + "', which does not exist.");
-        }
+        this.table = table;
         for (int i = 0; i < table.columns().size(); i++) {
             Column column = table.columns().get(i);
             int type = column.jdbcType();
@@ -152,13 +146,13 @@ public class SimpleDmlParser implements DmlParser {
     }
 
     // this parses simple statement with only one table
-    private void parseUpdate(Tables tables, TableId tableId, Update st) throws JSQLParserException {
+    private void parseUpdate(Table table, Update st) throws JSQLParserException {
         int tableCount = st.getTables().size();
         if (tableCount > 1 || tableCount == 0) {
             throw new JSQLParserException("DML includes " + tableCount + " tables");
         }
         net.sf.jsqlparser.schema.Table parseTable = st.getTables().get(0);
-        initColumns(tables, tableId, ParserUtils.stripeQuotes(parseTable.getName()));
+        initColumns(table, ParserUtils.stripeQuotes(parseTable.getName()));
 
         List<net.sf.jsqlparser.schema.Column> columns = st.getColumns();
         Alias alias = parseTable.getAlias();
@@ -176,8 +170,8 @@ public class SimpleDmlParser implements DmlParser {
         }
     }
 
-    private void parseInsert(Tables tables, TableId tableId, Insert st) {
-        initColumns(tables, tableId, ParserUtils.stripeQuotes(st.getTable().getName()));
+    private void parseInsert(Table table, Insert st) {
+        initColumns(table, ParserUtils.stripeQuotes(st.getTable().getName()));
         Alias alias = st.getTable().getAlias();
         aliasName = alias == null ? "" : alias.getName().trim();
 
@@ -194,8 +188,8 @@ public class SimpleDmlParser implements DmlParser {
         oldColumnValues.clear();
     }
 
-    private void parseDelete(Tables tables, TableId tableId, Delete st) {
-        initColumns(tables, tableId, ParserUtils.stripeQuotes(st.getTable().getName()));
+    private void parseDelete(Table table, Delete st) {
+        initColumns(table, ParserUtils.stripeQuotes(st.getTable().getName()));
         Alias alias = st.getTable().getAlias();
         aliasName = alias == null ? "" : alias.getName().trim();
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerDmlParserTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerDmlParserTest.java
@@ -14,14 +14,14 @@ import io.debezium.connector.oracle.logminer.parser.LogMinerDmlParser;
 import io.debezium.connector.oracle.logminer.valueholder.LogMinerDmlEntry;
 import io.debezium.data.Envelope.Operation;
 import io.debezium.doc.FixFor;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
 
 /**
  * @author Chris Cranford
  */
 public class LogMinerDmlParserTest {
-
-    private static final String CATALOG_NAME = "ORCLCDB1";
-    private static final String SCHEMA_NAME = "DEBEZIUM";
 
     private LogMinerDmlParser fastDmlParser;
 
@@ -38,14 +38,27 @@ public class LogMinerDmlParserTest {
     @Test
     @FixFor("DBZ-3078")
     public void testParsingInsert() throws Exception {
+        final Table table = Table.editor()
+                .tableId(TableId.parse("DEBEZIUM.TEST"))
+                .addColumn(Column.editor().name("ID").create())
+                .addColumn(Column.editor().name("NAME").create())
+                .addColumn(Column.editor().name("TS").create())
+                .addColumn(Column.editor().name("UT").create())
+                .addColumn(Column.editor().name("DATE").create())
+                .addColumn(Column.editor().name("UT2").create())
+                .addColumn(Column.editor().name("C1").create())
+                .addColumn(Column.editor().name("C2").create())
+                .addColumn(Column.editor().name("UNUSED").create())
+                .create();
+
         String sql = "insert into \"DEBEZIUM\".\"TEST\"(\"ID\",\"NAME\",\"TS\",\"UT\",\"DATE\",\"UT2\",\"C1\",\"C2\") values " +
                 "('1','Acme',TO_TIMESTAMP('2020-02-01 00:00:00.'),Unsupported Type," +
                 "TO_DATE('2020-02-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),Unsupported Type,NULL,NULL);";
 
-        LogMinerDmlEntry entry = fastDmlParser.parse(sql, null, null, null);
+        LogMinerDmlEntry entry = fastDmlParser.parse(sql, table, null);
         assertThat(entry.getCommandType()).isEqualTo(Operation.CREATE);
         assertThat(entry.getOldValues()).isEmpty();
-        assertThat(entry.getNewValues()).hasSize(8);
+        assertThat(entry.getNewValues()).hasSize(9);
         assertThat(entry.getNewValues().get(0).getColumnName()).isEqualTo("ID");
         assertThat(entry.getNewValues().get(1).getColumnName()).isEqualTo("NAME");
         assertThat(entry.getNewValues().get(2).getColumnName()).isEqualTo("TS");
@@ -53,6 +66,8 @@ public class LogMinerDmlParserTest {
         assertThat(entry.getNewValues().get(4).getColumnName()).isEqualTo("DATE");
         assertThat(entry.getNewValues().get(5).getColumnName()).isEqualTo("UT2");
         assertThat(entry.getNewValues().get(6).getColumnName()).isEqualTo("C1");
+        assertThat(entry.getNewValues().get(7).getColumnName()).isEqualTo("C2");
+        assertThat(entry.getNewValues().get(8).getColumnName()).isEqualTo("UNUSED");
         assertThat(entry.getNewValues().get(0).getColumnData()).isEqualTo("1");
         assertThat(entry.getNewValues().get(1).getColumnData()).isEqualTo("Acme");
         assertThat(entry.getNewValues().get(2).getColumnData()).isEqualTo("TO_TIMESTAMP('2020-02-01 00:00:00.')");
@@ -61,11 +76,26 @@ public class LogMinerDmlParserTest {
         assertThat(entry.getNewValues().get(5).getColumnData()).isNull();
         assertThat(entry.getNewValues().get(6).getColumnData()).isNull();
         assertThat(entry.getNewValues().get(7).getColumnData()).isNull();
+        assertThat(entry.getNewValues().get(8).getColumnData()).isNull();
     }
 
     @Test
     @FixFor("DBZ-3078")
     public void testParsingUpdate() throws Exception {
+        final Table table = Table.editor()
+                .tableId(TableId.parse("DEBEZIUM.TEST"))
+                .addColumn(Column.editor().name("ID").create())
+                .addColumn(Column.editor().name("NAME").create())
+                .addColumn(Column.editor().name("TS").create())
+                .addColumn(Column.editor().name("UT").create())
+                .addColumn(Column.editor().name("DATE").create())
+                .addColumn(Column.editor().name("UT2").create())
+                .addColumn(Column.editor().name("C1").create())
+                .addColumn(Column.editor().name("IS").create())
+                .addColumn(Column.editor().name("IS2").create())
+                .addColumn(Column.editor().name("UNUSED").create())
+                .create();
+
         String sql = "update \"DEBEZIUM\".\"TEST\" " +
                 "set \"NAME\" = 'Bob', \"TS\" = TO_TIMESTAMP('2020-02-02 00:00:00.'), \"UT\" = Unsupported Type, " +
                 "\"DATE\" = TO_DATE('2020-02-02 00:00:00', 'YYYY-MM-DD HH24:MI:SS'), \"UT2\" = Unsupported Type, " +
@@ -73,15 +103,19 @@ public class LogMinerDmlParserTest {
                 "\"UT\" = Unsupported Type and \"DATE\" = TO_DATE('2020-02-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS') and " +
                 "\"UT2\" = Unsupported Type and \"C1\" = NULL and \"IS\" IS NULL and \"IS2\" IS NULL;";
 
-        LogMinerDmlEntry entry = fastDmlParser.parse(sql, null, null, null);
+        LogMinerDmlEntry entry = fastDmlParser.parse(sql, table, null);
         assertThat(entry.getCommandType()).isEqualTo(Operation.UPDATE);
-        assertThat(entry.getOldValues()).hasSize(9);
+        assertThat(entry.getOldValues()).hasSize(10);
         assertThat(entry.getOldValues().get(0).getColumnName()).isEqualTo("ID");
         assertThat(entry.getOldValues().get(1).getColumnName()).isEqualTo("NAME");
         assertThat(entry.getOldValues().get(2).getColumnName()).isEqualTo("TS");
         assertThat(entry.getOldValues().get(3).getColumnName()).isEqualTo("UT");
         assertThat(entry.getOldValues().get(4).getColumnName()).isEqualTo("DATE");
         assertThat(entry.getOldValues().get(5).getColumnName()).isEqualTo("UT2");
+        assertThat(entry.getOldValues().get(6).getColumnName()).isEqualTo("C1");
+        assertThat(entry.getOldValues().get(7).getColumnName()).isEqualTo("IS");
+        assertThat(entry.getOldValues().get(8).getColumnName()).isEqualTo("IS2");
+        assertThat(entry.getOldValues().get(9).getColumnName()).isEqualTo("UNUSED");
         assertThat(entry.getOldValues().get(0).getColumnData()).isEqualTo("1");
         assertThat(entry.getOldValues().get(1).getColumnData()).isEqualTo("Acme");
         assertThat(entry.getOldValues().get(2).getColumnData()).isEqualTo("TO_TIMESTAMP('2020-02-01 00:00:00.')");
@@ -90,13 +124,19 @@ public class LogMinerDmlParserTest {
         assertThat(entry.getOldValues().get(5).getColumnData()).isNull();
         assertThat(entry.getOldValues().get(6).getColumnData()).isNull();
         assertThat(entry.getOldValues().get(7).getColumnData()).isNull();
-        assertThat(entry.getNewValues()).hasSize(9);
+        assertThat(entry.getOldValues().get(8).getColumnData()).isNull();
+        assertThat(entry.getOldValues().get(9).getColumnData()).isNull();
+        assertThat(entry.getNewValues()).hasSize(10);
         assertThat(entry.getNewValues().get(0).getColumnName()).isEqualTo("ID");
         assertThat(entry.getNewValues().get(1).getColumnName()).isEqualTo("NAME");
         assertThat(entry.getNewValues().get(2).getColumnName()).isEqualTo("TS");
         assertThat(entry.getNewValues().get(3).getColumnName()).isEqualTo("UT");
         assertThat(entry.getNewValues().get(4).getColumnName()).isEqualTo("DATE");
         assertThat(entry.getNewValues().get(5).getColumnName()).isEqualTo("UT2");
+        assertThat(entry.getNewValues().get(6).getColumnName()).isEqualTo("C1");
+        assertThat(entry.getNewValues().get(7).getColumnName()).isEqualTo("IS");
+        assertThat(entry.getNewValues().get(8).getColumnName()).isEqualTo("IS2");
+        assertThat(entry.getNewValues().get(9).getColumnName()).isEqualTo("UNUSED");
         assertThat(entry.getNewValues().get(0).getColumnData()).isEqualTo("1");
         assertThat(entry.getNewValues().get(1).getColumnData()).isEqualTo("Bob");
         assertThat(entry.getNewValues().get(2).getColumnData()).isEqualTo("TO_TIMESTAMP('2020-02-02 00:00:00.')");
@@ -106,24 +146,40 @@ public class LogMinerDmlParserTest {
         assertThat(entry.getNewValues().get(6).getColumnData()).isNull();
         assertThat(entry.getNewValues().get(7).getColumnData()).isNull();
         assertThat(entry.getNewValues().get(8).getColumnData()).isNull();
+        assertThat(entry.getNewValues().get(9).getColumnData()).isNull();
     }
 
     @Test
     @FixFor("DBZ-3078")
     public void testParsingDelete() throws Exception {
+        final Table table = Table.editor()
+                .tableId(TableId.parse("DEBEZIUM.TEST"))
+                .addColumn(Column.editor().name("ID").create())
+                .addColumn(Column.editor().name("NAME").create())
+                .addColumn(Column.editor().name("TS").create())
+                .addColumn(Column.editor().name("UT").create())
+                .addColumn(Column.editor().name("DATE").create())
+                .addColumn(Column.editor().name("IS").create())
+                .addColumn(Column.editor().name("IS2").create())
+                .addColumn(Column.editor().name("UNUSED").create())
+                .create();
+
         String sql = "delete from \"DEBEZIUM\".\"TEST\" " +
                 "where \"ID\" = '1' and \"NAME\" = 'Acme' and \"TS\" = TO_TIMESTAMP('2020-02-01 00:00:00.') and " +
                 "\"UT\" = Unsupported Type and \"DATE\" = TO_DATE('2020-02-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS') and " +
                 "\"IS\" IS NULL and \"IS2\" IS NULL;";
 
-        LogMinerDmlEntry entry = fastDmlParser.parse(sql, null, null, null);
+        LogMinerDmlEntry entry = fastDmlParser.parse(sql, table, null);
         assertThat(entry.getCommandType()).isEqualTo(Operation.DELETE);
-        assertThat(entry.getOldValues()).hasSize(7);
+        assertThat(entry.getOldValues()).hasSize(8);
         assertThat(entry.getOldValues().get(0).getColumnName()).isEqualTo("ID");
         assertThat(entry.getOldValues().get(1).getColumnName()).isEqualTo("NAME");
         assertThat(entry.getOldValues().get(2).getColumnName()).isEqualTo("TS");
         assertThat(entry.getOldValues().get(3).getColumnName()).isEqualTo("UT");
         assertThat(entry.getOldValues().get(4).getColumnName()).isEqualTo("DATE");
+        assertThat(entry.getOldValues().get(5).getColumnName()).isEqualTo("IS");
+        assertThat(entry.getOldValues().get(6).getColumnName()).isEqualTo("IS2");
+        assertThat(entry.getOldValues().get(7).getColumnName()).isEqualTo("UNUSED");
         assertThat(entry.getOldValues().get(0).getColumnData()).isEqualTo("1");
         assertThat(entry.getOldValues().get(1).getColumnData()).isEqualTo("Acme");
         assertThat(entry.getOldValues().get(2).getColumnData()).isEqualTo("TO_TIMESTAMP('2020-02-01 00:00:00.')");
@@ -131,32 +187,51 @@ public class LogMinerDmlParserTest {
         assertThat(entry.getOldValues().get(4).getColumnData()).isEqualTo("TO_DATE('2020-02-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS')");
         assertThat(entry.getOldValues().get(5).getColumnData()).isNull();
         assertThat(entry.getOldValues().get(6).getColumnData()).isNull();
+        assertThat(entry.getOldValues().get(7).getColumnData()).isNull();
         assertThat(entry.getNewValues()).isEmpty();
     }
 
     @Test
     @FixFor("DBZ-3235")
     public void testParsingUpdateWithNoWhereClauseIsAcceptable() throws Exception {
+        final Table table = Table.editor()
+                .tableId(TableId.parse("DEBEZIUM.TEST"))
+                .addColumn(Column.editor().name("COL1").create())
+                .addColumn(Column.editor().name("COL2").create())
+                .addColumn(Column.editor().name("COL3").create())
+                .addColumn(Column.editor().name("UNUSED").create())
+                .create();
+
         String sql = "update \"DEBEZIUM\".\"TEST\" set \"COL1\" = '1', \"COL2\" = NULL, \"COL3\" = 'Hello';";
 
-        LogMinerDmlEntry entry = fastDmlParser.parse(sql, null, null, null);
+        LogMinerDmlEntry entry = fastDmlParser.parse(sql, table, null);
         assertThat(entry.getCommandType()).isEqualTo(Operation.UPDATE);
         assertThat(entry.getOldValues()).isEmpty();
-        assertThat(entry.getNewValues()).hasSize(3);
+        assertThat(entry.getNewValues()).hasSize(4);
         assertThat(entry.getNewValues().get(0).getColumnName()).isEqualTo("COL1");
         assertThat(entry.getNewValues().get(0).getColumnData()).isEqualTo("1");
         assertThat(entry.getNewValues().get(1).getColumnName()).isEqualTo("COL2");
         assertThat(entry.getNewValues().get(1).getColumnData()).isNull();
         assertThat(entry.getNewValues().get(2).getColumnName()).isEqualTo("COL3");
         assertThat(entry.getNewValues().get(2).getColumnData()).isEqualTo("Hello");
+        assertThat(entry.getNewValues().get(3).getColumnName()).isEqualTo("UNUSED");
+        assertThat(entry.getNewValues().get(3).getColumnData()).isNull();
     }
 
     @Test
     @FixFor("DBZ-3235")
     public void testParsingDeleteWithNoWhereClauseIsAcceptable() throws Exception {
+        final Table table = Table.editor()
+                .tableId(TableId.parse("DEBEZIUM.TEST"))
+                .addColumn(Column.editor().name("COL1").create())
+                .addColumn(Column.editor().name("COL2").create())
+                .addColumn(Column.editor().name("COL3").create())
+                .addColumn(Column.editor().name("UNUSED").create())
+                .create();
+
         String sql = "delete from \"DEBEZIUM\".\"TEST\";";
 
-        LogMinerDmlEntry entry = fastDmlParser.parse(sql, null, null, null);
+        LogMinerDmlEntry entry = fastDmlParser.parse(sql, table, null);
         assertThat(entry.getCommandType()).isEqualTo(Operation.DELETE);
         assertThat(entry.getOldValues()).isEmpty();
         assertThat(entry.getNewValues()).isEmpty();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/OracleDmlParserTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/OracleDmlParserTest.java
@@ -38,6 +38,7 @@ import io.debezium.connector.oracle.logminer.valueholder.LogMinerDmlEntry;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.data.Envelope;
 import io.debezium.doc.FixFor;
+import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
 import io.debezium.util.IoUtil;
@@ -100,7 +101,7 @@ public class OracleDmlParserTest {
         LogMinerDmlEntry record = antlrDmlParser.getDmlEntry();
         verifyUpdate(record, false, true, 9);
 
-        record = sqlDmlParser.parse(dml, tables, TABLE_ID, "1");
+        record = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "1");
         verifyUpdate(record, false, true, 9);
     }
 
@@ -138,7 +139,7 @@ public class OracleDmlParserTest {
     private void parseDate(String format, boolean validateDate) {
         String dml = "update \"" + FULL_TABLE_NAME + "\" a set a.\"col7\" = " + format + ", a.\"col13\" = " + format + " where a.ID = 1;";
 
-        LogMinerDmlEntry record = sqlDmlParser.parse(dml, tables, TABLE_ID, "1");
+        LogMinerDmlEntry record = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "1");
         assertThat(record).isNotNull();
         assertThat(record.getNewValues()).isNotEmpty();
         assertThat(record.getOldValues()).isNotEmpty();
@@ -156,7 +157,7 @@ public class OracleDmlParserTest {
                 "and a.COL3 = 'text' and a.COL4 IS NULL and a.\"COL5\" IS NULL and a.COL6 IS NULL " +
                 "and a.COL8 = " + format + " and a.col11 is null;";
 
-        LogMinerDmlEntry record = sqlDmlParser.parse(dml, tables, TABLE_ID, "1");
+        LogMinerDmlEntry record = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "1");
         assertThat(record.getNewValues()).isNotEmpty();
         assertThat(record.getOldValues()).isNotEmpty();
 
@@ -176,7 +177,7 @@ public class OracleDmlParserTest {
         LogMinerDmlEntry record = antlrDmlParser.getDmlEntry();
         verifyInsert(record);
 
-        record = sqlDmlParser.parse(dml, tables, TABLE_ID, "1");
+        record = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "1");
         verifyInsert(record);
     }
 
@@ -192,7 +193,7 @@ public class OracleDmlParserTest {
         LogMinerDmlEntry record = antlrDmlParser.getDmlEntry();
         verifyDelete(record, true);
 
-        record = sqlDmlParser.parse(dml, tables, TABLE_ID, "1");
+        record = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "1");
         verifyDelete(record, true);
     }
 
@@ -211,7 +212,7 @@ public class OracleDmlParserTest {
         LogMinerDmlEntry record = antlrDmlParser.getDmlEntry();
         verifyUpdate(record, false, false, 9);
 
-        record = sqlDmlParser.parse(dml, tables, TABLE_ID, "1");
+        record = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "1");
         verifyUpdate(record, false, false, 9);
 
         dml = "delete from \"" + FULL_TABLE_NAME + "\" a ";
@@ -219,7 +220,7 @@ public class OracleDmlParserTest {
         record = antlrDmlParser.getDmlEntry();
         verifyDelete(record, false);
 
-        record = sqlDmlParser.parse(dml, tables, TABLE_ID, "1");
+        record = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "1");
         verifyDelete(record, false);
     }
 
@@ -235,7 +236,7 @@ public class OracleDmlParserTest {
         LogMinerDmlEntry record = antlrDmlParser.getDmlEntry();
         verifyInsert(record);
 
-        record = sqlDmlParser.parse(dml, tables, TABLE_ID, "1");
+        record = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "1");
         verifyInsert(record);
 
         dml = "delete from \"" + FULL_TABLE_NAME +
@@ -245,7 +246,7 @@ public class OracleDmlParserTest {
         record = antlrDmlParser.getDmlEntry();
         verifyDelete(record, true);
 
-        record = sqlDmlParser.parse(dml, tables, TABLE_ID, "");
+        record = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "");
         verifyDelete(record, true);
     }
 
@@ -266,7 +267,7 @@ public class OracleDmlParserTest {
         LogMinerDmlEntry record = antlrDmlParser.getDmlEntry();
         // verifyUpdate(record, true, true);
 
-        record = sqlDmlParser.parse(dml, tables, TABLE_ID, "");
+        record = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "");
         verifyUpdate(record, true, true, 11);
 
         dml = "update \"" + FULL_TABLE_NAME
@@ -276,7 +277,7 @@ public class OracleDmlParserTest {
                 "and COL3 = 'text' and COL4 IS NULL and \"COL5\" IS NULL and COL6 IS NULL " +
                 "and COL8 = TO_TIMESTAMP('2019-05-14 02:28:32') and col11 = " + SPATIAL_DATA + ";";
 
-        record = sqlDmlParser.parse(dml, tables, TABLE_ID, "");
+        record = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "");
     }
 
     @Test
@@ -291,7 +292,7 @@ public class OracleDmlParserTest {
                 +
                 "and COL8 = TO_TIMESTAMP('2019-05-14 02:28:32') and col11 = " + SPATIAL_DATA + ";";
 
-        LogMinerDmlEntry record = sqlDmlParser.parse(dml, tables, TABLE_ID, "");
+        LogMinerDmlEntry record = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "");
         boolean pass = record.getCommandType().equals(Envelope.Operation.UPDATE)
                 && record.getOldValues().size() == record.getNewValues().size()
                 && record.getNewValues().containsAll(record.getOldValues());
@@ -310,7 +311,7 @@ public class OracleDmlParserTest {
         antlrDmlParser.parse(dml, tables);
         assertThat(antlrDmlParser.getDmlEntry()).isNotNull();
 
-        LogMinerDmlEntry result = sqlDmlParser.parse(dml, tables, TABLE_ID, "1");
+        LogMinerDmlEntry result = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "1");
         assertThat(result).isNotNull();
         LogMinerColumnValue value = result.getNewValues().get(2);
         assertThat(value.getColumnData().toString()).contains("\\");
@@ -321,7 +322,7 @@ public class OracleDmlParserTest {
         antlrDmlParser.parse(dml, tables);
         assertThat(antlrDmlParser.getDmlEntry()).isNotNull();
 
-        result = sqlDmlParser.parse(dml, tables, TABLE_ID, "");
+        result = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "");
         assertThat(result).isNotNull();
         value = result.getOldValues().get(3);
         assertThat(value.getColumnData().toString()).contains("\\");
@@ -332,42 +333,42 @@ public class OracleDmlParserTest {
         String createStatement = IoUtil.read(IoUtil.getResourceAsStream("ddl/create_table.sql", null, getClass(), null, null));
         ddlParser.parse(createStatement, tables);
         String dml = null;
-        LogMinerDmlEntry result = sqlDmlParser.parse(dml, tables, TABLE_ID, "");
+        LogMinerDmlEntry result = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "");
         assertThat(result).isNull();
         dml = "select * from test;null;";
-        assertDmlParserException(dml, sqlDmlParser, tables, TABLE_ID, "");
+        assertDmlParserException(dml, sqlDmlParser, tables.forTable(TABLE_ID), "");
         assertThat(result).isNull();
         dml = "full dummy mess";
-        assertDmlParserException(dml, sqlDmlParser, tables, TABLE_ID, "");
+        assertDmlParserException(dml, sqlDmlParser, tables.forTable(TABLE_ID), "");
         dml = "delete from non_exiting_table " +
                 " where id = 6 and col1 = 2 and col2 = 'te\\xt' and col3 = 'tExt\\' and col4 is null and col5 is null " +
                 " and col6 is null and col8 is null and col9 is null and col10 is null and col11 is null and col12 is null";
-        assertDmlParserException(dml, sqlDmlParser, tables, TABLE_ID, "");
+        assertDmlParserException(dml, sqlDmlParser, tables.forTable(TABLE_ID), "");
 
         Update update = mock(Update.class);
         Mockito.when(update.getTables()).thenReturn(new ArrayList<>());
         dml = "update  \"" + FULL_TABLE_NAME + "\" set col1 = 3 " +
                 " where id = 6 and col1 = 2 and col2 = 'te\\xt' and col3 = 'tExt\\' and col4 is null and col5 is null " +
                 " and col6 is null and col8 is null and col9 is null and col10 is null and col11 is null and col12 is null and col20 is null";
-        result = sqlDmlParser.parse(dml, tables, TABLE_ID, "");
+        result = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "");
         assertThat(result.getOldValues().size()).isEqualTo(12);
         assertThat(result.getOldValues().size() == 12).isTrue();
 
         dml = "update \"" + FULL_TABLE_NAME + "\" set col1 = 3 " +
                 " where id = 6 and col1 = 2 and col2 = 'te\\xt' and col30 = 'tExt\\' and col4 is null and col5 is null " +
                 " and col6 is null and col8 is null and col9 is null and col10 is null and col11 is null and col21 is null";
-        result = sqlDmlParser.parse(dml, tables, TABLE_ID, "");
+        result = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "");
         assertThat(result.getNewValues().size()).isEqualTo(14);
 
         dml = "update table1, \"" + FULL_TABLE_NAME + "\" set col1 = 3 " +
                 " where id = 6 and col1 = 2 and col2 = 'te\\xt' and col3 = 'tExt\\' and col4 is null and col5 is null " +
                 " and col6 is null and col8 is null and col9 is null and col10 is null and col11 is null and col12 is null and col20 is null";
-        assertDmlParserException(dml, sqlDmlParser, tables, TABLE_ID, "");
+        assertDmlParserException(dml, sqlDmlParser, tables.forTable(TABLE_ID), "");
     }
 
-    private void assertDmlParserException(String sql, DmlParser parser, Tables tables, TableId tableId, String txId) {
+    private void assertDmlParserException(String sql, DmlParser parser, Table table, String txId) {
         try {
-            LogMinerDmlEntry dml = parser.parse(sql, tables, tableId, txId);
+            LogMinerDmlEntry dml = parser.parse(sql, table, txId);
         }
         catch (Exception e) {
             assertThat(e).isInstanceOf(DmlParserException.class);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/ValueHolderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/ValueHolderTest.java
@@ -83,7 +83,7 @@ public class ValueHolderTest {
         ddlParser.parse(createStatement, tables);
 
         String dml = "insert into \"" + FULL_TABLE_NAME + "\"  (\"column1\",\"column2\") values ('5','Text');";
-        LogMinerDmlEntry dmlEntryParsed = sqlDmlParser.parse(dml, tables, TABLE_ID, "1");
+        LogMinerDmlEntry dmlEntryParsed = sqlDmlParser.parse(dml, tables.forTable(TABLE_ID), "1");
 
         assertThat(dmlEntryParsed.equals(dmlEntryExpected)).isTrue();
         assertThat(dmlEntryExpected.getCommandType() == Envelope.Operation.CREATE).isTrue();


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3257

* Snapshot now emits clob/nclob values correctly (all adapters)
* Fixed bug with LogMiner emitting clob/nclob values when using new parser