### PR TITLE
ObjectOutputStream writing extra characters.

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/mapping/MaskStrings.java
+++ b/debezium-core/src/main/java/io/debezium/relational/mapping/MaskStrings.java
@@ -5,24 +5,20 @@
  */
 package io.debezium.relational.mapping;
 
-import java.io.ByteArrayOutputStream;
+import io.debezium.annotation.Immutable;
+import io.debezium.relational.Column;
+import io.debezium.relational.ValueConverter;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
-import java.io.ObjectOutput;
-import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.sql.Types;
 import java.util.Objects;
 import java.util.function.Function;
-
-import org.apache.kafka.connect.data.SchemaBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import io.debezium.annotation.Immutable;
-import io.debezium.relational.Column;
-import io.debezium.relational.ValueConverter;
 
 /**
  * A {@link ColumnMapper} implementation that ensures that string values are masked.
@@ -142,12 +138,8 @@ public class MaskStrings implements ColumnMapper {
         private String toHash(Serializable value) throws IOException {
             hashAlgorithm.reset();
             hashAlgorithm.update(salt);
-
-            try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                    ObjectOutput out = new ObjectOutputStream(bos)) {
-                out.writeObject(value);
-                return convertToHexadecimalFormat(hashAlgorithm.digest(bos.toByteArray()));
-            }
+            byte[] data = value.toString().getBytes();
+            return convertToHexadecimalFormat(hashAlgorithm.digest(data));
         }
 
         private String convertToHexadecimalFormat(byte[] bytes) {

--- a/debezium-core/src/test/java/io/debezium/relational/mapping/MaskStringsTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/mapping/MaskStringsTest.java
@@ -5,18 +5,16 @@
  */
 package io.debezium.relational.mapping;
 
-import static org.fest.assertions.Assertions.assertThat;
+import io.debezium.relational.Column;
+import io.debezium.relational.ValueConverter;
+import org.junit.Test;
 
 import java.sql.Types;
 
-import org.junit.Test;
-
-import io.debezium.relational.Column;
-import io.debezium.relational.ValueConverter;
+import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * @author Randall Hauch
- *
  */
 public class MaskStringsTest {
 
@@ -40,10 +38,16 @@ public class MaskStringsTest {
     @Test
     public void shouldTransformSameInputsToSameResultsForCharsetType() {
         converter = new MaskStrings("salt".getBytes(), "SHA-256").create(column);
-        assertThat(converter.convert("hello")).isEqualTo("af5843a0f0e728ab0332c8888b6e1190bfb79e584f0d40538de8f10df6ef29c6");
-        assertThat(converter.convert("hello")).isEqualTo("af5843a0f0e728ab0332c8888b6e1190bfb79e584f0d40538de8f10df6ef29c6");
-        assertThat(converter.convert("world")).isEqualTo("4588e1f2dcdc7fefc1515d3acd5acb9033478eace68286f383c337b9ff4464a3");
-        assertThat(converter.convert("world")).isEqualTo("4588e1f2dcdc7fefc1515d3acd5acb9033478eace68286f383c337b9ff4464a3");
+        assertThat(converter.convert("hello")).isEqualTo("cd31b3b98ece60cb739c0bf770b2de892ae0ad133f645513c3d83f08757a843a");
+        assertThat(converter.convert("hello")).isEqualTo("cd31b3b98ece60cb739c0bf770b2de892ae0ad133f645513c3d83f08757a843a");
+        assertThat(converter.convert("world")).isEqualTo("e84ac3142870113ddc6710c06f76421befc8e8ca6de64e98d2993ed8d41f4085");
+        assertThat(converter.convert("world")).isEqualTo("e84ac3142870113ddc6710c06f76421befc8e8ca6de64e98d2993ed8d41f4085");
     }
 
+    @Test
+    public void shouldTransformSameInputsToSameResultsForCharsetTypeWithMD5() {
+        converter = new MaskStrings("salt".getBytes(), "MD5").create(column);
+        assertThat(converter.convert("hello")).isEqualTo("06decc8b095724f80103712c235586be");
+        assertThat(converter.convert("world")).isEqualTo("172c8e95398cc72ab5358ead6981e7e5");
+    }
 }


### PR DESCRIPTION
Using ObjectOutputStream in the hash process causes data corruption.Because it performs a hash operation by adding abnormal characters to the front of the given value, the columns are corrupted and transmitted.Instead, a string conversion was performed and a byte array was obtained.

![image](https://user-images.githubusercontent.com/20913276/134496061-bc2b7bcf-0351-483c-b9ed-c2cfecdead3b.png)

You can use the following link to verify it.
https://www.symbionts.de/tools/hash/sha256-hash-salt-generator.html

![image](https://user-images.githubusercontent.com/20913276/134496444-9dcbc65b-8934-4d9d-bee8-7d1b9f443ebd.png)
