### PR TITLE
DBZ-2525 Don't qualify selected columns with table name;

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -494,15 +494,12 @@ public class PostgresConnection extends JdbcConnection {
     }
 
     @Override
-    public String quotedColumnIdString(String tableName, String columnName) {
-        if (tableName.contains("\"")) {
-            tableName = tableName.replaceAll("\"", "\"\"");
-        }
+    public String quotedColumnIdString(String columnName) {
         if (columnName.contains("\"")) {
             columnName = columnName.replaceAll("\"", "\"\"");
         }
 
-        return super.quotedColumnIdString(tableName, columnName);
+        return super.quotedColumnIdString(columnName);
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -1494,13 +1494,9 @@ public class JdbcConnection implements AutoCloseable {
     }
 
     /**
-     * Prepares qualified column names with appropriate quote character as per the specific database's rules
-     *
-     * @param tableName
-     * @param columnName
-     * @return formatted string
+     * Prepares qualified column names with appropriate quote character as per the specific database's rules.
      */
-    public String quotedColumnIdString(String tableName, String columnName) {
-        return openingQuoteCharacter + tableName + closingQuoteCharacter + "." + openingQuoteCharacter + columnName + closingQuoteCharacter;
+    public String quotedColumnIdString(String columnName) {
+        return openingQuoteCharacter + columnName + closingQuoteCharacter;
     }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -459,7 +459,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
                 .stream()
                 .filter(columnName -> additionalColumnFilter(table.id(), columnName))
                 .filter(columnName -> connectorConfig.getColumnFilter().matches(table.id().catalog(), table.id().schema(), table.id().table(), columnName))
-                .map(columnName -> jdbcConnection.quotedColumnIdString(table.id().table(), columnName))
+                .map(columnName -> jdbcConnection.quotedColumnIdString(columnName))
                 .collect(Collectors.toList());
 
         if (columnNames.isEmpty()) {
@@ -467,7 +467,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
 
             columnNames = table.retrieveColumnNames()
                     .stream()
-                    .map(columnName -> jdbcConnection.quotedColumnIdString(table.id().table(), columnName))
+                    .map(columnName -> jdbcConnection.quotedColumnIdString(columnName))
                     .collect(Collectors.toList());
         }
 


### PR DESCRIPTION
It shouldn't be needed as we select from a single table, and it caused the columns to not be found for the Db2 connector.

https://issues.redhat.com/browse/DBZ-2525

This is causing Db2 tests to fail (see https://github.com/debezium/debezium-connector-db2/pull/32).