### PR TITLE
DBZ-4078 Checking connection is valid before commit in readChunk()

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -206,9 +206,9 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<T extends Dat
             return;
         }
         try {
+            preReadChunk(context);
             // This commit should be unnecessary and might be removed later
             jdbcConnection.commit();
-            preReadChunk(context);
             context.startNewChunk();
             emitWindowOpen();
             while (context.snapshotRunning()) {


### PR DESCRIPTION
### Issue:
At-times, while executing [commit](https://github.com/debezium/debezium/blob/77eaa0a293d947bd264c85e20205cb84a9a16a53/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java#L210) during read-only incremental results in `com.mysql.cj.jdbc.exceptions.CommunicationsException`.

### Solution
 Seems like [Connection](https://github.com/debezium/debezium/blob/77eaa0a293d947bd264c85e20205cb84a9a16a53/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java#L315) object is not valid when the issue occurs. So calling  preReadChunk() before commit, which checks whether `connection` is valid or not.