### PR TITLE
DBZ-3770 Optimize ObjectMapper initialization by replacing repeated initialization with one time initilization

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/SourceInfo.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/SourceInfo.java
@@ -82,6 +82,8 @@ public final class SourceInfo extends BaseSourceInfo {
     public static final String LSN_KEY = "lsn";
     public static final String LAST_SNAPSHOT_RECORD_KEY = "last_snapshot_record";
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     private final String dbName;
 
     private Lsn lsn;
@@ -162,9 +164,8 @@ public final class SourceInfo extends BaseSourceInfo {
                 }
             }
         }
-        ObjectMapper mapper = new ObjectMapper();
         try {
-            return mapper.writeValueAsString(sequence);
+            return MAPPER.writeValueAsString(sequence);
         }
         catch (JsonProcessingException e) {
             throw new IllegalStateException(e);


### PR DESCRIPTION
https://issues.redhat.com/projects/DBZ/issues/DBZ-3770

DBZ-3770 Optimize ObjectMapper initialization by replacing repeated initialization with one time initilization in PostgreSQL `SourceInfo.sequence()`. Overall Performance Improvement of approx 5% - 15%.

Performance Benchmark was done for 1M row CDC events on a table with 4 columns (NOOP DebeziumEngine.notifying)

<div class="table-wrap">

.sequence() | Before | After | Diff
-- | -- | -- | --
1M Rows | 2,879 ms (9.4%) | 256 ms (1.1%) | -88.9% (x11.2 improvement)

</div>

**Before Optimization**

![before_optimization](https://user-images.githubusercontent.com/9495737/126109801-28c82188-f57b-4ed2-9580-d97b80a90876.png)

**After Optimization**

![after_optimization](https://user-images.githubusercontent.com/9495737/126109795-91924803-d444-4ef5-8171-dec5c48ad957.png)

JMH Benchmarks
```
Benchmark                                        Mode  Cnt        Score        Error  Units
PostgresConnectorConfigPerf.benchmark_1_before  thrpt    3   550040.596 ±  16847.245  ops/s
PostgresConnectorConfigPerf.benchmark_2_after   thrpt    3  4347346.228 ± 108381.634  ops/s
```