### PR TITLE
DBZ-3403 Semi Optimisation on MongoDB and MySQL connector for skipped.operations

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -594,6 +594,11 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
     }
 
     @Override
+    public boolean supportsOperationFiltering() {
+        return true;
+    }
+
+    @Override
     public String getContextName() {
         return Module.contextName();
     }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
@@ -236,7 +236,7 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
     }
 
     private Bson getSkippedOperationsFilter() {
-        Set<Operation> skippedOperations = taskContext.getConnectorConfig().getSkippedOps();
+        Set<Operation> skippedOperations = taskContext.getConnectorConfig().getSkippedOperations();
 
         if (skippedOperations.isEmpty()) {
             return null;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -974,6 +974,11 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
 
     protected static final Set<String> BUILT_IN_DB_NAMES = Collect.unmodifiableSet("mysql", "performance_schema", "sys", "information_schema");
 
+    @Override
+    public boolean supportsOperationFiltering() {
+        return true;
+    }
+
     private final Configuration config;
     private final SnapshotMode snapshotMode;
     private final SnapshotLockingMode snapshotLockingMode;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -797,7 +797,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
             return;
         }
         taskContext.getSchema().assureNonEmptySchema();
-        final Set<Operation> skippedOperations = connectorConfig.getSkippedOps();
+        final Set<Operation> skippedOperations = connectorConfig.getSkippedOperations();
 
         // Register our event handlers ...
         eventHandlers.put(EventType.STOP, this::handleServerStop);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/BinlogReader.java
@@ -323,7 +323,7 @@ public class BinlogReader extends AbstractReader {
     @Override
     protected void doStart() {
         context.dbSchema().assureNonEmptySchema();
-        Set<Operation> skippedOperations = context.getConnectorConfig().getSkippedOps();
+        Set<Operation> skippedOperations = context.getConnectorConfig().getSkippedOperations();
 
         // Register our event handlers ...
         eventHandlers.put(EventType.STOP, this::handleServerStop);

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -560,6 +560,10 @@ public abstract class CommonConnectorConfig {
         return customConverterRegistry;
     }
 
+    public boolean supportsOperationFiltering() {
+        return false;
+    }
+
     @SuppressWarnings("unchecked")
     private List<CustomConverter<SchemaBuilder, ConvertedField>> getCustomConverters() {
         final String converterNameList = config.getString(CUSTOM_CONVERTERS);

--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -7,10 +7,10 @@ package io.debezium.pipeline;
 
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Supplier;
 
 import org.apache.kafka.connect.data.Schema;
@@ -75,7 +75,7 @@ public class EventDispatcher<T extends DataCollectionId> {
     private final InconsistentSchemaHandler<T> inconsistentSchemaHandler;
     private final TransactionMonitor transactionMonitor;
     private final CommonConnectorConfig connectorConfig;
-    private final Set<Operation> skippedOperations;
+    private final EnumSet<Operation> skippedOperations;
     private final boolean neverSkip;
 
     private final Schema schemaChangeKeySchema;
@@ -117,7 +117,7 @@ public class EventDispatcher<T extends DataCollectionId> {
         this.streamingReceiver = new StreamingChangeRecordReceiver();
         this.emitTombstonesOnDelete = connectorConfig.isEmitTombstoneOnDelete();
         this.inconsistentSchemaHandler = inconsistentSchemaHandler != null ? inconsistentSchemaHandler : this::errorOnMissingSchema;
-        this.skippedOperations = connectorConfig.getSkippedOps();
+        this.skippedOperations = connectorConfig.getSkippedOperations();
         this.neverSkip = connectorConfig.supportsOperationFiltering() || this.skippedOperations.isEmpty();
 
         this.transactionMonitor = new TransactionMonitor(connectorConfig, metadataProvider, this::enqueueTransactionMessage);

--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -118,7 +118,7 @@ public class EventDispatcher<T extends DataCollectionId> {
         this.emitTombstonesOnDelete = connectorConfig.isEmitTombstoneOnDelete();
         this.inconsistentSchemaHandler = inconsistentSchemaHandler != null ? inconsistentSchemaHandler : this::errorOnMissingSchema;
         this.skippedOperations = connectorConfig.getSkippedOps();
-        this.neverSkip = this.skippedOperations.isEmpty();
+        this.neverSkip = connectorConfig.supportsOperationFiltering() || this.skippedOperations.isEmpty();
 
         this.transactionMonitor = new TransactionMonitor(connectorConfig, metadataProvider, this::enqueueTransactionMessage);
         this.signal = new Signal(connectorConfig, this);


### PR DESCRIPTION
After successful merging https://github.com/debezium/debezium/pull/1920. It's time for optimizing connectors for this feature. Currently, we already Implemented fro MongoDB connector and MySQL. but the problem here is that when we did it on the connector side, it's not necessary to check it on the core again.