### PR TITLE
DBZ-3429 Handling spaces in SQL Server properties

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -707,7 +707,7 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
 
         Map<TableId, String> snapshotSelectOverridesByTable = new HashMap<>();
 
-        for (String table : tableList.split(",")) {
+        for (String table : tableList.trim().split("\\s*,\\s*")) {
             snapshotSelectOverridesByTable.put(
                     TableId.parse(table),
                     getConfig().getString(SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + "." + table));


### PR DESCRIPTION
The handling of spaces in SQL Server properties is not consistent.  This fix is related to the following JIRA issue: https://issues.redhat.com/browse/DBZ-3429