### PR TITLE
Update mongodb.adoc

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -546,13 +546,6 @@ The following example shows the value portion of a change event that the connect
           "field": "patch"
         },
         {
-          "type": "string",
-          "optional": true,
-          "name": "io.debezium.data.Json",
-          "version": 1,
-          "field": "filter"
-        },
-        {
           "type": "struct",
           "fields": [
             {


### PR DESCRIPTION
AFAIK, a field _filter_ doesn't exist in create events, nor payload of the given change event value.