### PR TITLE
DBZ-2911 Fix Oracle test compatibility

### DIFF
--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SourceInfoTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SourceInfoTest.java
@@ -55,6 +55,7 @@ public class SourceInfoTest {
                 .field("ts_ms", Schema.INT64_SCHEMA)
                 .field("snapshot", AbstractSourceInfoStructMaker.SNAPSHOT_RECORD_SCHEMA)
                 .field("db", Schema.STRING_SCHEMA)
+                .field("sequence", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("schema", Schema.STRING_SCHEMA)
                 .field("table", Schema.STRING_SCHEMA)
                 .field("txId", Schema.OPTIONAL_STRING_SCHEMA)


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2911

This fixes a regression with Oracle test suite after merging PR #2172.