### PR TITLE
DBZ-4192 MongoDB connector support user defined topic delimiter

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -47,6 +47,9 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
     protected static final Pattern FIELD_RENAMES_PATTERN = Pattern.compile("^[*|\\w|\\s*]+(?:\\.[\\w]+\\.[\\w]+)+(\\.[\\w]+)*:(?:[\\w]+)+\\s*$");
     protected static final String QUALIFIED_FIELD_RENAMES_PATTERN = "<databaseName>.<collectionName>.<fieldName>.<nestedFieldName>:<newNestedFieldName>";
 
+    protected static final String TOPIC_DELIMITER = "topic.delimiter";
+    protected static final String DEFAULT_TOPIC_DELIMITER = ".";
+
     /**
      * The set of predefined SnapshotMode options or aliases.
      */
@@ -531,6 +534,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
     private final SnapshotMode snapshotMode;
     private final int snapshotMaxThreads;
     private final int cursorMaxAwaitTimeMs;
+    private final String topicDelimiter;
 
     public MongoDbConnectorConfig(Configuration config) {
         super(config, config.getString(LOGICAL_NAME), DEFAULT_SNAPSHOT_FETCH_SIZE);
@@ -540,6 +544,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
 
         this.snapshotMaxThreads = resolveSnapshotMaxThreads(config);
         this.cursorMaxAwaitTimeMs = config.getInteger(MongoDbConnectorConfig.CURSOR_MAX_AWAIT_TIME_MS, 0);
+        this.topicDelimiter = config.getString(TOPIC_DELIMITER, DEFAULT_TOPIC_DELIMITER);
     }
 
     private static int validateHosts(Configuration config, Field field, ValidationOutput problems) {
@@ -632,6 +637,10 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
 
     public int getCursorMaxAwaitTime() {
         return cursorMaxAwaitTimeMs;
+    }
+
+    public String getTopicDelimiter() {
+        return topicDelimiter;
     }
 
     @Override

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbTaskContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbTaskContext.java
@@ -33,7 +33,7 @@ public class MongoDbTaskContext extends CdcSourceTaskContext {
         this.filters = new Filters(config);
         this.connectorConfig = new MongoDbConnectorConfig(config);
         this.source = new SourceInfo(connectorConfig);
-        this.topicSelector = MongoDbTopicSelector.defaultSelector(serverName, connectorConfig.getHeartbeatTopicsPrefix());
+        this.topicSelector = MongoDbTopicSelector.selector(serverName, connectorConfig.getHeartbeatTopicsPrefix(), connectorConfig.getTopicDelimiter());
         this.serverName = config.getString(MongoDbConnectorConfig.LOGICAL_NAME);
         this.connectionContext = new ConnectionContext(config);
     }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbTopicSelector.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbTopicSelector.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.mongodb;
 
+import java.util.Objects;
 import java.util.StringJoiner;
 
 import io.debezium.annotation.ThreadSafe;
@@ -29,7 +30,16 @@ public class MongoDbTopicSelector {
      */
     public static TopicSelector<CollectionId> defaultSelector(String prefix, String heartbeatPrefix) {
         return TopicSelector.defaultSelector(prefix, heartbeatPrefix, ".",
-                (id, pref, delimiter) -> getTopicName(id, pref, delimiter));
+            MongoDbTopicSelector::getTopicName);
+    }
+
+    public static TopicSelector<CollectionId> selector(String prefix, String heartbeatPrefix, String delimiter) {
+        if (Objects.nonNull(delimiter)) {
+            return TopicSelector.defaultSelector(prefix, heartbeatPrefix, delimiter,
+                MongoDbTopicSelector::getTopicName);
+        } else {
+            return defaultSelector(prefix, heartbeatPrefix);
+        }
     }
 
     /**


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4192

This patch make mongodb connector support user defined topic delimiter to join topic. instead hard code "."

The user can use `topic.delimiter` param to config the topic delimiter they want, default "."

This patch is tested by `io.debezium.connector.mongodb.TopicSelectorTest`