### PR TITLE
Dbz 3297 user guide corrections for sqlserver connector

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -92,7 +92,7 @@ ifdef::product[]
 
 For details about how the connector works, see the following sections:
 
-* xref:how-debezium-sql-server-connectors-perform-database-snapshots[]
+* xref:sqlserver-snapshots[]
 * xref:how-the-debezium-sql-server-connector-reads-change-data-tables[]
 * xref:default-names-of-kafka-topics-that-receive-debezium-sql-server-change-event-records[]
 * xref:how-the-debezium-sql-server-connector-uses-the-schema-change-topic[]
@@ -102,7 +102,6 @@ For details about how the connector works, see the following sections:
 endif::product[]
 
 // Type: concept
-// ModuleID: how-debezium-sql-server-connectors-perform-database-snapshots
 // Title: How {prodname} SQL Server connectors perform database snapshots
 [[sqlserver-snapshots]]
 === Snapshots

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1620,6 +1620,53 @@ With link:https://zookeeper.apache.org[Zookeeper], http://kafka.apache.org/[Kafk
 Restart your Kafka Connect process to pick up the new JAR files.
 
 If you are working with immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s container images] for Zookeeper, Kafka, SQL Server and Kafka Connect with the SQL Server connector already installed and ready to run. You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and OpenShift].
+
+[[sqlserver-example-configuration]]
+=== Example configuration
+
+To use the connector to produce change events for a particular SQL Server database or cluster:
+
+. Enable the {link-prefix}:{link-sqlserver-connector}#setting-up-sqlserver[CDC on SQL Server] to publish the _CDC_ events in the database.
+. Create a configuration file for the SQL Server connector.
+
+When the connector starts, it will create a consistent snapshot of the schemas in your SQL Server database and start streaming changes, producing change event records for every row in which data was inserted, updated, or deleted.
+Optionally, you can configure the connector to produce change events for a subset of the schemas and tables in a database.
+For example you can ignore, mask, or truncate columns that contain sensitive data, that are larger than a specified size, or that you do not need.
+
+ifdef::community[]
+Following is an example of the configuration for a connector instance that captures data from a SQL Server server at port 1433 on 192.168.99.100, which we logically name `fullfillment`.
+Typically, you configure the {prodname} SQL Server connector in a `.json` file using the configuration properties available for the connector.
+
+[source,json]
+----
+{
+  "name": "inventory-connector", // <1>
+  "config": {
+    "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector", // <2>
+    "database.hostname": "192.168.99.100", // <3>
+    "database.port": "1433", // <4>
+    "database.user": "sa", // <5>
+    "database.password": "Password!", // <6>
+    "database.dbname": "testDB", // <7>
+    "database.server.name": "fullfillment", // <8>
+    "table.include.list": "dbo.customers", // <9>
+    "database.history.kafka.bootstrap.servers": "kafka:9092", // <10>
+    "database.history.kafka.topic": "dbhistory.fullfillment" // <11>
+  }
+}
+----
+<1> The name of our connector when we register it with a Kafka Connect service.
+<2> The name of this SQL Server connector class.
+<3> The address of the SQL Server instance.
+<4> The port number of the SQL Server instance.
+<5> The name of the SQL Server user
+<6> The password for the SQL Server user
+<7> The name of the database to capture changes from.
+<8> The logical name of the SQL Server instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
+<9> A list of all tables whose changes {prodname} should capture.
+<10> The list of Kafka brokers that this connector will use to write and recover DDL statements to the database history topic.
+<11> The name of the database history topic where the connector will write and recover DDL statements. This topic is for internal use only and should not be used by consumers.
+
 endif::community[]
 
 ifdef::product[]
@@ -1632,7 +1679,7 @@ For details about deploying the {prodname} SQL Server connector, see the followi
 // Type: procedure
 // ModuleID: deploying-debezium-sql-server-connectors
 [[sql-server-deploying-a-connector]]
-== Deploying {prodname} SQL Server connectors
+=== Deploying {prodname} SQL Server connectors
 
 To deploy a {prodname} SQL Server connector, you must build a custom Kafka Connect container image that contains the {prodname} connector archive, and then push this container image to a container registry.
 You then need to create the following custom resources (CRs):
@@ -1747,7 +1794,30 @@ The command updates the Kafka Connect environment on OpenShift by adding a Kafka
 +
 You configure a {prodname} SQL Server connector in a `.yaml` file that specifies the configuration properties for the connector.
 The connector configuration might instruct {prodname} to produce events for a subset of the schemas and tables, or it might set properties so that {prodname} ignores, masks, or truncates values in specified columns that are sensitive, too large, or not needed.
-For more information, see the {link-prefix}:{link-sqlserver-connector}#descriptions-of-debezium-sql-server-connector-configuration-properties[complete list of the SQL Server connector properties] that you can configure.
+endif::product[]
+For the complete list of the configuration properties that you can set for the {prodname} SQL Server connector, see {link-prefix}:{link-sqlserver-connector}#sqlserver-connector-properties[SQL Server connector properties].
+ifdef::community[]
+
+This configuration can be sent via POST to a running Kafka Connect service, which will then record the configuration and start up the one connector task that will connect to the SQL Server database, read the transaction log, and record events to Kafka topics.
+
+[[sqlserver-adding-connector-configuration]]
+=== Adding connector configuration
+
+To run a {prodname} SQL Server connector, create a connector configuration and add the configuration to your Kafka Connect cluster.
+
+.Prerequisites
+
+* SQL Server is set up to run a {prodname} connector.
+
+* A {prodname} SQL Server connector is installed.
+
+.Procedure
+
+. Create a configuration for the SQL Server connector.
+
+. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster.
+endif::community[]
+ifdef::product[]
 +
 The following example configures a {prodname} connector that connects to a SQL server host, `192.168.99.100`, on port `1433`.
 This host has a database named `testDB`, a table with the name `customers`, and `fulfillment` is the server's logical name.
@@ -1835,7 +1905,7 @@ The preceding command registers `fulfillment-connector` and the connector starts
 oc logs $(oc get pods -o name -l strimzi.io/cluster=my-connect-cluster)
 ----
 
-.. Review the log output to verify that the initial snapshot has been executed.
+.. Review the log output to verify that {prodname} performs the initial snapshot.
 The log displays output that is similar to the following messages:
 +
 [source,shell,options="nowrap"]
@@ -1854,179 +1924,18 @@ Downstream applications can subscribe to these topics.
 ----
 oc get kafkatopics
 ----
+endif::product[]
+
 .Results
 
-When the connector starts, it {link-prefix}:{link-sqlserver-connector}#how-debezium-sql-server-connectors-perform-database-snapshots[performs a consistent snapshot] of the SQL Server databases that the connector is configured for.
+When the connector starts, it {link-prefix}:{link-sqlserver-connector}#sqlserver-snapshots[performs a consistent snapshot] of the SQL Server databases that the connector is configured for.
 The connector then starts generating data change events for row-level operations and streaming the change event records to Kafka topics.
-
-endif::product[]
-
-ifdef::community[]
-Following is an example of the configuration for a connector instance that captures data from a SQL Server server at port 1433 on 192.168.99.100, which we logically name `fullfillment`.
-Typically, you configure the {prodname} SQL Server connector in a `.json` file using the configuration properties available for the connector.
-
-[source,json]
-----
-{
-  "name": "inventory-connector", // <1>
-  "config": {
-    "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector", // <2>
-    "database.hostname": "192.168.99.100", // <3>
-    "database.port": "1433", // <4>
-    "database.user": "sa", // <5>
-    "database.password": "Password!", // <6>
-    "database.dbname": "testDB", // <7>
-    "database.server.name": "fullfillment", // <8>
-    "table.include.list": "dbo.customers", // <9>
-    "database.history.kafka.bootstrap.servers": "kafka:9092", // <10>
-    "database.history.kafka.topic": "dbhistory.fullfillment" // <11>
-  }
-}
-----
-<1> The name of our connector when we register it with a Kafka Connect service.
-<2> The name of this SQL Server connector class.
-<3> The address of the SQL Server instance.
-<4> The port number of the SQL Server instance.
-<5> The name of the SQL Server user
-<6> The password for the SQL Server user
-<7> The name of the database to capture changes from.
-<8> The logical name of the SQL Server instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
-<9> A list of all tables whose changes {prodname} should capture.
-<10> The list of Kafka brokers that this connector will use to write and recover DDL statements to the database history topic.
-<11> The name of the database history topic where the connector will write and recover DDL statements. This topic is for internal use only and should not be used by consumers.
-
-endif::community[]
-
-ifdef::product[]
-
-The following example configures a {prodname} connector that connects to a SQL Server server host 192.168.99.100 on port 1433.
-This host has a database named `testDB`, and `fulfillment` is the server’s logical name.
-Typically, you configure the {prodname} SQL Server connector in a `.yaml` file in which you assign values to the configuration properties that are available for the connector.
-
-
-
-See the {link-prefix}:{link-sqlserver-connector}#sqlserver-connector-properties[complete list of connector properties] that can be specified in these configurations.
-
-You can send this configuration with a `POST` command to a running Kafka Connect service.
-The service records the configuration and starts the connector task that connects to the SQL Server database, reads the transaction log, and streams change event records to Kafka topics.
-
-
-// Type: procedure
-// ModuleID: adding-sql-server-connector-configuration-to-kafka-connect
-//Title: Adding SQL Server connector configuration to Kafka Connect
-[[sqlserver-adding-connector-configuration]]
-==== Adding connector configuration
-
-ifdef::community[]
-To run a {prodname} SQL Server connector, create a connector configuration and add the configuration to your Kafka Connect cluster.
-
-.Prerequisites
-
-* SQL Server is set up to run a {prodname} connector.
-
-* A {prodname} SQL Server connector is installed.
-
-.Procedure
-
-. Create a configuration for the SQL Server connector.
-
-. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster.
-
-endif::community[]
-
-ifdef::product[]
-
-You can use a provided {prodname} container to deploy a {prodname} SQL Server connector.
-In this procedure, you build a custom Kafka Connect container image for {prodname}, configure the {prodname} connector as needed,
-and then add your connector configuration to your Kafka Connect environment.
-
-.Prerequisites
-
-* Podman or Docker is installed and you have sufficient rights to create and manage containers.
-* You installed the {prodname} SQL Server connector archive.
-
-.Procedure
-
-. Extract the {prodname} SQL Server connector archive to create a directory structure for the connector plug-in, for example:
-+
-[subs=+macros]
-----
-pass:quotes[*tree ./my-plugins/*]
-./my-plugins/
-├── debezium-connector-sqlserver
-│   ├── ...
-----
-
-. Create and publish a custom image for running your {prodname} connector:
-
-.. Create a new `Dockerfile` by using `{DockerKafkaConnect}` as the base image. In the following example, you would replace _my-plugins_ with the name of your plug-ins directory:
-+
-[subs="+macros,+attributes"]
-----
-FROM {DockerKafkaConnect}
-USER root:root
-pass:quotes[COPY _./my-plugins/_ /opt/kafka/plugins/]
-USER 1001
-----
-+
-Before Kafka Connect starts running the connector, Kafka Connect loads any third-party plug-ins that are in the `/opt/kafka/plugins` directory.
-
-
-.. Point to the new container image by editing the `spec.image` property of the `KafkaConnect` custom resource.
-If this property is set, it overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator.
-For example:
-+
-[source,yaml,subs="+attributes"]
-----
-apiVersion: {KafkaConnectApiVersion}
-kind: KafkaConnect
-metadata:
-  name: my-connect-cluster
-  annotations:strimzi.io/use-connector-resources: "true"
-spec:
-  #...
-  image: debezium-container-for-sqlserver
-----
-+
-* In the `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml` file, edit the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable to point to the new container image and reinstall the Cluster Operator. If you edit this file you must apply it to your OpenShift cluster.
-
-. Create a `KafkaConnector` custom resource that defines your {prodname} SQL Server connector instance. See {LinkDebeziumUserGuide}#sqlserver-example-configuration[the connector configuration example].
-
-. Apply the connector instance, for example:
-+
-`oc apply -f inventory-connector.yaml`
-+
-This registers `inventory-connector` and the connector starts to run against the `inventory` database.
-
-. Verify that the connector was created and has started to capture changes in the specified database. You can verify the connector instance by watching the Kafka Connect log output as, for example, `inventory-connector` starts.
-
-.. Display the Kafka Connect log output:
-+
-[source,shell,options="nowrap"]
-----
-oc logs $(oc get pods -o name -l strimzi.io/name=my-connect-cluster)
-----
-
-.. Review the log output to verify that the initial snapshot has been executed. You should see something like the following lines:
-+
-[source,shell,options="nowrap"]
-----
-... INFO Starting snapshot for ...
-... INFO Snapshot is using user 'debezium' ...
-----
-
-endif::product[]
-
-.Results
-
-When the connector starts, it {link-prefix}:{link-sqlserver-connector}#sqlserver-snapshots[performs a consistent snapshot] of the SQL Server databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
-
 
 // Type: reference
 // ModuleID: descriptions-of-debezium-sql-server-connector-configuration-properties
 // Title: Descriptions of {prodname} SQL Server connector configuration properties
 [[sqlserver-connector-properties]]
-==== Connector properties
+=== Connector properties
 
 The following configuration properties are _required_ unless a default value is available.
 
@@ -2551,7 +2460,7 @@ For information about how to expose the preceding metrics through JMX, see the {
 // ModuleID: debezium-sql-server-connector-snapshot-metrics
 // Title: {prodname} SQL Server connector snapshot metrics
 [[sqlserver-snapshot-metrics]]
-==== Snapshot metrics
+=== Snapshot metrics
 
 The *MBean* is `debezium.sql_server:type=connector-metrics,context=snapshot,server=_<database.server.name>_`.
 
@@ -2561,7 +2470,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-
 // ModuleID: debezium-sql-server-connector-streaming-metrics
 // Title: {prodname} SQL Server connector streaming metrics
 [[sqlserver-streaming-metrics]]
-==== Streaming metrics
+=== Streaming metrics
 
 The *MBean* is `debezium.sql_server:type=connector-metrics,context=streaming,server=_<database.server.name>_`.
 
@@ -2571,7 +2480,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming
 // ModuleID: debezium-sql-server-connector-schema-history-metrics
 // Title: {prodname} SQL Server connector schema history metrics
 [[sqlserver-schema-history-metrics]]
-==== Schema history metrics
+=== Schema history metrics
 
 The *MBean* is `debezium.sql_server:type=connector-metrics,context=schema-history,server=_<database.server.name>_`.
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1615,25 +1615,29 @@ If the `continuous` parameter is set to `1`, the job pauses for the length of ti
 == Deployment
 
 ifdef::community[]
-With link:https://zookeeper.apache.org[Zookeeper], http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect] installed, the remaining tasks to deploy a {prodname} SQL Server connector are to download the https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/{debezium-version}/debezium-connector-sqlserver-{debezium-version}-plugin.tar.gz[connector's plug-in archive], extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
-Restart your Kafka Connect process to pick up the new JAR files.
+To deploy a {prodname} SQL Server connector, you install the {prodname} SQL Server connector archive, configure the connector, and start the connector by adding its configuration to Kafka Connect.
+
+.Prerequisites
+* link:https://zookeeper.apache.org/[Zookeeper], link:http://kafka.apache.org/[Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
+* SQL Server is installed and is {link-prefix}:{link-sqlserver-connector}#setting-up-sqlserver[set up to run the {prodname} connector].
+
+.Procedure
+. Download the {prodname} https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/{debezium-version}/debezium-connector-sqlserver-{debezium-version}-plugin.tar.gz[SQL Server connector plug-in archive]
+. Extract the files into your Kafka Connect environment.
+. Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
+. {link-prefix}:{link-sqlserver-connector}#sqlserver-example-configuration[Configure the connector] and {link-prefix}:{link-sqlserver-connector}#sqlserver-adding-connector-configuration[add the configuration to your Kafka Connect cluster.]
+. Restart your Kafka Connect process to pick up the new JAR files.
 
 If you are working with immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s container images] for Zookeeper, Kafka, SQL Server and Kafka Connect with the SQL Server connector already installed and ready to run. You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and OpenShift].
 
 [[sqlserver-example-configuration]]
-=== Example configuration
-
-To use the connector to produce change events for a particular SQL Server database or cluster:
-
-. Enable the {link-prefix}:{link-sqlserver-connector}#setting-up-sqlserver[CDC on SQL Server] to publish the _CDC_ events in the database.
-. Create a configuration file for the SQL Server connector.
-
-When the connector starts, it will create a consistent snapshot of the schemas in your SQL Server database and start streaming changes, producing change event records for every row in which data was inserted, updated, or deleted.
-Optionally, you can configure the connector to produce change events for a subset of the schemas and tables in a database.
-For example you can ignore, mask, or truncate columns that contain sensitive data, that are larger than a specified size, or that you do not need.
+=== SQL Server connector configuration example
 
 Following is an example of the configuration for a connector instance that captures data from a SQL Server server at port 1433 on 192.168.99.100, which we logically name `fullfillment`.
-Typically, you configure the {prodname} SQL Server connector in a `.json` file using the configuration properties available for the connector.
+Typically, you configure the {prodname} SQL Server connector in a JSON file by setting the configuration properties that are available for the connector.
+
+You can choose to produce events for a subset of the schemas and tables in a database.
+Optionally, you can ignore, mask, or truncate columns that contain sensitive data, that are larger than a specified size, or that you do not need.
 
 [source,json]
 ----
@@ -1672,7 +1676,7 @@ To deploy a {prodname} SQL Server connector, you add the connector files to Kafk
 For details about deploying the {prodname} SQL Server connector, see the following topics:
 
 * xref:deploying-debezium-sql-server-connectors[]
-* xref:descriptions-of-debezium-sql-server-connector-configuration-properties[]
+* xref:sql-server-connector-properties[]
 endif::product[]
 
 ifdef::product[]
@@ -1799,7 +1803,12 @@ For the complete list of the configuration properties that you can set for the {
 
 ifdef::community[]
 
-This configuration can be sent via POST to a running Kafka Connect service, which will then record the configuration and start up the one connector task that will connect to the SQL Server database, read the transaction log, and record events to Kafka topics.
+You can send this configuration with a `POST` command to a running Kafka Connect service.
+The service records the configuration and start up the one connector task that performs the following tasks:
+
+* Connects to the SQL Server database.
+* Reads the transaction log.
+* Records change events to Kafka topics.
 
 [[sqlserver-adding-connector-configuration]]
 === Adding connector configuration
@@ -1934,7 +1943,6 @@ When the connector starts, it {link-prefix}:{link-sqlserver-connector}#sqlserver
 The connector then starts generating data change events for row-level operations and streaming the change event records to Kafka topics.
 
 // Type: reference
-// ModuleID: descriptions-of-debezium-sql-server-connector-configuration-properties
 // Title: Descriptions of {prodname} SQL Server connector configuration properties
 [[sqlserver-connector-properties]]
 === Connector properties

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -32,7 +32,8 @@ For details about the {prodname} SQL Server connector and its use, see following
 * xref:descriptions-of-debezium-sql-server-connector-data-change-events[]
 * xref:how-debezium-sql-server-connectors-map-data-types[]
 * xref:setting-up-sql-server-for-use-with-the-debezium-sql-server-connector[]
-* xref:deploying-debezium-sql-server-connectors[]
+* xref:deployment-of-debezium-sql-server-connectors[]
+* xref:refreshing-capture-tables-after-a-schema-change[]
 * xref:monitoring-debezium-sql-server-connector-performance[]
 
 endif::product[]
@@ -1381,7 +1382,7 @@ a|_n/a_
 
 // Type: assembly
 // ModuleID: setting-up-sql-server-for-use-with-the-debezium-sql-server-connector
-//Title: Setting up SQL Server for use with the {prodname} connector
+//Title: Setting up SQL Server to run a {prodname} connector
 [[setting-up-sqlserver]]
 == Setting up SQL Server
 
@@ -1609,24 +1610,10 @@ If the `continuous` parameter is set to `1`, the job pauses for the length of ti
 * For more information about capture agent parameters, see the SQL Server documentation.
 
 // Type: assembly
-// ModuleID: deploying-and-managing-debezium-sql-server-connectors
-== Deployment and management of {prodname} SQL Server connectors
-
-ifdef::product[]
-
-For details about deploying and managing SQL Server connectors, see the following sections:
-
-* xref:deploying-debezium-sql-server-connectors[]
-* xref:refreshing-capture-tables-after-a-schema-change[]
-* xref:monitoring-debezium-sql-server-connector-performance[]
-
-endif::product[]
-
-// Type: assembly
-// ModuleID: deploying-debezium-sql-server-connectors
-// Title: Deploying the SQL Server connector
+// ModuleID: deployment-of-debezium-sql-server-connectors
+// Title: Deployment of {prodname} SQL Server connectors
 [[sqlserver-deploying-a-connector]]
-=== Deployment
+== Deployment
 
 ifdef::community[]
 With link:https://zookeeper.apache.org[Zookeeper], http://kafka.apache.org/[Kafka], and {link-kafka-docs}.html#connect[Kafka Connect] installed, the remaining tasks to deploy a {prodname} SQL Server connector are to download the https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/{debezium-version}/debezium-connector-sqlserver-{debezium-version}-plugin.tar.gz[connector's plug-in archive], extract the JAR files into your Kafka Connect environment, and add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
@@ -1636,118 +1623,146 @@ If you are working with immutable containers, see link:https://hub.docker.com/r/
 endif::community[]
 
 ifdef::product[]
-
+To deploy a {prodname} SQL Server connector, you add the connector files to Kafka Connect, create a custom container to run the connector, and then add connector configuration to your container.
 For details about deploying the {prodname} SQL Server connector, see the following topics:
 
-* xref:installing-debezium-sql-server-connectors[]
-* xref:debezium-sql-server-connector-configuration-example[]
-* xref:adding-sql-server-connector-configuration-to-kafka-connect[]
+* xref:deploying-debezium-sql-server-connectors[]
 * xref:descriptions-of-debezium-sql-server-connector-configuration-properties[]
 
-To deploy a {prodname} SQL Server connector, install the {prodname} SQL Server connector archive, configure the connector, and start the connector by adding its configuration to Kafka Connect.
-
-endif::product[]
-
-ifdef::product[]
 // Type: procedure
-// Title: Installing {prodname} SQL Server connectors
-[id="installing-debezium-sql-server-connectors"]
-==== Installing
+// ModuleID: deploying-debezium-sql-server-connectors
+[[sql-server-deploying-a-connector]]
+== Deploying {prodname} SQL Server connectors
 
-To install the SQL Server connector, follow the procedures in {LinkDebeziumInstallOpenShift}[{NameDebeziumInstallOpenShift}]. The main steps are:
+To deploy a {prodname} SQL Server connector, you must build a custom Kafka Connect container image that contains the {prodname} connector archive, and then push this container image to a container registry.
+You then need to create the following custom resources (CRs):
 
-. Use link:https://access.redhat.com/products/red-hat-amq#streams[Red Hat AMQ Streams] to set up Apache Kafka and Kafka Connect on OpenShift. AMQ Streams offers operators and images that bring Kafka to OpenShift.
+* A `KafkaConnect` CR that configures your Kafka Connector and that specifies the name of the image that you created to run your {prodname} connector.
+  You apply this CR to the OpenShift Kafka instance.
 
-. From a browser, open the link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions[Software Downloads page on the Red Hat Customer Portal],
-and download the {prodname} SQL Server connector.
+* A `KafkaConnector` CR that configures your {prodname} SQL Server connector.
+  You apply this CR to the OpenShift instance where Red Hat AMQ Streams is deployed.
 
-. Extract the connector files into your Kafka Connect environment.
-. Add the connector plug-in's parent directory to your Kafka Connect `plugin.path`, for example:
+
+.Prerequisites
+
+* SQL Server is running and you completed the steps to {LinkDebeziumUserGuide}#setting-up-sql-server-for-use-with-the-debezium-sql-server-connector[set up SQL Server to run a {prodname} connector].
+
+* link:https://access.redhat.com/products/red-hat-amq#streams[Red Hat AMQ Streams] was used to set up and start running Apache Kafka and Kafka Connect on OpenShift.
+  AMQ Streams offers operators and images that bring Kafka to OpenShift.
+
+* Podman or Docker is installed.
+
+* You have an account and permissions to create and manage containers in the container registry (such as `quay.io` or `docker.io`) to which you plan to add the container that will run your Debezium connector.
+
+.Procedure
+
+. Create the {prodname} SQL Server container for Kafka Connect:
+.. Download the {prodname} link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions[SQL Server connector archive].
+
+.. Extract the {prodname} SQL Server connector archive to create a directory structure for the connector plug-in, for example:
 +
-[source]
+[subs="+macros"]
 ----
-plugin.path=/kafka/connect
+./my-plugins/
+├── debezium-connector-sqlserver
+│   ├── ...
+----
+
+.. Create a Docker file that uses `{DockerKafkaConnect}` as the base image.
+For example, from a terminal window, enter the following, replacing `my-plugins` with the name of your plug-ins directory:
++
+[source,shell,subs="+attributes,+quotes"]
+----
+cat <<EOF >debezium-container-for-sqlserver.yaml // <1>
+FROM {DockerKafkaConnect}
+USER root:root
+COPY ./_<my-plugins>_/ /opt/kafka/plugins/ // <2>
+USER 1001
+EOF
+----
+<1> You can specify any file name that you want.
+<2> Replace `my-plugins` with the name of your plug-ins directory.
++
+The command creates a Docker file with the name `debezium-container-for-sqlserver.yaml` in the current directory.
+
+.. Build the container image from the `debezium-container-for-sqlserver.yaml` Docker file that you created in the previous step.
+From the directory that contains the file, open a terminal window and enter one of the following commands:
++
+[source,shell,options="nowrap"]
+----
+podman build -t debezium-container-for-sqlserver:latest .
 ----
 +
-The preceding example assumes that you extracted the {prodname} SQL Server connector to the `/kafka/connect/{prodname}-connector-sqlserver` path.
-
-. Restart your Kafka Connect process to ensure that it picks up the new JAR files.
-
-You also need to {LinkDebeziumUserGuide}#setting-up-sqlserver[set up SQL Server] to run a {prodname} connector.
-
-.Additional resources
-
-For more information about the deployment process, and deploying connectors with AMQ Streams, see the {prodname} installation guides.
-
-* {LinkDebeziumInstallOpenShift}[{NameDebeziumInstallOpenShift}]
-* {LinkDebeziumInstallRHEL}[{NameDebeziumInstallRHEL}]
-
-endif::product[]
-
-
-// Type: concept
-// ModuleID: debezium-sql-server-connector-configuration-example
-// Title: {prodname} SQL Server connector configuration example
-[[sqlserver-example-configuration]]
-==== Example configuration
-
-To use the connector to produce change events for a particular SQL Server database or cluster:
-
-. Enable the {link-prefix}:{link-sqlserver-connector}#setting-up-sqlserver[CDC on SQL Server] to publish the _CDC_ events in the database.
-. Create a configuration file for the SQL Server connector.
-
-When the connector starts, it will create a consistent snapshot of the schemas in your SQL Server database and start streaming changes, producing change event records for every row in which data was inserted, updated, or deleted.
-Optionally, you can configure the connector to produce change events for a subset of the schemas and tables in a database.
-For example you can ignore, mask, or truncate columns that contain sensitive data, that are larger than a specified size, or that you do not need.
-
-ifdef::community[]
-Following is an example of the configuration for a connector instance that captures data from a SQL Server server at port 1433 on 192.168.99.100, which we logically name `fullfillment`.
-Typically, you configure the {prodname} SQL Server connector in a `.json` file using the configuration properties available for the connector.
-
-[source,json]
+[source,shell,options="nowrap"]
 ----
-{
-  "name": "inventory-connector", // <1>
-  "config": {
-    "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector", // <2>
-    "database.hostname": "192.168.99.100", // <3>
-    "database.port": "1433", // <4>
-    "database.user": "sa", // <5>
-    "database.password": "Password!", // <6>
-    "database.dbname": "testDB", // <7>
-    "database.server.name": "fullfillment", // <8>
-    "table.include.list": "dbo.customers", // <9>
-    "database.history.kafka.bootstrap.servers": "kafka:9092", // <10>
-    "database.history.kafka.topic": "dbhistory.fullfillment" // <11>
-  }
-}
+docker build -t debezium-container-for-sqlserver:latest .
 ----
-<1> The name of our connector when we register it with a Kafka Connect service.
-<2> The name of this SQL Server connector class.
-<3> The address of the SQL Server instance.
-<4> The port number of the SQL Server instance.
-<5> The name of the SQL Server user
-<6> The password for the SQL Server user
-<7> The name of the database to capture changes from.
-<8> The logical name of the SQL Server instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
-<9> A list of all tables whose changes {prodname} should capture.
-<10> The list of Kafka brokers that this connector will use to write and recover DDL statements to the database history topic.
-<11> The name of the database history topic where the connector will write and recover DDL statements. This topic is for internal use only and should not be used by consumers.
+The preceding command builds a container image with the name `debezium-container-for-sqlserver`.
 
-endif::community[]
+.. Push your custom image to a container registry, such as quay.io or an internal container registry.
+The container registry must be available to the OpenShift instance where you want to deploy the image.
+Enter one of the following commands:
++
+[source,shell,subs="+quotes"]
+----
+podman push _<myregistry.io>_/debezium-container-for-sqlserver:latest
+----
++
+[source,shell,subs="+quotes"]
+----
+docker push _<myregistry.io>_/debezium-container-for-sqlserver:latest
+----
 
-ifdef::product[]
+.. Create a new {prodname} SQL Server KafkaConnect custom resource (CR).
+For example, create a KafkaConnect CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties as shown in the following example:
++
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnect
+metadata:
+  name: my-connect-cluster
+  annotations:strimzi.io/use-connector-resources: "true" // <1>
+spec:
+  #...
+  image: debezium-container-for-sqlserver  // <2>
+----
 
-The following example shows the configuration for a connector instance with the logical name `fullfillment` that captures a SQL Server server at port 1433 on 192.168.99.100.
-Typically, you configure the {prodname} SQL Server connector in a `.yaml` file in which you assign values to the configuration properties that are available for the connector.
+<1>  `metadata.annotations` indicates to the Cluster Operator that KafkaConnector resources are used to configure connectors in this Kafka Connect cluster.
 
+<2>  `spec.image` specifies the name of the image that you created to run your Debezium connector.
+This property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator
+
+.. Apply the `KafkaConnect` CR to the OpenShift Kafka instance by entering the following command:
++
+[source,shell,options="nowrap"]
+----
+oc create -f dbz-connect.yaml
+----
++
+The command updates the Kafka Connect environment on OpenShift by adding a Kafka Connector instance that specifies the name of the image that you created to run your {prodname} connector.
+
+. Create a `KafkaConnector` custom resource that configures your {prodname} SQL Server connector instance.
++
+You configure a {prodname} SQL Server connector in a `.yaml` file that specifies the configuration properties for the connector.
+The connector configuration might instruct {prodname} to produce events for a subset of the schemas and tables, or it might set properties so that {prodname} ignores, masks, or truncates values in specified columns that are sensitive, too large, or not needed.
+For more information, see the {link-prefix}:{link-sqlserver-connector}#descriptions-of-debezium-sql-server-connector-configuration-properties[complete list of the SQL Server connector properties] that you can configure.
++
+The following example configures a {prodname} connector that connects to a SQL server host, `192.168.99.100`, on port `1433`.
+This host has a database named `testDB`, a table with the name `customers`, and `fulfillment` is the server's logical name.
++
+.SQL Server `fulfillment-connector.yaml`
 [source,yaml,options="nowrap"]
 ----
-apiVersion: kafka.strimzi.io/v1beta1
+apiVersion: {KafkaConnectorApiVersion}
   kind: KafkaConnector
   metadata:
-    name: inventory-connector // <1>
-    labels: strimzi.io/cluster: my-connect-cluster
+    name: fulfillment-connector // <1>
+    labels:
+      strimzi.io/cluster: my-connect-cluster
+    annotations:
+      strimzi.io/use-connector-resources: 'true'
   spec:
     class: io.debezium.connector.sqlserver.SqlServerConnector // <2>
     config:
@@ -1762,7 +1777,6 @@ apiVersion: kafka.strimzi.io/v1beta1
       database.history.kafka.topic: dbhistory.fullfillment // <11>
 
 ----
-
 .Descriptions of connector configuration settings
 [cols="1,7",options="header",subs="+attributes"]
 |===
@@ -1803,11 +1817,99 @@ apiVersion: kafka.strimzi.io/v1beta1
 
 |===
 
+. Create your connector instance with Kafka Connect.
+  For example, if you saved your `KafkaConnector` resource in the `fulfillment-connector.yaml` file, you would run the following command:
++
+[source,shell,options="nowrap"]
+----
+oc apply -f fulfillment-connector.yaml
+----
++
+The preceding command registers `fulfillment-connector` and the connector starts to run against the `testDB` database as defined in the `KafkaConnector` CR.
+
+. Verify that the connector was created and has started:
+.. Display the Kafka Connect log output to verify that the connector was created and has started to capture changes in the specified database:
++
+[source,shell,options="nowrap"]
+----
+oc logs $(oc get pods -o name -l strimzi.io/cluster=my-connect-cluster)
+----
+
+.. Review the log output to verify that the initial snapshot has been executed.
+The log displays output that is similar to the following messages:
++
+[source,shell,options="nowrap"]
+----
+... INFO Starting snapshot for ...
+... INFO Snapshot is using user 'debezium' ...
+----
++
+If the connector starts correctly without errors, it creates a topic for each table whose changes the connector is capturing.
+For the example CR, there would be a topic for the table specified the `include.list` property.
+Downstream applications can subscribe to these topics.
+
+.. Verify that the connector created the topics by running the following command:
++
+[source,shell,options="nowrap"]
+----
+oc get kafkatopics
+----
+.Results
+
+When the connector starts, it {link-prefix}:{link-sqlserver-connector}#how-debezium-sql-server-connectors-perform-database-snapshots[performs a consistent snapshot] of the SQL Server databases that the connector is configured for.
+The connector then starts generating data change events for row-level operations and streaming the change event records to Kafka topics.
+
 endif::product[]
+
+ifdef::community[]
+Following is an example of the configuration for a connector instance that captures data from a SQL Server server at port 1433 on 192.168.99.100, which we logically name `fullfillment`.
+Typically, you configure the {prodname} SQL Server connector in a `.json` file using the configuration properties available for the connector.
+
+[source,json]
+----
+{
+  "name": "inventory-connector", // <1>
+  "config": {
+    "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector", // <2>
+    "database.hostname": "192.168.99.100", // <3>
+    "database.port": "1433", // <4>
+    "database.user": "sa", // <5>
+    "database.password": "Password!", // <6>
+    "database.dbname": "testDB", // <7>
+    "database.server.name": "fullfillment", // <8>
+    "table.include.list": "dbo.customers", // <9>
+    "database.history.kafka.bootstrap.servers": "kafka:9092", // <10>
+    "database.history.kafka.topic": "dbhistory.fullfillment" // <11>
+  }
+}
+----
+<1> The name of our connector when we register it with a Kafka Connect service.
+<2> The name of this SQL Server connector class.
+<3> The address of the SQL Server instance.
+<4> The port number of the SQL Server instance.
+<5> The name of the SQL Server user
+<6> The password for the SQL Server user
+<7> The name of the database to capture changes from.
+<8> The logical name of the SQL Server instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
+<9> A list of all tables whose changes {prodname} should capture.
+<10> The list of Kafka brokers that this connector will use to write and recover DDL statements to the database history topic.
+<11> The name of the database history topic where the connector will write and recover DDL statements. This topic is for internal use only and should not be used by consumers.
+
+endif::community[]
+
+ifdef::product[]
+
+The following example configures a {prodname} connector that connects to a SQL Server server host 192.168.99.100 on port 1433.
+This host has a database named `testDB`, and `fulfillment` is the server’s logical name.
+Typically, you configure the {prodname} SQL Server connector in a `.yaml` file in which you assign values to the configuration properties that are available for the connector.
+
+
 
 See the {link-prefix}:{link-sqlserver-connector}#sqlserver-connector-properties[complete list of connector properties] that can be specified in these configurations.
 
-This configuration can be sent via POST to a running Kafka Connect service, which will then record the configuration and start up the one connector task that will connect to the SQL Server database, read the transaction log, and record events to Kafka topics.
+You can send this configuration with a `POST` command to a running Kafka Connect service.
+The service records the configuration and starts the connector task that connects to the SQL Server database, reads the transaction log, and streams change event records to Kafka topics.
+
 
 // Type: procedure
 // ModuleID: adding-sql-server-connector-configuration-to-kafka-connect
@@ -1869,24 +1971,18 @@ USER 1001
 +
 Before Kafka Connect starts running the connector, Kafka Connect loads any third-party plug-ins that are in the `/opt/kafka/plugins` directory.
 
-.. Build the container image. For example, if you saved the `Dockerfile` that you created in the previous step as `debezium-container-for-sqlserver`, and if the `Dockerfile` is in the current directory, then you would run the following command:
-+
-`podman build -t debezium-container-for-sqlserver:latest .`
 
-.. Push your custom image to your container registry, for example:
-+
-`podman push debezium-container-for-sqlserver:latest`
-
-.. Point to the new container image. Do one of the following:
-+
-* Edit the `spec.image` property of the `KafkaConnector` custom resource. If this property is set, it overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator. For example:
+.. Point to the new container image by editing the `spec.image` property of the `KafkaConnect` custom resource.
+If this property is set, it overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator.
+For example:
 +
 [source,yaml,subs="+attributes"]
 ----
 apiVersion: {KafkaConnectApiVersion}
-kind: KafkaConnector
+kind: KafkaConnect
 metadata:
   name: my-connect-cluster
+  annotations:strimzi.io/use-connector-resources: "true"
 spec:
   #...
   image: debezium-container-for-sqlserver
@@ -1908,7 +2004,7 @@ This registers `inventory-connector` and the connector starts to run against the
 +
 [source,shell,options="nowrap"]
 ----
-oc logs $(oc get pods -o name -l strimzi.io/name=my-connect-cluster-connect)
+oc logs $(oc get pods -o name -l strimzi.io/name=my-connect-cluster)
 ----
 
 .. Review the log output to verify that the initial snapshot has been executed. You should see something like the following lines:
@@ -2265,12 +2361,11 @@ database.history.consumer.ssl.key.password=test1234
 
 Be sure to consult the {link-kafka-docs}.html[Kafka documentation] for all of the configuration properties for Kafka producers and consumers. (The SQL Server connector does use the {link-kafka-docs}.html#newconsumerconfigs[new consumer].)
 
-
 // Type: assembly
 // ModuleID: refreshing-capture-tables-after-a-schema-change
 // Title: Refreshing capture tables after a schema change
 [[sqlserver-schema-evolution]]
-=== Database schema evolution
+== Database schema evolution
 
 When change data capture is enabled for a SQL Server table, as changes occur in the table, event records are persisted to a capture table on the server.
 If you introduce a change in the structure of the source table change, for example, by adding a new column, that change is not dynamically reflected in the change table.
@@ -2312,7 +2407,7 @@ Similarly, columns that had been defined as required (`NOT NULL`), retain that d
 // ModuleID: debezium-sql-server-connector-running-an-offline-update-after-a-schema-change
 // Title: Running an offline update after a schema change
 [id="offline-schema-updates"]
-==== Offline schema updates
+=== Offline schema updates
 
 Offline schema updates provide the safest method for updating capture tables.
 However, offline updates might not be feasible for use with applications that require high-availability.
@@ -2336,7 +2431,7 @@ However, offline updates might not be feasible for use with applications that re
 // ModuleID: debezium-sql-server-connector-running-an-online-update-after-a-schema-change
 // Title: Running an online update after a schema change
 [id="online-schema-updates"]
-==== Online schema updates
+=== Online schema updates
 
 The procedure for completing an online schema updates is simpler than the procedure for running an offline schema update,
 and you can complete it without requiring any downtime in application and data processing.
@@ -2441,7 +2536,7 @@ GO
 // ModuleID: monitoring-debezium-sql-server-connector-performance
 // Title: Monitoring {prodname} SQL Server connector performance
 [[sqlserver-monitoring]]
-=== Monitoring
+== Monitoring
 
 The {prodname} SQL Server connector provides three types of metrics that are in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect provide.
 The connector provides the following metrics:

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1633,7 +1633,6 @@ When the connector starts, it will create a consistent snapshot of the schemas i
 Optionally, you can configure the connector to produce change events for a subset of the schemas and tables in a database.
 For example you can ignore, mask, or truncate columns that contain sensitive data, that are larger than a specified size, or that you do not need.
 
-ifdef::community[]
 Following is an example of the configuration for a connector instance that captures data from a SQL Server server at port 1433 on 192.168.99.100, which we logically name `fullfillment`.
 Typically, you configure the {prodname} SQL Server connector in a `.json` file using the configuration properties available for the connector.
 
@@ -1675,7 +1674,9 @@ For details about deploying the {prodname} SQL Server connector, see the followi
 
 * xref:deploying-debezium-sql-server-connectors[]
 * xref:descriptions-of-debezium-sql-server-connector-configuration-properties[]
+endif::product[]
 
+ifdef::product[]
 // Type: procedure
 // ModuleID: deploying-debezium-sql-server-connectors
 [[sql-server-deploying-a-connector]]
@@ -1770,25 +1771,25 @@ apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnect
 metadata:
   name: my-connect-cluster
-  annotations:strimzi.io/use-connector-resources: "true" // <1>
+  annotations:
+    strimzi.io/use-connector-resources: "true" // <1>
 spec:
   #...
   image: debezium-container-for-sqlserver  // <2>
 ----
-
 <1>  `metadata.annotations` indicates to the Cluster Operator that KafkaConnector resources are used to configure connectors in this Kafka Connect cluster.
-
 <2>  `spec.image` specifies the name of the image that you created to run your Debezium connector.
 This property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator
 
-.. Apply the `KafkaConnect` CR to the OpenShift Kafka instance by entering the following command:
+.. Apply the `KafkaConnect` CR to the OpenShift Kafka Connect environment by entering the following command:
 +
 [source,shell,options="nowrap"]
 ----
 oc create -f dbz-connect.yaml
 ----
 +
-The command updates the Kafka Connect environment on OpenShift by adding a Kafka Connector instance that specifies the name of the image that you created to run your {prodname} connector.
+The command adds a Kafka Connector instance that specifies the name of the image that you created to run your {prodname} connector.
+
 
 . Create a `KafkaConnector` custom resource that configures your {prodname} SQL Server connector instance.
 +
@@ -1796,6 +1797,7 @@ You configure a {prodname} SQL Server connector in a `.yaml` file that specifies
 The connector configuration might instruct {prodname} to produce events for a subset of the schemas and tables, or it might set properties so that {prodname} ignores, masks, or truncates values in specified columns that are sensitive, too large, or not needed.
 endif::product[]
 For the complete list of the configuration properties that you can set for the {prodname} SQL Server connector, see {link-prefix}:{link-sqlserver-connector}#sqlserver-connector-properties[SQL Server connector properties].
+
 ifdef::community[]
 
 This configuration can be sent via POST to a running Kafka Connect service, which will then record the configuration and start up the one connector task that will connect to the SQL Server database, read the transaction log, and record events to Kafka topics.
@@ -1847,6 +1849,7 @@ apiVersion: {KafkaConnectorApiVersion}
       database.history.kafka.topic: dbhistory.fullfillment // <11>
 
 ----
++
 .Descriptions of connector configuration settings
 [cols="1,7",options="header",subs="+attributes"]
 |===

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1915,7 +1915,7 @@ The log displays output that is similar to the following messages:
 ----
 +
 If the connector starts correctly without errors, it creates a topic for each table whose changes the connector is capturing.
-For the example CR, there would be a topic for the table specified the `include.list` property.
+For the example CR, there would be a topic for the table specified in the `include.list` property.
 Downstream applications can subscribe to these topics.
 
 .. Verify that the connector created the topics by running the following command:

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1825,7 +1825,7 @@ The following example configures a {prodname} connector that connects to a SQL s
 This host has a database named `testDB`, a table with the name `customers`, and `fulfillment` is the server's logical name.
 +
 .SQL Server `fulfillment-connector.yaml`
-[source,yaml,options="nowrap"]
+[source,yaml,subs="+attributes",options="nowrap"]
 ----
 apiVersion: {KafkaConnectorApiVersion}
   kind: KafkaConnector

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1630,47 +1630,8 @@ To deploy a {prodname} SQL Server connector, you install the {prodname} SQL Serv
 
 If you are working with immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s container images] for Åpache ZooKeeper, Apache Kafka, and Kafka Connect.
 You can pull the official link:https://hub.docker.com/_/microsoft-mssql-server[container images for Microsoft SQL Server on Linux] from Docker Hub.
+
 You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and OpenShift].
-
-[[sqlserver-example-configuration]]
-=== SQL Server connector configuration example
-
-Following is an example of the configuration for a connector instance that captures data from a SQL Server server at port 1433 on 192.168.99.100, which we logically name `fullfillment`.
-Typically, you configure the {prodname} SQL Server connector in a JSON file by setting the configuration properties that are available for the connector.
-
-You can choose to produce events for a subset of the schemas and tables in a database.
-Optionally, you can ignore, mask, or truncate columns that contain sensitive data, that are larger than a specified size, or that you do not need.
-
-[source,json]
-----
-{
-  "name": "inventory-connector", // <1>
-  "config": {
-    "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector", // <2>
-    "database.hostname": "192.168.99.100", // <3>
-    "database.port": "1433", // <4>
-    "database.user": "sa", // <5>
-    "database.password": "Password!", // <6>
-    "database.dbname": "testDB", // <7>
-    "database.server.name": "fullfillment", // <8>
-    "table.include.list": "dbo.customers", // <9>
-    "database.history.kafka.bootstrap.servers": "kafka:9092", // <10>
-    "database.history.kafka.topic": "dbhistory.fullfillment" // <11>
-  }
-}
-----
-<1> The name of our connector when we register it with a Kafka Connect service.
-<2> The name of this SQL Server connector class.
-<3> The address of the SQL Server instance.
-<4> The port number of the SQL Server instance.
-<5> The name of the SQL Server user
-<6> The password for the SQL Server user
-<7> The name of the database to capture changes from.
-<8> The logical name of the SQL Server instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
-<9> A list of all tables whose changes {prodname} should capture.
-<10> The list of Kafka brokers that this connector will use to write and recover DDL statements to the database history topic.
-<11> The name of the database history topic where the connector will write and recover DDL statements. This topic is for internal use only and should not be used by consumers.
-
 endif::community[]
 
 ifdef::product[]
@@ -1678,10 +1639,8 @@ To deploy a {prodname} SQL Server connector, you add the connector files to Kafk
 For details about deploying the {prodname} SQL Server connector, see the following topics:
 
 * xref:deploying-debezium-sql-server-connectors[]
-* xref:sql-server-connector-properties[]
-endif::product[]
+* xref:sqlserver-connector-properties[]
 
-ifdef::product[]
 // Type: procedure
 // ModuleID: deploying-debezium-sql-server-connectors
 [[sql-server-deploying-a-connector]]
@@ -1697,7 +1656,6 @@ You then need to create the following custom resources (CRs):
 
 * A `KafkaConnector` CR that defines your {prodname} SQL Server connector.
   Apply this CR to the same OpenShift instance where you apply the `KafkaConnect` CR.
-
 
 .Prerequisites
 
@@ -1753,7 +1711,7 @@ podman build -t debezium-container-for-sqlserver:latest .
 ----
 docker build -t debezium-container-for-sqlserver:latest .
 ----
-The preceding command builds a container image with the name `debezium-container-for-sqlserver`.
+The preceding commands build a container image with the name `debezium-container-for-sqlserver`.
 
 .. Push your custom image to a container registry, such as quay.io or an internal container registry.
 The container registry must be available to the OpenShift instance where you want to deploy the image.
@@ -1797,40 +1755,10 @@ oc create -f dbz-connect.yaml
 +
 The command adds a Kafka Connect instance that specifies the name of the image that you created to run your {prodname} connector.
 
-
 . Create a `KafkaConnector` custom resource that configures your {prodname} SQL Server connector instance.
 +
 You configure a {prodname} SQL Server connector in a `.yaml` file that specifies the configuration properties for the connector.
 The connector configuration might instruct {prodname} to produce events for a subset of the schemas and tables, or it might set properties so that {prodname} ignores, masks, or truncates values in specified columns that are sensitive, too large, or not needed.
-endif::product[]
-For the complete list of the configuration properties that you can set for the {prodname} SQL Server connector, see {link-prefix}:{link-sqlserver-connector}#sqlserver-connector-properties[SQL Server connector properties].
-
-ifdef::community[]
-
-You can send this configuration with a `POST` command to a running Kafka Connect service.
-The service records the configuration and start up the one connector task that performs the following tasks:
-
-* Connects to the SQL Server database.
-* Reads the transaction log.
-* Records change events to Kafka topics.
-
-[[sqlserver-adding-connector-configuration]]
-=== Adding connector configuration
-
-To run a {prodname} SQL Server connector, create a connector configuration and add the configuration to your Kafka Connect cluster.
-
-.Prerequisites
-
-* {link-prefix}:{link-sqlserver-connector}#setting-up-sqlserver[CDC is enabled on SQL Server].
-* A {prodname} SQL Server connector is installed.
-
-.Procedure
-
-. Create a configuration for the SQL Server connector.
-
-. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster.
-endif::community[]
-ifdef::product[]
 +
 The following example configures a {prodname} connector that connects to a SQL server host, `192.168.99.100`, on port `1433`.
 This host has a database named `testDB`, a table with the name `customers`, and `fulfillment` is the server's logical name.
@@ -1839,26 +1767,25 @@ This host has a database named `testDB`, a table with the name `customers`, and 
 [source,yaml,subs="+attributes",options="nowrap"]
 ----
 apiVersion: {KafkaConnectorApiVersion}
-  kind: KafkaConnector
-  metadata:
-    name: fulfillment-connector // <1>
-    labels:
-      strimzi.io/cluster: my-connect-cluster
-    annotations:
-      strimzi.io/use-connector-resources: 'true'
-  spec:
-    class: io.debezium.connector.sqlserver.SqlServerConnector // <2>
-    config:
-      database.hostname: 192.168.99.100 // <3>
-      database.port: 1433 // <4>
-      database.user: debezium // <5>
-      database.password: dbz // <6>
-      database.dbname: testDB // <7>
-      database.server.name: fullfullment // <8>
-      database.include.list: dbo.customers // <9>
-      database.history.kafka.bootstrap.servers: my-cluster-kafka-bootstrap:9092 // <10>
-      database.history.kafka.topic: dbhistory.fullfillment // <11>
-
+kind: KafkaConnector
+metadata:
+  name: fulfillment-connector // <1>
+  labels:
+    strimzi.io/cluster: my-connect-cluster
+  annotations:
+    strimzi.io/use-connector-resources: 'true'
+spec:
+  class: io.debezium.connector.sqlserver.SqlServerConnector // <2>
+  config:
+    database.hostname: 192.168.99.100 // <3>
+    database.port: 1433 // <4>
+    database.user: debezium // <5>
+    database.password: dbz // <6>
+    database.dbname: testDB // <7>
+    database.server.name: fullfullment // <8>
+    database.include.list: dbo.customers // <9>
+    database.history.kafka.bootstrap.servers: my-cluster-kafka-bootstrap:9092 // <10>
+    database.history.kafka.topic: dbhistory.fullfillment // <11>
 ----
 +
 .Descriptions of connector configuration settings
@@ -1938,7 +1865,77 @@ Downstream applications can subscribe to these topics.
 ----
 oc get kafkatopics
 ----
+
 endif::product[]
+
+ifdef::community[]
+[[sqlserver-example-configuration]]
+=== SQL Server connector configuration example
+
+Following is an example of the configuration for a connector instance that captures data from a SQL Server server at port 1433 on 192.168.99.100, which we logically name `fullfillment`.
+Typically, you configure the {prodname} SQL Server connector in a JSON file by setting the configuration properties that are available for the connector.
+
+You can choose to produce events for a subset of the schemas and tables in a database.
+Optionally, you can ignore, mask, or truncate columns that contain sensitive data, that are larger than a specified size, or that you do not need.
+
+[source,json]
+----
+{
+    "name": "inventory-connector", // <1>
+    "config": {
+        "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector", // <2>
+        "database.hostname": "192.168.99.100", // <3>
+        "database.port": "1433", // <4>
+        "database.user": "sa", // <5>
+        "database.password": "Password!", // <6>
+        "database.dbname": "testDB", // <7>
+        "database.server.name": "fullfillment", // <8>
+        "table.include.list": "dbo.customers", // <9>
+        "database.history.kafka.bootstrap.servers": "kafka:9092", // <10>
+        "database.history.kafka.topic": "dbhistory.fullfillment" // <11>
+    }
+}
+----
+<1> The name of our connector when we register it with a Kafka Connect service.
+<2> The name of this SQL Server connector class.
+<3> The address of the SQL Server instance.
+<4> The port number of the SQL Server instance.
+<5> The name of the SQL Server user
+<6> The password for the SQL Server user
+<7> The name of the database to capture changes from.
+<8> The logical name of the SQL Server instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
+<9> A list of all tables whose changes {prodname} should capture.
+<10> The list of Kafka brokers that this connector will use to write and recover DDL statements to the database history topic.
+<11> The name of the database history topic where the connector will write and recover DDL statements. This topic is for internal use only and should not be used by consumers.
+
+endif::community[]
+
+For the complete list of the configuration properties that you can set for the {prodname} SQL Server connector, see {link-prefix}:{link-sqlserver-connector}#sqlserver-connector-properties[SQL Server connector properties].
+
+ifdef::community[]
+You can send this configuration with a `POST` command to a running Kafka Connect service.
+The service records the configuration and start up the one connector task that performs the following tasks:
+
+* Connects to the SQL Server database.
+* Reads the transaction log.
+* Records change events to Kafka topics.
+
+[[sqlserver-adding-connector-configuration]]
+=== Adding connector configuration
+
+To start running a {prodname} SQL Server connector, create a connector configuration, and add the configuration to your Kafka Connect cluster.
+
+.Prerequisites
+
+* {link-prefix}:{link-sqlserver-connector}#setting-up-sqlserver[CDC is enabled on SQL Server].
+* The {prodname} SQL Server connector is installed.
+
+.Procedure
+
+. Create a configuration for the SQL Server connector.
+
+. Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster.
+endif::community[]
 
 .Results
 
@@ -1949,6 +1946,9 @@ The connector then starts generating data change events for row-level operations
 // Title: Descriptions of {prodname} SQL Server connector configuration properties
 [[sqlserver-connector-properties]]
 === Connector properties
+
+The {prodname} SQL Server connector has numerous configuration properties that you can use to achieve the right connector behavior for your application.
+Many properties have default values.
 
 The following configuration properties are _required_ unless a default value is available.
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1685,7 +1685,7 @@ ifdef::product[]
 [[sql-server-deploying-a-connector]]
 === Deploying {prodname} SQL Server connectors
 
-To deploy a {prodname} SQL Server connector, you must build a custom Kafka Connect container image that contains the {prodname} connector archive, and then push this container image to a container registry.
+To deploy a {prodname} SQL Server connector, you must build a custom Kafka Connect container image that contains the {prodname} connector archive, and then push this container image to a container registry. 
 You then need to create the following custom resources (CRs):
 
 * A `KafkaConnect` CR that configures your Kafka Connector and that specifies the name of the image that you created to run your {prodname} connector.

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1618,8 +1618,8 @@ ifdef::community[]
 To deploy a {prodname} SQL Server connector, you install the {prodname} SQL Server connector archive, configure the connector, and start the connector by adding its configuration to Kafka Connect.
 
 .Prerequisites
-* link:https://zookeeper.apache.org/[Zookeeper], link:http://kafka.apache.org/[Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
-* SQL Server is installed and is {link-prefix}:{link-sqlserver-connector}#setting-up-sqlserver[set up to run the {prodname} connector].
+* link:https://zookeeper.apache.org/[Apache ZooKeeper], link:http://kafka.apache.org/[Apache Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
+* SQL Server is installed, is {link-prefix}:{link-sqlserver-connector}#setting-up-sqlserver[configured for CDC], and is ready to be used with the {prodname} connector].
 
 .Procedure
 . Download the {prodname} https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/{debezium-version}/debezium-connector-sqlserver-{debezium-version}-plugin.tar.gz[SQL Server connector plug-in archive]
@@ -1628,7 +1628,9 @@ To deploy a {prodname} SQL Server connector, you install the {prodname} SQL Serv
 . {link-prefix}:{link-sqlserver-connector}#sqlserver-example-configuration[Configure the connector] and {link-prefix}:{link-sqlserver-connector}#sqlserver-adding-connector-configuration[add the configuration to your Kafka Connect cluster.]
 . Restart your Kafka Connect process to pick up the new JAR files.
 
-If you are working with immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s container images] for Zookeeper, Kafka, SQL Server and Kafka Connect with the SQL Server connector already installed and ready to run. You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and OpenShift].
+If you are working with immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s container images] for Åpache ZooKeeper, Apache Kafka, and Kafka Connect.
+You can pull the official link:https://hub.docker.com/_/microsoft-mssql-server[container images for Microsoft SQL Server on Linux] from Docker Hub.
+You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and OpenShift].
 
 [[sqlserver-example-configuration]]
 === SQL Server connector configuration example
@@ -1685,22 +1687,24 @@ ifdef::product[]
 [[sql-server-deploying-a-connector]]
 === Deploying {prodname} SQL Server connectors
 
-To deploy a {prodname} SQL Server connector, you must build a custom Kafka Connect container image that contains the {prodname} connector archive, and then push this container image to a container registry. 
+To deploy a {prodname} SQL Server connector, you must build a custom Kafka Connect container image that contains the {prodname} connector archive, and then push this container image to a container registry.
 You then need to create the following custom resources (CRs):
 
-* A `KafkaConnect` CR that configures your Kafka Connector and that specifies the name of the image that you created to run your {prodname} connector.
-  You apply this CR to the OpenShift Kafka instance.
+* A `KafkaConnect` CR that defines your Kafka Connect instance.
+  The `image` property in the CR specifies the name of the container image that you create to run your {prodname} connector.
+  You apply this CR to the OpenShift instance where link:https://access.redhat.com/products/red-hat-amq#streams[Red Hat {StreamsName}] is deployed.
+  {StreamsName} offers operators and images that bring Apache Kafka to OpenShift.
 
-* A `KafkaConnector` CR that configures your {prodname} SQL Server connector.
-  You apply this CR to the OpenShift instance where Red Hat AMQ Streams is deployed.
+* A `KafkaConnector` CR that defines your {prodname} SQL Server connector.
+  Apply this CR to the same OpenShift instance where you apply the `KafkaConnect` CR.
 
 
 .Prerequisites
 
 * SQL Server is running and you completed the steps to {LinkDebeziumUserGuide}#setting-up-sql-server-for-use-with-the-debezium-sql-server-connector[set up SQL Server to run a {prodname} connector].
 
-* link:https://access.redhat.com/products/red-hat-amq#streams[Red Hat AMQ Streams] was used to set up and start running Apache Kafka and Kafka Connect on OpenShift.
-  AMQ Streams offers operators and images that bring Kafka to OpenShift.
+* {StreamsName} is deployed on OpenShift and is running Apache Kafka and Kafka Connect.
+  For more information, see link:{LinkStreamsOpenShift}:/getting-started-str[{NameDebeziumInstallOpenShift}]
 
 * Podman or Docker is installed.
 
@@ -1791,7 +1795,7 @@ This property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in th
 oc create -f dbz-connect.yaml
 ----
 +
-The command adds a Kafka Connector instance that specifies the name of the image that you created to run your {prodname} connector.
+The command adds a Kafka Connect instance that specifies the name of the image that you created to run your {prodname} connector.
 
 
 . Create a `KafkaConnector` custom resource that configures your {prodname} SQL Server connector instance.
@@ -1817,7 +1821,7 @@ To run a {prodname} SQL Server connector, create a connector configuration and a
 
 .Prerequisites
 
-* {link-prefix}:{link-sqlserver-connector}#setting-up-sqlserver[SQL Server is set up to run a {prodname} connector].
+* {link-prefix}:{link-sqlserver-connector}#setting-up-sqlserver[CDC is enabled on SQL Server].
 * A {prodname} SQL Server connector is installed.
 
 .Procedure

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1817,8 +1817,7 @@ To run a {prodname} SQL Server connector, create a connector configuration and a
 
 .Prerequisites
 
-* SQL Server is set up to run a {prodname} connector.
-
+* {link-prefix}:{link-sqlserver-connector}#setting-up-sqlserver[SQL Server is set up to run a {prodname} connector].
 * A {prodname} SQL Server connector is installed.
 
 .Procedure


### PR DESCRIPTION
Jira: [DBZ-3297](https://issues.redhat.com/browse/DBZ-3297) 

This change to the SQL Server connector doc propagates downstream corrections to the deployment instructions that were implemented in the PG connector doc in Q3 2020. The changes required some restructuring.

Tested in a local Antora build. Other than restructuring the content to eliminate one unnecessary heading level, the changes do not have any effect on the documentation that is rendered upstream.  