### PR TITLE
DBZ-3415 Correct expansion of "SMT" acronym in filtering doc

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/filtering.adoc
+++ b/documentation/modules/ROOT/pages/configuration/filtering.adoc
@@ -15,7 +15,7 @@ toc::[]
 endif::community[]
 By default, {prodname} delivers every data change event that it receives to the Kafka broker.
 However, in many cases, you might be interested in only a subset of the events emitted by the producer.
-To enable you to process only the records that are relevant to you, {prodname} provides the _filter_ link:https://cwiki.apache.org/confluence/display/KAFKA/KIP-66%3A+Single+Message+Transforms+for+Kafka+Connect[simple message transform] (SMT).
+To enable you to process only the records that are relevant to you, {prodname} provides the _filter_ link:https://cwiki.apache.org/confluence/display/KAFKA/KIP-66%3A+Single+Message+Transforms+for+Kafka+Connect[single message transform] (SMT).
 
 ifdef::community[]
 [NOTE]


### PR DESCRIPTION
[DBZ-3415](https://issues.redhat.com/browse/DBZ-3415)

Correct erroneous expansion of SMT from "simple" message transform to "single" message transform.