### PR TITLE
fix resource leak due to Files.lines

### DIFF
--- a/debezium-core/src/main/java/io/debezium/util/IoUtil.java
+++ b/debezium-core/src/main/java/io/debezium/util/IoUtil.java
@@ -34,6 +34,7 @@ import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Stream;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -147,7 +148,9 @@ public class IoUtil {
      * @throws IOException if an I/O error occurs
      */
     public static void readLines(Path path, Consumer<String> lineProcessor) throws IOException {
-        Files.lines(path).forEach(lineProcessor);
+        try (Stream<String> stream = Files.lines(path)) {
+            stream.forEach(lineProcessor);
+        }
     }
 
     /**


### PR DESCRIPTION
Files.list will open stream, we should close it.

see jdk: the

{try} -with-resources construct should be used to ensure that the
stream's

{[@link|https://github.com/link] Stream#close close}
method is invoked after the stream
operations are completed.