### PR TITLE
DBZ-3546 default debezium.sink.pravega.transaction to false

### DIFF
--- a/debezium-server/debezium-server-pravega/src/main/java/io/debezium/server/pravega/PravegaChangeConsumer.java
+++ b/debezium-server/debezium-server-pravega/src/main/java/io/debezium/server/pravega/PravegaChangeConsumer.java
@@ -49,7 +49,7 @@ public class PravegaChangeConsumer extends BaseChangeConsumer implements ChangeC
     @ConfigProperty(name = PROP_SCOPE)
     String scope;
 
-    @ConfigProperty(name = PROP_TXN)
+    @ConfigProperty(name = PROP_TXN, defaultValue = "false")
     boolean txn;
 
     private ClientConfig clientConfig;


### PR DESCRIPTION
During manual testing of the Pravega sink, I found that I didn't set the default value of the `debezium.sink.pravega.transaction` config to false, as was intended & documented (https://debezium.io/documentation/reference/operations/debezium-server.html#pravega-transaction).