### PR TITLE
DBZ-3823 SQL Server connector doesn't handle retriable errors during task start

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SourceTimestampMode.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SourceTimestampMode.java
@@ -26,7 +26,7 @@ public enum SourceTimestampMode implements EnumeratedValue {
      */
     COMMIT("commit") {
         @Override
-        protected Instant getTimestamp(SqlServerConnection connection, Clock clock, ResultSet resultSet) throws SQLException {
+        protected Instant getTimestamp(Clock clock, ResultSet resultSet) throws SQLException {
             return resultSet.getTimestamp(resultSet.getMetaData().getColumnCount()).toInstant();
         }
 
@@ -50,7 +50,7 @@ public enum SourceTimestampMode implements EnumeratedValue {
     @Deprecated
     PROCESSING("processing") {
         @Override
-        protected Instant getTimestamp(SqlServerConnection connection, Clock clock, ResultSet resultSet) {
+        protected Instant getTimestamp(Clock clock, ResultSet resultSet) {
             return clock.currentTime();
         }
 
@@ -74,11 +74,10 @@ public enum SourceTimestampMode implements EnumeratedValue {
     /**
      * Returns the timestamp to be put in the source metadata of the event depending on the mode.
      *
-     * @param connection Server connection used to fetch the result set
      * @param clock System clock to source processing time from
      * @param resultSet  Result set representing the CDC event and its commit timestamp, if required by the mode
      */
-    protected abstract Instant getTimestamp(SqlServerConnection connection, Clock clock, ResultSet resultSet) throws SQLException;
+    protected abstract Instant getTimestamp(Clock clock, ResultSet resultSet) throws SQLException;
 
     /**
      * Returns the SQL fragment to be embedded into the {@code GET_ALL_CHANGES_FOR_TABLE} query depending on the mode.

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -9,7 +9,6 @@ import java.sql.SQLException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,12 +76,7 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
                 connectorConfig.getSkippedOperations());
         metadataConnection = new SqlServerConnection(jdbcConfig, clock, connectorConfig.getSourceTimestampMode(), valueConverters, () -> getClass().getClassLoader(),
                 connectorConfig.getSkippedOperations());
-        try {
-            dataConnection.setAutoCommit(false);
-        }
-        catch (SQLException e) {
-            throw new ConnectException(e);
-        }
+
         this.schema = new SqlServerDatabaseSchema(connectorConfig, valueConverters, topicSelector, schemaNameAdjuster);
         this.schema.initializeStorage();
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
@@ -34,7 +34,7 @@ public class SqlServerErrorHandler extends ErrorHandler {
                         || throwable.getMessage().contains("Connection reset")
                         || throwable.getMessage().contains("SHUTDOWN is in progress")
                         || throwable.getMessage().contains("The server failed to resume the transaction")
-                        || throwable.getMessage().contains("Connection refused (Connection refused)")
+                        || throwable.getMessage().contains("Verify the connection properties")
                         || throwable.getMessage()
                                 .startsWith("An insufficient number of arguments were supplied for the procedure or function cdc.fn_cdc_get_all_changes_")
                         || throwable.getMessage()

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
@@ -81,7 +81,7 @@ public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChange
     @Override
     protected SnapshotContext<SqlServerPartition, SqlServerOffsetContext> prepare(SqlServerPartition partition)
             throws Exception {
-        return new SqlServerSnapshotContext(partition, jdbcConnection.getRealDatabaseName());
+        return new SqlServerSnapshotContext(partition, jdbcConnection.getDatabaseName());
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -299,6 +299,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
         // For R/W database it is important to execute regular commits to maintain the size of TempDB
         if (connectorConfig.isReadOnlyDatabaseConnection() || pauseBetweenCommits.hasElapsed()) {
             dataConnection.commit();
+            metadataConnection.commit();
         }
     }
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -71,8 +71,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
     private final SqlServerConnection dataConnection;
 
     /**
-     * A separate connection for retrieving timestamps; without it, adaptive
-     * buffering will not work.
+     * A separate connection for retrieving details of the schema changes; without it, adaptive buffering will not work.
      *
      * @link https://docs.microsoft.com/en-us/sql/connect/jdbc/using-adaptive-buffering?view=sql-server-2017#guidelines-for-using-adaptive-buffering
      */
@@ -264,7 +263,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                             offsetContext.event(
                                     tableWithSmallestLsn.getChangeTable().getSourceTableId(),
                                     connectorConfig.getSourceTimestampMode().getTimestamp(
-                                            metadataConnection, clock, tableWithSmallestLsn.getResultSet()));
+                                            clock, tableWithSmallestLsn.getResultSet()));
 
                             dispatcher
                                     .dispatchDataChangeEvent(


### PR DESCRIPTION
See [DBZ-3823](https://issues.redhat.com/browse/DBZ-3823).

### Change summary

See https://github.com/debezium/debezium/pull/2572#issuecomment-896977723.

<details>
   <summary>Previous approach:</summary>

### Change summary

1. (optional) Do not wrap `SQLException` thrown from within `SqlServerConnection` constructor into a `RuntimeException`. This simplifies retriable error handling and should improve the user experience. The previously thrown "Couldn't obtain database name" error doesn't really provide any useful information to the operator. On the contrary, it makes them scroll one page down to get to the underlying connection error.
2. Use the error handler to convert the exception thrown during `BaseSourceTask#start(config)`. Otherwise, it's never a `RetriableException`.
3. Catch `RetriableException` in `BaseSourceTask#start(props)` and restart the task internally in the same way as if the exception was caught while polling the task.
4. Add some more patterns to identify a retriable connection error. Note, "Verify the connection properties" will be likely contained in the error messages covered by the existing patterns. E.g.:
   > The TCP/IP connection to the host localhost, port 1433 has failed. Error: "**Connection refused (Connection refused)**. **Verify the connection properties**. Make sure that an instance of SQL Server is running on the host and accepting TCP/IP connections at the port. Make sure that TCP connections to the port are not blocked by a firewall.".
   
   This is still necessary because some retriable error messages are quite generic. E.g.:
   
   > The TCP/IP connection to the host localhost, port 1433 has failed. Error: "sqlserver. Verify the connection properties. Make sure that an instance of SQL Server is running on the host and accepting TCP/IP connections at the port. Make sure that TCP connections to the port are not blocked by a firewall.".
   
   But still, need to be handled as retriable.

### Additional considerations

Note that there's a certain risk in false-positive detection of given exception as retriable. While a task is failing due to a retriable error and restarting, it's still `RUNNING` from the Connect API perspective. Given that there's no way to limit the number of retries or the duration of the fail-and-retry loop, the task may get stuck in this state and not detected as failing (e.g. using the [`connector-failed-task-count`](https://cwiki.apache.org/confluence/display/KAFKA/KIP-475%3A+New+Metrics+to+Measure+Number+of+Tasks+on+a+Connector#KIP475:NewMetricstoMeasureNumberofTasksonaConnector-PublicInterfaces) metric).

In order to reduce this risk, In addition to [retriable.restart.connector.wait.ms](https://debezium.io/documentation/reference/connectors/sqlserver.html#sqlserver-property-retriable-restart-connector-wait-ms), the connector could implement the option(s) for limiting the number of retries and/or the duration of the fail-and-retry loop.
</details>

### Testing considerations

Testing the changes via an integration test is challenging. For this scenario to reproduce, the connection that is instantiated by the connector should fail for the first time but succeed eventually. There's no way to make it behave this way unless the test suite is capable of starting/stopping the database server programmatically.

The changes have been tested manually using the tutorial on [using SQL Server](https://github.com/debezium/debezium-examples/tree/master/tutorial#using-sql-server):
1. Deploy the pipeline and confirm that the consumer receives CDC changes.
2. Stop the SQL Server instance:
   ```shell
   $ docker compose -f docker-compose-sqlserver.yaml stop sqlserver
   ```
3. Confirm that the task restarts at least twice (first during polling, then during start):
   ```
   connect_1    | 2021-08-04 01:45:16,753 INFO   ||  Awaiting end of restart backoff period after a retriable error   [io.debezium.connector.common.BaseSourceTask]
   connect_1    | 2021-08-04 01:45:18,755 INFO   ||  Starting SqlServerConnectorTask with configuration:   [io.debezium.connector.common.BaseSourceTask]
   ```
4. Start the SQL Server instance:
   ```shell
   $ docker compose -f docker-compose-sqlserver.yaml start sqlserver
   ```
5. Confirm that the consumer receives new CDC changes.