### PR TITLE
DBZ-4015 Efficient String Replacement using String.replace in TableIdParser (improvement of x4-x5 times)

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/TableId.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableId.java
@@ -37,8 +37,7 @@ public final class TableId implements DataCollectionId, Comparable<TableId> {
      * @return the table ID, or null if it could not be parsed
      */
     public static TableId parse(String str, boolean useCatalogBeforeSchema) {
-        String[] parts = TableIdParser.parse(str).stream()
-                .toArray(String[]::new);
+        String[] parts = TableIdParser.parse(str).toArray(new String[0]);
 
         return TableId.parse(parts, parts.length, useCatalogBeforeSchema);
     }

--- a/debezium-core/src/main/java/io/debezium/relational/TableIdParser.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableIdParser.java
@@ -22,6 +22,9 @@ import io.debezium.text.TokenStream.Tokens;
 class TableIdParser {
 
     private static final char SEPARATOR = '.';
+    private static final String SINGLE_QUOTES = "''";
+    private static final String DOUBLE_QUOTES = "\"\"";
+    private static final String BACKTICKS = "``";
 
     public static List<String> parse(String identifier) {
         TokenStream stream = new TokenStream(identifier, new TableIdTokenizer(identifier), true);
@@ -30,7 +33,10 @@ class TableIdParser {
         List<String> parts = new ArrayList<>();
 
         while (stream.hasNext()) {
-            parts.add(stream.consume().replaceAll("''", "'").replaceAll("\"\"", "\"").replaceAll("``", "`"));
+            parts.add(stream.consume()
+                    .replace(SINGLE_QUOTES, "'")
+                    .replace(DOUBLE_QUOTES, "\"")
+                    .replace(BACKTICKS, "`"));
         }
 
         return parts;

--- a/debezium-core/src/main/java/io/debezium/relational/TableIdParser.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableIdParser.java
@@ -30,7 +30,8 @@ class TableIdParser {
         TokenStream stream = new TokenStream(identifier, new TableIdTokenizer(identifier), true);
         stream.start();
 
-        List<String> parts = new ArrayList<>();
+        // at max three parts - catalog.schema.table
+        List<String> parts = new ArrayList<>(3);
 
         while (stream.hasNext()) {
             parts.add(stream.consume()

--- a/debezium-microbenchmark/src/main/java/io/debezium/performance/core/TableIdPerf.java
+++ b/debezium-microbenchmark/src/main/java/io/debezium/performance/core/TableIdPerf.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.performance.core;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import io.debezium.relational.TableId;
+
+@Fork(1)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode({ Mode.AverageTime })
+public class TableIdPerf {
+
+    @Param({
+            "table", "\"\"\"table\"\"\"",
+            "catalog.schema.table", "\"\"\"catalog\"\"\".\"\"\"schema\"\"\".\"\"\"table\"\"\""
+    })
+    private String value;
+
+    @Benchmark
+    public void benchmarkParse() {
+        TableId.parse(value);
+    }
+
+}


### PR DESCRIPTION
[DBZ-4015](https://issues.redhat.com/browse/DBZ-4015) Efficient String Replacement using String.replace in TableIdParser (improvement of x4-x5 times)

(https://medium.com/javarevisited/micro-optimizations-in-java-string-replaceall-c6d0edf2ef6)

Previously 1.5s - 2.5s is spent on `TableIdParser.parse` for 10M records of Incremental CDC which is around 15% - 25% of overall time taken (8s). Based on `String.replace` optimizations from Java 9, simply switching from `String.replaceAll` to `String.replace` would reduce the time spend on `TableIdParser.parse` by x4-x5 times. Corresponding JMH metrics are included for verifying performance improvement.

**JMH Benchmarks**
```java
package io.debezium.relational;

import io.debezium.text.TokenStream;
import org.openjdk.jmh.annotations.*;

import java.util.ArrayList;
import java.util.List;
import java.util.concurrent.TimeUnit;

@Fork(1)
@State(Scope.Thread)
@Warmup(iterations = 5, time = 1)
@Measurement(iterations = 5, time = 1)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@BenchmarkMode({Mode.AverageTime})
public class TableIdParserPerf {

    private static final String SINGLE_QUOTES = "''";
    private static final String DOUBLE_QUOTES = "\"\"";
    private static final String BACKTICKS = "``";

    @Param({
            "table", "\"\"\"table\"\"\"",
            "database.schema.table", "\"\"\"database\"\"\".\"\"\"schema\"\"\".\"\"\"table\"\"\""
    })
    private String value;

    @Benchmark
    public void benchmark_v1_replaceAll() {
        // make TableIdParser.TableIdTokenizer as public for this run
        TokenStream stream = new TokenStream(value, new TableIdParser.TableIdTokenizer(value), true);
        stream.start();
        List<String> parts = new ArrayList<>();
        while (stream.hasNext()) {
            parts.add(stream.consume().replaceAll("''", "'").replaceAll("\"\"", "\"").replaceAll("``", "`"));
        }
    }

    @Benchmark
    public void benchmark_v2_replace() {
        // make TableIdParser.TableIdTokenizer as public for this run
        TokenStream stream = new TokenStream(value, new TableIdParser.TableIdTokenizer(value), true);
        stream.start();
        List<String> parts = new ArrayList<>();
        while (stream.hasNext()) {
            parts.add(stream.consume()
                    .replace(SINGLE_QUOTES, "'")
                    .replace(DOUBLE_QUOTES, "\"")
                    .replace(BACKTICKS, "`"));
        }
    }

}
```
```
-- Java 8
Benchmark                                                                  (value)  Mode  Cnt     Score     Error  Units
TableIdParserPerf.benchmark_v1_replaceAll                                    table  avgt    5   585.145 ±   6.884  ns/op
TableIdParserPerf.benchmark_v1_replaceAll                              """table"""  avgt    5   744.955 ±  23.594  ns/op
TableIdParserPerf.benchmark_v1_replaceAll                    database.schema.table  avgt    5  1560.957 ±   6.536  ns/op
TableIdParserPerf.benchmark_v1_replaceAll  """database"""."""schema"""."""table"""  avgt    5  2254.646 ±  46.105  ns/op

TableIdParserPerf.benchmark_v2_replace                                       table  avgt    5   508.256 ± 161.296  ns/op
TableIdParserPerf.benchmark_v2_replace                                 """table"""  avgt    5   674.351 ±  16.951  ns/op
TableIdParserPerf.benchmark_v2_replace                       database.schema.table  avgt    5  1399.462 ±  72.010  ns/op
TableIdParserPerf.benchmark_v2_replace     """database"""."""schema"""."""table"""  avgt    5  2018.125 ±  89.956  ns/op

-- Java 11
Benchmark                                                                  (value)  Mode  Cnt     Score     Error  Units
TableIdParserPerf.benchmark_v1_replaceAll                                    table  avgt    5   583.312 ±  12.076  ns/op
TableIdParserPerf.benchmark_v1_replaceAll                              """table"""  avgt    5   797.073 ± 113.455  ns/op
TableIdParserPerf.benchmark_v1_replaceAll                    database.schema.table  avgt    5  1658.588 ±  51.087  ns/op
TableIdParserPerf.benchmark_v1_replaceAll  """database"""."""schema"""."""table"""  avgt    5  2331.021 ±  43.485  ns/op

TableIdParserPerf.benchmark_v2_replace                                       table  avgt    5    90.554 ±   2.104  ns/op
TableIdParserPerf.benchmark_v2_replace                                 """table"""  avgt    5   200.280 ±   8.302  ns/op
TableIdParserPerf.benchmark_v2_replace                       database.schema.table  avgt    5   313.518 ±   7.569  ns/op
TableIdParserPerf.benchmark_v2_replace     """database"""."""schema"""."""table"""  avgt    5   590.239 ±  10.997  ns/op

-- Java 17
Benchmark                                                                  (value)  Mode  Cnt     Score     Error  Units
TableIdParserPerf.benchmark_v1_replaceAll                                    table  avgt    5   545.151 ±  44.372  ns/op
TableIdParserPerf.benchmark_v1_replaceAll                              """table"""  avgt    5   710.302 ±  10.011  ns/op
TableIdParserPerf.benchmark_v1_replaceAll                    database.schema.table  avgt    5  1650.525 ±  24.297  ns/op
TableIdParserPerf.benchmark_v1_replaceAll  """database"""."""schema"""."""table"""  avgt    5  2210.604 ± 120.240  ns/op

TableIdParserPerf.benchmark_v2_replace                                       table  avgt    5    80.162 ±   1.222  ns/op
TableIdParserPerf.benchmark_v2_replace                                 """table"""  avgt    5   177.991 ±   3.420  ns/op
TableIdParserPerf.benchmark_v2_replace                       database.schema.table  avgt    5   283.235 ±   3.273  ns/op
TableIdParserPerf.benchmark_v2_replace     """database"""."""schema"""."""table"""  avgt    5   540.444 ±   3.877  ns/op
```

**Incremental CDC Benchmark** (Java 17)
```java
package io.debezium.connector.postgresql;

import java.sql.ResultSet;
import java.util.List;
import java.util.concurrent.TimeUnit;

import org.apache.kafka.connect.source.SourceRecord;
import org.apache.kafka.connect.storage.FileOffsetBackingStore;
import org.awaitility.Awaitility;
import org.openjdk.jmh.annotations.*;

import io.debezium.config.CommonConnectorConfig;
import io.debezium.config.Configuration;
import io.debezium.connector.postgresql.PostgresConnectorConfig.LogicalDecoder;
import io.debezium.connector.postgresql.connection.PostgresConnection;
import io.debezium.connector.postgresql.connection.ReplicationConnection;
import io.debezium.embedded.Connect;
import io.debezium.embedded.EmbeddedEngine;
import io.debezium.engine.ChangeEvent;
import io.debezium.engine.DebeziumEngine;

@Fork(1)
@State(Scope.Thread)
@Warmup(iterations = 2, time = 10)
@Measurement(iterations = 2, time = 10)
@OutputTimeUnit(TimeUnit.SECONDS)
@BenchmarkMode({ Mode.AverageTime })
public class IncrementalCDCPerf {

    @Param({ "10", "50", "500" })
    long pollIntervalMillis;
    Configuration configuration;
    Thread thread;

    @Setup(Level.Trial)
    public void setupTrial() {
        configuration = TestHelper.defaultConfig()
                .with(EmbeddedEngine.CONNECTOR_CLASS, PostgresConnector.class)
                .with(EmbeddedEngine.ENGINE_NAME, "postgres_cdc_perf")
                .with(EmbeddedEngine.OFFSET_STORAGE, FileOffsetBackingStore.class)
                .with(EmbeddedEngine.OFFSET_STORAGE_FILE_FILENAME, "f_offset.dat")
                .with(PostgresConnectorConfig.PLUGIN_NAME, LogicalDecoder.PGOUTPUT)
                .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER)
                .with(CommonConnectorConfig.POLL_INTERVAL_MS, pollIntervalMillis)
                .build();
    }

    @Setup(Level.Invocation)
    public void setupInvocation() throws InterruptedException {
        TestHelper.execute("DROP TABLE IF EXISTS properties");
        TestHelper.execute("CREATE TABLE properties (prop_name TEXT PRIMARY KEY, prop_value TEXT, timestamp TEXT, autoid INT)");
        DebeziumEngine<ChangeEvent<SourceRecord, SourceRecord>> engine = DebeziumEngine.create(Connect.class)
                .using(configuration.asProperties())
                .notifying(new DebeziumEngine.ChangeConsumer<ChangeEvent<SourceRecord, SourceRecord>>() {
                    private int rows = 0;

                    @Override
                    public void handleBatch(List<ChangeEvent<SourceRecord, SourceRecord>> records,
                                            DebeziumEngine.RecordCommitter<ChangeEvent<SourceRecord, SourceRecord>> committer)
                            throws InterruptedException {
                        rows += records.size();
                        committer.markBatchFinished();
                        if (rows >= 1_000_000) {
                            Thread.currentThread().interrupt();
                        }
                    }
                })
                .build();
        thread = new Thread(engine);
        thread.start();
        waitForDefaultReplicationSlotBeActive(LogicalDecoder.parse(configuration.getString(PostgresConnectorConfig.PLUGIN_NAME)));
        TestHelper.execute("INSERT INTO properties SELECT i::TEXT, i::TEXT, i::TEXT, i FROM generate_series(1, 1000000) AS t(i)");
    }

    @Benchmark // rename and run as benchmark_1_incremental_existing on master branch
    public void benchmark_2_incremental_optimized() throws InterruptedException {
        thread.join();
    }

    @TearDown(Level.Invocation)
    public void teardownInvocation() {
        thread.interrupt();
        TestHelper.dropDefaultReplicationSlot();
    }

    private void waitForDefaultReplicationSlotBeActive(LogicalDecoder logicalDecoder) {
        try (PostgresConnection connection = TestHelper.create()) {
            Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> connection.prepareQueryAndMap(
                    "select * from pg_replication_slots where slot_name = ? and database = ? and plugin = ? and active = true", statement -> {
                        statement.setString(1, ReplicationConnection.Builder.DEFAULT_SLOT_NAME);
                        statement.setString(2, "postgres");
                        statement.setString(3, logicalDecoder.getPostgresPluginName());
                    },
                    ResultSet::next));
        }
    }

}
```
```
Benchmark                                             (pollIntervalMillis)  Mode  Cnt  Score   Error  Units
IncrementalCDCPerf.benchmark_2_incremental_optimized                    10  avgt    2  7.113           s/op
IncrementalCDCPerf.benchmark_2_incremental_optimized                    50  avgt    2  7.340           s/op
IncrementalCDCPerf.benchmark_2_incremental_optimized                   500  avgt    2  7.925           s/op
```
Comparing the above JMH metrics with the one provided in [ChangeEventQueue Optimization PR](https://github.com/debezium/debezium/pull/2612) (included below), we could see ~2s reduction on each run. This equates to around 22% Performance Improvement.
```
Benchmark                                             (pollIntervalMillis)  Mode  Cnt   Score   Error  Units
IncrementalCDCPerf.benchmark_2_incremental_optimized                    10  avgt    2   9.131           s/op
IncrementalCDCPerf.benchmark_2_incremental_optimized                    50  avgt    2   9.380           s/op
IncrementalCDCPerf.benchmark_2_incremental_optimized                   500  avgt    2   9.780           s/op
```