### PR TITLE
DBZ-3295 Restrict all LogMiner results to specified SCN boundary

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
@@ -230,7 +230,7 @@ public class SqlUtils {
         query.append("(OPERATION_CODE IN (5,34) AND USERNAME NOT IN (").append(getExcludedUsers(logMinerUser)).append(")) ");
         // COMMIT/ROLLBACK
         query.append("OR (OPERATION_CODE IN (7,36)) ");
-        // INSERT/UPDATE/DELETE/DDL
+        // INSERT/UPDATE/DELETE
         query.append("OR ");
         query.append("(OPERATION_CODE IN (1,2,3) ");
         query.append("AND TABLE_NAME != '").append(LOGMNR_FLUSH_TABLE).append("' ");

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/SqlUtilsTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/SqlUtilsTest.java
@@ -34,13 +34,15 @@ public class SqlUtilsTest {
 
     private static final String LOG_MINER_CONTENT_QUERY_TEMPLATE = "SELECT SCN, SQL_REDO, OPERATION_CODE, TIMESTAMP, " +
             "XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, USERNAME " +
-            "FROM V$LOGMNR_CONTENTS WHERE OPERATION_CODE IN (1,2,3,5) AND SCN > ? AND SCN < ? " +
+            "FROM V$LOGMNR_CONTENTS WHERE SCN > ? AND SCN <= ? AND ((" +
+            "OPERATION_CODE IN (5,34) AND USERNAME NOT IN ('SYS','SYSTEM','${user}')) " +
+            "OR (OPERATION_CODE IN (7,36)) " +
+            "OR (OPERATION_CODE IN (1,2,3) " +
             "AND TABLE_NAME != '" + SqlUtils.LOGMNR_FLUSH_TABLE + "' " +
             "${systemTablePredicate}" +
             "${schemaPredicate}" +
             "${tablePredicate}" +
-            "OR (OPERATION_CODE IN (5,34) AND USERNAME NOT IN ('SYS','SYSTEM','${user}')) " +
-            "OR (OPERATION_CODE IN (7,36))";
+            "))";
 
     private static final String USERNAME = "USERNAME";
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3295

It was brought to our attention that certain operations such as COMMIT, ROLLBACK, MISSING_SCN, and DDL were not scoped to the defined SCN [start,end] window.  Additionally, the original change for DBZ-2875 in Beta2 would eventually lead to a situation where an event could be missed due to the SCN boundary being used in the LogMiner query.  Both of these have been addressed in this PR which should ultimately conclude changes needed for DBZ-2875.