### PR TITLE
DBZ-3449 Adding "quick" profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ First obtain the code by cloning the Git repository:
 
 Then build the code using Maven:
 
-    $ mvn clean install
+    $ mvn clean verify
 
 The build starts and uses several Docker containers for different DBMSes. Note that if Docker is not running or configured, you'll likely get an arcane error -- if this is the case, always verify that Docker is running, perhaps by using `docker ps` to list the running containers.
 
@@ -106,7 +106,15 @@ The build starts and uses several Docker containers for different DBMSes. Note t
 
 You can skip the integration tests and docker-builds with the following command:
 
-    $ mvn clean install -DskipITs
+    $ mvn clean verify -DskipITs
+
+### Building just the artifacs, without running tests, CheckStyle, etc.
+
+You can skip all non-essential plug-ins (tests, integration tests, CheckStyle, formatter, API compatibility check, etc.) using the "quick" build profile:
+
+    $ mvn clean verify -Pquick
+
+This comes in handy for producing connector JARs and/or archives as quickly as possible, e.g. for manual testing in Kafka Connect.
 
 ### Running tests of the Postgres connector using the wal2json or pgoutput logical decoding plug-ins
 

--- a/debezium-api/pom.xml
+++ b/debezium-api/pom.xml
@@ -81,4 +81,12 @@
             </resource>
         </resources>
     </build>
+    <profiles>
+        <profile>
+            <id>quick</id>
+            <properties>
+                <revapi.skip>true</revapi.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -280,7 +280,13 @@
                 </plugins>
             </build>
         </profile>
-
+        <profile>
+            <id>quick</id>
+            <properties>
+                <skipITs>true</skipITs>
+                <docker.skip>true</docker.skip>
+            </properties>
+        </profile>
       <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             Do not perform any Docker-related functionality
             To use, specify "-DskipITs" on the Maven command line.

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -588,6 +588,13 @@
           <docker.skip>true</docker.skip>
         </properties>
       </profile>
+      <profile>
+        <id>quick</id>
+        <properties>
+          <skipITs>true</skipITs>
+          <docker.skip>true</docker.skip>
+        </properties>
+      </profile>
       <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             Use the alternative Docker image for MySQL.
             To use, specify "-Dmysql-gtids" or -Pmysql-gtids on the Maven command line.

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -232,6 +232,13 @@
             </build>
         </profile>
         <profile>
+            <id>quick</id>
+            <properties>
+                <skipITs>true</skipITs>
+                <docker.skip>true</docker.skip>
+            </properties>
+        </profile>
+        <profile>
             <!-- Allows CI to build Oracle without the xstream.jar dependency -->
             <id>oracle-ci</id>
             <activation>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -326,6 +326,14 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>quick</id>
+            <properties>
+                <skipITs>true</skipITs>
+                <docker.skip>true</docker.skip>
+                <revapi.skip>true</revapi.skip>
+            </properties>
+        </profile>
         <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
               Do not perform any Docker-related functionality
               To use, specify "-DskipITs" on the Maven command line.

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -254,6 +254,13 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>quick</id>
+            <properties>
+                <skipITs>true</skipITs>
+                <docker.skip>true</docker.skip>
+            </properties>
+        </profile>
         <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
               Do not perform any Docker-related functionality
               To use, specify "-DskipITs" on the Maven command line.

--- a/debezium-ddl-parser/pom.xml
+++ b/debezium-ddl-parser/pom.xml
@@ -118,6 +118,12 @@
     </build>
     <profiles>
         <profile>
+            <id>quick</id>
+            <properties>
+                <antlr.tests.enabled>false</antlr.tests.enabled>
+            </properties>
+        </profile>
+        <profile>
             <id>skip-tests</id>
             <activation>
                 <activeByDefault>false</activeByDefault>

--- a/debezium-parent/pom.xml
+++ b/debezium-parent/pom.xml
@@ -31,11 +31,11 @@
         <version.staging.plugin>1.6.8</version.staging.plugin>
         <version.protoc.maven.plugin>3.8.0</version.protoc.maven.plugin>
         <version.javadoc.plugin>3.1.1</version.javadoc.plugin>
-        <version.code.formatter>2.11.0</version.code.formatter>
+        <version.code.formatter>2.15.0</version.code.formatter>
         <version.surefire.plugin>3.0.0-M3</version.surefire.plugin>
         <version.checkstyle.plugin>3.1.1</version.checkstyle.plugin>
         <version.release.plugin>2.5.3</version.release.plugin>
-        <version.impsort>1.3.2</version.impsort>
+        <version.impsort>1.6.0</version.impsort>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.checkstyle>8.32</version.checkstyle>
         <version.revapi.plugin>0.11.5</version.revapi.plugin>

--- a/debezium-server/debezium-server-core/pom.xml
+++ b/debezium-server/debezium-server-core/pom.xml
@@ -360,5 +360,11 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>quick</id>
+            <properties>
+                <skipITs>true</skipITs>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/debezium-server/debezium-server-pulsar/pom.xml
+++ b/debezium-server/debezium-server-pulsar/pom.xml
@@ -142,6 +142,13 @@
         </resources>
     </build>
     <profiles>
+        <profile>
+            <id>quick</id>
+            <properties>
+                <skipITs>true</skipITs>
+                <docker.skip>true</docker.skip>
+            </properties>
+        </profile>
         <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
               Do not perform any Docker-related functionality
               To use, specify "-DskipITs" on the Maven command line.

--- a/debezium-server/debezium-server-redis/pom.xml
+++ b/debezium-server/debezium-server-redis/pom.xml
@@ -136,6 +136,13 @@
         </resources>
     </build>
     <profiles>
+        <profile>
+            <id>quick</id>
+            <properties>
+                <skipITs>true</skipITs>
+                <docker.skip>true</docker.skip>
+            </properties>
+        </profile>
         <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
               Do not perform any Docker-related functionality
               To use, specify "-DskipITs" on the Maven command line.

--- a/pom.xml
+++ b/pom.xml
@@ -73,11 +73,11 @@
         <version.staging.plugin>1.6.8</version.staging.plugin>
         <version.protoc.maven.plugin>3.8.0</version.protoc.maven.plugin>
         <version.javadoc.plugin>3.1.1</version.javadoc.plugin>
-        <version.code.formatter>2.11.0</version.code.formatter>
+        <version.code.formatter>2.15.0</version.code.formatter>
         <version.surefire.plugin>3.0.0-M3</version.surefire.plugin>
         <version.checkstyle.plugin>3.1.1</version.checkstyle.plugin>
         <version.release.plugin>2.5.3</version.release.plugin>
-        <version.impsort>1.3.2</version.impsort>
+        <version.impsort>1.6.0</version.impsort>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.checkstyle>8.32</version.checkstyle>
         <version.revapi.plugin>0.11.5</version.revapi.plugin>
@@ -296,6 +296,15 @@
         </plugins>
     </build>
     <profiles>
+        <profile>
+            <id>quick</id>
+            <properties>
+                <skipTests>true</skipTests>
+                <checkstyle.skip>true</checkstyle.skip>
+                <format.skip>true</format.skip>
+                <docker.skip>true</docker.skip>
+            </properties>
+        </profile>
         <profile>
             <id>assembly</id>
             <properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3449

@Naros, @rk3rn3r, @jpechane, this allows to build the connector archives/JARs as quickly as possible via `mvn clean verify -Pquick`, without having to remember all the individual options for skipping plug-ins. Saw this in Quarkus and think it's a great idea, e.g. if you want to build the archives for manual testing in KC.