### PR TITLE
DBZ-3978 handle scn start event wrong order.

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
@@ -246,6 +246,9 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
         else if (transaction != null && !isRecentlyCommitted(transactionId)) {
             LOGGER.trace("Transaction {} is not yet committed and START event detected.", transactionId);
             transaction.start();
+            if (transaction.getUserName() == null) {
+                transaction.setUserName(row.getUserName());
+            }
         }
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractTransaction.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractTransaction.java
@@ -22,7 +22,7 @@ public abstract class AbstractTransaction implements Transaction {
     private final String transactionId;
     private final Scn startScn;
     private final Instant changeTime;
-    private final String userName;
+    private String userName;
 
     public AbstractTransaction(String transactionId, Scn startScn, Instant changeTime, String userName) {
         this.transactionId = transactionId;
@@ -49,6 +49,10 @@ public abstract class AbstractTransaction implements Transaction {
     @Override
     public String getUserName() {
         return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
     }
 
     @Override


### PR DESCRIPTION
We found that the SCN start event arrived after DML event, the username is only in the SCN start event. We need to set the username on receiving the out oder SCN start event.