### PR TITLE
DBZ-3413 Handle double single quotes in LogMinerDmlParser

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
@@ -417,6 +417,11 @@ public class LogMinerDmlParser implements DmlParser {
                 start = index + 1;
             }
             else if (c == '\'' && inColumnValue) {
+                // Skip over double single quote
+                if (inSingleQuote && lookAhead == '\'') {
+                    index += 1;
+                    continue;
+                }
                 // Set clause single-quoted column value
                 if (inSingleQuote) {
                     inSingleQuote = false;
@@ -544,6 +549,11 @@ public class LogMinerDmlParser implements DmlParser {
                 }
             }
             else if (c == '\'' && inColumnValue) {
+                // Skip over double single quote
+                if (inSingleQuote && lookAhead == '\'') {
+                    index += 1;
+                    continue;
+                }
                 // Where clause single-quoted column value
                 if (inSingleQuote) {
                     inSingleQuote = false;

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerDmlParserTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerDmlParserTest.java
@@ -346,8 +346,18 @@ public class LogMinerDmlParserTest {
                 .addColumn(Column.editor().name("COL2").create())
                 .create();
 
-        String sql = "update \"DEBEZIUM\".\"TEST\" set \"COL2\" = '1' where \"COL1\" = 'Bob''s dog' and \"COL2\" = '0';";
+        String sql = "insert into \"DEBEZIUM\".\"TEST\"(\"COL1\",\"COL2\") values ('Bob''s dog','0');";
         LogMinerDmlEntry entry = fastDmlParser.parse(sql, table, null);
+        assertThat(entry.getCommandType()).isEqualTo(Operation.CREATE);
+        assertThat(entry.getOldValues()).isEmpty();
+        assertThat(entry.getNewValues()).hasSize(2);
+        assertThat(entry.getNewValues().get(0).getColumnName()).isEqualTo("COL1");
+        assertThat(entry.getNewValues().get(0).getColumnData()).isEqualTo("Bob''s dog");
+        assertThat(entry.getNewValues().get(1).getColumnName()).isEqualTo("COL2");
+        assertThat(entry.getNewValues().get(1).getColumnData()).isEqualTo("0");
+
+        sql = "update \"DEBEZIUM\".\"TEST\" set \"COL2\" = '1' where \"COL1\" = 'Bob''s dog' and \"COL2\" = '0';";
+        entry = fastDmlParser.parse(sql, table, null);
         assertThat(entry.getCommandType()).isEqualTo(Operation.UPDATE);
         assertThat(entry.getOldValues()).hasSize(2);
         assertThat(entry.getOldValues().get(0).getColumnName()).isEqualTo("COL1");


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3413

Double single quotes are treated as 2 quotes instead of 1 escaped quote in the WHERE clause parsing function. Small change to fix this and added a unit test.