### PR TITLE
DBZ-3807 Make Oracle connector build with infinispan-buffer profile stable

### DIFF
--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -317,11 +317,26 @@
                 </dependency>
             </dependencies>
         </profile>
+        <!-- This profile should be used for testing connector with Infinispan only -->
         <profile>
             <id>infinispan-buffer</id>
             <properties>
                 <log.mining.buffer.type.name>infinispan</log.mining.buffer.type.name>
             </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration combine.self="override">
+                            <excludes>
+                                <!-- When compiling with this profile, xstream is not added by default -->
+                                <exclude>**/io/debezium/connector/oracle/xstream/**</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3807

I decided to leave the profiles as they were and just introduce the exclusion of the xstream sources when using this profile.  This profile is only used for running the test suite with a non-default buffer implementation, so this should be more than sufficient without compromising what other profiles do.
