### PR TITLE
DBZ-3479: Rework handling timezones in SQL Server connector

### DIFF
--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -115,6 +115,7 @@
                                     <SA_PASSWORD>${sqlserver.password}</SA_PASSWORD>
                                     <MSSQL_PID>Standard</MSSQL_PID>
                                     <MSSQL_AGENT_ENABLED>true</MSSQL_AGENT_ENABLED>
+                                    <TZ>Asia/Kathmandu</TZ>
                                 </env>
                                 <ports>
                                     <port>${sqlserver.port}:1433</port>

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -225,6 +225,10 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
             .withValidation(Field::isOptional)
             .withDescription("The SQL Server instance name");
 
+    /**
+     * @deprecated The connector will determine the database server timezone offset automatically.
+     */
+    @Deprecated
     public static final Field SERVER_TIMEZONE = Field.create(DATABASE_CONFIG_PREFIX + SqlServerConnection.SERVER_TIMEZONE_PROP_NAME)
             .withDisplayName("Server timezone")
             .withType(Type.STRING)
@@ -243,7 +247,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
                 return 0;
             })
             .withDescription("The timezone of the server used to correctly shift the commit transaction timestamp on the client side"
-                    + "Options include: Any valid Java ZoneId");
+                    + "Options include: Any valid Java ZoneId (deprecated, the connector will determine the database server timezone offset automatically)");
 
     public static final Field MAX_LSN_OPTIMIZATION = Field.createInternal("streaming.lsn.optimization")
             .withDisplayName("Max LSN Optimization")

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2246,17 +2246,6 @@ ifdef::community[]
 See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 endif::community[]
 
-|[[sqlserver-property-database-server-timezone]]<<sqlserver-property-database-server-timezone, `+database.server.timezone+`>>
-|
-| Timezone of the server.
-
-This property defines the timezone of the transaction timestamp (`ts_ms`) that is retrieved from the server (which is actually not zoned).
-By default, the value is unset.
-Set a value for the property only when running on SQL Server 2014 or older, and the database server and the JVM running the {prodname} connector use different timezones.
-
-When unset, default behavior is to use the timezone of the VM running the {prodname} connector. In this case, when running on on SQL Server 2014 or older and using different timezones on server and the connector, incorrect ts_ms values may be produced. +
-Possible values include "Z", "UTC", offset values like "+02:00", short zone ids like "CET", and long zone ids like "Europe/Paris".
-
 |[[sqlserver-property-provide-transaction-metadata]]<<sqlserver-property-provide-transaction-metadata, `+provide.transaction.metadata+`>>
 |`false`
 |When set to `true` {prodname} generates events with transaction boundaries and enriches data events envelope with transaction metadata.


### PR DESCRIPTION
See [DBZ-3479](https://issues.redhat.com/browse/DBZ-3479).

The current implementation works like this:
```sql
SELECT tran_begin_time,
CURRENT_TIMEZONE() AS TZ,
tran_begin_time AT TIME ZONE 'UTC' AS UTC
FROM testDB.cdc.lsn_time_mapping;
```
And yields the results like the following:
```
tran_begin_time         TZ                                      UTC
----------------------- --------------------------------------- ------------------------------
2021-04-28 16:26:36.387 (UTC-08:00) Pacific Time (US & Canada)  2021-04-28 16:26:36.387 +00:00
2021-04-28 16:26:36.360 (UTC-08:00) Pacific Time (US & Canada)  2021-04-28 16:26:36.360 +00:00
2021-04-28 16:26:43.293 (UTC-08:00) Pacific Time (US & Canada)  2021-04-28 16:26:43.293 +00:00
2021-04-28 16:26:45.347 (UTC-08:00) Pacific Time (US & Canada)  2021-04-28 16:26:45.347 +00:00
2021-04-28 16:26:45.333 (UTC-08:00) Pacific Time (US & Canada)  2021-04-28 16:26:45.333 +00:00
2021-04-28 16:26:45.567 (UTC-08:00) Pacific Time (US & Canada)  2021-04-28 16:26:45.567 +00:00
2021-04-28 16:31:50.070 (UTC-08:00) Pacific Time (US & Canada)  2021-04-28 16:31:50.070 +00:00
2021-04-28 16:36:55.047 (UTC-08:00) Pacific Time (US & Canada)  2021-04-28 16:36:55.047 +00:00
```
Note that the local time in the "UTC" column matches the server local time (PDT) which is wrong.

The proposed implementation effectively works like this:

```sql
SELECT tran_begin_time,
 CURRENT_TIMEZONE() AS TZ,
 TODATETIMEOFFSET(tran_begin_time, DATEPART(TZOFFSET, SYSDATETIMEOFFSET()))
FROM testDB.cdc.lsn_time_mapping;
```
It will yield a dataset like:
```
tran_begin_time         TZ                                      <anonymous>
----------------------- --------------------------------------- ------------------------------
2021-08-16 15:31:05.177 (UTC-08:00) Pacific Time (US & Canada)  2021-08-16 15:31:05.177 -07:00
2021-08-16 15:31:05.153 (UTC-08:00) Pacific Time (US & Canada)  2021-08-16 15:31:05.153 -07:00
```
The local time in the resulting column matches the server local time (correct) and the timezone offset matches the server timezone (also correct).

Conversion from the server timezone to the connector local timezone is handled by the JDBC driver.

## Testing considerations
1. Configure SQL Server to use a timezone different from the connector local timesone. E.g.
   ```diff
   diff --git a/debezium-connector-sqlserver/pom.xml b/debezium-connector-sqlserver/pom.xml
   index 0eb00b6ea..4bd228f7f 100644
   --- a/debezium-connector-sqlserver/pom.xml
   +++ b/debezium-connector-sqlserver/pom.xml
   @@ -115,6 +115,7 @@
                                        <SA_PASSWORD>${sqlserver.password}</SA_PASSWORD>
   +                                    <TZ>Europe/Minsk</TZ>
   ```
2. Choose an integration test and set a breakpoint somewhere where the source records become available.
3. Run the test and confirm that the timestamp in the record's source info corresponds to the current timestamp.