### PR TITLE
DBZ-3634 Enable DDL events to be filtered by include/exclude lists

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilder.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.util.Strings;
+
+/**
+ * A builder that is responsible for producing the query to be executed against the LogMiner view.
+ *
+ * @author Chris Cranford
+ */
+public class LogMinerQueryBuilder {
+
+    /**
+     * This represents a hash function generated for each row in the query that is meant to provide a
+     * unique hash value for each row within the scope of a transaction.
+     */
+    private static final String ROW_HASH = "ORA_HASH(SCN||OPERATION||RS_ID||SEQUENCE#||RTRIM(SUBSTR(SQL_REDO,1,256)))";
+    private static final String LOGMNR_CONTENTS_VIEW = "V$LOGMNR_CONTENTS";
+
+    /**
+     * Builds the LogMiner contents view query.
+     *
+     * The returned query will contain 2 bind parameters that the caller is responsible for binding before
+     * executing the query.  The first bind parameter is the lower-bounds of the SCN mining window that is
+     * not-inclusive while the second is the upper-bounds of the SCN mining window that is inclusive.
+     *
+     * The built query relies on the following columns from V$LOGMNR_CONTENTS:
+     * <pre>
+     *     SCN - the system change number at which the change was made
+     *     SQL_REDO - the reconstructed SQL statement that initiated the change
+     *     OPERATION - the database operation type name
+     *     OPERATION_CODE - the database operation numeric code
+     *     TIMESTAMP - the time when the change event occurred
+     *     XID - the transaction identifier the change participated in
+     *     CSF - the continuation flag, identifies rows that should be processed together as single row, 0=no, 1=yes
+     *     TABLE_NAME - the name of the table for which the change is for
+     *     SEG_OWNER - the name of the schema for which the change is for
+     *     USERNAME - the name of the database user that caused the change
+     *     ROW_ID - the unique identifier of the row that the change is for, may not always be set with valid value
+     *     ROLLBACK - the rollback flag, value of 0 or 1.  1 implies the row was rolled back
+     *     RS_ID - the rollback segment idenifier where the change record was record from
+     * </pre>
+     *
+     * @param connectorConfig connector configuration, should not be {@code null}
+     * @param userName jdbc connection username
+     * @return the SQL string to be used to fetch changes from Oracle LogMiner
+     */
+    public static String build(OracleConnectorConfig connectorConfig, String userName) {
+        final StringBuilder query = new StringBuilder(1024);
+        query.append("SELECT SCN, SQL_REDO, OPERATION_CODE, TIMESTAMP, XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, ");
+        query.append("USERNAME, ROW_ID, ROLLBACK, RS_ID, ").append(getRowHash()).append(" ");
+        query.append("FROM ").append(LOGMNR_CONTENTS_VIEW).append(" ");
+
+        // These bind parameters will be bound when the query is executed by the caller.
+        query.append("WHERE SCN > ? AND SCN <= ? ");
+        query.append("AND (");
+
+        // Always include START, COMMIT, MISSING_SCN, and ROLLBACK operations
+        query.append("(OPERATION_CODE IN (6,7,34,36)");
+
+        if (!connectorConfig.getDatabaseHistory().storeOnlyCapturedTables()) {
+            // In this mode, the connector will always be fed DDL operations for all tables even if they
+            // are not part of the inclusion/exclusion lists.
+            query.append(" OR ").append(buildDdlPredicate(userName)).append(" ");
+            // Insert, Update, Delete, SelectLob, LobWrite, LobTrim, and LobErase
+            query.append(") OR (OPERATION_CODE IN (1,2,3,9,10,11,29) ");
+        }
+        else {
+            // Insert, Update, Delete, SelectLob, LobWrite, LobTrim, and LobErase
+            query.append(") OR ((OPERATION_CODE IN (1,2,3,9,10,11,29) ");
+            // In this mode, the connector will filter DDL operations based on the table inclusion/exclusion lists
+            query.append("OR ").append(buildDdlPredicate(userName)).append(") ");
+        }
+
+        // Always ignore the flush table
+        query.append("AND TABLE_NAME != '").append(SqlUtils.LOGMNR_FLUSH_TABLE).append("' ");
+
+        // There are some common schemas that we automatically ignore when building the runtime Filter
+        // predicates and we put that same list of schemas here and apply those in the generated SQL.
+        if (!OracleConnectorConfig.EXCLUDED_SCHEMAS.isEmpty()) {
+            query.append("AND SEG_OWNER NOT IN (");
+            for (Iterator<String> i = OracleConnectorConfig.EXCLUDED_SCHEMAS.iterator(); i.hasNext();) {
+                String excludedSchema = i.next();
+                query.append("'").append(excludedSchema.toUpperCase()).append("'");
+                if (i.hasNext()) {
+                    query.append(",");
+                }
+            }
+            query.append(") ");
+        }
+
+        String schemaPredicate = buildSchemaPredicate(connectorConfig);
+        if (!Strings.isNullOrEmpty(schemaPredicate)) {
+            query.append("AND ").append(schemaPredicate).append(" ");
+        }
+
+        String tablePredicate = buildTablePredicate(connectorConfig);
+        if (!Strings.isNullOrEmpty(tablePredicate)) {
+            query.append("AND ").append(tablePredicate).append(" ");
+        }
+
+        query.append("))");
+
+        return query.toString();
+    }
+
+    /**
+     * Produces a hash of several columns in {@code V$LOGMNR_CONTENTS} to generate a unique identifier
+     * that can be used to recognize individual rows within the scope of a transaction.
+     *
+     * @return the row hashing function
+     */
+    private static String getRowHash() {
+        return ROW_HASH;
+    }
+
+    /**
+     * Builds a common SQL fragment used to obtain DDL operations via LogMiner.
+     *
+     * @param userName jdbc connection username, should not be {@code null}
+     * @return predicate that can be used to obtain DDL operations via LogMiner
+     */
+    private static String buildDdlPredicate(String userName) {
+        final StringBuilder predicate = new StringBuilder(256);
+        predicate.append("(OPERATION_CODE = 5 ");
+        predicate.append("AND USERNAME NOT IN ('SYS','SYSTEM','").append(userName.toUpperCase()).append("') ");
+        predicate.append("AND INFO NOT LIKE 'INTERNAL DDL%' ");
+        predicate.append("AND (TABLE_NAME IS NULL OR TABLE_NAME NOT LIKE 'ORA_TEMP_%'))");
+        return predicate.toString();
+    }
+
+    /**
+     * Builds a SQL predicate of what schemas to include/exclude based on the connector configuration.
+     *
+     * @param connectorConfig connector configuration, should not be {@code null}
+     * @return SQL predicate to filter results based on schema include/exclude configurations
+     */
+    private static String buildSchemaPredicate(OracleConnectorConfig connectorConfig) {
+        StringBuilder predicate = new StringBuilder();
+        if (Strings.isNullOrEmpty(connectorConfig.schemaIncludeList())) {
+            if (!Strings.isNullOrEmpty(connectorConfig.schemaExcludeList())) {
+                List<Pattern> patterns = Strings.listOfRegex(connectorConfig.schemaExcludeList(), 0);
+                predicate.append("(").append(listOfPatternsToSql(patterns, "SEG_OWNER", true)).append(")");
+            }
+        }
+        else {
+            List<Pattern> patterns = Strings.listOfRegex(connectorConfig.schemaIncludeList(), 0);
+            predicate.append("(").append(listOfPatternsToSql(patterns, "SEG_OWNER", false)).append(")");
+        }
+        return predicate.toString();
+    }
+
+    /**
+     * Builds a SQL predicate of what tables to include/exclude based on the connector configuration.
+     *
+     * @param connectorConfig connector configuration, should not be {@code null}
+     * @return SQL predicate to filter results based on table include/exclude configuration
+     */
+    private static String buildTablePredicate(OracleConnectorConfig connectorConfig) {
+        StringBuilder predicate = new StringBuilder();
+        if (Strings.isNullOrEmpty(connectorConfig.tableIncludeList())) {
+            if (!Strings.isNullOrEmpty(connectorConfig.tableExcludeList())) {
+                List<Pattern> patterns = Strings.listOfRegex(connectorConfig.tableExcludeList(), 0);
+                predicate.append("(").append(listOfPatternsToSql(patterns, "SEG_OWNER || '.' || TABLE_NAME", true)).append(")");
+            }
+        }
+        else {
+            List<Pattern> patterns = Strings.listOfRegex(connectorConfig.tableIncludeList(), 0);
+            predicate.append("(").append(listOfPatternsToSql(patterns, "SEG_OWNER || '.' || TABLE_NAME", false)).append(")");
+        }
+        return predicate.toString();
+    }
+
+    /**
+     * Takes a list of reg-ex patterns and builds an Oracle-specific predicate using {@code REGEXP_LIKE}
+     * in order to take the connector configuration include/exclude lists and assemble them as SQL
+     * predicates.
+     *
+     * @param patterns list of each individual include/exclude reg-ex patterns from connector configuration
+     * @param columnName the column in which the reg-ex patterns are to be applied against
+     * @param inclusion should be {@code true} when passing inclusion patterns, {@code false} otherwise
+     * @return
+     */
+    private static String listOfPatternsToSql(List<Pattern> patterns, String columnName, boolean inclusion) {
+        StringBuilder predicate = new StringBuilder();
+        for (Iterator<Pattern> i = patterns.iterator(); i.hasNext();) {
+            Pattern pattern = i.next();
+            if (inclusion) {
+                predicate.append("NOT ");
+            }
+            // NOTE: The REGEXP_LIKE operator was added in Oracle 10g (10.1.0.0.0)
+            final String text = resolveRegExpLikePattern(pattern);
+            predicate.append("REGEXP_LIKE(").append(columnName).append(",'").append(text).append("','i')");
+            if (i.hasNext()) {
+                // Exclude lists imply combining them via AND, Include lists imply combining them via OR?
+                predicate.append(inclusion ? " AND " : " OR ");
+            }
+        }
+        return predicate.toString();
+    }
+
+    /**
+     * The {@code REGEXP_LIKE} Oracle operator acts identical to the {@code LIKE} operator. Internally,
+     * it prepends and appends a "%" qualifier.  The include/exclude lists are meant to be explicit in
+     * that they have an implied "^" and "$" qualifier for start/end so that the LIKE operation does
+     * not mistakently filter "DEBEZIUM2" when using the reg-ex of "DEBEZIUM".
+     *
+     * @param pattern the pattern to be analyzed, should not be {@code null}
+     * @return the adjusted predicate, if necessary and doesn't already explicitly specify "^" or "$"
+     */
+    private static String resolveRegExpLikePattern(Pattern pattern) {
+        String text = pattern.pattern();
+        if (!text.startsWith("^")) {
+            text = "^" + text;
+        }
+        if (!text.endsWith("$")) {
+            text += "$";
+        }
+        return text;
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -139,7 +139,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
                             connectorConfig, streamingMetrics, transactionalBuffer, offsetContext, schema, dispatcher,
                             historyRecorder);
 
-                    final String query = SqlUtils.logMinerContentsQuery(connectorConfig, jdbcConnection.username());
+                    final String query = LogMinerQueryBuilder.build(connectorConfig, jdbcConnection.username());
                     try (PreparedStatement miningView = jdbcConnection.connection().prepareStatement(query, ResultSet.TYPE_FORWARD_ONLY,
                             ResultSet.CONCUR_READ_ONLY, ResultSet.HOLD_CURSORS_OVER_COMMIT)) {
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer;
+
+import static io.debezium.relational.RelationalDatabaseConnectorConfig.SCHEMA_EXCLUDE_LIST;
+import static io.debezium.relational.RelationalDatabaseConnectorConfig.SCHEMA_INCLUDE_LIST;
+import static io.debezium.relational.RelationalDatabaseConnectorConfig.TABLE_EXCLUDE_LIST;
+import static io.debezium.relational.RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST;
+import static io.debezium.relational.history.DatabaseHistory.STORE_ONLY_CAPTURED_TABLES_DDL;
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.Iterator;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import io.debezium.config.Configuration;
+import io.debezium.config.Field;
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
+import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
+import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.doc.FixFor;
+
+/**
+ * Unit test for the {@link LogMinerQueryBuilder}.
+ *
+ * @author Chris Cranford
+ */
+@SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER)
+public class LogMinerQueryBuilderTest {
+
+    @Rule
+    public TestRule skipRule = new SkipTestDependingOnAdapterNameRule();
+
+    /**
+     * A template that defines the expected SQL output when the configuration specifies
+     * {@code database.history.store.only.captured.tables.ddl} is {@code false}.
+     */
+    private static final String LOG_MINER_CONTENT_QUERY_TEMPLATE1 = "SELECT SCN, SQL_REDO, OPERATION_CODE, TIMESTAMP, " +
+            "XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, USERNAME, ROW_ID, ROLLBACK, RS_ID, " +
+            "ORA_HASH(SCN||OPERATION||RS_ID||SEQUENCE#||RTRIM(SUBSTR(SQL_REDO,1,256))) " +
+            "FROM V$LOGMNR_CONTENTS WHERE SCN > ? AND SCN <= ? AND ((" +
+            "OPERATION_CODE IN (6,7,34,36) OR " +
+            "(OPERATION_CODE = 5 AND USERNAME NOT IN ('SYS','SYSTEM','${user}') " +
+            "AND INFO NOT LIKE 'INTERNAL DDL%' " +
+            "AND (TABLE_NAME IS NULL OR TABLE_NAME NOT LIKE 'ORA_TEMP_%')) ) " +
+            "OR (OPERATION_CODE IN (1,2,3,9,10,11,29) " +
+            "AND TABLE_NAME != '" + SqlUtils.LOGMNR_FLUSH_TABLE + "' " +
+            "${systemTablePredicate}" +
+            "${schemaPredicate}" +
+            "${tablePredicate}" +
+            "))";
+
+    /**
+     * A template that defines the expected SQL output when the configuration specifies
+     * {@code database.history.store.only.captured.tables.ddl} is {@code true}.
+     */
+    private static final String LOG_MINER_CONTENT_QUERY_TEMPLATE2 = "SELECT SCN, SQL_REDO, OPERATION_CODE, TIMESTAMP, " +
+            "XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, USERNAME, ROW_ID, ROLLBACK, RS_ID, " +
+            "ORA_HASH(SCN||OPERATION||RS_ID||SEQUENCE#||RTRIM(SUBSTR(SQL_REDO,1,256))) " +
+            "FROM V$LOGMNR_CONTENTS WHERE SCN > ? AND SCN <= ? AND ((" +
+            "OPERATION_CODE IN (6,7,34,36)) OR " +
+            "((OPERATION_CODE IN (1,2,3,9,10,11,29) OR " +
+            "(OPERATION_CODE = 5 AND USERNAME NOT IN ('SYS','SYSTEM','${user}') " +
+            "AND INFO NOT LIKE 'INTERNAL DDL%' " +
+            "AND (TABLE_NAME IS NULL OR TABLE_NAME NOT LIKE 'ORA_TEMP_%'))) " +
+            "AND TABLE_NAME != '" + SqlUtils.LOGMNR_FLUSH_TABLE + "' " +
+            "${systemTablePredicate}" +
+            "${schemaPredicate}" +
+            "${tablePredicate}" +
+            "))";
+
+    private static final String USERNAME = "USERNAME";
+
+    @Test
+    @FixFor("DBZ-3009")
+    public void testLogMinerQueryWithNoFilters() {
+        Configuration config = TestHelper.defaultConfig().build();
+        OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
+
+        String result = LogMinerQueryBuilder.build(connectorConfig, USERNAME);
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, null, null));
+
+        config = TestHelper.defaultConfig().with(STORE_ONLY_CAPTURED_TABLES_DDL, true).build();
+        connectorConfig = new OracleConnectorConfig(config);
+
+        result = LogMinerQueryBuilder.build(connectorConfig, USERNAME);
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, null, null));
+    }
+
+    @Test
+    @FixFor("DBZ-3009")
+    public void testLogMinerQueryWithSchemaInclude() {
+        String schema = "AND (REGEXP_LIKE(SEG_OWNER,'^SCHEMA1$','i') OR REGEXP_LIKE(SEG_OWNER,'^SCHEMA2$','i')) ";
+        assertQueryWithConfig(SCHEMA_INCLUDE_LIST, "SCHEMA1,SCHEMA2", schema, null);
+    }
+
+    @Test
+    @FixFor("DBZ-3009")
+    public void testLogMinerQueryWithSchemaExclude() {
+        String schema = "AND (NOT REGEXP_LIKE(SEG_OWNER,'^SCHEMA1$','i') AND NOT REGEXP_LIKE(SEG_OWNER,'^SCHEMA2$','i')) ";
+        assertQueryWithConfig(OracleConnectorConfig.SCHEMA_EXCLUDE_LIST, "SCHEMA1,SCHEMA2", schema, null);
+    }
+
+    @Test
+    @FixFor("DBZ-3009")
+    public void testLogMinerQueryWithTableInclude() {
+        String table = "AND (REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEA$','i') " +
+                "OR REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEB$','i')) ";
+        assertQueryWithConfig(TABLE_INCLUDE_LIST, "DEBEZIUM\\.TABLEA,DEBEZIUM\\.TABLEB", null, table);
+    }
+
+    @Test
+    @FixFor("DBZ-3009")
+    public void testLogMinerQueryWithTableExcludes() {
+        String table = "AND (NOT REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEA$','i') " +
+                "AND NOT REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEB$','i')) ";
+        assertQueryWithConfig(TABLE_EXCLUDE_LIST, "DEBEZIUM\\.TABLEA,DEBEZIUM\\.TABLEB", null, table);
+    }
+
+    @Test
+    @FixFor("DBZ-3009")
+    public void testLogMinerQueryWithSchemaTableIncludes() {
+        String schema = "AND (REGEXP_LIKE(SEG_OWNER,'^SCHEMA1$','i') OR REGEXP_LIKE(SEG_OWNER,'^SCHEMA2$','i')) ";
+        String table = "AND (REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEA$','i') " +
+                "OR REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEB$','i')) ";
+        assertQueryWithConfig(SCHEMA_INCLUDE_LIST, "SCHEMA1,SCHEMA2", TABLE_INCLUDE_LIST, "DEBEZIUM\\.TABLEA,DEBEZIUM\\.TABLEB", schema, table);
+    }
+
+    @Test
+    @FixFor("DBZ-3009")
+    public void testLogMinerQueryWithSchemaTableExcludes() {
+        String schema = "AND (NOT REGEXP_LIKE(SEG_OWNER,'^SCHEMA1$','i') AND NOT REGEXP_LIKE(SEG_OWNER,'^SCHEMA2$','i')) ";
+        String table = "AND (NOT REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEA$','i') " +
+                "AND NOT REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEB$','i')) ";
+        assertQueryWithConfig(SCHEMA_EXCLUDE_LIST, "SCHEMA1,SCHEMA2", TABLE_EXCLUDE_LIST, "DEBEZIUM\\.TABLEA,DEBEZIUM\\.TABLEB", schema, table);
+    }
+
+    @Test
+    @FixFor("DBZ-3009")
+    public void testLogMinerQueryWithSchemaExcludeTableInclude() {
+        String schema = "AND (NOT REGEXP_LIKE(SEG_OWNER,'^SCHEMA1$','i') AND NOT REGEXP_LIKE(SEG_OWNER,'^SCHEMA2$','i')) ";
+        String table = "AND (REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEA$','i') " +
+                "OR REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEB$','i')) ";
+        assertQueryWithConfig(SCHEMA_EXCLUDE_LIST, "SCHEMA1,SCHEMA2", TABLE_INCLUDE_LIST, "DEBEZIUM\\.TABLEA,DEBEZIUM\\.TABLEB", schema, table);
+    }
+
+    private void assertQueryWithConfig(Field field, Object fieldValue, String schemaValue, String tableValue) {
+        Configuration config = TestHelper.defaultConfig().with(field, fieldValue).build();
+        OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
+
+        String result = LogMinerQueryBuilder.build(connectorConfig, USERNAME);
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue));
+
+        config = TestHelper.defaultConfig().with(field, fieldValue).with(STORE_ONLY_CAPTURED_TABLES_DDL, true).build();
+        connectorConfig = new OracleConnectorConfig(config);
+
+        result = LogMinerQueryBuilder.build(connectorConfig, USERNAME);
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue));
+    }
+
+    private void assertQueryWithConfig(Field field1, Object fieldValue1, Field field2, Object fieldValue2, String schemaValue, String tableValue) {
+        Configuration config = TestHelper.defaultConfig().with(field1, fieldValue1).with(field2, fieldValue2).build();
+        OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
+
+        String result = LogMinerQueryBuilder.build(connectorConfig, USERNAME);
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue));
+
+        config = TestHelper.defaultConfig().with(field1, fieldValue1).with(field2, fieldValue2)
+                .with(STORE_ONLY_CAPTURED_TABLES_DDL, true).build();
+        connectorConfig = new OracleConnectorConfig(config);
+
+        result = LogMinerQueryBuilder.build(connectorConfig, USERNAME);
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue));
+    }
+
+    private String resolveLogMineryContentQueryFromTemplate(OracleConnectorConfig config,
+                                                            String schemaReplacement,
+                                                            String tableReplacement) {
+        String query = config.getDatabaseHistory().storeOnlyCapturedTables()
+                ? LOG_MINER_CONTENT_QUERY_TEMPLATE2
+                : LOG_MINER_CONTENT_QUERY_TEMPLATE1;
+
+        if (!OracleConnectorConfig.EXCLUDED_SCHEMAS.isEmpty()) {
+            StringBuilder systemPredicate = new StringBuilder();
+            systemPredicate.append("AND SEG_OWNER NOT IN (");
+            for (Iterator<String> i = OracleConnectorConfig.EXCLUDED_SCHEMAS.iterator(); i.hasNext();) {
+                String excludedSchema = i.next();
+                systemPredicate.append("'").append(excludedSchema.toUpperCase()).append("'");
+                if (i.hasNext()) {
+                    systemPredicate.append(",");
+                }
+            }
+            systemPredicate.append(") ");
+            query = query.replace("${systemTablePredicate}", systemPredicate.toString());
+        }
+        else {
+            query = query.replace("${systemTablePredicate}", "");
+        }
+
+        query = query.replace("${schemaPredicate}", schemaReplacement == null ? "" : schemaReplacement);
+        query = query.replace("${tablePredicate}", tableReplacement == null ? "" : tableReplacement);
+        query = query.replace("${user}", USERNAME);
+        return query;
+    }
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/SqlUtilsTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/SqlUtilsTest.java
@@ -6,24 +6,20 @@
 package io.debezium.connector.oracle.logminer;
 
 import static org.fest.assertions.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.sql.SQLRecoverableException;
 import java.time.Duration;
-import java.util.Iterator;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
-import org.mockito.Mockito;
 
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot.AdapterName;
-import io.debezium.doc.FixFor;
 import io.debezium.relational.TableId;
 
 @SkipWhenAdapterNameIsNot(value = AdapterName.LOGMINER)
@@ -31,148 +27,6 @@ public class SqlUtilsTest {
 
     @Rule
     public TestRule skipRule = new SkipTestDependingOnAdapterNameRule();
-
-    private static final String LOG_MINER_CONTENT_QUERY_TEMPLATE = "SELECT SCN, SQL_REDO, OPERATION_CODE, TIMESTAMP, " +
-            "XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, USERNAME, ROW_ID, ROLLBACK, RS_ID, " +
-            "ORA_HASH(SCN||OPERATION||RS_ID||SEQUENCE#||RTRIM(SUBSTR(SQL_REDO,1,256))) " +
-            "FROM V$LOGMNR_CONTENTS WHERE SCN > ? AND SCN <= ? AND ((" +
-            "OPERATION_CODE IN (5,11,34) AND USERNAME NOT IN ('SYS','SYSTEM','${user}') AND INFO NOT LIKE 'INTERNAL DDL%' " +
-            "AND (TABLE_NAME IS NULL OR TABLE_NAME NOT LIKE 'ORA_TEMP_%')) " +
-            "OR (OPERATION_CODE IN (6,7,36)) " +
-            "OR (OPERATION_CODE IN (1,2,3,9,10,29) " +
-            "AND TABLE_NAME != '" + SqlUtils.LOGMNR_FLUSH_TABLE + "' " +
-            "${systemTablePredicate}" +
-            "${schemaPredicate}" +
-            "${tablePredicate}" +
-            "))";
-
-    private static final String USERNAME = "USERNAME";
-
-    @Test
-    @FixFor("DBZ-3009")
-    public void testLogMinerQueryWithNoFilters() {
-        OracleConnectorConfig config = mock(OracleConnectorConfig.class);
-        Mockito.when(config.schemaIncludeList()).thenReturn(null);
-        Mockito.when(config.schemaExcludeList()).thenReturn(null);
-        Mockito.when(config.tableIncludeList()).thenReturn(null);
-        Mockito.when(config.tableExcludeList()).thenReturn(null);
-
-        String result = SqlUtils.logMinerContentsQuery(config, USERNAME);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(null, null));
-    }
-
-    @Test
-    @FixFor("DBZ-3009")
-    public void testLogMinerQueryWithSchemaInclude() {
-        OracleConnectorConfig config = mock(OracleConnectorConfig.class);
-        Mockito.when(config.schemaIncludeList()).thenReturn("SCHEMA1,SCHEMA2");
-        Mockito.when(config.schemaExcludeList()).thenReturn(null);
-        Mockito.when(config.tableIncludeList()).thenReturn(null);
-        Mockito.when(config.tableExcludeList()).thenReturn(null);
-
-        String schema = "AND (REGEXP_LIKE(SEG_OWNER,'^SCHEMA1$','i') OR REGEXP_LIKE(SEG_OWNER,'^SCHEMA2$','i')) ";
-
-        String result = SqlUtils.logMinerContentsQuery(config, USERNAME);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(schema, null));
-    }
-
-    @Test
-    @FixFor("DBZ-3009")
-    public void testLogMinerQueryWithSchemaExclude() {
-        OracleConnectorConfig config = mock(OracleConnectorConfig.class);
-        Mockito.when(config.schemaIncludeList()).thenReturn(null);
-        Mockito.when(config.schemaExcludeList()).thenReturn("SCHEMA1,SCHEMA2");
-        Mockito.when(config.tableIncludeList()).thenReturn(null);
-        Mockito.when(config.tableExcludeList()).thenReturn(null);
-
-        String schema = "AND (NOT REGEXP_LIKE(SEG_OWNER,'^SCHEMA1$','i') AND NOT REGEXP_LIKE(SEG_OWNER,'^SCHEMA2$','i')) ";
-
-        String result = SqlUtils.logMinerContentsQuery(config, USERNAME);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(schema, null));
-    }
-
-    @Test
-    @FixFor("DBZ-3009")
-    public void testLogMinerQueryWithTableInclude() {
-        OracleConnectorConfig config = mock(OracleConnectorConfig.class);
-        Mockito.when(config.schemaIncludeList()).thenReturn(null);
-        Mockito.when(config.schemaExcludeList()).thenReturn(null);
-        Mockito.when(config.tableIncludeList()).thenReturn("DEBEZIUM\\.TABLEA,DEBEZIUM\\.TABLEB");
-        Mockito.when(config.tableExcludeList()).thenReturn(null);
-
-        String table = "AND (REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEA$','i') " +
-                "OR REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEB$','i')) ";
-
-        String result = SqlUtils.logMinerContentsQuery(config, USERNAME);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(null, table));
-    }
-
-    @Test
-    @FixFor("DBZ-3009")
-    public void testLogMinerQueryWithTableExcludes() {
-        OracleConnectorConfig config = mock(OracleConnectorConfig.class);
-        Mockito.when(config.schemaIncludeList()).thenReturn(null);
-        Mockito.when(config.schemaExcludeList()).thenReturn(null);
-        Mockito.when(config.tableIncludeList()).thenReturn(null);
-        Mockito.when(config.tableExcludeList()).thenReturn("DEBEZIUM\\.TABLEA,DEBEZIUM\\.TABLEB");
-
-        String table = "AND (NOT REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEA$','i') " +
-                "AND NOT REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEB$','i')) ";
-
-        String result = SqlUtils.logMinerContentsQuery(config, USERNAME);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(null, table));
-    }
-
-    @Test
-    @FixFor("DBZ-3009")
-    public void testLogMinerQueryWithSchemaTableIncludes() {
-        OracleConnectorConfig config = mock(OracleConnectorConfig.class);
-        Mockito.when(config.schemaIncludeList()).thenReturn("SCHEMA1,SCHEMA2");
-        Mockito.when(config.schemaExcludeList()).thenReturn(null);
-        Mockito.when(config.tableIncludeList()).thenReturn("DEBEZIUM\\.TABLEA,DEBEZIUM\\.TABLEB");
-        Mockito.when(config.tableExcludeList()).thenReturn(null);
-
-        String schema = "AND (REGEXP_LIKE(SEG_OWNER,'^SCHEMA1$','i') OR REGEXP_LIKE(SEG_OWNER,'^SCHEMA2$','i')) ";
-        String table = "AND (REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEA$','i') " +
-                "OR REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEB$','i')) ";
-
-        String result = SqlUtils.logMinerContentsQuery(config, USERNAME);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(schema, table));
-    }
-
-    @Test
-    @FixFor("DBZ-3009")
-    public void testLogMinerQueryWithSchemaTableExcludes() {
-        OracleConnectorConfig config = mock(OracleConnectorConfig.class);
-        Mockito.when(config.schemaIncludeList()).thenReturn(null);
-        Mockito.when(config.schemaExcludeList()).thenReturn("SCHEMA1,SCHEMA2");
-        Mockito.when(config.tableIncludeList()).thenReturn(null);
-        Mockito.when(config.tableExcludeList()).thenReturn("DEBEZIUM\\.TABLEA,DEBEZIUM\\.TABLEB");
-
-        String schema = "AND (NOT REGEXP_LIKE(SEG_OWNER,'^SCHEMA1$','i') AND NOT REGEXP_LIKE(SEG_OWNER,'^SCHEMA2$','i')) ";
-        String table = "AND (NOT REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEA$','i') " +
-                "AND NOT REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEB$','i')) ";
-
-        String result = SqlUtils.logMinerContentsQuery(config, USERNAME);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(schema, table));
-    }
-
-    @Test
-    @FixFor("DBZ-3009")
-    public void testLogMinerQueryWithSchemaExcludeTableInclude() {
-        OracleConnectorConfig config = mock(OracleConnectorConfig.class);
-        Mockito.when(config.schemaIncludeList()).thenReturn(null);
-        Mockito.when(config.schemaExcludeList()).thenReturn("SCHEMA1,SCHEMA2");
-        Mockito.when(config.tableIncludeList()).thenReturn("DEBEZIUM\\.TABLEA,DEBEZIUM\\.TABLEB");
-        Mockito.when(config.tableExcludeList()).thenReturn(null);
-
-        String schema = "AND (NOT REGEXP_LIKE(SEG_OWNER,'^SCHEMA1$','i') AND NOT REGEXP_LIKE(SEG_OWNER,'^SCHEMA2$','i')) ";
-        String table = "AND (REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEA$','i') " +
-                "OR REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEB$','i')) ";
-
-        String result = SqlUtils.logMinerContentsQuery(config, USERNAME);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(schema, table));
-    }
 
     @Test
     public void testStatements() {
@@ -325,29 +179,4 @@ public class SqlUtilsTest {
         assertThat(SqlUtils.connectionProblem(new Exception("12543 problem"))).isFalse();
     }
 
-    private String resolveLogMineryContentQueryFromTemplate(String schemaReplacement, String tableReplacement) {
-        String query = LOG_MINER_CONTENT_QUERY_TEMPLATE;
-
-        if (!OracleConnectorConfig.EXCLUDED_SCHEMAS.isEmpty()) {
-            StringBuilder systemPredicate = new StringBuilder();
-            systemPredicate.append("AND SEG_OWNER NOT IN (");
-            for (Iterator<String> i = OracleConnectorConfig.EXCLUDED_SCHEMAS.iterator(); i.hasNext();) {
-                String excludedSchema = i.next();
-                systemPredicate.append("'").append(excludedSchema.toUpperCase()).append("'");
-                if (i.hasNext()) {
-                    systemPredicate.append(",");
-                }
-            }
-            systemPredicate.append(") ");
-            query = query.replace("${systemTablePredicate}", systemPredicate.toString());
-        }
-        else {
-            query = query.replace("${systemTablePredicate}", "");
-        }
-
-        query = query.replace("${schemaPredicate}", schemaReplacement == null ? "" : schemaReplacement);
-        query = query.replace("${tablePredicate}", tableReplacement == null ? "" : tableReplacement);
-        query = query.replace("${user}", USERNAME);
-        return query;
-    }
 }

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1297,6 +1297,14 @@ Only alphanumeric characters, hyphens and underscores must be used.
 The safe default is `false`.
 Skipping should be used only with care as it can lead to data loss or mangling when the redo logs are being processed.
 
+|[[oracle-property-database-history-store-only-captured-tables-ddl]]<<oracle-property-database-history-store-only-captured-tables-ddl, `+database.history.store.only.captured.tables.ddl+`>>
+|`false`
+|A Boolean value that specifies whether the connector should record all DDL statements  +
++
+`true` records only those DDL statements that are relevant to tables whose changes are being captured by {prodname}. Set to `true` with care because missing data might become necessary if you change which tables have their changes captured. +
++
+The safe default is `false`.
+
 |[[oracle-property-snapshot-mode]]<<oracle-property-snapshot-mode, `+snapshot.mode+`>>
 |_initial_
 |A mode for taking an initial snapshot of the structure and optionally data of captured tables. Supported values are _initial_ (will take a snapshot of structure and data of captured tables; useful if topics should be populated with a complete representation of the data from the captured tables) and _schema_only_ (will take a snapshot of the structure of captured tables only; useful if only changes happening from now onwards should be propagated to topics). Once the snapshot is complete, the connector will continue reading change events from the database's redo logs.


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3634

So at the core this PR allows `DatabaseHistory.STORE_ONLY_CAPTURED_TABLES_DDL` to influence where the DDL predicate is placed in the LogMiner query.  If the setting is false, the behavior remains unchanged from the way the connector behaves now.  If the setting is true, the DDL events are predicated against the schema and table include/exclude lists.

In conjunction with this change, I took the opportunity to do a small refactor:

* All methods that relate to building the LogMiner query were moved to LogMinerQueryBuilder & removed from SqlUtils
* All tests related to LogMiner queries were moved to LogMinerQueryBuilderTest & removed from SqlUtilsTest
* The query was reworked have a slightly better SQL explain plan than before
* 