### PR TITLE
DBZ-3806 snapshot produce error results or different results from binlog

### DIFF
--- a/debezium-core/src/main/java/io/debezium/time/Timestamp.java
+++ b/debezium-core/src/main/java/io/debezium/time/Timestamp.java
@@ -6,7 +6,7 @@
 package io.debezium.time;
 
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.temporal.TemporalAdjuster;
 
 import org.apache.kafka.connect.data.Schema;
@@ -74,7 +74,8 @@ public class Timestamp {
             dateTime = dateTime.with(adjuster);
         }
 
-        return dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+        // return dateTime.toInstant(ZoneOffset.UTC).toEpochMilli();
+        return dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(); // bugfix:snapshot produce error results or different results from binlog
     }
 
     private Timestamp() {


### PR DESCRIPTION
See more in: https://issues.redhat.com/browse/DBZ-3806  and  https://github.com/debezium/debezium/pull/2809

This seems to be a bug since the early version，it may causes the snapshot phase to produce different results from the binlog phase. My debezium version is 1.2, bug the code in version 1.7 is still the same.

If you confirm that there is a problem with the logic, you can apply this fix to all versions 1.2-1.7