### PR TITLE
DBZ-4067 Correctly calculate mining session boundaries

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
@@ -62,6 +62,8 @@ public abstract class AbstractLogMinerEventProcessor implements LogMinerEventPro
 
     protected final Counters counters;
 
+    private Scn lastProcessedScn = Scn.NULL;
+
     public AbstractLogMinerEventProcessor(ChangeEventSourceContext context,
                                           OracleConnectorConfig connectorConfig,
                                           OracleDatabaseSchema schema,
@@ -127,6 +129,15 @@ public abstract class AbstractLogMinerEventProcessor implements LogMinerEventPro
     }
 
     /**
+     * Return the last processed system change number handled by the processor.
+     *
+     * @return the last processed system change number, never {@code null}.
+     */
+    protected Scn getLastProcessedScn() {
+        return lastProcessedScn;
+    }
+
+    /**
      * Returns the {@code TransactionCache} implementation.
      * @return the transaction cache, never {@code null}
      */
@@ -159,6 +170,9 @@ public abstract class AbstractLogMinerEventProcessor implements LogMinerEventPro
      * @throws InterruptedException if the dispatcher was interrupted sending an event
      */
     protected void processRow(LogMinerEventRow row) throws SQLException, InterruptedException {
+        if (!row.getEventType().equals(EventType.MISSING_SCN)) {
+            lastProcessedScn = row.getScn();
+        }
         switch (row.getEventType()) {
             case MISSING_SCN:
                 handleMissingScn(row);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/InfinispanLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/InfinispanLogMinerEventProcessor.java
@@ -407,6 +407,12 @@ public class InfinispanLogMinerEventProcessor extends AbstractLogMinerEventProce
         }
         else {
 
+            if (!getLastProcessedScn().isNull() && getLastProcessedScn().compareTo(endScn) < 0) {
+                // If the last processed SCN is before the endScn we need to use the last processed SCN as the
+                // next starting point as the LGWR buffer didn't flush all entries from memory to disk yet.
+                endScn = getLastProcessedScn();
+            }
+
             // update offsets
             offsetContext.setScn(endScn);
             metrics.setOldestScn(endScn);


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4067

It is not guaranteed that the flush strategy will force all LGWR buffer entries to be written to the redo logs in which case the mining boundaries must then be calculated based on the lastProcessedScn rather than the current batch endScn. This prevents event loss between mining sessions when this timing scenario occurs.

@jpechane This is the fix for the `IncrementalSnapshotIT` tests failing.  Could you give this a try against your Oracle 12 env as well to verify that it solves the problem?  I've ran the tests locally against both Oracle 12 and 19 using the memory & infinispan buffer types and all tests have passed.