### PR TITLE
DBZ-2975: Add partition awareness to source task components

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeEventSourceFactory.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeEventSourceFactory.java
@@ -19,7 +19,7 @@ import io.debezium.util.Clock;
  *
  * @author Chris Cranford
  */
-public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory<MongoDbOffsetContext> {
+public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory<MongoDbPartition, MongoDbOffsetContext> {
 
     private final MongoDbConnectorConfig configuration;
     private final ErrorHandler errorHandler;
@@ -39,7 +39,7 @@ public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory
     }
 
     @Override
-    public SnapshotChangeEventSource<MongoDbOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
+    public SnapshotChangeEventSource<MongoDbPartition, MongoDbOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
         return new MongoDbSnapshotChangeEventSource(
                 configuration,
                 taskContext,
@@ -51,7 +51,7 @@ public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory
     }
 
     @Override
-    public StreamingChangeEventSource<MongoDbOffsetContext> getStreamingChangeEventSource() {
+    public StreamingChangeEventSource<MongoDbPartition, MongoDbOffsetContext> getStreamingChangeEventSource() {
         return new MongoDbStreamingChangeEventSource(
                 configuration,
                 taskContext,

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbPartition.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbPartition.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import java.util.Map;
+
+import io.debezium.connector.common.Partition;
+
+public class MongoDbPartition implements Partition {
+
+    @Override
+    public Map<String, String> getSourcePartition() {
+        throw new UnsupportedOperationException("Currently unsupported by the MongoDB connector");
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        throw new UnsupportedOperationException("Currently unsupported by the MongoDB connector");
+    }
+
+    @Override
+    public int hashCode() {
+        throw new UnsupportedOperationException("Currently unsupported by the MongoDB connector");
+    }
+}

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
@@ -49,7 +49,7 @@ import io.debezium.util.Threads;
  *
  * @author Chris Cranford
  */
-public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEventSource<MongoDbOffsetContext> {
+public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEventSource<MongoDbPartition, MongoDbOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbSnapshotChangeEventSource.class);
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
@@ -47,7 +47,7 @@ import io.debezium.util.Threads;
  *
  * @author Chris Cranford
  */
-public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSource<MongoDbOffsetContext> {
+public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSource<MongoDbPartition, MongoDbOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbStreamingChangeEventSource.class);
 
@@ -79,7 +79,8 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
     }
 
     @Override
-    public void execute(ChangeEventSourceContext context, MongoDbOffsetContext offsetContext) throws InterruptedException {
+    public void execute(ChangeEventSourceContext context, MongoDbPartition partition, MongoDbOffsetContext offsetContext)
+            throws InterruptedException {
         final List<ReplicaSet> validReplicaSets = replicaSets.validReplicaSets();
 
         if (offsetContext == null) {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceFactory.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceFactory.java
@@ -25,7 +25,7 @@ import io.debezium.relational.TableId;
 import io.debezium.schema.DataCollectionId;
 import io.debezium.util.Clock;
 
-public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<MySqlOffsetContext> {
+public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<MySqlPartition, MySqlOffsetContext> {
 
     private final MySqlConnectorConfig configuration;
     private final MySqlConnection connection;
@@ -57,7 +57,7 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<M
     }
 
     @Override
-    public SnapshotChangeEventSource<MySqlOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
+    public SnapshotChangeEventSource<MySqlPartition, MySqlOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
         return new MySqlSnapshotChangeEventSource(configuration, connection, taskContext.getSchema(), dispatcher, clock,
                 (MySqlSnapshotChangeEventSourceMetrics) snapshotProgressListener, record -> modifyAndFlushLastRecord(record));
     }
@@ -68,7 +68,7 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<M
     }
 
     @Override
-    public StreamingChangeEventSource<MySqlOffsetContext> getStreamingChangeEventSource() {
+    public StreamingChangeEventSource<MySqlPartition, MySqlOffsetContext> getStreamingChangeEventSource() {
         queue.disableBuffering();
         return new MySqlStreamingChangeEventSource(
                 configuration,

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlOffsetContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlOffsetContext.java
@@ -195,11 +195,6 @@ public class MySqlOffsetContext implements OffsetContext {
         }
 
         @Override
-        public Map<String, ?> getPartition() {
-            return Collections.singletonMap(SERVER_PARTITION_KEY, connectorConfig.getLogicalName());
-        }
-
-        @Override
         public MySqlOffsetContext load(Map<String, ?> offset) {
             boolean snapshot = Boolean.TRUE.equals(offset.get(SourceInfo.SNAPSHOT_KEY)) || "true".equals(offset.get(SourceInfo.SNAPSHOT_KEY));
             boolean snapshotCompleted = Boolean.TRUE.equals(offset.get(SNAPSHOT_COMPLETED_KEY)) || "true".equals(offset.get(SNAPSHOT_COMPLETED_KEY));

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlPartition.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlPartition.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import io.debezium.connector.common.Partition;
+import io.debezium.util.Collect;
+
+public class MySqlPartition implements Partition {
+    private static final String SERVER_PARTITION_KEY = "server";
+
+    private final String serverName;
+
+    public MySqlPartition(String serverName) {
+        this.serverName = serverName;
+    }
+
+    @Override
+    public Map<String, String> getSourcePartition() {
+        return Collect.hashMapOf(SERVER_PARTITION_KEY, serverName);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final MySqlPartition other = (MySqlPartition) obj;
+        return Objects.equals(serverName, other.serverName);
+    }
+
+    @Override
+    public int hashCode() {
+        return serverName.hashCode();
+    }
+
+    static class Provider implements Partition.Provider<MySqlPartition> {
+        private final MySqlConnectorConfig connectorConfig;
+
+        Provider(MySqlConnectorConfig connectorConfig) {
+            this.connectorConfig = connectorConfig;
+        }
+
+        @Override
+        public Set<MySqlPartition> getPartitions() {
+            return Collections.singleton(new MySqlPartition(connectorConfig.getLogicalName()));
+        }
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
@@ -44,7 +44,7 @@ import io.debezium.util.Clock;
 import io.debezium.util.Collect;
 import io.debezium.util.Strings;
 
-public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEventSource<MySqlOffsetContext> {
+public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEventSource<MySqlPartition, MySqlOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MySqlSnapshotChangeEventSource.class);
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -87,7 +87,7 @@ import io.debezium.util.Threads;
  *
  * @author Jiri Pechanec
  */
-public class MySqlStreamingChangeEventSource implements StreamingChangeEventSource<MySqlOffsetContext> {
+public class MySqlStreamingChangeEventSource implements StreamingChangeEventSource<MySqlPartition, MySqlOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MySqlStreamingChangeEventSource.class);
 
@@ -793,7 +793,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
     }
 
     @Override
-    public void execute(ChangeEventSourceContext context, MySqlOffsetContext offsetContext) throws InterruptedException {
+    public void execute(ChangeEventSourceContext context, MySqlPartition partition, MySqlOffsetContext offsetContext) throws InterruptedException {
         if (!connectorConfig.getSnapshotMode().shouldStream()) {
             LOGGER.info("Streaming is disabled for snapshot mode {}", connectorConfig.getSnapshotMode());
             return;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/MySqlConnectorTask.java
@@ -32,6 +32,7 @@ import io.debezium.connector.mysql.MySqlConnector;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
 import io.debezium.connector.mysql.MySqlOffsetContext;
+import io.debezium.connector.mysql.MySqlPartition;
 import io.debezium.pipeline.ChangeEventSourceCoordinator;
 import io.debezium.schema.TopicSelector;
 import io.debezium.util.Collect;
@@ -45,7 +46,7 @@ import io.debezium.util.LoggingContext.PreviousContext;
  * @author Randall Hauch
  */
 @NotThreadSafe
-public final class MySqlConnectorTask extends BaseSourceTask<MySqlOffsetContext> {
+public final class MySqlConnectorTask extends BaseSourceTask<MySqlPartition, MySqlOffsetContext> {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private volatile MySqlTaskContext taskContext;
@@ -67,7 +68,7 @@ public final class MySqlConnectorTask extends BaseSourceTask<MySqlOffsetContext>
     }
 
     @Override
-    public ChangeEventSourceCoordinator<MySqlOffsetContext> start(Configuration config) {
+    public ChangeEventSourceCoordinator<MySqlPartition, MySqlOffsetContext> start(Configuration config) {
         final String serverName = config.getString(MySqlConnectorConfig.SERVER_NAME);
         PreviousContext prevLoggingContext = LoggingContext.forConnector(Module.contextName(), serverName, "task");
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -674,11 +674,13 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         stopConnector();
 
         // Read the last committed offsets, and verify the binlog coordinates ...
+        final String serverName = config.getString(MySqlConnectorConfig.SERVER_NAME);
         final MySqlOffsetContext.Loader loader = new MySqlOffsetContext.Loader(new MySqlConnectorConfig(Configuration.create()
-                .with(MySqlConnectorConfig.SERVER_NAME, config.getString(MySqlConnectorConfig.SERVER_NAME))
+                .with(MySqlConnectorConfig.SERVER_NAME, serverName)
                 .build()));
-        Map<String, ?> lastCommittedOffset = readLastCommittedOffset(config, loader.getPartition());
-        final MySqlOffsetContext offsetContext = (MySqlOffsetContext) loader.load(lastCommittedOffset);
+        final Map<String, String> partition = new MySqlPartition(serverName).getSourcePartition();
+        Map<String, ?> lastCommittedOffset = readLastCommittedOffset(config, partition);
+        final MySqlOffsetContext offsetContext = loader.load(lastCommittedOffset);
         final SourceInfo persistedOffsetSource = offsetContext.getSource();
         Testing.print("Position before inserts: " + positionBeforeInserts);
         Testing.print("Position after inserts:  " + positionAfterInserts);

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlPartitionTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlPartitionTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import io.debezium.connector.common.AbstractPartitionTest;
+
+public class MySqlPartitionTest extends AbstractPartitionTest<MySqlPartition> {
+
+    @Override
+    protected MySqlPartition createPartition1() {
+        return new MySqlPartition("server1");
+    }
+
+    @Override
+    protected MySqlPartition createPartition2() {
+        return new MySqlPartition("server2");
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
@@ -15,7 +15,7 @@ import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
 import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
 
-public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory<OracleOffsetContext> {
+public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory<OraclePartition, OracleOffsetContext> {
 
     private final OracleConnectorConfig configuration;
     private final OracleConnection jdbcConnection;
@@ -43,13 +43,13 @@ public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory<
     }
 
     @Override
-    public SnapshotChangeEventSource<OracleOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
+    public SnapshotChangeEventSource<OraclePartition, OracleOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
         return new OracleSnapshotChangeEventSource(configuration, jdbcConnection,
                 schema, dispatcher, clock, snapshotProgressListener);
     }
 
     @Override
-    public StreamingChangeEventSource<OracleOffsetContext> getStreamingChangeEventSource() {
+    public StreamingChangeEventSource<OraclePartition, OracleOffsetContext> getStreamingChangeEventSource() {
         return configuration.getAdapter().getSource(
                 jdbcConnection,
                 dispatcher,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OraclePartition.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OraclePartition.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import io.debezium.connector.common.Partition;
+import io.debezium.util.Collect;
+
+public class OraclePartition implements Partition {
+    private static final String SERVER_PARTITION_KEY = "server";
+
+    private final String serverName;
+
+    public OraclePartition(String serverName) {
+        this.serverName = serverName;
+    }
+
+    @Override
+    public Map<String, String> getSourcePartition() {
+        return Collect.hashMapOf(SERVER_PARTITION_KEY, serverName);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final OraclePartition other = (OraclePartition) obj;
+        return Objects.equals(serverName, other.serverName);
+    }
+
+    @Override
+    public int hashCode() {
+        return serverName.hashCode();
+    }
+
+    static class Provider implements Partition.Provider<OraclePartition> {
+        private final OracleConnectorConfig connectorConfig;
+
+        Provider(OracleConnectorConfig connectorConfig) {
+            this.connectorConfig = connectorConfig;
+        }
+
+        @Override
+        public Set<OraclePartition> getPartitions() {
+            return Collections.singleton(new OraclePartition(connectorConfig.getLogicalName()));
+        }
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -32,7 +32,7 @@ import io.debezium.util.Clock;
  *
  * @author Gunnar Morling
  */
-public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEventSource<OracleOffsetContext> {
+public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEventSource<OraclePartition, OracleOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OracleSnapshotChangeEventSource.class);
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
@@ -48,10 +48,13 @@ public interface StreamingAdapter {
 
     OffsetContext.Loader<OracleOffsetContext> getOffsetContextLoader();
 
-    StreamingChangeEventSource<OracleOffsetContext> getSource(OracleConnection connection, EventDispatcher<TableId> dispatcher,
-                                                              ErrorHandler errorHandler, Clock clock, OracleDatabaseSchema schema,
-                                                              OracleTaskContext taskContext, Configuration jdbcConfig,
-                                                              OracleStreamingChangeEventSourceMetrics streamingMetrics);
+    StreamingChangeEventSource<OraclePartition, OracleOffsetContext> getSource(OracleConnection connection,
+                                                                               EventDispatcher<TableId> dispatcher,
+                                                                               ErrorHandler errorHandler, Clock clock,
+                                                                               OracleDatabaseSchema schema,
+                                                                               OracleTaskContext taskContext,
+                                                                               Configuration jdbcConfig,
+                                                                               OracleStreamingChangeEventSourceMetrics streamingMetrics);
 
     /**
      * Returns whether table names are case sensitive.

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
@@ -11,6 +11,7 @@ import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.OracleOffsetContext;
+import io.debezium.connector.oracle.OraclePartition;
 import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
 import io.debezium.connector.oracle.OracleTaskContext;
 import io.debezium.document.Document;
@@ -54,14 +55,14 @@ public class LogMinerAdapter extends AbstractStreamingAdapter {
     }
 
     @Override
-    public StreamingChangeEventSource<OracleOffsetContext> getSource(OracleConnection connection,
-                                                                     EventDispatcher<TableId> dispatcher,
-                                                                     ErrorHandler errorHandler,
-                                                                     Clock clock,
-                                                                     OracleDatabaseSchema schema,
-                                                                     OracleTaskContext taskContext,
-                                                                     Configuration jdbcConfig,
-                                                                     OracleStreamingChangeEventSourceMetrics streamingMetrics) {
+    public StreamingChangeEventSource<OraclePartition, OracleOffsetContext> getSource(OracleConnection connection,
+                                                                                      EventDispatcher<TableId> dispatcher,
+                                                                                      ErrorHandler errorHandler,
+                                                                                      Clock clock,
+                                                                                      OracleDatabaseSchema schema,
+                                                                                      OracleTaskContext taskContext,
+                                                                                      Configuration jdbcConfig,
+                                                                                      OracleStreamingChangeEventSourceMetrics streamingMetrics) {
         return new LogMinerStreamingChangeEventSource(
                 connectorConfig,
                 connection,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerOracleOffsetContextLoader.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerOracleOffsetContextLoader.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.oracle.logminer;
 
-import java.util.Collections;
 import java.util.Map;
 
 import io.debezium.connector.oracle.OracleConnectorConfig;
@@ -24,11 +23,6 @@ public class LogMinerOracleOffsetContextLoader implements OffsetContext.Loader<O
 
     public LogMinerOracleOffsetContextLoader(OracleConnectorConfig connectorConfig) {
         this.connectorConfig = connectorConfig;
-    }
-
-    @Override
-    public Map<String, ?> getPartition() {
-        return Collections.singletonMap(OracleOffsetContext.SERVER_PARTITION_KEY, connectorConfig.getLogicalName());
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -45,6 +45,7 @@ import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.OracleOffsetContext;
+import io.debezium.connector.oracle.OraclePartition;
 import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
 import io.debezium.connector.oracle.Scn;
 import io.debezium.jdbc.JdbcConfiguration;
@@ -60,7 +61,7 @@ import io.debezium.util.Stopwatch;
  * A {@link StreamingChangeEventSource} based on Oracle's LogMiner utility.
  * The event handler loop is executed in a separate executor.
  */
-public class LogMinerStreamingChangeEventSource implements StreamingChangeEventSource<OracleOffsetContext> {
+public class LogMinerStreamingChangeEventSource implements StreamingChangeEventSource<OraclePartition, OracleOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LogMinerStreamingChangeEventSource.class);
 
@@ -115,7 +116,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
      *         change event source context
      */
     @Override
-    public void execute(ChangeEventSourceContext context, OracleOffsetContext offsetContext) {
+    public void execute(ChangeEventSourceContext context, OraclePartition partition, OracleOffsetContext offsetContext) {
         try (TransactionalBuffer transactionalBuffer = new TransactionalBuffer(connectorConfig, schema, clock, errorHandler, streamingMetrics)) {
             try {
                 startScn = offsetContext.getScn();

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamAdapter.java
@@ -11,6 +11,7 @@ import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.OracleOffsetContext;
+import io.debezium.connector.oracle.OraclePartition;
 import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
 import io.debezium.connector.oracle.OracleTaskContext;
 import io.debezium.connector.oracle.Scn;
@@ -65,14 +66,14 @@ public class XStreamAdapter extends AbstractStreamingAdapter {
     }
 
     @Override
-    public StreamingChangeEventSource<OracleOffsetContext> getSource(OracleConnection connection,
-                                                                     EventDispatcher<TableId> dispatcher,
-                                                                     ErrorHandler errorHandler,
-                                                                     Clock clock,
-                                                                     OracleDatabaseSchema schema,
-                                                                     OracleTaskContext taskContext,
-                                                                     Configuration jdbcConfig,
-                                                                     OracleStreamingChangeEventSourceMetrics streamingMetrics) {
+    public StreamingChangeEventSource<OraclePartition, OracleOffsetContext> getSource(OracleConnection connection,
+                                                                                      EventDispatcher<TableId> dispatcher,
+                                                                                      ErrorHandler errorHandler,
+                                                                                      Clock clock,
+                                                                                      OracleDatabaseSchema schema,
+                                                                                      OracleTaskContext taskContext,
+                                                                                      Configuration jdbcConfig,
+                                                                                      OracleStreamingChangeEventSourceMetrics streamingMetrics) {
         return new XstreamStreamingChangeEventSource(
                 connectorConfig,
                 connection,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamOracleOffsetContextLoader.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamOracleOffsetContextLoader.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.oracle.xstream;
 
-import java.util.Collections;
 import java.util.Map;
 
 import io.debezium.connector.oracle.OracleConnectorConfig;
@@ -26,11 +25,6 @@ public class XStreamOracleOffsetContextLoader implements OffsetContext.Loader<Or
 
     public XStreamOracleOffsetContextLoader(OracleConnectorConfig connectorConfig) {
         this.connectorConfig = connectorConfig;
-    }
-
-    @Override
-    public Map<String, ?> getPartition() {
-        return Collections.singletonMap(OracleOffsetContext.SERVER_PARTITION_KEY, connectorConfig.getLogicalName());
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -17,6 +17,7 @@ import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.OracleDatabaseVersion;
 import io.debezium.connector.oracle.OracleOffsetContext;
+import io.debezium.connector.oracle.OraclePartition;
 import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
 import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.SourceInfo;
@@ -39,7 +40,7 @@ import oracle.streams.XStreamUtility;
  *
  * @author Gunnar Morling
  */
-public class XstreamStreamingChangeEventSource implements StreamingChangeEventSource<OracleOffsetContext> {
+public class XstreamStreamingChangeEventSource implements StreamingChangeEventSource<OraclePartition, OracleOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(XstreamStreamingChangeEventSource.class);
 
@@ -78,7 +79,8 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
     }
 
     @Override
-    public void execute(ChangeEventSourceContext context, OracleOffsetContext offsetContext) throws InterruptedException {
+    public void execute(ChangeEventSourceContext context, OraclePartition partition, OracleOffsetContext offsetContext)
+            throws InterruptedException {
 
         LcrEventHandler eventHandler = new LcrEventHandler(connectorConfig, errorHandler, dispatcher, clock, schema, offsetContext,
                 TableNameCaseSensitivity.INSENSITIVE.equals(connectorConfig.getAdapter().getTableNameCaseSensitivity(jdbcConnection)), this,

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OraclePartitionTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OraclePartitionTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle;
+
+import io.debezium.connector.common.AbstractPartitionTest;
+
+public class OraclePartitionTest extends AbstractPartitionTest<OraclePartition> {
+
+    @Override
+    protected OraclePartition createPartition1() {
+        return new OraclePartition("server1");
+    }
+
+    @Override
+    protected OraclePartition createPartition2() {
+        return new OraclePartition("server2");
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFactory.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFactory.java
@@ -25,7 +25,7 @@ import io.debezium.relational.TableId;
 import io.debezium.schema.DataCollectionId;
 import io.debezium.util.Clock;
 
-public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactory<PostgresOffsetContext> {
+public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactory<PostgresPartition, PostgresOffsetContext> {
 
     private final PostgresConnectorConfig configuration;
     private final PostgresConnection jdbcConnection;
@@ -57,7 +57,7 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
     }
 
     @Override
-    public SnapshotChangeEventSource<PostgresOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
+    public SnapshotChangeEventSource<PostgresPartition, PostgresOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
         return new PostgresSnapshotChangeEventSource(
                 configuration,
                 snapshotter,
@@ -71,7 +71,7 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
     }
 
     @Override
-    public StreamingChangeEventSource<PostgresOffsetContext> getStreamingChangeEventSource() {
+    public StreamingChangeEventSource<PostgresPartition, PostgresOffsetContext> getStreamingChangeEventSource() {
         return new PostgresStreamingChangeEventSource(
                 configuration,
                 snapshotter,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.connect.errors.ConnectException;
@@ -49,7 +50,7 @@ import io.debezium.util.SchemaNameAdjuster;
  *
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
-public class PostgresConnectorTask extends BaseSourceTask<PostgresOffsetContext> {
+public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, PostgresOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgresConnectorTask.class);
     private static final String CONTEXT_NAME = "postgres-connector-task";
@@ -61,7 +62,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresOffsetContext>
     private volatile PostgresSchema schema;
 
     @Override
-    public ChangeEventSourceCoordinator<PostgresOffsetContext> start(Configuration config) {
+    public ChangeEventSourceCoordinator<PostgresPartition, PostgresOffsetContext> start(Configuration config) {
         final PostgresConnectorConfig connectorConfig = new PostgresConnectorConfig(config);
         final TopicSelector<TableId> topicSelector = PostgresTopicSelector.create(connectorConfig);
         final Snapshotter snapshotter = connectorConfig.getSnapshotter();
@@ -93,8 +94,10 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresOffsetContext>
 
         schema = new PostgresSchema(connectorConfig, typeRegistry, topicSelector, valueConverterBuilder.build(typeRegistry));
         this.taskContext = new PostgresTaskContext(connectorConfig, schema, topicSelector);
-        final PostgresOffsetContext previousOffset = getPreviousOffset(new PostgresOffsetContext.Loader(connectorConfig));
+        final Map<PostgresPartition, PostgresOffsetContext> previousOffsets = getPreviousOffsets(
+                new PostgresPartition.Provider(connectorConfig), new PostgresOffsetContext.Loader(connectorConfig));
         final Clock clock = Clock.system();
+        final PostgresOffsetContext previousOffset = getTheOnlyOffset(previousOffsets);
 
         LoggingContext.PreviousContext previousContext = taskContext.configureLoggingContext(CONTEXT_NAME);
         try {
@@ -197,8 +200,8 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresOffsetContext>
                     schemaNameAdjuster,
                     jdbcConnection);
 
-            ChangeEventSourceCoordinator<PostgresOffsetContext> coordinator = new PostgresChangeEventSourceCoordinator(
-                    previousOffset,
+            ChangeEventSourceCoordinator<PostgresPartition, PostgresOffsetContext> coordinator = new PostgresChangeEventSourceCoordinator(
+                    previousOffsets,
                     errorHandler,
                     PostgresConnector.class,
                     connectorConfig,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresOffsetContext.java
@@ -195,11 +195,6 @@ public class PostgresOffsetContext implements OffsetContext {
             this.connectorConfig = connectorConfig;
         }
 
-        @Override
-        public Map<String, ?> getPartition() {
-            return Collections.singletonMap(SERVER_PARTITION_KEY, connectorConfig.getLogicalName());
-        }
-
         private Long readOptionalLong(Map<String, ?> offset, String key) {
             final Object obj = offset.get(key);
             return (obj == null) ? null : ((Number) obj).longValue();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPartition.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresPartition.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import io.debezium.connector.common.Partition;
+import io.debezium.util.Collect;
+
+public class PostgresPartition implements Partition {
+    private static final String SERVER_PARTITION_KEY = "server";
+
+    private final String serverName;
+
+    public PostgresPartition(String serverName) {
+        this.serverName = serverName;
+    }
+
+    @Override
+    public Map<String, String> getSourcePartition() {
+        return Collect.hashMapOf(SERVER_PARTITION_KEY, serverName);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final PostgresPartition other = (PostgresPartition) obj;
+        return Objects.equals(serverName, other.serverName);
+    }
+
+    @Override
+    public int hashCode() {
+        return serverName.hashCode();
+    }
+
+    static class Provider implements Partition.Provider<PostgresPartition> {
+        private final PostgresConnectorConfig connectorConfig;
+
+        Provider(PostgresConnectorConfig connectorConfig) {
+            this.connectorConfig = connectorConfig;
+        }
+
+        @Override
+        public Set<PostgresPartition> getPartitions() {
+            return Collections.singleton(new PostgresPartition(connectorConfig.getLogicalName()));
+        }
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -29,7 +29,7 @@ import io.debezium.schema.SchemaChangeEvent;
 import io.debezium.schema.SchemaChangeEvent.SchemaChangeEventType;
 import io.debezium.util.Clock;
 
-public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeEventSource<PostgresOffsetContext> {
+public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeEventSource<PostgresPartition, PostgresOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgresSnapshotChangeEventSource.class);
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -35,7 +35,7 @@ import io.debezium.util.Threads;
  *
  * @author Horia Chiorean (hchiorea@redhat.com), Jiri Pechanec
  */
-public class PostgresStreamingChangeEventSource implements StreamingChangeEventSource<PostgresOffsetContext> {
+public class PostgresStreamingChangeEventSource implements StreamingChangeEventSource<PostgresPartition, PostgresOffsetContext> {
 
     private static final String KEEP_ALIVE_THREAD_NAME = "keep-alive";
 
@@ -86,7 +86,8 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
     }
 
     @Override
-    public void execute(ChangeEventSourceContext context, PostgresOffsetContext offsetContext) throws InterruptedException {
+    public void execute(ChangeEventSourceContext context, PostgresPartition partition, PostgresOffsetContext offsetContext)
+            throws InterruptedException {
         if (!snapshotter.shouldStream()) {
             LOGGER.info("Streaming is not enabled in correct configuration");
             return;

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresPartitionTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresPartitionTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import io.debezium.connector.common.AbstractPartitionTest;
+
+public class PostgresPartitionTest extends AbstractPartitionTest<PostgresPartition> {
+
+    @Override
+    protected PostgresPartition createPartition1() {
+        return new PostgresPartition("server1");
+    }
+
+    @Override
+    protected PostgresPartition createPartition2() {
+        return new PostgresPartition("server2");
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
@@ -20,7 +20,7 @@ import io.debezium.relational.TableId;
 import io.debezium.schema.DataCollectionId;
 import io.debezium.util.Clock;
 
-public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFactory<SqlServerOffsetContext> {
+public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFactory<SqlServerPartition, SqlServerOffsetContext> {
 
     private final SqlServerConnectorConfig configuration;
     private final SqlServerConnection dataConnection;
@@ -42,13 +42,13 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
     }
 
     @Override
-    public SnapshotChangeEventSource<SqlServerOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
+    public SnapshotChangeEventSource<SqlServerPartition, SqlServerOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
         return new SqlServerSnapshotChangeEventSource(configuration, dataConnection, schema, dispatcher, clock,
                 snapshotProgressListener);
     }
 
     @Override
-    public StreamingChangeEventSource<SqlServerOffsetContext> getStreamingChangeEventSource() {
+    public StreamingChangeEventSource<SqlServerPartition, SqlServerOffsetContext> getStreamingChangeEventSource() {
         return new SqlServerStreamingChangeEventSource(
                 configuration,
                 dataConnection,

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerOffsetContext.java
@@ -149,11 +149,6 @@ public class SqlServerOffsetContext implements OffsetContext {
         }
 
         @Override
-        public Map<String, ?> getPartition() {
-            return Collections.singletonMap(SERVER_PARTITION_KEY, connectorConfig.getLogicalName());
-        }
-
-        @Override
         public SqlServerOffsetContext load(Map<String, ?> offset) {
             final Lsn changeLsn = Lsn.valueOf((String) offset.get(SourceInfo.CHANGE_LSN_KEY));
             final Lsn commitLsn = Lsn.valueOf((String) offset.get(SourceInfo.COMMIT_LSN_KEY));

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerPartition.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerPartition.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import io.debezium.connector.common.Partition;
+import io.debezium.util.Collect;
+
+public class SqlServerPartition implements Partition {
+    private static final String SERVER_PARTITION_KEY = "server";
+
+    private final String serverName;
+
+    public SqlServerPartition(String serverName) {
+        this.serverName = serverName;
+    }
+
+    @Override
+    public Map<String, String> getSourcePartition() {
+        return Collect.hashMapOf(SERVER_PARTITION_KEY, serverName);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final SqlServerPartition other = (SqlServerPartition) obj;
+        return Objects.equals(serverName, other.serverName);
+    }
+
+    @Override
+    public int hashCode() {
+        return serverName.hashCode();
+    }
+
+    static class Provider implements Partition.Provider<SqlServerPartition> {
+        private final SqlServerConnectorConfig connectorConfig;
+
+        Provider(SqlServerConnectorConfig connectorConfig) {
+            this.connectorConfig = connectorConfig;
+        }
+
+        @Override
+        public Set<SqlServerPartition> getPartitions() {
+            return Collections.singleton(new SqlServerPartition(connectorConfig.getLogicalName()));
+        }
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
@@ -30,7 +30,7 @@ import io.debezium.schema.SchemaChangeEvent;
 import io.debezium.schema.SchemaChangeEvent.SchemaChangeEventType;
 import io.debezium.util.Clock;
 
-public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChangeEventSource<SqlServerOffsetContext> {
+public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChangeEventSource<SqlServerPartition, SqlServerOffsetContext> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerSnapshotChangeEventSource.class);
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -56,7 +56,7 @@ import io.debezium.util.Metronome;
  *
  * @author Jiri Pechanec
  */
-public class SqlServerStreamingChangeEventSource implements StreamingChangeEventSource<SqlServerOffsetContext> {
+public class SqlServerStreamingChangeEventSource implements StreamingChangeEventSource<SqlServerPartition, SqlServerOffsetContext> {
 
     private static final Pattern MISSING_CDC_FUNCTION_CHANGES_ERROR = Pattern.compile("Invalid object name 'cdc.fn_cdc_get_all_changes_(.*)'\\.");
 
@@ -107,7 +107,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
     }
 
     @Override
-    public void execute(ChangeEventSourceContext context, SqlServerOffsetContext offsetContext) throws InterruptedException {
+    public void execute(ChangeEventSourceContext context, SqlServerPartition partition, SqlServerOffsetContext offsetContext) throws InterruptedException {
         if (connectorConfig.getSnapshotMode().equals(SnapshotMode.INITIAL_ONLY)) {
             LOGGER.info("Streaming is not enabled in current configuration");
             return;

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerPartitionTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerPartitionTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import io.debezium.connector.common.AbstractPartitionTest;
+
+public class SqlServerPartitionTest extends AbstractPartitionTest<SqlServerPartition> {
+
+    @Override
+    protected SqlServerPartition createPartition1() {
+        return new SqlServerPartition("server1");
+    }
+
+    @Override
+    protected SqlServerPartition createPartition2() {
+        return new SqlServerPartition("server2");
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -22,6 +22,7 @@ import org.apache.kafka.connect.source.SourceTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.DebeziumException;
 import io.debezium.annotation.SingleThreadAccess;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;

--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -11,6 +11,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
@@ -40,7 +41,7 @@ import io.debezium.util.Strings;
  *
  * @author Gunnar Morling
  */
-public abstract class BaseSourceTask<O extends OffsetContext> extends SourceTask {
+public abstract class BaseSourceTask<P extends Partition, O extends OffsetContext> extends SourceTask {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseSourceTask.class);
     private static final long INITIAL_POLL_PERIOD_IN_MILLIS = TimeUnit.SECONDS.toMillis(5);
@@ -69,7 +70,7 @@ public abstract class BaseSourceTask<O extends OffsetContext> extends SourceTask
      * The change event source coordinator for those connectors adhering to the new
      * framework structure, {@code null} for legacy-style connectors.
      */
-    private ChangeEventSourceCoordinator<O> coordinator;
+    private ChangeEventSourceCoordinator<P, O> coordinator;
 
     /**
      * The latest offset that has been acknowledged by the Kafka producer. Will be
@@ -142,7 +143,7 @@ public abstract class BaseSourceTask<O extends OffsetContext> extends SourceTask
      *            the task configuration; implementations should wrap it in a dedicated implementation of
      *            {@link CommonConnectorConfig} and work with typed access to configuration properties that way
      */
-    protected abstract ChangeEventSourceCoordinator<O> start(Configuration config);
+    protected abstract ChangeEventSourceCoordinator<P, O> start(Configuration config);
 
     @Override
     public final List<SourceRecord> poll() throws InterruptedException {
@@ -297,28 +298,58 @@ public abstract class BaseSourceTask<O extends OffsetContext> extends SourceTask
     protected abstract Iterable<Field> getAllConfigurationFields();
 
     /**
-     * Loads the connector's persistent offset (if present) via the given loader.
+     * Loads the connector's persistent offsets (if present) via the given loader.
      */
-    protected O getPreviousOffset(OffsetContext.Loader<O> loader) {
-        Map<String, ?> partition = loader.getPartition();
+    protected Map<P, O> getPreviousOffsets(Partition.Provider<P> provider, OffsetContext.Loader<O> loader) {
+        Set<P> partitions = provider.getPartitions();
+        OffsetReader<P, O, OffsetContext.Loader<O>> reader = new OffsetReader<>(
+                context.offsetStorageReader(), loader);
+        Map<P, O> offsets = reader.offsets(partitions);
 
-        if (lastOffset != null) {
-            O offsetContext = loader.load(lastOffset);
-            LOGGER.info("Found previous offset after restart {}", offsetContext);
-            return offsetContext;
+        boolean found = false;
+        for (P partition : partitions) {
+            O offset = offsets.get(partition);
+
+            if (offset != null) {
+                found = true;
+                LOGGER.info("Found previous partition offset {}: {}", partition, offset);
+            }
         }
 
-        Map<String, Object> previousOffset = context.offsetStorageReader()
-                .offsets(Collections.singleton(partition))
-                .get(partition);
+        if (!found) {
+            LOGGER.info("No previous offsets found");
+        }
 
-        if (previousOffset != null) {
-            O offsetContext = loader.load(previousOffset);
-            LOGGER.info("Found previous offset {}", offsetContext);
-            return offsetContext;
+        return offsets;
+    }
+
+    /**
+     * Returns the offset of the only partition that the task is configured to use.
+     *
+     * This method is meant to be used only by the connectors that do not implement handling
+     * multiple partitions per task.
+     */
+    protected P getTheOnlyPartition(Map<P, O> offsets) {
+        if (offsets.size() != 1) {
+            throw new DebeziumException("The task must be configured to use exactly one partition, "
+                    + offsets.size() + " found");
         }
-        else {
-            return null;
+
+        return offsets.entrySet().iterator().next().getKey();
+    }
+
+    /**
+     * Returns the offset of the only partition that the task is configured to use.
+     *
+     * This method is meant to be used only by the connectors that do not implement handling
+     * multiple partitions per task.
+     */
+    protected O getTheOnlyOffset(Map<P, O> offsets) {
+        if (offsets.size() != 1) {
+            throw new DebeziumException("The task must be configured to use exactly one partition, "
+                    + offsets.size() + " found");
         }
+
+        return offsets.entrySet().iterator().next().getValue();
     }
 }

--- a/debezium-core/src/main/java/io/debezium/connector/common/OffsetReader.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/OffsetReader.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.common;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.storage.OffsetStorageReader;
+
+import io.debezium.pipeline.spi.OffsetContext;
+
+/**
+ * Provides access to the partition offsets stored by connectors.
+ */
+public class OffsetReader<P extends Partition, O extends OffsetContext, L extends OffsetContext.Loader<O>> {
+
+    private final OffsetStorageReader reader;
+    private final L loader;
+
+    public OffsetReader(OffsetStorageReader reader, L loader) {
+        this.reader = reader;
+        this.loader = loader;
+    }
+
+    /**
+     * Given the collection of connector-specific task partitions, returns their respective connector-specific offsets.
+     *
+     * If there is no offset stored for a given partition, the corresponding key will be mapped to a null.
+     */
+    public Map<P, O> offsets(Set<P> partitions) {
+        Set<Map<String, String>> sourcePartitions = partitions.stream()
+                .map(Partition::getSourcePartition)
+                .collect(Collectors.toCollection(HashSet::new));
+
+        Map<Map<String, String>, Map<String, Object>> sourceOffsets = reader.offsets(sourcePartitions);
+
+        Map<P, O> offsets = new LinkedHashMap<>();
+        partitions.forEach(partition -> {
+            Map<String, String> sourcePartition = partition.getSourcePartition();
+            Map<String, Object> sourceOffset = sourceOffsets.get(sourcePartition);
+            O offset = null;
+            if (sourceOffset != null) {
+                offset = loader.load(sourceOffset);
+            }
+            offsets.put(partition, offset);
+        });
+
+        return offsets;
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/connector/common/Partition.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/Partition.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.common;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Describes the source partition to be processed by the connector in connector-specific terms
+ * and provides its representation as a Kafka Connect source partition.
+ */
+public interface Partition {
+    Map<String, String> getSourcePartition();
+
+    /**
+     * Implementations provide a set of connector-specific partitions based on the connector task configuration.
+     */
+    interface Provider<P extends Partition> {
+        Set<P> getPartitions();
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.DebeziumException;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.ConfigurationDefaults;
+import io.debezium.connector.common.Partition;
 import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.spi.OffsetContext;
@@ -31,7 +32,7 @@ import io.debezium.util.Threads;
  *
  * @author Chris Cranford
  */
-public abstract class AbstractSnapshotChangeEventSource<O extends OffsetContext> implements SnapshotChangeEventSource<O> {
+public abstract class AbstractSnapshotChangeEventSource<P extends Partition, O extends OffsetContext> implements SnapshotChangeEventSource<P, O> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSnapshotChangeEventSource.class);
 
@@ -44,7 +45,7 @@ public abstract class AbstractSnapshotChangeEventSource<O extends OffsetContext>
     }
 
     @Override
-    public SnapshotResult<O> execute(ChangeEventSourceContext context, O previousOffset) throws InterruptedException {
+    public SnapshotResult<O> execute(ChangeEventSourceContext context, P partition, O previousOffset) throws InterruptedException {
         SnapshottingTask snapshottingTask = getSnapshottingTask(previousOffset);
         if (snapshottingTask.shouldSkipSnapshot()) {
             LOGGER.debug("Skipping snapshotting");

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeEventSourceFactory.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeEventSourceFactory.java
@@ -7,6 +7,7 @@ package io.debezium.pipeline.source.spi;
 
 import java.util.Optional;
 
+import io.debezium.connector.common.Partition;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.schema.DataCollectionId;
@@ -16,7 +17,7 @@ import io.debezium.schema.DataCollectionId;
  *
  * @author Gunnar Morling
  */
-public interface ChangeEventSourceFactory<O extends OffsetContext> {
+public interface ChangeEventSourceFactory<P extends Partition, O extends OffsetContext> {
 
     /**
      * Returns a snapshot change event source that may emit change events for schema and/or data changes. Depending on
@@ -30,12 +31,12 @@ public interface ChangeEventSourceFactory<O extends OffsetContext> {
      *
      * @return A snapshot change event source
      */
-    SnapshotChangeEventSource<O> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener);
+    SnapshotChangeEventSource<P, O> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener);
 
     /**
      * Returns a streaming change event source that starts streaming at the given offset.
      */
-    StreamingChangeEventSource<O> getStreamingChangeEventSource();
+    StreamingChangeEventSource<P, O> getStreamingChangeEventSource();
 
     /**
      * Returns and incremental snapshot change event source that can run in parallel with streaming

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/SnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/SnapshotChangeEventSource.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.pipeline.source.spi;
 
+import io.debezium.connector.common.Partition;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.SnapshotResult;
 
@@ -14,7 +15,7 @@ import io.debezium.pipeline.spi.SnapshotResult;
  *
  * @author Gunnar Morling
  */
-public interface SnapshotChangeEventSource<O extends OffsetContext> extends ChangeEventSource {
+public interface SnapshotChangeEventSource<P extends Partition, O extends OffsetContext> extends ChangeEventSource {
 
     /**
      * Executes this source. Implementations should regularly check via the given context if they should stop. If that's
@@ -23,11 +24,13 @@ public interface SnapshotChangeEventSource<O extends OffsetContext> extends Chan
      *
      * @param context
      *            contextual information for this source's execution
+     * @param partition
+     *            the source partition from which the snapshot should be taken
      * @param previousOffset
      *            previous offset restored from Kafka
      * @return an indicator to the position at which the snapshot was taken
      * @throws InterruptedException
      *             in case the snapshot was aborted before completion
      */
-    SnapshotResult<O> execute(ChangeEventSourceContext context, O previousOffset) throws InterruptedException;
+    SnapshotResult<O> execute(ChangeEventSourceContext context, P partition, O previousOffset) throws InterruptedException;
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingChangeEventSource.java
@@ -7,6 +7,7 @@ package io.debezium.pipeline.source.spi;
 
 import java.util.Map;
 
+import io.debezium.connector.common.Partition;
 import io.debezium.pipeline.spi.OffsetContext;
 
 /**
@@ -14,7 +15,7 @@ import io.debezium.pipeline.spi.OffsetContext;
  *
  * @author Gunnar Morling
  */
-public interface StreamingChangeEventSource<O extends OffsetContext> extends ChangeEventSource {
+public interface StreamingChangeEventSource<P extends Partition, O extends OffsetContext> extends ChangeEventSource {
 
     /**
      * Executes this source. Implementations should regularly check via the given context if they should stop. If that's
@@ -23,12 +24,14 @@ public interface StreamingChangeEventSource<O extends OffsetContext> extends Cha
      *
      * @param context
      *            contextual information for this source's execution
+     * @param partition
+     *            the source partition from which the changes should be streamed
      * @param offsetContext
      * @return an indicator to the position at which the snapshot was taken
      * @throws InterruptedException
      *             in case the snapshot was aborted before completion
      */
-    void execute(ChangeEventSourceContext context, O offsetContext) throws InterruptedException;
+    void execute(ChangeEventSourceContext context, P partition, O offsetContext) throws InterruptedException;
 
     /**
      * Commits the given offset with the source database. Used by some connectors

--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/OffsetContext.java
@@ -30,8 +30,6 @@ public interface OffsetContext {
      * Implementations load a connector-specific offset context based on the offset values stored in Kafka.
      */
     interface Loader<O extends OffsetContext> {
-        Map<String, ?> getPartition();
-
         O load(Map<String, ?> offset);
     }
 

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
+import io.debezium.connector.common.Partition;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.EventDispatcher.SnapshotReceiver;
@@ -50,7 +51,7 @@ import io.debezium.util.Threads.Timer;
  *
  * @author Gunnar Morling
  */
-public abstract class RelationalSnapshotChangeEventSource<O extends OffsetContext> extends AbstractSnapshotChangeEventSource<O> {
+public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O extends OffsetContext> extends AbstractSnapshotChangeEventSource<P, O> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RelationalSnapshotChangeEventSource.class);
 

--- a/debezium-core/src/test/java/io/debezium/connector/common/AbstractPartitionTest.java
+++ b/debezium-core/src/test/java/io/debezium/connector/common/AbstractPartitionTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.common;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+
+abstract public class AbstractPartitionTest<P extends Partition> {
+
+    @Test
+    public void equalPartitionsShouldBeEqual() {
+        assertThat(createPartition1()).isEqualTo(createPartition1());
+    }
+
+    @Test
+    public void nonEqualPartitionsShouldNotBeEqual() {
+        assertThat(createPartition1()).isNotEqualTo(createPartition2());
+    }
+
+    @Test
+    public void equalPartitionsShouldHaveEqualHashCodes() {
+        assertThat(createPartition1().hashCode()).isEqualTo(createPartition1().hashCode());
+    }
+
+    @Test
+    public void nonEqualPartitionsShouldHaveNonEqualHashCodes() {
+        assertThat(createPartition1().hashCode()).isNotEqualTo(createPartition2().hashCode());
+    }
+
+    protected abstract P createPartition1();
+
+    protected abstract P createPartition2();
+}


### PR DESCRIPTION
**Change summary**:
1. Introduce `Partition`, `Partition.Provider`  and `OffsetLoader` components.
2. Remove `getPartition()` from  `OffsetContext.Loader` since it's now the responsibility of `Partition.Provider`.
3. Parametrize base components and their implementations with `P extends Partition`.
4. `BaseSourceTask#getPreviousOffsets()` is now consistently used for recovering stored offsets.

**Notes**:
1. Apparently, the MongoDB connector is already capable of handling multiple source partitions but mapping of partitions to offsets is implemented within `io.debezium.connector.mongodb.SourceInfo`: https://github.com/debezium/debezium/blob/3a4788cc333e397c573e5228e573ed6e98670faa/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbOffsetContext.java#L130-L131
   Refactoring it here would be too challenging and is considered out of scope.
2. Temporary methods `BaseSourceTask#getTheOnlyPartition` and  `BaseSourceTask#getTheOnlyOffset` are introduce to align the currently single-partition implementation of existing connectors with the new multi-partition API.

**Questions**:
1. The `OffsetReader` implementation might be covered with a unit test, however, most of its dependencies are abstract. What would be the preferred way to test the logic?

**TODO**:
- [x] Address test failures
- [x] Update `debezium/debezium-connector-db2` (https://github.com/debezium/debezium-connector-db2/pull/26)
- [x] Update `debezium/debezium-connector-vitess` (https://github.com/debezium/debezium-connector-vitess/pull/38)
