### PR TITLE
Update CONTRIBUTE.md to reflect the new version of required tools and github pull request path

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -34,9 +34,9 @@ You can talk to us in our [chat room for users](https://gitter.im/debezium/user)
 The following software is required to work with the Debezium codebase and build it locally:
 
 * [Git 2.2.1](https://git-scm.com) or later
-* [JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) or [OpenJDK 8](http://openjdk.java.net/projects/jdk8/)
-* [Maven 3.2.1](https://maven.apache.org/index.html) or later
-* [Docker Engine 1.9](http://docs.docker.com/engine/installation/) or later
+* JDK 11 or later, e.g. [OpenJDK](http://openjdk.java.net/projects/jdk/)
+* [Apache Maven](https://maven.apache.org/index.html) 3.6.3 or later
+* [Docker Engine](https://docs.docker.com/engine/install/) or [Docker Desktop](https://docs.docker.com/desktop/) 1.9 or later
 
 See the links above for installation instructions on your platform. You can verify the versions are installed and running:
 
@@ -219,7 +219,7 @@ Once you're finished making your changes, your topic branch should have your com
 
     $ git push origin DBZ-1234
 
-Then, in a browser go to https://github.com/debezium/debezium, and you should see a small section near the top of the page with a button labeled "Create pull request". GitHub recognized that you pushed a new topic branch to your fork of the upstream repository, and it knows you probably want to create a pull request with those changes. Click on the button, and GitHub will present you with a short form that you should fill out with information about your pull request. The title should start with the JIRA issue and ending with a short phrase that summarizes the changes included in the pull request. (If the pull request contains a single commit, GitHub will automatically prepopulate the title and description fields from the commit message.)
+Then, in a browser go to your forked repository, and you should see a small section near the top of the page with a button labeled "Contribute". GitHub recognized that you pushed a new topic branch to your fork of the upstream repository, and it knows you probably want to create a pull request with those changes. Click on the button, and a button "Open pull request" will apper. Click it and GitHub will present you the "Comparing changes" page, where you can view all changes that you are about to submit. With all revised, click in "Create pull request" and a short form will be given, that you should fill out with information about your pull request. The title should start with the JIRA issue and ending with a short phrase that summarizes the changes included in the pull request. (If the pull request contains a single commit, GitHub will automatically prepopulate the title and description fields from the commit message.)
 
 When completed, press the "Create" button and copy the URL to the new pull request. Go to the corresponding JIRA issue and record the pull request by pasting the URL into the "Pull request" field. (Be sure to not overwrite any URLs that were already in this field; this is how a single issue is bound to multiple pull requests.) Also, please add a JIRA comment with a clear description of what you changed. You might even use the commit message (except for the first line).
 


### PR DESCRIPTION
I was following [CONTRIBUTE.md](https://github.com/debezium/debezium/blob/master/CONTRIBUTE.md) instructions to setup Debezium locally and it incurred into an error, since JDK 8 is no longer supported. I'm opening this PR to reflect the change.
I've also edited some parts of the GitHub pull request instructions because the path described there is not available anymore, after some Github UI changes.