### PR TITLE
DBZ-4037 Gracefully handle unsupported RAW data types

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
@@ -210,6 +210,9 @@ public class OracleValueConverters extends JdbcValueConverters {
                 return (data) -> convertIntervalYearMonth(column, fieldDefn, data);
             case OracleTypes.INTERVALDS:
                 return (data) -> convertIntervalDaySecond(column, fieldDefn, data);
+            case OracleTypes.RAW:
+                // Raw data types are not supported
+                return null;
         }
 
         return super.converter(column, fieldDefn);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/ColumnDefinitionParserListener.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/ColumnDefinitionParserListener.java
@@ -260,6 +260,13 @@ public class ColumnDefinitionParserListener extends BaseParserListener {
                         .jdbcType(Types.CLOB)
                         .type("CLOB");
             }
+            else if (ctx.native_datatype_element().RAW() != null) {
+                columnEditor
+                        .jdbcType(OracleTypes.RAW)
+                        .type("RAW");
+
+                setPrecision(precisionPart, columnEditor);
+            }
             else {
                 throw new IllegalArgumentException("Unsupported column type: " + ctx.native_datatype_element().getText());
             }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/CreateTableParserListener.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/CreateTableParserListener.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.antlr.v4.runtime.tree.ParseTreeListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.oracle.antlr.OracleDdlParser;
 import io.debezium.ddl.parser.oracle.generated.PlSqlParser;
@@ -20,6 +22,8 @@ import io.debezium.relational.TableId;
 import io.debezium.text.ParsingException;
 
 public class CreateTableParserListener extends BaseParserListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CreateTableParserListener.class);
 
     private final List<ParseTreeListener> listeners;
     private TableEditor tableEditor;
@@ -48,6 +52,9 @@ public class CreateTableParserListener extends BaseParserListener {
                 tableEditor = parser.databaseTables().editOrCreateTable(tableId);
                 super.enterCreate_table(ctx);
             }
+        }
+        else {
+            LOGGER.debug("Ignoring CREATE TABLE statement for non-captured table {}", tableId);
         }
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleSchemaMigrationIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleSchemaMigrationIT.java
@@ -1172,13 +1172,13 @@ public class OracleSchemaMigrationIT extends AbstractConnectorTest {
             assertNoRecordsToConsume();
 
             // Verify that Oracle DDL parser allows RAW column types for CREATE TABLE (included)
-            connection.execute("CREATE TABLE dbz4037 (id number(9,0), data raw(8), primary key(id))");
+            connection.execute("CREATE TABLE dbz4037 (id number(9,0), data raw(8), name varchar(50), primary key(id))");
             TestHelper.streamTable(connection, "dbz4037");
 
             // Verify that Oracle DDL parser allows RAW column types for ALTER TABLE (included)
             connection.execute("ALTER TABLE dbz4037 ADD data2 raw(10)");
 
-            connection.prepareUpdate("INSERT INTO dbz4037 (id,data,data2) values (1,?,?)", preparer -> {
+            connection.prepareUpdate("INSERT INTO dbz4037 (id,data,name,data2) values (1,?,'Acme 123',?)", preparer -> {
                 preparer.setBytes(1, "Test".getBytes());
                 preparer.setBytes(2, "T".getBytes());
             });
@@ -1192,6 +1192,7 @@ public class OracleSchemaMigrationIT extends AbstractConnectorTest {
             assertThat(after.get("ID")).isEqualTo(1);
             assertThat(after.get("DATA")).isNull();
             assertThat(after.get("DATA2")).isNull();
+            assertThat(after.get("NAME")).isEqualTo("Acme 123");
 
             assertNoRecordsToConsume();
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4037

This avoids the connector failing when a DDL statement contains a `RAW` column data type.  Instead, the connector will properly handle the unsupported column type by simply logging a warning about the unsupported type and still permitting the capture of changes for the table for other column data types that are supported.