### PR TITLE
DBZ-3240 Remove `database.tablename.case.insensitive` deprecated option

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/AbstractStreamingAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/AbstractStreamingAdapter.java
@@ -13,6 +13,15 @@ import io.debezium.document.Document;
  * @author Chris Cranford
  */
 public abstract class AbstractStreamingAdapter implements StreamingAdapter {
+
+    protected OracleConnectorConfig connectorConfig;
+    protected OracleConnection connection;
+
+    public void configure(OracleConnectorConfig connectorConfig, OracleConnection connection) {
+        this.connectorConfig = connectorConfig;
+        this.connection = connection;
+    }
+
     protected Scn resolveScn(Document document) {
         final String scn = document.getString(SourceInfo.SCN_KEY);
         if (scn == null) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/AbstractStreamingAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/AbstractStreamingAdapter.java
@@ -14,12 +14,10 @@ import io.debezium.document.Document;
  */
 public abstract class AbstractStreamingAdapter implements StreamingAdapter {
 
-    protected OracleConnectorConfig connectorConfig;
-    protected OracleConnection connection;
+    protected final OracleConnectorConfig connectorConfig;
 
-    public void configure(OracleConnectorConfig connectorConfig, OracleConnection connection) {
+    public AbstractStreamingAdapter(OracleConnectorConfig connectorConfig) {
         this.connectorConfig = connectorConfig;
-        this.connection = connection;
     }
 
     protected Scn resolveScn(Document document) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
@@ -1,8 +1,8 @@
 /*
-* Copyright Debezium Authors.
-*
-* Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
-*/
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.connector.oracle;
 
 import io.debezium.config.Configuration;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
@@ -1,8 +1,8 @@
 /*
- * Copyright Debezium Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
+* Copyright Debezium Authors.
+*
+* Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+*/
 package io.debezium.connector.oracle;
 
 import io.debezium.config.Configuration;
@@ -52,9 +52,7 @@ public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory 
     @Override
     public StreamingChangeEventSource getStreamingChangeEventSource(OffsetContext offsetContext) {
         return configuration.getAdapter().getSource(
-                configuration,
                 offsetContext,
-                jdbcConnection,
                 dispatcher,
                 errorHandler,
                 clock,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
@@ -53,6 +53,7 @@ public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory 
     public StreamingChangeEventSource getStreamingChangeEventSource(OffsetContext offsetContext) {
         return configuration.getAdapter().getSource(
                 offsetContext,
+                jdbcConnection,
                 dispatcher,
                 errorHandler,
                 clock,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -323,22 +322,6 @@ public class OracleConnection extends JdbcConnection {
             }
         }
         tables.overwriteTable(editor.create());
-    }
-
-    /**
-     * Resolve the table name case insensitivity used by the schema based on the following rules:
-     *
-     * <ul>
-     *     <li>If option is provided in connector configuration, it will be used.</li>
-     *     <li>Otherwise resolved by database version where Oracle 11 will be {@code true}; otherwise {@code false}.</li>
-     * </ul>
-     *
-     * @param connectorConfig the connector configuration
-     * @return whether table name case insensitivity is used
-     */
-    public boolean getTablenameCaseInsensitivity(OracleConnectorConfig connectorConfig) {
-        Optional<Boolean> configValue = connectorConfig.getTablenameCaseInsensitive();
-        return configValue.orElse(getOracleVersion().getMajor() == 11);
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -25,13 +25,12 @@ import io.debezium.config.Configuration;
 import io.debezium.config.EnumeratedValue;
 import io.debezium.config.Field;
 import io.debezium.config.Field.ValidationOutput;
+import io.debezium.config.Instantiator;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.connector.oracle.logminer.HistoryRecorder;
-import io.debezium.connector.oracle.logminer.LogMinerAdapter;
 import io.debezium.connector.oracle.logminer.NeverHistoryRecorder;
 import io.debezium.connector.oracle.logminer.SqlUtils;
-import io.debezium.connector.oracle.xstream.XStreamAdapter;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.relational.ColumnFilterMode;
 import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
@@ -522,7 +521,11 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
 
             @Override
             public StreamingAdapter getInstance(OracleConnectorConfig connectorConfig) {
-                return new XStreamAdapter(connectorConfig);
+                return Instantiator.getInstanceWithProvidedConstructorType(
+                        "io.debezium.connector.oracle.xstream.XStreamAdapter",
+                        StreamingAdapter.class::getClassLoader,
+                        OracleConnectorConfig.class,
+                        connectorConfig);
             }
         },
 
@@ -537,7 +540,11 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
 
             @Override
             public StreamingAdapter getInstance(OracleConnectorConfig connectorConfig) {
-                return new LogMinerAdapter(connectorConfig);
+                return Instantiator.getInstanceWithProvidedConstructorType(
+                        "io.debezium.connector.oracle.logminer.LogMinerAdapter",
+                        StreamingAdapter.class::getClassLoader,
+                        OracleConnectorConfig.class,
+                        connectorConfig);
             }
         };
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -9,7 +9,6 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import org.apache.kafka.common.config.ConfigDef;
@@ -95,14 +94,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     + "Options include: "
                     + "'initial' (the default) to specify the connector should run a snapshot only when no offsets are available for the logical server name; "
                     + "'schema_only' to specify the connector should run a snapshot of the schema when no offsets are available for the logical server name. ");
-
-    @Deprecated
-    public static final Field TABLENAME_CASE_INSENSITIVE = Field.create("database.tablename.case.insensitive")
-            .withDisplayName("Case insensitive table names")
-            .withType(Type.BOOLEAN)
-            .withDefault(false)
-            .withImportance(Importance.LOW)
-            .withDescription("Deprecated: Case insensitive table names; set to 'true' for Oracle 11g, 'false' (default) otherwise.");
 
     public static final Field ORACLE_VERSION = Field.createInternal("database.oracle.version")
             .withDisplayName("Oracle version, 11 or 12+")
@@ -304,7 +295,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     CONNECTOR_ADAPTER,
                     LOG_MINING_STRATEGY,
                     URL,
-                    TABLENAME_CASE_INSENSITIVE,
                     ORACLE_VERSION)
             .connector(
                     SNAPSHOT_ENHANCEMENT_TOKEN,
@@ -342,7 +332,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     private final String xoutServerName;
     private final SnapshotMode snapshotMode;
 
-    private final Boolean tablenameCaseInsensitive;
     private final String oracleVersion;
     private final HistoryRecorder logMiningHistoryRecorder;
     private final Configuration jdbcConfig;
@@ -375,7 +364,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         this.pdbName = toUpperCase(config.getString(PDB_NAME));
         this.xoutServerName = config.getString(XSTREAM_SERVER_NAME);
         this.snapshotMode = SnapshotMode.parse(config.getString(SNAPSHOT_MODE));
-        this.tablenameCaseInsensitive = resolveTableNameCaseInsensitivity(config);
         this.oracleVersion = config.getString(ORACLE_VERSION);
         this.logMiningHistoryRecorder = resolveLogMiningHistoryRecorder(config);
         this.jdbcConfig = config.subset(DATABASE_CONFIG_PREFIX, true);
@@ -434,17 +422,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
 
     public SnapshotMode getSnapshotMode() {
         return snapshotMode;
-    }
-
-    /**
-     * Returns whether table name case is insensitive or not.  The method may return {@code null}
-     * which indicates the connector configuration does not specify a value and should therefore
-     * be resolved by the {@link OracleConnection}.
-     *
-     * @return whether table case is insensitive, may be {@code null}.
-     */
-    public Optional<Boolean> getTablenameCaseInsensitive() {
-        return Optional.ofNullable(tablenameCaseInsensitive);
     }
 
     public String getOracleVersion() {
@@ -923,11 +900,4 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         return 0;
     }
 
-    private static Boolean resolveTableNameCaseInsensitivity(Configuration config) {
-        if (config.hasKey(TABLENAME_CASE_INSENSITIVE.name())) {
-            LOGGER.warn("The option '{}' is deprecated and will be removed in the future.", TABLENAME_CASE_INSENSITIVE.name());
-            return config.getBoolean(TABLENAME_CASE_INSENSITIVE);
-        }
-        return null;
-    }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
@@ -54,7 +54,7 @@ public class OracleConnectorTask extends BaseSourceTask {
         connectorConfig.getAdapter().configure(connectorConfig, jdbcConnection);
 
         OracleValueConverters valueConverters = new OracleValueConverters(connectorConfig, jdbcConnection);
-        this.schema = new OracleDatabaseSchema(connectorConfig, valueConverters, schemaNameAdjuster, topicSelector, jdbcConnection);
+        this.schema = new OracleDatabaseSchema(connectorConfig, valueConverters, schemaNameAdjuster, topicSelector);
         this.schema.initializeStorage();
 
         OffsetContext previousOffset = getPreviousOffset(connectorConfig.getAdapter().getOffsetContextLoader());

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
@@ -51,12 +51,13 @@ public class OracleConnectorTask extends BaseSourceTask {
 
         Configuration jdbcConfig = connectorConfig.jdbcConfig();
         jdbcConnection = new OracleConnection(jdbcConfig, () -> getClass().getClassLoader());
-        OracleValueConverters valueConverters = new OracleValueConverters(connectorConfig, jdbcConnection);
+        connectorConfig.getAdapter().configure(connectorConfig, jdbcConnection);
 
+        OracleValueConverters valueConverters = new OracleValueConverters(connectorConfig, jdbcConnection);
         this.schema = new OracleDatabaseSchema(connectorConfig, valueConverters, schemaNameAdjuster, topicSelector, jdbcConnection);
         this.schema.initializeStorage();
 
-        OffsetContext previousOffset = getPreviousOffset(connectorConfig.getAdapter().getOffsetContextLoader(connectorConfig));
+        OffsetContext previousOffset = getPreviousOffset(connectorConfig.getAdapter().getOffsetContextLoader());
 
         if (previousOffset != null) {
             schema.recover(previousOffset);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
@@ -17,6 +17,7 @@ import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.connector.common.BaseSourceTask;
+import io.debezium.connector.oracle.StreamingAdapter.TableNameCaseSensitivity;
 import io.debezium.pipeline.ChangeEventSourceCoordinator;
 import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.ErrorHandler;
@@ -51,10 +52,10 @@ public class OracleConnectorTask extends BaseSourceTask {
 
         Configuration jdbcConfig = connectorConfig.jdbcConfig();
         jdbcConnection = new OracleConnection(jdbcConfig, () -> getClass().getClassLoader());
-        connectorConfig.getAdapter().configure(connectorConfig, jdbcConnection);
 
         OracleValueConverters valueConverters = new OracleValueConverters(connectorConfig, jdbcConnection);
-        this.schema = new OracleDatabaseSchema(connectorConfig, valueConverters, schemaNameAdjuster, topicSelector);
+        TableNameCaseSensitivity tableNameCaseSensitivity = connectorConfig.getAdapter().getTableNameCaseSensitivity(jdbcConnection);
+        this.schema = new OracleDatabaseSchema(connectorConfig, valueConverters, schemaNameAdjuster, topicSelector, tableNameCaseSensitivity);
         this.schema.initializeStorage();
 
         OffsetContext previousOffset = getPreviousOffset(connectorConfig.getAdapter().getOffsetContextLoader());

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseSchema.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseSchema.java
@@ -41,7 +41,7 @@ public class OracleDatabaseSchema extends HistorizedRelationalDatabaseSchema {
                         connectorConfig.customConverterRegistry(),
                         connectorConfig.getSourceInfoStructMaker().schema(),
                         connectorConfig.getSanitizeFieldNames()),
-                connectorConfig.getAdapter().getTablenameCaseInsensitivity(connection.getOracleVersion()),
+                connectorConfig.getAdapter().getTablenameCaseInsensitivity(),
                 connectorConfig.getKeyMapper());
 
         this.ddlParser = new OracleDdlParser(valueConverters, connectorConfig.getTableFilters().dataCollectionFilter());

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseSchema.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseSchema.java
@@ -32,7 +32,8 @@ public class OracleDatabaseSchema extends HistorizedRelationalDatabaseSchema {
     private final OracleValueConverters valueConverters;
 
     public OracleDatabaseSchema(OracleConnectorConfig connectorConfig, OracleValueConverters valueConverters,
-                                SchemaNameAdjuster schemaNameAdjuster, TopicSelector<TableId> topicSelector) {
+                                SchemaNameAdjuster schemaNameAdjuster, TopicSelector<TableId> topicSelector,
+                                TableNameCaseSensitivity tableNameCaseSensitivity) {
         super(connectorConfig, topicSelector, connectorConfig.getTableFilters().dataCollectionFilter(),
                 connectorConfig.getColumnFilter(),
                 new TableSchemaBuilder(
@@ -41,7 +42,7 @@ public class OracleDatabaseSchema extends HistorizedRelationalDatabaseSchema {
                         connectorConfig.customConverterRegistry(),
                         connectorConfig.getSourceInfoStructMaker().schema(),
                         connectorConfig.getSanitizeFieldNames()),
-                TableNameCaseSensitivity.INSENSITIVE.equals(connectorConfig.getAdapter().getTableNameCaseSensitivity()),
+                TableNameCaseSensitivity.INSENSITIVE.equals(tableNameCaseSensitivity),
                 connectorConfig.getKeyMapper());
 
         this.ddlParser = new OracleDdlParser(valueConverters, connectorConfig.getTableFilters().dataCollectionFilter());

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseSchema.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseSchema.java
@@ -41,7 +41,7 @@ public class OracleDatabaseSchema extends HistorizedRelationalDatabaseSchema {
                         connectorConfig.customConverterRegistry(),
                         connectorConfig.getSourceInfoStructMaker().schema(),
                         connectorConfig.getSanitizeFieldNames()),
-                connection.getTablenameCaseInsensitivity(connectorConfig),
+                connectorConfig.getAdapter().getTablenameCaseInsensitivity(connection.getOracleVersion()),
                 connectorConfig.getKeyMapper());
 
         this.ddlParser = new OracleDdlParser(valueConverters, connectorConfig.getTableFilters().dataCollectionFilter());

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseSchema.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseSchema.java
@@ -8,6 +8,7 @@ package io.debezium.connector.oracle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.connector.oracle.StreamingAdapter.TableNameCaseSensitivity;
 import io.debezium.connector.oracle.antlr.OracleDdlParser;
 import io.debezium.relational.HistorizedRelationalDatabaseSchema;
 import io.debezium.relational.Table;
@@ -31,8 +32,7 @@ public class OracleDatabaseSchema extends HistorizedRelationalDatabaseSchema {
     private final OracleValueConverters valueConverters;
 
     public OracleDatabaseSchema(OracleConnectorConfig connectorConfig, OracleValueConverters valueConverters,
-                                SchemaNameAdjuster schemaNameAdjuster, TopicSelector<TableId> topicSelector,
-                                OracleConnection connection) {
+                                SchemaNameAdjuster schemaNameAdjuster, TopicSelector<TableId> topicSelector) {
         super(connectorConfig, topicSelector, connectorConfig.getTableFilters().dataCollectionFilter(),
                 connectorConfig.getColumnFilter(),
                 new TableSchemaBuilder(
@@ -41,7 +41,7 @@ public class OracleDatabaseSchema extends HistorizedRelationalDatabaseSchema {
                         connectorConfig.customConverterRegistry(),
                         connectorConfig.getSourceInfoStructMaker().schema(),
                         connectorConfig.getSanitizeFieldNames()),
-                connectorConfig.getAdapter().getTablenameCaseInsensitivity(),
+                TableNameCaseSensitivity.INSENSITIVE.equals(connectorConfig.getAdapter().getTableNameCaseSensitivity()),
                 connectorConfig.getKeyMapper());
 
         this.ddlParser = new OracleDdlParser(valueConverters, connectorConfig.getTableFilters().dataCollectionFilter());

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
@@ -31,4 +31,6 @@ public interface StreamingAdapter {
                                          OracleConnection connection, EventDispatcher<TableId> dispatcher, ErrorHandler errorHandler, Clock clock,
                                          OracleDatabaseSchema schema, OracleTaskContext taskContext, Configuration jdbcConfig,
                                          OracleStreamingChangeEventSourceMetrics streamingMetrics);
+
+    boolean getTablenameCaseInsensitivity(OracleDatabaseVersion databaseVersion);
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
@@ -42,7 +42,6 @@ public interface StreamingAdapter {
         INSENSITIVE
     };
 
-
     String getType();
 
     HistoryRecordComparator getHistoryRecordComparator();

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
@@ -21,16 +21,18 @@ import io.debezium.util.Clock;
  */
 public interface StreamingAdapter {
 
+    void configure(OracleConnectorConfig connectorConfig, OracleConnection connection);
+
     String getType();
 
     HistoryRecordComparator getHistoryRecordComparator();
 
-    OffsetContext.Loader getOffsetContextLoader(OracleConnectorConfig connectorConfig);
+    OffsetContext.Loader getOffsetContextLoader();
 
-    StreamingChangeEventSource getSource(OracleConnectorConfig connectorConfig, OffsetContext offsetContext,
-                                         OracleConnection connection, EventDispatcher<TableId> dispatcher, ErrorHandler errorHandler, Clock clock,
-                                         OracleDatabaseSchema schema, OracleTaskContext taskContext, Configuration jdbcConfig,
+    StreamingChangeEventSource getSource(OffsetContext offsetContext, EventDispatcher<TableId> dispatcher,
+                                         ErrorHandler errorHandler, Clock clock, OracleDatabaseSchema schema,
+                                         OracleTaskContext taskContext, Configuration jdbcConfig,
                                          OracleStreamingChangeEventSourceMetrics streamingMetrics);
 
-    boolean getTablenameCaseInsensitivity(OracleDatabaseVersion databaseVersion);
+    boolean getTablenameCaseInsensitivity();
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
@@ -21,6 +21,27 @@ import io.debezium.util.Clock;
  */
 public interface StreamingAdapter {
 
+    /**
+     * Controls whether table names are viewed as case-sensitive or not.
+     */
+    enum TableNameCaseSensitivity {
+        /**
+         * Sensitive case implies that the table names are taken from the JDBC driver and kept as-is
+         * in the in-memory relational objects.  Any {@link TableId} that is obtained will always
+         * have a table-name in the case that the driver provided.  This is the default behavior
+         * for almost all cases.
+         */
+        SENSITIVE,
+
+        /**
+         * Insensitive case implies that the table names are taken from the JDBC driver and converted
+         * to lower-case in the in-memory relational objects.  Any {@link TableId} that is obtained
+         * will always have a table-name in lower case regardless of how it may be represented in
+         * the database.
+         */
+        INSENSITIVE
+    };
+
     void configure(OracleConnectorConfig connectorConfig, OracleConnection connection);
 
     String getType();
@@ -34,5 +55,17 @@ public interface StreamingAdapter {
                                          OracleTaskContext taskContext, Configuration jdbcConfig,
                                          OracleStreamingChangeEventSourceMetrics streamingMetrics);
 
-    boolean getTablenameCaseInsensitivity();
+    /**
+     * Returns whether table names are case sensitive.
+     *
+     * By default the Oracle driver returns table names that are case sensitive.  The table names will
+     * be returned in upper-case by default and will only be returned in lower or mixed case when the
+     * table is created using double-quotes to preserve case.  The adapter aligns with the driver's
+     * behavior and enforces that table names are case sensitive by default.
+     *
+     * @return the case sensitivity setting for table names used by the connector's runtime adapter
+     */
+    default TableNameCaseSensitivity getTableNameCaseSensitivity() {
+        return TableNameCaseSensitivity.SENSITIVE;
+    }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
@@ -42,7 +42,6 @@ public interface StreamingAdapter {
         INSENSITIVE
     };
 
-    void configure(OracleConnectorConfig connectorConfig, OracleConnection connection);
 
     String getType();
 
@@ -50,7 +49,7 @@ public interface StreamingAdapter {
 
     OffsetContext.Loader getOffsetContextLoader();
 
-    StreamingChangeEventSource getSource(OffsetContext offsetContext, EventDispatcher<TableId> dispatcher,
+    StreamingChangeEventSource getSource(OffsetContext offsetContext, OracleConnection connection, EventDispatcher<TableId> dispatcher,
                                          ErrorHandler errorHandler, Clock clock, OracleDatabaseSchema schema,
                                          OracleTaskContext taskContext, Configuration jdbcConfig,
                                          OracleStreamingChangeEventSourceMetrics streamingMetrics);
@@ -63,9 +62,10 @@ public interface StreamingAdapter {
      * table is created using double-quotes to preserve case.  The adapter aligns with the driver's
      * behavior and enforces that table names are case sensitive by default.
      *
+     * @param connection database connection, should never be {@code null}
      * @return the case sensitivity setting for table names used by the connector's runtime adapter
      */
-    default TableNameCaseSensitivity getTableNameCaseSensitivity() {
+    default TableNameCaseSensitivity getTableNameCaseSensitivity(OracleConnection connection) {
         return TableNameCaseSensitivity.SENSITIVE;
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
@@ -69,9 +69,4 @@ public class LogMinerAdapter extends AbstractStreamingAdapter {
                 streamingMetrics);
     }
 
-    @Override
-    public boolean getTablenameCaseInsensitivity() {
-        // LogMiner does not support this, always return false.
-        return false;
-    }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
@@ -7,10 +7,7 @@ package io.debezium.connector.oracle.logminer;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.AbstractStreamingAdapter;
-import io.debezium.connector.oracle.OracleConnection;
-import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
-import io.debezium.connector.oracle.OracleDatabaseVersion;
 import io.debezium.connector.oracle.OracleOffsetContext;
 import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
 import io.debezium.connector.oracle.OracleTaskContext;
@@ -46,14 +43,12 @@ public class LogMinerAdapter extends AbstractStreamingAdapter {
     }
 
     @Override
-    public OffsetContext.Loader getOffsetContextLoader(OracleConnectorConfig connectorConfig) {
+    public OffsetContext.Loader getOffsetContextLoader() {
         return new LogMinerOracleOffsetContextLoader(connectorConfig);
     }
 
     @Override
-    public StreamingChangeEventSource getSource(OracleConnectorConfig connectorConfig,
-                                                OffsetContext offsetContext,
-                                                OracleConnection connection,
+    public StreamingChangeEventSource getSource(OffsetContext offsetContext,
                                                 EventDispatcher<TableId> dispatcher,
                                                 ErrorHandler errorHandler,
                                                 Clock clock,
@@ -75,7 +70,7 @@ public class LogMinerAdapter extends AbstractStreamingAdapter {
     }
 
     @Override
-    public boolean getTablenameCaseInsensitivity(OracleDatabaseVersion databaseVersion) {
+    public boolean getTablenameCaseInsensitivity() {
         // LogMiner does not support this, always return false.
         return false;
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
@@ -10,6 +10,7 @@ import io.debezium.connector.oracle.AbstractStreamingAdapter;
 import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
+import io.debezium.connector.oracle.OracleDatabaseVersion;
 import io.debezium.connector.oracle.OracleOffsetContext;
 import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
 import io.debezium.connector.oracle.OracleTaskContext;
@@ -71,5 +72,11 @@ public class LogMinerAdapter extends AbstractStreamingAdapter {
                 taskContext,
                 jdbcConfig,
                 streamingMetrics);
+    }
+
+    @Override
+    public boolean getTablenameCaseInsensitivity(OracleDatabaseVersion databaseVersion) {
+        // LogMiner does not support this, always return false.
+        return false;
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
@@ -7,6 +7,8 @@ package io.debezium.connector.oracle.logminer;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.AbstractStreamingAdapter;
+import io.debezium.connector.oracle.OracleConnection;
+import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.OracleOffsetContext;
 import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
@@ -26,6 +28,10 @@ import io.debezium.util.Clock;
 public class LogMinerAdapter extends AbstractStreamingAdapter {
 
     private static final String TYPE = "logminer";
+
+    public LogMinerAdapter(OracleConnectorConfig connectorConfig) {
+        super(connectorConfig);
+    }
 
     @Override
     public String getType() {
@@ -49,6 +55,7 @@ public class LogMinerAdapter extends AbstractStreamingAdapter {
 
     @Override
     public StreamingChangeEventSource getSource(OffsetContext offsetContext,
+                                                OracleConnection connection,
                                                 EventDispatcher<TableId> dispatcher,
                                                 ErrorHandler errorHandler,
                                                 Clock clock,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -149,7 +149,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
             return new TableId(lcr.getSourceDatabaseName(), lcr.getObjectOwner(), lcr.getObjectName());
         }
         else {
-            return new TableId(lcr.getSourceDatabaseName().toLowerCase(), lcr.getObjectOwner(), lcr.getObjectName().toLowerCase());
+            return new TableId(lcr.getSourceDatabaseName(), lcr.getObjectOwner(), lcr.getObjectName().toLowerCase());
         }
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamAdapter.java
@@ -7,6 +7,8 @@ package io.debezium.connector.oracle.xstream;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.AbstractStreamingAdapter;
+import io.debezium.connector.oracle.OracleConnection;
+import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.OracleOffsetContext;
 import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
@@ -30,6 +32,10 @@ import io.debezium.util.Clock;
 public class XStreamAdapter extends AbstractStreamingAdapter {
 
     private static final String TYPE = "xstream";
+
+    public XStreamAdapter(OracleConnectorConfig connectorConfig) {
+        super(connectorConfig);
+    }
 
     @Override
     public String getType() {
@@ -60,6 +66,7 @@ public class XStreamAdapter extends AbstractStreamingAdapter {
 
     @Override
     public StreamingChangeEventSource getSource(OffsetContext offsetContext,
+                                                OracleConnection connection,
                                                 EventDispatcher<TableId> dispatcher,
                                                 ErrorHandler errorHandler,
                                                 Clock clock,
@@ -79,11 +86,11 @@ public class XStreamAdapter extends AbstractStreamingAdapter {
     }
 
     @Override
-    public TableNameCaseSensitivity getTableNameCaseSensitivity() {
+    public TableNameCaseSensitivity getTableNameCaseSensitivity(OracleConnection connection) {
         // Always use tablename case insensitivity true when on Oracle 11, otherwise false.
         if (connection.getOracleVersion().getMajor() == 11) {
             return TableNameCaseSensitivity.SENSITIVE;
         }
-        return super.getTableNameCaseSensitivity();
+        return super.getTableNameCaseSensitivity(connection);
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamAdapter.java
@@ -7,10 +7,7 @@ package io.debezium.connector.oracle.xstream;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.AbstractStreamingAdapter;
-import io.debezium.connector.oracle.OracleConnection;
-import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
-import io.debezium.connector.oracle.OracleDatabaseVersion;
 import io.debezium.connector.oracle.OracleOffsetContext;
 import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
 import io.debezium.connector.oracle.OracleTaskContext;
@@ -57,14 +54,12 @@ public class XStreamAdapter extends AbstractStreamingAdapter {
     }
 
     @Override
-    public OffsetContext.Loader getOffsetContextLoader(OracleConnectorConfig connectorConfig) {
+    public OffsetContext.Loader getOffsetContextLoader() {
         return new XStreamOracleOffsetContextLoader(connectorConfig);
     }
 
     @Override
-    public StreamingChangeEventSource getSource(OracleConnectorConfig connectorConfig,
-                                                OffsetContext offsetContext,
-                                                OracleConnection connection,
+    public StreamingChangeEventSource getSource(OffsetContext offsetContext,
                                                 EventDispatcher<TableId> dispatcher,
                                                 ErrorHandler errorHandler,
                                                 Clock clock,
@@ -84,8 +79,8 @@ public class XStreamAdapter extends AbstractStreamingAdapter {
     }
 
     @Override
-    public boolean getTablenameCaseInsensitivity(OracleDatabaseVersion databaseVersion) {
+    public boolean getTablenameCaseInsensitivity() {
         // Always use tablename case insensitivity true when on Oracle 11, otherwise false.
-        return databaseVersion.getMajor() == 11;
+        return connection.getOracleVersion().getMajor() == 11;
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamAdapter.java
@@ -79,8 +79,11 @@ public class XStreamAdapter extends AbstractStreamingAdapter {
     }
 
     @Override
-    public boolean getTablenameCaseInsensitivity() {
+    public TableNameCaseSensitivity getTableNameCaseSensitivity() {
         // Always use tablename case insensitivity true when on Oracle 11, otherwise false.
-        return connection.getOracleVersion().getMajor() == 11;
+        if (connection.getOracleVersion().getMajor() == 11) {
+            return TableNameCaseSensitivity.SENSITIVE;
+        }
+        return super.getTableNameCaseSensitivity();
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamAdapter.java
@@ -10,6 +10,7 @@ import io.debezium.connector.oracle.AbstractStreamingAdapter;
 import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
+import io.debezium.connector.oracle.OracleDatabaseVersion;
 import io.debezium.connector.oracle.OracleOffsetContext;
 import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
 import io.debezium.connector.oracle.OracleTaskContext;
@@ -80,5 +81,11 @@ public class XStreamAdapter extends AbstractStreamingAdapter {
                 clock,
                 schema,
                 streamingMetrics);
+    }
+
+    @Override
+    public boolean getTablenameCaseInsensitivity(OracleDatabaseVersion databaseVersion) {
+        // Always use tablename case insensitivity true when on Oracle 11, otherwise false.
+        return databaseVersion.getMajor() == 11;
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -70,7 +70,7 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
         this.posVersion = resolvePosVersion(jdbcConnection, connectorConfig);
 
         this.eventHandler = new LcrEventHandler(connectorConfig, errorHandler, dispatcher, clock, schema, offsetContext,
-                TableNameCaseSensitivity.INSENSITIVE.equals(connectorConfig.getAdapter().getTableNameCaseSensitivity()), this,
+                TableNameCaseSensitivity.INSENSITIVE.equals(connectorConfig.getAdapter().getTableNameCaseSensitivity(jdbcConnection)), this,
                 streamingMetrics);
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -66,7 +66,7 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
         this.errorHandler = errorHandler;
         this.offsetContext = offsetContext;
         this.xStreamServerName = connectorConfig.getXoutServerName();
-        this.tablenameCaseInsensitive = connectorConfig.getAdapter().getTablenameCaseInsensitivity(jdbcConnection.getOracleVersion());
+        this.tablenameCaseInsensitive = connectorConfig.getAdapter().getTablenameCaseInsensitivity();
         this.posVersion = resolvePosVersion(jdbcConnection, connectorConfig);
 
         this.eventHandler = new LcrEventHandler(connectorConfig, errorHandler, dispatcher, clock, schema, offsetContext, tableNameCaseInsensitive, this,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -66,9 +66,9 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
         this.errorHandler = errorHandler;
         this.offsetContext = offsetContext;
         this.xStreamServerName = connectorConfig.getXoutServerName();
+        this.tablenameCaseInsensitive = connectorConfig.getAdapter().getTablenameCaseInsensitivity(jdbcConnection.getOracleVersion());
         this.posVersion = resolvePosVersion(jdbcConnection, connectorConfig);
 
-        boolean tableNameCaseInsensitive = jdbcConnection.getTablenameCaseInsensitivity(connectorConfig);
         this.eventHandler = new LcrEventHandler(connectorConfig, errorHandler, dispatcher, clock, schema, offsetContext, tableNameCaseInsensitive, this,
                 streamingMetrics);
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -20,6 +20,7 @@ import io.debezium.connector.oracle.OracleOffsetContext;
 import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
 import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.SourceInfo;
+import io.debezium.connector.oracle.StreamingAdapter.TableNameCaseSensitivity;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
@@ -66,10 +67,10 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
         this.errorHandler = errorHandler;
         this.offsetContext = offsetContext;
         this.xStreamServerName = connectorConfig.getXoutServerName();
-        this.tablenameCaseInsensitive = connectorConfig.getAdapter().getTablenameCaseInsensitivity();
         this.posVersion = resolvePosVersion(jdbcConnection, connectorConfig);
 
-        this.eventHandler = new LcrEventHandler(connectorConfig, errorHandler, dispatcher, clock, schema, offsetContext, tableNameCaseInsensitive, this,
+        this.eventHandler = new LcrEventHandler(connectorConfig, errorHandler, dispatcher, clock, schema, offsetContext,
+                TableNameCaseSensitivity.INSENSITIVE.equals(connectorConfig.getAdapter().getTableNameCaseSensitivity()), this,
                 streamingMetrics);
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
@@ -12,7 +12,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.Optional;
 
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -21,15 +20,11 @@ import org.slf4j.LoggerFactory;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.doc.FixFor;
-import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.relational.history.KafkaDatabaseHistory;
 
 public class OracleConnectorConfigTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OracleConnectorConfigTest.class);
-
-    private static final String TABLENAME_CASE_INSENSITIVE_WARNING = "The option '" + OracleConnectorConfig.TABLENAME_CASE_INSENSITIVE
-            + "' is deprecated and will be removed in the future.";
 
     @Test
     public void validXtreamNoUrl() throws Exception {
@@ -188,36 +183,4 @@ public class OracleConnectorConfigTest {
         assertThat(config.validateAndRecord(Collections.singletonList(transactionRetentionField), LOGGER::error)).isFalse();
     }
 
-    @Test
-    @FixFor("DBZ-3190")
-    public void shouldLogDeprecationWarningForTablenameCaseInsensitiveTrue() throws Exception {
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
-        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
-                Configuration.create().with(OracleConnectorConfig.TABLENAME_CASE_INSENSITIVE, true).build());
-
-        assertThat(connectorConfig.getTablenameCaseInsensitive()).isEqualTo(Optional.of(true));
-        assertThat(logInterceptor.containsMessage(TABLENAME_CASE_INSENSITIVE_WARNING)).isTrue();
-    }
-
-    @Test
-    @FixFor("DBZ-3190")
-    public void shouldLogDeprecationWarningForTablenameCaseInsensitiveFalse() throws Exception {
-        final LogInterceptor logInterceptor = new LogInterceptor();
-
-        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
-                Configuration.create().with(OracleConnectorConfig.TABLENAME_CASE_INSENSITIVE, false).build());
-
-        assertThat(connectorConfig.getTablenameCaseInsensitive()).isEqualTo(Optional.of(false));
-        assertThat(logInterceptor.containsMessage(TABLENAME_CASE_INSENSITIVE_WARNING)).isTrue();
-    }
-
-    @Test
-    @FixFor("DBZ-3190")
-    public void shouldNotBePresentWhenTablenameCaseInsensitiveNotSupplied() throws Exception {
-        final LogInterceptor logInterceptor = new LogInterceptor();
-        final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(Configuration.create().build());
-        assertThat(connectorConfig.getTablenameCaseInsensitive()).isEqualTo(Optional.empty());
-        assertThat(logInterceptor.containsMessage(TABLENAME_CASE_INSENSITIVE_WARNING)).isFalse();
-    }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
@@ -30,7 +30,7 @@ public class OracleOffsetContextTest {
     @Before
     public void beforeEach() throws Exception {
         this.connectorConfig = new OracleConnectorConfig(TestHelper.defaultConfig().build());
-        this.offsetLoader = connectorConfig.getAdapter().getOffsetContextLoader(connectorConfig);
+        this.offsetLoader = connectorConfig.getAdapter().getOffsetContextLoader();
     }
 
     @Test

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
@@ -30,6 +30,7 @@ public class OracleOffsetContextTest {
     @Before
     public void beforeEach() throws Exception {
         this.connectorConfig = new OracleConnectorConfig(TestHelper.defaultConfig().build());
+        connectorConfig.getAdapter().configure(connectorConfig, null);
         this.offsetLoader = connectorConfig.getAdapter().getOffsetContextLoader();
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
@@ -30,7 +30,6 @@ public class OracleOffsetContextTest {
     @Before
     public void beforeEach() throws Exception {
         this.connectorConfig = new OracleConnectorConfig(TestHelper.defaultConfig().build());
-        connectorConfig.getAdapter().configure(connectorConfig, null);
         this.offsetLoader = connectorConfig.getAdapter().getOffsetContextLoader();
     }
 

--- a/debezium-core/src/main/java/io/debezium/config/Instantiator.java
+++ b/debezium-core/src/main/java/io/debezium/config/Instantiator.java
@@ -41,8 +41,8 @@ public class Instantiator {
     }
 
     @SuppressWarnings("unchecked")
-    private static <T, C> T getInstanceWithProvidedConstructorType(String className, Supplier<ClassLoader> classloaderSupplier, Class<C> constructorType,
-                                                                   C constructorValue) {
+    public static <T, C> T getInstanceWithProvidedConstructorType(String className, Supplier<ClassLoader> classloaderSupplier, Class<C> constructorType,
+                                                                  C constructorValue) {
         if (className != null) {
             ClassLoader classloader = classloaderSupplier != null ? classloaderSupplier.get()
                     : Configuration.class.getClassLoader();


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2203
https://issues.redhat.com/browse/DBZ-3240