### PR TITLE
DBZ-3550 Upgrade to Quarkus 2.0

### DIFF
--- a/.github/workflows/server-workflow.yml
+++ b/.github/workflows/server-workflow.yml
@@ -49,4 +49,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Check changes in Debezium Server
-        run: mvn clean install -B -pl debezium-server -Pserver-ci -am -amd -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+        run: mvn clean install -B -pl debezium-testing/debezium-testing-testcontainers,debezium-server -Pserver-ci -am -amd -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -114,9 +114,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.debezium</groupId>
-            <artifactId>debezium-testing-testcontainers</artifactId>
-            <version>${project.version}</version>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/debezium-quarkus-outbox/deployment/pom.xml
+++ b/debezium-quarkus-outbox/deployment/pom.xml
@@ -21,10 +21,6 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy-deployment</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jackson-deployment</artifactId>
         </dependency>
         <dependency>

--- a/debezium-quarkus-outbox/runtime/pom.xml
+++ b/debezium-quarkus-outbox/runtime/pom.xml
@@ -27,11 +27,6 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-opentracing</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-resteasy</artifactId>
-        </dependency>
-
         <!-- Needed primarily for @Incubating annotation -->
         <dependency>
             <groupId>io.debezium</groupId>

--- a/debezium-quarkus-outbox/runtime/pom.xml
+++ b/debezium-quarkus-outbox/runtime/pom.xml
@@ -27,6 +27,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-opentracing</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy</artifactId>
+        </dependency>
 
         <!-- Needed primarily for @Incubating annotation -->
         <dependency>

--- a/debezium-quarkus-outbox/runtime/src/main/java/io/debezium/outbox/quarkus/internal/EventDispatcher.java
+++ b/debezium-quarkus-outbox/runtime/src/main/java/io/debezium/outbox/quarkus/internal/EventDispatcher.java
@@ -83,11 +83,11 @@ public class EventDispatcher {
                 .withTag(TYPE, event.getAggregateType())
                 .withTag(TIMESTAMP, event.getTimestamp().toString());
 
-        try (final Scope outboxSpanScope = spanBuilder.startActive(true)) {
+        try (final Scope outboxSpanScope = tracer.scopeManager().activate(spanBuilder.start())) {
+            final Span activeSpan = tracer.scopeManager().activeSpan();
 
-            Tags.COMPONENT.set(outboxSpanScope.span(), TRACING_COMPONENT);
-            tracer.inject(outboxSpanScope.span().context(),
-                    Format.Builtin.TEXT_MAP, exportedSpanData);
+            Tags.COMPONENT.set(activeSpan, TRACING_COMPONENT);
+            tracer.inject(activeSpan.context(), Format.Builtin.TEXT_MAP, exportedSpanData);
 
             // Define the entity map-mode object using property names and values
             final HashMap<String, Object> dataMap = new HashMap<>();

--- a/debezium-server/debezium-server-core/src/main/java/io/debezium/server/ConnectorLifecycle.java
+++ b/debezium-server/debezium-server-core/src/main/java/io/debezium/server/ConnectorLifecycle.java
@@ -87,7 +87,7 @@ public class ConnectorLifecycle implements HealthCheck, DebeziumEngine.Connector
     @Override
     public HealthCheckResponse call() {
         LOGGER.trace("Healthcheck called - live = '{}'", live);
-        return HealthCheckResponse.named("debezium").state(live).build();
+        return HealthCheckResponse.named("debezium").status(live).build();
     }
 
 }

--- a/debezium-server/debezium-server-core/src/test/java/io/debezium/server/TestConfigSource.java
+++ b/debezium-server/debezium-server-core/src/test/java/io/debezium/server/TestConfigSource.java
@@ -8,6 +8,7 @@ package io.debezium.server;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.eclipse.microprofile.config.spi.ConfigSource;
@@ -94,6 +95,11 @@ public class TestConfigSource implements ConfigSource {
     @Override
     public String getName() {
         return "test";
+    }
+
+    @Override
+    public Set<String> getPropertyNames() {
+        return config.keySet();
     }
 
     public static int waitForSeconds() {

--- a/debezium-server/debezium-server-pravega/pom.xml
+++ b/debezium-server/debezium-server-pravega/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>debezium-server-pravega</artifactId>
   <name>Debezium Server Pravega Sink Adapter</name>
   <properties>
-    <netty.version>4.1.50.Final</netty.version>
+    <netty.version>4.1.52.Final</netty.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/debezium-server/pom.xml
+++ b/debezium-server/pom.xml
@@ -50,6 +50,10 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-jackson</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.debezium</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <antlr.version>4.7.2</antlr.version>
 
         <!-- Quarkus -->
-        <quarkus.version>2.0.0.Alpha3</quarkus.version>
+        <quarkus.version>2.0.0.CR2</quarkus.version>
 
         <!-- Databases, should align with database drivers in debezium-bom -->
         <version.mysql.server>5.7</version.mysql.server>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <antlr.version>4.7.2</antlr.version>
 
         <!-- Quarkus -->
-        <quarkus.version>2.0.0.CR2</quarkus.version>
+        <quarkus.version>2.0.0.CR3</quarkus.version>
 
         <!-- Databases, should align with database drivers in debezium-bom -->
         <version.mysql.server>5.7</version.mysql.server>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <antlr.version>4.7.2</antlr.version>
 
         <!-- Quarkus -->
-        <quarkus.version>1.12.0.Final</quarkus.version>
+        <quarkus.version>2.0.0.Alpha3</quarkus.version>
 
         <!-- Databases, should align with database drivers in debezium-bom -->
         <version.mysql.server>5.7</version.mysql.server>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3550

* Upgrades Quarkus dependency to 2.0.0.Alpha3
* Fixes dependency issues in outbox extension pom
* Remove deprecated usages of OpenTracing API

This is marked as a draft PR as we're awaiting on the official release of Quarkus 2.0.0.Final in early June.