### PR TITLE
DBZ-3887 Major improvements for Throughput Bottleneck and Inefficient Batching in ChangeEventQueue

### DIFF
--- a/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
+++ b/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
@@ -6,13 +6,11 @@
 package io.debezium.connector.base;
 
 import java.time.Duration;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.Queue;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -27,7 +25,6 @@ import io.debezium.time.Temporals;
 import io.debezium.util.Clock;
 import io.debezium.util.LoggingContext;
 import io.debezium.util.LoggingContext.PreviousContext;
-import io.debezium.util.Metronome;
 import io.debezium.util.ObjectSizeCalculator;
 import io.debezium.util.Threads;
 import io.debezium.util.Threads.Timer;
@@ -66,11 +63,10 @@ public class ChangeEventQueue<T> implements ChangeEventQueueMetrics {
     private final int maxBatchSize;
     private final int maxQueueSize;
     private final long maxQueueSizeInBytes;
-    private final BlockingQueue<T> queue;
-    private final Metronome metronome;
+    private final Queue<T> queue;
     private final Supplier<PreviousContext> loggingContextSupplier;
-    private final AtomicLong currentQueueSizeInBytes = new AtomicLong(0);
-    private final Map<T, Long> objectMap = new ConcurrentHashMap<>();
+    private final Queue<Long> sizeInBytesQueue;
+    private long currentQueueSizeInBytes = 0;
 
     // Sometimes it is necessary to update the record before it is delivered depending on the content
     // of the following record. In that cases the easiest solution is to provide a single cell buffer
@@ -90,9 +86,9 @@ public class ChangeEventQueue<T> implements ChangeEventQueueMetrics {
         this.pollInterval = pollInterval;
         this.maxBatchSize = maxBatchSize;
         this.maxQueueSize = maxQueueSize;
-        this.queue = new LinkedBlockingDeque<>(maxQueueSize);
-        this.metronome = Metronome.sleeper(pollInterval, Clock.SYSTEM);
+        this.queue = new ArrayDeque<>(maxQueueSize);
         this.loggingContextSupplier = loggingContextSupplier;
+        this.sizeInBytesQueue = new ArrayDeque<>(maxQueueSize);
         this.maxQueueSizeInBytes = maxQueueSizeInBytes;
         this.buffering = buffering;
     }
@@ -199,19 +195,28 @@ public class ChangeEventQueue<T> implements ChangeEventQueueMetrics {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Enqueuing source record '{}'", record);
         }
-        // Waiting for queue to add more record.
-        while (maxQueueSizeInBytes > 0 && currentQueueSizeInBytes.get() > maxQueueSizeInBytes) {
-            Thread.sleep(pollInterval.toMillis());
-        }
-        // If we pass a positiveLong max.queue.size.in.bytes to enable handling queue size in bytes feature
-        if (maxQueueSizeInBytes > 0) {
-            long messageSize = ObjectSizeCalculator.getObjectSize(record);
-            objectMap.put(record, messageSize);
-            currentQueueSizeInBytes.addAndGet(messageSize);
-        }
 
-        // this will also raise an InterruptedException if the thread is interrupted while waiting for space in the queue
-        queue.put(record);
+        synchronized (this) {
+            while (queue.size() >= maxQueueSize || (maxQueueSizeInBytes > 0 && currentQueueSizeInBytes >= maxQueueSizeInBytes)) {
+                // notify poll() to drain queue
+                this.notifyAll();
+                // wait (indefinitely without any timeout) until poll() to drain queue and notify back
+                this.wait();
+            }
+
+            queue.add(record);
+            // If we pass a positiveLong max.queue.size.in.bytes to enable handling queue size in bytes feature
+            if (maxQueueSizeInBytes > 0) {
+                long messageSize = ObjectSizeCalculator.getObjectSize(record);
+                sizeInBytesQueue.add(messageSize);
+                currentQueueSizeInBytes += messageSize;
+            }
+
+            if (queue.size() >= maxBatchSize || (maxQueueSizeInBytes > 0 && currentQueueSizeInBytes >= maxQueueSizeInBytes)) {
+                // notify poll() to start draining queue and do not wait
+                this.notifyAll();
+            }
+        }
     }
 
     /**
@@ -227,29 +232,53 @@ public class ChangeEventQueue<T> implements ChangeEventQueueMetrics {
 
         try {
             LOGGER.debug("polling records...");
-            List<T> records = new ArrayList<>();
             final Timer timeout = Threads.timer(Clock.SYSTEM, Temporals.min(pollInterval, ConfigurationDefaults.RETURN_CONTROL_INTERVAL));
-            while (!timeout.expired() && queue.drainTo(records, maxBatchSize) == 0) {
-                throwProducerExceptionIfPresent();
+            synchronized (this) {
+                List<T> records = new ArrayList<>(Math.min(maxBatchSize, queue.size()));
+                while (drainRecords(records, maxBatchSize - records.size()) < maxBatchSize
+                        && (maxQueueSizeInBytes == 0 || currentQueueSizeInBytes < maxQueueSizeInBytes)
+                        && !timeout.expired()) {
+                    throwProducerExceptionIfPresent();
 
-                LOGGER.debug("no records available yet, sleeping a bit...");
-                // no records yet, so wait a bit
-                metronome.pause();
-                LOGGER.debug("checking for more records...");
-            }
-            if (maxQueueSizeInBytes > 0 && records.size() > 0) {
-                records.parallelStream().forEach((record) -> {
-                    if (objectMap.containsKey(record)) {
-                        currentQueueSizeInBytes.addAndGet(-objectMap.get(record));
-                        objectMap.remove(record);
+                    LOGGER.debug("no records available yet, sleeping a bit...");
+                    long remainingTimeoutMills = timeout.remaining().toMillis();
+                    if (remainingTimeoutMills > 0) {
+                        // notify doEnqueue() to resume processing (if anything is on wait())
+                        this.notifyAll();
+                        // no records yet, so wait a bit
+                        this.wait(remainingTimeoutMills);
                     }
-                });
+                    LOGGER.debug("checking for more records...");
+                }
+                // notify doEnqueue() to resume processing
+                this.notifyAll();
+                return records;
             }
-            return records;
         }
         finally {
             previousContext.restore();
         }
+    }
+
+    private long drainRecords(List<T> records, int maxElements) {
+        int queueSize = queue.size();
+        if (queueSize == 0) {
+            return records.size();
+        }
+        int recordsToDrain = Math.min(queueSize, maxElements);
+        T[] drainedRecords = (T[]) new Object[recordsToDrain];
+        for (int i = 0; i < recordsToDrain; i++) {
+            T record = queue.poll();
+            drainedRecords[i] = record;
+        }
+        if (maxQueueSizeInBytes > 0) {
+            for (int i = 0; i < recordsToDrain; i++) {
+                long objectSize = sizeInBytesQueue.poll();
+                currentQueueSizeInBytes -= objectSize;
+            }
+        }
+        records.addAll(Arrays.asList(drainedRecords));
+        return records.size();
     }
 
     public void producerException(final RuntimeException producerException) {
@@ -268,8 +297,8 @@ public class ChangeEventQueue<T> implements ChangeEventQueueMetrics {
     }
 
     @Override
-    public int remainingCapacity() {
-        return queue.remainingCapacity();
+    public synchronized int remainingCapacity() {
+        return maxQueueSize - queue.size();
     }
 
     @Override
@@ -278,7 +307,7 @@ public class ChangeEventQueue<T> implements ChangeEventQueueMetrics {
     }
 
     @Override
-    public long currentQueueSizeInBytes() {
-        return currentQueueSizeInBytes.get();
+    public synchronized long currentQueueSizeInBytes() {
+        return currentQueueSizeInBytes;
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3887

Major improvements for Throughput Bottleneck and Inefficient Batching in ChangeEventQueue

(Replaced naive metronome.pause and Thread.sleep with efficient wait() and notify())
- x10 - x100 Improvements in overall throughput
- Efficient batching based on maxBatchSize

This improvement would be visible across all supported databases

**Snapshot Benchmark**
```java
package io.debezium.connector.postgresql;

import io.debezium.config.CommonConnectorConfig;
import io.debezium.config.Configuration;
import io.debezium.connector.postgresql.PostgresConnectorConfig.LogicalDecoder;
import io.debezium.embedded.Connect;
import io.debezium.embedded.EmbeddedEngine;
import io.debezium.engine.ChangeEvent;
import io.debezium.engine.DebeziumEngine;
import org.apache.kafka.connect.source.SourceRecord;
import org.apache.kafka.connect.storage.FileOffsetBackingStore;
import org.openjdk.jmh.annotations.*;

import java.util.List;
import java.util.concurrent.TimeUnit;

@Fork(1)
@State(Scope.Thread)
@Warmup(iterations = 2, time = 10)
@Measurement(iterations = 2, time = 10)
@OutputTimeUnit(TimeUnit.SECONDS)
@BenchmarkMode({Mode.AverageTime})
public class CDCPerf {

    @Param({"10", "50", "500"})
    long pollIntervalMillis;
    Configuration configuration;
    DebeziumEngine<ChangeEvent<SourceRecord, SourceRecord>> engine;

    @Setup(Level.Trial)
    public void setupTrial() {
        TestHelper.execute("DROP TABLE IF EXISTS properties");
        TestHelper.execute("CREATE TABLE properties (prop_name TEXT PRIMARY KEY, prop_value TEXT, timestamp TEXT, autoid INT)");
        TestHelper.execute("INSERT INTO properties SELECT i::TEXT, i::TEXT, i::TEXT, i FROM generate_series(1, 1000000) AS t(i)");
        configuration = TestHelper.defaultConfig()
                .with(EmbeddedEngine.CONNECTOR_CLASS, PostgresConnector.class)
                .with(EmbeddedEngine.ENGINE_NAME, "postgres_cdc_perf")
                .with(EmbeddedEngine.OFFSET_STORAGE, FileOffsetBackingStore.class)
                .with(EmbeddedEngine.OFFSET_STORAGE_FILE_FILENAME, "f_offset.dat")
                .with(PostgresConnectorConfig.PLUGIN_NAME, LogicalDecoder.PGOUTPUT)
                .with(CommonConnectorConfig.POLL_INTERVAL_MS, pollIntervalMillis)
                .build();
    }

    @Setup(Level.Invocation)
    public void setupInvocation() {
        engine = DebeziumEngine.create(Connect.class)
                .using(configuration.asProperties())
                .notifying(new DebeziumEngine.ChangeConsumer<ChangeEvent<SourceRecord, SourceRecord>>() {
                    private int rows = 0;

                    @Override
                    public void handleBatch(List<ChangeEvent<SourceRecord, SourceRecord>> records, DebeziumEngine.RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>> committer) throws InterruptedException {
                        rows += records.size();
                        committer.markBatchFinished();
                        if (rows >= 1_000_000) {
                            Thread.currentThread().interrupt();
                        }
                    }
                })
                .build();
    }

    @Benchmark // rename and run as benchmark_1_snapshot_existing on master branch
    public void benchmark_2_snapshot_optimized() {
        engine.run();
    }

    @TearDown(Level.Invocation)
    public void teardownInvocation() {
        TestHelper.dropDefaultReplicationSlot();
    }

}
```
```
Benchmark                               (pollIntervalMillis)  Mode  Cnt   Score   Error  Units

CDCPerf.benchmark_1_snapshot_existing                     10  avgt    2   5.844           s/op
CDCPerf.benchmark_1_snapshot_existing                     50  avgt    2  10.214           s/op
CDCPerf.benchmark_1_snapshot_existing                    500  avgt    2  61.290           s/op

CDCPerf.benchmark_2_snapshot_optimized                    10  avgt    2   4.953           s/op
CDCPerf.benchmark_2_snapshot_optimized                    50  avgt    2   5.610           s/op
CDCPerf.benchmark_2_snapshot_optimized                   500  avgt    2   6.495           s/op
```

**Incremental CDC Benchmark**
```java
package io.debezium.connector.postgresql;

import io.debezium.config.CommonConnectorConfig;
import io.debezium.config.Configuration;
import io.debezium.connector.postgresql.PostgresConnectorConfig.LogicalDecoder;
import io.debezium.connector.postgresql.connection.PostgresConnection;
import io.debezium.connector.postgresql.connection.ReplicationConnection;
import io.debezium.embedded.Connect;
import io.debezium.embedded.EmbeddedEngine;
import io.debezium.engine.ChangeEvent;
import io.debezium.engine.DebeziumEngine;
import org.apache.kafka.connect.source.SourceRecord;
import org.apache.kafka.connect.storage.FileOffsetBackingStore;
import org.awaitility.Awaitility;
import org.openjdk.jmh.annotations.*;

import java.sql.ResultSet;
import java.util.List;
import java.util.concurrent.TimeUnit;

@Fork(1)
@State(Scope.Thread)
@Warmup(iterations = 2, time = 10)
@Measurement(iterations = 2, time = 10)
@OutputTimeUnit(TimeUnit.SECONDS)
@BenchmarkMode({Mode.AverageTime})
public class IncrementalCDCPerf {

    @Param({"10", "50", "500"})
    long pollIntervalMillis;
    Configuration configuration;
    Thread thread;

    @Setup(Level.Trial)
    public void setupTrial() {
        configuration = TestHelper.defaultConfig()
                .with(EmbeddedEngine.CONNECTOR_CLASS, PostgresConnector.class)
                .with(EmbeddedEngine.ENGINE_NAME, "postgres_cdc_perf")
                .with(EmbeddedEngine.OFFSET_STORAGE, FileOffsetBackingStore.class)
                .with(EmbeddedEngine.OFFSET_STORAGE_FILE_FILENAME, "f_offset.dat")
                .with(PostgresConnectorConfig.PLUGIN_NAME, LogicalDecoder.PGOUTPUT)
                .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER)
                .with(CommonConnectorConfig.POLL_INTERVAL_MS, pollIntervalMillis)
                .build();
    }

    @Setup(Level.Invocation)
    public void setupInvocation() throws InterruptedException {
        TestHelper.execute("DROP TABLE IF EXISTS properties");
        TestHelper.execute("CREATE TABLE properties (prop_name TEXT PRIMARY KEY, prop_value TEXT, timestamp TEXT, autoid INT)");
        DebeziumEngine<ChangeEvent<SourceRecord, SourceRecord>> engine = DebeziumEngine.create(Connect.class)
                .using(configuration.asProperties())
                .notifying(new DebeziumEngine.ChangeConsumer<ChangeEvent<SourceRecord, SourceRecord>>() {
                    private int rows = 0;

                    @Override
                    public void handleBatch(List<ChangeEvent<SourceRecord, SourceRecord>> records, DebeziumEngine.RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>> committer) throws InterruptedException {
                        rows += records.size();
                        committer.markBatchFinished();
                        if (rows >= 1_000_000) {
                            Thread.currentThread().interrupt();
                        }
                    }
                })
                .build();
        thread = new Thread(engine);
        thread.start();
        waitForDefaultReplicationSlotBeActive(LogicalDecoder.parse(configuration.getString(PostgresConnectorConfig.PLUGIN_NAME)));
        TestHelper.execute("INSERT INTO properties SELECT i::TEXT, i::TEXT, i::TEXT, i FROM generate_series(1, 1000000) AS t(i)");
    }

    @Benchmark // rename and run as benchmark_1_incremental_existing on master branch
    public void benchmark_2_incremental_optimized() throws InterruptedException {
        thread.join();
    }

    @TearDown(Level.Invocation)
    public void teardownInvocation() {
        thread.interrupt();
        TestHelper.dropDefaultReplicationSlot();
    }

    private void waitForDefaultReplicationSlotBeActive(LogicalDecoder logicalDecoder) {
        try (PostgresConnection connection = TestHelper.create()) {
            Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> connection.prepareQueryAndMap(
                    "select * from pg_replication_slots where slot_name = ? and database = ? and plugin = ? and active = true", statement -> {
                        statement.setString(1, ReplicationConnection.Builder.DEFAULT_SLOT_NAME);
                        statement.setString(2, "postgres");
                        statement.setString(3, logicalDecoder.getPostgresPluginName());
                    },
                    ResultSet::next));
        }
    }

}
```
```
Benchmark                                             (pollIntervalMillis)  Mode  Cnt   Score   Error  Units

IncrementalCDCPerf.benchmark_1_incremental_existing                     10  avgt    2   8.685           s/op
IncrementalCDCPerf.benchmark_1_incremental_existing                     50  avgt    2   9.271           s/op
IncrementalCDCPerf.benchmark_1_incremental_existing                    500  avgt    2  61.186           s/op

IncrementalCDCPerf.benchmark_2_incremental_optimized                    10  avgt    2   9.131           s/op
IncrementalCDCPerf.benchmark_2_incremental_optimized                    50  avgt    2   9.380           s/op
IncrementalCDCPerf.benchmark_2_incremental_optimized                   500  avgt    2   9.780           s/op
```

**ChangeEventQueue Benchmark**
```java
package io.debezium.connector.base;

import io.debezium.util.LoggingContext;
import org.openjdk.jmh.annotations.*;

import java.time.Duration;
import java.util.concurrent.TimeUnit;

import static io.debezium.config.CommonConnectorConfig.*;

@Fork(1)
@State(Scope.Thread)
@Warmup(iterations = 2, time = 5)
@Measurement(iterations = 2, time = 5)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@BenchmarkMode({Mode.AverageTime})
public class ChangeEventQueuePerf {

    @Param({"10", "50", "500"})
    long pollIntervalMillis;

    ChangeEventQueue<String> changeEventQueue;

    @Setup(Level.Iteration)
    public void setup() {
        changeEventQueue = new ChangeEventQueue.Builder<String>()
                .pollInterval(Duration.ofMillis(pollIntervalMillis))
                .maxQueueSize(DEFAULT_MAX_QUEUE_SIZE).maxBatchSize(DEFAULT_MAX_BATCH_SIZE)
                .loggingContextSupplier(() -> LoggingContext.forConnector("a", "b", "c"))
                .maxQueueSizeInBytes(DEFAULT_MAX_QUEUE_SIZE_IN_BYTES).build();
    }

    @Benchmark // rename and run benchmark_1_existing_per_10m on master branch
    public void benchmark_2_optimized_per_10m() throws InterruptedException {
        int totalRecords = 10_000_000;
        Thread t = new Thread(new Runnable() {
            private long noOfRecords = 0;

            @Override
            public void run() {
                try {
                    while (noOfRecords < totalRecords) {
                        noOfRecords += changeEventQueue.poll().size();
                    }
                } catch (InterruptedException e) {
                    throw new RuntimeException(e);
                }
            }
        });
        t.start();
        String data = "Change Data Capture Even via Debezium - ";
        for (int i = 1; i <= totalRecords; i++) {
            changeEventQueue.doEnqueue(data + i);
        }
        t.join();
    }

}
```
```
Benchmark                                           (pollIntervalMillis)  Mode  Cnt       Score   Error  Units

ChangeEventQueuePerf.benchmark_1_existing_per_10m                     10  avgt    2   12210.889          ms/op
ChangeEventQueuePerf.benchmark_1_existing_per_10m                     50  avgt    2   61025.820          ms/op
ChangeEventQueuePerf.benchmark_1_existing_per_10m                    500  avgt    2  608096.485          ms/op

ChangeEventQueuePerf.benchmark_2_optimized_per_10m                    10  avgt    2     474.661          ms/op
ChangeEventQueuePerf.benchmark_2_optimized_per_10m                    50  avgt    2     565.631          ms/op
ChangeEventQueuePerf.benchmark_2_optimized_per_10m                   500  avgt    2    1038.644          ms/op
```
Slightly increased time taken for different pollIntervalMillis is due to the wait time in processing last batch on each run.