### PR TITLE
[docs] Modify conditional delimiter in attempt to fix downstream error.

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -717,10 +717,10 @@ Details are in the following sections:
 
 endif::product[]
 
-ifndef::product[]
+ifdef::community[]
 Support for further data types will be added in subsequent releases.
 Please file a {jira-url}/browse/DBZ[JIRA issue] for any specific types that may be missing.
-endif::[]
+endif::community[]
 
 [id="oracle-character-types"]
 === Character and BLOB types


### PR DESCRIPTION
Lately, the script for fetching content for use downstream began complaining about unmatched conditional delimiters. This change standardizes the format of a conditional statement to align it with what the script typically expects.  