### PR TITLE
DBZ-3582 Update downstream MySQL doc to refer to streaming metrics

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2642,8 +2642,8 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-
 The {prodname} MySQL connector also provides the `HoldingGlobalLock` custom snapshot metric. This metric is set to a Boolean value that indicates whether the connector currently holds a global or table write lock.
 
 // Type: reference
-// ModuleID: monitoring-debezium-mysql-connector-binlog-reading
-// Title: Monitoring {prodname} MySQL connector binlog reading
+// ModuleID: monitoring-debezium-mysql-connector-record-streaming
+// Title: Monitoring {prodname} MySQL connector record streaming
 [[mysql-streaming-metrics]]
 === Streaming metrics
 


### PR DESCRIPTION
[DBZ-3582](https://issues.redhat.com/browse/DBZ-3582)

Per the documentation change made for [DBZ-3572](https://issues.redhat.com/browse/DBZ-3572), for Debezium 1.5 and later the MySQL connector now refers to streaming metrics rather than binlog metrics. To mirror that update downstream, this change modifies annotation comments in `mysql.adoc` that control the downstream titles and anchor IDs to also refer to streaming metrics. 