### PR TITLE
DBZ-3645 Make Oracle LOB support opt-in

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilder.java
@@ -72,11 +72,21 @@ public class LogMinerQueryBuilder {
             // are not part of the inclusion/exclusion lists.
             query.append(" OR ").append(buildDdlPredicate(userName)).append(" ");
             // Insert, Update, Delete, SelectLob, LobWrite, LobTrim, and LobErase
-            query.append(") OR (OPERATION_CODE IN (1,2,3,9,10,11,29) ");
+            if (connectorConfig.isLobEnabled()) {
+                query.append(") OR (OPERATION_CODE IN (1,2,3,9,10,11,29) ");
+            }
+            else {
+                query.append(") OR (OPERATION_CODE IN (1,2,3) ");
+            }
         }
         else {
             // Insert, Update, Delete, SelectLob, LobWrite, LobTrim, and LobErase
-            query.append(") OR ((OPERATION_CODE IN (1,2,3,9,10,11,29) ");
+            if (connectorConfig.isLobEnabled()) {
+                query.append(") OR ((OPERATION_CODE IN (1,2,3,9,10,11,29) ");
+            }
+            else {
+                query.append(") OR ((OPERATION_CODE IN (1,2,3) ");
+            }
             // In this mode, the connector will filter DDL operations based on the table inclusion/exclusion lists
             query.append("OR ").append(buildDdlPredicate(userName)).append(") ");
         }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
@@ -189,6 +189,10 @@ class LogMinerQueryResultProcessor {
                     break;
                 }
                 case RowMapper.SELECT_LOB_LOCATOR: {
+                    if (!connectorConfig.isLobEnabled()) {
+                        LOGGER.trace("SEL_LOB_LOCATOR operation skipped for '{}', LOB not enabled.", redoSql);
+                        continue;
+                    }
                     LOGGER.trace("SEL_LOB_LOCATOR: {}, REDO_SQL: {}", logMessage, redoSql);
                     final TableId tableId = RowMapper.getTableId(connectorConfig.getCatalogName(), resultSet);
                     final Table table = schema.tableFor(tableId);
@@ -204,6 +208,10 @@ class LogMinerQueryResultProcessor {
                     break;
                 }
                 case RowMapper.LOB_WRITE: {
+                    if (!connectorConfig.isLobEnabled()) {
+                        LOGGER.trace("LOB_WRITE operation skipped, LOB not enabled.");
+                        continue;
+                    }
                     final TableId tableId = RowMapper.getTableId(connectorConfig.getCatalogName(), resultSet);
                     if (schema.tableFor(tableId) == null) {
                         LogMinerHelper.logWarn(streamingMetrics, "LOB_WRITE for table '{}' is not known to the connector, skipped.", tableId);
@@ -214,6 +222,10 @@ class LogMinerQueryResultProcessor {
                     break;
                 }
                 case RowMapper.LOB_ERASE: {
+                    if (!connectorConfig.isLobEnabled()) {
+                        LOGGER.trace("LOB_ERASE operation skipped, LOB not enabled.");
+                        continue;
+                    }
                     final TableId tableId = RowMapper.getTableId(connectorConfig.getCatalogName(), resultSet);
                     if (schema.tableFor(tableId) == null) {
                         LogMinerHelper.logWarn(streamingMetrics, "LOB_ERASE for table '{}' is not known to the connector, skipped.", tableId);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -150,7 +150,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
                             streamingMetrics.calculateTimeDifference(getSystime(jdbcConnection));
 
                             Instant start = Instant.now();
-                            endScn = getEndScn(jdbcConnection, startScn, streamingMetrics, connectorConfig.getLogMiningBatchSizeDefault());
+                            endScn = getEndScn(jdbcConnection, startScn, endScn, streamingMetrics, connectorConfig.getLogMiningBatchSizeDefault());
                             flushLogWriter(jdbcConnection, jdbcConfiguration, isRac, racHosts);
 
                             if (hasLogSwitchOccurred()) {
@@ -170,11 +170,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
                                 currentRedoLogSequences = getCurrentRedoLogSequences();
                             }
 
-                            Scn miningStartScn = offsetContext.getCommitScn();
-                            if (miningStartScn == null) {
-                                miningStartScn = offsetContext.getScn();
-                            }
-                            startLogMining(jdbcConnection, miningStartScn, endScn, strategy, isContinuousMining, streamingMetrics);
+                            startLogMining(jdbcConnection, startScn, endScn, strategy, isContinuousMining, streamingMetrics);
 
                             LOGGER.trace("Fetching LogMiner view results SCN {} to {}", startScn, endScn);
                             stopwatch.start();

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -114,7 +114,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
      */
     @Override
     public void execute(ChangeEventSourceContext context, OracleOffsetContext offsetContext) {
-        try (TransactionalBuffer transactionalBuffer = new TransactionalBuffer(schema, clock, errorHandler, streamingMetrics)) {
+        try (TransactionalBuffer transactionalBuffer = new TransactionalBuffer(connectorConfig, schema, clock, errorHandler, streamingMetrics)) {
             try {
                 startScn = offsetContext.getScn();
                 createFlushTable(jdbcConnection);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBuffer.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/TransactionalBuffer.java
@@ -320,6 +320,8 @@ public final class TransactionalBuffer implements AutoCloseable {
                 dispatcher.dispatchHeartbeatEvent(offsetContext);
             }
 
+            streamingMetrics.calculateLagMetrics(timestamp.toInstant());
+
             if (lastCommittedScn.compareTo(maxCommittedScn) > 0) {
                 LOGGER.trace("Updated transaction buffer max commit SCN to '{}'", lastCommittedScn);
                 maxCommittedScn = lastCommittedScn;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -260,9 +260,11 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
 
     @Override
     public void processChunk(ChunkColumnValue chunk) throws StreamsException {
-        // Store the chunk in the chunk map
-        // Chunks will be processed once the end of the row is reached
-        columnChunks.computeIfAbsent(chunk.getColumnName(), v -> new ChunkColumnValues()).add(chunk);
+        if (connectorConfig.isLobEnabled()) {
+            // Store the chunk in the chunk map
+            // Chunks will be processed once the end of the row is reached
+            columnChunks.computeIfAbsent(chunk.getColumnName(), v -> new ChunkColumnValues()).add(chunk);
+        }
 
         if (chunk.isEndOfRow()) {
             try {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
@@ -89,6 +89,7 @@ public class OracleBlobDataTypesIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.BLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         start(OracleConnector.class, config);
@@ -120,6 +121,7 @@ public class OracleBlobDataTypesIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.BLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         start(OracleConnector.class, config);
@@ -265,6 +267,7 @@ public class OracleBlobDataTypesIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.BLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         start(OracleConnector.class, config);
@@ -418,6 +421,7 @@ public class OracleBlobDataTypesIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.BLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         start(OracleConnector.class, config);
@@ -564,6 +568,7 @@ public class OracleBlobDataTypesIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.BLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         start(OracleConnector.class, config);
@@ -720,6 +725,7 @@ public class OracleBlobDataTypesIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.BLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         start(OracleConnector.class, config);
@@ -907,6 +913,7 @@ public class OracleBlobDataTypesIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.BLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         LogInterceptor logInterceptor = new LogInterceptor();
@@ -955,6 +962,7 @@ public class OracleBlobDataTypesIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.BLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         start(OracleConnector.class, config);
@@ -1024,6 +1032,7 @@ public class OracleBlobDataTypesIT extends AbstractConnectorTest {
 
             Configuration config = TestHelper.defaultConfig()
                     .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM.DBZ3631")
+                    .with(OracleConnectorConfig.LOB_ENABLED, true)
                     .build();
 
             start(OracleConnector.class, config);
@@ -1060,6 +1069,95 @@ public class OracleBlobDataTypesIT extends AbstractConnectorTest {
         }
         finally {
             TestHelper.dropTable(connection, "dbz3631");
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-3645")
+    public void shouldNotEmitBlobFieldValuesWhenLobSupportIsNotEnabled() throws Exception {
+        boolean logMinerAdapter = TestHelper.adapter().equals(OracleConnectorConfig.ConnectorAdapter.LOG_MINER);
+        TestHelper.dropTable(connection, "dbz3645");
+        try {
+            connection.execute("CREATE TABLE dbz3645 (id numeric(9,0), data blob, primary key(id))");
+            TestHelper.streamTable(connection, "dbz3645");
+
+            // Small data
+            Blob blob1 = createBlob(part(BIN_DATA, 0, 250));
+            connection.prepareQuery("INSERT INTO dbz3645 (id,data) values (1,?)", ps -> ps.setBlob(1, blob1), null);
+
+            // Large data
+            Blob blob2 = createBlob(part(BIN_DATA, 0, 25000));
+            connection.prepareQuery("INSERT INTO dbz3645 (id,data) values (2,?)", ps -> ps.setBlob(1, blob2), null);
+            connection.commit();
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ3645")
+                    .with(OracleConnectorConfig.LOG_MINING_STRATEGY, "online_catalog")
+                    .with(OracleConnectorConfig.LOB_ENABLED, false)
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            // Get snapshot records
+            SourceRecords sourceRecords = consumeRecordsByTopic(2);
+            List<SourceRecord> table = sourceRecords.recordsForTopic(topicName("DBZ3645"));
+            assertThat(table).hasSize(2);
+
+            SourceRecord record = table.get(0);
+            Struct after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isNull();
+
+            record = table.get(1);
+            after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(2);
+            assertThat(after.get("DATA")).isNull();
+
+            // Small data and large data
+            connection.prepareQuery("INSERT INTO dbz3645 (id,data) values (3,?)", ps -> ps.setBlob(1, blob1), null);
+            connection.prepareQuery("INSERT INTO dbz3645 (id,data) values (4,?)", ps -> ps.setBlob(1, blob2), null);
+            connection.commit();
+
+            // Get streaming records
+            sourceRecords = consumeRecordsByTopic(logMinerAdapter ? 3 : 2);
+            table = sourceRecords.recordsForTopic(topicName("DBZ3645"));
+            assertThat(table).hasSize(3);
+
+            record = table.get(0);
+            after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(3);
+            assertThat(after.get("DATA")).isNull();
+            assertThat(((Struct) record.value()).get("op")).isEqualTo("c");
+
+            // LogMiner will pickup a separate update for BLOB fields.
+            // There is no way to differentiate this change from any other UPDATE so the connector
+            // will continue to emit it, but as a stand-alone UPDATE rather than merging it with
+            // the parent INSERT as it would when LOB is enabled.
+            if (logMinerAdapter) {
+                record = table.get(1);
+                after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+                assertThat(after.get("ID")).isEqualTo(3);
+                assertThat(after.get("DATA")).isEqualTo(getByteBufferFromBlob(blob1));
+                assertThat(((Struct) record.value()).get("op")).isEqualTo("u");
+            }
+
+            // the second insert won't emit an update due to the blob field being set by using the
+            // SELECT_LOB_LOCATOR, LOB_WRITE, and LOB_TRIM operators when using LogMiner and the
+            // BLOB field will be excluded automatically by Xstream due to skipping chunk processing.
+            record = table.get(logMinerAdapter ? 2 : 1);
+            after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(4);
+            assertThat(after.get("DATA")).isNull();
+            assertThat(((Struct) record.value()).get("op")).isEqualTo("c");
+
+            // As a sanity, there should be no more records.
+            assertNoRecordsToConsume();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz3645");
         }
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
@@ -97,6 +97,7 @@ public class OracleClobDataTypeIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         start(OracleConnector.class, config);
@@ -132,6 +133,7 @@ public class OracleClobDataTypeIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         start(OracleConnector.class, config);
@@ -311,6 +313,7 @@ public class OracleClobDataTypeIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         start(OracleConnector.class, config);
@@ -498,6 +501,7 @@ public class OracleClobDataTypeIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         start(OracleConnector.class, config);
@@ -678,6 +682,7 @@ public class OracleClobDataTypeIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         start(OracleConnector.class, config);
@@ -868,6 +873,7 @@ public class OracleClobDataTypeIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         start(OracleConnector.class, config);
@@ -1072,6 +1078,7 @@ public class OracleClobDataTypeIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         LogInterceptor logInterceptor = new LogInterceptor();
@@ -1122,6 +1129,7 @@ public class OracleClobDataTypeIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         start(OracleConnector.class, config);
@@ -1199,6 +1207,7 @@ public class OracleClobDataTypeIT extends AbstractConnectorTest {
 
         Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CLOB_TEST")
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         start(OracleConnector.class, config);
@@ -1409,6 +1418,7 @@ public class OracleClobDataTypeIT extends AbstractConnectorTest {
 
             Configuration config = TestHelper.defaultConfig()
                     .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM.DBZ3631")
+                    .with(OracleConnectorConfig.LOB_ENABLED, true)
                     .build();
 
             start(OracleConnector.class, config);
@@ -1445,6 +1455,93 @@ public class OracleClobDataTypeIT extends AbstractConnectorTest {
         }
         finally {
             TestHelper.dropTable(connection, "dbz3631");
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-3645")
+    public void shouldNotEmitClobFieldValuesWhenLobSupportIsNotEnabled() throws Exception {
+        boolean logMinerAdapter = TestHelper.adapter().equals(OracleConnectorConfig.ConnectorAdapter.LOG_MINER);
+        TestHelper.dropTable(connection, "dbz3645");
+        try {
+            connection.execute("CREATE TABLE dbz3645 (id numeric(9,0), data clob, primary key(id))");
+            TestHelper.streamTable(connection, "dbz3645");
+
+            // Small data
+            connection.execute("INSERT INTO dbz3645 (id,data) values (1,'Test1')");
+
+            // Large data
+            Clob clob1 = createClob(part(JSON_DATA, 0, 25000));
+            connection.prepareQuery("INSERT INTO dbz3645 (id,data) values (2,?)", ps -> ps.setClob(1, clob1), null);
+            connection.commit();
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ3645")
+                    .with(OracleConnectorConfig.LOB_ENABLED, false)
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            // Get snapshot records
+            SourceRecords sourceRecords = consumeRecordsByTopic(2);
+            List<SourceRecord> table = sourceRecords.recordsForTopic(topicName("DBZ3645"));
+            assertThat(table).hasSize(2);
+
+            SourceRecord record = table.get(0);
+            Struct after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isNull();
+
+            record = table.get(1);
+            after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(2);
+            assertThat(after.get("DATA")).isNull();
+
+            // Small data and large data
+            connection.executeWithoutCommitting("INSERT INTO dbz3645 (id,data) values (3,'Test3')");
+            connection.prepareQuery("INSERT INTO dbz3645 (id,data) values (4,?)", ps -> ps.setClob(1, clob1), null);
+            connection.commit();
+
+            // Get streaming records
+            sourceRecords = consumeRecordsByTopic(logMinerAdapter ? 3 : 2);
+            table = sourceRecords.recordsForTopic(topicName("DBZ3645"));
+            assertThat(table).hasSize(3);
+
+            record = table.get(0);
+            after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(3);
+            assertThat(after.get("DATA")).isNull();
+            assertThat(((Struct) record.value()).get("op")).isEqualTo("c");
+
+            // LogMiner will pickup a separate update for CLOB fields.
+            // There is no way to differentiate this change from any other UPDATE so the connector
+            // will continue to emit it, but as a stand-alone UPDATE rather than merging it with
+            // the parent INSERT as it would when LOB is enabled.
+            if (logMinerAdapter) {
+                record = table.get(1);
+                after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+                assertThat(after.get("ID")).isEqualTo(3);
+                assertThat(after.get("DATA")).isEqualTo("Test3");
+                assertThat(((Struct) record.value()).get("op")).isEqualTo("u");
+            }
+
+            // the second insert won't emit an update due to the clob field being set by using the
+            // SELECT_LOB_LOCATOR, LOB_WRITE, and LOB_TRIM operators when using LogMiner and the
+            // CLOB field will be excluded automatically by Xstream due to skipping chunk processing.
+            record = table.get(logMinerAdapter ? 2 : 1);
+            after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(4);
+            assertThat(after.get("DATA")).isNull();
+            assertThat(((Struct) record.value()).get("op")).isEqualTo("c");
+
+            // As a sanity, there should be no more records.
+            assertNoRecordsToConsume();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz3645");
         }
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -1600,6 +1600,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
 
             Configuration config = TestHelper.defaultConfig()
                     .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.CLOB_TEST")
+                    .with(OracleConnectorConfig.LOB_ENABLED, true)
                     .build();
 
             start(OracleConnector.class, config);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SnapshotDatatypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SnapshotDatatypesIT.java
@@ -55,6 +55,7 @@ public class SnapshotDatatypesIT extends AbstractOracleDatatypesTest {
 
         Configuration config = connectorConfig()
                 .with(OracleConnectorConfig.TIME_PRECISION_MODE, temporalPrecisionMode)
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         start(OracleConnector.class, config);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/StreamingDatatypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/StreamingDatatypesIT.java
@@ -44,6 +44,7 @@ public class StreamingDatatypesIT extends AbstractOracleDatatypesTest {
 
         Configuration config = connectorConfig()
                 .with(OracleConnectorConfig.TIME_PRECISION_MODE, temporalPrecisionMode)
+                .with(OracleConnectorConfig.LOB_ENABLED, true)
                 .build();
 
         createTables();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionalBufferTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/TransactionalBufferTest.java
@@ -110,7 +110,7 @@ public class TransactionalBufferTest {
         clock = mock(Clock.class);
 
         streamingMetrics = new OracleStreamingChangeEventSourceMetrics(taskContext, queue, null, connectorConfig);
-        transactionalBuffer = new TransactionalBuffer(schema, clock, errorHandler, streamingMetrics);
+        transactionalBuffer = new TransactionalBuffer(connectorConfig, schema, clock, errorHandler, streamingMetrics);
     }
 
     @After

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1526,6 +1526,14 @@ Any transaction that exceeds this configured value will be discarded entirely an
 While this option allows the behavior to be configured on a case-by-case basis,
 we have plans to enhance this behavior in a future release by means of adding a scalable transaction buffer, (see {link-prefix}:{jira-url}/browse/DBZ-3123[DBZ-3123]).
 
+|[[oracle-property-lob-enabled]]<<oracle-property-lob-enabled, `+lob.enabled+`>>
+|`false`
+|Controls whether or not large object (CLOB or BLOB) column values are emitted in change events. +
+ +
+By default, change events will have large object columns but they will not have any values.
+There is a certain amount of overhead in processing and managing large object column types and payloads.
+In order to capture large object values and have them serialized in the change events, set this option to `true`.
+
 |[[oracle-property-rac-nodes]]<<oracle-property-rac-nodes, `+rac.nodes+`>>
 |
 |A comma-separated list of RAC node host names or addresses.


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3645

- [X] Introduce new configuration option `lob.enabled` to control whether LOB fields are processed.
- [x] Document new configuration option
- [x] ~~Change SCN mining window to re-query when commits occur to transactions started before window.~~
- [x] Guarantee `getEndScn()` function never returns a SCN before the starting SCN