### PR TITLE
DBZ-3612 Do not parse Oracle ALTER TABLE ddl for unknown tables

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/AlterTableParserListener.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/AlterTableParserListener.java
@@ -60,6 +60,10 @@ public class AlterTableParserListener extends BaseParserListener {
     public void enterAlter_table(PlSqlParser.Alter_tableContext ctx) {
         previousTableId = null;
         TableId tableId = new TableId(catalogName, schemaName, getTableName(ctx.tableview_name()));
+        if (parser.databaseTables().forTable(tableId) == null) {
+            LOGGER.debug("Ignoring ALTER TABLE statement for non-captured table {}", tableId);
+            return;
+        }
         tableEditor = parser.databaseTables().editTable(tableId);
         if (tableEditor == null) {
             throw new ParsingException(null, "Trying to alter table " + tableId.toString()


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3612

Using MySQL as a guide, I added a similar check to the `ALTER TABLE` listener to silently return and ignore these DDL events if the table is not known to the connector, logging a message on debug level for visibility.