### PR TITLE
DBZ-3896 Support multi-statement table DDLs

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -354,6 +354,9 @@ public class OracleConnection extends JdbcConnection {
             // The storage and segment attributes aren't necessary
             executeWithoutCommitting("begin dbms_metadata.set_transform_param(DBMS_METADATA.SESSION_TRANSFORM, 'STORAGE', false); end;");
             executeWithoutCommitting("begin dbms_metadata.set_transform_param(DBMS_METADATA.SESSION_TRANSFORM, 'SEGMENT_ATTRIBUTES', false); end;");
+            // In case DDL is returned as multiple DDL statements, this allows the parser to parse each separately.
+            // This is only critical during streaming as during snapshot the table structure is built from JDBC driver queries.
+            executeWithoutCommitting("begin dbms_metadata.set_transform_param(DBMS_METADATA.SESSION_TRANSFORM, 'SQLTERMINATOR', true); end;");
             return queryAndMap("SELECT dbms_metadata.get_ddl('TABLE','" + tableId.table() + "','" + tableId.schema() + "') FROM DUAL", rs -> {
                 if (!rs.next()) {
                     throw new DebeziumException("Could not get DDL metadata for table: " + tableId);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/OracleDdlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/OracleDdlParser.java
@@ -65,7 +65,7 @@ public class OracleDdlParser extends AntlrDdlParser<PlSqlLexer, PlSqlParser> {
 
     @Override
     public ParseTree parseTree(PlSqlParser parser) {
-        return parser.unit_statement();
+        return parser.sql_script();
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/AlterTableParserListener.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/AlterTableParserListener.java
@@ -224,4 +224,35 @@ public class AlterTableParserListener extends BaseParserListener {
         }, tableEditor);
         super.exitRename_column_clause(ctx);
     }
+
+    @Override
+    public void enterConstraint_clauses(PlSqlParser.Constraint_clausesContext ctx) {
+        parser.runIfNotNull(() -> {
+            if (ctx.ADD() != null) {
+                // ALTER TABLE ADD PRIMARY KEY
+                List<String> primaryKeyColumns = new ArrayList<>();
+                for (PlSqlParser.Out_of_line_constraintContext constraint : ctx.out_of_line_constraint()) {
+                    if (constraint.PRIMARY() != null && constraint.KEY() != null) {
+                        for (PlSqlParser.Column_nameContext columnNameContext : constraint.column_name()) {
+                            primaryKeyColumns.add(getColumnName(columnNameContext));
+                        }
+                    }
+                }
+                if (!primaryKeyColumns.isEmpty()) {
+                    tableEditor.setPrimaryKeyNames(primaryKeyColumns);
+                }
+            }
+            else if (ctx.MODIFY() != null && ctx.PRIMARY() != null && ctx.KEY() != null) {
+                // ALTER TABLE MODIFY PRIMARY KEY columns
+                List<String> primaryKeyColumns = new ArrayList<>();
+                for (PlSqlParser.Column_nameContext columnNameContext : ctx.column_name()) {
+                    primaryKeyColumns.add(getColumnName(columnNameContext));
+                }
+                if (!primaryKeyColumns.isEmpty()) {
+                    tableEditor.setPrimaryKeyNames(primaryKeyColumns);
+                }
+            }
+        }, tableEditor);
+        super.enterConstraint_clauses(ctx);
+    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3896

This PR supersedes #2616 by not only enabling the semicolon terminator in Oracle multi-statement table DDL queries but it also supports detecting primary key changes using indexes in conjunction with `ALTER TABLE` such as:

```
CREATE TABLE sample (id NUMBER(*,0), DATA varchar2(25));
CREATE UNIQUE INDEX sample_pk ON sample ("ID");
ALTER TABLE sample ADD CONSTRAINT idx_sample_pk PRIMARY KEY ("ID") USING INDEX "SAMPLE_PK";
```
