### PR TITLE
DBZ-3813 Add `rac.nodes` port validation

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -416,7 +416,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
 
         // LogMiner
         this.logMiningStrategy = LogMiningStrategy.parse(config.getString(LOG_MINING_STRATEGY));
-        this.racNodes = resovleRacNodes(config);
+        this.racNodes = resolveRacNodes(config);
         this.logMiningContinuousMine = config.getBoolean(CONTINUOUS_MINE);
         this.logMiningArchiveLogRetention = Duration.ofHours(config.getLong(LOG_MINING_ARCHIVE_LOG_HOURS));
         this.logMiningBatchSizeMin = config.getInteger(LOG_MINING_BATCH_SIZE_MIN);
@@ -1038,7 +1038,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         return Module.name();
     }
 
-    private Set<String> resovleRacNodes(Configuration config) {
+    private Set<String> resolveRacNodes(Configuration config) {
         final boolean portProvided = config.hasKey(PORT.name());
         final Set<String> nodes = Strings.setOf(config.getString(RAC_NODES), String::new);
         return nodes.stream().map(node -> {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -1099,7 +1099,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                 for (String racNode : racNodes) {
                     String[] parts = racNode.split(":");
                     if (parts.length == 1) {
-                        problems.accept(field, racNode, "Must be specified as 'ip:port' since no 'database.port' is provided");
+                        problems.accept(field, racNode, "Must be specified as 'ip/hostname:port' since no 'database.port' is provided");
                         errors++;
                     }
                 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -153,19 +154,12 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withValidation(Field::isNonNegativeInteger)
             .withDescription("Hours to keep long running transactions in transaction buffer between log mining sessions.  By default, all transactions are retained.");
 
-    public static final Field RAC_SYSTEM = Field.create("database.rac")
-            .withDisplayName("Oracle RAC")
-            .withType(Type.BOOLEAN)
-            .withWidth(Width.SHORT)
-            .withImportance(Importance.HIGH)
-            .withDefault(false)
-            .withDescription("Flag to if it is RAC system");
-
     public static final Field RAC_NODES = Field.create("rac.nodes")
             .withDisplayName("Oracle RAC nodes")
             .withType(Type.STRING)
             .withWidth(Width.SHORT)
             .withImportance(Importance.HIGH)
+            .withValidation(OracleConnectorConfig::validateRacNodes)
             .withDescription("A comma-separated list of RAC node hostnames or ip addresses");
 
     public static final Field URL = Field.create(DATABASE_CONFIG_PREFIX + "url")
@@ -336,7 +330,6 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .connector(
                     SNAPSHOT_ENHANCEMENT_TOKEN,
                     SNAPSHOT_LOCKING_MODE,
-                    RAC_SYSTEM,
                     RAC_NODES,
                     LOG_MINING_ARCHIVE_LOG_HOURS,
                     LOG_MINING_BATCH_SIZE_DEFAULT,
@@ -423,7 +416,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
 
         // LogMiner
         this.logMiningStrategy = LogMiningStrategy.parse(config.getString(LOG_MINING_STRATEGY));
-        this.racNodes = Strings.setOf(config.getString(RAC_NODES), String::new);
+        this.racNodes = resovleRacNodes(config);
         this.logMiningContinuousMine = config.getBoolean(CONTINUOUS_MINE);
         this.logMiningArchiveLogRetention = Duration.ofHours(config.getLong(LOG_MINING_ARCHIVE_LOG_HOURS));
         this.logMiningBatchSizeMin = config.getInteger(LOG_MINING_BATCH_SIZE_MIN);
@@ -1045,6 +1038,22 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         return Module.name();
     }
 
+    private Set<String> resovleRacNodes(Configuration config) {
+        final boolean portProvided = config.hasKey(PORT.name());
+        final Set<String> nodes = Strings.setOf(config.getString(RAC_NODES), String::new);
+        return nodes.stream().map(node -> {
+            if (portProvided && !node.contains(":")) {
+                return node + ":" + config.getInteger(PORT);
+            }
+            else {
+                if (!portProvided && !node.contains(":")) {
+                    throw new DebeziumException("RAC node '" + node + "' must specify a port.");
+                }
+                return node;
+            }
+        }).collect(Collectors.toSet());
+    }
+
     public static int validateOutServerName(Configuration config, Field field, ValidationOutput problems) {
         if (ConnectorAdapter.XSTREAM.equals(ConnectorAdapter.parse(config.getString(CONNECTOR_ADAPTER)))) {
             return Field.isRequired(config, field, problems);
@@ -1077,5 +1086,25 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             return Field.isRequired(config, field, problems);
         }
         return 0;
+    }
+
+    public static int validateRacNodes(Configuration config, Field field, ValidationOutput problems) {
+        int errors = 0;
+        if (ConnectorAdapter.LOG_MINER.equals(ConnectorAdapter.parse(config.getString(CONNECTOR_ADAPTER)))) {
+            // If no "database.port" is specified, guarantee that "rac.nodes" (if not empty) specifies the
+            // port designation for each comma-delimited value.
+            final boolean portProvided = config.hasKey(PORT.name());
+            if (!portProvided) {
+                final Set<String> racNodes = Strings.setOf(config.getString(RAC_NODES), String::new);
+                for (String racNode : racNodes) {
+                    String[] parts = racNode.split(":");
+                    if (parts.length == 1) {
+                        problems.accept(field, racNode, "Must be specified as 'ip:port' since no 'database.port' is provided");
+                        errors++;
+                    }
+                }
+            }
+        }
+        return errors;
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/logwriter/RacCommitLogWriterFlushStrategy.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/logwriter/RacCommitLogWriterFlushStrategy.java
@@ -119,7 +119,8 @@ public class RacCommitLogWriterFlushStrategy implements LogWriterFlushStrategy {
         // Create strategies by host
         for (String hostName : hosts) {
             try {
-                flushStrategies.put(hostName, createHostFlushStrategy(hostName));
+                final String[] parts = hostName.split(":");
+                flushStrategies.put(hostName, createHostFlushStrategy(parts[0], Integer.parseInt(parts[1])));
             }
             catch (SQLException e) {
                 throw new DebeziumException("Cannot connect to RAC node '" + hostName + "'", e);
@@ -127,9 +128,10 @@ public class RacCommitLogWriterFlushStrategy implements LogWriterFlushStrategy {
         }
     }
 
-    private CommitLogWriterFlushStrategy createHostFlushStrategy(String hostName) throws SQLException {
+    private CommitLogWriterFlushStrategy createHostFlushStrategy(String hostName, Integer port) throws SQLException {
         JdbcConfiguration jdbcHostConfig = JdbcConfiguration.adapt(jdbcConfiguration.edit()
-                .with(JdbcConfiguration.HOSTNAME, hostName).build());
+                .with(JdbcConfiguration.HOSTNAME, hostName)
+                .with(JdbcConfiguration.PORT, port).build());
 
         LOGGER.debug("Creating flush connection to RAC node '{}'", hostName);
         return new CommitLogWriterFlushStrategy(jdbcHostConfig);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
@@ -223,6 +223,22 @@ public class OracleConnectorConfigTest {
         assertThat(connectorConfig.getRacNodes()).hasSize(2);
         assertThat(connectorConfig.getRacNodes()).contains("1.2.3.4:1521", "1.2.3.5:1522");
 
+        // Test rac.nodes using different ports with no database.port
+        config = Configuration.create().with(racNodes, "1.2.3.4:1523,1.2.3.5:1522").build();
+        assertThat(config.validateAndRecord(Collections.singletonList(racNodes), LOGGER::error)).isTrue();
+
+        connectorConfig = new OracleConnectorConfig(config);
+        assertThat(connectorConfig.getRacNodes()).hasSize(2);
+        assertThat(connectorConfig.getRacNodes()).contains("1.2.3.4:1523", "1.2.3.5:1522");
+
+        // Test rac.nodes using different ports that differ from database.port
+        config = Configuration.create().with(port, "1521").with(racNodes, "1.2.3.4:1523,1.2.3.5:1522").build();
+        assertThat(config.validateAndRecord(Collections.singletonList(racNodes), LOGGER::error)).isTrue();
+
+        connectorConfig = new OracleConnectorConfig(config);
+        assertThat(connectorConfig.getRacNodes()).hasSize(2);
+        assertThat(connectorConfig.getRacNodes()).contains("1.2.3.4:1523", "1.2.3.5:1522");
+
         // Test rac.nodes using no port with no database port
         config = Configuration.create().with(racNodes, "1.2.3.4,1.2.3.5").build();
         assertThat(config.validateAndRecord(Collections.singletonList(racNodes), LOGGER::error)).isFalse();

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2239,7 +2239,29 @@ To capture large object values and serialized them in change events, set this op
 |[[oracle-property-rac-nodes]]<<oracle-property-rac-nodes, `+rac.nodes+`>>
 |No default
 |A comma-separated list of Oracle Real Application Clusters (RAC) node host names or addresses.
-This field is required to enable use with Oracle RAC.
+This field is required to enable Oracle RAC support.
+Specify the list of RAC nodes by using one of the following methods:
+
+* Specify a value for xref:oracle-property-database-port[`database.port`], and use the specified port value for each address in the `rac.nodes` list.
+For example:
++
+[source,properties]
+----
+database.port=1521
+rac.nodes=192.168.1.100,192.168.1.101
+----
+
+* Specify a value for xref:oracle-property-database-port[`database.port`], and override the default port for one or more entries in the list.
+The list can include entries that use the default `database.port` value, and entries that define their own unique port values.
+For example:
++
+[source,properties]
+----
+database.port=1521
+rac.nodes=192.168.1.100,192.168.1.101:1522
+----
+
+If you supply a raw JDBC URL for the database by using the xref:oracle-property-database-url[`database.url`] property, instead of defining a value for `database.port`, each RAC node entry must explicitly specify a port value.
 
 |[[oracle-property-skipped-operations]]<<oracle-property-skipped-operations, `+skipped.operations+`>>
 |No default


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3813

So the underlying core problem here was that the user did not provide a `database.port` but instead only a `database.url`.  This caused a regression when using the connector in RAC mode because the RAC connections expected a PORT value to be supplied but it was not available.

This also raised a valid concern that a RAC node does not have to be configured with the same port across the entire cluster.  In fact, Node A could use port 1521 while Node B uses port 1522.  Unfortunately, the connector's RAC code didn't support this scenario at all, so this PR aims to address both the above and this concern.

* If `rac.nodes` is not provided, no special validation occurs.
* If `rac.nodes` is provided and an entry has no port, `database.port` must be specified.

The idea is that this allows the following configuration:
```
database.port=1521
database.url=...
rac.nodes=node-a,node-b:1522,node-c
```

This allows Node B to operate on a non-standard port 1522 while the other two nodes operate on the default port.  The same configuration can also be provide as follows:

```
database.url=...
rac.nodes=node-a:1521,node-b:1522,node-c:1521
```

This allows the user to skip specifying the `database.port` since they use `database.url`.

@roldanbob - can you check the docs changes please.
