### PR TITLE
DBZ-3409 Fix links to Streams content in downstream doc.

### DIFF
--- a/documentation/modules/ROOT/pages/operations/monitoring.adoc
+++ b/documentation/modules/ROOT/pages/operations/monitoring.adoc
@@ -139,10 +139,10 @@ ifdef::product[]
 == Monitoring {prodname} on OpenShift
 
 If you are using {prodname} on OpenShift, you can obtain JMX metrics by opening a JMX port on `9999`.
-For more information, see link:{LinkStreamsOpenShift}#assembly-jmx-options-deployment-configuration-kafka[JMX Options].
+For more information, see link:{LinkStreamsOpenShift}#assembly-jmx-options-deployment-configuration-kafka[JMX Options] in {NameStreamsOpenShift}.
 
 In addition, you can use Prometheus and Grafana to monitor the JMX metrics.
-For more information, see link:{LinkStreamsOpenShift}/#assembly-metrics-setup-str[Introducing Metrics].
+For more information, see link:{LinkDeployStreamsOpenShift}/#assembly-metrics-str[Introducing Metrics to Kafka], in {NameDeployStreamsOpenShift}.
 
 endif::product[]
 


### PR DESCRIPTION
Jira [DBZ-3409](https://issues.redhat.com/browse/DBZ-3409)

AMQ content linked from the downstream Debezium _Monitoring_ topic was moved to a new location, breaking the existing link. Updated the link URL to use a new attribute that refers to the new AMQ title that now includes the target content. 

I successfully tested the change in a downstream build. 

This change has no effect on the documentation that's exposed upstream.  