### PR TITLE
DBZ-3525 Fix link, standardize intro and prereqs in `Deploying` topics.

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1550,6 +1550,7 @@ Apply this CR to the same OpenShift instance where you applied the `KafkaConnect
 * Db2 is running and you completed the steps to {LinkDebeziumUserGuide}#setting-up-db2-to-run-a-debezium-connector[set up Db2 to work with a {prodname} connector].
 
 * {StreamsName} is deployed on OpenShift and is running Apache Kafka and Kafka Connect.
+For more information, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOpenShift}].
 
 * Podman or Docker is installed.
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -18,6 +18,23 @@ endif::community[]
 {prodname}'s MongoDB connector tracks a MongoDB replica set or a MongoDB sharded cluster for document changes in databases and collections, recording those changes as events in Kafka topics.
 The connector automatically handles the addition or removal of shards in a sharded cluster, changes in membership of each replica set, elections within each replica set, and awaiting the resolution of communications problems.
 
+ifdef::product[]
+
+Information and procedures for using a {prodname} MongoDB connector is organized as follows:
+
+* xref:overview-of-debezium-mongodb-connector[]
+* xref:how-debezium-mongodb-connectors-work[]
+* xref:descriptions-of-debezium-mongodb-connector-data-change-events[]
+* xref:setting-up-mongodb-to-work-with-debezium[]
+* xref:deployment-of-debezium-mongodb-connectors[]
+* xref:monitoring-debezium-mongodb-connector-performance[]
+* xref:how-debezium-mongodb-connectors-handle-faults-and-problems[]
+
+endif::product[]
+
+// Type: concept
+// Title: Overview of {prodname} MongoDB connector
+// ModuleID: overview-of-debezium-mongodb-connector
 [[mongodb-overview]]
 == Overview
 
@@ -1445,7 +1462,6 @@ The {prodname} MongoDB connector also provides the following custom streaming me
 // Type: concept
 // ModuleID: how-debezium-mongodb-connectors-handle-faults-and-problems
 // Title: How {prodname} MongoDB connectors handle faults and problems
-[[mongodb-fault-tolerance]]
 [[mongodb-when-things-go-wrong]]
 == MongoDB connector common issues
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -117,7 +117,7 @@ When the connector restarts after having crashed or been stopped gracefully, the
 This database history topic is for connector use only. The connector can optionally See {link-prefix}:{link-mysql-connector}#mysql-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
 
 When the MySQL connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied there are helper tables created during the migration process.
-The connector needs to be configured to capture change to these helper tables. 
+The connector needs to be configured to capture change to these helper tables.
 If consumers do not need the records generated for helper tables then a single message transform can be applied to filter them out.
 
 See {link-prefix}:{link-mysql-connector}#mysql-topic-names[default names for topics] that receive {prodname} event records.
@@ -1828,7 +1828,7 @@ You then need to create the following custom resources (CRs):
 * MySQL is running and you completed the steps to {LinkDebeziumUserGuide}#setting-up-mysql-to-run-a-debezium-connector[set up MySQL to work with a {prodname} connector].
 
 * {StreamsName} is deployed on OpenShift and is running Apache Kafka and Kafka Connect.
-  For more information, see link:{LinkStreamsOpenShift}:/getting-started-str[{NameDebeziumInstallOpenShift}].
+For more information, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOpenShift}].
 
 * Podman or Docker is installed.
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2137,15 +2137,20 @@ To deploy a {prodname} PostgreSQL connector, add the connector files to Kafka Co
 To deploy a {prodname} PostgreSQL connector, you need to build a custom Kafka Connect container image that contains the {prodname} connector archive and push this container image to a container registry.
 You then need to create two custom resources (CRs):
 
-* A `KafkaConnect` CR that configures your Kafka Connector and that specifies the name of the image that you created to run your {prodname} connector. You apply this CR to the OpenShift Kafka instance.
+* A `KafkaConnect` CR that defines your Kafka Connect instance.
+The `image` property in the CR specifies the name of the container image that you create to run your {prodname} connector.
+You apply this CR to the OpenShift instance where link:https://access.redhat.com/products/red-hat-amq#streams[Red Hat {StreamsName}] is deployed.
+{StreamsName} offers operators and images that bring Apache Kafka to OpenShift.
 
-* A `KafkaConnector` CR that configures your {prodname} PostgreSQL connector. You apply this CR to the OpenShift instance where Red Hat AMQ Streams is deployed.
+* A `KafkaConnector` CR that defines your {prodname} Db2 connector.
+Apply this CR to the same OpenShift instance where you applied the `KafkaConnect` CR.
 
 .Prerequisites
 
 * PostgreSQL is running and you performed the steps to {LinkDebeziumUserGuide}#setting-up-postgresql-to-run-a-debezium-connector[set up PostgreSQL to run a {prodname} connector].
 
-* link:https://access.redhat.com/products/red-hat-amq#streams[Red Hat AMQ Streams] was used to set up and start running Apache Kafka and Kafka Connect on OpenShift. AMQ Streams offers operators and images that bring Kafka to OpenShift.
+* {StreamsName} is deployed on OpenShift and is running Apache Kafka and Kafka Connect.
+  For more information, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOpenShift}].
 
 * Podman or Docker is installed.
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1665,7 +1665,7 @@ You then need to create the following custom resources (CRs):
 * SQL Server is running and you completed the steps to {LinkDebeziumUserGuide}#setting-up-sql-server-for-use-with-the-debezium-sql-server-connector[set up SQL Server to work with a {prodname} connector].
 
 * {StreamsName} is deployed on OpenShift and is running Apache Kafka and Kafka Connect.
-  For more information, see link:{LinkStreamsOpenShift}:/getting-started-str[{NameDebeziumInstallOpenShift}]
+  For more information, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOpenShift}]
 
 * Podman or Docker is installed.
 


### PR DESCRIPTION
[DBZ-3525](https://issues.redhat.com/browse/DBZ-3525)

This change corrects the link targets for cross-references to the AMQ Streams documentation. The links broke after the Streams docs were refactored and the target topics were moved from the _Using_ guide to the _Deploying and Upgrading_ guide.  

In searching for instances where the incorrect links were used, I realized that the introductory content and prerequisites in the downstream _Deploying_ topics lacked consistency across the different connectors, so I made changes to address the inconsistencies. 

There's also a metadata change to the MongoDB content to correct the way that the file is split when it's fetched for downstream use.  As part of this change, I removed the `[[mongodb-fault-tolerance]]` anchor id that was one of two anchors applied to the topic _MongoDB connector common issues_. The extra ID prevented the tooling that we use to fetch the content for downstream use from parsing the file correctly. Removing the ID "means some links which may fly around out in the wild will be broken."
But, per @gunnarmorling, the concern about breaking anchor links is minor.

I ran a local Antora build to confirm that none of these changes affect the way that content renders upstream.