### PR TITLE
DBZ-3278 Retry on MongoDB timeouts

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbErrorHandler.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbErrorHandler.java
@@ -24,7 +24,9 @@ public class MongoDbErrorHandler extends ErrorHandler {
         if (throwable instanceof org.apache.kafka.connect.errors.ConnectException) {
             Throwable cause = throwable.getCause();
             while ((cause != null) && (cause != throwable)) {
-                if (cause instanceof com.mongodb.MongoSocketException) {
+                if (cause instanceof com.mongodb.MongoSocketException ||
+                        cause instanceof com.mongodb.MongoTimeoutException ||
+                        cause instanceof com.mongodb.MongoExecutionTimeoutException) {
                     return true;
                 }
                 else {


### PR DESCRIPTION
When connecting to the server or executing some queries, due to
networking issues, timeouts sometimes occur which would crash the whole
connector. By including a few extra exceptions in the error handler we
make sure it will retry in these situations.

I couldn't find any unit tests for this but let me know if something in the integration tests could be added.

Fixes https://issues.redhat.com/browse/DBZ-3278