### PR TITLE
DBZ-3947 Fix empty high watermark check

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotContext.java
@@ -80,7 +80,7 @@ public class MySqlReadOnlyIncrementalSnapshotContext<T> extends AbstractIncremen
             return true;
         }
         String[] gtid = GTID_DELIMITER.split(currentGtid);
-        GtidSet.UUIDSet uuidSet = highWatermark.forServerWithId(gtid[0]);
+        GtidSet.UUIDSet uuidSet = getUuidSet(gtid[0]);
         if (uuidSet != null) {
             long maxTransactionId = uuidSet.getIntervals().stream()
                     .mapToLong(GtidSet.Interval::getEnd)
@@ -95,6 +95,10 @@ public class MySqlReadOnlyIncrementalSnapshotContext<T> extends AbstractIncremen
             }
         }
         return false;
+    }
+
+    private GtidSet.UUIDSet getUuidSet(String serverId) {
+        return highWatermark.getUUIDSets().isEmpty() ? lowWatermark.forServerWithId(serverId) : highWatermark.forServerWithId(serverId);
     }
 
     public boolean serverUuidChanged() {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/ReadOnlyIncrementalSnapshotIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/ReadOnlyIncrementalSnapshotIT.java
@@ -36,6 +36,22 @@ public class ReadOnlyIncrementalSnapshotIT extends IncrementalSnapshotIT {
     }
 
     @Test
+    public void emptyHighWatermark() throws Exception {
+        Testing.Print.enable();
+
+        populateTable();
+        startConnector();
+
+        sendAdHocSnapshotSignal();
+
+        final int expectedRecordCount = ROW_COUNT;
+        final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(expectedRecordCount);
+        for (int i = 0; i < expectedRecordCount; i++) {
+            Assertions.assertThat(dbChanges).includes(MapAssert.entry(i + 1, i));
+        }
+    }
+
+    @Test
     public void filteredEvents() throws Exception {
         Testing.Print.enable();
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3947

Related to https://issues.redhat.com/browse/DBZ-3577

Check heartbeat reaching low watermark in case the high watermark is empty(no binlog events between watermarks)