### PR TITLE
DBZ-3412 Fix internal cross-reference link in content-based-routing doc

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/content-based-routing.adoc
+++ b/documentation/modules/ROOT/pages/configuration/content-based-routing.adoc
@@ -169,7 +169,7 @@ It is recommended to use either the xref:content-based-router-topic-regex[topic.
 == Language specifics
 
 The way that you express content-based routing conditions depends on the scripting language that you use.
-For example, as shown in the {link-prefix}:{link-content-based-routing}#example-basic-content-based-routing-configuration[basic configuration example], when you use `Groovy` as the expression language,
+For example, as shown in the xref:example-basic-content-based-routing-configuration[basic configuration example], when you use `Groovy` as the expression language,
 the following expression reroutes all update (`u`) records to the `updates` topic, while routing other records to the default topic:
 
 [source,groovy]


### PR DESCRIPTION
[DBZ-3412](https://issues.redhat.com/browse/DBZ-3412)

An attribute string in an internal cross reference link failed to resolve downstream. 
I replaced the series of attributes in the link with a basic xref statement. 

Tested in local upstream and downstream doc builds and confirmed that the link works in both instances.