### PR TITLE
[ci] Don't test with MongoDB 3.2 on GH Actions;

### DIFF
--- a/.github/workflows/mongodb-workflow.yml
+++ b/.github/workflows/mongodb-workflow.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version-mongo-server: ["3.2", "4.0", "4.2"]
+        version-mongo-server: ["4.0", "4.2"]
     steps:
       - uses: actions/checkout@v2
       - name: Cache local Maven repository


### PR DESCRIPTION
It's still tested via Jenkins, plus it's unsupported by now.

@jpechane 