### PR TITLE
[docs] fix typo in mongodb connector example

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1089,7 +1089,7 @@ Optionally, you can filter out collections that are not needed.
     "connector.class": "io.debezium.connector.mongodb.MongoDbConnector", // <2>
     "mongodb.hosts": "rs0/192.168.99.100:27017", // <3>
     "mongodb.name": "fullfillment", // <4>
-    "collection.include.list": "inventory[.]*", // <5>
+    "collection.include.list": "inventory[.]*" // <5>
   }
 }
 ----


### PR DESCRIPTION
Hello,

First, thanks for making this project open source. It is such a great piece of software.
While I was playing with it and try to configure a mongodb connector, I noticed that the json example to configure a mongodb connector is not valid. There is an unnecessary comma at the end of the payload.

Here is a minor contribution that could help and could save some time for the future users.