### PR TITLE
DBZ-3259 Remove references to upstream docker setup

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1326,8 +1326,9 @@ The administrator must then enable CDC for each table that you want Debezium to 
 
 .Prerequisites
 
-* On the server where Db2 is running, the content in `debezium-connector-db2/src/test/docker/db2-cdc-docker` is available in the `$HOME/asncdctools/src` directory.
-* You are logged in as the `db2instl` user, which is the default instance and user name when using the Db2 docker container image.
+* You are logged in to Db2 as the `db2instl` user.
+* On the Db2 host, the Debezium management UDFs are available in the $HOME/asncdctools/src directory.
+ UDFs are available from the link:https://github.com/debezium/debezium-examples/tree/master/tutorial/debezium-db2-init/db2server[Debezium examples repository].
 
 .Procedure
 


### PR DESCRIPTION
Jira [DBZ-3259](https://issues.redhat.com/browse/DBZ-3259)

This change updates the Db2 connector doc to remove references to the Db2 docker container image, and apply standard prerequisites section formatting.