### PR TITLE
DBZ-3870 PostgreSQL - Performance Improvements in PostgresChangeRecordEmitter

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -242,6 +242,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                                     connectorConfig,
                                     schema,
                                     connection,
+                                    tableId,
                                     message));
 
                     maybeWarnAboutGrowingWalBacklog(dispatched);


### PR DESCRIPTION
[DBZ-3870](https://issues.redhat.com/browse/DBZ-3870)

1) Reuse parsed TableId to avoid expensive PostgresSchema.parse() call
2) Immediate conditional return in synchronizeTableSchema() call