### PR TITLE
DBZ-2975: Extract offset context from object states to method signatures

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeEventSourceFactory.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeEventSourceFactory.java
@@ -12,7 +12,6 @@ import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
-import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.util.Clock;
 
 /**
@@ -20,7 +19,7 @@ import io.debezium.util.Clock;
  *
  * @author Chris Cranford
  */
-public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory {
+public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory<MongoDbOffsetContext> {
 
     private final MongoDbConnectorConfig configuration;
     private final ErrorHandler errorHandler;
@@ -40,12 +39,11 @@ public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory
     }
 
     @Override
-    public SnapshotChangeEventSource getSnapshotChangeEventSource(OffsetContext offsetContext, SnapshotProgressListener snapshotProgressListener) {
+    public SnapshotChangeEventSource<MongoDbOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
         return new MongoDbSnapshotChangeEventSource(
                 configuration,
                 taskContext,
                 replicaSets,
-                (MongoDbOffsetContext) offsetContext,
                 dispatcher,
                 clock,
                 snapshotProgressListener,
@@ -53,12 +51,11 @@ public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory
     }
 
     @Override
-    public StreamingChangeEventSource getStreamingChangeEventSource(OffsetContext offsetContext) {
+    public StreamingChangeEventSource<MongoDbOffsetContext> getStreamingChangeEventSource() {
         return new MongoDbStreamingChangeEventSource(
                 configuration,
                 taskContext,
                 replicaSets,
-                (MongoDbOffsetContext) offsetContext,
                 dispatcher,
                 errorHandler,
                 clock);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
@@ -44,7 +44,7 @@ import io.debezium.util.SchemaNameAdjuster;
  * @author Randall Hauch
  */
 @ThreadSafe
-public final class MongoDbConnectorTask extends BaseSourceTask {
+public final class MongoDbConnectorTask extends BaseSourceTask<MongoDbOffsetContext> {
 
     private static final String CONTEXT_NAME = "mongodb-connector-task";
 
@@ -63,7 +63,7 @@ public final class MongoDbConnectorTask extends BaseSourceTask {
     }
 
     @Override
-    public ChangeEventSourceCoordinator start(Configuration config) {
+    public ChangeEventSourceCoordinator<MongoDbOffsetContext> start(Configuration config) {
         final MongoDbConnectorConfig connectorConfig = new MongoDbConnectorConfig(config);
         final SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create();
 
@@ -103,7 +103,7 @@ public final class MongoDbConnectorTask extends BaseSourceTask {
                     metadataProvider,
                     schemaNameAdjuster);
 
-            ChangeEventSourceCoordinator coordinator = new ChangeEventSourceCoordinator(
+            ChangeEventSourceCoordinator<MongoDbOffsetContext> coordinator = new ChangeEventSourceCoordinator<>(
                     previousOffsets,
                     errorHandler,
                     MongoDbConnector.class,

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
@@ -47,7 +47,7 @@ import io.debezium.util.Threads;
  *
  * @author Chris Cranford
  */
-public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSource {
+public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSource<MongoDbOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbStreamingChangeEventSource.class);
 
@@ -58,38 +58,42 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
     private static final String OPERATION_CONTROL = "c";
     private static final String TX_OPS = "applyOps";
 
+    private final MongoDbConnectorConfig connectorConfig;
     private final EventDispatcher<CollectionId> dispatcher;
     private final ErrorHandler errorHandler;
     private final Clock clock;
-    private final MongoDbOffsetContext offsetContext;
     private final ConnectionContext connectionContext;
     private final ReplicaSets replicaSets;
     private final MongoDbTaskContext taskContext;
 
     public MongoDbStreamingChangeEventSource(MongoDbConnectorConfig connectorConfig, MongoDbTaskContext taskContext,
-                                             ReplicaSets replicaSets, MongoDbOffsetContext offsetContext,
+                                             ReplicaSets replicaSets,
                                              EventDispatcher<CollectionId> dispatcher, ErrorHandler errorHandler, Clock clock) {
+        this.connectorConfig = connectorConfig;
         this.connectionContext = taskContext.getConnectionContext();
         this.dispatcher = dispatcher;
         this.errorHandler = errorHandler;
         this.clock = clock;
         this.replicaSets = replicaSets;
         this.taskContext = taskContext;
-        this.offsetContext = (offsetContext != null) ? offsetContext : initializeOffsets(connectorConfig, replicaSets);
     }
 
     @Override
-    public void execute(ChangeEventSourceContext context) throws InterruptedException {
+    public void execute(ChangeEventSourceContext context, MongoDbOffsetContext offsetContext) throws InterruptedException {
         final List<ReplicaSet> validReplicaSets = replicaSets.validReplicaSets();
+
+        if (offsetContext == null) {
+            offsetContext = initializeOffsets(connectorConfig, replicaSets);
+        }
 
         try {
             if (validReplicaSets.size() == 1) {
                 // Streams the replica-set changes in the current thread
-                streamChangesForReplicaSet(context, validReplicaSets.get(0));
+                streamChangesForReplicaSet(context, validReplicaSets.get(0), offsetContext);
             }
             else if (validReplicaSets.size() > 1) {
                 // Starts a thread for each replica-set and executes the streaming process
-                streamChangesForReplicaSets(context, validReplicaSets);
+                streamChangesForReplicaSets(context, validReplicaSets, offsetContext);
             }
         }
         finally {
@@ -97,14 +101,15 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
         }
     }
 
-    private void streamChangesForReplicaSet(ChangeEventSourceContext context, ReplicaSet replicaSet) {
+    private void streamChangesForReplicaSet(ChangeEventSourceContext context, ReplicaSet replicaSet,
+                                            MongoDbOffsetContext offsetContext) {
         MongoPrimary primaryClient = null;
         try {
             primaryClient = establishConnectionToPrimary(replicaSet);
             if (primaryClient != null) {
                 final AtomicReference<MongoPrimary> primaryReference = new AtomicReference<>(primaryClient);
                 primaryClient.execute("read from oplog on '" + replicaSet + "'", primary -> {
-                    readOplog(primary, primaryReference.get(), replicaSet, context);
+                    readOplog(primary, primaryReference.get(), replicaSet, context, offsetContext);
                 });
             }
         }
@@ -119,7 +124,8 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
         }
     }
 
-    private void streamChangesForReplicaSets(ChangeEventSourceContext context, List<ReplicaSet> replicaSets) {
+    private void streamChangesForReplicaSets(ChangeEventSourceContext context, List<ReplicaSet> replicaSets,
+                                             MongoDbOffsetContext offsetContext) {
         final int threads = replicaSets.size();
         final ExecutorService executor = Threads.newFixedThreadPool(MongoDbConnector.class, taskContext.serverName(), "replicator-streaming", threads);
         final CountDownLatch latch = new CountDownLatch(threads);
@@ -129,7 +135,7 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
         replicaSets.forEach(replicaSet -> {
             executor.submit(() -> {
                 try {
-                    streamChangesForReplicaSet(context, replicaSet);
+                    streamChangesForReplicaSet(context, replicaSet, offsetContext);
                 }
                 finally {
                     latch.countDown();
@@ -162,7 +168,8 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
         });
     }
 
-    private void readOplog(MongoClient primary, MongoPrimary primaryClient, ReplicaSet replicaSet, ChangeEventSourceContext context) {
+    private void readOplog(MongoClient primary, MongoPrimary primaryClient, ReplicaSet replicaSet, ChangeEventSourceContext context,
+                           MongoDbOffsetContext offsetContext) {
         final ReplicaSetOffsetContext rsOffsetContext = offsetContext.getReplicaSetOffsetContext(replicaSet);
 
         final BsonTimestamp oplogStart = rsOffsetContext.lastOffsetTimestamp();

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/EventBuffer.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/EventBuffer.java
@@ -74,7 +74,7 @@ class EventBuffer {
      * An entry point to the buffer that should be used by BinlogReader to push events.
      * @param event to be stored in the buffer
      */
-    public void add(Event event) {
+    public void add(MySqlOffsetContext offsetContext, Event event) {
         if (event == null) {
             return;
         }
@@ -83,7 +83,7 @@ class EventBuffer {
         // buffer was full and the end of the TX; in this case there's nothing to do
         // besides directly emitting the events
         if (isReplayingEventsBeyondBufferCapacity()) {
-            streamingChangeEventSource.handleEvent(event);
+            streamingChangeEventSource.handleEvent(offsetContext, event);
             return;
         }
 
@@ -92,23 +92,23 @@ class EventBuffer {
             LOGGER.debug("Received query command: {}", event);
             String sql = command.getSql().trim();
             if (sql.equalsIgnoreCase("BEGIN")) {
-                beginTransaction(event);
+                beginTransaction(offsetContext, event);
             }
             else if (sql.equalsIgnoreCase("COMMIT")) {
-                completeTransaction(true, event);
+                completeTransaction(offsetContext, true, event);
             }
             else if (sql.equalsIgnoreCase("ROLLBACK")) {
                 rollbackTransaction();
             }
             else {
-                consumeEvent(event);
+                consumeEvent(offsetContext, event);
             }
         }
         else if (event.getHeader().getEventType() == EventType.XID) {
-            completeTransaction(true, event);
+            completeTransaction(offsetContext, true, event);
         }
         else {
-            consumeEvent(event);
+            consumeEvent(offsetContext, event);
         }
     }
 
@@ -157,19 +157,19 @@ class EventBuffer {
         return largeTxNotBufferedPosition != null;
     }
 
-    private void consumeEvent(Event event) {
+    private void consumeEvent(MySqlOffsetContext offsetContext, Event event) {
         if (txStarted) {
             addToBuffer(event);
         }
         else {
-            streamingChangeEventSource.handleEvent(event);
+            streamingChangeEventSource.handleEvent(offsetContext, event);
         }
     }
 
-    private void beginTransaction(Event event) {
+    private void beginTransaction(MySqlOffsetContext offsetContext, Event event) {
         if (txStarted) {
             LOGGER.warn("New transaction started but the previous was not completed, processing the buffer");
-            completeTransaction(false, null);
+            completeTransaction(offsetContext, false, null);
         }
         else {
             txStarted = true;
@@ -184,7 +184,7 @@ class EventBuffer {
      * @param wellFormed
      * @param event
      */
-    private void completeTransaction(boolean wellFormed, Event event) {
+    private void completeTransaction(MySqlOffsetContext offsetContext, boolean wellFormed, Event event) {
         LOGGER.debug("Committing transaction");
         if (event != null) {
             addToBuffer(event);
@@ -195,7 +195,7 @@ class EventBuffer {
         }
         LOGGER.debug("Executing events from buffer");
         for (Event e : buffer) {
-            streamingChangeEventSource.handleEvent(e);
+            streamingChangeEventSource.handleEvent(offsetContext, e);
         }
         LOGGER.debug("Executing events from binlog that have not fit into buffer");
         if (isInBufferFullMode()) {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceFactory.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceFactory.java
@@ -21,12 +21,11 @@ import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
-import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.relational.TableId;
 import io.debezium.schema.DataCollectionId;
 import io.debezium.util.Clock;
 
-public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory {
+public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<MySqlOffsetContext> {
 
     private final MySqlConnectorConfig configuration;
     private final MySqlConnection connection;
@@ -58,8 +57,8 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory {
     }
 
     @Override
-    public SnapshotChangeEventSource getSnapshotChangeEventSource(OffsetContext offsetContext, SnapshotProgressListener snapshotProgressListener) {
-        return new MySqlSnapshotChangeEventSource(configuration, (MySqlOffsetContext) offsetContext, connection, taskContext.getSchema(), dispatcher, clock,
+    public SnapshotChangeEventSource<MySqlOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
+        return new MySqlSnapshotChangeEventSource(configuration, connection, taskContext.getSchema(), dispatcher, clock,
                 (MySqlSnapshotChangeEventSourceMetrics) snapshotProgressListener, record -> modifyAndFlushLastRecord(record));
     }
 
@@ -69,11 +68,10 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory {
     }
 
     @Override
-    public StreamingChangeEventSource getStreamingChangeEventSource(OffsetContext offsetContext) {
+    public StreamingChangeEventSource<MySqlOffsetContext> getStreamingChangeEventSource() {
         queue.disableBuffering();
         return new MySqlStreamingChangeEventSource(
                 configuration,
-                (MySqlOffsetContext) offsetContext,
                 connection,
                 dispatcher,
                 errorHandler,
@@ -84,7 +82,7 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory {
 
     @Override
     public Optional<IncrementalSnapshotChangeEventSource<? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(
-                                                                                                                              OffsetContext offsetContext,
+                                                                                                                              MySqlOffsetContext offsetContext,
                                                                                                                               SnapshotProgressListener snapshotProgressListener,
                                                                                                                               DataChangeEventListener dataChangeEventListener) {
         final SignalBasedIncrementalSnapshotChangeEventSource<TableId> incrementalSnapshotChangeEventSource = new SignalBasedIncrementalSnapshotChangeEventSource<TableId>(

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -88,7 +88,7 @@ public class MySqlConnectorTask extends BaseSourceTask<MySqlOffsetContext> {
 
         validateBinlogConfiguration(connectorConfig);
 
-        MySqlOffsetContext previousOffset = (MySqlOffsetContext) getPreviousOffset(new MySqlOffsetContext.Loader(connectorConfig));
+        MySqlOffsetContext previousOffset = getPreviousOffset(new MySqlOffsetContext.Loader(connectorConfig));
         if (previousOffset == null) {
             LOGGER.info("No previous offset found");
         }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -41,7 +41,7 @@ import io.debezium.util.SchemaNameAdjuster;
  * @author Jiri Pechanec
  *
  */
-public class MySqlConnectorTask extends BaseSourceTask {
+public class MySqlConnectorTask extends BaseSourceTask<MySqlOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MySqlConnectorTask.class);
     private static final String CONTEXT_NAME = "mysql-connector-task";
@@ -58,7 +58,7 @@ public class MySqlConnectorTask extends BaseSourceTask {
     }
 
     @Override
-    public ChangeEventSourceCoordinator start(Configuration config) {
+    public ChangeEventSourceCoordinator<MySqlOffsetContext> start(Configuration config) {
         final Clock clock = Clock.system();
         final MySqlConnectorConfig connectorConfig = new MySqlConnectorConfig(
                 config.edit()
@@ -134,7 +134,7 @@ public class MySqlConnectorTask extends BaseSourceTask {
 
         final MySqlStreamingChangeEventSourceMetrics streamingMetrics = new MySqlStreamingChangeEventSourceMetrics(taskContext, queue, metadataProvider);
 
-        ChangeEventSourceCoordinator coordinator = new ChangeEventSourceCoordinator(
+        ChangeEventSourceCoordinator<MySqlOffsetContext> coordinator = new ChangeEventSourceCoordinator<>(
                 previousOffset,
                 errorHandler,
                 MySqlConnector.class,

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlOffsetContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlOffsetContext.java
@@ -186,7 +186,7 @@ public class MySqlOffsetContext implements OffsetContext {
         return offset;
     }
 
-    public static class Loader implements OffsetContext.Loader {
+    public static class Loader implements OffsetContext.Loader<MySqlOffsetContext> {
 
         private final MySqlConnectorConfig connectorConfig;
 
@@ -200,7 +200,7 @@ public class MySqlOffsetContext implements OffsetContext {
         }
 
         @Override
-        public OffsetContext load(Map<String, ?> offset) {
+        public MySqlOffsetContext load(Map<String, ?> offset) {
             boolean snapshot = Boolean.TRUE.equals(offset.get(SourceInfo.SNAPSHOT_KEY)) || "true".equals(offset.get(SourceInfo.SNAPSHOT_KEY));
             boolean snapshotCompleted = Boolean.TRUE.equals(offset.get(SNAPSHOT_COMPLETED_KEY)) || "true".equals(offset.get(SNAPSHOT_COMPLETED_KEY));
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -87,7 +87,7 @@ import io.debezium.util.Threads;
  *
  * @author Jiri Pechanec
  */
-public class MySqlStreamingChangeEventSource implements StreamingChangeEventSource {
+public class MySqlStreamingChangeEventSource implements StreamingChangeEventSource<MySqlOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MySqlStreamingChangeEventSource.class);
 
@@ -114,7 +114,6 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
     private final MySqlConnectorConfig connectorConfig;
     private final MySqlConnection connection;
     private final EventDispatcher<TableId> eventDispatcher;
-    private final MySqlOffsetContext offsetContext;
     private final ErrorHandler errorHandler;
 
     @SingleThreadAccess("binlog client thread")
@@ -180,7 +179,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
         void emit(TableId tableId, T data) throws InterruptedException;
     }
 
-    public MySqlStreamingChangeEventSource(MySqlConnectorConfig connectorConfig, MySqlOffsetContext offsetContext, MySqlConnection connection,
+    public MySqlStreamingChangeEventSource(MySqlConnectorConfig connectorConfig, MySqlConnection connection,
                                            EventDispatcher<TableId> dispatcher, ErrorHandler errorHandler, Clock clock,
                                            MySqlTaskContext taskContext, MySqlStreamingChangeEventSourceMetrics metrics) {
 
@@ -190,8 +189,6 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
         this.clock = clock;
         this.eventDispatcher = dispatcher;
         this.errorHandler = errorHandler;
-        // With snapshot mode NEVER the initial context is not created by snapshot
-        this.offsetContext = (offsetContext == null) ? MySqlOffsetContext.initial(connectorConfig) : offsetContext;
         this.metrics = metrics;
 
         eventDeserializationFailureHandlingMode = connectorConfig.getEventProcessingFailureHandlingMode();
@@ -288,7 +285,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
         client.setEventDeserializer(eventDeserializer);
     }
 
-    protected void onEvent(Event event) {
+    protected void onEvent(MySqlOffsetContext offsetContext, Event event) {
         long ts = 0;
 
         if (event.getHeader().getEventType() == EventType.HEARTBEAT) {
@@ -313,11 +310,11 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
         metrics.setMilliSecondsBehindSource(ts);
     }
 
-    protected void ignoreEvent(Event event) {
+    protected void ignoreEvent(MySqlOffsetContext offsetContext, Event event) {
         LOGGER.trace("Ignoring event due to missing handler: {}", event);
     }
 
-    protected void handleEvent(Event event) {
+    protected void handleEvent(MySqlOffsetContext offsetContext, Event event) {
         if (event == null) {
             return;
         }
@@ -349,7 +346,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
         // If there is a handler for this event, forward the event to it ...
         try {
             // Forward the event to the handler ...
-            eventHandlers.getOrDefault(eventType, this::ignoreEvent).accept(event);
+            eventHandlers.getOrDefault(eventType, (e) -> ignoreEvent(offsetContext, e)).accept(event);
 
             // Generate heartbeat message if the time is right
             eventDispatcher.dispatchHeartbeatEvent(offsetContext);
@@ -396,7 +393,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
      *
      * @param event the server stopped event to be processed; may not be null
      */
-    protected void handleServerStop(Event event) {
+    protected void handleServerStop(MySqlOffsetContext offsetContext, Event event) {
         LOGGER.debug("Server stopped: {}", event);
     }
 
@@ -406,7 +403,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
      *
      * @param event the server stopped event to be processed; may not be null
      */
-    protected void handleServerHeartbeat(Event event) {
+    protected void handleServerHeartbeat(MySqlOffsetContext offsetContext, Event event) {
         LOGGER.trace("Server heartbeat: {}", event);
     }
 
@@ -416,7 +413,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
      *
      * @param event the server stopped event to be processed; may not be null
      */
-    protected void handleServerIncident(Event event) {
+    protected void handleServerIncident(MySqlOffsetContext offsetContext, Event event) {
         if (event.getData() instanceof EventDataDeserializationExceptionData) {
             metrics.onErroneousEvent("source = " + event.toString());
             EventDataDeserializationExceptionData data = event.getData();
@@ -462,7 +459,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
      *
      * @param event the database change data event to be processed; may not be null
      */
-    protected void handleRotateLogsEvent(Event event) {
+    protected void handleRotateLogsEvent(MySqlOffsetContext offsetContext, Event event) {
         LOGGER.debug("Rotating logs: {}", event);
         RotateEventData command = unwrapData(event);
         assert command != null;
@@ -482,7 +479,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
      *
      * @param event the GTID event to be processed; may not be null
      */
-    protected void handleGtidEvent(Event event) {
+    protected void handleGtidEvent(MySqlOffsetContext offsetContext, Event event) {
         LOGGER.debug("GTID transaction: {}", event);
         GtidEventData gtidEvent = unwrapData(event);
         String gtid = gtidEvent.getGtid();
@@ -504,7 +501,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
      *
      * @param event the database change data event to be processed; may not be null
      */
-    protected void handleRowsQuery(Event event) {
+    protected void handleRowsQuery(MySqlOffsetContext offsetContext, Event event) {
         // Unwrap the RowsQueryEvent
         final RowsQueryEventData lastRowsQueryEventData = unwrapData(event);
 
@@ -519,7 +516,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
      * @param event the database change data event to be processed; may not be null
      * @throws InterruptedException if this thread is interrupted while recording the DDL statements
      */
-    protected void handleQueryEvent(Event event) throws InterruptedException {
+    protected void handleQueryEvent(MySqlOffsetContext offsetContext, Event event) throws InterruptedException {
         QueryEventData command = unwrapData(event);
         LOGGER.debug("Received query command: {}", event);
         String sql = command.getSql().trim();
@@ -537,7 +534,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
             return;
         }
         if (sql.equalsIgnoreCase("COMMIT")) {
-            handleTransactionCompletion(event);
+            handleTransactionCompletion(offsetContext, event);
             return;
         }
 
@@ -591,7 +588,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
         }
     }
 
-    private void handleTransactionCompletion(Event event) throws InterruptedException {
+    private void handleTransactionCompletion(MySqlOffsetContext offsetContext, Event event) throws InterruptedException {
         // We are completing the transaction ...
         eventDispatcher.dispatchTransactionCommittedEvent(offsetContext);
         offsetContext.commitTransaction();
@@ -614,7 +611,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
      *
      * @param event the update event; never null
      */
-    protected void handleUpdateTableMetadata(Event event) {
+    protected void handleUpdateTableMetadata(MySqlOffsetContext offsetContext, Event event) {
         TableMapEventData metadata = unwrapData(event);
         long tableNumber = metadata.getTableId();
         String databaseName = metadata.getDatabase();
@@ -624,7 +621,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
             LOGGER.debug("Received update table metadata event: {}", event);
         }
         else {
-            informAboutUnknownTableIfRequired(event, tableId, "update table metadata");
+            informAboutUnknownTableIfRequired(offsetContext, event, tableId, "update table metadata");
         }
     }
 
@@ -633,7 +630,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
      * don't know, either ignore that event or raise a warning or error as per the
      * {@link MySqlConnectorConfig#INCONSISTENT_SCHEMA_HANDLING_MODE} configuration.
      */
-    private void informAboutUnknownTableIfRequired(Event event, TableId tableId, String typeToLog) {
+    private void informAboutUnknownTableIfRequired(MySqlOffsetContext offsetContext, Event event, TableId tableId, String typeToLog) {
         if (tableId != null && connectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId)) {
             metrics.onErroneousEvent("source = " + tableId + ", event " + event);
             EventHeaderV4 eventHeader = event.getHeader();
@@ -676,8 +673,8 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
      * @param event the database change data event to be processed; may not be null
      * @throws InterruptedException if this thread is interrupted while blocking
      */
-    protected void handleInsert(Event event) throws InterruptedException {
-        handleChange(event, "insert", WriteRowsEventData.class, x -> taskContext.getSchema().getTableId(x.getTableId()), WriteRowsEventData::getRows,
+    protected void handleInsert(MySqlOffsetContext offsetContext, Event event) throws InterruptedException {
+        handleChange(offsetContext, event, "insert", WriteRowsEventData.class, x -> taskContext.getSchema().getTableId(x.getTableId()), WriteRowsEventData::getRows,
                 (tableId, row) -> eventDispatcher.dispatchDataChangeEvent(tableId, new MySqlChangeRecordEmitter(offsetContext, clock, Operation.CREATE, null, row)));
     }
 
@@ -687,8 +684,8 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
      * @param event the database change data event to be processed; may not be null
      * @throws InterruptedException if this thread is interrupted while blocking
      */
-    protected void handleUpdate(Event event) throws InterruptedException {
-        handleChange(event, "update", UpdateRowsEventData.class, x -> taskContext.getSchema().getTableId(x.getTableId()), UpdateRowsEventData::getRows,
+    protected void handleUpdate(MySqlOffsetContext offsetContext, Event event) throws InterruptedException {
+        handleChange(offsetContext, event, "update", UpdateRowsEventData.class, x -> taskContext.getSchema().getTableId(x.getTableId()), UpdateRowsEventData::getRows,
                 (tableId, row) -> eventDispatcher.dispatchDataChangeEvent(tableId,
                         new MySqlChangeRecordEmitter(offsetContext, clock, Operation.UPDATE, row.getKey(), row.getValue())));
     }
@@ -699,12 +696,13 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
      * @param event the database change data event to be processed; may not be null
      * @throws InterruptedException if this thread is interrupted while blocking
      */
-    protected void handleDelete(Event event) throws InterruptedException {
-        handleChange(event, "delete", DeleteRowsEventData.class, x -> taskContext.getSchema().getTableId(x.getTableId()), DeleteRowsEventData::getRows,
+    protected void handleDelete(MySqlOffsetContext offsetContext, Event event) throws InterruptedException {
+        handleChange(offsetContext, event, "delete", DeleteRowsEventData.class, x -> taskContext.getSchema().getTableId(x.getTableId()), DeleteRowsEventData::getRows,
                 (tableId, row) -> eventDispatcher.dispatchDataChangeEvent(tableId, new MySqlChangeRecordEmitter(offsetContext, clock, Operation.DELETE, row, null)));
     }
 
-    private <T extends EventData, U> void handleChange(Event event, String changeType, Class<T> eventDataClass, TableIdProvider<T> tableIdProvider,
+    private <T extends EventData, U> void handleChange(MySqlOffsetContext offsetContext, Event event, String changeType, Class<T> eventDataClass,
+                                                       TableIdProvider<T> tableIdProvider,
                                                        RowsProvider<T, U> rowsProvider, BinlogChangeEmitter<U> changeEmitter)
             throws InterruptedException {
         if (skipEvent) {
@@ -747,7 +745,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
             }
         }
         else {
-            informAboutUnknownTableIfRequired(event, tableId, changeType + " row");
+            informAboutUnknownTableIfRequired(offsetContext, event, tableId, changeType + " row");
         }
         startingRowNumber = 0;
     }
@@ -758,7 +756,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
      * @param event the database change data event to be processed; may not be null
      * @throws InterruptedException if this thread is interrupted while blocking
      */
-    protected void viewChange(Event event) throws InterruptedException {
+    protected void viewChange(MySqlOffsetContext offsetContext, Event event) throws InterruptedException {
         LOGGER.debug("View Change event: {}", event);
         // do nothing
     }
@@ -769,7 +767,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
      * @param event the database change data event to be processed; may not be null
      * @throws InterruptedException if this thread is interrupted while blocking
      */
-    protected void prepareTransaction(Event event) throws InterruptedException {
+    protected void prepareTransaction(MySqlOffsetContext offsetContext, Event event) throws InterruptedException {
         LOGGER.debug("XA Prepare event: {}", event);
         // do nothing
     }
@@ -791,7 +789,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
     }
 
     @Override
-    public void execute(ChangeEventSourceContext context) throws InterruptedException {
+    public void execute(ChangeEventSourceContext context, MySqlOffsetContext offsetContext) throws InterruptedException {
         if (!connectorConfig.getSnapshotMode().shouldStream()) {
             LOGGER.info("Streaming is disabled for snapshot mode {}", connectorConfig.getSnapshotMode());
             return;
@@ -799,46 +797,56 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
         taskContext.getSchema().assureNonEmptySchema();
         final Set<Operation> skippedOperations = connectorConfig.getSkippedOperations();
 
+        final MySqlOffsetContext effectiveOffsetContext = offsetContext != null
+                ? offsetContext
+                : MySqlOffsetContext.initial(connectorConfig);
+
         // Register our event handlers ...
-        eventHandlers.put(EventType.STOP, this::handleServerStop);
-        eventHandlers.put(EventType.HEARTBEAT, this::handleServerHeartbeat);
-        eventHandlers.put(EventType.INCIDENT, this::handleServerIncident);
-        eventHandlers.put(EventType.ROTATE, this::handleRotateLogsEvent);
-        eventHandlers.put(EventType.TABLE_MAP, this::handleUpdateTableMetadata);
-        eventHandlers.put(EventType.QUERY, this::handleQueryEvent);
+        eventHandlers.put(EventType.STOP, (event) -> handleServerStop(effectiveOffsetContext, event));
+        eventHandlers.put(EventType.HEARTBEAT, (event) -> handleServerHeartbeat(effectiveOffsetContext, event));
+        eventHandlers.put(EventType.INCIDENT, (event) -> handleServerIncident(effectiveOffsetContext, event));
+        eventHandlers.put(EventType.ROTATE, (event) -> handleRotateLogsEvent(effectiveOffsetContext, event));
+        eventHandlers.put(EventType.TABLE_MAP, (event) -> handleUpdateTableMetadata(effectiveOffsetContext, event));
+        eventHandlers.put(EventType.QUERY, (event) -> handleQueryEvent(effectiveOffsetContext, event));
 
         if (!skippedOperations.contains(Operation.CREATE)) {
-            eventHandlers.put(EventType.WRITE_ROWS, this::handleInsert);
-            eventHandlers.put(EventType.EXT_WRITE_ROWS, this::handleInsert);
+            eventHandlers.put(EventType.WRITE_ROWS, (event) -> handleInsert(effectiveOffsetContext, event));
+            eventHandlers.put(EventType.EXT_WRITE_ROWS, (event) -> handleInsert(effectiveOffsetContext, event));
         }
 
         if (!skippedOperations.contains(Operation.UPDATE)) {
-            eventHandlers.put(EventType.UPDATE_ROWS, this::handleUpdate);
-            eventHandlers.put(EventType.EXT_UPDATE_ROWS, this::handleUpdate);
+            eventHandlers.put(EventType.UPDATE_ROWS, (event) -> handleUpdate(effectiveOffsetContext, event));
+            eventHandlers.put(EventType.EXT_UPDATE_ROWS, (event) -> handleUpdate(effectiveOffsetContext, event));
         }
 
         if (!skippedOperations.contains(Operation.DELETE)) {
-            eventHandlers.put(EventType.DELETE_ROWS, this::handleDelete);
-            eventHandlers.put(EventType.EXT_DELETE_ROWS, this::handleDelete);
+            eventHandlers.put(EventType.DELETE_ROWS, (event) -> handleDelete(effectiveOffsetContext, event));
+            eventHandlers.put(EventType.EXT_DELETE_ROWS, (event) -> handleDelete(effectiveOffsetContext, event));
         }
 
-        eventHandlers.put(EventType.VIEW_CHANGE, this::viewChange);
-        eventHandlers.put(EventType.XA_PREPARE, this::prepareTransaction);
-        eventHandlers.put(EventType.XID, this::handleTransactionCompletion);
+        eventHandlers.put(EventType.VIEW_CHANGE, (event) -> viewChange(effectiveOffsetContext, event));
+        eventHandlers.put(EventType.XA_PREPARE, (event) -> prepareTransaction(effectiveOffsetContext, event));
+        eventHandlers.put(EventType.XID, (event) -> handleTransactionCompletion(effectiveOffsetContext, event));
 
         // Conditionally register ROWS_QUERY handler to parse SQL statements.
         if (connectorConfig.includeSqlQuery()) {
-            eventHandlers.put(EventType.ROWS_QUERY, this::handleRowsQuery);
+            eventHandlers.put(EventType.ROWS_QUERY, (event) -> handleRowsQuery(effectiveOffsetContext, event));
         }
 
-        client.registerEventListener(connectorConfig.bufferSizeForStreamingChangeEventSource() == 0
-                ? this::handleEvent
-                : (new EventBuffer(connectorConfig.bufferSizeForStreamingChangeEventSource(), this, context))::add);
+        BinaryLogClient.EventListener listener;
+        if (connectorConfig.bufferSizeForStreamingChangeEventSource() == 0) {
+            listener = (event) -> handleEvent(effectiveOffsetContext, event);
+        }
+        else {
+            EventBuffer buffer = new EventBuffer(connectorConfig.bufferSizeForStreamingChangeEventSource(), this, context);
+            listener = (event) -> buffer.add(effectiveOffsetContext, event);
+        }
+        client.registerEventListener(listener);
 
-        client.registerLifecycleListener(new ReaderThreadLifecycleListener());
-        client.registerEventListener(this::onEvent);
+        client.registerLifecycleListener(new ReaderThreadLifecycleListener(effectiveOffsetContext));
+        client.registerEventListener((event) -> onEvent(effectiveOffsetContext, event));
         if (LOGGER.isDebugEnabled()) {
-            client.registerEventListener(this::logEvent);
+            client.registerEventListener((event) -> logEvent(effectiveOffsetContext, event));
         }
 
         final boolean isGtidModeEnabled = connection.isGtidModeEnabled();
@@ -848,7 +856,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
         String availableServerGtidStr = connection.knownGtidSet();
         if (isGtidModeEnabled) {
             // The server is using GTIDs, so enable the handler ...
-            eventHandlers.put(EventType.GTID, this::handleGtidEvent);
+            eventHandlers.put(EventType.GTID, (event) -> handleGtidEvent(effectiveOffsetContext, event));
 
             // Now look at the GTID set from the server and what we've previously seen ...
             GtidSet availableServerGtidSet = new GtidSet(availableServerGtidStr);
@@ -857,34 +865,34 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
             GtidSet purgedServerGtidSet = connection.purgedGtidSet();
             LOGGER.info("GTID set purged on server: {}", purgedServerGtidSet);
 
-            GtidSet filteredGtidSet = filterGtidSet(availableServerGtidSet, purgedServerGtidSet);
+            GtidSet filteredGtidSet = filterGtidSet(effectiveOffsetContext, availableServerGtidSet, purgedServerGtidSet);
             if (filteredGtidSet != null) {
                 // We've seen at least some GTIDs, so start reading from the filtered GTID set ...
                 LOGGER.info("Registering binlog reader with GTID set: {}", filteredGtidSet);
                 String filteredGtidSetStr = filteredGtidSet.toString();
                 client.setGtidSet(filteredGtidSetStr);
-                offsetContext.setCompletedGtidSet(filteredGtidSetStr);
+                effectiveOffsetContext.setCompletedGtidSet(filteredGtidSetStr);
                 gtidSet = new com.github.shyiko.mysql.binlog.GtidSet(filteredGtidSetStr);
             }
             else {
                 // We've not yet seen any GTIDs, so that means we have to start reading the binlog from the beginning ...
-                client.setBinlogFilename(offsetContext.getSource().binlogFilename());
-                client.setBinlogPosition(offsetContext.getSource().binlogPosition());
+                client.setBinlogFilename(effectiveOffsetContext.getSource().binlogFilename());
+                client.setBinlogPosition(effectiveOffsetContext.getSource().binlogPosition());
                 gtidSet = new com.github.shyiko.mysql.binlog.GtidSet("");
             }
         }
         else {
             // The server is not using GTIDs, so start reading the binlog based upon where we last left off ...
-            client.setBinlogFilename(offsetContext.getSource().binlogFilename());
-            client.setBinlogPosition(offsetContext.getSource().binlogPosition());
+            client.setBinlogFilename(effectiveOffsetContext.getSource().binlogFilename());
+            client.setBinlogPosition(effectiveOffsetContext.getSource().binlogPosition());
         }
 
         // We may be restarting in the middle of a transaction, so see how far into the transaction we have already processed...
-        initialEventsToSkip = offsetContext.eventsToSkipUponRestart();
+        initialEventsToSkip = effectiveOffsetContext.eventsToSkipUponRestart();
         LOGGER.info("Skip {} events on streaming start", initialEventsToSkip);
 
         // Set the starting row number, which is the next row number to be read ...
-        startingRowNumber = offsetContext.rowsToSkipUponRestart();
+        startingRowNumber = effectiveOffsetContext.rowsToSkipUponRestart();
         LOGGER.info("Skip {} rows on streaming start", startingRowNumber);
 
         // Only when we reach the first BEGIN event will we start to skip events ...
@@ -1024,7 +1032,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
         logStreamingSourceState(Level.ERROR);
     }
 
-    protected void logEvent(Event event) {
+    protected void logEvent(MySqlOffsetContext offsetContext, Event event) {
         LOGGER.trace("Received event: {}", event);
     }
 
@@ -1062,7 +1070,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
      * @return A GTID set meant for consuming from a MySQL binlog; may return null if the SourceInfo has no GTIDs and therefore
      *         none were filtered
      */
-    public GtidSet filterGtidSet(GtidSet availableServerGtidSet, GtidSet purgedServerGtid) {
+    public GtidSet filterGtidSet(MySqlOffsetContext offsetContext, GtidSet availableServerGtidSet, GtidSet purgedServerGtid) {
         String gtidStr = offsetContext.gtidSet();
         if (gtidStr == null) {
             return null;
@@ -1143,6 +1151,12 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
     }
 
     protected final class ReaderThreadLifecycleListener implements LifecycleListener {
+        private final MySqlOffsetContext offsetContext;
+
+        ReaderThreadLifecycleListener(MySqlOffsetContext offsetContext) {
+            this.offsetContext = offsetContext;
+        }
+
         @Override
         public void onDisconnect(BinaryLogClient client) {
             if (LOGGER.isInfoEnabled()) {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/MySqlConnectorTask.java
@@ -31,6 +31,7 @@ import io.debezium.connector.mysql.Module;
 import io.debezium.connector.mysql.MySqlConnector;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
+import io.debezium.connector.mysql.MySqlOffsetContext;
 import io.debezium.pipeline.ChangeEventSourceCoordinator;
 import io.debezium.schema.TopicSelector;
 import io.debezium.util.Collect;
@@ -44,7 +45,7 @@ import io.debezium.util.LoggingContext.PreviousContext;
  * @author Randall Hauch
  */
 @NotThreadSafe
-public final class MySqlConnectorTask extends BaseSourceTask {
+public final class MySqlConnectorTask extends BaseSourceTask<MySqlOffsetContext> {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private volatile MySqlTaskContext taskContext;
@@ -66,7 +67,7 @@ public final class MySqlConnectorTask extends BaseSourceTask {
     }
 
     @Override
-    public ChangeEventSourceCoordinator start(Configuration config) {
+    public ChangeEventSourceCoordinator<MySqlOffsetContext> start(Configuration config) {
         final String serverName = config.getString(MySqlConnectorConfig.SERVER_NAME);
         PreviousContext prevLoggingContext = LoggingContext.forConnector(Module.contextName(), serverName, "task");
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
@@ -12,11 +12,10 @@ import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
-import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
 
-public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory {
+public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory<OracleOffsetContext> {
 
     private final OracleConnectorConfig configuration;
     private final OracleConnection jdbcConnection;
@@ -44,15 +43,14 @@ public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory 
     }
 
     @Override
-    public SnapshotChangeEventSource getSnapshotChangeEventSource(OffsetContext offsetContext, SnapshotProgressListener snapshotProgressListener) {
-        return new OracleSnapshotChangeEventSource(configuration, (OracleOffsetContext) offsetContext, jdbcConnection,
+    public SnapshotChangeEventSource<OracleOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
+        return new OracleSnapshotChangeEventSource(configuration, jdbcConnection,
                 schema, dispatcher, clock, snapshotProgressListener);
     }
 
     @Override
-    public StreamingChangeEventSource getStreamingChangeEventSource(OffsetContext offsetContext) {
+    public StreamingChangeEventSource<OracleOffsetContext> getStreamingChangeEventSource() {
         return configuration.getAdapter().getSource(
-                offsetContext,
                 jdbcConnection,
                 dispatcher,
                 errorHandler,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
@@ -46,7 +46,7 @@ public interface StreamingAdapter {
 
     HistoryRecordComparator getHistoryRecordComparator();
 
-    OffsetContext.Loader getOffsetContextLoader();
+    OffsetContext.Loader<OracleOffsetContext> getOffsetContextLoader();
 
     StreamingChangeEventSource<OracleOffsetContext> getSource(OracleConnection connection, EventDispatcher<TableId> dispatcher,
                                                               ErrorHandler errorHandler, Clock clock, OracleDatabaseSchema schema,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
@@ -48,10 +48,10 @@ public interface StreamingAdapter {
 
     OffsetContext.Loader getOffsetContextLoader();
 
-    StreamingChangeEventSource getSource(OffsetContext offsetContext, OracleConnection connection, EventDispatcher<TableId> dispatcher,
-                                         ErrorHandler errorHandler, Clock clock, OracleDatabaseSchema schema,
-                                         OracleTaskContext taskContext, Configuration jdbcConfig,
-                                         OracleStreamingChangeEventSourceMetrics streamingMetrics);
+    StreamingChangeEventSource<OracleOffsetContext> getSource(OracleConnection connection, EventDispatcher<TableId> dispatcher,
+                                                              ErrorHandler errorHandler, Clock clock, OracleDatabaseSchema schema,
+                                                              OracleTaskContext taskContext, Configuration jdbcConfig,
+                                                              OracleStreamingChangeEventSourceMetrics streamingMetrics);
 
     /**
      * Returns whether table names are case sensitive.

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
@@ -54,18 +54,16 @@ public class LogMinerAdapter extends AbstractStreamingAdapter {
     }
 
     @Override
-    public StreamingChangeEventSource getSource(OffsetContext offsetContext,
-                                                OracleConnection connection,
-                                                EventDispatcher<TableId> dispatcher,
-                                                ErrorHandler errorHandler,
-                                                Clock clock,
-                                                OracleDatabaseSchema schema,
-                                                OracleTaskContext taskContext,
-                                                Configuration jdbcConfig,
-                                                OracleStreamingChangeEventSourceMetrics streamingMetrics) {
+    public StreamingChangeEventSource<OracleOffsetContext> getSource(OracleConnection connection,
+                                                                     EventDispatcher<TableId> dispatcher,
+                                                                     ErrorHandler errorHandler,
+                                                                     Clock clock,
+                                                                     OracleDatabaseSchema schema,
+                                                                     OracleTaskContext taskContext,
+                                                                     Configuration jdbcConfig,
+                                                                     OracleStreamingChangeEventSourceMetrics streamingMetrics) {
         return new LogMinerStreamingChangeEventSource(
                 connectorConfig,
-                (OracleOffsetContext) offsetContext,
                 connection,
                 dispatcher,
                 errorHandler,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
@@ -49,7 +49,7 @@ public class LogMinerAdapter extends AbstractStreamingAdapter {
     }
 
     @Override
-    public OffsetContext.Loader getOffsetContextLoader() {
+    public OffsetContext.Loader<OracleOffsetContext> getOffsetContextLoader() {
         return new LogMinerOracleOffsetContextLoader(connectorConfig);
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerOracleOffsetContextLoader.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerOracleOffsetContextLoader.java
@@ -18,7 +18,7 @@ import io.debezium.pipeline.txmetadata.TransactionContext;
 /**
  * @author Chris Cranford
  */
-public class LogMinerOracleOffsetContextLoader implements OffsetContext.Loader {
+public class LogMinerOracleOffsetContextLoader implements OffsetContext.Loader<OracleOffsetContext> {
 
     private final OracleConnectorConfig connectorConfig;
 
@@ -32,7 +32,7 @@ public class LogMinerOracleOffsetContextLoader implements OffsetContext.Loader {
     }
 
     @Override
-    public OffsetContext load(Map<String, ?> offset) {
+    public OracleOffsetContext load(Map<String, ?> offset) {
         boolean snapshot = Boolean.TRUE.equals(offset.get(SourceInfo.SNAPSHOT_KEY));
         boolean snapshotCompleted = Boolean.TRUE.equals(offset.get(OracleOffsetContext.SNAPSHOT_COMPLETED_KEY));
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamAdapter.java
@@ -60,7 +60,7 @@ public class XStreamAdapter extends AbstractStreamingAdapter {
     }
 
     @Override
-    public OffsetContext.Loader getOffsetContextLoader() {
+    public OffsetContext.Loader<OracleOffsetContext> getOffsetContextLoader() {
         return new XStreamOracleOffsetContextLoader(connectorConfig);
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamAdapter.java
@@ -65,18 +65,16 @@ public class XStreamAdapter extends AbstractStreamingAdapter {
     }
 
     @Override
-    public StreamingChangeEventSource getSource(OffsetContext offsetContext,
-                                                OracleConnection connection,
-                                                EventDispatcher<TableId> dispatcher,
-                                                ErrorHandler errorHandler,
-                                                Clock clock,
-                                                OracleDatabaseSchema schema,
-                                                OracleTaskContext taskContext,
-                                                Configuration jdbcConfig,
-                                                OracleStreamingChangeEventSourceMetrics streamingMetrics) {
+    public StreamingChangeEventSource<OracleOffsetContext> getSource(OracleConnection connection,
+                                                                     EventDispatcher<TableId> dispatcher,
+                                                                     ErrorHandler errorHandler,
+                                                                     Clock clock,
+                                                                     OracleDatabaseSchema schema,
+                                                                     OracleTaskContext taskContext,
+                                                                     Configuration jdbcConfig,
+                                                                     OracleStreamingChangeEventSourceMetrics streamingMetrics) {
         return new XstreamStreamingChangeEventSource(
                 connectorConfig,
-                (OracleOffsetContext) offsetContext,
                 connection,
                 dispatcher,
                 errorHandler,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamOracleOffsetContextLoader.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamOracleOffsetContextLoader.java
@@ -20,7 +20,7 @@ import io.debezium.pipeline.txmetadata.TransactionContext;
  *
  * @author Chris Cranford
  */
-public class XStreamOracleOffsetContextLoader implements OffsetContext.Loader {
+public class XStreamOracleOffsetContextLoader implements OffsetContext.Loader<OracleOffsetContext> {
 
     private final OracleConnectorConfig connectorConfig;
 
@@ -34,7 +34,7 @@ public class XStreamOracleOffsetContextLoader implements OffsetContext.Loader {
     }
 
     @Override
-    public OffsetContext load(Map<String, ?> offset) {
+    public OracleOffsetContext load(Map<String, ?> offset) {
         boolean snapshot = Boolean.TRUE.equals(offset.get(SourceInfo.SNAPSHOT_KEY));
         boolean snapshotCompleted = Boolean.TRUE.equals(offset.get(OracleOffsetContext.SNAPSHOT_COMPLETED_KEY));
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFactory.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFactory.java
@@ -21,12 +21,11 @@ import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
-import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.relational.TableId;
 import io.debezium.schema.DataCollectionId;
 import io.debezium.util.Clock;
 
-public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactory {
+public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactory<PostgresOffsetContext> {
 
     private final PostgresConnectorConfig configuration;
     private final PostgresConnection jdbcConnection;
@@ -58,11 +57,10 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
     }
 
     @Override
-    public SnapshotChangeEventSource getSnapshotChangeEventSource(OffsetContext offsetContext, SnapshotProgressListener snapshotProgressListener) {
+    public SnapshotChangeEventSource<PostgresOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
         return new PostgresSnapshotChangeEventSource(
                 configuration,
                 snapshotter,
-                (PostgresOffsetContext) offsetContext,
                 jdbcConnection,
                 schema,
                 dispatcher,
@@ -73,11 +71,10 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
     }
 
     @Override
-    public StreamingChangeEventSource getStreamingChangeEventSource(OffsetContext offsetContext) {
+    public StreamingChangeEventSource<PostgresOffsetContext> getStreamingChangeEventSource() {
         return new PostgresStreamingChangeEventSource(
                 configuration,
                 snapshotter,
-                (PostgresOffsetContext) offsetContext,
                 jdbcConnection,
                 dispatcher,
                 errorHandler,
@@ -89,7 +86,7 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
 
     @Override
     public Optional<IncrementalSnapshotChangeEventSource<? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(
-                                                                                                                              OffsetContext offsetContext,
+                                                                                                                              PostgresOffsetContext offsetContext,
                                                                                                                               SnapshotProgressListener snapshotProgressListener,
                                                                                                                               DataChangeEventListener dataChangeEventListener) {
         final SignalBasedIncrementalSnapshotChangeEventSource<TableId> incrementalSnapshotChangeEventSource = new SignalBasedIncrementalSnapshotChangeEventSource<TableId>(

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -49,7 +49,7 @@ import io.debezium.util.SchemaNameAdjuster;
  *
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
-public class PostgresConnectorTask extends BaseSourceTask {
+public class PostgresConnectorTask extends BaseSourceTask<PostgresOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgresConnectorTask.class);
     private static final String CONTEXT_NAME = "postgres-connector-task";
@@ -61,7 +61,7 @@ public class PostgresConnectorTask extends BaseSourceTask {
     private volatile PostgresSchema schema;
 
     @Override
-    public ChangeEventSourceCoordinator start(Configuration config) {
+    public ChangeEventSourceCoordinator<PostgresOffsetContext> start(Configuration config) {
         final PostgresConnectorConfig connectorConfig = new PostgresConnectorConfig(config);
         final TopicSelector<TableId> topicSelector = PostgresTopicSelector.create(connectorConfig);
         final Snapshotter snapshotter = connectorConfig.getSnapshotter();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -197,7 +197,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresOffsetContext>
                     schemaNameAdjuster,
                     jdbcConnection);
 
-            ChangeEventSourceCoordinator<PostgresOffsetContext> coordinator = new PostgresChangeEventSourceCoordinator (
+            ChangeEventSourceCoordinator<PostgresOffsetContext> coordinator = new PostgresChangeEventSourceCoordinator(
                     previousOffset,
                     errorHandler,
                     PostgresConnector.class,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -93,7 +93,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresOffsetContext>
 
         schema = new PostgresSchema(connectorConfig, typeRegistry, topicSelector, valueConverterBuilder.build(typeRegistry));
         this.taskContext = new PostgresTaskContext(connectorConfig, schema, topicSelector);
-        final PostgresOffsetContext previousOffset = (PostgresOffsetContext) getPreviousOffset(new PostgresOffsetContext.Loader(connectorConfig));
+        final PostgresOffsetContext previousOffset = getPreviousOffset(new PostgresOffsetContext.Loader(connectorConfig));
         final Clock clock = Clock.system();
 
         LoggingContext.PreviousContext previousContext = taskContext.configureLoggingContext(CONTEXT_NAME);
@@ -197,7 +197,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresOffsetContext>
                     schemaNameAdjuster,
                     jdbcConnection);
 
-            ChangeEventSourceCoordinator coordinator = new PostgresChangeEventSourceCoordinator(
+            ChangeEventSourceCoordinator<PostgresOffsetContext> coordinator = new PostgresChangeEventSourceCoordinator (
                     previousOffset,
                     errorHandler,
                     PostgresConnector.class,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
@@ -187,7 +187,7 @@ public class PostgresOffsetContext implements OffsetContext {
         return sourceInfo.xmin();
     }
 
-    public static class Loader implements OffsetContext.Loader {
+    public static class Loader implements OffsetContext.Loader<PostgresOffsetContext> {
 
         private final PostgresConnectorConfig connectorConfig;
 
@@ -207,7 +207,7 @@ public class PostgresOffsetContext implements OffsetContext {
 
         @SuppressWarnings("unchecked")
         @Override
-        public OffsetContext load(Map<String, ?> offset) {
+        public PostgresOffsetContext load(Map<String, ?> offset) {
             final Lsn lsn = Lsn.valueOf(readOptionalLong(offset, SourceInfo.LSN_KEY));
             final Lsn lastCompletelyProcessedLsn = Lsn.valueOf(readOptionalLong(offset, LAST_COMPLETELY_PROCESSED_LSN_KEY));
             final Lsn lastCommitLsn = Lsn.valueOf(readOptionalLong(offset, LAST_COMPLETELY_PROCESSED_LSN_KEY));

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
@@ -16,12 +16,11 @@ import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
-import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.relational.TableId;
 import io.debezium.schema.DataCollectionId;
 import io.debezium.util.Clock;
 
-public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFactory {
+public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFactory<SqlServerOffsetContext> {
 
     private final SqlServerConnectorConfig configuration;
     private final SqlServerConnection dataConnection;
@@ -43,16 +42,15 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
     }
 
     @Override
-    public SnapshotChangeEventSource getSnapshotChangeEventSource(OffsetContext offsetContext, SnapshotProgressListener snapshotProgressListener) {
-        return new SqlServerSnapshotChangeEventSource(configuration, (SqlServerOffsetContext) offsetContext, dataConnection, schema, dispatcher, clock,
+    public SnapshotChangeEventSource<SqlServerOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
+        return new SqlServerSnapshotChangeEventSource(configuration, dataConnection, schema, dispatcher, clock,
                 snapshotProgressListener);
     }
 
     @Override
-    public StreamingChangeEventSource getStreamingChangeEventSource(OffsetContext offsetContext) {
+    public StreamingChangeEventSource<SqlServerOffsetContext> getStreamingChangeEventSource() {
         return new SqlServerStreamingChangeEventSource(
                 configuration,
-                (SqlServerOffsetContext) offsetContext,
                 dataConnection,
                 metadataConnection,
                 dispatcher,
@@ -63,7 +61,7 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
 
     @Override
     public Optional<IncrementalSnapshotChangeEventSource<? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(
-                                                                                                                              OffsetContext offsetContext,
+                                                                                                                              SqlServerOffsetContext offsetContext,
                                                                                                                               SnapshotProgressListener snapshotProgressListener,
                                                                                                                               DataChangeEventListener dataChangeEventListener) {
         final SignalBasedIncrementalSnapshotChangeEventSource<TableId> incrementalSnapshotChangeEventSource = new SignalBasedIncrementalSnapshotChangeEventSource<TableId>(

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -23,7 +23,6 @@ import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.metrics.DefaultChangeEventSourceMetricsFactory;
-import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
 import io.debezium.relational.history.DatabaseHistory;
@@ -38,7 +37,7 @@ import io.debezium.util.SchemaNameAdjuster;
  * @author Jiri Pechanec
  *
  */
-public class SqlServerConnectorTask extends BaseSourceTask {
+public class SqlServerConnectorTask extends BaseSourceTask<SqlServerOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerConnectorTask.class);
     private static final String CONTEXT_NAME = "sql-server-connector-task";
@@ -56,7 +55,7 @@ public class SqlServerConnectorTask extends BaseSourceTask {
     }
 
     @Override
-    public ChangeEventSourceCoordinator start(Configuration config) {
+    public ChangeEventSourceCoordinator<SqlServerOffsetContext> start(Configuration config) {
         final Clock clock = Clock.system();
         final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(config);
         final TopicSelector<TableId> topicSelector = SqlServerTopicSelector.defaultSelector(connectorConfig);
@@ -84,7 +83,7 @@ public class SqlServerConnectorTask extends BaseSourceTask {
         this.schema = new SqlServerDatabaseSchema(connectorConfig, valueConverters, topicSelector, schemaNameAdjuster);
         this.schema.initializeStorage();
 
-        final OffsetContext previousOffset = getPreviousOffset(new SqlServerOffsetContext.Loader(connectorConfig));
+        final SqlServerOffsetContext previousOffset = (SqlServerOffsetContext) getPreviousOffset(new SqlServerOffsetContext.Loader(connectorConfig));
         if (previousOffset != null) {
             schema.recover(previousOffset);
         }
@@ -114,7 +113,7 @@ public class SqlServerConnectorTask extends BaseSourceTask {
                 metadataProvider,
                 schemaNameAdjuster);
 
-        ChangeEventSourceCoordinator coordinator = new ChangeEventSourceCoordinator(
+        ChangeEventSourceCoordinator<SqlServerOffsetContext> coordinator = new ChangeEventSourceCoordinator<>(
                 previousOffset,
                 errorHandler,
                 SqlServerConnector.class,

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -83,7 +83,7 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerOffsetContex
         this.schema = new SqlServerDatabaseSchema(connectorConfig, valueConverters, topicSelector, schemaNameAdjuster);
         this.schema.initializeStorage();
 
-        final SqlServerOffsetContext previousOffset = (SqlServerOffsetContext) getPreviousOffset(new SqlServerOffsetContext.Loader(connectorConfig));
+        final SqlServerOffsetContext previousOffset = getPreviousOffset(new SqlServerOffsetContext.Loader(connectorConfig));
         if (previousOffset != null) {
             schema.recover(previousOffset);
         }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
@@ -140,7 +140,7 @@ public class SqlServerOffsetContext implements OffsetContext {
         sourceInfo.setSnapshot(SnapshotRecord.FALSE);
     }
 
-    public static class Loader implements OffsetContext.Loader {
+    public static class Loader implements OffsetContext.Loader<SqlServerOffsetContext> {
 
         private final SqlServerConnectorConfig connectorConfig;
 
@@ -154,7 +154,7 @@ public class SqlServerOffsetContext implements OffsetContext {
         }
 
         @Override
-        public OffsetContext load(Map<String, ?> offset) {
+        public SqlServerOffsetContext load(Map<String, ?> offset) {
             final Lsn changeLsn = Lsn.valueOf((String) offset.get(SourceInfo.CHANGE_LSN_KEY));
             final Lsn commitLsn = Lsn.valueOf((String) offset.get(SourceInfo.COMMIT_LSN_KEY));
             boolean snapshot = Boolean.TRUE.equals(offset.get(SourceInfo.SNAPSHOT_KEY));

--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -39,7 +39,7 @@ import io.debezium.util.Strings;
  *
  * @author Gunnar Morling
  */
-public abstract class BaseSourceTask extends SourceTask {
+public abstract class BaseSourceTask<O extends OffsetContext> extends SourceTask {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseSourceTask.class);
     private static final long INITIAL_POLL_PERIOD_IN_MILLIS = TimeUnit.SECONDS.toMillis(5);
@@ -68,7 +68,7 @@ public abstract class BaseSourceTask extends SourceTask {
      * The change event source coordinator for those connectors adhering to the new
      * framework structure, {@code null} for legacy-style connectors.
      */
-    private ChangeEventSourceCoordinator coordinator;
+    private ChangeEventSourceCoordinator<O> coordinator;
 
     /**
      * The latest offset that has been acknowledged by the Kafka producer. Will be
@@ -141,7 +141,7 @@ public abstract class BaseSourceTask extends SourceTask {
      *            the task configuration; implementations should wrap it in a dedicated implementation of
      *            {@link CommonConnectorConfig} and work with typed access to configuration properties that way
      */
-    protected abstract ChangeEventSourceCoordinator start(Configuration config);
+    protected abstract ChangeEventSourceCoordinator<O> start(Configuration config);
 
     @Override
     public final List<SourceRecord> poll() throws InterruptedException {

--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -298,11 +298,11 @@ public abstract class BaseSourceTask<O extends OffsetContext> extends SourceTask
     /**
      * Loads the connector's persistent offset (if present) via the given loader.
      */
-    protected OffsetContext getPreviousOffset(OffsetContext.Loader loader) {
+    protected O getPreviousOffset(OffsetContext.Loader<O> loader) {
         Map<String, ?> partition = loader.getPartition();
 
         if (lastOffset != null) {
-            OffsetContext offsetContext = loader.load(lastOffset);
+            O offsetContext = loader.load(lastOffset);
             LOGGER.info("Found previous offset after restart {}", offsetContext);
             return offsetContext;
         }
@@ -312,7 +312,7 @@ public abstract class BaseSourceTask<O extends OffsetContext> extends SourceTask
                 .get(partition);
 
         if (previousOffset != null) {
-            OffsetContext offsetContext = loader.load(previousOffset);
+            O offsetContext = loader.load(previousOffset);
             LOGGER.info("Found previous offset {}", offsetContext);
             return offsetContext;
         }

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -82,7 +82,7 @@ public class ChangeEventSourceCoordinator<O extends OffsetContext> {
         this.schema = schema;
     }
 
-    public synchronized <T extends CdcSourceTaskContext> void start(T taskContext, ChangeEventQueueMetrics changeEventQueueMetrics,
+    public synchronized void start(CdcSourceTaskContext taskContext, ChangeEventQueueMetrics changeEventQueueMetrics,
                                                                     EventMetadataProvider metadataProvider) {
         AtomicReference<LoggingContext.PreviousContext> previousLogContext = new AtomicReference<>();
         try {
@@ -141,7 +141,7 @@ public class ChangeEventSourceCoordinator<O extends OffsetContext> {
         }
     }
 
-    protected CatchUpStreamingResult executeCatchUpStreaming(OffsetContext previousOffset, ChangeEventSourceContext context,
+    protected CatchUpStreamingResult executeCatchUpStreaming(O previousOffset, ChangeEventSourceContext context,
                                                              SnapshotChangeEventSource<O> snapshotSource)
             throws InterruptedException {
         return new CatchUpStreamingResult(false);

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -83,7 +83,7 @@ public class ChangeEventSourceCoordinator<O extends OffsetContext> {
     }
 
     public synchronized void start(CdcSourceTaskContext taskContext, ChangeEventQueueMetrics changeEventQueueMetrics,
-                                                                    EventMetadataProvider metadataProvider) {
+                                   EventMetadataProvider metadataProvider) {
         AtomicReference<LoggingContext.PreviousContext> previousLogContext = new AtomicReference<>();
         try {
             this.snapshotMetrics = changeEventSourceMetricsFactory.getSnapshotMetrics(taskContext, changeEventQueueMetrics, metadataProvider);

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeEventSourceFactory.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeEventSourceFactory.java
@@ -16,28 +16,26 @@ import io.debezium.schema.DataCollectionId;
  *
  * @author Gunnar Morling
  */
-public interface ChangeEventSourceFactory {
+public interface ChangeEventSourceFactory<O extends OffsetContext> {
 
     /**
      * Returns a snapshot change event source that may emit change events for schema and/or data changes. Depending on
      * the snapshot mode, a given source may decide to do nothing at all if a previous offset is given. In this case it
      * should return that given offset context from its
-     * {@link StreamingChangeEventSource#execute(io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContext)}
+     * {@link StreamingChangeEventSource#execute(ChangeEventSource.ChangeEventSourceContext, io.debezium.pipeline.spi.OffsetContext)}
      * method.
      *
-     * @param offsetContext
-     *            A context representing a restored offset from an earlier run of this connector. May be {@code null}.
      * @param snapshotProgressListener
      *            A listener called for changes in the state of snapshot. May be {@code null}.
      *
      * @return A snapshot change event source
      */
-    SnapshotChangeEventSource getSnapshotChangeEventSource(OffsetContext offsetContext, SnapshotProgressListener snapshotProgressListener);
+    SnapshotChangeEventSource<O> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener);
 
     /**
      * Returns a streaming change event source that starts streaming at the given offset.
      */
-    StreamingChangeEventSource getStreamingChangeEventSource(OffsetContext offsetContext);
+    StreamingChangeEventSource<O> getStreamingChangeEventSource();
 
     /**
      * Returns and incremental snapshot change event source that can run in parallel with streaming
@@ -50,7 +48,7 @@ public interface ChangeEventSourceFactory {
      *
      * @return An incremental snapshot change event source
      */
-    default Optional<IncrementalSnapshotChangeEventSource<? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(OffsetContext offsetContext,
+    default Optional<IncrementalSnapshotChangeEventSource<? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(O offsetContext,
                                                                                                                                SnapshotProgressListener snapshotProgressListener,
                                                                                                                                DataChangeEventListener dataChangeEventListener) {
         return Optional.empty();

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/SnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/SnapshotChangeEventSource.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.pipeline.source.spi;
 
+import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.SnapshotResult;
 
 /**
@@ -13,7 +14,7 @@ import io.debezium.pipeline.spi.SnapshotResult;
  *
  * @author Gunnar Morling
  */
-public interface SnapshotChangeEventSource extends ChangeEventSource {
+public interface SnapshotChangeEventSource<O extends OffsetContext> extends ChangeEventSource {
 
     /**
      * Executes this source. Implementations should regularly check via the given context if they should stop. If that's
@@ -22,9 +23,11 @@ public interface SnapshotChangeEventSource extends ChangeEventSource {
      *
      * @param context
      *            contextual information for this source's execution
+     * @param previousOffset
+     *            previous offset restored from Kafka
      * @return an indicator to the position at which the snapshot was taken
      * @throws InterruptedException
      *             in case the snapshot was aborted before completion
      */
-    SnapshotResult execute(ChangeEventSourceContext context) throws InterruptedException;
+    SnapshotResult<O> execute(ChangeEventSourceContext context, O previousOffset) throws InterruptedException;
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingChangeEventSource.java
@@ -7,12 +7,14 @@ package io.debezium.pipeline.source.spi;
 
 import java.util.Map;
 
+import io.debezium.pipeline.spi.OffsetContext;
+
 /**
  * A change event source that emits events from a DB log, such as MySQL's binlog or similar.
  *
  * @author Gunnar Morling
  */
-public interface StreamingChangeEventSource extends ChangeEventSource {
+public interface StreamingChangeEventSource<O extends OffsetContext> extends ChangeEventSource {
 
     /**
      * Executes this source. Implementations should regularly check via the given context if they should stop. If that's
@@ -21,11 +23,12 @@ public interface StreamingChangeEventSource extends ChangeEventSource {
      *
      * @param context
      *            contextual information for this source's execution
+     * @param offsetContext
      * @return an indicator to the position at which the snapshot was taken
      * @throws InterruptedException
      *             in case the snapshot was aborted before completion
      */
-    void execute(ChangeEventSourceContext context) throws InterruptedException;
+    void execute(ChangeEventSourceContext context, O offsetContext) throws InterruptedException;
 
     /**
      * Commits the given offset with the source database. Used by some connectors

--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
@@ -11,8 +11,10 @@ import java.util.Map;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
 import io.debezium.pipeline.txmetadata.TransactionContext;
+import io.debezium.pipeline.txmetadata.TransactionMonitor;
 import io.debezium.schema.DataCollectionId;
 
 /**
@@ -27,10 +29,10 @@ public interface OffsetContext {
     /**
      * Implementations load a connector-specific offset context based on the offset values stored in Kafka.
      */
-    interface Loader {
+    interface Loader<O extends OffsetContext> {
         Map<String, ?> getPartition();
 
-        OffsetContext load(Map<String, ?> offset);
+        O load(Map<String, ?> offset);
     }
 
     Map<String, ?> getPartition();

--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/SnapshotResult.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/SnapshotResult.java
@@ -5,26 +5,26 @@
  */
 package io.debezium.pipeline.spi;
 
-public class SnapshotResult {
+public class SnapshotResult<O extends OffsetContext> {
 
     private final SnapshotResultStatus status;
-    private final OffsetContext offset;
+    private final O offset;
 
-    private SnapshotResult(SnapshotResultStatus status, OffsetContext offset) {
+    private SnapshotResult(SnapshotResultStatus status, O offset) {
         this.status = status;
         this.offset = offset;
     }
 
-    public static SnapshotResult completed(OffsetContext offset) {
-        return new SnapshotResult(SnapshotResultStatus.COMPLETED, offset);
+    public static <O extends OffsetContext> SnapshotResult<O> completed(O offset) {
+        return new SnapshotResult<>(SnapshotResultStatus.COMPLETED, offset);
     }
 
-    public static SnapshotResult aborted() {
-        return new SnapshotResult(SnapshotResultStatus.ABORTED, null);
+    public static <O extends OffsetContext> SnapshotResult<O> aborted() {
+        return new SnapshotResult<>(SnapshotResultStatus.ABORTED, null);
     }
 
-    public static SnapshotResult skipped(OffsetContext offset) {
-        return new SnapshotResult(SnapshotResultStatus.SKIPPED, offset);
+    public static <O extends OffsetContext> SnapshotResult<O> skipped(O offset) {
+        return new SnapshotResult<>(SnapshotResultStatus.SKIPPED, offset);
     }
 
     public boolean isCompletedOrSkipped() {
@@ -35,7 +35,7 @@ public class SnapshotResult {
         return status;
     }
 
-    public OffsetContext getOffset() {
+    public O getOffset() {
         return offset;
     }
 


### PR DESCRIPTION
See the [Partitioned APIs](https://github.com/morozov/debezium-design-documents/blob/DDD-1/DDD-1.md#introduce-partitioned-apis-13-16-18) section of https://github.com/debezium/debezium-design-documents/pull/1 for the reference.

**Change summary**:
1. The offset context has been added to all API methods that depend on it and removed from the constructors and factory methods.
2. The classes have been parameterized with `<O extends OffsetContext>` since each connector's classes can only work with their respective offset context implementation.

**TODO**:
- [x] ~~The PostgreSQL connector failure is irrelevant (it used to pass previously)~~
- [x] Update `debezium/debezium-connector-db2` (https://github.com/debezium/debezium-connector-db2/pull/23)
- [x] Update `debezium/debezium-connector-vitess` (https://github.com/debezium/debezium-connector-vitess/pull/35)
