### PR TITLE
DBZ-3867 Signaling table id column too small in example

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -73,7 +73,7 @@ Such table could be created with a DDL command similar to:
 
 [source,sql]
 ----
-CREATE TABLE debezium_signal (id VARCHAR(32) PRIMARY KEY, type VARCHAR(32) NOT NULL, data VARCHAR(2048) NULL);
+CREATE TABLE debezium_signal (id VARCHAR(42) PRIMARY KEY, type VARCHAR(32) NOT NULL, data VARCHAR(2048) NULL);
 ----
 
 .Example of a signal record


### PR DESCRIPTION
The `id` column holds UUID in string form (36 characters) and can be appended with suffix `-open` or `-close` (a maximum of 6 characters); so 42 characters would be the minimal length of the `id` column.