### PR TITLE
DBZ-4151 Prevent possible OutOfMemoryError with tracking schema changes

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/memory/MemoryLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/memory/MemoryLogMinerEventProcessor.java
@@ -327,7 +327,7 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
     @Override
     protected void handleSchemaChange(LogMinerEventRow row) throws InterruptedException {
         super.handleSchemaChange(row);
-        if (row.getTableName() != null) {
+        if (row.getTableName() != null && getConfig().isLobEnabled()) {
             schemaChangesCache.add(row.getScn());
         }
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4151

This is for 1.7 / 1.8.