### PR TITLE
DBZ-3841 upgrade Pravega to 0.9.1

### DIFF
--- a/debezium-server/debezium-server-bom/pom.xml
+++ b/debezium-server/debezium-server-bom/pom.xml
@@ -17,7 +17,7 @@
         <version.pulsar>2.5.2</version.pulsar>
         <version.eventhubs>5.1.1</version.eventhubs>
         <version.jedis>3.5.2</version.jedis>
-        <version.pravega>0.9.0</version.pravega>
+        <version.pravega>0.9.1</version.pravega>
 
         <version.commons.logging>1.2</version.commons.logging>
     </properties>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3841

Pravega 0.9.1 was released in June 2021.