### PR TITLE
DBZ-3539 Mark xstream dependency scope as provided

### DIFF
--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -184,6 +184,7 @@
                 <dependency>
                     <groupId>com.oracle.instantclient</groupId>
                     <artifactId>xstreams</artifactId>
+                    <scope>provided</scope>
                 </dependency>
             </dependencies>
         </profile>
@@ -196,6 +197,7 @@
                 <dependency>
                     <groupId>com.oracle.instantclient</groupId>
                     <artifactId>xstreams</artifactId>
+                    <scope>provided</scope>
                 </dependency>
             </dependencies>
             <build>
@@ -301,6 +303,7 @@
                 <dependency>
                     <groupId>com.oracle.instantclient</groupId>
                     <artifactId>xstreams</artifactId>
+                    <scope>provided</scope>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3539

I believe this should restore the exclusion of the dependency in the distribution to behave in the same way prior to DBZ-3365.