### PR TITLE
DBZ-2975: Use fully-qualified table and procedure names

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
 import io.debezium.config.Configuration;
 import io.debezium.connector.common.RelationalBaseSourceConnector;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
-import io.debezium.util.Clock;
 import io.debezium.util.Strings;
 
 /**
@@ -60,8 +59,9 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
 
         Configuration config = Configuration.from(properties);
         final SqlServerConnectorConfig sqlServerConfig = new SqlServerConnectorConfig(config);
+        final String databaseName = sqlServerConfig.getDatabaseName();
         try (SqlServerConnection connection = connect(sqlServerConfig)) {
-            final String realDatabaseName = connection.retrieveRealDatabaseName();
+            final String realDatabaseName = connection.retrieveRealDatabaseName(databaseName);
             if (!sqlServerConfig.isMultiPartitionModeEnabled()) {
                 taskConfig.put(SqlServerConnectorConfig.DATABASE_NAME.name(), realDatabaseName);
             }
@@ -117,7 +117,8 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
     }
 
     private SqlServerConnection connect(SqlServerConnectorConfig sqlServerConfig) {
-        return new SqlServerConnection(sqlServerConfig.jdbcConfig(), Clock.system(),
-                sqlServerConfig.getSourceTimestampMode(), null);
+        return new SqlServerConnection(sqlServerConfig.jdbcConfig(),
+                sqlServerConfig.getSourceTimestampMode(), null,
+                sqlServerConfig.isMultiPartitionModeEnabled());
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -225,6 +225,18 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
             .withValidation(Field::isOptional)
             .withDescription("The SQL Server instance name");
 
+    public static final Field DATABASE_NAME = RelationalDatabaseConnectorConfig.DATABASE_NAME
+            .withNoValidation()
+            .withValidation(SqlServerConnectorConfig::validateDatabaseName);
+
+    public static final Field DATABASE_NAMES = Field.create(DATABASE_CONFIG_PREFIX + "names")
+            .withDisplayName("Databases")
+            .withType(Type.LIST)
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.HIGH)
+            .withValidation(SqlServerConnectorConfig::validateDatabaseNames)
+            .withDescription("The names of the databases from which the connector should capture changes");
+
     /**
      * @deprecated The connector will determine the database server timezone offset automatically.
      */
@@ -309,6 +321,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
             .name("SQL Server")
             .type(
                     DATABASE_NAME,
+                    DATABASE_NAMES,
                     HOSTNAME,
                     PORT,
                     USER,
@@ -344,12 +357,29 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
     private final SourceTimestampMode sourceTimestampMode;
     private final boolean readOnlyDatabaseConnection;
     private final int maxTransactionsPerIteration;
+    private final boolean multiPartitionMode;
 
     public SqlServerConnectorConfig(Configuration config) {
         super(SqlServerConnector.class, config, config.getString(SERVER_NAME), new SystemTablesPredicate(), x -> x.schema() + "." + x.table(), true,
                 ColumnFilterMode.SCHEMA);
 
-        this.databaseName = config.getString(DATABASE_NAME);
+        final String databaseName = config.getString(DATABASE_NAME.name());
+        final String databaseNames = config.getString(DATABASE_NAMES.name());
+
+        if (databaseName != null) {
+            multiPartitionMode = false;
+            this.databaseName = databaseName;
+        }
+        else if (databaseNames != null) {
+            multiPartitionMode = true;
+            this.databaseName = databaseNames;
+            LOGGER.info("Multi-partition mode is enabled");
+        }
+        else {
+            multiPartitionMode = false;
+            this.databaseName = null;
+        }
+
         this.instanceName = config.getString(INSTANCE);
         this.snapshotMode = SnapshotMode.parse(config.getString(SNAPSHOT_MODE), SNAPSHOT_MODE.defaultValueAsString());
 
@@ -380,6 +410,10 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
 
     public String getInstanceName() {
         return instanceName;
+    }
+
+    public boolean isMultiPartitionModeEnabled() {
+        return multiPartitionMode;
     }
 
     public SnapshotIsolationMode getSnapshotIsolationMode() {
@@ -446,5 +480,31 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
     @Override
     public String getConnectorName() {
         return Module.name();
+    }
+
+    private static int validateDatabaseName(Configuration config, Field field, Field.ValidationOutput problems) {
+        if (config.hasKey(field) && config.hasKey(DATABASE_NAMES)) {
+            problems.accept(field, null, "Cannot be specified alongside " + DATABASE_NAMES);
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private static int validateDatabaseNames(Configuration config, Field field, Field.ValidationOutput problems) {
+        String databaseNames = config.getString(field);
+        int count = 0;
+        if (databaseNames != null) {
+            if (config.hasKey(DATABASE_NAME)) {
+                problems.accept(field, null, "Cannot be specified alongside " + DATABASE_NAME);
+                ++count;
+            }
+            if (databaseNames.contains(",")) {
+                problems.accept(field, databaseNames, "Only a single database name is currently supported");
+                ++count;
+            }
+        }
+
+        return count;
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -483,8 +483,8 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
     }
 
     private static int validateDatabaseName(Configuration config, Field field, Field.ValidationOutput problems) {
-        if (config.hasKey(field) && config.hasKey(DATABASE_NAMES)) {
-            problems.accept(field, null, "Cannot be specified alongside " + DATABASE_NAMES);
+        if (!config.hasKey(field) && !config.hasKey(DATABASE_NAMES)) {
+            problems.accept(field, null, "Either " + DATABASE_NAME + " or " + DATABASE_NAMES + " must be specified");
             return 1;
         }
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -72,10 +72,10 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
         final Configuration jdbcConfig = config.filter(
                 x -> !(x.startsWith(DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING) || x.equals(HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY.name())))
                 .subset("database.", true);
-        dataConnection = new SqlServerConnection(jdbcConfig, clock, connectorConfig.getSourceTimestampMode(), valueConverters, () -> getClass().getClassLoader(),
-                connectorConfig.getSkippedOperations());
-        metadataConnection = new SqlServerConnection(jdbcConfig, clock, connectorConfig.getSourceTimestampMode(), valueConverters, () -> getClass().getClassLoader(),
-                connectorConfig.getSkippedOperations());
+        dataConnection = new SqlServerConnection(jdbcConfig, connectorConfig.getSourceTimestampMode(), valueConverters, () -> getClass().getClassLoader(),
+                connectorConfig.getSkippedOperations(), connectorConfig.isMultiPartitionModeEnabled());
+        metadataConnection = new SqlServerConnection(jdbcConfig, connectorConfig.getSourceTimestampMode(), valueConverters, () -> getClass().getClassLoader(),
+                connectorConfig.getSkippedOperations(), connectorConfig.isMultiPartitionModeEnabled());
 
         this.schema = new SqlServerDatabaseSchema(connectorConfig, valueConverters, topicSelector, schemaNameAdjuster);
         this.schema.initializeStorage();

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerPartition.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerPartition.java
@@ -15,16 +15,35 @@ import io.debezium.util.Collect;
 
 public class SqlServerPartition implements Partition {
     private static final String SERVER_PARTITION_KEY = "server";
+    private static final String DATABASE_PARTITION_KEY = "database";
 
     private final String serverName;
+    private final String databaseName;
+    private final Map<String, String> sourcePartition;
+    private final int hashCode;
 
-    public SqlServerPartition(String serverName) {
+    public SqlServerPartition(String serverName, String databaseName, boolean multiPartitionMode) {
         this.serverName = serverName;
+        this.databaseName = databaseName;
+
+        this.sourcePartition = Collect.hashMapOf(SERVER_PARTITION_KEY, serverName);
+        if (multiPartitionMode) {
+            this.sourcePartition.put(DATABASE_PARTITION_KEY, databaseName);
+        }
+
+        this.hashCode = Objects.hash(serverName, databaseName);
     }
 
     @Override
     public Map<String, String> getSourcePartition() {
-        return Collect.hashMapOf(SERVER_PARTITION_KEY, serverName);
+        return sourcePartition;
+    }
+
+    /**
+     * Returns the SQL Server database name corresponding to the partition.
+     */
+    String getDatabaseName() {
+        return databaseName;
     }
 
     @Override
@@ -36,12 +55,12 @@ public class SqlServerPartition implements Partition {
             return false;
         }
         final SqlServerPartition other = (SqlServerPartition) obj;
-        return Objects.equals(serverName, other.serverName);
+        return Objects.equals(serverName, other.serverName) && Objects.equals(databaseName, other.databaseName);
     }
 
     @Override
     public int hashCode() {
-        return serverName.hashCode();
+        return hashCode;
     }
 
     static class Provider implements Partition.Provider<SqlServerPartition> {
@@ -53,7 +72,10 @@ public class SqlServerPartition implements Partition {
 
         @Override
         public Set<SqlServerPartition> getPartitions() {
-            return Collections.singleton(new SqlServerPartition(connectorConfig.getLogicalName()));
+            return Collections.singleton(new SqlServerPartition(
+                    connectorConfig.getLogicalName(),
+                    connectorConfig.getDatabaseName(),
+                    connectorConfig.isMultiPartitionModeEnabled()));
         }
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -58,7 +58,7 @@ import io.debezium.util.Metronome;
  */
 public class SqlServerStreamingChangeEventSource implements StreamingChangeEventSource<SqlServerPartition, SqlServerOffsetContext> {
 
-    private static final Pattern MISSING_CDC_FUNCTION_CHANGES_ERROR = Pattern.compile("Invalid object name 'cdc.fn_cdc_get_all_changes_(.*)'\\.");
+    private static final Pattern MISSING_CDC_FUNCTION_CHANGES_ERROR = Pattern.compile("Invalid object name '(.*)\\.cdc.fn_cdc_get_all_changes_(.*)'\\.");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerStreamingChangeEventSource.class);
 
@@ -112,6 +112,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
             return;
         }
 
+        final String databaseName = partition.getDatabaseName();
         final Metronome metronome = Metronome.sleeper(pollInterval, clock);
         final Queue<SqlServerChangeTable> schemaChangeCheckpoints = new PriorityQueue<>((x, y) -> x.getStopLsn().compareTo(y.getStopLsn()));
         try {
@@ -130,7 +131,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
             boolean shouldIncreaseFromLsn = offsetContext.isSnapshotCompleted();
             while (context.isRunning()) {
                 commitTransaction();
-                final Lsn toLsn = getToLsn(dataConnection, lastProcessedPosition, maxTransactionsPerIteration);
+                final Lsn toLsn = getToLsn(dataConnection, databaseName, lastProcessedPosition, maxTransactionsPerIteration);
 
                 // Shouldn't happen if the agent is running, but it is better to guard against such situation
                 if (!toLsn.isAvailable()) {
@@ -148,14 +149,14 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                 // Reading interval is inclusive so we need to move LSN forward but not for first
                 // run as TX might not be streamed completely
                 final Lsn fromLsn = lastProcessedPosition.getCommitLsn().isAvailable() && shouldIncreaseFromLsn
-                        ? dataConnection.incrementLsn(lastProcessedPosition.getCommitLsn())
+                        ? dataConnection.incrementLsn(databaseName, lastProcessedPosition.getCommitLsn())
                         : lastProcessedPosition.getCommitLsn();
                 shouldIncreaseFromLsn = true;
 
                 while (!schemaChangeCheckpoints.isEmpty()) {
                     migrateTable(partition, schemaChangeCheckpoints, offsetContext);
                 }
-                if (!dataConnection.listOfNewChangeTables(fromLsn, toLsn).isEmpty()) {
+                if (!dataConnection.listOfNewChangeTables(databaseName, fromLsn, toLsn).isEmpty()) {
                     final SqlServerChangeTable[] tables = getCdcTablesToQuery(partition, offsetContext);
                     tablesSlot.set(tables);
                     for (SqlServerChangeTable table : tables) {
@@ -166,7 +167,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                     }
                 }
                 try {
-                    dataConnection.getChangesForTables(tablesSlot.get(), fromLsn, toLsn, resultSets -> {
+                    dataConnection.getChangesForTables(databaseName, tablesSlot.get(), fromLsn, toLsn, resultSets -> {
 
                         long eventSerialNoInInitialTx = 1;
                         final int tableCount = resultSets.length;
@@ -283,7 +284,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                     dataConnection.rollback();
                 }
                 catch (SQLException e) {
-                    tablesSlot.set(processErrorFromChangeTableQuery(e, tablesSlot.get()));
+                    tablesSlot.set(processErrorFromChangeTableQuery(databaseName, e, tablesSlot.get()));
                 }
             }
         }
@@ -307,17 +308,19 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
             throws InterruptedException, SQLException {
         final SqlServerChangeTable newTable = schemaChangeCheckpoints.poll();
         LOGGER.info("Migrating schema to {}", newTable);
-        Table tableSchema = metadataConnection.getTableSchemaFromTable(newTable);
+        Table tableSchema = metadataConnection.getTableSchemaFromTable(partition.getDatabaseName(), newTable);
         dispatcher.dispatchSchemaChangeEvent(newTable.getSourceTableId(),
                 new SqlServerSchemaChangeEventEmitter(partition, offsetContext, newTable, tableSchema,
                         SchemaChangeEventType.ALTER));
         newTable.setSourceTable(tableSchema);
     }
 
-    private SqlServerChangeTable[] processErrorFromChangeTableQuery(SQLException exception, SqlServerChangeTable[] currentChangeTables) throws Exception {
+    private SqlServerChangeTable[] processErrorFromChangeTableQuery(String databaseName, SQLException exception,
+                                                                    SqlServerChangeTable[] currentChangeTables)
+            throws Exception {
         final Matcher m = MISSING_CDC_FUNCTION_CHANGES_ERROR.matcher(exception.getMessage());
-        if (m.matches()) {
-            final String captureName = m.group(1);
+        if (m.matches() && m.group(1).equals(databaseName)) {
+            final String captureName = m.group(2);
             LOGGER.info("Table is no longer captured with capture instance {}", captureName);
             return Arrays.asList(currentChangeTables).stream()
                     .filter(x -> !x.getCaptureInstance().equals(captureName))
@@ -327,7 +330,8 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
     }
 
     private SqlServerChangeTable[] getCdcTablesToQuery(SqlServerPartition partition, SqlServerOffsetContext offsetContext) throws SQLException, InterruptedException {
-        final Set<SqlServerChangeTable> cdcEnabledTables = dataConnection.listOfChangeTables();
+        final String databaseName = partition.getDatabaseName();
+        final Set<SqlServerChangeTable> cdcEnabledTables = dataConnection.listOfChangeTables(databaseName);
         if (cdcEnabledTables.isEmpty()) {
             LOGGER.warn("No table has enabled CDC or security constraints prevents getting the list of change tables");
         }
@@ -362,7 +366,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                     futureTable = captures.get(0);
                 }
                 currentTable.setStopLsn(futureTable.getStartLsn());
-                futureTable.setSourceTable(dataConnection.getTableSchemaFromTable(futureTable));
+                futureTable.setSourceTable(dataConnection.getTableSchemaFromTable(databaseName, futureTable));
                 tables.add(futureTable);
                 LOGGER.info("Multiple capture instances present for the same table: {} and {}", currentTable, futureTable);
             }
@@ -379,7 +383,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                                 partition,
                                 offsetContext,
                                 currentTable,
-                                dataConnection.getTableSchemaFromTable(currentTable),
+                                dataConnection.getTableSchemaFromTable(databaseName, currentTable),
                                 SchemaChangeEventType.CREATE));
             }
 
@@ -396,20 +400,20 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
     /**
      * @return the log sequence number up until which the connector should query changes from the database.
      */
-    private Lsn getToLsn(SqlServerConnection connection, TxLogPosition lastProcessedPosition,
+    private Lsn getToLsn(SqlServerConnection connection, String databaseName, TxLogPosition lastProcessedPosition,
                          int maxTransactionsPerIteration)
             throws SQLException {
 
         if (maxTransactionsPerIteration == 0) {
-            return connection.getMaxTransactionLsn();
+            return connection.getMaxTransactionLsn(databaseName);
         }
 
         final Lsn fromLsn = lastProcessedPosition.getCommitLsn();
 
         if (!fromLsn.isAvailable()) {
-            return connection.getNthTransactionLsnFromBeginning(maxTransactionsPerIteration);
+            return connection.getNthTransactionLsnFromBeginning(databaseName, maxTransactionsPerIteration);
         }
 
-        return connection.getNthTransactionLsnFromLast(fromLsn, maxTransactionsPerIteration);
+        return connection.getNthTransactionLsnFromLast(databaseName, fromLsn, maxTransactionsPerIteration);
     }
 }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotWithSelectOverridesIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotWithSelectOverridesIT.java
@@ -92,7 +92,7 @@ public class SnapshotWithSelectOverridesIT extends AbstractConnectorTest {
 
     @Test
     @FixFor("DBZ-1224")
-    public void takeSnapshotWithOverrides() throws Exception {
+    public void takeSnapshotWithOverridesInSinglePartitionMode() throws Exception {
         final Configuration config = TestHelper.defaultConfig()
                 .with(
                         RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
@@ -104,7 +104,27 @@ public class SnapshotWithSelectOverridesIT extends AbstractConnectorTest {
                         RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + ".dbo.table3",
                         "SELECT * FROM [dbo].[table3] where soft_deleted = 0")
                 .build();
+        takeSnapshotWithOverrides(config);
+    }
 
+    @Test
+    @FixFor({ "DBZ-1224", "DBZ-2975" })
+    public void takeSnapshotWithOverridesInMultiPartitionMode() throws Exception {
+        final Configuration config = TestHelper.defaultMultiPartitionConfig()
+                .with(
+                        RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
+                        "dbo.table1,dbo.table3")
+                .with(
+                        RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + ".dbo.table1",
+                        "SELECT * FROM [" + TestHelper.TEST_DATABASE + "].[dbo].[table1] where soft_deleted = 0 order by id desc")
+                .with(
+                        RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + ".dbo.table3",
+                        "SELECT * FROM [" + TestHelper.TEST_DATABASE + "].[dbo].[table3] where soft_deleted = 0")
+                .build();
+        takeSnapshotWithOverrides(config);
+    }
+
+    private void takeSnapshotWithOverrides(Configuration config) throws Exception {
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
 
@@ -138,7 +158,7 @@ public class SnapshotWithSelectOverridesIT extends AbstractConnectorTest {
 
     @Test
     @FixFor("DBZ-3429")
-    public void takeSnapshotWithOverridesWithAdditionalWhitespace() throws Exception {
+    public void takeSnapshotWithOverridesWithAdditionalWhitespaceInSinglePartitionMode() throws Exception {
         final Configuration config = TestHelper.defaultConfig()
                 .with(
                         RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
@@ -150,7 +170,27 @@ public class SnapshotWithSelectOverridesIT extends AbstractConnectorTest {
                         RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + ".dbo.table3",
                         "SELECT * FROM [dbo].[table3] where soft_deleted = 0")
                 .build();
+        takeSnapshotWithOverridesWithAdditionalWhitespace(config);
+    }
 
+    @Test
+    @FixFor({ "DBZ-3429", "DBZ-2975" })
+    public void takeSnapshotWithOverridesWithAdditionalWhitespaceInMultiPartitionMode() throws Exception {
+        final Configuration config = TestHelper.defaultMultiPartitionConfig()
+                .with(
+                        RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
+                        "  dbo.table1 , dbo.table3  ")
+                .with(
+                        RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + ".dbo.table1",
+                        "SELECT * FROM [" + TestHelper.TEST_DATABASE + "].[dbo].[table1] where soft_deleted = 0 order by id desc")
+                .with(
+                        RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + ".dbo.table3",
+                        "SELECT * FROM [" + TestHelper.TEST_DATABASE + "].[dbo].[table3] where soft_deleted = 0")
+                .build();
+        takeSnapshotWithOverridesWithAdditionalWhitespace(config);
+    }
+
+    private void takeSnapshotWithOverridesWithAdditionalWhitespace(Configuration config) throws Exception {
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
@@ -196,7 +196,7 @@ public class SqlServerConnectionIT {
 
             SqlServerChangeTable changeTable = new SqlServerChangeTable(new TableId("testDB", "dbo", "table_with_defaults"),
                     null, 0, null, null, capturedColumns);
-            Table table = connection.getTableSchemaFromTable(changeTable);
+            Table table = connection.getTableSchemaFromTable(TestHelper.TEST_DATABASE, changeTable);
 
             assertColumnHasNotDefaultValue(table, "int_no_default_not_null");
             assertColumnHasDefaultValue(table, "int_no_default", null);
@@ -310,7 +310,7 @@ public class SqlServerConnectionIT {
             // and issue a test call to a CDC wrapper function
             Awaitility.await()
                     .atMost(5, TimeUnit.SECONDS)
-                    .until(() -> connection.getMinLsn("table_with_defaults").isAvailable()); // Need to wait to make sure the min_lsn is available
+                    .until(() -> connection.getMinLsn(TestHelper.TEST_DATABASE, "table_with_defaults").isAvailable()); // Need to wait to make sure the min_lsn is available
             List<String> capturedColumns = Arrays
                     .asList(
                             "int_no_default_not_null",
@@ -345,7 +345,7 @@ public class SqlServerConnectionIT {
 
             SqlServerChangeTable changeTable = new SqlServerChangeTable(new TableId("testDB", "dbo", "table_with_defaults"),
                     null, 0, null, null, capturedColumns);
-            Table table = connection.getTableSchemaFromTable(changeTable);
+            Table table = connection.getTableSchemaFromTable(TestHelper.TEST_DATABASE, changeTable);
 
             assertColumnHasNotDefaultValue(table, "int_no_default_not_null");
             assertColumnHasDefaultValue(table, "int_no_default", null);

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorConfigTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorConfigTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.relational.history.KafkaDatabaseHistory;
+
+public class SqlServerConnectorConfigTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerConnectorConfigTest.class);
+
+    @Test
+    public void noDatabaseName() {
+        final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(
+                defaultConfig().build());
+        assertTrue(connectorConfig.validateAndRecord(SqlServerConnectorConfig.ALL_FIELDS, LOGGER::error));
+    }
+
+    @Test
+    public void onlyDatabaseName() {
+        final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(
+                defaultConfig()
+                        .with(SqlServerConnectorConfig.DATABASE_NAME, "testDB")
+                        .build());
+        assertTrue(connectorConfig.validateAndRecord(SqlServerConnectorConfig.ALL_FIELDS, LOGGER::error));
+    }
+
+    @Test
+    public void onlyDatabaseNames() {
+        final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(
+                defaultConfig()
+                        .with(SqlServerConnectorConfig.DATABASE_NAMES, "testDB")
+                        .build());
+        assertTrue(connectorConfig.validateAndRecord(SqlServerConnectorConfig.ALL_FIELDS, LOGGER::error));
+    }
+
+    @Test
+    public void databaseNameAndDatabaseNames() {
+        final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(
+                defaultConfig()
+                        .with(SqlServerConnectorConfig.DATABASE_NAME, "testDB")
+                        .with(SqlServerConnectorConfig.DATABASE_NAMES, "testDB")
+                        .build());
+        assertFalse(connectorConfig.validateAndRecord(SqlServerConnectorConfig.ALL_FIELDS, LOGGER::error));
+    }
+
+    @Test
+    public void multipleDatabaseNames() {
+        final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(
+                defaultConfig()
+                        .with(SqlServerConnectorConfig.DATABASE_NAMES, "testDB1,testDB2")
+                        .build());
+        assertFalse(connectorConfig.validateAndRecord(SqlServerConnectorConfig.ALL_FIELDS, LOGGER::error));
+    }
+
+    private Configuration.Builder defaultConfig() {
+        return Configuration.create()
+                .with(SqlServerConnectorConfig.SERVER_NAME, "server")
+                .with(SqlServerConnectorConfig.HOSTNAME, "localhost")
+                .with(SqlServerConnectorConfig.USER, "debezium")
+                .with(KafkaDatabaseHistory.BOOTSTRAP_SERVERS, "localhost:9092")
+                .with(KafkaDatabaseHistory.TOPIC, "history");
+    }
+}

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorConfigTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorConfigTest.java
@@ -23,7 +23,7 @@ public class SqlServerConnectorConfigTest {
     public void noDatabaseName() {
         final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(
                 defaultConfig().build());
-        assertTrue(connectorConfig.validateAndRecord(SqlServerConnectorConfig.ALL_FIELDS, LOGGER::error));
+        assertFalse(connectorConfig.validateAndRecord(SqlServerConnectorConfig.ALL_FIELDS, LOGGER::error));
     }
 
     @Test

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -751,21 +751,21 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> {
             // Wait for max lsn to be available
-            if (!connection.getMaxLsn().isAvailable()) {
+            if (!connection.getMaxLsn(TestHelper.TEST_DATABASE).isAvailable()) {
                 return false;
             }
 
             // verify pre-snapshot inserts have succeeded
             Map<String, Boolean> resultMap = new HashMap<>();
-            connection.listOfChangeTables().forEach(ct -> {
+            connection.listOfChangeTables(TestHelper.TEST_DATABASE).forEach(ct -> {
                 final String tableName = ct.getChangeTableId().table();
                 if (tableName.endsWith("dbo_" + tableaCT) || tableName.endsWith("dbo_" + tablebCT)) {
                     try {
-                        final Lsn minLsn = connection.getMinLsn(tableName);
-                        final Lsn maxLsn = connection.getMaxLsn();
+                        final Lsn minLsn = connection.getMinLsn(TestHelper.TEST_DATABASE, tableName);
+                        final Lsn maxLsn = connection.getMaxLsn(TestHelper.TEST_DATABASE);
                         SqlServerChangeTable[] tables = Collections.singletonList(ct).toArray(new SqlServerChangeTable[]{});
                         final List<Integer> ids = new ArrayList<>();
-                        connection.getChangesForTables(tables, minLsn, maxLsn, resultsets -> {
+                        connection.getChangesForTables(TestHelper.TEST_DATABASE, tables, minLsn, maxLsn, resultsets -> {
                             final ResultSet rs = resultsets[0];
                             while (rs.next()) {
                                 ids.add(rs.getInt("id"));
@@ -2077,7 +2077,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS).until(() -> {
             Testing.debug("Waiting for initial changes to be propagated to CDC structures");
-            return connection.getMaxLsn().isAvailable();
+            return connection.getMaxLsn(TestHelper.TEST_DATABASE).isAvailable();
         });
 
         start(SqlServerConnector.class, config);

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerPartitionTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerPartitionTest.java
@@ -11,11 +11,11 @@ public class SqlServerPartitionTest extends AbstractPartitionTest<SqlServerParti
 
     @Override
     protected SqlServerPartition createPartition1() {
-        return new SqlServerPartition("server1");
+        return new SqlServerPartition("server1", "database1", false);
     }
 
     @Override
     protected SqlServerPartition createPartition2() {
-        return new SqlServerPartition("server2");
+        return new SqlServerPartition("server2", "database2", false);
     }
 }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TransactionMetadataIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TransactionMetadataIT.java
@@ -149,19 +149,19 @@ public class TransactionMetadataIT extends AbstractConnectorTest {
             connection.execute("INSERT INTO tablea VALUES(-1, '-a')");
 
             Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> {
-                if (!connection.getMaxLsn().isAvailable()) {
+                if (!connection.getMaxLsn(TestHelper.TEST_DATABASE).isAvailable()) {
                     return false;
                 }
 
-                for (SqlServerChangeTable ct : connection.listOfChangeTables()) {
+                for (SqlServerChangeTable ct : connection.listOfChangeTables(TestHelper.TEST_DATABASE)) {
                     final String tableName = ct.getChangeTableId().table();
                     if (tableName.endsWith("dbo_" + connection.getNameOfChangeTable("tablea"))) {
                         try {
-                            final Lsn minLsn = connection.getMinLsn(tableName);
-                            final Lsn maxLsn = connection.getMaxLsn();
+                            final Lsn minLsn = connection.getMinLsn(TestHelper.TEST_DATABASE, tableName);
+                            final Lsn maxLsn = connection.getMaxLsn(TestHelper.TEST_DATABASE);
                             final AtomicReference<Boolean> found = new AtomicReference<>(false);
                             SqlServerChangeTable[] tables = Collections.singletonList(ct).toArray(new SqlServerChangeTable[]{});
-                            connection.getChangesForTables(tables, minLsn, maxLsn, resultsets -> {
+                            connection.getChangesForTables(TestHelper.TEST_DATABASE, tables, minLsn, maxLsn, resultsets -> {
                                 final ResultSet rs = resultsets[0];
                                 while (rs.next()) {
                                     if (rs.getInt("id") == -1) {

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -39,7 +39,6 @@ import io.debezium.jdbc.JdbcValueConverters;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.history.FileDatabaseHistory;
-import io.debezium.util.Clock;
 import io.debezium.util.IoUtil;
 import io.debezium.util.Strings;
 import io.debezium.util.Testing;
@@ -95,8 +94,7 @@ public class TestHelper {
     }
 
     public static JdbcConfiguration adminJdbcConfig() {
-        return JdbcConfiguration.copy(Configuration.fromSystemProperties("database."))
-                .withDefault(JdbcConfiguration.DATABASE, "master")
+        return JdbcConfiguration.copy(Configuration.fromSystemProperties(SqlServerConnectorConfig.DATABASE_CONFIG_PREFIX))
                 .withDefault(JdbcConfiguration.HOSTNAME, "localhost")
                 .withDefault(JdbcConfiguration.PORT, 1433)
                 .withDefault(JdbcConfiguration.USER, "sa")
@@ -105,8 +103,7 @@ public class TestHelper {
     }
 
     public static JdbcConfiguration defaultJdbcConfig() {
-        return JdbcConfiguration.copy(Configuration.fromSystemProperties("database."))
-                .withDefault(JdbcConfiguration.DATABASE, TEST_DATABASE)
+        return JdbcConfiguration.copy(Configuration.fromSystemProperties(SqlServerConnectorConfig.DATABASE_CONFIG_PREFIX))
                 .withDefault(JdbcConfiguration.HOSTNAME, "localhost")
                 .withDefault(JdbcConfiguration.PORT, 1433)
                 .withDefault(JdbcConfiguration.USER, "sa")
@@ -114,11 +111,7 @@ public class TestHelper {
                 .build();
     }
 
-    /**
-     * Returns a default configuration suitable for most test cases. Can be amended/overridden in individual tests as
-     * needed.
-     */
-    public static Configuration.Builder defaultConfig() {
+    public static Configuration.Builder defaultConnectorConfig() {
         JdbcConfiguration jdbcConfiguration = defaultJdbcConfig();
         Configuration.Builder builder = Configuration.create();
 
@@ -129,6 +122,23 @@ public class TestHelper {
                 .with(SqlServerConnectorConfig.DATABASE_HISTORY, FileDatabaseHistory.class)
                 .with(FileDatabaseHistory.FILE_PATH, DB_HISTORY_PATH)
                 .with(RelationalDatabaseConnectorConfig.INCLUDE_SCHEMA_CHANGES, false);
+    }
+
+    /**
+     * Returns a default connector configuration suitable for most test cases. Can be amended/overridden
+     * in individual tests as needed.
+     */
+    public static Configuration.Builder defaultConfig() {
+        return defaultConnectorConfig()
+                .with(SqlServerConnectorConfig.DATABASE_NAME.name(), TEST_DATABASE);
+    }
+
+    /**
+     * Returns a default configuration for connectors in multi-partition mode.
+     */
+    public static Configuration.Builder defaultMultiPartitionConfig() {
+        return defaultConnectorConfig()
+                .with(SqlServerConnectorConfig.DATABASE_NAMES.name(), TEST_DATABASE);
     }
 
     public static void createTestDatabase() {
@@ -210,13 +220,18 @@ public class TestHelper {
     }
 
     public static SqlServerConnection adminConnection() {
-        return new SqlServerConnection(TestHelper.adminJdbcConfig(), Clock.system(), SourceTimestampMode.getDefaultMode(),
-                new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE, null));
+        return new SqlServerConnection(TestHelper.adminJdbcConfig(), SourceTimestampMode.getDefaultMode(),
+                new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE, null), true);
     }
 
     public static SqlServerConnection testConnection() {
-        return new SqlServerConnection(TestHelper.defaultJdbcConfig(), Clock.system(), SourceTimestampMode.getDefaultMode(),
-                new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE, null));
+        Configuration config = defaultJdbcConfig()
+                .edit()
+                .with(JdbcConfiguration.ON_CONNECT_STATEMENTS, "USE [" + TEST_DATABASE + "]")
+                .build();
+
+        return new SqlServerConnection(config, SourceTimestampMode.getDefaultMode(),
+                new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE, null), true);
     }
 
     /**
@@ -386,7 +401,7 @@ public class TestHelper {
                     .atMost(60, TimeUnit.SECONDS)
                     .pollDelay(Duration.ofSeconds(0))
                     .pollInterval(Duration.ofMillis(100))
-                    .until(() -> connection.getMaxLsn().isAvailable());
+                    .until(() -> connection.getMaxLsn(TEST_DATABASE).isAvailable());
         }
         catch (ConditionTimeoutException e) {
             throw new IllegalArgumentException("A max LSN was not available", e);
@@ -417,19 +432,19 @@ public class TestHelper {
                     .atMost(60, TimeUnit.SECONDS)
                     .pollDelay(Duration.ofSeconds(0))
                     .pollInterval(Duration.ofMillis(100)).until(() -> {
-                        if (!connection.getMaxLsn().isAvailable()) {
+                        if (!connection.getMaxLsn(TEST_DATABASE).isAvailable()) {
                             return false;
                         }
 
-                        for (SqlServerChangeTable ct : connection.listOfChangeTables()) {
+                        for (SqlServerChangeTable ct : connection.listOfChangeTables(TEST_DATABASE)) {
                             final String ctTableName = ct.getChangeTableId().table();
                             if (ctTableName.endsWith("dbo_" + connection.getNameOfChangeTable(tableName))) {
                                 try {
-                                    final Lsn minLsn = connection.getMinLsn(ctTableName);
-                                    final Lsn maxLsn = connection.getMaxLsn();
+                                    final Lsn minLsn = connection.getMinLsn(TEST_DATABASE, ctTableName);
+                                    final Lsn maxLsn = connection.getMaxLsn(TEST_DATABASE);
                                     final CdcRecordFoundBlockingMultiResultSetConsumer consumer = new CdcRecordFoundBlockingMultiResultSetConsumer(handler);
                                     SqlServerChangeTable[] tables = Collections.singletonList(ct).toArray(new SqlServerChangeTable[]{});
-                                    connection.getChangesForTables(tables, minLsn, maxLsn, consumer);
+                                    connection.getChangesForTables(TEST_DATABASE, tables, minLsn, maxLsn, consumer);
                                     return consumer.isFound();
                                 }
                                 catch (Exception e) {
@@ -472,19 +487,19 @@ public class TestHelper {
                     .atMost(30, TimeUnit.SECONDS)
                     .pollDelay(Duration.ofSeconds(0))
                     .pollInterval(Duration.ofMillis(100)).until(() -> {
-                        if (!connection.getMaxLsn().isAvailable()) {
+                        if (!connection.getMaxLsn(TEST_DATABASE).isAvailable()) {
                             return false;
                         }
 
-                        for (SqlServerChangeTable ct : connection.listOfChangeTables()) {
+                        for (SqlServerChangeTable ct : connection.listOfChangeTables(TEST_DATABASE)) {
                             final String ctTableName = ct.getChangeTableId().table();
                             if (ctTableName.endsWith(connection.getNameOfChangeTable(captureInstanceName))) {
                                 try {
-                                    final Lsn minLsn = connection.getMinLsn(ctTableName);
-                                    final Lsn maxLsn = connection.getMaxLsn();
+                                    final Lsn minLsn = connection.getMinLsn(TEST_DATABASE, ctTableName);
+                                    final Lsn maxLsn = connection.getMaxLsn(TEST_DATABASE);
                                     final CdcRecordFoundBlockingMultiResultSetConsumer consumer = new CdcRecordFoundBlockingMultiResultSetConsumer(handler);
                                     SqlServerChangeTable[] tables = Collections.singletonList(ct).toArray(new SqlServerChangeTable[]{});
-                                    connection.getChangesForTables(tables, minLsn, maxLsn, consumer);
+                                    connection.getChangesForTables(TEST_DATABASE, tables, minLsn, maxLsn, consumer);
                                     return consumer.isFound();
                                 }
                                 catch (Exception e) {

--- a/debezium-core/src/main/java/io/debezium/config/Configuration.java
+++ b/debezium-core/src/main/java/io/debezium/config/Configuration.java
@@ -983,6 +983,17 @@ public interface Configuration {
     }
 
     /**
+     * Determine whether this configuration contains a key-value pair associated with the given field and the value
+     * is non-null.
+     *
+     * @param field the field; may not be null
+     * @return true if the configuration contains the key, or false otherwise
+     */
+    default boolean hasKey(Field field) {
+        return hasKey(field.name());
+    }
+
+    /**
      * Get the set of keys in this configuration.
      *
      * @return the set of keys; never null but possibly empty

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -182,7 +182,7 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.HIGH)
             .withValidation(Field::isRequired)
-            .withDescription("The name of the database the connector should be monitoring");
+            .withDescription("The name of the database from which the connector should capture changes");
 
     public static final Field SERVER_NAME = Field.create(DATABASE_CONFIG_PREFIX + "server.name")
             .withDisplayName("Namespace")

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2004,6 +2004,15 @@ The following configuration properties are _required_ unless a default value is 
 |[[sqlserver-property-database-dbname]]<<sqlserver-property-database-dbname, `+database.dbname+`>>
 |
 |The name of the SQL Server database from which to stream the changes
+Must not be used with `database.names`.
+
+|[[sqlserver-property-database-names]]<<sqlserver-property-database-names, `+database.names+`>>
+|
+|The comma-separated list of the SQL Server database names from which to stream the changes.
+Currently, only one database name is supported. Must not be used with `database.dbname`.
+
+This option is *experimental* and must not be used in production. Using it will make the behavior of the connector
+incompatible with the default configuration with no upgrade or downgrade path.
 
 |[[sqlserver-property-database-server-name]]<<sqlserver-property-database-server-name, `+database.server.name+`>>
 |

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2012,7 +2012,11 @@ Must not be used with `database.names`.
 Currently, only one database name is supported. Must not be used with `database.dbname`.
 
 This option is *experimental* and must not be used in production. Using it will make the behavior of the connector
-incompatible with the default configuration with no upgrade or downgrade path.
+incompatible with the default configuration with no upgrade or downgrade path:
+
+* The connector will use different keys for its committed offset messages.
+* The SQL statements used in `snapshot.select.statement.overrides` will have to use the database name
+  as part of the fully-qualified table name.
 
 |[[sqlserver-property-database-server-name]]<<sqlserver-property-database-server-name, `+database.server.name+`>>
 |


### PR DESCRIPTION
**Key highlights**:
1. The SQL Server connection used by the task no longer `USE`s any database and ignores the `DATABASE` parameter when building the JDBC connection string. All object names used in SQL statements must be fully qualified.
2. As a result, the test connection used by integration tests has to execute `USE testDB` upon connecting to the instance. Whether this is temporary or not will depend on what we decide to do with the test suite later on.
3. The connection has to be explicitly tested by the connector since the real database name is no longer retrieved from within the connection constructor, and even though `getSqlServerVersion()` still attempts to connect, it won't throw an exception if it fails. We may want to reconsider this design and let it throw an exception instead.
4. The notion of the "real database name" has been moved out from the task to the partition provider. It's planned to move it further to the connector as part of fixing [DBZ-3823](https://issues.redhat.com/browse/DBZ-3823).
5. The `databaseName` property has been added to `SqlServerPartition` and is exposed via `getSourcePartition()` only in multi-partition mode. Otherwise, it would be a breaking change.

**Backward compatibility considerations**:
1. Users can opt into the multi-partition mode by using `database.names` instead of `dabase.dbname` in the connector configuration. Currently, only one database name is supported.
2. `SnapshotWithSelectOverridesIT` has been refactored to cover both the single-partition and multi-partition configuration scenarios.