### PR TITLE
DBZ-3272 adjust positions of delimiters for product conditionals

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -38,9 +38,7 @@ endif::community[]
 
 ifdef::product[]
 The Db2 connector has been tested with Db2/Linux {db2-version}.
-endif::product[]
 
-ifdef::product[]
 Information and procedures for using a {prodname} Db2 connector is organized as follows:
 
 * xref:overview-of-debezium-db2-connector[]
@@ -1524,7 +1522,9 @@ To deploy a {prodname} Db2 connector, install the {prodname} Db2 connector archi
 * xref:debezium-db2-connector-configuration-example[]
 * xref:adding-debezium-db2-connector-configuration-to-kafka-connect[]
 * xref:descriptions-of-debezium-db2-connector-configuration-properties[]
+endif::product[]
 
+ifdef::product[]
 // Type: concept
 [id="steps-for-installing-debezium-db2-connectors"]
 === Steps for installing {prodname} Db2 connectors


### PR DESCRIPTION
Jira [DBZ-3272](https://issues.redhat.com/browse/DBZ-3272)

There ifdef/endif delimiters that enclose conditonal text in `db2.adoc` appear to be causing some problems for the splitter utility that breaks the upstream files into modular files when they're fetched to the downstream repo.

I updated the following instances where text is conditionalized for downstream-only use:

- Merged a pair of delimiters for the `product` conditional that were applied in succession (Lines 39 -54)
- Broke one set of delimiters that spanned topic boundaries into two separate sets (Lines 1518-1552).

I applied the change downstream already, and it remedied the problem. This change should be backported to the 1.4 branch to avoid regressions in case there's a need to refresh content. 
 