### PR TITLE
DBZ-3769: throw sqlexception from postgres message decoder

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -326,7 +326,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         decoderContext.getSchema().applySchemaChangesForTable(relationId, table);
     }
 
-    private List<io.debezium.relational.Column> getTableColumnsFromDatabase(PostgresConnection connection, DatabaseMetaData databaseMetadata, TableId tableId) {
+    private List<io.debezium.relational.Column> getTableColumnsFromDatabase(PostgresConnection connection, DatabaseMetaData databaseMetadata, TableId tableId) throws SQLException {
         List<io.debezium.relational.Column> readColumns = new ArrayList<>();
         try {
             try (ResultSet columnMetadata = databaseMetadata.getColumns(null, tableId.schema(), tableId.table(), null)) {
@@ -338,6 +338,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         }
         catch (SQLException e) {
             LOGGER.warn("Failed to read column metadata for '{}.{}'", tableId.schema(), tableId.table());
+            throw e;
             // todo: DBZ-766 Should this throw the exception or just log the warning?
         }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -338,9 +338,8 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
             }
         }
         catch (SQLException e) {
-            LOGGER.warn("Failed to read column metadata for '{}.{}'", tableId.schema(), tableId.table());
+            LOGGER.error("Failed to read column metadata for '{}.{}'", tableId.schema(), tableId.table());
             throw e;
-            // todo: DBZ-766 Should this throw the exception or just log the warning?
         }
 
         return readColumns;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -326,7 +326,8 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
         decoderContext.getSchema().applySchemaChangesForTable(relationId, table);
     }
 
-    private List<io.debezium.relational.Column> getTableColumnsFromDatabase(PostgresConnection connection, DatabaseMetaData databaseMetadata, TableId tableId) throws SQLException {
+    private List<io.debezium.relational.Column> getTableColumnsFromDatabase(PostgresConnection connection, DatabaseMetaData databaseMetadata, TableId tableId)
+            throws SQLException {
         List<io.debezium.relational.Column> readColumns = new ArrayList<>();
         try {
             try (ResultSet columnMetadata = databaseMetadata.getColumns(null, tableId.schema(), tableId.table(), null)) {


### PR DESCRIPTION
I was asked to submit a PR for the code changes we made to 1.6.0.Final to increase visibility into a backend I/O error we were getting. Didn't add any actual handling here yet, just threw the exception up so we could see what it is. 