### PR TITLE
DBZ-3372 Add missing space and insert missing docker build command

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2149,7 +2149,8 @@ To deploy a {prodname} PostgreSQL connector, add the connector files to Kafka Co
 [[postgresql-deploying-a-connector]]
 === Deploying connectors
 
-To deploy a {prodname} PostgreSQL connector, you need to build a custom Kafka Connect container image that contains the {prodname} connector archive and push this container image to a container registry.You then need to create two custom resources (CRs):
+To deploy a {prodname} PostgreSQL connector, you need to build a custom Kafka Connect container image that contains the {prodname} connector archive and push this container image to a container registry.
+You then need to create two custom resources (CRs):
 
 * A `KafkaConnect` CR that configures your Kafka Connector and that specifies the name of the image that you created to run your {prodname} connector. You apply this CR to the OpenShift Kafka instance.
 
@@ -2202,6 +2203,11 @@ From the directory that contains the file, open a terminal window and enter one 
 [source,shell,options="nowrap"]
 ----
 podman build -t debezium-container-for-postgresql:latest .
+----
++
+[source,shell,options="nowrap"]
+----
+docker build -t debezium-container-for-postgresql:latest .
 ----
 +
 The `build` command builds a container image with the name `debezium-container-for-postgresql`.


### PR DESCRIPTION
Jira [DBZ-3372](https://issues.redhat.com/browse/DBZ-3372)

Minor edits to the downstream content in the Deployment section of the PG connector doc. 
Tested the changes in a local Antora build to confirm that they are not visible in the upstream version of the content.