### PR TITLE
DBZ-3447 Order Field definitions for connector configurations

### DIFF
--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorTest.java
@@ -38,8 +38,8 @@ public class MongoDbConnectorTest {
             assertThat(key.defaultValue).isEqualTo(expected.defaultValue());
             assertThat(key.dependents).isEqualTo(expected.dependents());
             assertThat(key.width).isNotNull();
-            assertThat(key.group).isNotNull();
-            assertThat(key.orderInGroup).isGreaterThan(0);
+            assertThat(key.group).isEqualTo(expected.groupName());
+            assertThat(key.orderInGroup).isEqualTo(expected.orderInGroup());
             assertThat(key.validator).isNull();
             assertThat(key.recommender).isNull();
         });

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorTest.java
@@ -42,8 +42,8 @@ public class MySqlConnectorTest {
             }
             assertThat(key.dependents).isEqualTo(expected.dependents());
             assertThat(key.width).isNotNull();
-            assertThat(key.group).isNotNull();
-            assertThat(key.orderInGroup).isGreaterThan(0);
+            assertThat(key.group).isEqualTo(expected.groupName());
+            assertThat(key.orderInGroup).isEqualTo(expected.orderInGroup());
             assertThat(key.validator).isNull();
             assertThat(key.recommender).isNull();
         });

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorTest.java
@@ -65,8 +65,8 @@ public class OracleConnectorTest {
             }
             assertThat(key.dependents).isEqualTo(expected.dependents());
             assertThat(key.width).isNotNull();
-            assertThat(key.group).isNotNull();
-            assertThat(key.orderInGroup).isGreaterThan(0);
+            assertThat(key.group).isEqualTo(expected.groupName());
+            assertThat(key.orderInGroup).isEqualTo(expected.orderInGroup());
             assertThat(key.validator).isNull();
             assertThat(key.recommender).isNull();
         });

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorTest.java
@@ -65,8 +65,8 @@ public class SqlServerConnectorTest {
             }
             assertThat(key.dependents).isEqualTo(expected.dependents());
             assertThat(key.width).isNotNull();
-            assertThat(key.group).isNotNull();
-            assertThat(key.orderInGroup).isGreaterThan(0);
+            assertThat(key.group).isEqualTo(expected.groupName());
+            assertThat(key.orderInGroup).isEqualTo(expected.orderInGroup());
             assertThat(key.validator).isNull();
             assertThat(key.recommender).isNull();
         });


### PR DESCRIPTION
This patch adds two extra properties for Field instances, namely *groupName* and *orderInGroup*, which is later used to sort a List&lt;Field>. Now calls to `ConfigDefinition#all()` and `ConfigDefinition#configDef()`  returns a sorted list of configuration options for all connectors.

https://issues.redhat.com/browse/DBZ-3447

Signed-off-by: Alfusainey Jallow <alf.jallow@gmail.com>