### PR TITLE
DBZ-3319 Fix race condition with log switch detection

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/SqlUtils.java
@@ -121,6 +121,10 @@ public class SqlUtils {
         return String.format("SELECT F.MEMBER FROM %s LOG, %s F  WHERE LOG.GROUP#=F.GROUP# AND LOG.STATUS='CURRENT'", LOG_VIEW, LOGFILE_VIEW);
     }
 
+    static String currentRedoLogSequenceQuery() {
+        return String.format("SELECT SEQUENCE# FROM %s WHERE STATUS = 'CURRENT'", LOG_VIEW);
+    }
+
     static String databaseSupplementalLoggingAllCheckQuery() {
         return String.format("SELECT 'KEY', SUPPLEMENTAL_LOG_DATA_ALL FROM %s", DATABASE_VIEW);
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/SqlUtilsTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/SqlUtilsTest.java
@@ -226,6 +226,10 @@ public class SqlUtilsTest {
         expected = "SELECT F.MEMBER FROM V$LOG LOG, V$LOGFILE F  WHERE LOG.GROUP#=F.GROUP# AND LOG.STATUS='CURRENT'";
         assertThat(result).isEqualTo(expected);
 
+        result = SqlUtils.currentRedoLogSequenceQuery();
+        expected = "SELECT SEQUENCE# FROM V$LOG WHERE STATUS = 'CURRENT'";
+        assertThat(result).isEqualTo(expected);
+
         result = SqlUtils.databaseSupplementalLoggingAllCheckQuery();
         expected = "SELECT 'KEY', SUPPLEMENTAL_LOG_DATA_ALL FROM V$DATABASE";
         assertThat(result).isEqualTo(expected);


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3319

Rather than relying on log switch detection by looking at the name of the current log file, this change uses the unique and always
increasing sequence to derive the log switch state to avoid any type of ambiguity.