### PR TITLE
Dbz 3974 schema change doc updates

### DIFF
--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -5,6 +5,7 @@ on:
   # be executed in any flows triggered by it
   pull_request_target:
     branches: [ master ]
+    types: [ opened ]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -33,4 +34,4 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Hi @${{ github.event.pull_request.user.login }}, thanks for your contribution. Please add missing author name(s) and alias name(s) to the [COPYRIGHT.txt](https://github.com/debezium/debezium/blob/master/COPYRIGHT.txt) and [Aliases.txt](https://github.com/debezium/debezium/blob/master/jenkins-jobs/scripts/config/Aliases.txt) respectively.
+            Welcome as a new contributor to Debezium, @${{ github.event.pull_request.user.login }}. Reviewers, please add missing author name(s) and alias name(s) to the [COPYRIGHT.txt](https://github.com/debezium/debezium/blob/master/COPYRIGHT.txt) and [Aliases.txt](https://github.com/debezium/debezium/blob/master/jenkins-jobs/scripts/config/Aliases.txt) respectively.

--- a/.github/workflows/formatting-check.yml
+++ b/.github/workflows/formatting-check.yml
@@ -2,6 +2,8 @@ name: Formatting Check
 on:
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '.github/**'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,43 @@
 All notable changes are documented in this file. Release numbers follow [Semantic Versioning](http://semver.org)
 
 
+## 1.7.0.Final
+September 30th 2021 [Detailed release notes](https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12317320&version=12374879)
+
+### New features since 1.7.0.CR2
+
+* DBZ-UI - Provide list of configurations [DBZ-3960](https://issues.jboss.org/browse/DBZ-3960)
+
+
+### Breaking changes since 1.7.0.CR2
+
+* Cassandra UUID handling [DBZ-3885](https://issues.jboss.org/browse/DBZ-3885)
+
+
+### Fixes since 1.7.0.CR2
+
+* java.lang.RuntimeException: com.microsoft.sqlserver.jdbc.SQLServerException: The connection is closed [DBZ-3346](https://issues.jboss.org/browse/DBZ-3346)
+* Oracle connector unable to start in archive only mode [DBZ-3712](https://issues.jboss.org/browse/DBZ-3712)
+* DDL statement couldn't be parsed [DBZ-4026](https://issues.jboss.org/browse/DBZ-4026)
+* Question about handling Raw column types [DBZ-4037](https://issues.jboss.org/browse/DBZ-4037)
+* Fixing wrong log dir location in Kafka container image [DBZ-4048](https://issues.jboss.org/browse/DBZ-4048)
+* Incremental snapshotting of a table can be prematurely terminated after restart [DBZ-4057](https://issues.jboss.org/browse/DBZ-4057)
+* Documentation - Setting up Db2 - Step 10 (Start the ASN agent) is not accurate [DBZ-4044](https://issues.jboss.org/browse/DBZ-4044)
+* Debezium Server uses MySQL driver version as defined in Quarkus not in Debezium [DBZ-4049](https://issues.jboss.org/browse/DBZ-4049)
+* Events are missed with Oracle connector due to LGWR buffer not being flushed to redo logs [DBZ-4067](https://issues.jboss.org/browse/DBZ-4067)
+* Postgres JDBC Driver version causes connection issues on some cloud Postgres instances [DBZ-4060](https://issues.jboss.org/browse/DBZ-4060)
+
+
+### Other changes since 1.7.0.CR2
+
+* Oracle IncrementalSnapshotIT invalid table test fails [DBZ-4040](https://issues.jboss.org/browse/DBZ-4040)
+* Document how to enable schema for JSON messages [DBZ-4041](https://issues.jboss.org/browse/DBZ-4041)
+* Trigger contributor check action only when PR is opened [DBZ-4058](https://issues.jboss.org/browse/DBZ-4058)
+* Provide JMH benchmark for ChangeEventQueue [DBZ-4050](https://issues.jboss.org/browse/DBZ-4050)
+* Commit message action fails for multi-line commit messages [DBZ-4047](https://issues.jboss.org/browse/DBZ-4047)
+
+
+
 ## 1.7.0.CR2
 Spetember 23rd 2021 [Detailed release notes](https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12317320&version=12374333)
 
@@ -39,7 +76,7 @@ None
 
 
 ## 1.7.0.CR1
-Spetember 16th 2021 [Detailed release notes](https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12317320&version=12373513)
+September 16th 2021 [Detailed release notes](https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12317320&version=12373513)
 
 ### New features since 1.7.0.Beta1
 

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -331,6 +331,7 @@ yangsanity
 Yilong Chang
 Yiming Liu
 Yoann Rodière
+Yossi Shirizli
 Yuan Zhang
 Zheng Wang
 Zoran Regvart

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -101,7 +101,7 @@ Fabio Cantarini
 Fahim Farook
 Faizan
 Fatih Güçlü Akkaya
-Fándly Gergő 
+Fándly Gergő
 Felix Eckhardt
 Fintan Bolton
 Frank Koornstra
@@ -170,6 +170,7 @@ Josh Arenberg
 Josh Stanfield
 Joy Gao
 Juan Antonio Pedraza
+Judah Rand
 Jun Du
 Jure Kajzer
 Justin Hiza

--- a/debezium-api/pom.xml
+++ b/debezium-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-api/pom.xml
+++ b/debezium-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-api/pom.xml
+++ b/debezium-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-assembly-descriptors/pom.xml
+++ b/debezium-assembly-descriptors/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-assembly-descriptors/pom.xml
+++ b/debezium-assembly-descriptors/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-assembly-descriptors/pom.xml
+++ b/debezium-assembly-descriptors/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -16,16 +16,6 @@
         <version.confluent.platform>6.0.2</version.confluent.platform>
         <version.apicurio>2.0.0.Final</version.apicurio>
 
-        <!-- Database drivers, should align with databases in debezium-build-parent -->
-        <version.postgresql.driver>42.2.14</version.postgresql.driver>
-        <version.mysql.driver>8.0.26</version.mysql.driver>
-        <version.mysql.binlog>0.25.3</version.mysql.binlog>
-        <version.mongo.driver>4.2.1</version.mongo.driver>
-        <version.sqlserver.driver>7.2.2.jre8</version.sqlserver.driver>
-        <version.oracle.driver>21.1.0.0</version.oracle.driver>
-        <version.db2.driver>11.5.0.0</version.db2.driver>
-        <version.cassandra.driver>3.11.0</version.cassandra.driver>
-
         <!-- Connectors -->
         <version.com.google.protobuf>3.8.0</version.com.google.protobuf>
         <version.dropwizard>4.0.1</version.dropwizard>

--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -610,8 +610,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
             if (showStartScnNotInArchiveLogs) {
                 LOGGER.warn("Starting SCN {} is not yet in archive logs, waiting for archive log switch.", startScn);
                 showStartScnNotInArchiveLogs = false;
-                pauseBetweenMiningSessions();
-                continue;
+                Metronome.sleeper(connectorConfig.getArchiveLogOnlyScnPollTime(), clock).pause();
             }
         }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
@@ -62,6 +62,8 @@ public abstract class AbstractLogMinerEventProcessor implements LogMinerEventPro
 
     protected final Counters counters;
 
+    private Scn lastProcessedScn = Scn.NULL;
+
     public AbstractLogMinerEventProcessor(ChangeEventSourceContext context,
                                           OracleConnectorConfig connectorConfig,
                                           OracleDatabaseSchema schema,
@@ -127,6 +129,15 @@ public abstract class AbstractLogMinerEventProcessor implements LogMinerEventPro
     }
 
     /**
+     * Return the last processed system change number handled by the processor.
+     *
+     * @return the last processed system change number, never {@code null}.
+     */
+    protected Scn getLastProcessedScn() {
+        return lastProcessedScn;
+    }
+
+    /**
      * Returns the {@code TransactionCache} implementation.
      * @return the transaction cache, never {@code null}
      */
@@ -159,6 +170,9 @@ public abstract class AbstractLogMinerEventProcessor implements LogMinerEventPro
      * @throws InterruptedException if the dispatcher was interrupted sending an event
      */
     protected void processRow(LogMinerEventRow row) throws SQLException, InterruptedException {
+        if (!row.getEventType().equals(EventType.MISSING_SCN)) {
+            lastProcessedScn = row.getScn();
+        }
         switch (row.getEventType()) {
             case MISSING_SCN:
                 handleMissingScn(row);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/InfinispanLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/InfinispanLogMinerEventProcessor.java
@@ -407,6 +407,12 @@ public class InfinispanLogMinerEventProcessor extends AbstractLogMinerEventProce
         }
         else {
 
+            if (!getLastProcessedScn().isNull() && getLastProcessedScn().compareTo(endScn) < 0) {
+                // If the last processed SCN is before the endScn we need to use the last processed SCN as the
+                // next starting point as the LGWR buffer didn't flush all entries from memory to disk yet.
+                endScn = getLastProcessedScn();
+            }
+
             // update offsets
             offsetContext.setScn(endScn);
             metrics.setOldestScn(endScn);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -2129,6 +2129,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
 
             Configuration config = TestHelper.defaultConfig()
                     .with(OracleConnectorConfig.LOG_MINING_ARCHIVE_LOG_ONLY_MODE, true)
+                    .with(OracleConnectorConfig.LOG_MINING_ARCHIVE_LOG_ONLY_SCN_POLL_INTERVAL_MS, 2000)
                     .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ3712")
                     .build();
 
@@ -2164,6 +2165,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
             TestHelper.streamTable(connection, "dbz3712");
 
             Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.LOG_MINING_ARCHIVE_LOG_ONLY_SCN_POLL_INTERVAL_MS, 2000)
                     .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ3712")
                     .build();
 
@@ -2184,6 +2186,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
 
             config = TestHelper.defaultConfig()
                     .with(OracleConnectorConfig.LOG_MINING_ARCHIVE_LOG_ONLY_MODE, true)
+                    .with(OracleConnectorConfig.LOG_MINING_ARCHIVE_LOG_ONLY_SCN_POLL_INTERVAL_MS, 2000)
                     .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ3712")
                     .build();
 

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresDefaultValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresDefaultValueConverter.java
@@ -141,6 +141,7 @@ class PostgresDefaultValueConverter {
         result.put("serial", v -> Integer.parseInt(extractDefault(v, "0")));
         result.put("int8", v -> Long.parseLong(extractDefault(v, "0"))); // Sample values: `123`, `'9223372036854775807'::bigint`
         result.put("bigserial", v -> Long.parseLong(extractDefault(v, "0")));
+        result.put("smallserial", v -> Short.parseShort(extractDefault(v, "0")));
 
         result.put("json", v -> extractDefault(v, "{}")); // Sample value: '{}'::json
         result.put("jsonb", v -> extractDefault(v, "{}")); // Sample value: '{}'::jsonb

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -2299,7 +2299,8 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         waitForStreamingRunning();
 
         // Check that publication was created
-        assertTrue(TestHelper.publicationExists());
+        Awaitility.await("Wait until publication is created").atMost(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS)
+                .until(TestHelper::publicationExists);
 
         // Stop connector, drop publication
         stopConnector();
@@ -2311,7 +2312,8 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         waitForStreamingRunning();
 
         // Check that publication was created
-        assertTrue(TestHelper.publicationExists());
+        Awaitility.await("Wait until publication is created").atMost(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS)
+                .until(TestHelper::publicationExists);
 
         // Stop Connector and check log messages
         stopConnector(value -> {

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
@@ -31,6 +31,7 @@ public class SqlServerErrorHandler extends ErrorHandler {
                 && (throwable.getMessage().contains("Connection timed out (Read failed)")
                         || throwable.getMessage().contains("Connection timed out (Write failed)")
                         || throwable.getMessage().contains("The connection has been closed.")
+                        || throwable.getMessage().contains("The connection is closed.")
                         || throwable.getMessage().contains("Connection reset")
                         || throwable.getMessage().contains("SHUTDOWN is in progress")
                         || throwable.getMessage().contains("The server failed to resume the transaction")

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -161,6 +161,7 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
         eventDispatcher.setEventListener(streamingMetrics);
         streamingConnected(true);
         LOGGER.info("Starting streaming");
+        streamingSource.init();
         incrementalSnapshotChangeEventSource.ifPresent(x -> x.init(offsetContext));
         streamingSource.execute(context, partition, offsetContext);
         LOGGER.info("Finished streaming");

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingChangeEventSource.java
@@ -18,6 +18,15 @@ import io.debezium.pipeline.spi.Partition;
 public interface StreamingChangeEventSource<P extends Partition, O extends OffsetContext> extends ChangeEventSource {
 
     /**
+     * Initializes the streaming source.
+     * Called before incremental snapshot init.
+     *
+     * @throws InterruptedException
+     */
+    default void init() throws InterruptedException {
+    }
+
+    /**
      * Executes this source. Implementations should regularly check via the given context if they should stop. If that's
      * the case, they should abort their processing and perform any clean-up needed, such as rolling back pending
      * transactions, releasing locks etc.

--- a/debezium-ddl-parser/pom.xml
+++ b/debezium-ddl-parser/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-ddl-parser/pom.xml
+++ b/debezium-ddl-parser/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-ddl-parser/pom.xml
+++ b/debezium-ddl-parser/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlLexer.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlLexer.g4
@@ -45,6 +45,7 @@ LINE_COMMENT:                        (
 // Common Keywords
 
 ADD:                                 'ADD';
+ADMIN:                               'ADMIN';
 ALL:                                 'ALL';
 ALTER:                               'ALTER';
 ALWAYS:                              'ALWAYS';

--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -1981,7 +1981,7 @@ indexColumnName
     ;
 
 userName
-    : STRING_USER_NAME | ID | STRING_LITERAL;
+    : STRING_USER_NAME | ID | STRING_LITERAL | keywordsCanBeId;
 
 mysqlVariable
     : LOCAL_ID
@@ -2343,8 +2343,8 @@ specificFunction
       '(' expression
        ',' expression
          (RETURNING convertedDataType)?
-         ((NULL | ERROR | (DEFAULT defaultValue)) ON EMPTY)?
-         ((NULL | ERROR | (DEFAULT defaultValue)) ON ERROR)?
+         ((NULL_LITERAL | ERROR | (DEFAULT defaultValue)) ON EMPTY)?
+         ((NULL_LITERAL | ERROR | (DEFAULT defaultValue)) ON ERROR)?
        ')'                                                          #jsonValueFunctionCall
     ;
 
@@ -2508,7 +2508,7 @@ dataTypeBase
 
 keywordsCanBeId
     : ACCOUNT | ACTION | AFTER | AGGREGATE | ALGORITHM | ANY
-    | AT | AUDIT_ADMIN | AUTHORS | AUTOCOMMIT | AUTOEXTEND_SIZE
+    | AT | ADMIN | AUDIT_ADMIN | AUTHORS | AUTOCOMMIT | AUTOEXTEND_SIZE
     | AUTO_INCREMENT | AVG | AVG_ROW_LENGTH | BACKUP_ADMIN | BEGIN | BINLOG | BINLOG_ADMIN | BINLOG_ENCRYPTION_ADMIN | BIT | BIT_AND | BIT_OR | BIT_XOR
     | BLOCK | BOOL | BOOLEAN | BTREE | CACHE | CASCADED | CHAIN | CHANGED
     | CHANNEL | CHECKSUM | PAGE_CHECKSUM | CATALOG_NAME | CIPHER

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/grant.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/grant.sql
@@ -1,5 +1,6 @@
 GRANT ALL ON tbl TO admin@localhost;
 GRANT ALL ON tbl TO admin;
+GRANT ALL ON tbl TO audit_admin;
 GRANT ALL PRIVILEGES ON tbl TO admin;
 GRANT ALL ON *.* TO admin;
 GRANT USAGE ON *.* TO foo2@test IDENTIFIED BY 'mariadb';

--- a/debezium-embedded/pom.xml
+++ b/debezium-embedded/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-embedded/pom.xml
+++ b/debezium-embedded/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-embedded/pom.xml
+++ b/debezium-embedded/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-microbenchmark-oracle/pom.xml
+++ b/debezium-microbenchmark-oracle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-microbenchmark-oracle/pom.xml
+++ b/debezium-microbenchmark-oracle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-microbenchmark-oracle/pom.xml
+++ b/debezium-microbenchmark-oracle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-microbenchmark/pom.xml
+++ b/debezium-microbenchmark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-microbenchmark/pom.xml
+++ b/debezium-microbenchmark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-microbenchmark/pom.xml
+++ b/debezium-microbenchmark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-parent/pom.xml
+++ b/debezium-parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-build-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/debezium-parent/pom.xml
+++ b/debezium-parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-build-parent</artifactId>
-    <version>1.7.0.Final</version>
+    <version>1.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/debezium-parent/pom.xml
+++ b/debezium-parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-build-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.7.0.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/debezium-quarkus-outbox/deployment/pom.xml
+++ b/debezium-quarkus-outbox/deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/deployment/pom.xml
+++ b/debezium-quarkus-outbox/deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/deployment/pom.xml
+++ b/debezium-quarkus-outbox/deployment/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/integration-tests/pom.xml
+++ b/debezium-quarkus-outbox/integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/integration-tests/pom.xml
+++ b/debezium-quarkus-outbox/integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/integration-tests/pom.xml
+++ b/debezium-quarkus-outbox/integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/pom.xml
+++ b/debezium-quarkus-outbox/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/pom.xml
+++ b/debezium-quarkus-outbox/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/pom.xml
+++ b/debezium-quarkus-outbox/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/runtime/pom.xml
+++ b/debezium-quarkus-outbox/runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/runtime/pom.xml
+++ b/debezium-quarkus-outbox/runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-quarkus-outbox/runtime/pom.xml
+++ b/debezium-quarkus-outbox/runtime/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-quarkus-outbox-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/debezium-scripting/pom.xml
+++ b/debezium-scripting/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-scripting/pom.xml
+++ b/debezium-scripting/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-scripting/pom.xml
+++ b/debezium-scripting/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-bom/pom.xml
+++ b/debezium-server/debezium-server-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-bom/pom.xml
+++ b/debezium-server/debezium-server-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-bom/pom.xml
+++ b/debezium-server/debezium-server-bom/pom.xml
@@ -55,11 +55,13 @@
                 <artifactId>mysql-connector-java</artifactId>
                 <version>${version.mysql.driver}</version>
             </dependency>
+            <!--
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
                 <version>${version.postgresql.driver}</version>
             </dependency>
+	    -->
 
             <!-- Debezium dependencies -->
             <dependency>

--- a/debezium-server/debezium-server-bom/pom.xml
+++ b/debezium-server/debezium-server-bom/pom.xml
@@ -49,6 +49,18 @@
                 <scope>import</scope>
             </dependency>
 
+            <!-- Override Quarkus default driver versions -->
+            <dependency>
+                <groupId>mysql</groupId>
+                <artifactId>mysql-connector-java</artifactId>
+                <version>${version.mysql.driver}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.postgresql</groupId>
+                <artifactId>postgresql</artifactId>
+                <version>${version.postgresql.driver}</version>
+            </dependency>
+
             <!-- Debezium dependencies -->
             <dependency>
                 <groupId>io.debezium</groupId>

--- a/debezium-server/debezium-server-bom/pom.xml
+++ b/debezium-server/debezium-server-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-core/pom.xml
+++ b/debezium-server/debezium-server-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-core/pom.xml
+++ b/debezium-server/debezium-server-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-core/pom.xml
+++ b/debezium-server/debezium-server-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-dist/pom.xml
+++ b/debezium-server/debezium-server-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-dist/pom.xml
+++ b/debezium-server/debezium-server-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-dist/pom.xml
+++ b/debezium-server/debezium-server-dist/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-eventhubs/pom.xml
+++ b/debezium-server/debezium-server-eventhubs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-eventhubs/pom.xml
+++ b/debezium-server/debezium-server-eventhubs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-eventhubs/pom.xml
+++ b/debezium-server/debezium-server-eventhubs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-kafka/pom.xml
+++ b/debezium-server/debezium-server-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-kafka/pom.xml
+++ b/debezium-server/debezium-server-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-kafka/pom.xml
+++ b/debezium-server/debezium-server-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-kinesis/pom.xml
+++ b/debezium-server/debezium-server-kinesis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-kinesis/pom.xml
+++ b/debezium-server/debezium-server-kinesis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-kinesis/pom.xml
+++ b/debezium-server/debezium-server-kinesis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-nats-streaming/pom.xml
+++ b/debezium-server/debezium-server-nats-streaming/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-nats-streaming/pom.xml
+++ b/debezium-server/debezium-server-nats-streaming/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-nats-streaming/pom.xml
+++ b/debezium-server/debezium-server-nats-streaming/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-pravega/pom.xml
+++ b/debezium-server/debezium-server-pravega/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-server</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>debezium-server-pravega</artifactId>

--- a/debezium-server/debezium-server-pravega/pom.xml
+++ b/debezium-server/debezium-server-pravega/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-server</artifactId>
-    <version>1.7.0.Final</version>
+    <version>1.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>debezium-server-pravega</artifactId>

--- a/debezium-server/debezium-server-pravega/pom.xml
+++ b/debezium-server/debezium-server-pravega/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-server</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.7.0.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>debezium-server-pravega</artifactId>

--- a/debezium-server/debezium-server-pubsub/pom.xml
+++ b/debezium-server/debezium-server-pubsub/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-pubsub/pom.xml
+++ b/debezium-server/debezium-server-pubsub/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-pubsub/pom.xml
+++ b/debezium-server/debezium-server-pubsub/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-pulsar/pom.xml
+++ b/debezium-server/debezium-server-pulsar/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-pulsar/pom.xml
+++ b/debezium-server/debezium-server-pulsar/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-pulsar/pom.xml
+++ b/debezium-server/debezium-server-pulsar/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-redis/pom.xml
+++ b/debezium-server/debezium-server-redis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-redis/pom.xml
+++ b/debezium-server/debezium-server-redis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/debezium-server-redis/pom.xml
+++ b/debezium-server/debezium-server-redis/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-server</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/pom.xml
+++ b/debezium-server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/pom.xml
+++ b/debezium-server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-server/pom.xml
+++ b/debezium-server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
 	<relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/debezium-testing/debezium-testing-system/pom.xml
+++ b/debezium-testing/debezium-testing-system/pom.xml
@@ -97,7 +97,7 @@
     <database.db2.cdc.schema>ASNCDC</database.db2.cdc.schema>
 
     <!--Debezium connector versions-->
-    <version.debezium.connector>1.7.0-SNAPSHOT</version.debezium.connector>
+    <version.debezium.connector>${project.version}</version.debezium.connector>
   </properties>
 
   <dependencyManagement>

--- a/debezium-testing/debezium-testing-system/pom.xml
+++ b/debezium-testing/debezium-testing-system/pom.xml
@@ -97,7 +97,7 @@
     <database.db2.cdc.schema>ASNCDC</database.db2.cdc.schema>
 
     <!--Debezium connector versions-->
-    <version.debezium.connector>${project.version}</version.debezium.connector>
+    <version.debezium.connector>1.7.0.Final</version.debezium.connector>
   </properties>
 
   <dependencyManagement>

--- a/debezium-testing/debezium-testing-system/pom.xml
+++ b/debezium-testing/debezium-testing-system/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-testing</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.7.0.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/debezium-testing/debezium-testing-system/pom.xml
+++ b/debezium-testing/debezium-testing-system/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-testing</artifactId>
-    <version>1.7.0.Final</version>
+    <version>1.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -97,7 +97,7 @@
     <database.db2.cdc.schema>ASNCDC</database.db2.cdc.schema>
 
     <!--Debezium connector versions-->
-    <version.debezium.connector>1.7.0.Final</version.debezium.connector>
+    <version.debezium.connector>1.7.0-SNAPSHOT</version.debezium.connector>
   </properties>
 
   <dependencyManagement>

--- a/debezium-testing/debezium-testing-system/pom.xml
+++ b/debezium-testing/debezium-testing-system/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-testing</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/debezium-testing/debezium-testing-testcontainers/pom.xml
+++ b/debezium-testing/debezium-testing-testcontainers/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-testing</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/debezium-testing/debezium-testing-testcontainers/pom.xml
+++ b/debezium-testing/debezium-testing-testcontainers/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-testing</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.7.0.Final</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/debezium-testing/debezium-testing-testcontainers/pom.xml
+++ b/debezium-testing/debezium-testing-testcontainers/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-testing</artifactId>
-    <version>1.7.0.Final</version>
+    <version>1.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/debezium-testing/pom.xml
+++ b/debezium-testing/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <relativePath>../debezium-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/debezium-testing/pom.xml
+++ b/debezium-testing/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-parent</artifactId>
-    <version>1.7.0.Final</version>
+    <version>1.7.0-SNAPSHOT</version>
     <relativePath>../debezium-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/debezium-testing/pom.xml
+++ b/debezium-testing/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.7.0.Final</version>
     <relativePath>../debezium-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -8,12 +8,12 @@ nav:
 
 asciidoc:
   attributes:
-    debezium-version: '1.7.0.CR2'
+    debezium-version: '1.7.0.Final'
     debezium-dev-version: '1.7'
     debezium-kafka-version: '2.8.0'
-    debezium-docker-label: '1.6'
+    debezium-docker-label: '1.7'
     DockerKafkaConnect: registry.redhat.io/amq7/amq-streams-kafka-28-rhel8:1.8.0
-    install-version: '1.6'
+    install-version: '1.7'
     assemblies: '../assemblies'
     modules: '../../modules'
     mysql-version: '8.0'

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1457,6 +1457,18 @@ After you set up the Db2 server, use the UDFs to control Db2 replication (ASN) w
 ----
 VALUES ASNCDC.ASNCDCSERVICES('start','asncdc');
 ----
++ 
+This will return one of these:
++
+.. asncap is already running
+.. start +-->+ <COMMAND>
++
+In this case, run the retrieved <COMMAND> in the terminal, for example:
++
+[source,shell]
+----
+/database/config/db2inst1/sqllib/bin/asncap capture_schema=asncdc capture_server=SAMPLE &
+----
 
 . Put tables into capture mode. Invoke the following statement for each table that you want to put into capture. Replace `MYSCHEMA`  with the name of the schema that contains the table you want to put into capture mode. Likewise, replace `MYTABLE` with the name of the table to put into capture mode:
 +

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -130,14 +130,17 @@ include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot
 [id="how-debezium-db2-connectors-read-change-data-tables"]
 === Change-data tables
 
-After a complete snapshot, when a {prodname} Db2 connector starts for the first time, the connector identifies the change-data table for each source table that is in capture mode. The connector does the following for each change-data table:
+After a complete snapshot, when a {prodname} Db2 connector starts for the first time, the connector identifies the change-data table for each source table that is in capture mode.
+The connector does the following for each change-data table:
 
 . Reads change events that were created between the last stored, highest LSN and the current, highest LSN.
-. Orders the change events according to the commit LSN and the change LSN for each event. This ensures that the connector emits the change events in the order in which the table changes occurred.
+. Orders the change events according to the commit LSN and the change LSN for each event.
+  This ensures that the connector emits the change events in the order in which the table changes occurred.
 . Passes commit and change LSNs as offsets to Kafka Connect.
 . Stores the highest LSN that the connector passed to Kafka Connect.
 
-After a restart, the connector resumes emitting change events from the offset (commit and change LSNs) where it left off. While the connector is running and emitting change events, if you remove a table from capture mode or add a table to capture mode, the connector detects this and modifies its behavior accordingly.
+After a restart, the connector resumes emitting change events from the offset (commit and change LSNs) where it left off.
+While the connector is running and emitting change events, if you remove a table from capture mode or add a table to capture mode, the connector detects the change, and modifies its behavior accordingly.
 
 // Type: concept
 // ModuleID: default-names-of-kafka-topics-that-receive-db2-change-event-records
@@ -145,11 +148,14 @@ After a restart, the connector resumes emitting change events from the offset (c
 [[db2-topic-names]]
 === Topic names
 
-By default, the Db2 connector writes change events for all insert, update, and delete operations on a single table to a single Kafka topic. The name of the Kafka topic has the following format:
+By default, the Db2 connector writes change events for all `INSERT`, `UPDATE`, and `DELETE` operations that occur in a table to a single Apache Kafka topic.
+The connector uses the following convention to name change event topics:
 
 _databaseName_._schemaName_._tableName_
 
-_databaseName_:: The logical name of the connector as specified with the `database.server.name` connector configuration property.
+The following list provides definitions for the components of the default name:
+
+_databaseName_:: The logical name of the connector as specified by the xref:db2-property-database-server-name[`database.server.name`] connector configuration property.
 
 _schemaName_:: The name of the schema in which the operation occurred.
 
@@ -162,6 +168,8 @@ For example, consider a Db2 installation with the `mydatabase` database,  which 
 * `mydatabase.MYSCHEMA.CUSTOMERS`
 * `mydatabase.MYSCHEMA.ORDERS`
 
+The connector applies similar naming conventions to label its internal database history topics, xref:about-the-debezium-db2-connector-schema-change-topic[schema change topics], and xref:db2-transaction-metadata[transaction metadata topics].
+
 To configure a Db2 connector to emit change events to differently-named Kafka topics, see the documentation for the {link-prefix}:{link-topic-routing}#topic-routing[topic routing transformation].
 
 // Type: concept
@@ -169,7 +177,13 @@ To configure a Db2 connector to emit change events to differently-named Kafka to
 [id="about-the-debezium-db2-connector-schema-change-topic"]
 === Schema change topic
 
-For a table that is in capture mode, the {prodname} Db2 connector stores the history of schema changes to that table in a database history topic. This topic reflects an internal connector state and you should not use it. If your application needs to track schema changes, there is a public schema change topic. The name of the schema change topic is the same as the logical server name specified in the connector configuration.
+For a table that is in capture mode, the {prodname} Db2 connector stores the history of schema changes that occur in the table in an internal database history topic.
+This topic reflects an internal connector state and you should not use it directly.
+Applications that require notifications about schema changes should obtain the information from the public schema change topic.
+
+The connector writes schema change events to a Kafka schema change topic that has the name `_<serverName>_` where `_<serverName>_` is the logical server name that is specified in the xref:db2-property-database-server-name[`database.server.name`] connector configuration property.
+
+
 
 [WARNING]
 ====
@@ -293,7 +307,9 @@ A message to the schema change topic contains a logical representation of the ta
 
 |2
 |`ddl`
-|Always `null` for the Db2 connector. For other connectors, this field contains the DDL responsible for the schema change. This DDL is not available to Db2 connectors.
+|Always `null` for the Db2 connector.
+For other connectors, this field contains the DDL responsible for the schema change.
+This DDL is not available to Db2 connectors.
 
 |3
 |`tableChanges`
@@ -325,7 +341,8 @@ a|Describes the kind of change. The value is one of the following:
 
 |===
 
-In messages to the schema change topic, the key is the name of the database that contains the schema change. In the following example, the `payload` field contains the key:
+In messages that the connector sends to the schema change topic, the message key is the name of the database that contains the schema change.
+In the following example, the `payload` field contains the key:
 
 [source,json,indent=0,subs="+attributes"]
 ----
@@ -364,12 +381,14 @@ In messages to the schema change topic, the key is the name of the database that
 Metadata for transactions that occur before you deploy the connector is not available.
 ====
 
-For every transaction `BEGIN` and `END`, {prodname} generates an event that contains the following fields:
+{prodname} generates transaction boundary events for the `BEGIN` and `END` delimiters in every transaction.
+Transaction boundary events contain the following fields:
 
-* `status` - `BEGIN` or `END`
-* `id` - string representation of unique transaction identifier
-* `event_count` (for `END` events) - total number of events emitted by the transaction
-* `data_collections` (for `END` events) - an array of pairs of `data_collection` and `event_count` that provides the number of events emitted by changes originating from the given data collection
+`status`:: `BEGIN` or `END`.
+`id`:: String representation of the unique transaction identifier.
+`event_count` (for `END` events):: Total number of events emitted by the transaction.
+`data_collections` (for `END` events):: An array of pairs of `data_collection` and `event_count` elements.
+that indicates the number of events that the connector emits for changes that originate from a data collection.
 
 .Example
 
@@ -399,16 +418,16 @@ For every transaction `BEGIN` and `END`, {prodname} generates an event that cont
 }
 ----
 
-The connector emits transaction events to the `_database.server.name_.transaction` topic.
+The connector emits transaction events to the xref:db2-property-database-server-name[`_<database.server.name>_`]`.transaction` topic.
 
 .Data change event enrichment
 
 When transaction metadata is enabled the connector enriches the change event  `Envelope` with a new `transaction` field.
 This field provides information about every event in the form of a composite of fields:
 
-* `id` - string representation of unique transaction identifier
-* `total_order` - absolute position of the event among all events generated by the transaction
-* `data_collection_order` - the per-data collection position of the event among all events that were emitted by the transaction
+`id`:: String representation of unique transaction identifier.
+`total_order`:: The absolute position of the event among all events generated by the transaction.
+`data_collection_order`:: The per-data collection position of the event among all events that were emitted by the transaction.
 
 Following is an example of a message:
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -132,17 +132,23 @@ Because these hosted options do not allow a global read lock, table-level locks 
 [[mysql-schema-history-topic]]
 === Schema history topic
 
-When a database client queries a database, the client uses the database’s current schema. However, the database schema can be changed at any time, which means that the connector must be able to identify what the schema was at the time each insert, update, or delete operation was recorded. Also, a connector cannot just use the current schema because the connector might be processing events that are relatively old and may have been recorded before the tables' schemas were changed.
+When a database client queries a database, the client uses the database’s current schema.
+However, the database schema can be changed at any time, which means that the connector must be able to identify what the schema was at the time each insert, update, or delete operation was recorded.
+Also, a connector cannot just use the current schema because the connector might be processing events that are relatively old that were recorded before the tables' schemas were changed.
 
-To handle this, MySQL includes in the binlog not only the row-level changes to the data, but also the DDL statements that are applied to the database. As the connector reads the binlog and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema. The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event. In a separate database history Kafka topic, the connector records all DDL statements along with the position in the binlog where each DDL statement appeared.
+To handle this, MySQL includes in the binlog not only the row-level changes to the data, but also the DDL statements that are applied to the database.
+As the connector reads the binlog and comes across these DDL statements, it parses them and updates an in-memory representation of each table’s schema.
+The connector uses this schema representation to identify the structure of the tables at the time of each insert, update, or delete operation and to produce the appropriate change event.
+In a separate database history Kafka topic, the connector records all DDL statements along with the position in the binlog where each DDL statement appeared.
 
-When the connector restarts after having crashed or been stopped gracefully, the connector starts reading the binlog from a specific position, that is, from a specific point in time. The connector rebuilds the table structures that existed at this point in time by reading the database history Kafka topic and parsing all DDL statements up to the point in the binlog where the connector is starting.
+When the connector restarts after having crashed or been stopped gracefully, the connector starts reading the binlog from a specific position, that is, from a specific point in time.
+The connector rebuilds the table structures that existed at this point in time by reading the database history Kafka topic and parsing all DDL statements up to the point in the binlog where the connector is starting.
 
 This database history topic is for connector use only. The connector can optionally {link-prefix}:{link-mysql-connector}#mysql-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
 
-When the MySQL connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied there are helper tables created during the migration process.
+When the MySQL connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied, there are helper tables created during the migration process.
 The connector needs to be configured to capture change to these helper tables.
-If consumers do not need the records generated for helper tables then a single message transform can be applied to filter them out.
+If consumers do not need the records generated for helper tables, then a single message transform can be applied to filter them out.
 
 See {link-prefix}:{link-mysql-connector}#mysql-topic-names[default names for topics] that receive {prodname} event records.
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -18,8 +18,8 @@ toc::[]
 
 [NOTE]
 ====
-A new capturing implementation for the Debezium MySQL connector has been created as of Debezium 1.5,
-based on the common connector framework used by all the other Kafka Connect connectors of Debezium.
+A new capturing implementation for the {prodname} MySQL connector has been created as of {prodname} 1.5,
+based on the common connector framework used by the other {prodname} Kafka Connect connectors.
 
 If you encounter any issues with the new MySQL connector implementation, please log a link:https://issues.redhat.com/browse/DBZ[Jira issue]; in this case, you can use the legacy implementation by setting the `internal.implementation=legacy` connector configuration option
 (note this option as well as the legacy connector implementation itself is scheduled for removal in a future Debezium version).
@@ -152,169 +152,211 @@ See {link-prefix}:{link-mysql-connector}#mysql-topic-names[default names for top
 [id="mysql-schema-change-topic"]
 === Schema change topic
 
-You can configure a {prodname} MySQL connector to produce schema change events that include all DDL statements applied to databases in the MySQL server. The connector emits these events to a Kafka topic named _serverName_ where _serverName_ is the name of the connector as specified by the `database.server.name` connector configuration property.
+You can configure a {prodname} MySQL connector to produce schema change events that describe schema changes that are applied to captured tables in the database.
+The connector writes schema change events to a Kafka topic named `_<serverName>_`, where `_serverName_` is the logical server name that is specified in the xref:mysql-property-database-server-name[`database.server.name`] connector configuration property.
+Messages sent to the schema change topic contain a payload, and, optionally, also contain the schema of the change event message.
 
-If you choose to use _schema change events_, ensure that you consume records from the schema change topic. The database history topic is for connector use only.
+The payload of a schema change event message includes the following elements:
 
-IMPORTANT: A global order for events emitted to the schema change topic is vital. Therefore, you must not partition the database history topic. This means that you must specify a partition count of `1` when creating the database history topic. When relying on auto topic creation, make sure that Kafka’s `num.partitions` configuration option, which specifies the default number of partitions, is set to `1`.
+`ddl`:: Provides the SQL `CREATE`, `ALTER`, or `DROP` statement that results in the schema change.
+`databaseName`:: The name of the database to which the statements are applied.
+`pos`:: The position in the binlog where the statements appear.
+`tableChanges`::  A structured representation of the entire table schema after the schema change.
+The `tableChanges` field contains an array that includes entries for each column of the table.
+Because the structured representation presents data in JSON or Avro format, consumers can easily read messages without first processing them through a DDL parser.
 
-Each record that the connector emits to the schema change topic contains a message key that includes the name of the connected database when the DDL statement was applied, for example:
+Along with the schema change topic, the connector also stores the history of schema changes in an internal database history topic.
+This database history topic is for internal connector use only and you should not use it directly.
+Ensure that applications that require notifications about schema changes consume that information only from the schema change topic.
 
-[source,json,subs="+attributes"]
-----
-{
-  "schema": {
-    "type": "struct",
-    "name": "io.debezium.connector.mysql.SchemaChangeKey",
-    "optional": false,
-    "fields": [
-      {
-        "field": "databaseName",
-        "type": "string",
-        "optional": false
-      }
-    ]
-  },
-  "payload": {
-    "databaseName": "inventory"
-  }
-}
-----
+[IMPORTANT]
+====
+Never partition the database history topic.
+For the database history topic to function correctly, it must maintain a consistent, global order of the event records that the connector emits to it.
 
-The schema change event record value contains a structure that includes the DDL statements, the name of the database to which the statements were applied, and the position in the binlog where the statements appeared, for example:
+To ensure that the topic is not split among partitions, set the partition count for the topic by using one of the following methods:
 
+* If you create the database history topic manually, specify a partition count of `1`.
+* If you use the Apache Kafka broker to create the database history topic automatically, the topic is created, set the value of the link:{link-kafka-docs}/#brokerconfigs_num.partitions[Kafka `num.partitions`] configuration option to `1`.
+====
+
+[WARNING]
+====
+The format of the messages that a connector emits to its schema change topic is in an incubating state and is subject to change without notice.
+====
+
+.Example: MySQL schema change event message
 [source,json,subs="attributes"]
 ----
 {
   "schema": {
-    "type": "struct",
-    "name": "io.debezium.connector.mysql.SchemaChangeValue",
-    "optional": false,
-    "fields": [
-      {
-        "field": "databaseName",
-        "type": "string",
-        "optional": false
-      },
-      {
-        "field": "ddl",
-        "type": "string",
-        "optional": false
-      },
-      {
-        "field": "source",
-        "type": "struct",
-        "name": "io.debezium.connector.mysql.Source",
-        "optional": false,
-        "fields": [
-          {
-            "type": "string",
-            "optional": true,
-            "field": "version"
-          },
-          {
-            "type": "string",
-            "optional": false,
-            "field": "name"
-          },
-          {
-            "type": "int64",
-            "optional": false,
-            "field": "server_id"
-          },
-          {
-            "type": "int64",
-            "optional": false,
-            "field": "ts_ms"
-          },
-          {
-            "type": "string",
-            "optional": true,
-            "field": "gtid"
-          },
-          {
-            "type": "string",
-            "optional": false,
-            "field": "file"
-          },
-          {
-            "type": "int64",
-            "optional": false,
-            "field": "pos"
-          },
-          {
-            "type": "int32",
-            "optional": false,
-            "field": "row"
-          },
-          {
-            "type": "boolean",
-            "optional": true,
-            "default": false,
-            "field": "snapshot"
-          },
-          {
-            "type": "int64",
-            "optional": true,
-            "field": "thread"
-          },
-          {
-            "type": "string",
-            "optional": true,
-            "field": "db"
-          },
-          {
-            "type": "string",
-            "optional": true,
-            "field": "table"
-          },
-          {
-            "type": "string",
-            "optional": true,
-            "field": "query"
-          }
-        ]
-      }
-    ]
+  ...
   },
   "payload": {
-    "databaseName": "inventory",
-    "ddl": "CREATE TABLE products ( id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255) NOT NULL, description VARCHAR(512), weight FLOAT ); ALTER TABLE products AUTO_INCREMENT = 101;",
-    "source" : {
-      "version": "{debezium-version}",
-      "name": "mysql-server-1",
-      "server_id": 0,
-      "ts_ms": 0,
-      "gtid": null,
-      "file": "mysql-bin.000003",
-      "pos": 154,
-      "row": 0,
-      "snapshot": true,
-      "thread": null,
-      "db": null,
-      "table": null,
-      "query": null
-    }
+        "source": {  // <1>
+        "version": "{debezium-version}",
+        "connector": "mysql",
+        "name": "dbserver1",
+        "ts_ms": 0,
+        "snapshot": "false",
+        "db": "inventory",
+        "sequence": null,
+        "table": "customers",
+        "server_id": 0,
+        "gtid": null,
+        "file": "mysql-bin.000003",
+        "pos": 219,
+        "row": 0,
+        "thread": null,
+        "query": null
+    },
+    "databaseName": "inventory", // <2>
+    "schemaName": null,
+    "ddl": "ALTER TABLE customers ADD COLUMN middle_name VARCHAR(2000)", // <3>
+    "tableChanges": [  // <4>
+        {
+        "type": "ALTER", // <5>
+        "id": "\"inventory\".\"customers\"",  // <6>
+        "table": { // <7>
+            "defaultCharsetName": "latin1",
+            "primaryKeyColumnNames": [  // <8>
+                "id"
+            ],
+            "columns": [ // <9>
+                {
+                "name": "id",
+                "jdbcType": 4,
+                "nativeType": null,
+                "typeName": "INT",
+                "typeExpression": "INT",
+                "charsetName": null,
+                "length": 11,
+                "scale": null,
+                "position": 1,
+                "optional": false,
+                "autoIncremented": true,
+                "generated": true
+            },
+            {
+                "name": "first_name",
+                "jdbcType": 12,
+                "nativeType": null,
+                "typeName": "VARCHAR",
+                "typeExpression": "VARCHAR",
+                "charsetName": "latin1",
+                "length": 255,
+                "scale": null,
+                "position": 2,
+                "optional": false,
+                "autoIncremented": false,
+                "generated": false
+            },                        {
+                "name": "last_name",
+                "jdbcType": 12,
+                "nativeType": null,
+                "typeName": "VARCHAR",
+                "typeExpression": "VARCHAR",
+                "charsetName": "latin1",
+                "length": 255,
+                "scale": null,
+                "position": 3,
+                "optional": false,
+                "autoIncremented": false,
+                "generated": false
+            },
+            {
+                "name": "email",
+                "jdbcType": 12,
+                "nativeType": null,
+                "typeName": "VARCHAR",
+                "typeExpression": "VARCHAR",
+                "charsetName": "latin1",
+                "length": 255,
+                "scale": null,
+                "position": 4,
+                "optional": false,
+                "autoIncremented": false,
+                "generated": false
+            },
+            {
+                "name": "middle_name",
+                "jdbcType": 12,
+                "nativeType": null,
+                "typeName": "VARCHAR",
+                "typeExpression": "VARCHAR",
+                "charsetName": "latin1",
+                "length": 2000,
+                "scale": null,
+                "position": 5,
+                "optional": true,
+                "autoIncremented": false,
+                "generated": false
+            }
+          ]
+        }
+      }
+    ]
   }
 }
 ----
 
-The `ddl` field might contain multiple DDL statements. Each statement applies to the database in the `databaseName` field. The statements appear in the order in which they were applied to the database. The `source` field is structured exactly as a standard data change event written to table-specific topics. This field is useful to correlate events on different topics.
+.Descriptions of fields in messages emitted to the schema change topic
+[cols="1,4,5",options="header"]
+|===
+|Item |Field name |Description
 
-[source,json,subs="+attributes"]
-----
-....
-"payload": {
-    "databaseName": "inventory",
-    "ddl": "CREATE TABLE products ( id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,...)",
-    "source" : {
-        ...
-    }
-}
-....
-----
+|1
+|`source`
+|The `source` field is structured exactly as standard data change events that the connector writes to table-specific topics.
+This field is useful to correlate events on different topics.
 
-A client can submit multiple DDL statements to be applied to multiple databases. If MySQL applies them atomically, the connector takes the DDL statements in order, groups them by database, and creates a schema change event for each group. If MySQL applies them individually, the connector creates a separate schema change event for each statement.
+|2
+|`databaseName` +
+`schemaName`
+|Identifies the database and the schema that contains the change.
+The value of the `databaseName` field is used as the message key for the record.
+
+|3
+|`ddl`
+|This field contains the DDL that is responsible for the schema change.
+The `ddl` field can contain multiple DDL statements.
+Each statement applies to the database in the `databaseName` field.
+Multiple DDL statements appear in the order in which they were applied to the database. +
+ +
+Clients can submit multiple DDL statements that apply to multiple databases.
+If MySQL applies them atomically, the connector takes the DDL statements in order, groups them by database, and creates a schema change event for each group.
+If MySQL applies them individually, the connector creates a separate schema change event for each statement.
+
+|4
+|`tableChanges`
+|An array of one or more items that contain the schema changes generated by a DDL command.
+
+|5
+|`type`
+a|Describes the kind of change. The value is one of the following:
+
+`CREATE`:: Table created.
+`ALTER`:: Table modified.
+`DROP`:: Table deleted.
+
+|6
+|`id`
+|Full identifier of the table that was created, altered, or dropped.
+In the case of a table rename, this identifier is a concatenation of `_<old>_,_<new>_` table names.
+
+|7
+|`table`
+|Represents table metadata after the applied change.
+
+|8
+|`primaryKeyColumnNames`
+|List of columns that compose the table's primary key.
+
+|9
+|`columns`
+|Metadata for each column in the changed table.
+
+|===
 
 See also: {link-prefix}:{link-mysql-connector}#mysql-schema-history-topic[schema history topic].
 
@@ -479,17 +521,22 @@ endif::community[]
 [[mysql-topic-names]]
 === Topic names
 
-The default behavior is that a {prodname} MySQL connector writes events for all `INSERT`, `UPDATE`, and `DELETE` operations in one table to one Kafka topic. The Kafka topic naming convention is as follows:
+By default, the MySQL connector writes change events for all `INSERT`, `UPDATE`, and `DELETE` operations that occur in a table to a single Apache Kafka topic.
+The connector uses the following convention to name change event topics:
 
 _serverName.databaseName.tableName_
 
-Suppose that `fulfillment` is the server name, `inventory` is the database name, and the database contains tables named `orders`, `customers`, and `products`. The {prodname} MySQL connector emits events to three Kafka topics, one for each table in the database:
+Suppose that `fulfillment` is the server name, `inventory` is the database name, and the database contains tables named `orders`, `customers`, and `products`.
+The {prodname} MySQL connector emits events to three Kafka topics, one for each table in the database:
 
 ----
 fulfillment.inventory.orders
 fulfillment.inventory.customers
 fulfillment.inventory.products
 ----
+
+The connector applies similar naming conventions to label its internal database history topics, xref:about-the-debezium-mysql-connector-schema-change-topic[schema change topics], and xref:mysql-transaction-metadata[transaction metadata topics].
+
 [[mysql-transaction-metadata]]
 === Transaction metadata
 
@@ -502,12 +549,14 @@ fulfillment.inventory.products
 Metadata for transactions that occur before you deploy the connector is not available.
 ====
 
-For every transaction `BEGIN` and `END`, {prodname} generates an event that contains the following fields:
+{prodname} generates transaction boundary events for the `BEGIN` and `END` delimiters in every transaction.
+Transaction boundary events contain the following fields:
 
-* `status` - `BEGIN` or `END`
-* `id` - string representation of unique transaction identifier
-* `event_count` (for `END` events) - total number of events emitted by the transaction
-* `data_collections` (for `END` events) - an array of pairs of `data_collection` and `event_count` that provides the number of events emitted by changes originating from given data collection
+`status`:: `BEGIN` or `END`.
+`id`:: String representation of the unique transaction identifier.
+`event_count` (for `END` events):: Total number of events emitted by the transaction.
+`data_collections` (for `END` events):: An array of pairs of `data_collection` and `event_count` elements.
+that indicates the number of events that the connector emits for changes that originate from a data collection.
 
 .Example
 
@@ -537,7 +586,7 @@ For every transaction `BEGIN` and `END`, {prodname} generates an event that cont
 }
 ----
 
-Transaction events are written to the topic named `_database.server.name_.transaction`.
+The connector emits transaction events to the xref:mysql-property-database-server-name[`_<database.server.name>_`]`.transaction` topic.
 
 .Change data event enrichment
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -138,7 +138,7 @@ To handle this, MySQL includes in the binlog not only the row-level changes to t
 
 When the connector restarts after having crashed or been stopped gracefully, the connector starts reading the binlog from a specific position, that is, from a specific point in time. The connector rebuilds the table structures that existed at this point in time by reading the database history Kafka topic and parsing all DDL statements up to the point in the binlog where the connector is starting.
 
-This database history topic is for connector use only. The connector can optionally See {link-prefix}:{link-mysql-connector}#mysql-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
+This database history topic is for connector use only. The connector can optionally {link-prefix}:{link-mysql-connector}#mysql-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
 
 When the MySQL connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied there are helper tables created during the migration process.
 The connector needs to be configured to capture change to these helper tables.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2243,6 +2243,11 @@ Set this option to `true` to force the connector to mine archive logs only.
 After you set the connector to mine only the archive logs, the latency between an operation being committed and the connector emitting an associated change event might increase.
 The degree of latency depends on how frequently the database is configured to archive online redo logs.
 
+|[[oracle-property-log-mining-archive-log-only-scn-poll-interval-ms]]<<oracle-property-log-mining-archive-log-only-scn-poll-interval-ms, `+log.mining.archive.log.only.scn.poll.interval.ms+`>>
+|`10000`
+|The number of milliseconds the connector will sleep in between polling to determine if the starting system change number is in the archive logs.
+If `log.mining.archive.log.only.mode` is not enabled, this setting is not used.
+
 |[[oracle-property-log-mining-transaction-retention-hours]]<<oracle-property-log-mining-transaction-retention-hours, `log.mining.transaction.retention.hours`>>
 |`0`
 |Positive integer value that specifies the number of hours to retain long running transactions between redo log switches.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -120,10 +120,18 @@ include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot
 [[oracle-topic-names]]
 === Topic names
 
-The default behavior is that a {prodname} Oracle connector writes events for all `INSERT`, `UPDATE`, and `DELETE` operations in one table to one Kafka topic.
-The Kafka topic naming convention is as follows:
+By default, the Oracle connector writes change events for all `INSERT`, `UPDATE`, and `DELETE` operations that occur in a table to a single Apache Kafka topic.
+The connector uses the following convention to name change event topics:
 
 _serverName.schemaName.tableName_
+
+The following list provides definitions for the components of the default name:
+
+_serverName_:: The logical name of the server as specified by the xref:oracle-property-database-server-name[`database.server.name`] connector configuration property.
+
+_schemaName_:: The name of the schema in which the operation occurred.
+
+_tableName_:: The name of the table in which the operation occurred.
 
 For example, if `fulfillment` is the server name, `inventory` is the schema name, and the database contains tables with the names `orders`, `customers`, and `products`,
 the {prodname} Oracle connector emits events to the following Kafka topics, one for each table in the database:
@@ -134,16 +142,19 @@ fulfillment.inventory.customers
 fulfillment.inventory.products
 ----
 
+The connector applies similar naming conventions to label its internal database history topics, xref:about-the-debezium-db2-connector-schema-change-topic[schema change topics], and xref:db2-transaction-metadata[transaction metadata topics].
+
 // Type: concept
 // ModuleID: how-debezium-oracle-connectors-expose-database-schema-changes
 // Title: How {prodname} Oracle connectors expose database schema changes
 [[oracle-schema-change-topic]]
 === Schema change topic
 
-The {prodname} Oracle connector stores the history of schema changes in a database history topic.
+The {prodname} Oracle connector stores the history of schema changes in an internal database history topic.
 This topic reflects an internal connector state and you should not use it directly.
 Applications that require notifications about schema changes should obtain the information from the public schema change topic.
-The connector writes schema change events to a Kafka topic named `<serverName>`, where `serverName` is the name of the connector that is specified in the `database.server.name` configuration property.
+
+The connector writes schema change events to a Kafka topic named `_<serverName>_`, where `_serverName_` is the name of the connector that is specified in the xref:oracle-property-database-server-name[`database.server.name`] configuration property.
 
 ifdef::community[]
 [WARNING]
@@ -314,7 +325,7 @@ In the case of a table rename, this identifier is a concatenation of `_<old>_,_<
 
 |===
 
-Messages that the connector sends to the schema change topic use a message key that is equal to the name of the database that contains the schema change.
+In messages that the connector sends to the schema change topic, the message key is the name of the database that contains the schema change.
 In the following example, the `payload` field contains the key:
 
 [source,json,indent=0,subs="+attributes"]
@@ -360,7 +371,7 @@ Transaction boundary events contain the following fields:
 `status`:: `BEGIN` or `END`
 `id`:: String representation of unique transaction identifier.
 `event_count` (for `END` events):: Total number of events emmitted by the transaction.
-`data_collections` (for `END` events):: An array of pairs of `data_collection` and `event_count` that provides number of events emitted by changes originating from the given data collection.
+`data_collections` (for `END` events):: An array of pairs of `data_collection` and `event_count` elements that indicates number of events that the connector emits for changes that originate from a data collection.
 
 The following example shows a typical transaction boundary message:
 
@@ -392,7 +403,7 @@ The following example shows a typical transaction boundary message:
 }
 ----
 
-The transaction events are written to the topic named `_<database.server.name>_.transaction`.
+The connector emits transaction events to the xref:oracle-property-database-server-name[`_<database.server.name>_`]`.transaction` topic.
 
 //Type: concept
 //ModuleID: debezium-oracle-connector-change-data-event-enrichment
@@ -485,7 +496,7 @@ CREATE TABLE customers (
 );
 ----
 
-If the value of the `database.server.name` configuration property is set to `server1`,
+If the value of the xref:oracle-property-database-server-name[`_<database.server.name>_`]`.transaction` configuration property is set to `server1`,
 the JSON representation for every change event that occurs in the `customers` table in the database features the following key structure:
 
 [source,json,indent=0,sub="attributes"]

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -309,11 +309,16 @@ See {link-prefix}:{link-postgresql-connector}#setting-up-postgresql[Setting up P
 [[postgresql-topic-names]]
 === Topics names
 
-The PostgreSQL connector writes events for all insert, update, and delete operations on a single table to a single Kafka topic. By default, the Kafka topic name is _serverName_._schemaName_._tableName_ where:
+By default, the PostgreSQL connector writes events for all `INSERT`, `UPDATE`, and `DELETE` operations that occur in a table to a single Apache Kafka topic.
+The connector uses the following convention to name change event topics:
 
-* _serverName_ is the logical name of the connector as specified with the `database.server.name` connector configuration property.
-* _schemaName_ is the name of the database schema where the operation occurred.
-* _tableName_ is the name of the database table in which the operation occurred.
+_serverName.schemaName.tableName_
+
+The following list provides definitions for the components of the default name:
+
+_serverName_:: The logical name of the connector, as specified by the xref:postgresql-property-database-server-name[`database.server.name`] configuration property.
+_schemaName_:: The name of the database schema in which the change event occurred.
+_tableName_:: The name of the database table in which the change event occurred.
 
 For example, suppose that `fulfillment` is the logical server name in the configuration for a connector that is capturing changes in a PostgreSQL installation that has a `postgres` database and an `inventory` schema that contains four tables: `products`, `products_on_hand`, `customers`, and `orders`. The connector would stream records to these four Kafka topics:
 
@@ -328,6 +333,9 @@ Now suppose that the tables are not part of a specific schema but were created i
 * `fulfillment.public.products_on_hand`
 * `fulfillment.public.customers`
 * `fulfillment.public.orders`
+
+The connector applies similar naming conventions to label its xref:postgresql-transaction-metadata[transaction metadata topics].
+
 
 // Type: concept
 // ModuleID: metadata-in-debezium-postgresql-change-event-records

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -158,11 +158,13 @@ The connector is able to detect whether CDC is enabled or disabled for included 
 [[sqlserver-topic-names]]
 === Topic names
 
-The SQL Server connector writes events for all `INSERT`, `UPDATE`, and `DELETE` operations for a specific table to a single Kafka topic.
-By default, the Kafka topic name takes the form _serverName_._schemaName_._tableName_.
+By default, the SQL Server connector writes events for all `INSERT`, `UPDATE`, and `DELETE` operations that occur in a table to a single Apache Kafka topic.
+The connector uses the following convention to name change event topics: 
+`_<serverName>_._<schemaName>_._<tableName>_`
+
 The following list provides definitions for the components of the default name:
 
-_serverName_:: The logical name of the connector, as specified by the `database.server.name` configuration property.
+_serverName_:: The logical name of the connector, as specified by the xref:sqlserver-property-database-server-name[`database.server.name`] configuration property.
 _schemaName_:: The name of the database schema in which the change event occurred.
 _tableName_:: The name of the database table in which the change event occurred.
 
@@ -175,6 +177,8 @@ The connector would stream records to the following Kafka topics:
 * `fulfillment.dbo.customers`
 * `fulfillment.dbo.orders`
 
+The connector applies similar naming conventions to label its internal database history topics, xref:about-the-debezium-sqlserver-connector-schema-change-topic[schema change topics], and xref:sqlserver-transaction-metadata[transaction metadata topics].
+
 If the default topic name do not meet your requirements, you can configure custom topic names.
 To configure custom topic names, you specify regular expressions in the logical topic routing SMT.
 For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].
@@ -183,12 +187,14 @@ For more information about using the logical topic routing SMT to customize topi
 // Type: concept
 // ModuleID: how-the-debezium-sql-server-connector-uses-the-schema-change-topic
 // Title: How the {prodname} SQL Server connector uses the schema change topic
+[[about-the-debezium-sqlserver-connector-schema-change-topic]]
 === Schema change topic
 
-For each table for which CDC is enabled, the {prodname} SQL Server connector stores a history of schema changes in a database history topic.
+For each table for which CDC is enabled, the {prodname} SQL Server connector stores a history of schema changes in an internal database history topic.
 This topic reflects an internal connector state and you should not use it directly.
-Application that require notifications about schema changes, should obtain the information from the public schema change topic.
-The connector writes all of these events to a Kafka topic named `<serverName>`, where `serverName` is the name of the connector that is specified in the database.server.name configuration property.
+Applications that require notifications about schema changes should obtain the information from the public schema change topic.
+
+The connector writes schema change events to a Kafka topic with the name `_<serverName>_`, where `_serverName_` is the name of the connector that is specified in the xref:sqlserver-property-database-server-name[`database.server.name`] property.
 
 [WARNING]
 ====
@@ -312,7 +318,9 @@ A message to the schema change topic contains a logical representation of the ta
 
 |2
 |`ddl`
-|Always `null` for the SQL Server connector. For other connectors, this field contains the DDL responsible for the schema change. This DDL is not available to SQL Server connectors.
+|Always `null` for the SQL Server connector.
+For other connectors, this field contains the DDL responsible for the schema change.
+This DDL is not available to SQL Server connectors.
 
 |3
 |`tableChanges`
@@ -344,8 +352,8 @@ a|Describes the kind of change. The value is one of the following:
 
 |===
 
-In messages that the connector sends to the schema change topic, the key is the name of the database that contains the schema change.
-In the following example, the `payload` field contains the key:
+In messages that the connector sends to the schema change topic, the message key is the name of the database that contains the schema change.
+In the following example, the `payload` field contains the message key:
 
 [source,json,indent=0,subs="+attributes"]
 ----
@@ -997,10 +1005,10 @@ Database transactions are represented by a statement block that is enclosed betw
 {prodname} generates transaction boundary events for the `BEGIN` and `END` delimiters in every transaction.
 Transaction boundary events contain the following fields:
 
-`status`:: `BEGIN` or `END`
-`id`:: String representation of unique transaction identifier.
-`event_count` (for `END` events):: Total number of events emitted by the transaction.
-`data_collections` (for `END` events):: An array of pairs of `data_collection` and `event_count` that provides the number of events emitted by changes originating from given data collection.
+`status`:: `BEGIN` or `END`.
+`id`:: String representation of the unique transaction identifier.
+`event_count` (for `END` events):: Total number of events that the connector emits for the transaction.
+`data_collections` (for `END` events):: An array of pairs of `data_collection` and `event_count` elements that indicates the number of events that the connector emits for changes that originate from a data collection.
 
 [WARNING]
 ====
@@ -1038,7 +1046,7 @@ The following example shows a typical transaction boundary message:
 }
 ----
 
-The transaction events are written to the topic named `<database.server.name>.transaction`.
+The transaction events are written to the xref:sqlserver-property-database-server-name[`_<database.server.name>_`]`.transaction` topic.
 
 //Type: concept
 //ModuleID: change-data-event-enrichment
@@ -1047,9 +1055,9 @@ The transaction events are written to the topic named `<database.server.name>.tr
 When transaction metadata is enabled, the data message `Envelope` is enriched with a new `transaction` field.
 This field provides information about every event in the form of a composite of fields:
 
-`id`:: String representation of unique transaction identifier
-`total_order`:: The absolute position of the event among all events generated by the transaction
-`data_collection_order`:: The per-data collection position of the event among all events that were emitted by the transaction
+`id`:: String representation of unique transaction identifier.
+`total_order`:: The absolute position of the event among all events generated by the transaction.
+`data_collection_order`:: The per-data collection position of the event among all events that were emitted by the transaction.
 
 The following example shows what a typical message looks like:
 

--- a/documentation/modules/ROOT/pages/operations/debezium-ui.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-ui.adoc
@@ -23,7 +23,37 @@ The UI is implemented as a https://quarkus.io/[Quarkus]-based web application.  
 
 == Installation and Configuration
 
-==== Debezium UI container image
+
+=== Configure the Debezium UI
+The following table shows the environment variables for the https://hub.docker.com/r/debezium/debezium-ui[Debezium UI container image] and the related parameter names inside `application.properties` when running the Java application without the container.
+
+[cols="1,2,2,2,6",options="header"]
+
+|===
+|Item |Environment variable |Parameter name in application.properties |Default value |Description
+
+|1
+|DEPLOYMENT_MODE[[DEPLOYMENT_MODE]]
+|`deployment.mode`
+|default
+|Specifies how the Debezium UI is deployed. +
+ +
+For example, in some environments it might not be possible to reach the underlying backend, Kafka Connect REST interface or databases, then the link:#DEPLOYMENT_MODE[deployment mode] can be switched to match the underlying infrastructure. +
+ +
+`default` The default deployment mode. It uses the Debezium UI backend with the configured Kafka Connect clusters via the Kafka Connect REST interface (see link:#KAFKA_CONNECT_URI[KAFKA_CONNECT_URI] how they are configured). +
+ +
+ +
+`validation.disabled` When set to validation.disabled the UI frontend will not call the backend to validate the user input nor check the availability and proper configuration of database connections. That mode is used to only generate the Debezium connector JSON configuration without the UI backend validation. +
+ +
+|2
+|KAFKA_CONNECT_URI[[KAFKA_CONNECT_URI]]
+|`kafka.connect.uri`
+|http://connect:8083
+|A comma-separated list to one or more URLs of Kafka Connect REST interfaces to specify the Kafka Connect clusters that should be managed by the Debezium UI.
+
+|===
+
+=== Debezium UI container image
 
 The Debezium UI https://hub.docker.com/r/debezium/debezium-ui[container image] is available for running the UI.  To start the UI and connect to an existing Kafka Connect instance via Docker (where KAFKA_CONNECT_URI supplies the comma-separated list of available URI(s)):
 
@@ -38,7 +68,8 @@ The UI connects to Kafka Connect via REST, so you need to make sure that the lat
 Currently, the UI connects to un-authenticated Kafka Connect instances.  Also, there's no authorization or authentication implemented in the UI itself yet.  Until that is the case, you should secure the components e.g. with your own proxy for authorization, if needed.
 ====
 
-==== Self-contained example
+
+=== Self-contained example
 
 A self-contained example https://github.com/debezium/debezium-examples/tree/master/ui-demo[ui-demo] is available, which is included under https://github.com/debezium/debezium-examples[debezium-examples] on Github.  The ui-demo includes a docker-compose file which brings up several sources with data as well as the UI. Please refer to the https://github.com/debezium/debezium-examples/tree/master/ui-demo[README file] for more details on running the Debezium ui-demo.
 

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -86,6 +86,7 @@ jackey.zhang,Jackey Zhang
 gvaquez-ubi,Gilles Vaquez
 camile.sing,Camile Sing
 camilesing,Camile Sing
+spicy-sauce,Yossi Shirizli
 bep7520,Blake Peno
 Kate,Katerina Galieva
 pkgonan,민규 김

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -92,3 +92,4 @@ Kate,Katerina Galieva
 pkgonan,민규 김
 jiabao.sun,Jiabao Sun
 indraraj,Indra Shukla
+judahrand,Judah Rand

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.debezium</groupId>
     <artifactId>debezium-build-parent</artifactId>
-    <version>1.7.0.Final</version>
+    <version>1.7.0-SNAPSHOT</version>
     <name>Debezium Build Aggregator</name>
     <description>Debezium is an open source change data capture platform</description>
     <packaging>pom</packaging>
@@ -20,7 +20,7 @@
         <connection>scm:git:git@github.com:debezium/debezium.git</connection>
         <developerConnection>scm:git:git@github.com:debezium/debezium.git</developerConnection>
         <url>https://github.com/debezium/debezium</url>
-        <tag>v1.7.0.Final</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.debezium</groupId>
     <artifactId>debezium-build-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <name>Debezium Build Aggregator</name>
     <description>Debezium is an open source change data capture platform</description>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.debezium</groupId>
     <artifactId>debezium-build-parent</artifactId>
-    <version>1.7.0-SNAPSHOT</version>
+    <version>1.7.0.Final</version>
     <name>Debezium Build Aggregator</name>
     <description>Debezium is an open source change data capture platform</description>
     <packaging>pom</packaging>
@@ -20,7 +20,7 @@
         <connection>scm:git:git@github.com:debezium/debezium.git</connection>
         <developerConnection>scm:git:git@github.com:debezium/debezium.git</developerConnection>
         <url>https://github.com/debezium/debezium</url>
-        <tag>HEAD</tag>
+        <tag>v1.7.0.Final</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,17 @@
         <!-- Quarkus -->
         <quarkus.version>2.0.0.Final</quarkus.version>
 
-        <!-- Databases, should align with database drivers in debezium-bom -->
+        <!-- Database drivers, should align with databases -->
+        <version.postgresql.driver>42.2.14</version.postgresql.driver>
+        <version.mysql.driver>8.0.26</version.mysql.driver>
+        <version.mysql.binlog>0.25.3</version.mysql.binlog>
+        <version.mongo.driver>4.2.1</version.mongo.driver>
+        <version.sqlserver.driver>7.2.2.jre8</version.sqlserver.driver>
+        <version.oracle.driver>21.1.0.0</version.oracle.driver>
+        <version.db2.driver>11.5.0.0</version.db2.driver>
+        <version.cassandra.driver>3.11.0</version.cassandra.driver>
+
+        <!-- Databases, should align with database drivers -->
         <version.mysql.server>5.7</version.mysql.server>
         <version.mongo.server>3.6</version.mongo.server>
         <version.cassandra>3.11.10</version.cassandra>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <quarkus.version>2.0.0.Final</quarkus.version>
 
         <!-- Database drivers, should align with databases -->
-        <version.postgresql.driver>42.2.14</version.postgresql.driver>
+        <version.postgresql.driver>42.2.22</version.postgresql.driver>
         <version.mysql.driver>8.0.26</version.mysql.driver>
         <version.mysql.binlog>0.25.3</version.mysql.binlog>
         <version.mongo.driver>4.2.1</version.mongo.driver>

--- a/support/checkstyle/pom.xml
+++ b/support/checkstyle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/support/checkstyle/pom.xml
+++ b/support/checkstyle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/support/checkstyle/pom.xml
+++ b/support/checkstyle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/support/ide-configs/pom.xml
+++ b/support/ide-configs/pom.xml
@@ -3,7 +3,7 @@
    <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/support/ide-configs/pom.xml
+++ b/support/ide-configs/pom.xml
@@ -3,7 +3,7 @@
    <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
         <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/support/ide-configs/pom.xml
+++ b/support/ide-configs/pom.xml
@@ -3,7 +3,7 @@
    <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/support/revapi/pom.xml
+++ b/support/revapi/pom.xml
@@ -3,7 +3,7 @@
    <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.8.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/support/revapi/pom.xml
+++ b/support/revapi/pom.xml
@@ -3,7 +3,7 @@
    <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.7.0.Final</version>
         <relativePath>../../pom.xml</relativePath>
    </parent>
 

--- a/support/revapi/pom.xml
+++ b/support/revapi/pom.xml
@@ -3,7 +3,7 @@
    <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-build-parent</artifactId>
-        <version>1.7.0.Final</version>
+        <version>1.7.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
    </parent>
 


### PR DESCRIPTION
[DBZ-3974](https://issues.redhat.com/browse/DBZ-3974)

This change adds missing information to the MySQL connector doc about the `tableChanges` field in schema change messages and also updates the Db2, Oracle, PostgreSQL, and SQL Server connector docs for consistency.

Changes tested in a local Antora build. 