### PR TITLE
DBZ-3502 Update link to Streams Kafka Connect logging properties content

### DIFF
--- a/documentation/modules/ROOT/pages/operations/logging.adoc
+++ b/documentation/modules/ROOT/pages/operations/logging.adoc
@@ -302,7 +302,7 @@ ifdef::product[]
 == {prodname} logging on OpenShift
 
 If you are using {prodname} on OpenShift, you can use the Kafka Connect loggers to configure the {prodname} loggers and logging levels.
-For more information, see link:{LinkStreamsOpenShift}#con-kafka-connect-logging-deployment-configuration-kafka-connect[Kafka Connect loggers].
+For more information about configuring logging properties in a Kafka Connect schema, see link:{LinkStreamsOpenShift}#type-KafkaConnectSpec-schema-reference[{NameStreamsOpenShift}].
 
 endif::product[]
 


### PR DESCRIPTION
[DBZ-3502](https://issues.redhat.com/browse/DBZ-3502)

This change updates a link in content that is conditionalized for product use only and modifies the wording of the sentence that contains the link. The change is necessary for the Q3 release of Debezium, because the former target topic in the Streams 7.7 doc was moved when the Streams doc was restructured for its 2021.Q2 release.