### PR TITLE
DBZ-2665 Add database history docs to new engine docs

### DIFF
--- a/documentation/modules/ROOT/pages/development/engine.adoc
+++ b/documentation/modules/ROOT/pages/development/engine.adoc
@@ -422,6 +422,49 @@ The default is a periodic commity policy based upon time intervals.
 |The Converter class that should be used to serialize and deserialize value data for offsets. The default is JSON converter.
 |===
 
+[[database-history-properties]]
+=== Database history properties
+
+Some of the connectors also requires additional set of properties that configures database history:
+
+* MySQL
+* SQL Server
+* Oracle
+* Db2
+
+Without proper configuration of the database history the connectors will refuse to start.
+The default configuration expects a Kafka cluster to be available.
+For other deployments, a file-based database history storage implementation is available.
+
+[cols="35%a,10%a,55%a",options="header"]
+|=======================
+|Property
+|Default
+|Description
+
+|`database.history`
+|`<...>.KafkaDatabaseHistory`
+|The name of the Java class that is responsible for persistence of the database history. +
+It must implement `<...>.DatabaseHistory` interface.
+
+|`database.history.file.filename`
+|`""`
+|Path to a file where the database history is stored. +
+Required when `database.history` is set to the `<...>.FileDatabaseHistory`.
+
+|`database.history.kafka.topic`
+|`""`
+|The Kafka topic where the database history is stored. +
+Required when `database.history` is set to the `<...>.KafkaDatabaseHistory`.
+
+|`database.history.kafka.bootstrap.servers`
+|`""`
+|The initial list of Kafka cluster servers to connect to.
+The cluster provides the topic to store the database history. +
+Required when `database.history` is set to the `<...>.KafkaDatabaseHistory`.
+
+|=======================
+
 == Handling Failures
 
 When the engine executes, its connector is actively recording the source offset inside each source record, and the engine is periodically flushing those offsets to persistent storage.


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2665

Originally added to the *obsolete* docs not the current one.