### PR TITLE
DBZ-3961-specify-when-connectors-begin-to-collect-metadata

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -355,7 +355,16 @@ In messages to the schema change topic, the key is the name of the database that
 [[db2-transaction-metadata]]
 === Transaction metadata
 
-{prodname} can generate events that represent transaction boundaries and that enrich change data event messages. For every transaction `BEGIN` and `END`, {prodname} generates an event that contains the following fields:
+{prodname} can generate events that represent transaction boundaries and that enrich change data event messages.
+
+[NOTE]
+.Limits on when {prodname} receives transaction metadata
+====
+{prodname} registers and receives metadata only for transactions that occur after you deploy the connector.
+Metadata for transactions that occur before you deploy the connector is not available.
+====
+
+For every transaction `BEGIN` and `END`, {prodname} generates an event that contains the following fields:
 
 * `status` - `BEGIN` or `END`
 * `id` - string representation of unique transaction identifier

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -254,6 +254,14 @@ This ensures that all events for a specific document are always totally ordered.
 === Transaction Metadata
 
 {prodname} can generate events that represents transaction metadata boundaries and enrich change data event messages.
+
+[NOTE]
+.Limits on when {prodname} receives transaction metadata
+====
+{prodname} registers and receives metadata only for transactions that occur after you deploy the connector.
+Metadata for transactions that occur before you deploy the connector is not available.
+====
+
 For every transaction `BEGIN` and `END`, {prodname} generates an event that contains the following fields:
 
 `status`:: `BEGIN` or `END`

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -459,7 +459,16 @@ fulfillment.inventory.products
 [[mysql-transaction-metadata]]
 === Transaction metadata
 
-{prodname} can generate events that represent transaction boundaries and that enrich data change event messages. For every transaction `BEGIN` and `END`, {prodname} generates an event that contains the following fields:
+{prodname} can generate events that represent transaction boundaries and that enrich data change event messages.
+
+[NOTE]
+.Limits on when {prodname} receives transaction metadata
+====
+{prodname} registers and receives metadata only for transactions that occur after you deploy the connector.
+Metadata for transactions that occur before you deploy the connector is not available.
+====
+
+For every transaction `BEGIN` and `END`, {prodname} generates an event that contains the following fields:
 
 * `status` - `BEGIN` or `END`
 * `id` - string representation of unique transaction identifier

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -346,6 +346,13 @@ In the following example, the `payload` field contains the key:
 
 {prodname} can generate events that represent transaction metadata boundaries and that enrich data change event messages.
 
+[NOTE]
+.Limits on when {prodname} receives transaction metadata
+====
+{prodname} registers and receives metadata only for transactions that occur after you deploy the connector.
+Metadata for transactions that occur before you deploy the connector is not available.
+====
+
 Database transactions are represented by a statement block that is enclosed between the `BEGIN` and `END` keywords.
 {prodname} generates transaction boundary events for the `BEGIN` and `END` delimiters in every transaction.
 Transaction boundary events contain the following fields:

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -365,7 +365,16 @@ In addition to a {link-prefix}:{link-postgresql-connector}#postgresql-events[_da
 [[postgresql-transaction-metadata]]
 === Transaction metadata
 
-{prodname} can generate events that represent transaction boundaries and that enrich data change event messages. For every transaction `BEGIN` and `END`, {prodname} generates an event that contains the following fields:
+{prodname} can generate events that represent transaction boundaries and that enrich data change event messages.
+
+[NOTE]
+.Limits on when {prodname} receives transaction metadata
+====
+{prodname} registers and receives metadata only for transactions that occur after you deploy the connector.
+Metadata for transactions that occur before you deploy the connector is not available.
+====
+
+For every transaction `BEGIN` and `END`, {prodname} generates an event that contains the following fields:
 
 * `status` - `BEGIN` or `END`
 * `id` - string representation of unique transaction identifier

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -986,6 +986,13 @@ When a row is deleted, the _delete_ event value still works with log compaction,
 
 {prodname} can generate events that represent transaction boundaries and that enrich data change event messages.
 
+[NOTE]
+.Limits on when {prodname} receives transaction metadata
+====
+{prodname} registers and receives metadata only for transactions that occur after you deploy the connector.
+Metadata for transactions that occur before you deploy the connector is not available.
+====
+
 Database transactions are represented by a statement block that is enclosed between the `BEGIN` and `END` keywords.
 {prodname} generates transaction boundary events for the `BEGIN` and `END` delimiters in every transaction.
 Transaction boundary events contain the following fields:


### PR DESCRIPTION
[DBZ-3961](https://issues.redhat.com/browse/DBZ-3961)

Add note to the Transaction metadata sections in each of the connector docs to inform users that the connectors capture transaction metadata only for operations that occur after the connector is deployed. 

This change implements input that was originally proposed in PR #2657 (DBZ-3845). 