### PR TITLE
DBZ-3563 Deduplicate logs based on sequence number and not scn ranges

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogFile.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogFile.java
@@ -19,6 +19,7 @@ public class LogFile {
     private final String fileName;
     private final Scn firstScn;
     private final Scn nextScn;
+    private final Long sequence;
     private final boolean current;
 
     /**
@@ -27,9 +28,10 @@ public class LogFile {
      * @param fileName the file name
      * @param firstScn the first system change number in the log
      * @param nextScn the first system change number in the following log
+     * @param sequence the unique log sequence number
      */
-    public LogFile(String fileName, Scn firstScn, Scn nextScn) {
-        this(fileName, firstScn, nextScn, false);
+    public LogFile(String fileName, Scn firstScn, Scn nextScn, Long sequence) {
+        this(fileName, firstScn, nextScn, sequence, false);
     }
 
     /**
@@ -38,12 +40,14 @@ public class LogFile {
      * @param fileName the file name
      * @param firstScn the first system change number in the log
      * @param nextScn the first system change number in the following log
+     * @param sequence the unique log sequence number
      * @param current whether the log file is the current one
      */
-    public LogFile(String fileName, Scn firstScn, Scn nextScn, boolean current) {
+    public LogFile(String fileName, Scn firstScn, Scn nextScn, Long sequence, boolean current) {
         this.fileName = fileName;
         this.firstScn = firstScn;
         this.nextScn = nextScn;
+        this.sequence = sequence;
         this.current = current;
     }
 
@@ -59,6 +63,10 @@ public class LogFile {
         return isCurrent() ? Scn.MAX : nextScn;
     }
 
+    public Long getSequence() {
+        return sequence;
+    }
+
     /**
      * Returns whether this log file instance is considered the current online redo log record.
      */
@@ -66,19 +74,9 @@ public class LogFile {
         return current;
     }
 
-    /**
-     * Returns whether the specified {@code other} log file has the same SCN range as this instance.
-     *
-     * @param other the other log file instance
-     * @return true if both have the same SCN range; otherwise false
-     */
-    public boolean isSameRange(LogFile other) {
-        return Objects.equals(firstScn, other.getFirstScn()) && Objects.equals(nextScn, other.getNextScn());
-    }
-
     @Override
     public int hashCode() {
-        return Objects.hash(firstScn, nextScn);
+        return Objects.hash(sequence);
     }
 
     @Override
@@ -89,6 +87,7 @@ public class LogFile {
         if (!(obj instanceof LogFile)) {
             return false;
         }
-        return isSameRange((LogFile) obj);
+        final LogFile other = (LogFile) obj;
+        return Objects.equals(sequence, other.sequence);
     }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/LogMinerHelperTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/LogMinerHelperTest.java
@@ -53,6 +53,9 @@ public class LogMinerHelperTest {
         Mockito.when(rs.getString(anyInt())).thenAnswer(it -> {
             return mockRows[current - 1][(Integer) it.getArguments()[0] - 1];
         });
+        Mockito.when(rs.getLong(anyInt())).thenAnswer(it -> {
+            return Long.valueOf(mockRows[current - 1][(Integer) it.getArguments()[0] - 1]);
+        });
 
         Mockito.doAnswer(a -> {
             JdbcConnection.ResultSetConsumer consumer = a.getArgument(1);


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3563

This Oracle RAC deployments this de-duplication logic and previous iterations were not compliant and lead to duplicate log files being added to the mining session, thus resulting in ORA-01289 errors.  This PR adjusts the de-duplication logic to rather be based upon the atomically assigned log sequence number, which will guarantee we don't mine multiple logs with the same sequence.