### PR TITLE
DBZ-3840 allow run.sh to work on Cygwin, MinGW & MSYS2

### DIFF
--- a/debezium-server/debezium-server-dist/src/main/resources/distro/run.sh
+++ b/debezium-server/debezium-server-dist/src/main/resources/distro/run.sh
@@ -11,6 +11,12 @@ else
   JAVA_BINARY="$JAVA_HOME/bin/java"
 fi
 
+if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ]; then
+  PATH_SEP=";"
+else
+  PATH_SEP=":"
+fi
+
 RUNNER=$(ls debezium-server-*runner.jar)
 
-exec $JAVA_BINARY $DEBEZIUM_OPTS $JAVA_OPTS -cp "$RUNNER:conf:lib/*" io.debezium.server.Main
+exec $JAVA_BINARY $DEBEZIUM_OPTS $JAVA_OPTS -cp "$RUNNER"$PATH_SEP"conf"$PATH_SEP"lib/*" io.debezium.server.Main


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3840

Debezium Server's `run.sh` startup script fails on Windows due to a difference in path separators between Windows (";") and Linux (":").

This fix allows `run.sh` to succeed on Git Bash for Windows, Cygwin, MinGW, and MSYS2.