### PR TITLE
fixed: Ignore file parent dir if exists

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/history/FileDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/FileDatabaseHistory.java
@@ -78,7 +78,11 @@ public final class FileDatabaseHistory extends AbstractDatabaseHistory {
                     if (!storageExists()) {
                         // Create parent directories if we have them ...
                         if (path.getParent() != null) {
-                            Files.createDirectories(path.getParent());
+                            try {
+                                Files.createDirectories(path.getParent());
+                            }catch (FileAlreadyExistsException ex){
+                                // do nothing
+                            }
                         }
                         try {
                             Files.createFile(path);


### PR DESCRIPTION
```diff
--- debezium-core/src/main/java/io/debezium/relational/history/FileDatabaseHistory.java (revision 7b399ae6f1ec5cdc649aa0df021e546b2b1e51b2)
+++ debezium-core/src/main/java/io/debezium/relational/history/FileDatabaseHistory.java (date 1630059061684)
@@ -78,7 +78,11 @@
                     if (!storageExists()) {
                         // Create parent directories if we have them ...
                         if (path.getParent() != null) {
-                            Files.createDirectories(path.getParent());
+                            try {
+                                Files.createDirectories(path.getParent());
+                            }catch (FileAlreadyExistsException ex){
+                                // do nothing
+                            }
                         }
                         try {
                             Files.createFile(path);
```