### PR TITLE
DBZ-3430 Update links to point to new Service Registry Install guide

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/avro.adoc
+++ b/documentation/modules/ROOT/pages/configuration/avro.adoc
@@ -13,39 +13,40 @@
 
 toc::[]
 
-A {prodname} connector works in the Kafka Connect framework to capture each row-level change in a database by generating a change event record. 
-For each change event record, the {prodname} connector completes the following actions: 
+A {prodname} connector works in the Kafka Connect framework to capture each row-level change in a database by generating a change event record.
+For each change event record, the {prodname} connector completes the following actions:
 
 . Applies configured transformations.
 . Serializes the record key and value into a binary form by using the configured link:https://kafka.apache.org/documentation/#connect_running[Kafka Connect converters].
 . Writes the record to the correct Kafka topic.
 
-You can specify converters for each individual {prodname} connector instance. 
-Kafka Connect provides a JSON converter that serializes the record keys and values into JSON documents. 
-The default behavior is that the JSON converter includes the record's message schema, which makes each record very verbose. 
-The {link-prefix}:{link-tutorial}[{name-tutorial}] shows what the records look like when both payload and schemas are included. 
-If you want records to be serialized with JSON, consider setting the following connector configuration properties to `false`: 
+You can specify converters for each individual {prodname} connector instance.
+Kafka Connect provides a JSON converter that serializes the record keys and values into JSON documents.
+The default behavior is that the JSON converter includes the record's message schema, which makes each record very verbose.
+The {link-prefix}:{link-tutorial}[{name-tutorial}] shows what the records look like when both payload and schemas are included.
+If you want records to be serialized with JSON, consider setting the following connector configuration properties to `false`:
 
 * `key.converter.schemas.enable`
 * `value.converter.schemas.enable`
 
-Setting these properties to `false` excludes the verbose schema information from each record. 
+Setting these properties to `false` excludes the verbose schema information from each record.
 
-Alternatively, you can serialize the record keys and values by using https://avro.apache.org/[Apache Avro]. 
-The Avro binary format is compact and efficient. 
-Avro schemas make it possible to ensure that each record has the correct structure. 
-Avro's schema evolution mechanism enables schemas to evolve. 
-This is essential for {prodname} connectors, which dynamically generate each record's schema to match the structure of the database table that was changed. 
-Over time, change event records written to the same Kafka topic might have different versions of the same schema. 
+Alternatively, you can serialize the record keys and values by using https://avro.apache.org/[Apache Avro].
+The Avro binary format is compact and efficient.
+Avro schemas make it possible to ensure that each record has the correct structure.
+Avro's schema evolution mechanism enables schemas to evolve.
+This is essential for {prodname} connectors, which dynamically generate each record's schema to match the structure of the database table that was changed.
+Over time, change event records written to the same Kafka topic might have different versions of the same schema.
 Avro serialization makes it easier for the consumers of change event records to adapt to a changing record schema.
 
 ifdef::community[]
-To use Apache Avro serialization, you must deploy a schema registry that manages Avro message schemas and their versions. 
+To use Apache Avro serialization, you must deploy a schema registry that manages Avro message schemas and their versions.
 Available options include the {registry-name-full} as well as the Confluent Schema Registry. Both are described here.
 endif::community[]
 
 ifdef::product[]
-To use Apache Avro serialization, you must deploy a schema registry that manages Avro message schemas and their versions. For information about setting up this registry, see the documentation for  {LinkServiceRegistryGetStart}[{registry-name-full}].
+To use Apache Avro serialization, you must deploy a schema registry that manages Avro message schemas and their versions.
+For information about setting up this registry, see the documentation for link:{LinkServiceRegistryInstall}[{NameServiceRegistryInstall}].
 endif::product[]
 
 // Type: concept
@@ -58,11 +59,11 @@ The link:https://github.com/Apicurio/apicurio-registry[{registry}] open-source p
 endif::community[]
 
 ifdef::product[]
-{LinkServiceRegistryGetStart}[{registry-name-full}] provides the following components that work with Avro:
+link:{LinkServiceRegistryUser}[{registry-name-full}] provides the following components that work with Avro:
 endif::product[]
 
-* An Avro converter that you can specify in {prodname} connector configurations. 
-This converter maps Kafka Connect schemas to Avro schemas. 
+* An Avro converter that you can specify in {prodname} connector configurations.
+This converter maps Kafka Connect schemas to Avro schemas.
 The converter then uses the Avro schemas to serialize the record keys and values into Avro's compact binary form.
 
 * An API and schema registry that tracks:
@@ -74,15 +75,15 @@ The converter then uses the Avro schemas to serialize the record keys and values
 Because the Avro schemas are stored in this registry, each record needs to contain only a tiny _schema identifier_.
 This makes each record even smaller. For an I/O bound system like Kafka, this means more total throughput for producers and consumers.
 
-* Avro _Serdes_ (serializers and deserializers) for Kafka producers and consumers. 
+* Avro _Serdes_ (serializers and deserializers) for Kafka producers and consumers.
 Kafka consumer applications that you write to consume change event records can use Avro Serdes to deserialize the change event records.
 
 To use the {registry} with {prodname}, add {registry} converters and their dependencies to the Kafka Connect container image that you are using for running a {prodname} connector.
 
 [NOTE]
 ====
-The {registry} project also provides a JSON converter. 
-This converter combines the advantage of less verbose messages with human-readable JSON. 
+The {registry} project also provides a JSON converter.
+This converter combines the advantage of less verbose messages with human-readable JSON.
 Messages do not contain the schema information themselves, but only a schema ID.
 ====
 
@@ -96,13 +97,13 @@ To use converters provided by {registry} you need to provide `apicurio.registry.
 [id="overview-of-deploying-a-debezium-connector-that-uses-avro-serialization"]
 == Deployment overview
 
-To deploy a {prodname} connector that uses Avro serialization, you must complete three main tasks: 
+To deploy a {prodname} connector that uses Avro serialization, you must complete three main tasks:
 
 ifdef::community[]
 . Deploy an link:https://github.com/Apicurio/apicurio-registry[{registry-name-full}] instance.
 endif::community[]
 ifdef::product[]
-. Deploy a link:{LinkServiceRegistryGetStart}[{registry-name-full} instance by following the instructions in {NameServiceRegistryGetStart}].
+. Deploy a {registry-name-full} instance by following the instructions in link:{LinkServiceRegistryInstall}[{NameServiceRegistryInstall}].
 endif::product[]
 
 ifdef::community[]
@@ -112,7 +113,7 @@ ifdef::product[]
 . Install the Avro converter by downloading the {prodname} link:https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=red.hat.integration&downloadType=distributions[Service Registry Kafka Connect] zip file and extracting it into the {prodname} connector's directory.
 endif::product[]
 
-. Configure a {prodname} connector instance to use Avro serialization by setting configuration properties as follows: 
+. Configure a {prodname} connector instance to use Avro serialization by setting configuration properties as follows:
 +
 [source,options="nowrap"]
 ----
@@ -137,7 +138,7 @@ ifdef::community[]
 In your environment, you might want to use a provided {prodname} container image to deploy {prodname} connectors that use Avro serialization. Follow the procedure here to do that. In this procedure, you enable Apicurio converters on the {prodname} Kafka Connect container image, and configure the {prodname} connector to use the Avro converter.
 endif::community[]
 ifdef::product[]
-In your environment, you might want to use a provided {prodname} container to deploy {prodname} connectors that use Avro serialization. 
+In your environment, you might want to use a provided {prodname} container to deploy {prodname} connectors that use Avro serialization.
 Complete the following procedure to build a custom Kafka Connect container image for {prodname}, and configure the {prodname} connector to use the Avro converter.
 endif::product[]
 
@@ -149,7 +150,7 @@ endif::product[]
 .Procedure
 
 ifdef::community[]
-. Deploy an instance of {registry}. 
+. Deploy an instance of {registry}.
 +
 The following example uses a non-production, in-memory, {registry} instance:
 +
@@ -187,13 +188,13 @@ docker run -it --rm --name connect \
 endif::community[]
 
 ifdef::product[]
-. Deploy an instance of {registry}. See link:{LinkServiceRegistryGetStart}#installing-registry-operatorhub[{NameServiceRegistryGetStart}, Installing Service Registry from the OpenShift OperatorHub], which provides instructions for: 
+. Deploy an instance of {registry}. See link:{LinkServiceRegistryInstall}[{NameServiceRegistryInstall}], which provides instructions for:
 +
+* Installing {registry}
 * Installing AMQ Streams
 * Setting up AMQ Streams storage
-* Installing {registry}
 
-. Extract the {prodname} connector archives to create a directory structure for the connector plug-ins. 
+. Extract the {prodname} connector archives to create a directory structure for the connector plug-ins.
 If you downloaded and extracted the archives for multiple {prodname} connectors, the resulting directory structure looks like the one in the following example:
 +
 [subs=+macros]
@@ -216,12 +217,12 @@ pass:quotes[*tree ./my-plugins/*]
 .. Extract the archive into the desired {prodname} connector directory.
 
 +
-To configure more than one type of {prodname} connector to use Avro serialization, extract the archive into the directory for each relevant connector type. 
+To configure more than one type of {prodname} connector to use Avro serialization, extract the archive into the directory for each relevant connector type.
 Although extracting the archive to each directory duplicates the files, by doing so you remove the possibility of conflicting dependencies.
 
 . Create and publish a custom image for running {prodname} connectors that are configured to use the Avro converter:
 
-.. Create a new `Dockerfile` by using `{DockerKafkaConnect}` as the base image. 
+.. Create a new `Dockerfile` by using `{DockerKafkaConnect}` as the base image.
 In the following example, replace _my-plugins_ with the name of your plug-ins directory:
 +
 [subs=+macros]
@@ -244,8 +245,8 @@ Before Kafka Connect starts running the connector, Kafka Connect loads any third
 
 .. Point to the new container image. Do one of the following:
 +
-* Edit the `KafkaConnect.spec.image` property of the `KafkaConnect` custom resource. 
-If set, this property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator. 
+* Edit the `KafkaConnect.spec.image` property of the `KafkaConnect` custom resource.
+If set, this property overrides the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable in the Cluster Operator.
 For example:
 +
 [source,yaml,subs=attributes+]
@@ -261,8 +262,8 @@ spec:
 +
 * In the `install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml` file, edit the `STRIMZI_DEFAULT_KAFKA_CONNECT_IMAGE` variable to point to the new container image and reinstall the Cluster Operator. If you edit this file you will need to apply it to your OpenShift cluster.
 
-. Deploy each {prodname} connector that is configured to use the Avro converter. 
-For each {prodname} connector:  
+. Deploy each {prodname} connector that is configured to use the Avro converter.
+For each {prodname} connector:
 
 .. Create a {prodname} connector instance. The following `inventory-connector.yaml` file example creates a `KafkaConnector` custom resource that defines a MySQL connector instance that is configured to use the Avro converter:
 +
@@ -271,22 +272,22 @@ For each {prodname} connector:
 apiVersion: kafka.strimzi.io/v1beta1
 kind: KafkaConnector
 metadata:
-  name: inventory-connector  
+  name: inventory-connector
   labels:
     strimzi.io/cluster: my-connect-cluster
 spec:
   class: io.debezium.connector.mysql.MySqlConnector
-  tasksMax: 1  
-  config:  
-    database.hostname: mysql  
+  tasksMax: 1
+  config:
+    database.hostname: mysql
     database.port: 3306
     database.user: debezium
     database.password: dbz
-    database.server.id: 184054  
-    database.server.name: dbserver1  
+    database.server.id: 184054
+    database.server.name: dbserver1
     database.include.list: inventory
     database.history.kafka.bootstrap.servers: my-cluster-kafka-bootstrap:9092
-    database.history.kafka.topic: schema-changes.inventory  
+    database.history.kafka.topic: schema-changes.inventory
     key.converter: io.apicurio.registry.utils.converter.AvroConverter
     key.converter.apicurio.registry.url: http://apicurio:8080/api
     key.converter.apicurio.registry.global-id: io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy
@@ -294,14 +295,14 @@ spec:
     value.converter.apicurio.registry.url: http://apicurio:8080/api
     value.converter.apicurio.registry.global-id: io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy
 ----
-   
-.. Apply the connector instance, for example: 
+
+.. Apply the connector instance, for example:
 +
 `oc apply -f inventory-connector.yaml`
 +
 This registers `inventory-connector` and the connector starts to run against the `inventory` database.
 
-. Verify that the connector was created and has started to track changes in the specified database. 
+. Verify that the connector was created and has started to track changes in the specified database.
 You can verify the connector instance by watching the Kafka Connect log output as, for example, `inventory-connector` starts.
 
 .. Display the Kafka Connect log output:
@@ -311,8 +312,8 @@ You can verify the connector instance by watching the Kafka Connect log output a
 oc logs $(oc get pods -o name -l strimzi.io/name=my-connect-cluster-connect)
 ----
 
-.. Review the log output to verify that the initial snapshot has been executed. 
-You should see something like the following lines: 
+.. Review the log output to verify that the initial snapshot has been executed.
+You should see something like the following lines:
 +
 [source,shell,options="nowrap"]
 ----
@@ -357,7 +358,7 @@ ifdef::community[]
 [id="confluent-schema-registry"]
 == Confluent Schema Registry
 
-There is an alternative https://github.com/confluentinc/schema-registry[schema registry] implementation provided by Confluent. 
+There is an alternative https://github.com/confluentinc/schema-registry[schema registry] implementation provided by Confluent.
 The configuration is slightly different.
 
 . In your {prodname} connector configuration, specify the following properties:
@@ -434,7 +435,7 @@ As stated in the Avro link:https://avro.apache.org/docs/current/spec.html#names[
 
 {prodname} uses the column's name as the basis for the corresponding Avro field.
 This can lead to problems during serialization if the column name does not also adhere to the Avro naming rules.
-Each {prodname} connector provides a configuration property, `sanitize.field.names` that you can set to `true` if you have columns that do not adhere to Avro rules for names. 
+Each {prodname} connector provides a configuration property, `sanitize.field.names` that you can set to `true` if you have columns that do not adhere to Avro rules for names.
 Setting `sanitize.field.names` to `true` allows serialization of non-conformant fields without having to actually modify your schema.
 
 ifdef::community[]


### PR DESCRIPTION
[DBZ-3430](https://issues.redhat.com/browse/DBZ-3430)

The Localization detected broken links in the Debezium documentation and requested updates. 
Links in the downstream content in `avro.adoc` pointed to the discontinued _Getting Started with Service Registry_ document. This change updates the links so that they now point to the replacement guide, _Installing and Deploying Service Registry on OpenShift_. 

This change modifies only content that is conditionalized for downstream use. 
I tested the change on a local Antora build and confirmed that there is no effect on the upstream _Avro Serialization_ chapter.

If possible, please backport this to 1.5.