### PR TITLE
Dbz 3459 add database history properties omitted from connector docs

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1835,16 +1835,21 @@ The connector then starts generating data change events for row-level operations
 [[db2-connector-properties]]
 === Connector properties
 
-The {prodname} Db2 connector has numerous configuration properties that you can use to achieve the right connector behavior for your application. Many properties have default values. Information about the properties is organized as follows:
+The {prodname} Db2 connector has numerous configuration properties that you can use to achieve the right connector behavior for your application.
+Many properties have default values.
+Information about the properties is organized as follows:
 
 * xref:db2-required-configuration-properties[Required configuration properties]
 * xref:db2-advanced-configuration-properties[Advanced configuration properties]
-* xref:db2-pass-through-properties[Pass-through configuration properties]
+* xref:db2-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
+* xref:db2-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
+* xref:db2-database-history-properties-for-configuring-connector-behavior[Database history properties for configuring connector behavior]
 
 [id="db2-required-configuration-properties"]
+==== Required connector configuration properties
+
 The following configuration properties are _required_ unless a default value is available.
 
-.Required connector configuration properties
 [cols="30%a,25%a,45%a",options="header"]
 |===
 |Property |Default |Description
@@ -1983,9 +1988,10 @@ If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column tha
 |===
 
 [id="db2-advanced-configuration-properties"]
+==== Advanced connector configuration properties
+
 The following _advanced_ configuration properties have defaults that work in most situations and therefore rarely need to be specified in the connector's configuration.
 
-.Advanced connector configuration properties
 [cols="30%a,25%a,45%a",options="header"]
 |===
 |Property |Default |Description

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1841,9 +1841,10 @@ Information about the properties is organized as follows:
 
 * xref:db2-required-configuration-properties[Required configuration properties]
 * xref:db2-advanced-configuration-properties[Advanced configuration properties]
-* xref:debezium-{context}-connector-database-history-and-pass-through-configuration-properties[{prodname} connector database history and pass-through configuration properties]
-//* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
-//* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
+* xref:debezium-{context}-connector-database-history-configuration-properties[Database history connector configuration properties] that control how {prodname} processes events that it reads from the database history topic.
+** xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties] 
+* xref:debezium-{context}-connector-pass-through-database-driver-configuration-properties[Pass-through database driver properties] that control the behavior of the database driver.
+
 
 [id="db2-required-configuration-properties"]
 ==== Required {prodname} Db2 connector configuration properties
@@ -2101,10 +2102,15 @@ The name format is _schema-name.table-name_.
 
 |===
 
-[id="debezium-{context}-connector-database-history-and-pass-through-configuration-properties"]
-==== {prodname} connector database history and pass-through configuration properties
+[id="debezium-{context}-connector-database-history-configuration-properties"]
+==== {prodname} connector database history configuration properties
 
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
+
+[id="debezium-{context}-connector-pass-through-database-driver-configuration-properties"]
+==== {prodname} connector pass-through database driver configuration properties
+
+include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-database-driver-configuration-properties.adoc[leveloffset=+1]
 
 // Type: assembly
 // ModuleID: monitoring-debezium-db2-connector-performance

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1841,12 +1841,12 @@ Information about the properties is organized as follows:
 
 * xref:db2-required-configuration-properties[Required configuration properties]
 * xref:db2-advanced-configuration-properties[Advanced configuration properties]
-* xref:db2-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
-* xref:db2-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
-* xref:db2-database-history-properties-for-configuring-connector-behavior[Database history properties for configuring connector behavior]
+* xref:{context}-database-history-properties-for-configuring-connector-behavior[Database history connector configuration properties]
+* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
+* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
 
 [id="db2-required-configuration-properties"]
-==== Required connector configuration properties
+==== Required {prodname} Db2 connector configuration properties
 
 The following configuration properties are _required_ unless a default value is available.
 
@@ -2101,52 +2101,9 @@ The name format is _schema-name.table-name_.
 
 |===
 
+==== Connector database history and pass-through configuration properties
+
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
-////
-[id="{context}-pass-through-configuration-properties-for-database-drivers"]
-==== Pass-through configuration properties for database drivers
-
-The {prodname} connector provides for pass-through configuration of the database driver.
-Pass-through database properties begin with the prefix `database.*`.
-For example, the connector passes properties such as `database.foobar=false` to the JDBC URL.
-Debezium strips the `database.` prefix before it passes the property to the database driver.
-
-[id="{context}-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients"]
-==== Pass-through database history properties for configuring producer and consumer clients
-
-When a connector starts, {prodname} relies on a Kafka producer to write schema changes to the database history topic, and a Kafka consumer to read from the database history topic.
-You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.\*` and `database.history.consumer.*` prefixes.
-The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
-
-[source,indent=0]
-----
-database.history.producer.security.protocol=SSL
-database.history.producer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
-database.history.producer.ssl.keystore.password=test1234
-database.history.producer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
-database.history.producer.ssl.truststore.password=test1234
-database.history.producer.ssl.key.password=test1234
-database.history.consumer.security.protocol=SSL
-database.history.consumer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
-database.history.consumer.ssl.keystore.password=test1234
-database.history.consumer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
-database.history.consumer.ssl.truststore.password=test1234
-database.history.consumer.ssl.key.password=test1234
-----
-
-As is the case with the xref:{context}-pass-through-configuration-properties-for-database-drivers[pass-through properties for database drivers], {prodname} strips the prefixes from the properties before it passes them to configure the database history producer or consumer client.
-
-See the Kafka documentation for more details about link:https://kafka.apache.org/documentation.html#producerconfigs[Kafka producer configuration properties] and link:https://kafka.apache.org/documentation.html#consumerconfigs[Kafka consumer configuration properties].
-
-[id="{context}-database-history-properties-for-configuring-connector-behavior"]
-==== Database history properties for configuring connector behavior
-
-In addition to the pass-through database history properties that you use to configure producers or consumers, there is a set of `database.history.*` properties whose names do not include `producer` or `consumer`.
-You use these `database.history` properties to define how the {context} connector processes event data that it reads from the schema history.
-
-The following table describes the `database.history` properties for configuring the {prodname} {context} connector.
-////
-
 
 // Type: assembly
 // ModuleID: monitoring-debezium-db2-connector-performance

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2101,18 +2101,20 @@ The name format is _schema-name.table-name_.
 
 |===
 
+include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
+////
 [id="{context}-pass-through-configuration-properties-for-database-drivers"]
 ==== Pass-through configuration properties for database drivers
 
 The {prodname} connector provides for pass-through configuration of the database driver.
 Pass-through database properties begin with the prefix `database.*`.
-For example, the property `database.tinyInt1isBit=false` is passed to the JDBC URL.
-Debezium strips the prefix before it passes the property to the database driver.
+For example, the connector passes properties such as `database.foobar=false` to the JDBC URL.
+Debezium strips the `database.` prefix before it passes the property to the database driver.
 
 [id="{context}-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients"]
 ==== Pass-through database history properties for configuring producer and consumer clients
 
-{prodname} relies on a Kafka producer to write schema changes to database history topics, and a Kafka consumer to read from database history topics when a connector starts.
+When a connector starts, {prodname} relies on a Kafka producer to write schema changes to the database history topic, and a Kafka consumer to read from the database history topic.
 You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.\*` and `database.history.consumer.*` prefixes.
 The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
 
@@ -2132,7 +2134,7 @@ database.history.consumer.ssl.truststore.password=test1234
 database.history.consumer.ssl.key.password=test1234
 ----
 
-As is the case with the xref:{context}-pass-through-configuration-properties-for-database-drivers[pass-through properties for database drivers], {prodname} strips the prefixes from the properties before {prodname} it passes them to configure the database history producer or consumer client.
+As is the case with the xref:{context}-pass-through-configuration-properties-for-database-drivers[pass-through properties for database drivers], {prodname} strips the prefixes from the properties before it passes them to configure the database history producer or consumer client.
 
 See the Kafka documentation for more details about link:https://kafka.apache.org/documentation.html#producerconfigs[Kafka producer configuration properties] and link:https://kafka.apache.org/documentation.html#consumerconfigs[Kafka consumer configuration properties].
 
@@ -2143,8 +2145,8 @@ In addition to the pass-through database history properties that you use to conf
 You use these `database.history` properties to define how the {context} connector processes event data that it reads from the schema history.
 
 The following table describes the `database.history` properties for configuring the {prodname} {context} connector.
+////
 
-include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 
 // Type: assembly
 // ModuleID: monitoring-debezium-db2-connector-performance

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1841,9 +1841,9 @@ Information about the properties is organized as follows:
 
 * xref:db2-required-configuration-properties[Required configuration properties]
 * xref:db2-advanced-configuration-properties[Advanced configuration properties]
-* xref:{context}-database-history-properties-for-configuring-connector-behavior[Database history connector configuration properties]
-* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
-* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
+* xref:debezium-{context}-connector-database-history-and-pass-through-configuration-properties[{prodname} connector database history and pass-through configuration properties]
+//* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
+//* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
 
 [id="db2-required-configuration-properties"]
 ==== Required {prodname} Db2 connector configuration properties
@@ -2101,7 +2101,8 @@ The name format is _schema-name.table-name_.
 
 |===
 
-==== Connector database history and pass-through configuration properties
+[id="debezium-{context}-connector-database-history-and-pass-through-configuration-properties"]
+==== {prodname} connector database history and pass-through configuration properties
 
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1885,14 +1885,6 @@ The following configuration properties are _required_ unless a default value is 
 |
 |Logical name that identifies and provides a namespace for the particular Db2 database server that hosts the database for which {prodname} is capturing changes. Only alphanumeric characters, hyphens and underscores must be used in the database server logical name. The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
 
-|[[db2-property-database-history-kafka-topic]]<<db2-property-database-history-kafka-topic, `+database.history.kafka.topic+`>>
-|
-|The full name of the Kafka topic where the connector stores the database schema history.
-
-|[[db2-property-database-history-kafka-bootstrap-servers]]<<db2-property-database-history-kafka-bootstrap-servers, `+database.history.kafka.bootstrap.servers+`>>
-|
-|A list of host/port pairs that the connector uses to establish an initial connection to the Kafka cluster. This connection is used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. Each pair should point to the same Kafka cluster used by the {prodname} Kafka Connect process.
-
 |[[db2-property-table-include-list]]<<db2-property-table-include-list, `+table.include.list+`>>
 |
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you want the connector to capture. Any table not included in the include list does not have its changes captured. Each identifier is of the form _schemaName_._tableName_. By default, the connector captures changes in every non-system table. Do not also set the `table.exclude.list` property.
@@ -2103,16 +2095,20 @@ The name format is _schema-name.table-name_.
 
 |===
 
-[id="db2-pass-through-properties"]
-.Pass-through connector configuration properties
+[id="{context}-pass-through-configuration-properties-for-database-drivers"]
+==== Pass-through configuration properties for database drivers
 
-The connector also supports _pass-through_ configuration properties that it uses when it creates Kafka producers and consumers:
+The {prodname} connector provides for pass-through configuration of the database driver.
+Pass-through database properties begin with the prefix `database.*`.
+For example, the property `database.tinyInt1isBit=false` is passed to the JDBC URL.
+Debezium strips the prefix before it passes the property to the database driver.
 
- * All connector configuration properties that begin with the `database.history.producer.` prefix are used (without the prefix) when creating the Kafka producer that writes to the database history topic.
+[id="{context}-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients"]
+==== Pass-through database history properties for configuring producer and consumer clients
 
- * All connector configuration properties that begin with the  `database.history.consumer.` prefix are used (without the prefix) when creating the Kafka consumer that reads the database history when the connector starts.
-
-For example, the following connector configuration properties {link-kafka-docs}.html#security_configclients[secure connections to the Kafka broker]:
+{prodname} relies on a Kafka producer to write schema changes to database history topics, and a Kafka consumer to read from database history topics when a connector starts.
+You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.*` and `database.history.consumer.*` prefixes.
+The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
 
 [source,indent=0]
 ----
@@ -2130,9 +2126,19 @@ database.history.consumer.ssl.truststore.password=test1234
 database.history.consumer.ssl.key.password=test1234
 ----
 
-Be sure to consult the {link-kafka-docs}.html[Kafka documentation] for all of the configuration properties for Kafka producers and consumers. Note that the Db2 connector uses the {link-kafka-docs}.html#newconsumerconfigs[new consumer].
+As is the case with the xref:{context}-pass-through-configuration-properties-for-database-drivers[pass-through properties for database drivers], {prodname} strips the prefixes from the properties before {prodname} it passes them to configure the database history producer or consumer client.
 
-Also, the connector passes configuration properties that start with `database.` to the JDBC URL, for example, `database.applicationName=debezium`.
+See the Kafka documentation for more details about link:https://kafka.apache.org/documentation.html#producerconfigs[Kafka producer configuration properties] and link:https://kafka.apache.org/documentation.html#consumerconfigs[Kafka consumer configuration properties].
+
+[id="{context}-database-history-properties-for-configuring-connector-behavior"]
+==== Database history properties for configuring connector behavior
+
+In addition to the pass-through database history properties that you use to configure producers or consumers, there is a set of `database.history.*` properties whose names do not include `producer` or `consumer`.
+You use these `database.history` properties to define how the {context} connector processes event data that it reads from the schema history.
+
+The following table describes the `database.history` properties for configuring the {prodname} {context} connector.
+
+include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 
 // Type: assembly
 // ModuleID: monitoring-debezium-db2-connector-performance

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2113,7 +2113,7 @@ Debezium strips the prefix before it passes the property to the database driver.
 ==== Pass-through database history properties for configuring producer and consumer clients
 
 {prodname} relies on a Kafka producer to write schema changes to database history topics, and a Kafka consumer to read from database history topics when a connector starts.
-You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.*` and `database.history.consumer.*` prefixes.
+You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.\*` and `database.history.consumer.*` prefixes.
 The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
 
 [source,indent=0]

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1842,7 +1842,7 @@ Information about the properties is organized as follows:
 * xref:db2-required-configuration-properties[Required configuration properties]
 * xref:db2-advanced-configuration-properties[Advanced configuration properties]
 * xref:debezium-{context}-connector-database-history-configuration-properties[Database history connector configuration properties] that control how {prodname} processes events that it reads from the database history topic.
-** xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties] 
+** xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties]
 * xref:debezium-{context}-connector-pass-through-database-driver-configuration-properties[Pass-through database driver properties] that control the behavior of the database driver.
 
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2558,7 +2558,7 @@ Debezium strips the prefix before it passes the property to the database driver.
 ==== Pass-through database history properties for configuring producer and consumer clients
 
 {prodname} relies on a Kafka producer to write schema changes to database history topics, and a Kafka consumer to read from database history topics when a connector starts.
-You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.*` and `database.history.consumer.*` prefixes.
+You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.\*` and `database.history.consumer.*` prefixes.
 The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
 
 [source,indent=0]

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2120,12 +2120,14 @@ Information about the properties is organized as follows:
 
 * xref:mysql-required-connector-configuration-properties[Required connector configuration properties]
 * xref:mysql-advanced-connector-configuration-properties[Advanced connector configuration properties]
-* xref:mysql-pass-through-configuration-properties[Pass-through configuration properties]
+* xref:mysql-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
+* xref:mysql-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
+* xref:mysql-database-history-properties-for-configuring-connector-behavior[Database history properties for configuring connector behavior]
 
 [id="mysql-required-connector-configuration-properties"]
 The following configuration properties are _required_ unless a default value is available.
 
-.Required MySQL connector configuration properties
+==== Required MySQL connector configuration properties
 [cols="33%a,17%a,50%a",options="header",subs="+attributes"]
 |===
 |Property |Default |Description
@@ -2166,14 +2168,6 @@ Only alphanumeric characters, hyphens and underscores must be used in the databa
 |[[mysql-property-database-server-id]]<<mysql-property-database-server-id, `+database.server.id+`>>
 |_random_
 |A numeric ID of this database client, which must be unique across all currently-running database processes in the MySQL cluster. This connector joins the MySQL database cluster as another server (with this unique ID) so it can read the binlog. By default, a random number between 5400 and 6400 is generated, though the recommendation is to explicitly set a value.
-
-|[[mysql-property-database-history-kafka-topic]]<<mysql-property-database-history-kafka-topic, `+database.history.kafka.topic+`>>
-|
-|The full name of the Kafka topic where the connector stores the database schema history.
-
-|[[mysql-property-database-history-kafka-bootstrap-servers]]<<mysql-property-database-history-kafka-bootstrap-servers, `+database.history.kafka.bootstrap.servers+`>>
-|
-|A list of host/port pairs that the connector uses for establishing an initial connection to the Kafka cluster. This connection is used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. Each pair should point to the same Kafka cluster used by the Kafka Connect process.
 
 |[[mysql-property-database-include-list]]<<mysql-property-database-include-list, `+database.include.list+`>>
 |_empty string_
@@ -2395,7 +2389,7 @@ If `table_a` has an `id` column, and `regex_1` is `^i` (matches any column that 
 |===
 
 [id="mysql-advanced-connector-configuration-properties"]
-.Advanced MySQL connector configuration properties
+==== Advanced MySQL connector configuration properties
 
 The following table describes {link-prefix}:{link-mysql-connector}#mysql-advanced-connector-configuration-properties[advanced MySQL connector properties]. The default values for these properties rarely need to be changed. Therefore, you do not need to specify them in the connector configuration.
 
@@ -2412,37 +2406,6 @@ The following table describes {link-prefix}:{link-mysql-connector}#mysql-advance
 |`true`
 |A Boolean value that specifies whether built-in system tables should be ignored. This applies regardless of the table include and exclude lists. By default, system tables are excluded from having their changes captured, and no events are generated when changes are made to any system tables.
 
-|[[mysql-property-database-history-kafka-recovery-poll-interval-ms]]<<mysql-property-database-history-kafka-recovery-poll-interval-ms, `+database.history.kafka.recovery.poll.interval.ms+`>>
-|`100`
-|An integer value that specifies the maximum number of milliseconds the connector should wait during startup/recovery while polling for persisted data. The default is 100ms.
-
-|[[mysql-property-database-history-kafka-recovery-attempts]]<<mysql-property-database-history-kafka-recovery-attempts, `+database.history.kafka.recovery.attempts+`>>
-|`4`
-|The maximum number of times that the connector should try to read persisted history data before the connector recovery fails with an error. The maximum amount of time to wait after receiving no data is `recovery.attempts` x `recovery.poll.interval.ms`.
-
-|[[mysql-property-database-history-skip-unparseable-ddl]]<<mysql-property-database-history-skip-unparseable-ddl, `+database.history.skip.unparseable.ddl+`>>
-|`false`
-|A Boolean value that specifies whether the connector should ignore malformed or unknown database statements or stop processing so a human can fix the issue.
-The safe default is `false`.
-Skipping should be used only with care as it can lead to data loss or mangling when the binlog is being processed.
-
-|[[mysql-property-database-history-store-only-monitored-tables-ddl]]<<mysql-property-database-history-store-only-monitored-tables-ddl, `+database.history.store.only.monitored.tables.ddl+`>>
-_Deprecated and scheduled for removal in a future release; use {link-prefix}:{link-mysql-connector}#mysql-property-database-history-store-only-captured-tables-ddl[`database.history.store.only.captured.tables.ddl`] instead._
-|`false`
-|A Boolean value that specifies whether the connector should record all DDL statements  +
- +
-`true` records only those DDL statements that are relevant to tables whose changes are being captured by {prodname}. Set to `true` with care because missing data might become necessary if you change which tables have their changes captured. +
- +
-The safe default is `false`.
-
-|[[mysql-property-database-history-store-only-captured-tables-ddl]]<<mysql-property-database-history-store-only-captured-tables-ddl, `+database.history.store.only.captured.tables.ddl+`>>
-|`false`
-|A Boolean value that specifies whether the connector should record all DDL statements  +
- +
-`true` records only those DDL statements that are relevant to tables whose changes are being captured by {prodname}. Set to `true` with care because missing data might become necessary if you change which tables have their changes captured. +
- +
-The safe default is `false`.
-
 |[[mysql-property-database-ssl-mode]]<<mysql-property-database-ssl-mode, `+database.ssl.mode+`>>
 |`disabled`
 |Specifies whether to use an encrypted connection. Possible settings are: +
@@ -2456,7 +2419,7 @@ The safe default is `false`.
 `verify_ca` behaves like `required` but additionally it verifies the server TLS certificate against the configured Certificate Authority (CA) certificates and fails if the server TLS certificate does not match any valid CA certificates. +
  +
 `verify_identity` behaves like `verify_ca` but additionally verifies that the server certificate matches the host of the remote connection.
-
+ifdef::community[]
 |[[mysql-property-binlog-buffer-size]]<<mysql-property-binlog-buffer-size, `+binlog.buffer.size+`>>
 |0
 |The size of a look-ahead buffer used by the binlog reader. The default setting of `0` disables buffering. +
@@ -2469,7 +2432,7 @@ The size of the binlog buffer defines the maximum number of changes in the trans
 If the size of the transaction is larger than the buffer then {prodname} must rewind and re-read the events that have not fit into the buffer while streaming. +
  +
 NOTE: This feature is incubating. Feedback is encouraged. It is expected that this feature is not completely polished.
-
+endif::community[]
 |[[mysql-property-snapshot-mode]]<<mysql-property-snapshot-mode, `+snapshot.mode+`>>
 |`initial`
 |Specifies the criteria for running a snapshot when the connector starts. Possible settings are: +
@@ -2583,14 +2546,20 @@ The name format is _database-name.table-name_.
 
 |===
 
-[id="mysql-pass-through-configuration-properties"]
-.Pass-through configuration properties
+[id="{context}-pass-through-configuration-properties-for-database-drivers"]
+==== Pass-through configuration properties for database drivers
 
-The MySQL connector also supports pass-through configuration properties that are used when creating the Kafka producer and consumer.
-Specifically, all connector configuration properties that begin with the `database.history.producer.` prefix are used (without the prefix) when creating the Kafka producer that writes to the database history.
-All properties that begin with the prefix `database.history.consumer.` are used (without the prefix) when creating the Kafka consumer that reads the database history upon connector start-up.
+The {prodname} MySQL connector provides for pass-through configuration of the database driver.
+Pass-through database properties begin with the prefix `database.*`.
+For example, the property `database.tinyInt1isBit=false` is passed to the JDBC URL.
+Debezium strips the prefix before it passes the property to the database driver.
 
-For example, the following connector configuration properties can be used to secure connections to the Kafka broker:
+[id="{context}-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients"]
+==== Pass-through database history properties for configuring producer and consumer clients
+
+{prodname} relies on a Kafka producer to write schema changes to database history topics, and a Kafka consumer to read from database history topics when a connector starts.
+You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.*` and `database.history.consumer.*` prefixes.
+The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
 
 ----
 database.history.producer.security.protocol=SSL
@@ -2607,12 +2576,19 @@ database.history.consumer.ssl.truststore.password=test1234
 database.history.consumer.ssl.key.password=test1234
 ----
 
-See link:{link-kafka-docs}.html[the Kafka documentation] for more details about _pass-through_ properties.
+As is the case with the xref:{context}-pass-through-configuration-properties-for-database-drivers[pass-through properties for database drivers], {prodname} strips the prefixes from the properties before {prodname} it passes them to configure the database history producer or consumer client.
 
-[id="mysql-pass-through-properties-for-database-drivers"]
-.Pass-through properties for database drivers
+See the Kafka documentation for more details about link:https://kafka.apache.org/documentation.html#producerconfigs[Kafka producer configuration properties] and link:https://kafka.apache.org/documentation.html#consumerconfigs[Kafka consumer configuration properties].
 
-In addition to the pass-through properties for the Kafka producer and consumer, there are {link-prefix}:{link-mysql-connector}#mysql-pass-through-properties-for-database-drivers[pass-through properties for database drivers]. These properties have the `database.` prefix. For example, `database.tinyInt1isBit=false` is passed to the JDBC URL.
+[id="{context}-database-history-properties-for-configuring-connector-behavior"]
+==== Database history properties for configuring connector behavior
+
+In addition to the pass-through database history properties that you use to configure producers or consumers, there is a set of `database.history.*` properties whose names do not include `producer` or `consumer`.
+You use these `database.history` properties to define how the {context} connector processes event data that it reads from the schema history.
+
+The following table describes the `database.history` properties for configuring the {prodname} {context} connector.
+
+include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 
 
 // Type: assembly

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2561,6 +2561,7 @@ Debezium strips the prefix before it passes the property to the database driver.
 You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.*` and `database.history.consumer.*` prefixes.
 The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
 
+[source,indent=0]
 ----
 database.history.producer.security.protocol=SSL
 database.history.producer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2121,9 +2121,9 @@ Information about the properties is organized as follows:
 
 * xref:mysql-required-connector-configuration-properties[Required connector configuration properties]
 * xref:mysql-advanced-connector-configuration-properties[Advanced connector configuration properties]
-* xref:debezium-{context}-connector-database-history-and-pass-through-configuration-properties[{prodname} connector database history and pass-through configuration properties]
-//* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
-//* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
+* xref:debezium-{context}-connector-database-history-configuration-properties[Database history connector configuration properties] that control how {prodname} processes events that it reads from the database history topic.
+** xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties]
+* xref:debezium-{context}-connector-pass-through-database-driver-configuration-properties[Pass-through database driver properties] that control the behavior of the database driver.
 
 [id="mysql-required-connector-configuration-properties"]
 The following configuration properties are _required_ unless a default value is available.
@@ -2547,10 +2547,15 @@ The name format is _database-name.table-name_.
 
 |===
 
-[id="debezium-{context}-connector-database-history-and-pass-through-configuration-properties"]
-==== {prodname} connector database history and pass-through configuration properties
+[id="debezium-{context}-connector-database-history-configuration-properties"]
+==== {prodname} connector database history configuration properties
 
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
+
+[id="debezium-{context}-connector-pass-through-database-driver-configuration-properties"]
+==== {prodname} connector pass-through database driver configuration properties
+
+include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-database-driver-configuration-properties.adoc[leveloffset=+1]
 
 // Type: assembly
 // ModuleID: monitoring-debezium-mysql-connector-performance

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2549,7 +2549,7 @@ The name format is _database-name.table-name_.
 [id="{context}-pass-through-configuration-properties-for-database-drivers"]
 ==== Pass-through configuration properties for database drivers
 
-The {prodname} MySQL connector provides for pass-through configuration of the database driver.
+The {prodname} connector provides for pass-through configuration of the database driver.
 Pass-through database properties begin with the prefix `database.*`.
 For example, the property `database.tinyInt1isBit=false` is passed to the JDBC URL.
 Debezium strips the prefix before it passes the property to the database driver.

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2546,6 +2546,9 @@ The name format is _database-name.table-name_.
 
 |===
 
+include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
+
+////
 [id="{context}-pass-through-configuration-properties-for-database-drivers"]
 ==== Pass-through configuration properties for database drivers
 
@@ -2588,8 +2591,8 @@ In addition to the pass-through database history properties that you use to conf
 You use these `database.history` properties to define how the {context} connector processes event data that it reads from the schema history.
 
 The following table describes the `database.history` properties for configuring the {prodname} {context} connector.
+////
 
-include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 
 
 // Type: assembly

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2120,14 +2120,14 @@ Information about the properties is organized as follows:
 
 * xref:mysql-required-connector-configuration-properties[Required connector configuration properties]
 * xref:mysql-advanced-connector-configuration-properties[Advanced connector configuration properties]
-* xref:mysql-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
-* xref:mysql-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
-* xref:mysql-database-history-properties-for-configuring-connector-behavior[Database history properties for configuring connector behavior]
+* xref:{context}-database-history-properties-for-configuring-connector-behavior[Database history connector configuration properties]
+* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
+* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
 
 [id="mysql-required-connector-configuration-properties"]
 The following configuration properties are _required_ unless a default value is available.
 
-==== Required MySQL connector configuration properties
+==== Required {prodname} MySQL connector configuration properties
 [cols="33%a,17%a,50%a",options="header",subs="+attributes"]
 |===
 |Property |Default |Description
@@ -2545,55 +2545,9 @@ The name format is _database-name.table-name_.
 |Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See {link-prefix}:{link-mysql-connector}#mysql-transaction-metadata[Transaction metadata] for details.
 
 |===
+==== Connector database history and pass-through configuration properties
 
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
-
-////
-[id="{context}-pass-through-configuration-properties-for-database-drivers"]
-==== Pass-through configuration properties for database drivers
-
-The {prodname} connector provides for pass-through configuration of the database driver.
-Pass-through database properties begin with the prefix `database.*`.
-For example, the property `database.tinyInt1isBit=false` is passed to the JDBC URL.
-Debezium strips the prefix before it passes the property to the database driver.
-
-[id="{context}-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients"]
-==== Pass-through database history properties for configuring producer and consumer clients
-
-{prodname} relies on a Kafka producer to write schema changes to database history topics, and a Kafka consumer to read from database history topics when a connector starts.
-You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.\*` and `database.history.consumer.*` prefixes.
-The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
-
-[source,indent=0]
-----
-database.history.producer.security.protocol=SSL
-database.history.producer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
-database.history.producer.ssl.keystore.password=test1234
-database.history.producer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
-database.history.producer.ssl.truststore.password=test1234
-database.history.producer.ssl.key.password=test1234
-database.history.consumer.security.protocol=SSL
-database.history.consumer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
-database.history.consumer.ssl.keystore.password=test1234
-database.history.consumer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
-database.history.consumer.ssl.truststore.password=test1234
-database.history.consumer.ssl.key.password=test1234
-----
-
-As is the case with the xref:{context}-pass-through-configuration-properties-for-database-drivers[pass-through properties for database drivers], {prodname} strips the prefixes from the properties before {prodname} it passes them to configure the database history producer or consumer client.
-
-See the Kafka documentation for more details about link:https://kafka.apache.org/documentation.html#producerconfigs[Kafka producer configuration properties] and link:https://kafka.apache.org/documentation.html#consumerconfigs[Kafka consumer configuration properties].
-
-[id="{context}-database-history-properties-for-configuring-connector-behavior"]
-==== Database history properties for configuring connector behavior
-
-In addition to the pass-through database history properties that you use to configure producers or consumers, there is a set of `database.history.*` properties whose names do not include `producer` or `consumer`.
-You use these `database.history` properties to define how the {context} connector processes event data that it reads from the schema history.
-
-The following table describes the `database.history` properties for configuring the {prodname} {context} connector.
-////
-
-
 
 // Type: assembly
 // ModuleID: monitoring-debezium-mysql-connector-performance

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2120,9 +2120,9 @@ Information about the properties is organized as follows:
 
 * xref:mysql-required-connector-configuration-properties[Required connector configuration properties]
 * xref:mysql-advanced-connector-configuration-properties[Advanced connector configuration properties]
-* xref:{context}-database-history-properties-for-configuring-connector-behavior[Database history connector configuration properties]
-* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
-* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
+* xref:debezium-{context}-connector-database-history-and-pass-through-configuration-properties[{prodname} connector database history and pass-through configuration properties]
+//* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
+//* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
 
 [id="mysql-required-connector-configuration-properties"]
 The following configuration properties are _required_ unless a default value is available.
@@ -2545,7 +2545,9 @@ The name format is _database-name.table-name_.
 |Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See {link-prefix}:{link-mysql-connector}#mysql-transaction-metadata[Transaction metadata] for details.
 
 |===
-==== Connector database history and pass-through configuration properties
+
+[id="debezium-{context}-connector-database-history-and-pass-through-configuration-properties"]
+==== {prodname} connector database history and pass-through configuration properties
 
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -1304,7 +1304,7 @@ Such columns are converted into an equivalent `io.debezium.time.ZonedTimestamp` 
 
 The time zone of the JVM running Kafka Connect and Debezium does not affect these conversions.
 
-More details about properties related to termporal values are in the documentation for {link-prefix}:{link-mysql-connector}#mysql-connector-properties[MySQL connector configuration properties].
+More details about properties related to temporal values are in the documentation for {link-prefix}:{link-mysql-connector}#mysql-connector-properties[MySQL connector configuration properties].
 
 time.precision.mode=adaptive_time_microseconds(default)::
 The MySQL connector determines the literal type and semantic type based on the column's data type definition so that events represent exactly the values in the database. All time fields are in microseconds. Only positive `TIME` field values in the range of `00:00:00.000000` to `23:59:59.999999` can be captured correctly.
@@ -1753,7 +1753,7 @@ This option is available in MySQL 5.6 and later.
 .Prerequisites
 
 * A MySQL server.
-* Basic knowlede of SQL commands.
+* Basic knowledge of SQL commands.
 * Access to the MySQL configuration file.
 
 .Procedure
@@ -1806,7 +1806,7 @@ To deploy a {prodname} MySQL connector, you add the connector files to Kafka Con
 For details about deploying the {prodname} MySQL connector, see the following topics:
 
 * xref:deploying-debezium-mysql-connectors[]
-* xref:mysql-connector-properties[]
+* xref:descriptions-of-debezium-mysql-connector-configuration-properties[]
 
 // Type: procedure
 // ModuleID: deploying-debezium-mysql-connectors
@@ -2111,6 +2111,7 @@ The connector then starts generating data change events for row-level operations
 
 // Type: reference
 // Title: Description of {prodname} MySQL connector configuration properties
+// ModuleID: descriptions-of-debezium-mysql-connector-configuration-properties
 [[mysql-connector-properties]]
 === Connector properties
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1283,20 +1283,6 @@ Only alphanumeric characters, hyphens and underscores must be used.
 `logminer` (the default) to use the native Oracle LogMiner API;
 `xstream` to use the Oracle XStreams API.
 
-|[[oracle-property-database-history-kafka-topic]]<<oracle-property-database-history-kafka-topic, `+database.history.kafka.topic+`>>
-|
-|The full name of the Kafka topic where the connector will store the database schema history.
-
-|[[oracle-property-database-history-kafka-bootstrap-servers]]<<oracle-property-database-history-kafka-bootstrap-servers, `+database.history.kafka.bootstrap.servers+`>>
-|
-|A list of host/port pairs that the connector will use for establishing an initial connection to the Kafka cluster. This connection will be used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. This should point to the same Kafka cluster used by the Kafka Connect process.
-
-|[[oracle-property-database-history-skip-unparseable-ddl]]<<oracle-property-database-history-skip-unparseable-ddl, `+database.history.skip.unparseable.ddl+`>>
-|`false`
-|A Boolean value that specifies whether the connector should ignore malformed or unknown database statements or stop processing so a human can fix the issue.
-The safe default is `false`.
-Skipping should be used only with care as it can lead to data loss or mangling when the redo logs are being processed.
-
 |[[oracle-property-snapshot-mode]]<<oracle-property-snapshot-mode, `+snapshot.mode+`>>
 |_initial_
 |A mode for taking an initial snapshot of the structure and optionally data of captured tables. Supported values are _initial_ (will take a snapshot of structure and data of captured tables; useful if topics should be populated with a complete representation of the data from the captured tables) and _schema_only_ (will take a snapshot of the structure of captured tables only; useful if only changes happening from now onwards should be propagated to topics). Once the snapshot is complete, the connector will continue reading change events from the database's redo logs.
@@ -1544,6 +1530,52 @@ The operations include: `c` for inserts/create, `u` for updates, and `d` for del
 By default, no operations are skipped.
 
 |===
+
+[id="{context}-pass-through-configuration-properties-for-database-drivers"]
+==== Pass-through configuration properties for database drivers
+
+The {prodname} MySQL connector provides for pass-through configuration of the database driver.
+Pass-through database properties begin with the prefix `database.*`.
+For example, the property `database.tinyInt1isBit=false` is passed to the JDBC URL.
+Debezium strips the prefix before it passes the property to the database driver.
+
+[id="{context}-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients"]
+==== Pass-through database history properties for configuring producer and consumer clients
+
+{prodname} relies on a Kafka producer to write schema changes to database history topics, and a Kafka consumer to read from database history topics when a connector starts.
+You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.*` and `database.history.consumer.*` prefixes.
+The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
+
+[source,indent=0]
+----
+database.history.producer.security.protocol=SSL
+database.history.producer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
+database.history.producer.ssl.keystore.password=test1234
+database.history.producer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
+database.history.producer.ssl.truststore.password=test1234
+database.history.producer.ssl.key.password=test1234
+database.history.consumer.security.protocol=SSL
+database.history.consumer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
+database.history.consumer.ssl.keystore.password=test1234
+database.history.consumer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
+database.history.consumer.ssl.truststore.password=test1234
+database.history.consumer.ssl.key.password=test1234
+----
+
+As is the case with the xref:{context}-pass-through-configuration-properties-for-database-drivers[pass-through properties for database drivers], {prodname} strips the prefixes from the properties before {prodname} it passes them to configure the database history producer or consumer client.
+
+See the Kafka documentation for more details about link:https://kafka.apache.org/documentation.html#producerconfigs[Kafka producer configuration properties] and link:https://kafka.apache.org/documentation.html#consumerconfigs[Kafka consumer configuration properties].
+
+[id="{context}-database-history-properties-for-configuring-connector-behavior"]
+==== Database history properties for configuring connector behavior
+
+In addition to the pass-through database history properties that you use to configure producers or consumers, there is a set of `database.history.*` properties whose names do not include `producer` or `consumer`.
+You use these `database.history` properties to define how the {context} connector processes event data that it reads from the schema history.
+
+The following table describes the `database.history` properties for configuring the {prodname} {context} connector.
+
+include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
+
 
 [[oracle-monitoring]]
 == Monitoring

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1229,9 +1229,9 @@ Many properties have default values.
 Information about the properties is organized as follows:
 
 * xref:{context}-required-connector-configuration-properties[Required connector configuration properties]
-* xref:{context}-database-history-properties-for-configuring-connector-behavior[Database history connector configuration properties]
-* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
-* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
+* xref:debezium-{context}-connector-database-history-and-pass-through-configuration-properties[{prodname} connector database history and pass-through configuration properties]
+//* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
+//* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
 
 [id="oracle-required-connector-configuration-properties"]
 ==== Required {prodname} Oracle connector configuration properties
@@ -1542,7 +1542,8 @@ By default, no operations are skipped.
 
 |===
 
-==== Connector database history and pass-through configuration properties
+[id="debezium-{context}-connector-database-history-and-pass-through-configuration-properties"]
+==== {prodname} connector database history and pass-through configuration properties
 
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1222,20 +1222,8 @@ When using a non-CDB installation, do *not* specify the `database.pdb.name`.
 ====
 
 [[oracle-connector-properties]]
-=== Connector properties
+=== Connector Properties
 
-The {prodname} Oracle connector has numerous configuration properties that you can use to achieve the right connector behavior for your application.
-Many properties have default values.
-Information about the properties is organized as follows:
-
-* xref:{context}-required-connector-configuration-properties[Required connector {prodname} configuration properties]
-* xref:debezium-{context}-connector-database-history-configuration-properties[Database history connector configuration properties] that control how {prodname} processes events that it reads from the database history topic.
-** xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties]
-* xref:debezium-{context}-connector-pass-through-database-driver-configuration-properties[Pass-through database driver properties] that control the behavior of the database driver.
-
-
-[id="oracle-required-connector-configuration-properties"]
-==== Required {prodname} Oracle connector configuration properties
 The following configuration properties are _required_ unless a default value is available.
 
 [cols="30%a,25%a,45%a"]
@@ -1517,6 +1505,14 @@ If the captured table(s) schema changes infrequently or never, this is the ideal
 |The number of hours in the past from SYSDATE to mine archive logs.
 Using the default `0` will mine all archive logs.
 
+|[[oracle-property-log-mining-archive-log-only-mode]]<<oracle-property-log-mining-archive-log-only-mode, `+log.mining.archive.log.only.mode+`>>
+|`false`
+|Controls whether or not the connector mines changes from just archive logs or a combination of the online redo logs and archive logs (the default). +
+ +
+For some environments where online redo logs are archived frequently enough to cause LogMiner session failures,
+this opt-in feature only mines archive logs which are guaranteed to be reliable unlike the circular buffer nature of redo logs that can be archived at any point, leading to LogMiner session errors.
+Note that by using this opt-in feature, events will be emitted with a certain amount of latency that is entirely dependent on how frequently online redo logs are archived by Oracle.
+
 |[[oracle-property-log-mining-transaction-retention-hours]]<<oracle-property-log-mining-transaction-retention-hours, `log.mining.transaction.retention.hours`>>
 |`0`
 |Positive integer value that specifies the number of hours to retain long running transactions between redo log switches.
@@ -1565,17 +1561,17 @@ The {prodname} Oracle connector has three metric types in addition to the built-
 Please refer to the {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[monitoring documentation] for details of how to expose these metrics via JMX.
 
 [[oracle-monitoring-snapshots]]
-[[oracle-snapshot-metrics]]
 === Snapshot Metrics
 
+[[oracle-snapshot-metrics]]
 The *MBean* is `debezium.oracle:type=connector-metrics,context=snapshot,server=_<database.server.name>_`.
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
 [[oracle-monitoring-streaming]]
-[[oracle-streaming-metrics]]
 === Streaming Metrics
 
+[[oracle-streaming-metrics]]
 The *MBean* is `debezium.oracle:type=connector-metrics,context=streaming,server=_<database.server.name>_`.
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1543,7 +1543,7 @@ Debezium strips the prefix before it passes the property to the database driver.
 ==== Pass-through database history properties for configuring producer and consumer clients
 
 {prodname} relies on a Kafka producer to write schema changes to database history topics, and a Kafka consumer to read from database history topics when a connector starts.
-You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.*` and `database.history.consumer.*` prefixes.
+You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.\*` and `database.history.consumer.*` prefixes.
 The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
 
 [source,indent=0]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1221,6 +1221,7 @@ When using CDB installations, specify `database.pdb.name`. +
 When using a non-CDB installation, do *not* specify the `database.pdb.name`.
 ====
 
+
 [[oracle-connector-properties]]
 === Connector Properties
 
@@ -1228,12 +1229,13 @@ The {prodname} Oracle connector has numerous configuration properties that you c
 Many properties have default values.
 Information about the properties is organized as follows:
 
-* xref:mysql-required-connector-configuration-properties[Required connector configuration properties]
+* xref:required-debezium-{context}-connector-configuration-properties[Required {prodname} Oracle connector configuration properties]
 * xref:debezium-{context}-connector-database-history-configuration-properties[Database history connector configuration properties] that control how {prodname} processes events that it reads from the database history topic.
 ** xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties]
 * xref:debezium-{context}-connector-pass-through-database-driver-configuration-properties[Pass-through database driver properties] that control the behavior of the database driver.
 
-
+[id="required-debezium-{context}-connector-configuration-properties"]
+==== Required {prodname} Oracle connector configuration properties
 The following configuration properties are _required_ unless a default value is available.
 
 [cols="30%a,25%a,45%a"]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1222,8 +1222,19 @@ When using a non-CDB installation, do *not* specify the `database.pdb.name`.
 ====
 
 [[oracle-connector-properties]]
-=== Connector Properties
+=== Connector properties
 
+The {prodname} Oracle connector has numerous configuration properties that you can use to achieve the right connector behavior for your application.
+Many properties have default values.
+Information about the properties is organized as follows:
+
+* xref:{context}-required-connector-configuration-properties[Required connector configuration properties]
+* xref:{context}-database-history-properties-for-configuring-connector-behavior[Database history connector configuration properties]
+* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
+* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
+
+[id="oracle-required-connector-configuration-properties"]
+==== Required {prodname} Oracle connector configuration properties
 The following configuration properties are _required_ unless a default value is available.
 
 [cols="30%a,25%a,45%a"]
@@ -1531,55 +1542,9 @@ By default, no operations are skipped.
 
 |===
 
+==== Connector database history and pass-through configuration properties
+
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
-
-////
-[id="{context}-pass-through-configuration-properties-for-database-drivers"]
-==== Pass-through configuration properties for database drivers
-
-The {prodname} connector provides for pass-through configuration of the database driver.
-Pass-through database properties begin with the prefix `database.*`.
-For example, the property `database.tinyInt1isBit=false` is passed to the JDBC URL.
-Debezium strips the prefix before it passes the property to the database driver.
-
-See the Kafka documentation for more details about link:https://kafka.apache.org/documentation.html#producerconfigs[Kafka producer configuration properties] and link:https://kafka.apache.org/documentation.html#consumerconfigs[Kafka consumer configuration properties].
-
-[id="{context}-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients"]
-==== Pass-through database history properties for configuring producer and consumer clients
-
-{prodname} relies on a Kafka producer to write schema changes to database history topics, and a Kafka consumer to read from database history topics when a connector starts.
-You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.\*` and `database.history.consumer.*` prefixes.
-The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
-
-[source,indent=0]
-----
-database.history.producer.security.protocol=SSL
-database.history.producer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
-database.history.producer.ssl.keystore.password=test1234
-database.history.producer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
-database.history.producer.ssl.truststore.password=test1234
-database.history.producer.ssl.key.password=test1234
-database.history.consumer.security.protocol=SSL
-database.history.consumer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
-database.history.consumer.ssl.keystore.password=test1234
-database.history.consumer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
-database.history.consumer.ssl.truststore.password=test1234
-database.history.consumer.ssl.key.password=test1234
-----
-
-As is the case with the xref:{context}-pass-through-configuration-properties-for-database-drivers[pass-through properties for database drivers], {prodname} strips the prefixes from the properties before {prodname} it passes them to configure the database history producer or consumer client.
-
-
-[id="{context}-database-history-properties-for-configuring-connector-behavior"]
-==== Database history properties for configuring connector behavior
-
-In addition to the pass-through database history properties that you use to configure producers or consumers, there is a set of `database.history.*` properties whose names do not include `producer` or `consumer`.
-You use these `database.history` properties to define how the {context} connector processes event data that it reads from the schema history.
-
-The following table describes the `database.history` properties for configuring the {prodname} {context} connector.
-////
-
-
 
 [[oracle-monitoring]]
 == Monitoring

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1531,6 +1531,9 @@ By default, no operations are skipped.
 
 |===
 
+include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
+
+////
 [id="{context}-pass-through-configuration-properties-for-database-drivers"]
 ==== Pass-through configuration properties for database drivers
 
@@ -1538,6 +1541,8 @@ The {prodname} connector provides for pass-through configuration of the database
 Pass-through database properties begin with the prefix `database.*`.
 For example, the property `database.tinyInt1isBit=false` is passed to the JDBC URL.
 Debezium strips the prefix before it passes the property to the database driver.
+
+See the Kafka documentation for more details about link:https://kafka.apache.org/documentation.html#producerconfigs[Kafka producer configuration properties] and link:https://kafka.apache.org/documentation.html#consumerconfigs[Kafka consumer configuration properties].
 
 [id="{context}-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients"]
 ==== Pass-through database history properties for configuring producer and consumer clients
@@ -1564,7 +1569,6 @@ database.history.consumer.ssl.key.password=test1234
 
 As is the case with the xref:{context}-pass-through-configuration-properties-for-database-drivers[pass-through properties for database drivers], {prodname} strips the prefixes from the properties before {prodname} it passes them to configure the database history producer or consumer client.
 
-See the Kafka documentation for more details about link:https://kafka.apache.org/documentation.html#producerconfigs[Kafka producer configuration properties] and link:https://kafka.apache.org/documentation.html#consumerconfigs[Kafka consumer configuration properties].
 
 [id="{context}-database-history-properties-for-configuring-connector-behavior"]
 ==== Database history properties for configuring connector behavior
@@ -1573,8 +1577,8 @@ In addition to the pass-through database history properties that you use to conf
 You use these `database.history` properties to define how the {context} connector processes event data that it reads from the schema history.
 
 The following table describes the `database.history` properties for configuring the {prodname} {context} connector.
+////
 
-include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 
 
 [[oracle-monitoring]]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1534,7 +1534,7 @@ By default, no operations are skipped.
 [id="{context}-pass-through-configuration-properties-for-database-drivers"]
 ==== Pass-through configuration properties for database drivers
 
-The {prodname} MySQL connector provides for pass-through configuration of the database driver.
+The {prodname} connector provides for pass-through configuration of the database driver.
 Pass-through database properties begin with the prefix `database.*`.
 For example, the property `database.tinyInt1isBit=false` is passed to the JDBC URL.
 Debezium strips the prefix before it passes the property to the database driver.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1228,10 +1228,11 @@ The {prodname} Oracle connector has numerous configuration properties that you c
 Many properties have default values.
 Information about the properties is organized as follows:
 
-* xref:{context}-required-connector-configuration-properties[Required connector configuration properties]
-* xref:debezium-{context}-connector-database-history-and-pass-through-configuration-properties[{prodname} connector database history and pass-through configuration properties]
-//* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
-//* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
+* xref:{context}-required-connector-configuration-properties[Required connector {prodname} configuration properties]
+* xref:debezium-{context}-connector-database-history-configuration-properties[Database history connector configuration properties] that control how {prodname} processes events that it reads from the database history topic.
+** xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties]
+* xref:debezium-{context}-connector-pass-through-database-driver-configuration-properties[Pass-through database driver properties] that control the behavior of the database driver.
+
 
 [id="oracle-required-connector-configuration-properties"]
 ==== Required {prodname} Oracle connector configuration properties
@@ -1542,10 +1543,15 @@ By default, no operations are skipped.
 
 |===
 
-[id="debezium-{context}-connector-database-history-and-pass-through-configuration-properties"]
-==== {prodname} connector database history and pass-through configuration properties
+[id="debezium-{context}-connector-database-history-configuration-properties"]
+==== {prodname} connector database history configuration properties
 
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
+
+[id="debezium-{context}-connector-pass-through-database-driver-configuration-properties"]
+==== {prodname} connector pass-through database driver configuration properties
+
+include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-database-driver-configuration-properties.adoc[leveloffset=+1]
 
 [[oracle-monitoring]]
 == Monitoring

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1224,6 +1224,16 @@ When using a non-CDB installation, do *not* specify the `database.pdb.name`.
 [[oracle-connector-properties]]
 === Connector Properties
 
+The {prodname} Oracle connector has numerous configuration properties that you can use to achieve the right connector behavior for your application.
+Many properties have default values.
+Information about the properties is organized as follows:
+
+* xref:mysql-required-connector-configuration-properties[Required connector configuration properties]
+* xref:debezium-{context}-connector-database-history-configuration-properties[Database history connector configuration properties] that control how {prodname} processes events that it reads from the database history topic.
+** xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties]
+* xref:debezium-{context}-connector-pass-through-database-driver-configuration-properties[Pass-through database driver properties] that control the behavior of the database driver.
+
+
 The following configuration properties are _required_ unless a default value is available.
 
 [cols="30%a,25%a,45%a"]

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1958,9 +1958,9 @@ Information about the properties is organized as follows:
 
 * xref:{context}-required-connector-configuration-properties[Required connector configuration properties]
 * xref:{context}-advanced-connector-configuration-properties[Advanced connector configuration properties]
-* xref:{context}-database-history-properties-for-configuring-connector-behavior[Database history connector configuration properties]
-* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
-* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
+* xref:debezium-{context}-connector-database-history-and-pass-through-configuration-properties[{prodname} connector database history and pass-through configuration properties]
+//* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
+//* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
 
 
 [id="{context}-required-connector-configuration-properties"]
@@ -2276,7 +2276,8 @@ The name format is _database_name.schema-name.table-name_.
 
 |===
 
-==== Connector database history and pass-through configuration properties
+[id="debezium-{context}-connector-database-history-and-pass-through-configuration-properties"]
+==== {prodname} connector database history and pass-through configuration properties
 
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2276,6 +2276,9 @@ The name format is _database_name.schema-name.table-name_.
 
 |===
 
+include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
+
+////
 [id="{context}-pass-through-configuration-properties-for-database-drivers"]
 ==== Pass-through configuration properties for database drivers
 
@@ -2318,8 +2321,8 @@ In addition to the pass-through database history properties that you use to conf
 You use these `database.history` properties to define how the {context} connector processes event data that it reads from the schema history.
 
 The following table describes the `database.history` properties for configuring the {prodname} {context} connector.
+////
 
-include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 
 // Type: assembly
 // ModuleID: refreshing-capture-tables-after-a-schema-change

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1958,13 +1958,13 @@ Information about the properties is organized as follows:
 
 * xref:{context}-required-connector-configuration-properties[Required connector configuration properties]
 * xref:{context}-advanced-connector-configuration-properties[Advanced connector configuration properties]
+* xref:{context}-database-history-properties-for-configuring-connector-behavior[Database history connector configuration properties]
+* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
 * xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
-* xref:{context}-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
-* xref:{context}-database-history-properties-for-configuring-connector-behavior[Database history properties for configuring connector behavior]
 
 
 [id="{context}-required-connector-configuration-properties"]
-==== Required SQL Server connector configuration properties
+==== Required {prodname} SQL Server connector configuration properties
 
 The following configuration properties are _required_ unless a default value is available.
 
@@ -2276,52 +2276,9 @@ The name format is _database_name.schema-name.table-name_.
 
 |===
 
+==== Connector database history and pass-through configuration properties
+
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
-
-////
-[id="{context}-pass-through-configuration-properties-for-database-drivers"]
-==== Pass-through configuration properties for database drivers
-
-The {prodname} connector provides for pass-through configuration of the database driver.
-Pass-through database properties begin with the prefix `database.*`.
-For example, the property `database.tinyInt1isBit=false` is passed to the JDBC URL.
-Debezium strips the prefix before it passes the property to the database driver.
-
-[id="{context}-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients"]
-==== Pass-through database history properties for configuring producer and consumer clients
-
-{prodname} relies on a Kafka producer to write schema changes to database history topics, and a Kafka consumer to read from database history topics when a connector starts.
-You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.\*` and `database.history.consumer.*` prefixes.
-The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
-
-[source, indent=0]
-----
-database.history.producer.security.protocol=SSL
-database.history.producer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
-database.history.producer.ssl.keystore.password=test1234
-database.history.producer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
-database.history.producer.ssl.truststore.password=test1234
-database.history.producer.ssl.key.password=test1234
-database.history.consumer.security.protocol=SSL
-database.history.consumer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
-database.history.consumer.ssl.keystore.password=test1234
-database.history.consumer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
-database.history.consumer.ssl.truststore.password=test1234
-database.history.consumer.ssl.key.password=test1234
-----
-
-As is the case with the xref:{context}-pass-through-configuration-properties-for-database-drivers[pass-through properties for database drivers], {prodname} strips the prefixes from the properties before {prodname} it passes them to configure the database history producer or consumer client.
-
-See the Kafka documentation for more details about link:https://kafka.apache.org/documentation.html#producerconfigs[Kafka producer configuration properties] and link:https://kafka.apache.org/documentation.html#consumerconfigs[Kafka consumer configuration properties].
-
-[id="{context}-database-history-properties-for-configuring-connector-behavior"]
-==== Database history properties for configuring connector behavior
-
-In addition to the pass-through database history properties that you use to configure producers or consumers, there is a set of `database.history.*` properties whose names do not include `producer` or `consumer`.
-You use these `database.history` properties to define how the {context} connector processes event data that it reads from the schema history.
-
-The following table describes the `database.history` properties for configuring the {prodname} {context} connector.
-////
 
 
 // Type: assembly

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1954,6 +1954,18 @@ The connector then starts generating data change events for row-level operations
 The {prodname} SQL Server connector has numerous configuration properties that you can use to achieve the right connector behavior for your application.
 Many properties have default values.
 
+Information about the properties is organized as follows:
+
+* xref:{context}-required-connector-configuration-properties[Required connector configuration properties]
+* xref:{context}-advanced-connector-configuration-properties[Advanced connector configuration properties]
+* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
+* xref:{context}-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
+* xref:{context}-database-history-properties-for-configuring-connector-behavior[Database history properties for configuring connector behavior]
+
+
+[id="{context}-required-connector-configuration-properties"]
+==== Required SQL Server connector configuration properties
+
 The following configuration properties are _required_ unless a default value is available.
 
 [cols="30%a,25%a,45%a",options="header"]
@@ -1998,15 +2010,6 @@ The following configuration properties are _required_ unless a default value is 
 |
 |Logical name that identifies and provides a namespace for the SQL Server database server that you want {prodname} to capture. The logical name should be unique across all other connectors, since it is used as a prefix for all Kafka topic names emanating from this connector.
 Only alphanumeric characters, hyphens and underscores must be used.
-
-|[[sqlserver-property-database-history-kafka-topic]]<<sqlserver-property-database-history-kafka-topic, `+database.history.kafka.topic+`>>
-|
-|The full name of the Kafka topic where the connector will store the database schema history.
-
-|[[sqlserver-property-database-history-kafka-bootstrap-servers]]<<sqlserver-property-database-history-kafka-bootstrap-servers, `+database.history.kafka.bootstrap.servers+`>>
-|
-|A list of host and port pairs that the connector will use for establishing an initial connection to the Kafka cluster.
-This connection is used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. This should point to the same Kafka cluster used by the Kafka Connect process.
 
 |[[sqlserver-property-table-include-list]]<<sqlserver-property-table-include-list, `+table.include.list+`>>
 |
@@ -2111,6 +2114,9 @@ Fully-qualified tables could be defined as _schemaName_._tableName_.
 |bytes
 |Specifies how binary (`binary`, `varbinary`) columns should be represented in change events, including: `bytes` represents binary data as byte array (default), `base64` represents binary data as base64-encoded String, `hex` represents binary data as hex-encoded (base16) String
 |===
+
+[id="sqlserver-advanced-connector-configuration-properties"]
+==== Advanced SQL Server connector configuration properties
 
 The following _advanced_ configuration properties have good defaults that will work in most situations and therefore rarely need to be specified in the connector's configuration.
 
@@ -2270,13 +2276,22 @@ The name format is _database_name.schema-name.table-name_.
 
 |===
 
-The connector also supports _pass-through_ configuration properties that are used when creating the Kafka producer and consumer. Specifically, all connector configuration properties that begin with the `database.history.producer.` prefix are used (without the prefix) when creating the Kafka producer that writes to the database history, and all those that begin with the prefix `database.history.consumer.` are used (without the prefix) when creating the Kafka consumer that reads the database history upon connector startup.
+[id="{context}-pass-through-configuration-properties-for-database-drivers"]
+==== Pass-through configuration properties for database drivers
 
-For example, the following connector configuration properties can be used to {link-kafka-docs}.html#security_configclients[secure connections to the Kafka broker]:
+The {prodname} connector provides for pass-through configuration of the database driver.
+Pass-through database properties begin with the prefix `database.*`.
+For example, the property `database.tinyInt1isBit=false` is passed to the JDBC URL.
+Debezium strips the prefix before it passes the property to the database driver.
 
-In addition to the _pass-through_ to the Kafka producer and consumer, the properties starting with `database.`, e.g. `database.applicationName=debezium` are passed to the JDBC URL.
+[id="{context}-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients"]
+==== Pass-through database history properties for configuring producer and consumer clients
 
-[source,properties,indent=0]
+{prodname} relies on a Kafka producer to write schema changes to database history topics, and a Kafka consumer to read from database history topics when a connector starts.
+You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.*` and `database.history.consumer.*` prefixes.
+The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
+
+[source, indent=0]
 ----
 database.history.producer.security.protocol=SSL
 database.history.producer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
@@ -2292,7 +2307,19 @@ database.history.consumer.ssl.truststore.password=test1234
 database.history.consumer.ssl.key.password=test1234
 ----
 
-Be sure to consult the {link-kafka-docs}.html[Kafka documentation] for all of the configuration properties for Kafka producers and consumers. (The SQL Server connector does use the {link-kafka-docs}.html#newconsumerconfigs[new consumer].)
+As is the case with the xref:{context}-pass-through-configuration-properties-for-database-drivers[pass-through properties for database drivers], {prodname} strips the prefixes from the properties before {prodname} it passes them to configure the database history producer or consumer client.
+
+See the Kafka documentation for more details about link:https://kafka.apache.org/documentation.html#producerconfigs[Kafka producer configuration properties] and link:https://kafka.apache.org/documentation.html#consumerconfigs[Kafka consumer configuration properties].
+
+[id="{context}-database-history-properties-for-configuring-connector-behavior"]
+==== Database history properties for configuring connector behavior
+
+In addition to the pass-through database history properties that you use to configure producers or consumers, there is a set of `database.history.*` properties whose names do not include `producer` or `consumer`.
+You use these `database.history` properties to define how the {context} connector processes event data that it reads from the schema history.
+
+The following table describes the `database.history` properties for configuring the {prodname} {context} connector.
+
+include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 
 // Type: assembly
 // ModuleID: refreshing-capture-tables-after-a-schema-change

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2288,7 +2288,7 @@ Debezium strips the prefix before it passes the property to the database driver.
 ==== Pass-through database history properties for configuring producer and consumer clients
 
 {prodname} relies on a Kafka producer to write schema changes to database history topics, and a Kafka consumer to read from database history topics when a connector starts.
-You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.*` and `database.history.consumer.*` prefixes.
+You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.\*` and `database.history.consumer.*` prefixes.
 The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
 
 [source, indent=0]

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1958,10 +1958,9 @@ Information about the properties is organized as follows:
 
 * xref:{context}-required-connector-configuration-properties[Required connector configuration properties]
 * xref:{context}-advanced-connector-configuration-properties[Advanced connector configuration properties]
-* xref:debezium-{context}-connector-database-history-and-pass-through-configuration-properties[{prodname} connector database history and pass-through configuration properties]
-//* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties for configuring producer and consumer clients]
-//* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through configuration properties for database drivers]
-
+* xref:debezium-{context}-connector-database-history-configuration-properties[Database history connector configuration properties] that control how {prodname} processes events that it reads from the database history topic.
+** xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties]
+* xref:debezium-{context}-connector-pass-through-database-driver-configuration-properties[Pass-through database driver properties] that control the behavior of the database driver.
 
 [id="{context}-required-connector-configuration-properties"]
 ==== Required {prodname} SQL Server connector configuration properties
@@ -2276,10 +2275,15 @@ The name format is _database_name.schema-name.table-name_.
 
 |===
 
-[id="debezium-{context}-connector-database-history-and-pass-through-configuration-properties"]
-==== {prodname} connector database history and pass-through configuration properties
+[id="debezium-{context}-connector-database-history-configuration-properties"]
+==== {prodname} connector database history configuration properties
 
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
+
+[id="debezium-{context}-connector-pass-through-database-driver-configuration-properties"]
+==== {prodname} connector pass-through database driver configuration properties
+
+include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-database-driver-configuration-properties.adoc[leveloffset=+1]
 
 
 // Type: assembly

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -1,3 +1,47 @@
+[id="{context}-pass-through-configuration-properties-for-database-drivers"]
+=== Pass-through configuration properties for database drivers
+
+The {prodname} connector provides for pass-through configuration of the database driver.
+Pass-through database properties begin with the prefix `database.*`.
+For example, the connector passes properties such as `database.foobar=false` to the JDBC URL.
+Debezium strips the `database.` prefix before it passes the property to the database driver.
+
+See the Kafka documentation for more details about link:https://kafka.apache.org/documentation.html#producerconfigs[Kafka producer configuration properties] and link:https://kafka.apache.org/documentation.html#consumerconfigs[Kafka consumer configuration properties].
+
+[id="{context}-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients"]
+=== Pass-through database history properties for configuring producer and consumer clients
+
+{prodname} relies on a Kafka producer to write schema changes to database history topics.
+Similarly, it relies on a Kafka consumer to read from database history topics when a connector starts.
+You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.\*` and `database.history.consumer.*` prefixes.
+The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
+
+[source,indent=0]
+----
+database.history.producer.security.protocol=SSL
+database.history.producer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
+database.history.producer.ssl.keystore.password=test1234
+database.history.producer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
+database.history.producer.ssl.truststore.password=test1234
+database.history.producer.ssl.key.password=test1234
+database.history.consumer.security.protocol=SSL
+database.history.consumer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
+database.history.consumer.ssl.keystore.password=test1234
+database.history.consumer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
+database.history.consumer.ssl.truststore.password=test1234
+database.history.consumer.ssl.key.password=test1234
+----
+
+As is the case with the xref:{context}-pass-through-configuration-properties-for-database-drivers[pass-through properties for database drivers], {prodname} strips the prefixes from the properties before {prodname} it passes them to configure the database history producer or consumer client.
+
+[id="{context}-database-history-properties-for-configuring-connector-behavior"]
+=== Database history properties for configuring connector behavior
+
+In addition to the pass-through database history properties that you use to configure producers or consumers, there is a set of `database.history.*` properties whose names do not include `producer` or `consumer`.
+You use these `database.history` properties to define how the {context} connector processes event data that it reads from the schema history.
+
+The following table describes the `database.history` properties for configuring the {prodname} {context} connector.
+
 .Connector database history configuration properties
 [cols="33%a,17%a,50%a",options="header",subs="+attributes"]
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -13,7 +13,7 @@ The following table describes the `database.history` properties for configuring 
 
 |[[{context}-property-database-history-kafka-bootstrap-servers]]<<{context}-property-database-history-kafka-bootstrap-servers, `+database.history.kafka.bootstrap.servers+`>>
 |
-|A list of host/port pairs that the connector uses for establishing an initial connection to the Kafka cluster. This connection is used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. Each pair should point to the same Kafka cluster used by the Kafka Connect process.
+|A list of host/port pairs that the connector uses for establishing an initial connection to the Kafka cluster. This connection is used for retrieving the database schema history previously stored by the connector, and for writing each DDL statement read from the source database. Each pair should point to the same Kafka cluster used by the Kafka Connect process.
 
 |[[{context}-property-database-history-kafka-recovery-poll-interval-ms]]<<{context}-property-database-history-kafka-recovery-poll-interval-ms, `+database.history.kafka.recovery.poll.interval.ms+`>>
 |`100`

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -1,44 +1,9 @@
-[id="{context}-pass-through-configuration-properties-for-database-drivers"]
-=== Pass-through configuration properties for database drivers
-
-The {prodname} connector provides for pass-through configuration of the database driver.
-Pass-through database properties begin with the prefix `database.*`.
-For example, the connector passes properties such as `database.foobar=false` to the JDBC URL.
-Debezium strips the `database.` prefix before it passes the property to the database driver.
-
-See the Kafka documentation for more details about link:https://kafka.apache.org/documentation.html#producerconfigs[Kafka producer configuration properties] and link:https://kafka.apache.org/documentation.html#consumerconfigs[Kafka consumer configuration properties].
-
-[id="{context}-passthrough-database-history-properties-for-configuring-producer-and-consumer-clients"]
-=== Pass-through database history properties for configuring producer and consumer clients
-
-{prodname} relies on a Kafka producer to write schema changes to database history topics.
-Similarly, it relies on a Kafka consumer to read from database history topics when a connector starts.
-You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.\*` and `database.history.consumer.*` prefixes.
-The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
-
-[source,indent=0]
-----
-database.history.producer.security.protocol=SSL
-database.history.producer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
-database.history.producer.ssl.keystore.password=test1234
-database.history.producer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
-database.history.producer.ssl.truststore.password=test1234
-database.history.producer.ssl.key.password=test1234
-database.history.consumer.security.protocol=SSL
-database.history.consumer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
-database.history.consumer.ssl.keystore.password=test1234
-database.history.consumer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
-database.history.consumer.ssl.truststore.password=test1234
-database.history.consumer.ssl.key.password=test1234
-----
-
-As is the case with the xref:{context}-pass-through-configuration-properties-for-database-drivers[pass-through properties for database drivers], {prodname} strips the prefixes from the properties before {prodname} it passes them to configure the database history producer or consumer client.
 
 [id="{context}-database-history-properties-for-configuring-connector-behavior"]
-=== Database history properties for configuring connector behavior
+.Database history connector configuration properties
 
-In addition to the pass-through database history properties that you use to configure producers or consumers, there is a set of `database.history.*` properties whose names do not include `producer` or `consumer`.
-You use these `database.history` properties to define how the {context} connector processes event data that it reads from the schema history.
+{prodname} provides a set of `database.history.*` properties that control how connectors process control how the connector processes events that it reads from the schema history topic.
+These `database.history` properties specify how the {context} connector processes the event data that it reads from the database history.
 
 The following table describes the `database.history` properties for configuring the {prodname} {context} connector.
 
@@ -69,20 +34,58 @@ The safe default is `false`.
 Skipping should be used only with care as it can lead to data loss or mangling when the binlog is being processed.
 
 |[[{context}-property-database-history-store-only-monitored-tables-ddl]]<<{context}-property-database-history-store-only-monitored-tables-ddl, `+database.history.store.only.monitored.tables.ddl+`>> +
- +
++
 _Deprecated and scheduled for removal in a future release; use xref:{context}-property-database-history-store-only-captured-tables-ddl[`database.history.store.only.captured.tables.ddl`] instead._
 |`false`
 |A Boolean value that specifies whether the connector should record all DDL statements  +
- +
++
 `true` records only those DDL statements that are relevant to tables whose changes are being captured by {prodname}. Set to `true` with care because missing data might become necessary if you change which tables have their changes captured. +
- +
++
 The safe default is `false`.
 
 |[[{context}-property-database-history-store-only-captured-tables-ddl]]<<{context}-property-database-history-store-only-captured-tables-ddl, `+database.history.store.only.captured.tables.ddl+`>>
 |`false`
 |A Boolean value that specifies whether the connector should record all DDL statements  +
- +
++
 `true` records only those DDL statements that are relevant to tables whose changes are being captured by {prodname}. Set to `true` with care because missing data might become necessary if you change which tables have their changes captured. +
- +
++
 The safe default is `false`.
 |===
+
+[id="{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients"]
+.Pass-through database history properties for configuring producer and consumer clients
+
+{prodname} relies on a Kafka producer to write schema changes to database history topics.
+Similarly, it relies on a Kafka consumer to read from database history topics when a connector starts.
+You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.\*` and `database.history.consumer.*` prefixes.
+The pass-through producer and consumer database history properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
+
+[source,indent=0]
+----
+database.history.producer.security.protocol=SSL
+database.history.producer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
+database.history.producer.ssl.keystore.password=test1234
+database.history.producer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
+database.history.producer.ssl.truststore.password=test1234
+database.history.producer.ssl.key.password=test1234
+
+database.history.consumer.security.protocol=SSL
+database.history.consumer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
+database.history.consumer.ssl.keystore.password=test1234
+database.history.consumer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
+database.history.consumer.ssl.truststore.password=test1234
+database.history.consumer.ssl.key.password=test1234
+----
+
+{prodname} strips the prefix from the property name before it passes the property to the Kafka client.
+
+See the Kafka documentation for more details about link:https://kafka.apache.org/documentation.html#producerconfigs[Kafka producer configuration properties] and link:https://kafka.apache.org/documentation.html#consumerconfigs[Kafka consumer configuration properties].
+
+[id="{context}-pass-through-configuration-properties-for-database-drivers"]
+.Pass-through configuration properties for database drivers
+
+The {prodname} connector provides for pass-through configuration of the database driver.
+Pass-through database properties begin with the prefix `database.*`.
+For example, the connector passes properties such as `database.foobar=false` to the JDBC URL.
+
+As is the case with the xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[pass-through properties for database history clients], {prodname} strips the prefixes from the properties before {prodname} it passes them to configure the database history producer or consumer client.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -1,7 +1,14 @@
+You can specify the following sets of connector properties to control how {prodname} interacts with the database history topic:
+
+
+* xref:{context}-database-history-properties-for-configuring-connector-behavior[Database history connector configuration properties] that control how {prodname} processes events that it reads from the database history topic.
+* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties] that control how Kafka producer and consumer clients interact with the Kafka broker.
+* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through database driver properties] that control the behavior of the database driver.
+
 
 [id="{context}-database-history-properties-for-configuring-connector-behavior"]
 .Database history connector configuration properties
-
+{empty} +
 {prodname} provides a set of `database.history.*` properties that control how connectors process control how the connector processes events that it reads from the schema history topic.
 These `database.history` properties specify how the {context} connector processes the event data that it reads from the database history.
 
@@ -54,7 +61,7 @@ The safe default is `false`.
 
 [id="{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients"]
 .Pass-through database history properties for configuring producer and consumer clients
-
+{empty} +
 {prodname} relies on a Kafka producer to write schema changes to database history topics.
 Similarly, it relies on a Kafka consumer to read from database history topics when a connector starts.
 You define the configuration for the Kafka producer and consumer clients by assigning values to a set of pass-through configuration properties that begin with the `database.history.producer.\*` and `database.history.consumer.*` prefixes.
@@ -83,7 +90,7 @@ See the Kafka documentation for more details about link:https://kafka.apache.org
 
 [id="{context}-pass-through-configuration-properties-for-database-drivers"]
 .Pass-through configuration properties for database drivers
-
+{empty} +
 The {prodname} connector provides for pass-through configuration of the database driver.
 Pass-through database properties begin with the prefix `database.*`.
 For example, the connector passes properties such as `database.foobar=false` to the JDBC URL.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -1,15 +1,4 @@
-You can specify the following sets of connector properties to control how {prodname} interacts with the database history topic:
-
-
-* xref:{context}-database-history-properties-for-configuring-connector-behavior[Database history connector configuration properties] that control how {prodname} processes events that it reads from the database history topic.
-* xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties] that control how Kafka producer and consumer clients interact with the Kafka broker.
-* xref:{context}-pass-through-configuration-properties-for-database-drivers[Pass-through database driver properties] that control the behavior of the database driver.
-
-
-[id="{context}-database-history-properties-for-configuring-connector-behavior"]
-.Database history connector configuration properties
-{empty} +
-{prodname} provides a set of `database.history.*` properties that control how connectors process control how the connector processes events that it reads from the schema history topic.
+{prodname} provides a set of `database.history.*` properties that control how the connector processes events that it reads from the schema history topic.
 These `database.history` properties specify how the {context} connector processes the event data that it reads from the database history.
 
 The following table describes the `database.history` properties for configuring the {prodname} {context} connector.
@@ -87,12 +76,3 @@ database.history.consumer.ssl.key.password=test1234
 {prodname} strips the prefix from the property name before it passes the property to the Kafka client.
 
 See the Kafka documentation for more details about link:https://kafka.apache.org/documentation.html#producerconfigs[Kafka producer configuration properties] and link:https://kafka.apache.org/documentation.html#consumerconfigs[Kafka consumer configuration properties].
-
-[id="{context}-pass-through-configuration-properties-for-database-drivers"]
-.Pass-through configuration properties for database drivers
-{empty} +
-The {prodname} connector provides for pass-through configuration of the database driver.
-Pass-through database properties begin with the prefix `database.*`.
-For example, the connector passes properties such as `database.foobar=false` to the JDBC URL.
-
-As is the case with the xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[pass-through properties for database history clients], {prodname} strips the prefixes from the properties before {prodname} it passes them to configure the database history producer or consumer client.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -43,7 +43,7 @@ The safe default is `false`.
 |`false`
 |A Boolean value that specifies whether the connector should record all DDL statements
 +
-`true` records only those DDL statements that are relevant to tables whose changes are being captured by {prodname}. Set to `true` with care because missing data might become necessary if you change which tables have their changes captured. +
+`true` records only those DDL statements that are relevant to tables whose changes are being captured by {prodname}. Set to `true` with care because missing data might become necessary if you change which tables have their changes captured.
 +
 The safe default is `false`.
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -1,0 +1,44 @@
+.Connector database history configuration properties
+[cols="33%a,17%a,50%a",options="header",subs="+attributes"]
+|===
+|Property |Default |Description
+|[[{context}-property-database-history-kafka-topic]]<<{context}-property-database-history-kafka-topic, `+database.history.kafka.topic+`>>
+|
+|The full name of the Kafka topic where the connector stores the database schema history.
+
+|[[{context}-property-database-history-kafka-bootstrap-servers]]<<{context}-property-database-history-kafka-bootstrap-servers, `+database.history.kafka.bootstrap.servers+`>>
+|
+|A list of host/port pairs that the connector uses for establishing an initial connection to the Kafka cluster. This connection is used for retrieving database schema history previously stored by the connector, and for writing each DDL statement read from the source database. Each pair should point to the same Kafka cluster used by the Kafka Connect process.
+
+|[[{context}-property-database-history-kafka-recovery-poll-interval-ms]]<<{context}-property-database-history-kafka-recovery-poll-interval-ms, `+database.history.kafka.recovery.poll.interval.ms+`>>
+|`100`
+|An integer value that specifies the maximum number of milliseconds the connector should wait during startup/recovery while polling for persisted data. The default is 100ms.
+
+|[[{context}-property-database-history-kafka-recovery-attempts]]<<{context}-property-database-history-kafka-recovery-attempts, `+database.history.kafka.recovery.attempts+`>>
+|`4`
+|The maximum number of times that the connector should try to read persisted history data before the connector recovery fails with an error. The maximum amount of time to wait after receiving no data is `recovery.attempts` x `recovery.poll.interval.ms`.
+
+|[[{context}-property-database-history-skip-unparseable-ddl]]<<{context}-property-database-history-skip-unparseable-ddl, `+database.history.skip.unparseable.ddl+`>>
+|`false`
+|A Boolean value that specifies whether the connector should ignore malformed or unknown database statements or stop processing so a human can fix the issue.
+The safe default is `false`.
+Skipping should be used only with care as it can lead to data loss or mangling when the binlog is being processed.
+
+|[[{context}-property-database-history-store-only-monitored-tables-ddl]]<<{context}-property-database-history-store-only-monitored-tables-ddl, `+database.history.store.only.monitored.tables.ddl+`>> +
+ +
+_Deprecated and scheduled for removal in a future release; use xref:{context}-property-database-history-store-only-captured-tables-ddl[`database.history.store.only.captured.tables.ddl`] instead._
+|`false`
+|A Boolean value that specifies whether the connector should record all DDL statements  +
+ +
+`true` records only those DDL statements that are relevant to tables whose changes are being captured by {prodname}. Set to `true` with care because missing data might become necessary if you change which tables have their changes captured. +
+ +
+The safe default is `false`.
+
+|[[{context}-property-database-history-store-only-captured-tables-ddl]]<<{context}-property-database-history-store-only-captured-tables-ddl, `+database.history.store.only.captured.tables.ddl+`>>
+|`false`
+|A Boolean value that specifies whether the connector should record all DDL statements  +
+ +
+`true` records only those DDL statements that are relevant to tables whose changes are being captured by {prodname}. Set to `true` with care because missing data might become necessary if you change which tables have their changes captured. +
+ +
+The safe default is `false`.
+|===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -35,7 +35,7 @@ _Deprecated and scheduled for removal in a future release; use xref:{context}-pr
 |`false`
 |A Boolean value that specifies whether the connector should record all DDL statements  +
 +
-`true` records only those DDL statements that are relevant to tables whose changes are being captured by {prodname}. Set to `true` with care because missing data might become necessary if you change which tables have their changes captured. +
+`true` records only those DDL statements that are relevant to tables whose changes are being captured by {prodname}. Set to `true` with care because missing data might become necessary if you change which tables have their changes captured.
 +
 The safe default is `false`.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -29,7 +29,7 @@ The following table describes the `database.history` properties for configuring 
 The safe default is `false`.
 Skipping should be used only with care as it can lead to data loss or mangling when the binlog is being processed.
 
-|[[{context}-property-database-history-store-only-monitored-tables-ddl]]<<{context}-property-database-history-store-only-monitored-tables-ddl, `+database.history.store.only.monitored.tables.ddl+`>> +
+|[[{context}-property-database-history-store-only-monitored-tables-ddl]]<<{context}-property-database-history-store-only-monitored-tables-ddl, `+database.history.store.only.monitored.tables.ddl+`>>
 +
 _Deprecated and scheduled for removal in a future release; use xref:{context}-property-database-history-store-only-captured-tables-ddl[`database.history.store.only.captured.tables.ddl`] instead._
 |`false`

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -41,7 +41,7 @@ The safe default is `false`.
 
 |[[{context}-property-database-history-store-only-captured-tables-ddl]]<<{context}-property-database-history-store-only-captured-tables-ddl, `+database.history.store.only.captured.tables.ddl+`>>
 |`false`
-|A Boolean value that specifies whether the connector should record all DDL statements  +
+|A Boolean value that specifies whether the connector should record all DDL statements
 +
 `true` records only those DDL statements that are relevant to tables whose changes are being captured by {prodname}. Set to `true` with care because missing data might become necessary if you change which tables have their changes captured. +
 +

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -33,7 +33,7 @@ Skipping should be used only with care as it can lead to data loss or mangling w
 +
 _Deprecated and scheduled for removal in a future release; use xref:{context}-property-database-history-store-only-captured-tables-ddl[`database.history.store.only.captured.tables.ddl`] instead._
 |`false`
-|A Boolean value that specifies whether the connector should record all DDL statements  +
+|A Boolean value that specifies whether the connector should record all DDL statements 
 +
 `true` records only those DDL statements that are relevant to tables whose changes are being captured by {prodname}. Set to `true` with care because missing data might become necessary if you change which tables have their changes captured.
 +

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -1,4 +1,4 @@
-{prodname} provides a set of `database.history.*` properties that control how the connector processes events that it reads from the schema history topic.
+{prodname} provides a set of `database.history.*` properties that control how the connector interacts with the schema history topic.
 These `database.history` properties specify how the {context} connector processes the event data that it reads from the database history.
 
 The following table describes the `database.history` properties for configuring the {prodname} {context} connector.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-pass-through-database-driver-configuration-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-pass-through-database-driver-configuration-properties.adoc
@@ -2,4 +2,4 @@ The {prodname} connector provides for pass-through configuration of the database
 Pass-through database properties begin with the prefix `database.*`.
 For example, the connector passes properties such as `database.foobar=false` to the JDBC URL.
 
-As is the case with the xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[pass-through properties for database history clients], {prodname} strips the prefixes from the properties before it passes them to configure the database history producer or consumer client.
+As is the case with the xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[pass-through properties for database history clients], {prodname} strips the prefixes from the properties before it passes them to the database driver.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-pass-through-database-driver-configuration-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-pass-through-database-driver-configuration-properties.adoc
@@ -1,0 +1,5 @@
+The {prodname} connector provides for pass-through configuration of the database driver.
+Pass-through database properties begin with the prefix `database.*`.
+For example, the connector passes properties such as `database.foobar=false` to the JDBC URL.
+
+As is the case with the xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[pass-through properties for database history clients], {prodname} strips the prefixes from the properties before it passes them to configure the database history producer or consumer client.


### PR DESCRIPTION
[DBZ-3459](https://issues.redhat.com/browse/DBZ-3459)

This change extracts the `database.history.*` properties from the tables of connector configuration properties for the Db2, MySQL, Oracle, and SQL Server connector docs  to a shared partial. 
It also adds consistent sections  to each of the docs to describe the use of passthrough properties for configuring database drivers and database history clients.

I tested the changes in local upstream and  downstream builds.

There are some other pending issues related to property tables, for example, [DBZ-3160](https://issues.redhat.com/browse/DBZ-3160), which concerns extracting the entirety of the connector properties into a shared source, and [DBZ-3120](https://issues.redhat.com/browse/DBZ-3120), which proposes to convert tables to description lists. Taking a stepwise approach, implementing single-sourcing for the database history properties first, and can later take on the full monty. Might eventually also want to move the pass-through sections to a shared file as well.

Please backport the changes to the 1.5 and 1.6 branches.