### PR TITLE
DBZ-3638 Modify Mysql SourceInfo to be public

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
@@ -89,7 +89,7 @@ import io.debezium.relational.TableId;
  * @author Randall Hauch
  */
 @NotThreadSafe
-final class SourceInfo extends BaseSourceInfo {
+public final class SourceInfo extends BaseSourceInfo {
 
     // Avro Schema doesn't allow "-" to be included as field name, use "_" instead.
     // Ref https://issues.apache.org/jira/browse/AVRO-838.

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SourceInfo.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SourceInfo.java
@@ -97,7 +97,7 @@ import io.debezium.util.Collect;
  * @author Randall Hauch
  */
 @NotThreadSafe
-final class SourceInfo extends BaseSourceInfo {
+public final class SourceInfo extends BaseSourceInfo {
 
     // Avro Schema doesn't allow "-" to be included as field name, use "_" instead.
     // Ref https://issues.apache.org/jira/browse/AVRO-838.


### PR DESCRIPTION
I see every SourceInfo is public, except for mysql