### PR TITLE
DBZ-4152: Upgrade mysql-binlog-connector-java to v0.25.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <!-- Database drivers, should align with databases -->
         <version.postgresql.driver>42.2.24</version.postgresql.driver>
         <version.mysql.driver>8.0.26</version.mysql.driver>
-        <version.mysql.binlog>0.25.3</version.mysql.binlog>
+        <version.mysql.binlog>0.25.4</version.mysql.binlog>
         <version.mongo.driver>4.2.1</version.mongo.driver>
         <version.sqlserver.driver>7.2.2.jre8</version.sqlserver.driver>
         <version.oracle.driver>21.1.0.0</version.oracle.driver>


### PR DESCRIPTION
See [DBZ-4152](https://issues.redhat.com/browse/DBZ-4152), https://github.com/osheroff/mysql-binlog-connector-java/pull/55.