### PR TITLE
DBZ-3631 Fix Xstream to emit NULL BLOB/CLOB values when fields explicitly set to NULL like LogMiner implementation did.

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -318,16 +318,19 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         for (ChunkColumnValue chunkValue : chunkValues) {
             data.append(chunkValue.getColumnData().stringValue());
         }
-        return data.toString();
+        return data.length() == 0 ? null : data.toString();
     }
 
     private byte[] resolveBlobChunkValue(List<ChunkColumnValue> chunkValues) {
         long size = chunkValues.stream().map(ChunkColumnValue::getColumnData).mapToLong(Datum::getLength).sum();
-        ByteBuffer buffer = ByteBuffer.allocate((int) size);
-        for (ChunkColumnValue columnValue : chunkValues) {
-            buffer.put(columnValue.getColumnData().getBytes());
+        if (size > 0) {
+            ByteBuffer buffer = ByteBuffer.allocate((int) size);
+            for (ChunkColumnValue columnValue : chunkValues) {
+                buffer.put(columnValue.getColumnData().getBytes());
+            }
+            return buffer.array();
         }
-        return buffer.array();
+        return null;
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -322,7 +322,10 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     }
 
     private byte[] resolveBlobChunkValue(List<ChunkColumnValue> chunkValues) {
-        long size = chunkValues.stream().map(ChunkColumnValue::getColumnData).mapToLong(Datum::getLength).sum();
+        long size = 0;
+        for (ChunkColumnValue chunkValue : chunkValues) {
+            size += ((Datum) chunkValue).getLength();
+        }
         if (size > 0) {
             ByteBuffer buffer = ByteBuffer.allocate((int) size);
             for (ChunkColumnValue columnValue : chunkValues) {


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3631

This is a small follow-up on DBZ-3631.  During testing those changes with Xstream, a small inconsistency was identified where Xstream emitted empty strings and empty byte buffer values for CLOB/BLOB respectively if the fields were being set to NULL where-as LogMiner emitted actual `null` values.  This follow-up makes that behavior consistent across both adapters to emit `null`.