### PR TITLE
DBZ-3978 Exclude usernames at transaction level

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilder.java
@@ -7,7 +7,6 @@ package io.debezium.connector.oracle.logminer;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 import io.debezium.connector.oracle.OracleConnectorConfig;
@@ -127,19 +126,6 @@ public class LogMinerQueryBuilder {
         }
 
         query.append("))");
-
-        Set<String> excludedUsers = connectorConfig.getLogMiningUsernameExcludes();
-        if (!excludedUsers.isEmpty()) {
-            query.append(" AND USERNAME NOT IN (");
-            for (Iterator<String> i = excludedUsers.iterator(); i.hasNext();) {
-                String user = i.next();
-                query.append("'").append(user).append("'");
-                if (i.hasNext()) {
-                    query.append(",");
-                }
-            }
-            query.append(")");
-        }
 
         return query.toString();
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/Transaction.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/Transaction.java
@@ -32,6 +32,7 @@ public class Transaction {
     private Instant changeTime;
     private List<LogMinerEvent> events;
     private Set<Long> hashes;
+    private String userName;
 
     @VisibleForMarshalling
     public Transaction(String transactionId, Scn startScn, Instant changeTime, List<LogMinerEvent> events, Set<Long> hashes) {
@@ -81,6 +82,16 @@ public class Transaction {
         });
     }
 
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        if (userName != null && !"UNKNOWN".equalsIgnoreCase(userName)) {
+            this.userName = userName;
+        }
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -102,7 +113,7 @@ public class Transaction {
     public String toString() {
         return "Transaction{" +
                 "transactionId='" + transactionId + '\'' +
-                ", startScn=" + startScn +
-                '}';
+                ", startScn=" + startScn + ", userName='" + userName +
+                "'}";
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
@@ -209,7 +209,9 @@ public abstract class AbstractLogMinerEventProcessor implements LogMinerEventPro
         final String transactionId = row.getTransactionId();
         final Transaction transaction = getTransactionCache().get(transactionId);
         if (transaction == null && !isRecentlyCommitted(transactionId)) {
-            getTransactionCache().put(transactionId, new Transaction(transactionId, row.getScn(), row.getChangeTime()));
+            Transaction newTransaction = new Transaction(transactionId, row.getScn(), row.getChangeTime());
+            newTransaction.setUserName(row.getUserName());
+            getTransactionCache().put(transactionId, newTransaction);
             metrics.setActiveTransactions(getTransactionCache().size());
         }
     }
@@ -460,8 +462,9 @@ public abstract class AbstractLogMinerEventProcessor implements LogMinerEventPro
         if (isTransactionIdAllowed(transactionId)) {
             Transaction transaction = getTransactionCache().get(transactionId);
             if (transaction == null) {
-                LOGGER.trace("Transaction {} not in cache, creating.", transactionId);
+                LOGGER.debug("Transaction {} not in cache for DML, creating.", transactionId);
                 transaction = new Transaction(transactionId, row.getScn(), row.getChangeTime());
+                transaction.setUserName(row.getUserName());
                 getTransactionCache().put(transactionId, transaction);
             }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/memory/MemoryLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/memory/MemoryLogMinerEventProcessor.java
@@ -215,6 +215,14 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
             return;
         }
 
+        if (transaction.getUserName() == null && !transaction.getEvents().isEmpty()) {
+            LOGGER.warn("Got transaction with null username {}", transaction);
+        }
+        else if (getConfig().getLogMiningUsernameExcludes().contains(transaction.getUserName())) {
+            LOGGER.debug("Skipping transaction with excluded username {}", transaction);
+            return;
+        }
+
         final Scn smallestScn = transactionCache.getMinimumScn();
         metrics.setOldestScn(smallestScn.isNull() ? Scn.valueOf(-1) : smallestScn);
         abandonedTransactionsCache.remove(transactionId);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
@@ -61,8 +61,7 @@ public class LogMinerQueryBuilderTest {
             "${systemTablePredicate}" +
             "${schemaPredicate}" +
             "${tablePredicate}" +
-            "))" +
-            "${userNamePredicate}";
+            "))";
 
     /**
      * A template that defines the expected SQL output when the configuration specifies
@@ -83,8 +82,7 @@ public class LogMinerQueryBuilderTest {
             "${systemTablePredicate}" +
             "${schemaPredicate}" +
             "${tablePredicate}" +
-            "))" +
-            "${userNamePredicate}";
+            "))";
 
     @Test
     @FixFor("DBZ-3009")
@@ -93,39 +91,39 @@ public class LogMinerQueryBuilderTest {
         OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
 
         String result = LogMinerQueryBuilder.build(connectorConfig);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, null, null, null));
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, null, null));
 
         config = TestHelper.defaultConfig().with(LOB_ENABLED, true).build();
         connectorConfig = new OracleConnectorConfig(config);
 
         result = LogMinerQueryBuilder.build(connectorConfig);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, null, null, null));
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, null, null));
 
         config = TestHelper.defaultConfig().with(STORE_ONLY_CAPTURED_TABLES_DDL, true).build();
         connectorConfig = new OracleConnectorConfig(config);
 
         result = LogMinerQueryBuilder.build(connectorConfig);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, null, null, null));
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, null, null));
 
         config = TestHelper.defaultConfig().with(STORE_ONLY_CAPTURED_TABLES_DDL, true).with(LOB_ENABLED, true).build();
         connectorConfig = new OracleConnectorConfig(config);
 
         result = LogMinerQueryBuilder.build(connectorConfig);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, null, null, null));
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, null, null));
     }
 
     @Test
     @FixFor("DBZ-3009")
     public void testLogMinerQueryWithSchemaInclude() {
         String schema = "AND (REGEXP_LIKE(SEG_OWNER,'^SCHEMA1$','i') OR REGEXP_LIKE(SEG_OWNER,'^SCHEMA2$','i')) ";
-        assertQueryWithConfig(SCHEMA_INCLUDE_LIST, "SCHEMA1,SCHEMA2", schema, null, null);
+        assertQueryWithConfig(SCHEMA_INCLUDE_LIST, "SCHEMA1,SCHEMA2", schema, null);
     }
 
     @Test
     @FixFor("DBZ-3009")
     public void testLogMinerQueryWithSchemaExclude() {
         String schema = "AND (NOT REGEXP_LIKE(SEG_OWNER,'^SCHEMA1$','i') AND NOT REGEXP_LIKE(SEG_OWNER,'^SCHEMA2$','i')) ";
-        assertQueryWithConfig(OracleConnectorConfig.SCHEMA_EXCLUDE_LIST, "SCHEMA1,SCHEMA2", schema, null, null);
+        assertQueryWithConfig(OracleConnectorConfig.SCHEMA_EXCLUDE_LIST, "SCHEMA1,SCHEMA2", schema, null);
     }
 
     @Test
@@ -133,7 +131,7 @@ public class LogMinerQueryBuilderTest {
     public void testLogMinerQueryWithTableInclude() {
         String table = "AND (REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEA$','i') " +
                 "OR REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEB$','i')) ";
-        assertQueryWithConfig(TABLE_INCLUDE_LIST, "DEBEZIUM\\.TABLEA,DEBEZIUM\\.TABLEB", null, table, null);
+        assertQueryWithConfig(TABLE_INCLUDE_LIST, "DEBEZIUM\\.TABLEA,DEBEZIUM\\.TABLEB", null, table);
     }
 
     @Test
@@ -141,7 +139,7 @@ public class LogMinerQueryBuilderTest {
     public void testLogMinerQueryWithTableExcludes() {
         String table = "AND (NOT REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEA$','i') " +
                 "AND NOT REGEXP_LIKE(SEG_OWNER || '.' || TABLE_NAME,'^DEBEZIUM\\.TABLEB$','i')) ";
-        assertQueryWithConfig(TABLE_EXCLUDE_LIST, "DEBEZIUM\\.TABLEA,DEBEZIUM\\.TABLEB", null, table, null);
+        assertQueryWithConfig(TABLE_EXCLUDE_LIST, "DEBEZIUM\\.TABLEA,DEBEZIUM\\.TABLEB", null, table);
     }
 
     @Test
@@ -171,37 +169,30 @@ public class LogMinerQueryBuilderTest {
         assertQueryWithConfig(SCHEMA_EXCLUDE_LIST, "SCHEMA1,SCHEMA2", TABLE_INCLUDE_LIST, "DEBEZIUM\\.TABLEA,DEBEZIUM\\.TABLEB", schema, table);
     }
 
-    @Test
-    @FixFor("DBZ-3671")
-    public void testLogMinerExcludeUsersInQuery() {
-        String users = " AND USERNAME NOT IN ('user1','user2','user')";
-        assertQueryWithConfig(OracleConnectorConfig.LOG_MINING_USERNAME_EXCLUDE_LIST, "user1,user2,user", null, null, users);
-    }
-
-    private void assertQueryWithConfig(Field field, Object fieldValue, String schemaValue, String tableValue, String userValue) {
+    private void assertQueryWithConfig(Field field, Object fieldValue, String schemaValue, String tableValue) {
         Configuration config = TestHelper.defaultConfig().with(field, fieldValue).build();
         OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
 
         String result = LogMinerQueryBuilder.build(connectorConfig);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue, userValue));
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue));
 
         config = TestHelper.defaultConfig().with(field, fieldValue).with(LOB_ENABLED, true).build();
         connectorConfig = new OracleConnectorConfig(config);
 
         result = LogMinerQueryBuilder.build(connectorConfig);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue, userValue));
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue));
 
         config = TestHelper.defaultConfig().with(field, fieldValue).with(STORE_ONLY_CAPTURED_TABLES_DDL, true).build();
         connectorConfig = new OracleConnectorConfig(config);
 
         result = LogMinerQueryBuilder.build(connectorConfig);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue, userValue));
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue));
 
         config = TestHelper.defaultConfig().with(field, fieldValue).with(STORE_ONLY_CAPTURED_TABLES_DDL, true).with(LOB_ENABLED, true).build();
         connectorConfig = new OracleConnectorConfig(config);
 
         result = LogMinerQueryBuilder.build(connectorConfig);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue, userValue));
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue));
     }
 
     private void assertQueryWithConfig(Field field1, Object fieldValue1, Field field2, Object fieldValue2, String schemaValue, String tableValue) {
@@ -209,20 +200,20 @@ public class LogMinerQueryBuilderTest {
         OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
 
         String result = LogMinerQueryBuilder.build(connectorConfig);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue, null));
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue));
 
         config = TestHelper.defaultConfig().with(field1, fieldValue1).with(field2, fieldValue2).with(LOB_ENABLED, true).build();
         connectorConfig = new OracleConnectorConfig(config);
 
         result = LogMinerQueryBuilder.build(connectorConfig);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue, null));
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue));
 
         config = TestHelper.defaultConfig().with(field1, fieldValue1).with(field2, fieldValue2)
                 .with(STORE_ONLY_CAPTURED_TABLES_DDL, true).build();
         connectorConfig = new OracleConnectorConfig(config);
 
         result = LogMinerQueryBuilder.build(connectorConfig);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue, null));
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue));
 
         config = TestHelper.defaultConfig().with(field1, fieldValue1).with(field2, fieldValue2)
                 .with(STORE_ONLY_CAPTURED_TABLES_DDL, true)
@@ -231,13 +222,12 @@ public class LogMinerQueryBuilderTest {
         connectorConfig = new OracleConnectorConfig(config);
 
         result = LogMinerQueryBuilder.build(connectorConfig);
-        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue, null));
+        assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schemaValue, tableValue));
     }
 
     private String resolveLogMineryContentQueryFromTemplate(OracleConnectorConfig config,
                                                             String schemaReplacement,
-                                                            String tableReplacement,
-                                                            String userNameReplacement) {
+                                                            String tableReplacement) {
         String query = config.getDatabaseHistory().storeOnlyCapturedTables()
                 ? LOG_MINER_CONTENT_QUERY_TEMPLATE2
                 : LOG_MINER_CONTENT_QUERY_TEMPLATE1;
@@ -262,7 +252,6 @@ public class LogMinerQueryBuilderTest {
         query = query.replace("${operationCodes}", config.isLobEnabled() ? OPERATION_CODES_LOB_ENABLED : OPERATION_CODES_LOB_DISABLED);
         query = query.replace("${schemaPredicate}", schemaReplacement == null ? "" : schemaReplacement);
         query = query.replace("${tablePredicate}", tableReplacement == null ? "" : tableReplacement);
-        query = query.replace("${userNamePredicate}", userNameReplacement == null ? "" : userNameReplacement.toString());
         return query;
     }
 }

--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -1,6 +1,6 @@
 name: reference
 title: Debezium Documentation
-version: 'master'
+version: '1.7'
 nav:
   - modules/ROOT/nav.adoc
 


### PR DESCRIPTION
Oracle only write the username in the first record of a transaction in redo log, if the transaction spans two logminer queries, the returned records in the second query will have an UNKNOWN user name, so the record will not be filtered with current implementation.

We can change the implementation to exclude username at transaction level.