### PR TITLE
DBZ-3897 Add display version stable

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -1,6 +1,7 @@
 name: reference
 title: Debezium Documentation
 version: '1.7'
+display_version: 'stable'
 nav:
   - modules/ROOT/nav.adoc
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3897

`display_version: 'stable'` display as `stable` in version drop-down but link to `1.7`