### PR TITLE
DBZ-2457 DBZ-2994 SCN rework

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -30,7 +30,6 @@ import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.connector.oracle.logminer.HistoryRecorder;
 import io.debezium.connector.oracle.logminer.NeverHistoryRecorder;
-import io.debezium.connector.oracle.logminer.Scn;
 import io.debezium.connector.oracle.logminer.SqlUtils;
 import io.debezium.connector.oracle.xstream.LcrPosition;
 import io.debezium.connector.oracle.xstream.OracleVersion;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -512,11 +512,12 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
 
             private Scn resolveScn(Document document) {
                 // prioritize reading scn as string and if not found, fallback to long data types
-                if (document.getString(SourceInfo.SCN_KEY) == null) {
+                final String scn = document.getString(SourceInfo.SCN_KEY);
+                if (scn == null) {
                     Long scnValue = document.getLong(SourceInfo.SCN_KEY);
                     Scn.valueOf(scnValue == null ? 0 : scnValue);
                 }
-                return Scn.valueOf(document.getString(SourceInfo.SCN_KEY));
+                return Scn.valueOf(scn);
             }
         };
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleEventMetadataProvider.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleEventMetadataProvider.java
@@ -40,9 +40,8 @@ class OracleEventMetadataProvider implements EventMetadataProvider {
         if (source == null) {
             return null;
         }
-        final Long scn = sourceInfo.getInt64(SourceInfo.SCN_KEY);
-        return Collect.hashMapOf(
-                SourceInfo.SCN_KEY, scn == null ? "null" : Long.toString(scn));
+        final String scn = sourceInfo.getString(SourceInfo.SCN_KEY);
+        return Collect.hashMapOf(SourceInfo.SCN_KEY, scn == null ? "null" : scn);
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleOffsetContext.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleOffsetContext.java
@@ -14,7 +14,6 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
 import io.debezium.connector.SnapshotRecord;
-import io.debezium.connector.oracle.logminer.Scn;
 import io.debezium.connector.oracle.xstream.LcrPosition;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.txmetadata.TransactionContext;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleOffsetContext.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleOffsetContext.java
@@ -120,7 +120,8 @@ public class OracleOffsetContext implements OffsetContext {
         if (sourceInfo.isSnapshot()) {
             Map<String, Object> offset = new HashMap<>();
 
-            offset.put(SourceInfo.SCN_KEY, sourceInfo.getScn());
+            final Scn scn = sourceInfo.getScn();
+            offset.put(SourceInfo.SCN_KEY, scn != null ? scn.toString() : scn);
             offset.put(SourceInfo.SNAPSHOT_KEY, true);
             offset.put(SNAPSHOT_COMPLETED_KEY, snapshotCompleted);
 
@@ -132,8 +133,10 @@ public class OracleOffsetContext implements OffsetContext {
                 offset.put(SourceInfo.LCR_POSITION_KEY, sourceInfo.getLcrPosition().toString());
             }
             else {
-                offset.put(SourceInfo.SCN_KEY, sourceInfo.getScn());
-                offset.put(SourceInfo.COMMIT_SCN_KEY, sourceInfo.getCommitScn());
+                final Scn scn = sourceInfo.getScn();
+                final Scn commitScn = sourceInfo.getCommitScn();
+                offset.put(SourceInfo.SCN_KEY, scn != null ? scn.toString() : null);
+                offset.put(SourceInfo.COMMIT_SCN_KEY, commitScn != null ? commitScn.toString() : null);
             }
             return transactionContext.store(offset);
         }
@@ -157,11 +160,11 @@ public class OracleOffsetContext implements OffsetContext {
         sourceInfo.setCommitScn(commitScn);
     }
 
-    public String getScn() {
+    public Scn getScn() {
         return sourceInfo.getScn();
     }
 
-    public String getCommitScn() {
+    public Scn getCommitScn() {
         return sourceInfo.getCommitScn();
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -280,7 +280,7 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
     @Override
     protected Optional<String> getSnapshotSelect(RelationalSnapshotContext snapshotContext, TableId tableId) {
         final OracleOffsetContext offset = (OracleOffsetContext) snapshotContext.offset;
-        final String snapshotOffset = offset.getScn();
+        final String snapshotOffset = offset.getScn().toString();
         assert snapshotOffset != null;
         return Optional.of("SELECT * FROM " + quote(tableId) + " AS OF SCN " + snapshotOffset);
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -18,7 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.oracle.logminer.LogMinerHelper;
-import io.debezium.connector.oracle.logminer.Scn;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -123,7 +123,7 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
 
         ctx.offset = OracleOffsetContext.create()
                 .logicalName(connectorConfig)
-                .scn(currentScn.longValue())
+                .scn(currentScn)
                 .transactionContext(new TransactionContext())
                 .build();
     }
@@ -280,7 +280,9 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
 
     @Override
     protected Optional<String> getSnapshotSelect(RelationalSnapshotContext snapshotContext, TableId tableId) {
-        long snapshotOffset = (Long) snapshotContext.offset.getOffset().get("scn");
+        final OracleOffsetContext offset = (OracleOffsetContext) snapshotContext.offset;
+        final String snapshotOffset = offset.getScn();
+        assert snapshotOffset != null;
         return Optional.of("SELECT * FROM " + quote(tableId) + " AS OF SCN " + snapshotOffset);
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSourceInfoStructMaker.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSourceInfoStructMaker.java
@@ -25,6 +25,8 @@ public class OracleSourceInfoStructMaker extends AbstractSourceInfoStructMaker<S
                 .field(SourceInfo.SCN_KEY, Schema.OPTIONAL_INT64_SCHEMA)
                 .field(SourceInfo.COMMIT_SCN_KEY, Schema.OPTIONAL_INT64_SCHEMA)
                 .field(SourceInfo.LCR_POSITION_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                .field(SourceInfo.SCN2_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                .field(SourceInfo.COMMIT2_SCN_KEY, Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
     }
 
@@ -39,13 +41,15 @@ public class OracleSourceInfoStructMaker extends AbstractSourceInfoStructMaker<S
                 .put(SourceInfo.SCHEMA_NAME_KEY, sourceInfo.getTableId().schema())
                 .put(SourceInfo.TABLE_NAME_KEY, sourceInfo.getTableId().table())
                 .put(SourceInfo.TXID_KEY, sourceInfo.getTransactionId())
-                .put(SourceInfo.SCN_KEY, sourceInfo.getScn());
+                .put(SourceInfo.SCN_KEY, sourceInfo.getScn() != null ? Long.parseLong(sourceInfo.getScn()) : 0L)
+                .put(SourceInfo.SCN2_KEY, sourceInfo.getScn());
 
         if (sourceInfo.getLcrPosition() != null) {
             ret.put(SourceInfo.LCR_POSITION_KEY, sourceInfo.getLcrPosition().toString());
         }
         if (sourceInfo.getCommitScn() != null) {
-            ret.put(SourceInfo.COMMIT_SCN_KEY, sourceInfo.getCommitScn());
+            ret.put(SourceInfo.COMMIT_SCN_KEY, sourceInfo.getCommitScn() != null ? Long.parseLong(sourceInfo.getCommitScn()) : 0L);
+            ret.put(SourceInfo.COMMIT2_SCN_KEY, sourceInfo.getCommitScn());
         }
         return ret;
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSourceInfoStructMaker.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSourceInfoStructMaker.java
@@ -35,17 +35,20 @@ public class OracleSourceInfoStructMaker extends AbstractSourceInfoStructMaker<S
 
     @Override
     public Struct struct(SourceInfo sourceInfo) {
+        final String scn = sourceInfo.getScn() == null ? null : sourceInfo.getScn().toString();
+        final String commitScn = sourceInfo.getCommitScn() == null ? null : sourceInfo.getCommitScn().toString();
+
         final Struct ret = super.commonStruct(sourceInfo)
                 .put(SourceInfo.SCHEMA_NAME_KEY, sourceInfo.getTableId().schema())
                 .put(SourceInfo.TABLE_NAME_KEY, sourceInfo.getTableId().table())
                 .put(SourceInfo.TXID_KEY, sourceInfo.getTransactionId())
-                .put(SourceInfo.SCN_KEY, sourceInfo.getScn());
+                .put(SourceInfo.SCN_KEY, scn);
 
         if (sourceInfo.getLcrPosition() != null) {
             ret.put(SourceInfo.LCR_POSITION_KEY, sourceInfo.getLcrPosition().toString());
         }
-        if (sourceInfo.getCommitScn() != null) {
-            ret.put(SourceInfo.COMMIT_SCN_KEY, sourceInfo.getCommitScn());
+        if (commitScn != null) {
+            ret.put(SourceInfo.COMMIT_SCN_KEY, commitScn);
         }
         return ret;
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSourceInfoStructMaker.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSourceInfoStructMaker.java
@@ -22,11 +22,9 @@ public class OracleSourceInfoStructMaker extends AbstractSourceInfoStructMaker<S
                 .field(SourceInfo.SCHEMA_NAME_KEY, Schema.STRING_SCHEMA)
                 .field(SourceInfo.TABLE_NAME_KEY, Schema.STRING_SCHEMA)
                 .field(SourceInfo.TXID_KEY, Schema.OPTIONAL_STRING_SCHEMA)
-                .field(SourceInfo.SCN_KEY, Schema.OPTIONAL_INT64_SCHEMA)
-                .field(SourceInfo.COMMIT_SCN_KEY, Schema.OPTIONAL_INT64_SCHEMA)
+                .field(SourceInfo.SCN_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                .field(SourceInfo.COMMIT_SCN_KEY, Schema.OPTIONAL_STRING_SCHEMA)
                 .field(SourceInfo.LCR_POSITION_KEY, Schema.OPTIONAL_STRING_SCHEMA)
-                .field(SourceInfo.SCN2_KEY, Schema.OPTIONAL_STRING_SCHEMA)
-                .field(SourceInfo.COMMIT2_SCN_KEY, Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
     }
 
@@ -41,15 +39,13 @@ public class OracleSourceInfoStructMaker extends AbstractSourceInfoStructMaker<S
                 .put(SourceInfo.SCHEMA_NAME_KEY, sourceInfo.getTableId().schema())
                 .put(SourceInfo.TABLE_NAME_KEY, sourceInfo.getTableId().table())
                 .put(SourceInfo.TXID_KEY, sourceInfo.getTransactionId())
-                .put(SourceInfo.SCN_KEY, sourceInfo.getScn() != null ? Long.parseLong(sourceInfo.getScn()) : 0L)
-                .put(SourceInfo.SCN2_KEY, sourceInfo.getScn());
+                .put(SourceInfo.SCN_KEY, sourceInfo.getScn());
 
         if (sourceInfo.getLcrPosition() != null) {
             ret.put(SourceInfo.LCR_POSITION_KEY, sourceInfo.getLcrPosition().toString());
         }
         if (sourceInfo.getCommitScn() != null) {
-            ret.put(SourceInfo.COMMIT_SCN_KEY, sourceInfo.getCommitScn() != null ? Long.parseLong(sourceInfo.getCommitScn()) : 0L);
-            ret.put(SourceInfo.COMMIT2_SCN_KEY, sourceInfo.getCommitScn());
+            ret.put(SourceInfo.COMMIT_SCN_KEY, sourceInfo.getCommitScn());
         }
         return ret;
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/Scn.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/Scn.java
@@ -16,24 +16,26 @@ import java.util.Objects;
 public class Scn implements Comparable<Scn> {
 
     /**
-     * Represents an Scn that is considered INVALID, useful as a placeholder.
-     */
-    public static final Scn INVALID = new Scn(BigInteger.valueOf(-1));
-
-    /**
      * Represents an Scn that implies the maximum possible value of an SCN, useful as a placeholder.
      */
     public static final Scn MAX = new Scn(BigInteger.valueOf(-2));
 
     /**
-     * Represents an Scn with a value of {@code 0}.
+     * Represents an Scn without a value.
      */
-    public static final Scn ZERO = new Scn(BigInteger.ZERO);
+    public static final Scn NULL = new Scn(null);
 
     private final BigInteger scn;
 
     public Scn(BigInteger scn) {
         this.scn = scn;
+    }
+
+    /**
+     * Returns whether this {@link Scn} is null and contains no value.
+     */
+    public boolean isNull() {
+        return this.scn == null;
     }
 
     /**
@@ -59,7 +61,7 @@ public class Scn implements Comparable<Scn> {
     /**
      * Construct a {@link Scn} from a string value.
      *
-     * @param value string value
+     * @param value string value, should not be null
      * @return instance of Scn
      */
     public static Scn valueOf(String value) {
@@ -70,7 +72,7 @@ public class Scn implements Comparable<Scn> {
      * Get the Scn represented as a {@code long} data type.
      */
     public long longValue() {
-        return scn.longValue();
+        return isNull() ? 0 : scn.longValue();
     }
 
     /**
@@ -80,6 +82,15 @@ public class Scn implements Comparable<Scn> {
      * @return {@code this + value}
      */
     public Scn add(Scn value) {
+        if (isNull() && value.isNull()) {
+            return Scn.NULL;
+        }
+        else if (value.isNull()) {
+            return new Scn(scn);
+        }
+        else if (isNull()) {
+            return new Scn(value.scn);
+        }
         return new Scn(scn.add(value.scn));
     }
 
@@ -90,17 +101,35 @@ public class Scn implements Comparable<Scn> {
      * @return {@code this - value}
      */
     public Scn subtract(Scn value) {
+        if (isNull() && value.isNull()) {
+            return Scn.NULL;
+        }
+        else if (value.isNull()) {
+            return new Scn(scn);
+        }
+        else if (isNull()) {
+            return new Scn(value.scn.negate());
+        }
         return new Scn(scn.subtract(value.scn));
     }
 
     /**
-     * Compares this {@code SCn} with the specified {@code Scn}.
+     * Compares this {@code Scn} with the specified {@code Scn}.
      *
      * @param o {@code Scn} to which this {@code Scn} is to be compared
      * @return -1, 0, or 1 as this {code Scn} is numerically less than, equal to, or greater than {@code o}.
      */
     @Override
     public int compareTo(Scn o) {
+        if (isNull() && o.isNull()) {
+            return 0;
+        }
+        else if (isNull() && !o.isNull()) {
+            return -1;
+        }
+        else if (!isNull() && o.isNull()) {
+            return 1;
+        }
         return scn.compareTo(o.scn);
     }
 
@@ -123,6 +152,6 @@ public class Scn implements Comparable<Scn> {
 
     @Override
     public String toString() {
-        return scn.toString();
+        return isNull() ? "null" : scn.toString();
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/Scn.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/Scn.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.connector.oracle.logminer;
+package io.debezium.connector.oracle;
 
 import java.math.BigInteger;
 import java.util.Objects;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/SourceInfo.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/SourceInfo.java
@@ -17,12 +17,14 @@ public class SourceInfo extends BaseSourceInfo {
 
     public static final String TXID_KEY = "txId";
     public static final String SCN_KEY = "scn";
+    public static final String SCN2_KEY = "scn2";
     public static final String COMMIT_SCN_KEY = "commit_scn";
+    public static final String COMMIT2_SCN_KEY = "commit2_scn";
     public static final String LCR_POSITION_KEY = "lcr_position";
     public static final String SNAPSHOT_KEY = "snapshot";
 
-    private long scn;
-    private Long commitScn;
+    private String scn;
+    private String commitScn;
     private LcrPosition lcrPosition;
     private String transactionId;
     private Instant sourceTime;
@@ -32,19 +34,19 @@ public class SourceInfo extends BaseSourceInfo {
         super(connectorConfig);
     }
 
-    public long getScn() {
+    public String getScn() {
         return scn;
     }
 
-    public Long getCommitScn() {
+    public String getCommitScn() {
         return commitScn;
     }
 
-    public void setScn(long scn) {
+    public void setScn(String scn) {
         this.scn = scn;
     }
 
-    public void setCommitScn(Long commitScn) {
+    public void setCommitScn(String commitScn) {
         this.commitScn = commitScn;
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/SourceInfo.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/SourceInfo.java
@@ -17,9 +17,7 @@ public class SourceInfo extends BaseSourceInfo {
 
     public static final String TXID_KEY = "txId";
     public static final String SCN_KEY = "scn";
-    public static final String SCN2_KEY = "scn2";
     public static final String COMMIT_SCN_KEY = "commit_scn";
-    public static final String COMMIT2_SCN_KEY = "commit2_scn";
     public static final String LCR_POSITION_KEY = "lcr_position";
     public static final String SNAPSHOT_KEY = "snapshot";
 
@@ -42,12 +40,20 @@ public class SourceInfo extends BaseSourceInfo {
         return commitScn;
     }
 
-    public void setScn(String scn) {
-        this.scn = scn;
+    public void setScn(Scn scn) {
+        if (scn == null) {
+            this.scn = null;
+            return;
+        }
+        this.scn = scn.toString();
     }
 
-    public void setCommitScn(String commitScn) {
-        this.commitScn = commitScn;
+    public void setCommitScn(Scn commitScn) {
+        if (commitScn == null) {
+            this.commitScn = null;
+            return;
+        }
+        this.commitScn = commitScn.toString();
     }
 
     public LcrPosition getLcrPosition() {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/SourceInfo.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/SourceInfo.java
@@ -21,8 +21,8 @@ public class SourceInfo extends BaseSourceInfo {
     public static final String LCR_POSITION_KEY = "lcr_position";
     public static final String SNAPSHOT_KEY = "snapshot";
 
-    private String scn;
-    private String commitScn;
+    private Scn scn;
+    private Scn commitScn;
     private LcrPosition lcrPosition;
     private String transactionId;
     private Instant sourceTime;
@@ -32,28 +32,20 @@ public class SourceInfo extends BaseSourceInfo {
         super(connectorConfig);
     }
 
-    public String getScn() {
+    public Scn getScn() {
         return scn;
     }
 
-    public String getCommitScn() {
+    public Scn getCommitScn() {
         return commitScn;
     }
 
     public void setScn(Scn scn) {
-        if (scn == null) {
-            this.scn = null;
-            return;
-        }
-        this.scn = scn.toString();
+        this.scn = scn;
     }
 
     public void setCommitScn(Scn commitScn) {
-        if (commitScn == null) {
-            this.commitScn = null;
-            return;
-        }
-        this.commitScn = commitScn.toString();
+        this.commitScn = commitScn;
     }
 
     public LcrPosition getLcrPosition() {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/HistoryRecorder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/HistoryRecorder.java
@@ -8,6 +8,7 @@ package io.debezium.connector.oracle.logminer;
 import java.sql.Timestamp;
 
 import io.debezium.common.annotation.Incubating;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.jdbc.JdbcConfiguration;
 
 /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogFile.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogFile.java
@@ -7,6 +7,8 @@ package io.debezium.connector.oracle.logminer;
 
 import java.util.Objects;
 
+import io.debezium.connector.oracle.Scn;
+
 /**
  * Represents a redo or archive log in Oracle.
  *

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
@@ -518,7 +518,7 @@ public class LogMinerHelper {
      * @param transactionRetention duration to tolerate long running transactions
      * @return optional SCN as a watermark for abandonment
      */
-    public static Optional<Long> getLastScnToAbandon(OracleConnection connection, Long offsetScn, Duration transactionRetention) {
+    public static Optional<Scn> getLastScnToAbandon(OracleConnection connection, Scn offsetScn, Duration transactionRetention) {
         try {
             String query = SqlUtils.diffInDaysQuery(offsetScn);
             Float diffInDays = (Float) getSingleResult(connection, query, DATATYPE.FLOAT);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
@@ -32,6 +32,7 @@ import io.debezium.DebeziumException;
 import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.TableId;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerMetrics.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerMetrics.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.metrics.Metrics;
 
 /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerMetrics.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerMetrics.java
@@ -195,8 +195,8 @@ public class LogMinerMetrics extends Metrics implements LogMinerMetricsMXBean {
     }
 
     @Override
-    public Long getCurrentScn() {
-        return currentScn.get().longValue();
+    public String getCurrentScn() {
+        return currentScn.get().toString();
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerMetrics.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerMetrics.java
@@ -79,7 +79,7 @@ public class LogMinerMetrics extends Metrics implements LogMinerMetricsMXBean {
     LogMinerMetrics(CdcSourceTaskContext taskContext, OracleConnectorConfig connectorConfig) {
         super(taskContext, "log-miner");
 
-        currentScn.set(Scn.INVALID);
+        currentScn.set(Scn.NULL);
         currentLogFileName = new AtomicReference<>();
         minimumLogsMined.set(0L);
         maximumLogsMined.set(0L);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerMetricsMXBean.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerMetricsMXBean.java
@@ -13,7 +13,7 @@ public interface LogMinerMetricsMXBean {
     /**
      * @return the current system change number of the database
      */
-    Long getCurrentScn();
+    String getCurrentScn();
 
     /**
      * @return array of current filenames to be used by the mining session.

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
@@ -238,9 +238,9 @@ class LogMinerQueryResultProcessor {
             metrics.setLastDurationOfBatchProcessing(totalTime);
 
             warnStuckScn();
-            currentOffsetScn = Scn.valueOf(offsetContext.getScn());
+            currentOffsetScn = offsetContext.getScn();
             if (offsetContext.getCommitScn() != null) {
-                currentOffsetCommitScn = Scn.valueOf(offsetContext.getCommitScn());
+                currentOffsetCommitScn = offsetContext.getCommitScn();
             }
         }
 
@@ -261,16 +261,16 @@ class LogMinerQueryResultProcessor {
      */
     private void warnStuckScn() {
         if (offsetContext != null && offsetContext.getCommitScn() != null) {
-            final Scn scn = Scn.valueOf(offsetContext.getScn());
-            final Scn commitScn = Scn.valueOf(offsetContext.getCommitScn());
-            if (currentOffsetScn.equals(scn) && !currentOffsetCommitScn.equals(offsetContext.getCommitScn())) {
+            final Scn scn = offsetContext.getScn();
+            final Scn commitScn = offsetContext.getCommitScn();
+            if (currentOffsetScn.equals(scn) && !currentOffsetCommitScn.equals(commitScn)) {
                 stuckScnCounter++;
                 // logWarn only once
                 if (stuckScnCounter == 25) {
                     LogMinerHelper.logWarn(transactionalBufferMetrics,
                             "Offset SCN {} is not changing. It indicates long transaction(s). " +
                                     "Offset commit SCN: {}",
-                            currentOffsetScn, offsetContext.getCommitScn());
+                            currentOffsetScn, commitScn);
                     transactionalBufferMetrics.incrementScnFreezeCounter();
                 }
             }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
@@ -10,7 +10,6 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,8 +54,8 @@ class LogMinerQueryResultProcessor {
     private final OracleConnectorConfig connectorConfig;
     private final Clock clock;
     private final Logger LOGGER = LoggerFactory.getLogger(LogMinerQueryResultProcessor.class);
-    private Scn currentOffsetScn;
-    private Scn currentOffsetCommitScn;
+    private Scn currentOffsetScn = Scn.NULL;
+    private Scn currentOffsetCommitScn = Scn.NULL;
     private long stuckScnCounter = 0;
     private HistoryRecorder historyRecorder;
 
@@ -264,7 +263,7 @@ class LogMinerQueryResultProcessor {
         if (offsetContext != null && offsetContext.getCommitScn() != null) {
             final Scn scn = offsetContext.getScn();
             final Scn commitScn = offsetContext.getCommitScn();
-            if (Objects.equals(currentOffsetScn, scn) && !Objects.equals(currentOffsetCommitScn, commitScn)) {
+            if (currentOffsetScn.equals(scn) && !currentOffsetCommitScn.equals(commitScn)) {
                 stuckScnCounter++;
                 // logWarn only once
                 if (stuckScnCounter == 25) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,8 +55,8 @@ class LogMinerQueryResultProcessor {
     private final OracleConnectorConfig connectorConfig;
     private final Clock clock;
     private final Logger LOGGER = LoggerFactory.getLogger(LogMinerQueryResultProcessor.class);
-    private Scn currentOffsetScn = Scn.ZERO;
-    private Scn currentOffsetCommitScn = Scn.ZERO;
+    private Scn currentOffsetScn;
+    private Scn currentOffsetCommitScn;
     private long stuckScnCounter = 0;
     private HistoryRecorder historyRecorder;
 
@@ -263,7 +264,7 @@ class LogMinerQueryResultProcessor {
         if (offsetContext != null && offsetContext.getCommitScn() != null) {
             final Scn scn = offsetContext.getScn();
             final Scn commitScn = offsetContext.getCommitScn();
-            if (currentOffsetScn.equals(scn) && !currentOffsetCommitScn.equals(commitScn)) {
+            if (Objects.equals(currentOffsetScn, scn) && !Objects.equals(currentOffsetCommitScn, commitScn)) {
                 stuckScnCounter++;
                 // logWarn only once
                 if (stuckScnCounter == 25) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
@@ -20,6 +20,7 @@ import io.debezium.connector.oracle.OracleConnectorConfig.LogMiningDmlParser;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.OracleOffsetContext;
 import io.debezium.connector.oracle.OracleValueConverters;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.logminer.parser.DmlParser;
 import io.debezium.connector.oracle.logminer.parser.DmlParserException;
 import io.debezium.connector.oracle.logminer.parser.LogMinerDmlParser;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -119,7 +119,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
                 LOGGER.trace("Current time {} ms, database difference {} ms", System.currentTimeMillis(), databaseTimeMs);
                 transactionalBuffer.setDatabaseTimeDifference(databaseTimeMs);
 
-                startScn = Scn.valueOf(offsetContext.getScn());
+                startScn = offsetContext.getScn();
                 createFlushTable(jdbcConnection);
 
                 if (!isContinuousMining && startScn.compareTo(getFirstOnlineLogScn(jdbcConnection, archiveLogRetention)) < 0) {
@@ -229,7 +229,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
     private void abandonOldTransactionsIfExist(OracleConnection connection, TransactionalBuffer transactionalBuffer) {
         Duration transactionRetention = connectorConfig.getLogMiningTransactionRetention();
         if (!Duration.ZERO.equals(transactionRetention)) {
-            final Scn offsetScn = Scn.valueOf(offsetContext.getScn());
+            final Scn offsetScn = offsetContext.getScn();
             Optional<Scn> lastScnToAbandonTransactions = getLastScnToAbandon(connection, offsetScn, transactionRetention);
             lastScnToAbandonTransactions.ifPresent(thresholdScn -> {
                 transactionalBuffer.abandonLongTransactions(thresholdScn, offsetContext);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -42,6 +42,7 @@ import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.OracleOffsetContext;
 import io.debezium.connector.oracle.OracleTaskContext;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -185,7 +185,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
 
                                 if (transactionalBuffer.isEmpty()) {
                                     LOGGER.debug("Transactional buffer empty, updating offset's SCN {}", startScn);
-                                    offsetContext.setScn(startScn.longValue());
+                                    offsetContext.setScn(startScn);
                                 }
                             }
 
@@ -228,7 +228,8 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
     private void abandonOldTransactionsIfExist(OracleConnection connection, TransactionalBuffer transactionalBuffer) {
         Duration transactionRetention = connectorConfig.getLogMiningTransactionRetention();
         if (!Duration.ZERO.equals(transactionRetention)) {
-            Optional<Long> lastScnToAbandonTransactions = getLastScnToAbandon(connection, offsetContext.getScn(), transactionRetention);
+            final Scn offsetScn = Scn.valueOf(offsetContext.getScn());
+            Optional<Scn> lastScnToAbandonTransactions = getLastScnToAbandon(connection, offsetScn, transactionRetention);
             lastScnToAbandonTransactions.ifPresent(thresholdScn -> {
                 transactionalBuffer.abandonLongTransactions(thresholdScn, offsetContext);
                 offsetContext.setScn(thresholdScn);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/NeverHistoryRecorder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/NeverHistoryRecorder.java
@@ -7,6 +7,7 @@ package io.debezium.connector.oracle.logminer;
 
 import java.sql.Timestamp;
 
+import io.debezium.connector.oracle.Scn;
 import io.debezium.jdbc.JdbcConfiguration;
 
 /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/RowMapper.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/RowMapper.java
@@ -114,7 +114,7 @@ public class RowMapper {
 
     public static Scn getScn(TransactionalBufferMetrics metrics, ResultSet rs) {
         try {
-            return new Scn(rs.getBigDecimal(SCN));
+            return Scn.valueOf(rs.getString(SCN));
         }
         catch (SQLException e) {
             logError(metrics, e, "SCN");

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/RowMapper.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/RowMapper.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.relational.TableId;
 import io.debezium.util.HexConverter;
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/RowMapper.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/RowMapper.java
@@ -119,7 +119,7 @@ public class RowMapper {
         }
         catch (SQLException e) {
             logError(metrics, e, "SCN");
-            return Scn.INVALID;
+            return Scn.NULL;
         }
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/Scn.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/Scn.java
@@ -5,7 +5,7 @@
  */
 package io.debezium.connector.oracle.logminer;
 
-import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Objects;
 
 /**
@@ -18,22 +18,21 @@ public class Scn implements Comparable<Scn> {
     /**
      * Represents an Scn that is considered INVALID, useful as a placeholder.
      */
-    public static final Scn INVALID = new Scn(new BigDecimal(-1));
+    public static final Scn INVALID = new Scn(BigInteger.valueOf(-1));
 
     /**
      * Represents an Scn that implies the maximum possible value of an SCN, useful as a placeholder.
      */
-    public static final Scn MAX = new Scn(new BigDecimal(-2));
+    public static final Scn MAX = new Scn(BigInteger.valueOf(-2));
 
     /**
      * Represents an Scn with a value of {@code 0}.
      */
-    public static final Scn ZERO = new Scn(BigDecimal.ZERO);
+    public static final Scn ZERO = new Scn(BigInteger.ZERO);
 
-    private final BigDecimal scn;
+    private final BigInteger scn;
 
-    public Scn(BigDecimal scn) {
-        assert scn.scale() == 0;
+    public Scn(BigInteger scn) {
         this.scn = scn;
     }
 
@@ -44,7 +43,7 @@ public class Scn implements Comparable<Scn> {
      * @return instance of Scn
      */
     public static Scn valueOf(int value) {
-        return new Scn(new BigDecimal(value));
+        return new Scn(BigInteger.valueOf(value));
     }
 
     /**
@@ -54,7 +53,7 @@ public class Scn implements Comparable<Scn> {
      * @return instance of Scn
      */
     public static Scn valueOf(long value) {
-        return new Scn(new BigDecimal(value));
+        return new Scn(BigInteger.valueOf(value));
     }
 
     /**
@@ -64,7 +63,7 @@ public class Scn implements Comparable<Scn> {
      * @return instance of Scn
      */
     public static Scn valueOf(String value) {
-        return new Scn(new BigDecimal(value));
+        return new Scn(new BigInteger(value));
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.relational.TableId;
 import io.debezium.util.Strings;
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
@@ -372,11 +372,11 @@ public class SqlUtils {
     /**
      * This method return query which converts given SCN in days and deduct from the current day
      */
-    public static String diffInDaysQuery(Long scn) {
+    public static String diffInDaysQuery(Scn scn) {
         if (scn == null) {
             return null;
         }
-        return "select sysdate - CAST(scn_to_timestamp(" + scn + ") as date) from dual";
+        return "select sysdate - CAST(scn_to_timestamp(" + scn.toString() + ") as date) from dual";
     }
 
     public static boolean connectionProblem(Throwable e) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBuffer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBuffer.java
@@ -138,7 +138,7 @@ public final class TransactionalBuffer implements AutoCloseable {
 
         // On the restarting connector, we start from SCN in the offset. There is possibility to commit a transaction(s) which were already committed.
         // Currently we cannot use ">=", because we may lose normal commit which may happen at the same time. TODO use audit table to prevent duplications
-        if ((offsetContext.getCommitScn() != null && offsetContext.getCommitScn() > scn.longValue()) || lastCommittedScn.longValue() > scn.longValue()) {
+        if ((offsetContext.getCommitScn() != null && Scn.valueOf(offsetContext.getCommitScn()).compareTo(scn) > 0) || lastCommittedScn.compareTo(scn) > 0) {
             LogMinerHelper.logWarn(metrics,
                     "Transaction {} was already processed, ignore. Committed SCN in offset is {}, commit SCN of the transaction is {}, last committed SCN is {}",
                     transactionId, offsetContext.getCommitScn(), scn, lastCommittedScn);
@@ -224,9 +224,9 @@ public final class TransactionalBuffer implements AutoCloseable {
      * @param thresholdScn the smallest SVN of any transaction to keep in the buffer. All others will be removed.
      * @param offsetContext the offset context
      */
-    void abandonLongTransactions(Long thresholdScn, OracleOffsetContext offsetContext) {
+    void abandonLongTransactions(Scn thresholdScn, OracleOffsetContext offsetContext) {
         LogMinerHelper.logWarn(metrics, "All transactions with first SCN <= {} will be abandoned, offset: {}", thresholdScn, offsetContext.getScn());
-        Scn threshold = Scn.valueOf(thresholdScn);
+        Scn threshold = Scn.valueOf(thresholdScn.toString());
         Scn smallestScn = calculateSmallestScn();
         if (smallestScn == null) {
             // no transactions in the buffer

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBuffer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBuffer.java
@@ -57,7 +57,7 @@ public final class TransactionalBuffer implements AutoCloseable {
     TransactionalBuffer(OracleTaskContext taskContext, ErrorHandler errorHandler) {
         this.transactions = new HashMap<>();
         this.errorHandler = errorHandler;
-        this.lastCommittedScn = Scn.ZERO;
+        this.lastCommittedScn = Scn.NULL;
         this.abandonedTransactionIds = new HashSet<>();
         this.rolledBackTransactionIds = new HashSet<>();
 
@@ -262,7 +262,7 @@ public final class TransactionalBuffer implements AutoCloseable {
                         .map(transaction -> transaction.firstScn)
                         .min(Scn::compareTo)
                         .orElseThrow(() -> new DataException("Cannot calculate smallest SCN"));
-        metrics.setOldestScn(scn == null ? Scn.INVALID : scn);
+        metrics.setOldestScn(scn == null ? Scn.valueOf(-1) : scn);
         return scn;
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBuffer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBuffer.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.annotation.NotThreadSafe;
 import io.debezium.connector.oracle.OracleOffsetContext;
 import io.debezium.connector.oracle.OracleTaskContext;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.ChangeEventSource;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBuffer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBuffer.java
@@ -139,7 +139,7 @@ public final class TransactionalBuffer implements AutoCloseable {
 
         // On the restarting connector, we start from SCN in the offset. There is possibility to commit a transaction(s) which were already committed.
         // Currently we cannot use ">=", because we may lose normal commit which may happen at the same time. TODO use audit table to prevent duplications
-        if ((offsetContext.getCommitScn() != null && Scn.valueOf(offsetContext.getCommitScn()).compareTo(scn) > 0) || lastCommittedScn.compareTo(scn) > 0) {
+        if ((offsetContext.getCommitScn() != null && offsetContext.getCommitScn().compareTo(scn) > 0) || lastCommittedScn.compareTo(scn) > 0) {
             LogMinerHelper.logWarn(metrics,
                     "Transaction {} was already processed, ignore. Committed SCN in offset is {}, commit SCN of the transaction is {}, last committed SCN is {}",
                     transactionId, offsetContext.getCommitScn(), scn, lastCommittedScn);
@@ -183,7 +183,7 @@ public final class TransactionalBuffer implements AutoCloseable {
             metrics.setActiveTransactions(transactions.size());
             metrics.incrementCommittedDmlCounter(commitCallbacks.size());
             metrics.setCommittedScn(scn);
-            metrics.setOffsetScn(Scn.valueOf(offsetContext.getScn()));
+            metrics.setOffsetScn(offsetContext.getScn());
             metrics.setLastCommitDuration(Duration.between(start, Instant.now()).toMillis());
         }
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBufferMetrics.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBufferMetrics.java
@@ -50,10 +50,10 @@ public class TransactionalBufferMetrics extends Metrics implements Transactional
     TransactionalBufferMetrics(CdcSourceTaskContext taskContext) {
         super(taskContext, "log-miner-transactional-buffer");
         startTime = Instant.now();
-        oldestScn.set(Scn.INVALID);
-        committedScn.set(Scn.INVALID);
+        oldestScn.set(Scn.NULL);
+        committedScn.set(Scn.NULL);
         timeDifference.set(0);
-        offsetScn.set(Scn.ZERO);
+        offsetScn.set(Scn.NULL);
         reset();
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBufferMetrics.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBufferMetrics.java
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.metrics.Metrics;
 
 /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/valueholder/LogMinerDmlEntry.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/valueholder/LogMinerDmlEntry.java
@@ -8,7 +8,7 @@ package io.debezium.connector.oracle.logminer.valueholder;
 import java.sql.Timestamp;
 import java.util.List;
 
-import io.debezium.connector.oracle.logminer.Scn;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.data.Envelope;
 
 public interface LogMinerDmlEntry {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/valueholder/LogMinerDmlEntryImpl.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/valueholder/LogMinerDmlEntryImpl.java
@@ -9,7 +9,7 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.Objects;
 
-import io.debezium.connector.oracle.logminer.Scn;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.data.Envelope;
 
 /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrPosition.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrPosition.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.debezium.connector.oracle.logminer.Scn;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.util.HexConverter;
 import io.debezium.util.Strings;
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrPosition.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrPosition.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.connector.oracle.logminer.Scn;
 import io.debezium.util.HexConverter;
 import io.debezium.util.Strings;
 
@@ -28,13 +29,13 @@ public class LcrPosition implements Comparable<LcrPosition> {
 
     private final byte[] rawPosition;
     private final String stringFromat;
-    private final long scn;
+    private final Scn scn;
 
     public LcrPosition(byte[] rawPosition) {
         this.rawPosition = rawPosition;
         this.stringFromat = HexConverter.convertToHexString(rawPosition);
         try {
-            scn = XStreamUtility.getSCNFromPosition(rawPosition).longValue();
+            scn = new Scn(XStreamUtility.getSCNFromPosition(rawPosition).bigIntegerValue());
         }
         catch (SQLException | StreamsException e) {
             throw new RuntimeException(e);
@@ -53,7 +54,7 @@ public class LcrPosition implements Comparable<LcrPosition> {
         return rawPosition;
     }
 
-    public long getScn() {
+    public Scn getScn() {
         return scn;
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -16,6 +16,7 @@ import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.OracleOffsetContext;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.SourceInfo;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
@@ -110,7 +111,7 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
         if (xsOut != null) {
             LOGGER.debug("Sending message to request recording of offsets to Oracle");
             final LcrPosition lcrPosition = LcrPosition.valueOf((String) offset.get(SourceInfo.LCR_POSITION_KEY));
-            final String scn = (String) offset.get(SourceInfo.SCN2_KEY);
+            final Scn scn = OracleOffsetContext.getScnFromOffsetMapByKey(offset, SourceInfo.SCN_KEY);
             // We can safely overwrite the message even if it was not processed. The watermarked will be set to the highest
             // (last) delivered value in a single step instead of incrementally
             sendPublishedPosition(lcrPosition, scn);
@@ -140,8 +141,8 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
         return xsOut;
     }
 
-    private void sendPublishedPosition(final LcrPosition lcrPosition, final String scn) {
-        lcrMessage.set(new PositionAndScn(lcrPosition, (scn != null) ? convertScnToPosition(scn) : null));
+    private void sendPublishedPosition(final LcrPosition lcrPosition, final Scn scn) {
+        lcrMessage.set(new PositionAndScn(lcrPosition, (scn != null) ? convertScnToPosition(scn.toString()) : null));
     }
 
     PositionAndScn receivePublishedPosition() {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -118,9 +118,9 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
         }
     }
 
-    private byte[] convertScnToPosition(String scn) {
+    private byte[] convertScnToPosition(Scn scn) {
         try {
-            return XStreamUtility.convertSCNToPosition(new NUMBER(scn, 0), this.posVersion);
+            return XStreamUtility.convertSCNToPosition(new NUMBER(scn.toString(), 0), this.posVersion);
         }
         catch (SQLException | StreamsException e) {
             throw new RuntimeException(e);
@@ -142,7 +142,7 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
     }
 
     private void sendPublishedPosition(final LcrPosition lcrPosition, final Scn scn) {
-        lcrMessage.set(new PositionAndScn(lcrPosition, (scn != null) ? convertScnToPosition(scn.toString()) : null));
+        lcrMessage.set(new PositionAndScn(lcrPosition, (scn != null) ? convertScnToPosition(scn) : null));
     }
 
     PositionAndScn receivePublishedPosition() {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/LogMinerHelperIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/LogMinerHelperIT.java
@@ -29,7 +29,6 @@ import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.logminer.LogFile;
 import io.debezium.connector.oracle.logminer.LogMinerHelper;
-import io.debezium.connector.oracle.logminer.Scn;
 import io.debezium.connector.oracle.logminer.SqlUtils;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.embedded.AbstractConnectorTest;

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/LogMinerHelperTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/LogMinerHelperTest.java
@@ -23,7 +23,6 @@ import org.mockito.Mockito;
 
 import io.debezium.connector.oracle.logminer.LogFile;
 import io.debezium.connector.oracle.logminer.LogMinerHelper;
-import io.debezium.connector.oracle.logminer.Scn;
 
 public class LogMinerHelperTest {
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
@@ -41,7 +41,9 @@ public class OracleOffsetContextTest {
 
         final OracleOffsetContext offsetContext = (OracleOffsetContext) offsetLoader.load(offsetValues);
         assertThat(offsetContext.getScn()).isEqualTo(Scn.valueOf("12345"));
-        assertThat(offsetContext.getCommitScn()).isEqualTo(Scn.valueOf("23456"));
+        if (TestHelper.adapter().equals(OracleConnectorConfig.ConnectorAdapter.LOG_MINER)) {
+            assertThat(offsetContext.getCommitScn()).isEqualTo(Scn.valueOf("23456"));
+        }
     }
 
     @Test
@@ -53,7 +55,9 @@ public class OracleOffsetContextTest {
 
         final OracleOffsetContext offsetContext = (OracleOffsetContext) offsetLoader.load(offsetValues);
         assertThat(offsetContext.getScn()).isEqualTo(Scn.valueOf("12345"));
-        assertThat(offsetContext.getCommitScn()).isEqualTo(Scn.valueOf("23456"));
+        if (TestHelper.adapter().equals(OracleConnectorConfig.ConnectorAdapter.LOG_MINER)) {
+            assertThat(offsetContext.getCommitScn()).isEqualTo(Scn.valueOf("23456"));
+        }
     }
 
     @Test

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
@@ -40,8 +40,8 @@ public class OracleOffsetContextTest {
         offsetValues.put(SourceInfo.COMMIT_SCN_KEY, 23456L);
 
         final OracleOffsetContext offsetContext = (OracleOffsetContext) offsetLoader.load(offsetValues);
-        assertThat(offsetContext.getScn()).isEqualTo("12345");
-        assertThat(offsetContext.getCommitScn()).isEqualTo("23456");
+        assertThat(offsetContext.getScn()).isEqualTo(Scn.valueOf("12345"));
+        assertThat(offsetContext.getCommitScn()).isEqualTo(Scn.valueOf("23456"));
     }
 
     @Test
@@ -52,8 +52,8 @@ public class OracleOffsetContextTest {
         offsetValues.put(SourceInfo.COMMIT_SCN_KEY, "23456");
 
         final OracleOffsetContext offsetContext = (OracleOffsetContext) offsetLoader.load(offsetValues);
-        assertThat(offsetContext.getScn()).isEqualTo("12345");
-        assertThat(offsetContext.getCommitScn()).isEqualTo("23456");
+        assertThat(offsetContext.getScn()).isEqualTo(Scn.valueOf("12345"));
+        assertThat(offsetContext.getCommitScn()).isEqualTo(Scn.valueOf("23456"));
     }
 
     @Test

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit test that validates the behavior of the {@link OracleOffsetContext} and its friends.
+ *
+ * @author Chris Cranford
+ */
+public class OracleOffsetContextTest {
+
+    private OracleConnectorConfig connectorConfig;
+    private OracleOffsetContext.Loader offsetLoader;
+
+    @Before
+    public void beforeEach() throws Exception {
+        this.connectorConfig = new OracleConnectorConfig(TestHelper.defaultConfig().build());
+        this.offsetLoader = new OracleOffsetContext.Loader(connectorConfig, TestHelper.adapter());
+    }
+
+    @Test
+    @FixFor("DBZ-2994")
+    public void shouldReadLegacyScnAndCommitScnFieldsWhenNewNotProvided() throws Exception {
+        final Map<String, Object> offsetValues = new HashMap<>();
+        offsetValues.put(SourceInfo.SCN_KEY, 12345L);
+        offsetValues.put(SourceInfo.COMMIT_SCN_KEY, 23456L);
+
+        final OracleOffsetContext offsetContext = (OracleOffsetContext) offsetLoader.load(offsetValues);
+        assertThat(offsetContext.getScn()).isEqualTo("12345");
+        assertThat(offsetContext.getCommitScn()).isEqualTo("23456");
+    }
+
+    @Test
+    @FixFor("DBZ-2994")
+    public void shouldReadNewScnAndCommitScnFieldsWhenLegacyNotProvided() throws Exception {
+        final Map<String, Object> offsetValues = new HashMap<>();
+        offsetValues.put(SourceInfo.SCN2_KEY, "12345");
+        offsetValues.put(SourceInfo.COMMIT2_SCN_KEY, "23456");
+
+        final OracleOffsetContext offsetContext = (OracleOffsetContext) offsetLoader.load(offsetValues);
+        assertThat(offsetContext.getScn()).isEqualTo("12345");
+        assertThat(offsetContext.getCommitScn()).isEqualTo("23456");
+    }
+
+    @Test
+    @FixFor("DBZ-2994")
+    public void shouldPrioritizeNewScnAndCommitScnFields() throws Exception {
+        final Map<String, Object> offsetValues = new HashMap<>();
+        offsetValues.put(SourceInfo.SCN_KEY, 12345L);
+        offsetValues.put(SourceInfo.COMMIT_SCN_KEY, 23456L);
+        offsetValues.put(SourceInfo.SCN2_KEY, "345678");
+        offsetValues.put(SourceInfo.COMMIT2_SCN_KEY, "456789");
+
+        final OracleOffsetContext offsetContext = (OracleOffsetContext) offsetLoader.load(offsetValues);
+        assertThat(offsetContext.getScn()).isEqualTo("345678");
+        assertThat(offsetContext.getCommitScn()).isEqualTo("456789");
+    }
+
+    @Test
+    @FixFor("DBZ-2994")
+    public void shouldHandleNullScnAndCommitScnValues() throws Exception {
+        final Map<String, Object> offsetValues = new HashMap<>();
+        offsetValues.put(SourceInfo.SCN_KEY, null);
+        offsetValues.put(SourceInfo.COMMIT_SCN_KEY, null);
+        offsetValues.put(SourceInfo.SCN2_KEY, null);
+        offsetValues.put(SourceInfo.COMMIT2_SCN_KEY, null);
+
+        final OracleOffsetContext offsetContext = (OracleOffsetContext) offsetLoader.load(offsetValues);
+        assertThat(offsetContext.getScn()).isNull();
+        assertThat(offsetContext.getCommitScn()).isNull();
+    }
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
@@ -34,7 +34,7 @@ public class OracleOffsetContextTest {
 
     @Test
     @FixFor("DBZ-2994")
-    public void shouldReadLegacyScnAndCommitScnFieldsWhenNewNotProvided() throws Exception {
+    public void shouldreadScnAndCommitScnAsLongValues() throws Exception {
         final Map<String, Object> offsetValues = new HashMap<>();
         offsetValues.put(SourceInfo.SCN_KEY, 12345L);
         offsetValues.put(SourceInfo.COMMIT_SCN_KEY, 23456L);
@@ -46,28 +46,14 @@ public class OracleOffsetContextTest {
 
     @Test
     @FixFor("DBZ-2994")
-    public void shouldReadNewScnAndCommitScnFieldsWhenLegacyNotProvided() throws Exception {
+    public void shouldReadScnAndCommitScnAsStringValues() throws Exception {
         final Map<String, Object> offsetValues = new HashMap<>();
-        offsetValues.put(SourceInfo.SCN2_KEY, "12345");
-        offsetValues.put(SourceInfo.COMMIT2_SCN_KEY, "23456");
+        offsetValues.put(SourceInfo.SCN_KEY, "12345");
+        offsetValues.put(SourceInfo.COMMIT_SCN_KEY, "23456");
 
         final OracleOffsetContext offsetContext = (OracleOffsetContext) offsetLoader.load(offsetValues);
         assertThat(offsetContext.getScn()).isEqualTo("12345");
         assertThat(offsetContext.getCommitScn()).isEqualTo("23456");
-    }
-
-    @Test
-    @FixFor("DBZ-2994")
-    public void shouldPrioritizeNewScnAndCommitScnFields() throws Exception {
-        final Map<String, Object> offsetValues = new HashMap<>();
-        offsetValues.put(SourceInfo.SCN_KEY, 12345L);
-        offsetValues.put(SourceInfo.COMMIT_SCN_KEY, 23456L);
-        offsetValues.put(SourceInfo.SCN2_KEY, "345678");
-        offsetValues.put(SourceInfo.COMMIT2_SCN_KEY, "456789");
-
-        final OracleOffsetContext offsetContext = (OracleOffsetContext) offsetLoader.load(offsetValues);
-        assertThat(offsetContext.getScn()).isEqualTo("345678");
-        assertThat(offsetContext.getCommitScn()).isEqualTo("456789");
     }
 
     @Test
@@ -76,8 +62,6 @@ public class OracleOffsetContextTest {
         final Map<String, Object> offsetValues = new HashMap<>();
         offsetValues.put(SourceInfo.SCN_KEY, null);
         offsetValues.put(SourceInfo.COMMIT_SCN_KEY, null);
-        offsetValues.put(SourceInfo.SCN2_KEY, null);
-        offsetValues.put(SourceInfo.COMMIT2_SCN_KEY, null);
 
         final OracleOffsetContext offsetContext = (OracleOffsetContext) offsetLoader.load(offsetValues);
         assertThat(offsetContext.getScn()).isNull();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SourceInfoTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SourceInfoTest.java
@@ -58,11 +58,9 @@ public class SourceInfoTest {
                 .field("schema", Schema.STRING_SCHEMA)
                 .field("table", Schema.STRING_SCHEMA)
                 .field("txId", Schema.OPTIONAL_STRING_SCHEMA)
-                .field("scn", Schema.OPTIONAL_INT64_SCHEMA)
-                .field("commit_scn", Schema.OPTIONAL_INT64_SCHEMA)
+                .field("scn", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("commit_scn", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("lcr_position", Schema.OPTIONAL_STRING_SCHEMA)
-                .field("scn2", Schema.OPTIONAL_STRING_SCHEMA)
-                .field("commit2_scn", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
 
         VerifyRecord.assertConnectSchemasAreEqual(null, source.schema(), schema);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SourceInfoTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SourceInfoTest.java
@@ -61,6 +61,8 @@ public class SourceInfoTest {
                 .field("scn", Schema.OPTIONAL_INT64_SCHEMA)
                 .field("commit_scn", Schema.OPTIONAL_INT64_SCHEMA)
                 .field("lcr_position", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("scn2", Schema.OPTIONAL_STRING_SCHEMA)
+                .field("commit2_scn", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
 
         VerifyRecord.assertConnectSchemasAreEqual(null, source.schema(), schema);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerMetricsTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerMetricsTest.java
@@ -50,7 +50,7 @@ public class LogMinerMetricsTest {
         assertThat(metrics.getTotalCapturedDmlCount() == 1).isTrue();
 
         metrics.setCurrentScn(Scn.valueOf(1000L));
-        assertThat(metrics.getCurrentScn()).isEqualTo(1000L);
+        assertThat(metrics.getCurrentScn()).isEqualTo("1000");
 
         metrics.setBatchSize(10);
         assertThat(metrics.getBatchSize() == connectorConfig.getLogMiningBatchSizeDefault()).isTrue();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerMetricsTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerMetricsTest.java
@@ -21,6 +21,7 @@ import org.mockito.Mockito;
 import io.debezium.config.Configuration;
 import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot.AdapterName;

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerUtilsTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerUtilsTest.java
@@ -25,8 +25,8 @@ import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot.AdapterName;
 @SkipWhenAdapterNameIsNot(value = AdapterName.LOGMINER)
 public class LogMinerUtilsTest {
 
-    private static final Scn SCN = new Scn(BigDecimal.ONE);
-    private static final Scn OTHER_SCN = new Scn(BigDecimal.TEN);
+    private static final Scn SCN = new Scn(BigInteger.ONE);
+    private static final Scn OTHER_SCN = new Scn(BigInteger.TEN);
 
     @Rule
     public TestRule skipRule = new SkipTestDependingOnAdapterNameRule();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerUtilsTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerUtilsTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 
 import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot.AdapterName;

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/RowMapperTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/RowMapperTest.java
@@ -104,7 +104,7 @@ public class RowMapperTest {
         verify(rs).getString(1);
         Mockito.when(rs.getString(1)).thenThrow(SQLException.class);
         scn = RowMapper.getScn(metrics, rs);
-        assertThat(scn).isEqualTo(Scn.INVALID);
+        assertThat(scn).isEqualTo(Scn.NULL);
         verify(rs, times(2)).getString(1);
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/RowMapperTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/RowMapperTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -34,7 +34,7 @@ import io.debezium.relational.TableId;
 @SkipWhenAdapterNameIsNot(value = AdapterName.LOGMINER)
 public class RowMapperTest {
 
-    private static final Scn SCN_ONE = new Scn(BigDecimal.ONE);
+    private static final Scn SCN_ONE = new Scn(BigInteger.ONE);
 
     private ResultSet rs;
     private TransactionalBufferMetrics metrics;
@@ -97,14 +97,14 @@ public class RowMapperTest {
 
     @Test
     public void testGetScn() throws SQLException {
-        Mockito.when(rs.getBigDecimal(1)).thenReturn(new BigDecimal(1));
+        Mockito.when(rs.getString(1)).thenReturn("1");
         Scn scn = RowMapper.getScn(metrics, rs);
         assertThat(scn).isEqualTo(Scn.valueOf(1L));
-        verify(rs).getBigDecimal(1);
-        Mockito.when(rs.getBigDecimal(1)).thenThrow(SQLException.class);
+        verify(rs).getString(1);
+        Mockito.when(rs.getString(1)).thenThrow(SQLException.class);
         scn = RowMapper.getScn(metrics, rs);
         assertThat(scn).isEqualTo(Scn.INVALID);
-        verify(rs, times(2)).getBigDecimal(1);
+        verify(rs, times(2)).getString(1);
     }
 
     @Test

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/RowMapperTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/RowMapperTest.java
@@ -25,6 +25,7 @@ import org.junit.rules.TestRule;
 import org.mockito.Mockito;
 
 import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot.AdapterName;

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/SqlUtilsTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/SqlUtilsTest.java
@@ -20,6 +20,7 @@ import org.junit.rules.TestRule;
 import org.mockito.Mockito;
 
 import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot.AdapterName;

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/SqlUtilsTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/SqlUtilsTest.java
@@ -200,7 +200,7 @@ public class SqlUtilsTest {
         expected = "TRUNCATE TABLE table_name";
         assertThat(result).isEqualTo(expected);
 
-        result = SqlUtils.diffInDaysQuery(123L);
+        result = SqlUtils.diffInDaysQuery(Scn.valueOf(123L));
         expected = "select sysdate - CAST(scn_to_timestamp(123) as date) from dual";
         assertThat(expected.equals(result)).isTrue();
         result = SqlUtils.diffInDaysQuery(null);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionalBufferMetricsTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionalBufferMetricsTest.java
@@ -19,6 +19,7 @@ import org.junit.rules.TestRule;
 import org.mockito.Mockito;
 
 import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIs;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionalBufferTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionalBufferTest.java
@@ -10,7 +10,7 @@ import static io.debezium.config.CommonConnectorConfig.DEFAULT_MAX_QUEUE_SIZE;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
@@ -54,7 +54,7 @@ public class TransactionalBufferTest {
     private static final String SQL_ONE = "update table";
     private static final String SQL_TWO = "insert into table";
     private static final String MESSAGE = "OK";
-    private static final Scn SCN_ONE = new Scn(BigDecimal.ONE);
+    private static final Scn SCN_ONE = new Scn(BigInteger.ONE);
     private static final Scn SCN = SCN_ONE;
     private static final Scn OTHER_SCN = Scn.valueOf(10L);
     private static final Scn LARGEST_SCN = Scn.valueOf(100L);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionalBufferTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionalBufferTest.java
@@ -33,6 +33,7 @@ import io.debezium.connector.oracle.OracleConnector;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleOffsetContext;
 import io.debezium.connector.oracle.OracleTaskContext;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot.AdapterName;

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionalBufferTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionalBufferTest.java
@@ -122,7 +122,7 @@ public class TransactionalBufferTest {
     public void testIsEmptyWhenTransactionIsCommitted() throws InterruptedException {
         CountDownLatch commitLatch = new CountDownLatch(1);
         transactionalBuffer.registerCommitCallback(TRANSACTION_ID, SCN, Instant.now(), (timestamp, smallestScn, commitScn, counter) -> commitLatch.countDown());
-        offsetContext = new OracleOffsetContext(connectorConfig, SCN.longValue(), SCN.longValue(), (LcrPosition) null, false, true, new TransactionContext());
+        offsetContext = new OracleOffsetContext(connectorConfig, SCN.toString(), SCN.toString(), (LcrPosition) null, false, true, new TransactionContext());
         transactionalBuffer.commit(TRANSACTION_ID, SCN.add(SCN_ONE), offsetContext, TIMESTAMP, () -> true, MESSAGE, dispatcher);
         commitLatch.await();
         Thread.sleep(1000);
@@ -169,7 +169,7 @@ public class TransactionalBufferTest {
             smallestScnContainer.set(smallestScn);
             commitLatch.countDown();
         });
-        offsetContext = new OracleOffsetContext(connectorConfig, SCN.longValue(), SCN.longValue(), null, false, true, new TransactionContext());
+        offsetContext = new OracleOffsetContext(connectorConfig, SCN.toString(), SCN.toString(), null, false, true, new TransactionContext());
         transactionalBuffer.commit(TRANSACTION_ID, SCN.add(SCN_ONE), offsetContext, TIMESTAMP, () -> true, MESSAGE, dispatcher);
         commitLatch.await();
 
@@ -188,7 +188,7 @@ public class TransactionalBufferTest {
         });
         transactionalBuffer.registerCommitCallback(OTHER_TRANSACTION_ID, OTHER_SCN, Instant.now(), (timestamp, smallestScn, commitScn, counter) -> {
         });
-        offsetContext = new OracleOffsetContext(connectorConfig, SCN.longValue(), SCN.longValue(), null, false, true, new TransactionContext());
+        offsetContext = new OracleOffsetContext(connectorConfig, SCN.toString(), SCN.toString(), null, false, true, new TransactionContext());
         transactionalBuffer.commit(TRANSACTION_ID, SCN.add(SCN_ONE), offsetContext, TIMESTAMP, () -> true, MESSAGE, dispatcher);
         commitLatch.await();
         // after commit, it stays the same because OTHER_TRANSACTION_ID is not committed yet
@@ -207,7 +207,7 @@ public class TransactionalBufferTest {
             smallestScnContainer.set(smallestScn);
             commitLatch.countDown();
         });
-        offsetContext = new OracleOffsetContext(connectorConfig, OTHER_SCN.longValue(), OTHER_SCN.longValue(), null, false, true, new TransactionContext());
+        offsetContext = new OracleOffsetContext(connectorConfig, OTHER_SCN.toString(), OTHER_SCN.toString(), null, false, true, new TransactionContext());
         transactionalBuffer.commit(OTHER_TRANSACTION_ID, OTHER_SCN.add(SCN_ONE), offsetContext, TIMESTAMP, () -> true, MESSAGE, dispatcher);
         commitLatch.await();
         assertThat(smallestScnContainer.get()).isEqualTo(SCN);
@@ -219,8 +219,8 @@ public class TransactionalBufferTest {
     public void testAbandoningOneTransaction() {
         transactionalBuffer.registerCommitCallback(TRANSACTION_ID, SCN, Instant.now(), (timestamp, smallestScn, commitScn, counter) -> {
         });
-        offsetContext = new OracleOffsetContext(connectorConfig, SCN.longValue(), SCN.longValue(), (LcrPosition) null, false, true, new TransactionContext());
-        transactionalBuffer.abandonLongTransactions(SCN.longValue(), offsetContext);
+        offsetContext = new OracleOffsetContext(connectorConfig, SCN.toString(), SCN.toString(), (LcrPosition) null, false, true, new TransactionContext());
+        transactionalBuffer.abandonLongTransactions(SCN, offsetContext);
         assertThat(transactionalBuffer.isEmpty()).isEqualTo(true);
     }
 
@@ -230,7 +230,7 @@ public class TransactionalBufferTest {
         });
         transactionalBuffer.registerCommitCallback(OTHER_TRANSACTION_ID, OTHER_SCN, Instant.now(), (timestamp, smallestScn, commitScn, counter) -> {
         });
-        transactionalBuffer.abandonLongTransactions(SCN.longValue(), offsetContext);
+        transactionalBuffer.abandonLongTransactions(SCN, offsetContext);
         assertThat(transactionalBuffer.isEmpty()).isEqualTo(false);
     }
 
@@ -248,7 +248,7 @@ public class TransactionalBufferTest {
 
     private void commitTransaction(TransactionalBuffer.CommitCallback commitCallback) {
         transactionalBuffer.registerCommitCallback(TRANSACTION_ID, SCN, Instant.now(), commitCallback);
-        offsetContext = new OracleOffsetContext(connectorConfig, SCN.longValue(), SCN.longValue(), null, false, true, new TransactionContext());
+        offsetContext = new OracleOffsetContext(connectorConfig, SCN.toString(), SCN.toString(), null, false, true, new TransactionContext());
         transactionalBuffer.commit(TRANSACTION_ID, SCN.add(SCN_ONE), offsetContext, TIMESTAMP, () -> true, MESSAGE, dispatcher);
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionalBufferTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionalBufferTest.java
@@ -123,7 +123,7 @@ public class TransactionalBufferTest {
     public void testIsEmptyWhenTransactionIsCommitted() throws InterruptedException {
         CountDownLatch commitLatch = new CountDownLatch(1);
         transactionalBuffer.registerCommitCallback(TRANSACTION_ID, SCN, Instant.now(), (timestamp, smallestScn, commitScn, counter) -> commitLatch.countDown());
-        offsetContext = new OracleOffsetContext(connectorConfig, SCN.toString(), SCN.toString(), (LcrPosition) null, false, true, new TransactionContext());
+        offsetContext = new OracleOffsetContext(connectorConfig, SCN, SCN, (LcrPosition) null, false, true, new TransactionContext());
         transactionalBuffer.commit(TRANSACTION_ID, SCN.add(SCN_ONE), offsetContext, TIMESTAMP, () -> true, MESSAGE, dispatcher);
         commitLatch.await();
         Thread.sleep(1000);
@@ -170,7 +170,7 @@ public class TransactionalBufferTest {
             smallestScnContainer.set(smallestScn);
             commitLatch.countDown();
         });
-        offsetContext = new OracleOffsetContext(connectorConfig, SCN.toString(), SCN.toString(), null, false, true, new TransactionContext());
+        offsetContext = new OracleOffsetContext(connectorConfig, SCN, SCN, null, false, true, new TransactionContext());
         transactionalBuffer.commit(TRANSACTION_ID, SCN.add(SCN_ONE), offsetContext, TIMESTAMP, () -> true, MESSAGE, dispatcher);
         commitLatch.await();
 
@@ -189,7 +189,7 @@ public class TransactionalBufferTest {
         });
         transactionalBuffer.registerCommitCallback(OTHER_TRANSACTION_ID, OTHER_SCN, Instant.now(), (timestamp, smallestScn, commitScn, counter) -> {
         });
-        offsetContext = new OracleOffsetContext(connectorConfig, SCN.toString(), SCN.toString(), null, false, true, new TransactionContext());
+        offsetContext = new OracleOffsetContext(connectorConfig, SCN, SCN, null, false, true, new TransactionContext());
         transactionalBuffer.commit(TRANSACTION_ID, SCN.add(SCN_ONE), offsetContext, TIMESTAMP, () -> true, MESSAGE, dispatcher);
         commitLatch.await();
         // after commit, it stays the same because OTHER_TRANSACTION_ID is not committed yet
@@ -208,7 +208,7 @@ public class TransactionalBufferTest {
             smallestScnContainer.set(smallestScn);
             commitLatch.countDown();
         });
-        offsetContext = new OracleOffsetContext(connectorConfig, OTHER_SCN.toString(), OTHER_SCN.toString(), null, false, true, new TransactionContext());
+        offsetContext = new OracleOffsetContext(connectorConfig, OTHER_SCN, OTHER_SCN, null, false, true, new TransactionContext());
         transactionalBuffer.commit(OTHER_TRANSACTION_ID, OTHER_SCN.add(SCN_ONE), offsetContext, TIMESTAMP, () -> true, MESSAGE, dispatcher);
         commitLatch.await();
         assertThat(smallestScnContainer.get()).isEqualTo(SCN);
@@ -220,7 +220,7 @@ public class TransactionalBufferTest {
     public void testAbandoningOneTransaction() {
         transactionalBuffer.registerCommitCallback(TRANSACTION_ID, SCN, Instant.now(), (timestamp, smallestScn, commitScn, counter) -> {
         });
-        offsetContext = new OracleOffsetContext(connectorConfig, SCN.toString(), SCN.toString(), (LcrPosition) null, false, true, new TransactionContext());
+        offsetContext = new OracleOffsetContext(connectorConfig, SCN, SCN, (LcrPosition) null, false, true, new TransactionContext());
         transactionalBuffer.abandonLongTransactions(SCN, offsetContext);
         assertThat(transactionalBuffer.isEmpty()).isEqualTo(true);
     }
@@ -249,7 +249,7 @@ public class TransactionalBufferTest {
 
     private void commitTransaction(TransactionalBuffer.CommitCallback commitCallback) {
         transactionalBuffer.registerCommitCallback(TRANSACTION_ID, SCN, Instant.now(), commitCallback);
-        offsetContext = new OracleOffsetContext(connectorConfig, SCN.toString(), SCN.toString(), null, false, true, new TransactionContext());
+        offsetContext = new OracleOffsetContext(connectorConfig, SCN, SCN, null, false, true, new TransactionContext());
         transactionalBuffer.commit(TRANSACTION_ID, SCN.add(SCN_ONE), offsetContext, TIMESTAMP, () -> true, MESSAGE, dispatcher);
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/ValueHolderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/ValueHolderTest.java
@@ -8,6 +8,7 @@ package io.debezium.connector.oracle.logminer;
 import static org.fest.assertions.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
@@ -39,7 +40,7 @@ import io.debezium.util.IoUtil;
 
 @SkipWhenAdapterNameIsNot(value = AdapterName.LOGMINER)
 public class ValueHolderTest {
-    private static final Scn SCN_ONE = new Scn(BigDecimal.ONE);
+    private static final Scn SCN_ONE = new Scn(BigInteger.ONE);
     private static final String TABLE_NAME = "TEST";
     private static final String CATALOG_NAME = "CATALOG";
     private static final String SCHEMA_NAME = "DEBEZIUM";

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/ValueHolderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/ValueHolderTest.java
@@ -22,6 +22,7 @@ import org.junit.rules.TestRule;
 
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleValueConverters;
+import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.antlr.OracleDdlParser;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -526,12 +526,12 @@ Let's look at what a _create_ event value might look like for our `customers` ta
                         "field": "txId"
                     },
                     {
-                        "type": "int64",
+                        "type": "string",
                         "optional": true,
                         "field": "scn"
                     },
                     {
-                        "type": "int64",
+                        "type": "string",
                         "optional": true,
                         "field": "commit_scn"
                     },
@@ -572,8 +572,8 @@ Let's look at what a _create_ event value might look like for our `customers` ta
             "name": "server1",
             "ts_ms": 1520085154000,
             "txId": "6.28.807",
-            "scn": 2122185,
-            "commit_scn": 2122185,
+            "scn": "2122185",
+            "commit_scn": "2122185",
             "snapshot": false
         },
         "op": "c",
@@ -626,8 +626,8 @@ Here's an example:
             "name": "server1",
             "ts_ms": 1520085811000,
             "txId": "6.9.809",
-            "scn": 2125544,
-            "commit_scn": 2125544,
+            "scn": "2125544",
+            "commit_scn": "2125544",
             "snapshot": false
         },
         "op": "u",
@@ -675,8 +675,8 @@ Now, let's look at the value of a _delete_ event for the same table. Once again,
             "name": "server1",
             "ts_ms": 1520085153000,
             "txId": "6.28.807",
-            "scn": 2122184,
-            "commit_scn": 2122184,
+            "scn": "2122184",
+            "commit_scn": "2122184",
             "snapshot": false
         },
         "op": "d",
@@ -1648,7 +1648,7 @@ The *MBean* is `debezium.oracle:type=connector-metrics,context=log-miner,server=
 |Attributes |Type |Description
 
 |[[log-miner-metrics-currentscn]]<<log-miner-metrics-currentscn, `+CurrentScn+`>>
-|`long`
+|`string`
 |The most recent SCN that has been processed.
 
 |[[log-miner-metrics-currentredologfilename]]<<log-miner-metrics-currentredologfilename, `+CurrentRedoLogFileName+`>>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2457
https://issues.redhat.com/browse/DBZ-2994

This PR finalizes all the SCN work by moving to using `BigInteger` over `BigDecimal` as well as moving to storing SCN values in the `SourceInfo` block and offsets as string-based values.  For the offsets, I followed Jiri's suggestion to make this backward compatible by reading the legacy values but always writing to the new field names. 

I also added a separate commit where I moved `Scn` up one package since it's now used by code that is in common between both the XStream and LogMiner adapters.  I made this a separate commit as I thought maybe this would help reviewing the actual impacting code changes easier.