### PR TITLE
DBZ-3858 Fix links in topic auto-create, CBR, outbox & connector docs

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/content-based-routing.adoc
+++ b/documentation/modules/ROOT/pages/configuration/content-based-routing.adoc
@@ -175,7 +175,7 @@ You can use one of the following methods to configure the connector to apply the
 == Language specifics
 
 The way that you express content-based routing conditions depends on the scripting language that you use.
-For example, as shown in the xref:example-basic-content-based-routing-configuration[basic configuration example], when you use `Groovy` as the expression language,
+For example, as shown in the {link-prefix}:{link-content-based-routing}#example-basic-content-based-routing-configuration[basic configuration example], when you use `Groovy` as the expression language,
 the following expression reroutes all update (`u`) records to the `updates` topic, while routing other records to the default topic:
 
 [source,groovy]

--- a/documentation/modules/ROOT/pages/configuration/outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/configuration/outbox-event-router.adoc
@@ -21,7 +21,7 @@ To implement the outbox pattern in a {prodname} application, configure a {prodna
 * Apply the {prodname} outbox event router single message transformation (SMT)
 
 A {prodname} connector that is configured to apply the outbox SMT should capture changes that occur in an outbox table only.
-For more information, see xref:options-for-applying-the-transformation-selectively[Options for applying the transformation selectively].
+For more information, see {link-prefix}:{link-outbox-event-router}#options-for-applying-the-transformation-selectively[Options for applying the transformation selectively].
 
 A connector can capture changes in more than one outbox table only if each outbox table has the same structure.
 
@@ -185,7 +185,7 @@ Because the structure of these other messages different from the structure of th
 You can use one of the following methods to configure the connector to apply the SMT selectively:
 
 * {link-prefix}:{link-smt-predicates}#applying-transformation-selectively[Configure an SMT predicate for the transformation].
-* Use the xref:filter-topic-regex[topic.regex] configuration option for the SMT.
+* Use the xref:outbox-event-router-property-route-topic-regex[route.topic.regex] configuration option for the SMT.
 
 // Type: concept
 // Title: Using Avro as the payload format in {prodname} outbox messages

--- a/documentation/modules/ROOT/pages/configuration/topic-auto-create-config.adoc
+++ b/documentation/modules/ROOT/pages/configuration/topic-auto-create-config.adoc
@@ -83,8 +83,8 @@ You specify topic configuration properties in the {prodname} connector configura
 The connector configuration defines a default topic creation group, and, optionally, one or more custom topic creation groups.
 Custom topic creation groups use lists of topic name patterns to specify the topics to which the group's settings apply.
 
-For details about how Kafka Connect matches topics to topic creation groups, see xref:topic-creation-groups[Topic creation groups].
-For more information about how configuration properties are assigned to groups, see xref:topic-creation-group-configuration-properties[Topic creation group configuration properties].
+For details about how Kafka Connect matches topics to topic creation groups, see {link-prefix}:{link-topic-auto-creation}#topic-creation-groups[Topic creation groups].
+For more information about how configuration properties are assigned to groups, see {link-prefix}:{link-topic-auto-creation}#topic-creation-group-configuration-properties[Topic creation group configuration properties].
 
 By default, topics that Kafka Connect creates are named based on the pattern `server.schema.table`, for example, `dbserver.myschema.inventory`.
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1407,7 +1407,7 @@ A value of `0` disables this behavior.
 The {prodname} MongoDB connector has two metric types in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect have.
 
 * {link-prefix}:{link-mongodb-connector}#mongodb-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
-* {link-prefix}:{link-mongodb-connector}#mongodb-streaming-metrics[Steaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
+* {link-prefix}:{link-mongodb-connector}#mongodb-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
 
 The {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details about how to expose these metrics by using JMX.
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1406,8 +1406,8 @@ A value of `0` disables this behavior.
 
 The {prodname} MongoDB connector has two metric types in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect have.
 
-* <<mongodb-snapshot-metrics, Snapshot metrics>> provide information about connector operation while performing a snapshot.
-* <<mongodb-streaming-metrics, Streaming metrics>> provide information about connector operation when the connector is capturing changes and streaming change event records.
+* {link-prefix}:{link-mongodb-connector}#mongodb-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
+* {link-prefix}:{link-mongodb-connector}#mongodb-streaming-metrics[Steaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
 
 The {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details about how to expose these metrics by using JMX.
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -114,7 +114,7 @@ To use the {prodname} connector to stream changes from a PostgreSQL database, th
 Although one way to grant the necessary privileges is to provide the user with `superuser` privileges, doing so potentially exposes your PostgreSQL data to unauthorized access.
 Rather than granting excessive privileges to the {prodname} user, it is best to create a dedicated {prodname} replication user to which you grant specific privileges.
 
-For more information about configuring privileges for the {prodname} PostgreSQL user, see xref:postgresql-permissions[Setting up permissions].
+For more information about configuring privileges for the {prodname} PostgreSQL user, see {link-prefix}:{link-postgresql-connector}#postgresql-permissions[Setting up permissions].
 For more information about PostgreSQL logical replication security, see the link:https://www.postgresql.org/docs/current/logical-replication-security.html[PostgreSQL documentation].
 
 // Type: concept
@@ -1978,7 +1978,7 @@ endif::community[]
 Setting up a PostgreSQL server to run a {prodname} connector requires a database user that can perform replications.
 Replication can be performed only by a database user that has appropriate permissions and only for a configured number of hosts.
 
-Although, by default, superusers have the necessary `REPLICATION` and `LOGIN` roles, as mentioned in xref:postgresql-security[Security], it is best not to provide the {prodname} replication user with elevated privileges.
+Although, by default, superusers have the necessary `REPLICATION` and `LOGIN` roles, as mentioned in {link-prefix}:{link-postgresql-connector}#postgresql-security[Security], it is best not to provide the {prodname} replication user with elevated privileges.
 Instead, create a {prodname} user that has the the minimum required privileges.
 
 .Prerequisites
@@ -2726,9 +2726,9 @@ If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column tha
  +
 `skip` causes those event to be omitted (the default). +
  +
-`include` causes hos events to be included. +
-+
-Please see xref:postgresql-truncate-events[] for the structure of _truncate_ events and their ordering semantics.
+`include` causes those events to be included. +
+ +
+For information about the structure of _truncate_ events and about their ordering semantics, see xref:postgresql-truncate-events[].
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2308,8 +2308,8 @@ As a {prodname} user, you must coordinate tasks with the SQL Server database ope
 
 You can use one of the following methods to update capture tables after a schema change:
 
-* xref:offline-schema-updates[]. In offline schema updates, capture tables are updated after you stop the {prodname} connector.
-* xref:online-schema-updates[]. In online schema updates, capture tables are updated while the {prodname} connector is running.
+* {link-prefix}:{link-sqlserver-connector}#offline-schema-updates[Offline schema updates] require you to stop the {prodname} connector before you can update capture tables.
+* {link-prefix}:{link-sqlserver-connector}#online-schema-updates[Online schema updates] can update capture tables while the {prodname} connector is running.
 
 There are advantages and disadvantages to using each type of procedure.
 
@@ -2471,9 +2471,9 @@ GO
 The {prodname} SQL Server connector provides three types of metrics that are in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect provide.
 The connector provides the following metrics:
 
-* <<sqlserver-snapshot-metrics, snapshot metrics>>; for monitoring the connector when performing snapshots.
-* <<sqlserver-streaming-metrics, streaming metrics>>; for monitoring the connector when reading CDC table data.
-* <<sqlserver-schema-history-metrics, schema history metrics>>; for monitoring the status of the connector's schema history.
+* {link-prefix}:{link-sqlserver-connector}#sqlserver-snapshot-metrics[Snapshot metrics] for monitoring the connector when performing snapshots.
+* {link-prefix}:{link-sqlserver-connector}#sqlserver-streaming-metrics[Streaming metrics] for monitoring the connector when reading CDC table data.
+* {link-prefix}:{link-sqlserver-connector}#sqlserver-schema-history-metrics[Schema history metrics] for monitoring the status of the connector's schema history.
 
 For information about how to expose the preceding metrics through JMX, see the {link-prefix}:{link-debezium-monitoring}[{prodname} monitoring documentation].
 


### PR DESCRIPTION
[DBZ-3858](https://issues.redhat.com/browse/DBZ-3858)

This change modifies the format of links that caused build failures downstream that required manually fixing each of the dozen or so links every time that I refreshed content from the upstream branch. The links in question each targets an anchor ID that differs in the upstream and downstream documentation, and I suspect that the way the links were constructed prevented the fetch script from converting the links for downstream use. Not 100% sure that the update will completely resolve the problem. 

I verified that the links in the upstream content work as expected in a local Antora build. 