### PR TITLE
[1.6] DBZ-4067 Correctly calculate mining session boundaries

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryResultProcessor.java
@@ -60,6 +60,7 @@ class LogMinerQueryResultProcessor {
 
     private Scn currentOffsetScn = Scn.NULL;
     private Scn currentOffsetCommitScn = Scn.NULL;
+    private Scn lastProcessedScn = Scn.NULL;
     private long stuckScnCounter = 0;
 
     LogMinerQueryResultProcessor(ChangeEventSourceContext context, OracleConnectorConfig connectorConfig,
@@ -125,6 +126,10 @@ class LogMinerQueryResultProcessor {
 
             String logMessage = String.format("transactionId=%s, SCN=%s, table_name=%s, segOwner=%s, operationCode=%s, offsetSCN=%s, " +
                     " commitOffsetSCN=%s", txId, scn, tableName, segOwner, operationCode, offsetContext.getScn(), offsetContext.getCommitScn());
+
+            if (operationCode != RowMapper.MISSING_SCN) {
+                lastProcessedScn = scn;
+            }
 
             switch (operationCode) {
                 case RowMapper.START: {
@@ -308,6 +313,10 @@ class LogMinerQueryResultProcessor {
 
         streamingMetrics.addProcessedRows(rows);
         historyRecorder.flush();
+    }
+
+    Scn getLastProcessedScn() {
+        return lastProcessedScn;
     }
 
     private boolean hasNext(ResultSet resultSet) throws SQLException {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -206,6 +206,14 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
                                     startScn = transactionalBuffer.updateOffsetContext(offsetContext, dispatcher);
                                 }
                                 else {
+
+                                    final Scn lastProcessedScn = processor.getLastProcessedScn();
+                                    if (!lastProcessedScn.isNull() && lastProcessedScn.compareTo(endScn) < 0) {
+                                        // If the last processed SCN is before the endScn we need to use the last processed SCN as the
+                                        // next starting point as the LGWR buffer didn't flush all entries from memory to disk yet.
+                                        endScn = lastProcessedScn;
+                                    }
+
                                     if (transactionalBuffer.isEmpty()) {
                                         LOGGER.debug("Buffer is empty, updating offset SCN to {}", endScn);
                                         offsetContext.setScn(endScn);


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4067

It is not guaranteed that the flush strategy will force all LGWR buffer entries
to be written to the redo logs in which case the mining boundaries must then be
calculated based on the lastProcessedScn rather than the current batch endScn.
This prevents event loss between mining sessions when this timing scenario
occurs.

(cherry-picked from commit 582a169f928b9c97510d6fe43f8c5d1061bb176c)