### PR TITLE
DBZ-3827 Debezium Server Kinesis Sink Cannot Handle Null Events

### DIFF
--- a/debezium-server/debezium-server-kinesis/src/main/java/io/debezium/server/kinesis/KinesisChangeConsumer.java
+++ b/debezium-server/debezium-server-kinesis/src/main/java/io/debezium/server/kinesis/KinesisChangeConsumer.java
@@ -100,10 +100,15 @@ public class KinesisChangeConsumer extends BaseChangeConsumer implements Debeziu
             throws InterruptedException {
         for (ChangeEvent<Object, Object> record : records) {
             LOGGER.trace("Received event '{}'", record);
+            Object rv = record.value();
+            if (rv == null) {
+                rv = "";
+            }
+
             final PutRecordRequest putRecord = PutRecordRequest.builder()
                     .partitionKey((record.key() != null) ? getString(record.key()) : nullKey)
                     .streamName(streamNameMapper.map(record.destination()))
-                    .data(SdkBytes.fromByteArray(getBytes(record.value())))
+                    .data(SdkBytes.fromByteArray(getBytes(rv)))
                     .build();
             client.putRecord(putRecord);
             committer.markProcessed(record);


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3827

Address issue of a record value potentially being `null` by defining an empty string to ensure `getBytes()` passes as expected.