### PR TITLE
DBZ-3613 Specify when snapshot metrics are available.

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -4,6 +4,7 @@
 = {prodname} connector for Db2
 
 :context: db2
+:mbean-name: {context}
 ifdef::community[]
 
 :toc:
@@ -2138,8 +2139,6 @@ The {prodname} Db2 connector provides three types of metrics that are in additio
 [[db2-snapshot-metrics]]
 === Snapshot metrics
 
-The *MBean* is `debezium.db2:type=connector-metrics,context=snapshot,server=_<database.server.name>_`.
-
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc[leveloffset=+1]
@@ -2150,8 +2149,6 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-increment
 [[db2-streaming-metrics]]
 === Streaming metrics
 
-The *MBean* is `debezium.db2:type=connector-metrics,context=streaming,server=_<database.server.name>_`.
-
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 
 // Type: reference
@@ -2159,8 +2156,6 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming
 // Title: Monitoring {prodname} Db2 connector schema history
 [[db2-schema-history-metrics]]
 === Schema history metrics
-
-The *MBean* is `debezium.db2:type=connector-metrics,context=schema-history,server=_<database.server.name>_`.
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc[leveloffset=+1]
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -4,6 +4,7 @@
 = {prodname} connector for MongoDB
 
 :context: mongodb
+:mbean-name: {context}
 ifdef::community[]
 
 :toc:
@@ -1422,8 +1423,6 @@ The {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} moni
 [[mongodb-snapshot-metrics]]
 === Snapshot Metrics
 
-The *MBean* is `debezium.mongodb:type=connector-metrics,context=snapshot,server=_<mongodb.name>_`.
-
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
 The {prodname} MongoDB connector also provides the following custom snapshot metrics:
@@ -1443,8 +1442,6 @@ The {prodname} MongoDB connector also provides the following custom snapshot met
 // Title: Monitoring {prodname} MongoDB connector record streaming
 [[mongodb-streaming-metrics]]
 === Streaming Metrics
-
-The *MBean* is `debezium.sql_server:type=connector-metrics,context=streaming,server=_<mongodb.name>_`.
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -4,6 +4,7 @@
 = {prodname} connector for MySQL
 
 :context: mysql
+:mbean-name: {context}
 ifdef::community[]
 
 :toc:
@@ -2624,8 +2625,6 @@ The {prodname} MySQL connector provides three types of metrics that are in addit
 [[mysql-snapshot-metrics]]
 === Snapshot metrics
 
-The *MBean* is `debezium.mysql:type=connector-metrics,context=snapshot,server=_<database.server.name>_`.
-
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc[leveloffset=+1]
@@ -2637,8 +2636,6 @@ The {prodname} MySQL connector also provides the `HoldingGlobalLock` custom snap
 // Title: Monitoring {prodname} MySQL connector record streaming
 [[mysql-streaming-metrics]]
 === Streaming metrics
-
-The *MBean* is `debezium.mysql:type=connector-metrics,context=streaming,server=<database.server.name>`.
 
 Transaction-related attributes are available only if binlog event buffering is enabled. See {link-prefix}:{link-mysql-connector}#mysql-property-binlog-buffer-size[`binlog.buffer.size`] in the advanced connector configuration properties for more details.
 
@@ -2694,8 +2691,6 @@ The {prodname} MySQL connector also provides the following additional streaming 
 // Title: Monitoring {prodname} MySQL connector schema history
 [[mysql-schema-history-metrics]]
 === Schema history metrics
-
-The *MBean* is `debezium.mysql:type=connector-metrics,context=schema-history,server=_<database.server.name>_`.
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc[leveloffset=+1]
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -4,6 +4,7 @@
 = {prodname} Connector for Oracle
 
 :context: oracle
+:mbean-name: {context}
 ifdef::community[]
 :toc:
 :toc-placement: macro
@@ -192,7 +193,7 @@ The following example shows a typical schema change message in JSON format:
       "lcr_position" : null
     },
     "databaseName": "ORCLPDB1", // <1>
-    "schemaName": "DEBEZIUM", // 
+    "schemaName": "DEBEZIUM", //
     "ddl": "CREATE TABLE \"DEBEZIUM\".\"CUSTOMERS\" \n   (    \"ID\" NUMBER(9,0) NOT NULL ENABLE, \n    \"FIRST_NAME\" VARCHAR2(255), \n    \"LAST_NAME" VARCHAR2(255), \n    \"EMAIL\" VARCHAR2(255), \n     PRIMARY KEY (\"ID\") ENABLE, \n     SUPPLEMENTAL LOG DATA (ALL) COLUMNS\n   ) SEGMENT CREATION IMMEDIATE \n  PCTFREE 10 PCTUSED 40 INITRANS 1 MAXTRANS 255 \n NOCOMPRESS LOGGING\n  STORAGE(INITIAL 65536 NEXT 1048576 MINEXTENTS 1 MAXEXTENTS 2147483645\n  PCTINCREASE 0 FREELISTS 1 FREELIST GROUPS 1\n  BUFFER_POOL DEFAULT FLASH_CACHE DEFAULT CELL_FLASH_CACHE DEFAULT)\n  TABLESPACE \"USERS\" ", // <2>
     "tableChanges": [ // <3>
       {
@@ -2307,7 +2308,6 @@ Please refer to the {link-prefix}:{link-debezium-monitoring}#monitoring-debezium
 === Snapshot Metrics
 
 [[oracle-monitoring-snapshots]]
-The *MBean* is `debezium.oracle:type=connector-metrics,context=snapshot,server=_<database.server.name>_`.
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
@@ -2320,7 +2320,6 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-increment
 === Streaming Metrics
 
 [[oracle-monitoring-streaming]]
-The *MBean* is `debezium.oracle:type=connector-metrics,context=streaming,server=_<database.server.name>_`.
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 
@@ -2553,7 +2552,6 @@ This should always be `0`; however when allowing unparsable DDL to be skipped, t
 === Schema History Metrics
 
 [[oracle-monitoring-schema-history]]
-The *MBean* is `debezium.oracle:type=connector-metrics,context=schema-history,server=_<database.server.name>_`.
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc[leveloffset=+1]
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -4,6 +4,7 @@
 = {prodname} connector for PostgreSQL
 
 :context: postgresql
+:mbean-name: postgres
 ifdef::community[]
 
 :toc:
@@ -2949,8 +2950,6 @@ The {prodname} PostgreSQL connector provides two types of metrics that are in ad
 [[postgresql-snapshot-metrics]]
 === Snapshot metrics
 
-The *MBean* is `debezium.postgres:type=connector-metrics,context=snapshot,server=_<database.server.name>_`.
-
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc[leveloffset=+1]
@@ -2960,8 +2959,6 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-increment
 // Title: Monitoring {prodname} PostgreSQL connector record streaming
 [[postgresql-streaming-metrics]]
 === Streaming metrics
-
-The *MBean* is `debezium.postgres:type=connector-metrics,context=streaming,server=_<database.server.name>_`.
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -5,6 +5,7 @@
 = {prodname} connector for SQL Server
 
 :context: sqlserver
+:mbean-name: sql_server
 ifdef::community[]
 
 :toc:
@@ -2485,8 +2486,6 @@ For information about how to expose the preceding metrics through JMX, see the {
 [[sqlserver-snapshot-metrics]]
 === Snapshot metrics
 
-The *MBean* is `debezium.sql_server:type=connector-metrics,context=snapshot,server=_<database.server.name>_`.
-
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc[leveloffset=+1]
@@ -2497,8 +2496,6 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-increment
 [[sqlserver-streaming-metrics]]
 === Streaming metrics
 
-The *MBean* is `debezium.sql_server:type=connector-metrics,context=streaming,server=_<database.server.name>_`.
-
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 
 // Type: reference
@@ -2506,7 +2503,5 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming
 // Title: {prodname} SQL Server connector schema history metrics
 [[sqlserver-schema-history-metrics]]
 === Schema history metrics
-
-The *MBean* is `debezium.sql_server:type=connector-metrics,context=schema-history,server=_<database.server.name>_`.
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc[leveloffset=+1]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc
@@ -1,3 +1,7 @@
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=schema-history,server=_<{context}.server.name>_`.
+
+The following table lists the schema history metrics that are available.
+
 [cols="45%a,25%a,30%a",options="header"]
 |===
 |Attributes |Type |Description

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
@@ -1,3 +1,9 @@
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=snapshot,server=_<{context}.server.name>_`.
+
+Snapshot metrics are not exposed unless a snapshot operation is active, or if a snapshot has occurred since the last connector start.
+
+The following table lists the shapshot metrics that are available.
+
 [cols="45%a,25%a,30%a",options="header"]
 |===
 |Attributes |Type |Description

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc
@@ -1,3 +1,7 @@
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=streaming,server=_<{context}.server.name>_`.
+
+The following table lists the streaming metrics that are available.
+
 [cols="45%a,25%a,30%a",options="header"]
 |===
 |Attributes |Type |Description


### PR DESCRIPTION
Add content to shared file that specifies when snapshot metrics are exposed. Also move information about MBean for each metric type from the connector files to the shared file.

Do we want to backport this to 1.6 for the next downstream release?