### PR TITLE
Fix typo in outbox.adoc (on branch master)

### DIFF
--- a/documentation/modules/ROOT/pages/integrations/outbox.adoc
+++ b/documentation/modules/ROOT/pages/integrations/outbox.adoc
@@ -32,7 +32,7 @@ In order to start using the {prodname} Outbox Quarkus extension, the extension n
 ----
 <dependency>
   <groupId>io.debezium</groupId>
-  <artfiactId>debezium-quarkus-outbox</artfiactId>
+  <artifactId>debezium-quarkus-outbox</artifactId>
   <version>{debezium-version}</version>
 </dependency>
 ----


### PR DESCRIPTION
I already created a PR (#2461), that got merged, but I've just seen, that it was only for version `1.5`.

So here's the PR for the master branch.