### PR TITLE
DBZ-4197 Process transaction started/committed in read-only incremental snapshot

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -276,10 +276,16 @@ public class EventDispatcher<T extends DataCollectionId> {
 
     public void dispatchTransactionCommittedEvent(Partition partition, OffsetContext offset) throws InterruptedException {
         transactionMonitor.transactionComittedEvent(partition, offset);
+        if (incrementalSnapshotChangeEventSource != null) {
+            incrementalSnapshotChangeEventSource.processTransactionCommittedEvent(partition, offset);
+        }
     }
 
     public void dispatchTransactionStartedEvent(Partition partition, String transactionId, OffsetContext offset) throws InterruptedException {
         transactionMonitor.transactionStartedEvent(partition, transactionId, offset);
+        if (incrementalSnapshotChangeEventSource != null) {
+            incrementalSnapshotChangeEventSource.processTransactionStartedEvent(partition, offset);
+        }
     }
 
     public void dispatchConnectorEvent(ConnectorEvent event) {

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
@@ -34,4 +34,10 @@ public interface IncrementalSnapshotChangeEventSource<T extends DataCollectionId
 
     default void processFilteredEvent(Partition partition, OffsetContext offsetContext) throws InterruptedException {
     }
+
+    default void processTransactionStartedEvent(Partition partition, OffsetContext offsetContext) throws InterruptedException {
+    }
+
+    default void processTransactionCommittedEvent(Partition partition, OffsetContext offsetContext) throws InterruptedException {
+    }
 }


### PR DESCRIPTION
Processing transaction started/committed events in MySQL read-only incremental snapshot allows making progress faster in case there are too few other binlog events

https://issues.redhat.com/browse/DBZ-4197