### PR TITLE
DBZ-4196 Support schema changes during incremental snapshot

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -988,7 +988,8 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
                     ENABLE_TIME_ADJUSTER,
                     BINARY_HANDLING_MODE,
                     ROW_COUNT_FOR_STREAMING_RESULT_SETS,
-                    INCREMENTAL_SNAPSHOT_CHUNK_SIZE)
+                    INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
+                    INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES)
             .events(
                     INCLUDE_SQL_QUERY,
                     TABLE_IGNORE_BUILTIN,
@@ -1017,6 +1018,11 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
 
     @Override
     public boolean supportsOperationFiltering() {
+        return true;
+    }
+
+    @Override
+    protected boolean supportsSchemaChangesDuringIncrementalSnapshot() {
         return true;
     }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -73,7 +73,7 @@ import io.debezium.util.Clock;
  * <p>A window can be opened and closed right away by the same event. This can happen when a high watermark is an empty set, which means there were no binlog events during the chunk select. Chunk will get inserted right after the low watermark, no events will be deduplicated from the chunk</p>
  * <br/>
  * <b>No updates for included tables</b>
- * <p>It’s important to receive binlog events for the Backfill to make progress.All binlog events are checked against the low and high watermarks, including the events from the tables that aren’t included in the connector. This guarantees that the window processing mode gets updated even when none of the tables included in the connector are getting binlog events.</p>
+ * <p>It’s important to receive binlog events for the incremental snapshot to make progress. All binlog events are checked against the low and high watermarks, including the events from the tables that aren’t included in the connector. This guarantees that the window processing mode gets updated even when none of the tables included in the connector are getting binlog events.</p>
  */
 public class MySqlReadOnlyIncrementalSnapshotChangeEventSource<T extends DataCollectionId> extends AbstractIncrementalSnapshotChangeEventSource<T> {
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/IncrementalSnapshotIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/IncrementalSnapshotIT.java
@@ -14,11 +14,11 @@ import org.junit.Before;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SnapshotMode;
 import io.debezium.jdbc.JdbcConnection;
-import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotTest;
+import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotWithSchemaChangesSupportTest;
 import io.debezium.relational.TableId;
 import io.debezium.util.Testing;
 
-public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<MySqlConnector> {
+public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotWithSchemaChangesSupportTest<MySqlConnector> {
 
     protected static final String SERVER_NAME = "is_test";
     protected final UniqueDatabase DATABASE = new UniqueDatabase(SERVER_NAME, "incremental_snapshot-test").withDbHistoryPath(DB_HISTORY_PATH);
@@ -49,6 +49,7 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<MySql
                 .with(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
                 .with(MySqlConnectorConfig.SIGNAL_DATA_COLLECTION, DATABASE.qualifiedTableName("debezium_signal"))
                 .with(MySqlConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 10)
+                .with(MySqlConnectorConfig.INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES, true)
                 .with(MySqlConnector.IMPLEMENTATION_PROP, "new");
     }
 
@@ -75,5 +76,49 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<MySql
     @Override
     protected String signalTableName() {
         return TableId.parse(DATABASE.qualifiedTableName("debezium_signal")).toQuotedString('`');
+    }
+
+    @Override
+    protected String tableName(String table) {
+        return TableId.parse(DATABASE.qualifiedTableName(table)).toQuotedString('`');
+    }
+
+    @Override
+    protected String alterColumnStatement(String table, String column, String type) {
+        return String.format("ALTER TABLE %s MODIFY COLUMN %s %s", table, column, type);
+    }
+
+    @Override
+    protected String alterColumnSetNotNullStatement(String table, String column, String type) {
+        return String.format("ALTER TABLE %s MODIFY COLUMN %s %s NOT NULL", table, column, type);
+    }
+
+    @Override
+    protected String alterColumnDropNotNullStatement(String table, String column, String type) {
+        return String.format("ALTER TABLE %s MODIFY COLUMN %s %s NULL", table, column, type);
+    }
+
+    @Override
+    protected String alterColumnSetDefaultStatement(String table, String column, String type, String defaultValue) {
+        return String.format("ALTER TABLE %s MODIFY COLUMN %s %s DEFAULT %s", table, column, type, defaultValue);
+    }
+
+    @Override
+    protected String alterColumnDropDefaultStatement(String table, String column, String type) {
+        return String.format("ALTER TABLE %s MODIFY COLUMN %s %s", table, column, type);
+    }
+
+    @Override
+    protected void executeRenameTable(JdbcConnection connection, String newTable) throws SQLException {
+        connection.setAutoCommit(false);
+        String query = String.format("RENAME TABLE %s to %s, %s to %s", tableName(), "old_table", newTable, tableName());
+        logger.info(query);
+        connection.executeWithoutCommitting(query);
+        connection.commit();
+    }
+
+    @Override
+    protected String createTableStatement(String newTable, String copyTable) {
+        return String.format("CREATE TABLE %s LIKE %s", newTable, copyTable);
     }
 }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/ReadOnlyIncrementalSnapshotIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/ReadOnlyIncrementalSnapshotIT.java
@@ -15,6 +15,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.fest.assertions.Assertions;
 import org.fest.assertions.MapAssert;
@@ -174,6 +175,7 @@ public class ReadOnlyIncrementalSnapshotIT extends IncrementalSnapshotIT {
                 expectedRecordCount,
                 x -> true,
                 k -> k.getInt32("pk1") * 1_000 + k.getInt32("pk2") * 100 + k.getInt32("pk3") * 10 + k.getInt32("pk4"),
+                record -> ((Struct) record.value()).getStruct("after").getInt32(valueFieldName()),
                 DATABASE.topicForTable("a4"),
                 null);
         for (int i = 0; i < expectedRecordCount; i++) {
@@ -195,6 +197,7 @@ public class ReadOnlyIncrementalSnapshotIT extends IncrementalSnapshotIT {
                 expectedRecordCount,
                 x -> true,
                 k -> k.getInt32("pk1") * 1_000 + k.getInt32("pk2") * 100 + k.getInt32("pk3") * 10 + k.getInt32("pk4"),
+                record -> ((Struct) record.value()).getStruct("after").getInt32(valueFieldName()),
                 DATABASE.topicForTable("a42"),
                 null);
         for (int i = 0; i < expectedRecordCount; i++) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
@@ -9,6 +9,7 @@ package io.debezium.connector.postgresql;
 import java.sql.SQLException;
 import java.util.Map;
 
+import org.apache.kafka.connect.data.Struct;
 import org.fest.assertions.Assertions;
 import org.fest.assertions.MapAssert;
 import org.junit.After;
@@ -123,6 +124,7 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
                 expectedRecordCount,
                 x -> true,
                 k -> k.getInt32("pk1") * 1_000 + k.getInt32("pk2") * 100 + k.getInt32("pk3") * 10 + k.getInt32("pk4"),
+                record -> ((Struct) record.value()).getStruct("after").getInt32(valueFieldName()),
                 "test_server.s1.a4",
                 null);
         for (int i = 0; i < expectedRecordCount; i++) {
@@ -144,6 +146,7 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
                 expectedRecordCount,
                 x -> true,
                 k -> k.getInt32("pk1") * 1_000 + k.getInt32("pk2") * 100 + k.getInt32("pk3") * 10 + k.getInt32("pk4"),
+                record -> ((Struct) record.value()).getStruct("after").getInt32(valueFieldName()),
                 "test_server.s1.a42",
                 null);
         for (int i = 0; i < expectedRecordCount; i++) {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -347,7 +347,9 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
                     SOURCE_TIMESTAMP_MODE,
                     MAX_TRANSACTIONS_PER_ITERATION,
                     BINARY_HANDLING_MODE,
-                    INCREMENTAL_SNAPSHOT_OPTION_RECOMPILE)
+                    INCREMENTAL_SNAPSHOT_OPTION_RECOMPILE,
+                    INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
+                    INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES)
             .excluding(
                     SCHEMA_WHITELIST,
                     SCHEMA_INCLUDE_LIST,
@@ -459,6 +461,11 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
 
     @Override
     public boolean supportsOperationFiltering() {
+        return true;
+    }
+
+    @Override
+    protected boolean supportsSchemaChangesDuringIncrementalSnapshot() {
         return true;
     }
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -358,7 +358,7 @@ public class TestHelper {
      *            the source table columns that are to be included in the change table, may not be {@code null}
      * @throws SQLException if anything unexpected fails
      */
-    public static void enableTableCdc(SqlServerConnection connection, String tableName, String captureName, List<String> captureColumnList) throws SQLException {
+    public static void enableTableCdc(JdbcConnection connection, String tableName, String captureName, List<String> captureColumnList) throws SQLException {
         Objects.requireNonNull(tableName);
         Objects.requireNonNull(captureName);
         Objects.requireNonNull(captureColumnList);
@@ -374,7 +374,7 @@ public class TestHelper {
      *            the name of the table, may not be {@code null}
      * @throws SQLException if anything unexpected fails
      */
-    public static void disableTableCdc(SqlServerConnection connection, String name) throws SQLException {
+    public static void disableTableCdc(JdbcConnection connection, String name) throws SQLException {
         Objects.requireNonNull(name);
         String disableCdcForTableStmt = DISABLE_TABLE_CDC.replace(STATEMENTS_PLACEHOLDER, name);
         connection.execute(disableCdcForTableStmt);

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
 import io.debezium.annotation.NotThreadSafe;
+import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.util.HexConverter;
 
@@ -72,6 +73,10 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
      * The largest PK in the table at the start of snapshot.
      */
     private Object[] maximumKey;
+
+    private Table schema;
+
+    private boolean schemaVerificationPassed;
 
     public AbstractIncrementalSnapshotContext(boolean useCatalogBeforeSchema) {
         this.useCatalogBeforeSchema = useCatalogBeforeSchema;
@@ -211,6 +216,8 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
         lastEventKeySent = null;
         chunkEndPosition = null;
         maximumKey = null;
+        schema = null;
+        schemaVerificationPassed = false;
     }
 
     public void revertChunk() {
@@ -242,6 +249,27 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
 
     public Optional<Object[]> maximumKey() {
         return Optional.ofNullable(maximumKey);
+    }
+
+    @Override
+    public Table getSchema() {
+        return schema;
+    }
+
+    @Override
+    public void setSchema(Table schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public boolean isSchemaVerificationPassed() {
+        return schemaVerificationPassed;
+    }
+
+    @Override
+    public void setSchemaVerificationPassed(boolean schemaVerificationPassed) {
+        this.schemaVerificationPassed = schemaVerificationPassed;
+        LOGGER.info("Incremental snapshot's schema verification passed = {}, schema = {}", schemaVerificationPassed, schema);
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.debezium.relational.Table;
+
 public interface IncrementalSnapshotContext<T> {
 
     T currentDataCollectionId();
@@ -46,4 +48,12 @@ public interface IncrementalSnapshotContext<T> {
     Map<String, Object> store(Map<String, Object> offset);
 
     void revertChunk();
+
+    void setSchema(Table schema);
+
+    Table getSchema();
+
+    boolean isSchemaVerificationPassed();
+
+    void setSchemaVerificationPassed(boolean schemaVerificationPassed);
 }

--- a/debezium-core/src/main/java/io/debezium/relational/ColumnImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnImpl.java
@@ -165,7 +165,7 @@ final class ColumnImpl implements Column, Comparable<Column> {
         if (obj instanceof Column) {
             Column that = (Column) obj;
             return this.name().equalsIgnoreCase(that.name()) &&
-                    this.typeExpression().equalsIgnoreCase(that.typeExpression()) &&
+                    Strings.equalsIgnoreCase(this.typeExpression(), that.typeExpression()) &&
                     this.typeName().equalsIgnoreCase(that.typeName()) &&
                     this.jdbcType() == that.jdbcType() &&
                     Strings.equalsIgnoreCase(this.charsetName(), that.charsetName()) &&

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotWithSchemaChangesSupportTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotWithSchemaChangesSupportTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.snapshot.incremental;
+
+import static org.apache.kafka.connect.data.Schema.Type.INT32;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.jdbc.JdbcConnection;
+
+public abstract class AbstractIncrementalSnapshotWithSchemaChangesSupportTest<T extends SourceConnector> extends AbstractIncrementalSnapshotTest<T> {
+
+    protected abstract String tableName(String table);
+
+    protected abstract String alterColumnStatement(String table, String column, String type);
+
+    protected abstract String alterColumnSetNotNullStatement(String table, String column, String type);
+
+    protected abstract String alterColumnDropNotNullStatement(String table, String column, String type);
+
+    protected abstract String alterColumnSetDefaultStatement(String table, String column, String type, String defaultValue);
+
+    protected abstract String alterColumnDropDefaultStatement(String table, String column, String type);
+
+    protected abstract void executeRenameTable(JdbcConnection connection, String newTable) throws SQLException;
+
+    protected abstract String createTableStatement(String newTable, String copyTable);
+
+    @Test
+    public void schemaChanges() throws Exception {
+        Print.enable();
+
+        populateTable();
+        startConnector();
+
+        sendAdHocSnapshotSignal();
+
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.setAutoCommit(true);
+            connection.execute(String.format("INSERT INTO %s (pk, aa) VALUES (%s, %s)", tableName(), ROW_COUNT + 11, ROW_COUNT + 10));
+            connection.execute(alterColumnStatement(tableName(), "aa", "VARCHAR(5)"));
+            connection.execute(String.format("INSERT INTO %s (pk, aa) VALUES (%s, '%s')", tableName(), ROW_COUNT + 10, ROW_COUNT + 9));
+            for (int i = 0; i < 9 && !Thread.interrupted(); i += 3) {
+                connection.execute(String.format("ALTER TABLE %s ADD c INT", tableName()));
+                connection.execute(String.format("INSERT INTO %s (pk, aa, c) VALUES (%s, '%s', %s)", tableName(), i + ROW_COUNT + 1, i + ROW_COUNT, 1));
+                connection.execute(alterColumnStatement(tableName(), "c", "VARCHAR(5)"));
+                connection.execute(String.format("INSERT INTO %s (pk, aa, c) VALUES (%s, '%s', '%s')", tableName(), i + ROW_COUNT + 2, i + ROW_COUNT + 1, "1"));
+                connection.execute(String.format("ALTER TABLE %s DROP COLUMN c", tableName()));
+                connection.execute(String.format("INSERT INTO %s (pk, aa) VALUES (%s, '%s')", tableName(), i + ROW_COUNT + 3, i + ROW_COUNT + 2));
+            }
+        }
+
+        final int expectedRecordCount = ROW_COUNT + 11;
+        final Map<Integer, SourceRecord> dbChanges = consumeRecordsMixedWithIncrementalSnapshot(expectedRecordCount);
+        for (int i = 0; i < expectedRecordCount; i++) {
+            assertTrue(String.format("missing PK %d", i + 1), dbChanges.containsKey(i + 1));
+            SourceRecord record = dbChanges.get(i + 1);
+            final Schema.Type valueType = record.valueSchema().field("after").schema().field(valueFieldName()).schema().type();
+            if (valueType == INT32) {
+                final int value = ((Struct) record.value()).getStruct("after").getInt32(valueFieldName());
+                assertEquals(i, value);
+            }
+            else {
+                String value = ((Struct) record.value()).getStruct("after").getString(valueFieldName());
+                assertEquals(Integer.toString(i), value);
+            }
+        }
+    }
+
+    @Test
+    public void renameTable() throws Exception {
+        Print.enable();
+
+        populateTable();
+        final String newTable = "new_table";
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.setAutoCommit(true);
+            connection.execute(createTableStatement(tableName(newTable), tableName()));
+            connection.execute(String.format("INSERT INTO %s SELECT * FROM %s", tableName(newTable), tableName()));
+            connection.execute(String.format("ALTER TABLE %s ADD c varchar(5)", tableName(newTable)));
+        }
+        startConnector();
+        sendAdHocSnapshotSignal();
+
+        final int updatedRowCount = 10;
+        final AtomicInteger recordCounter = new AtomicInteger();
+        final AtomicBoolean tableRenamed = new AtomicBoolean();
+        final Map<Integer, SourceRecord> dbChanges = consumeRecordsMixedWithIncrementalSnapshot(ROW_COUNT, x -> true,
+                x -> {
+                    if (recordCounter.addAndGet(x.size()) > 10 && !tableRenamed.get()) {
+                        try (JdbcConnection connection = databaseConnection()) {
+                            executeRenameTable(connection, newTable);
+                            connection.executeWithoutCommitting(
+                                    String.format("UPDATE %s SET c = 'c' WHERE pk >= %s", tableName(), ROW_COUNT - updatedRowCount));
+                            connection.commit();
+                        }
+                        catch (SQLException e) {
+                            throw new RuntimeException(e);
+                        }
+                        tableRenamed.set(true);
+                    }
+                });
+        for (int i = 0; i < ROW_COUNT - updatedRowCount; i++) {
+            assertTrue(dbChanges.containsKey(i + 1));
+            SourceRecord record = dbChanges.get(i + 1);
+            final int value = ((Struct) record.value()).getStruct("after").getInt32(valueFieldName());
+            assertEquals(i, value);
+            if (((Struct) record.value()).schema().field("c") != null) {
+                final String c = ((Struct) record.value()).getStruct("after").getString("c");
+                assertNull(c);
+            }
+        }
+
+        for (int i = ROW_COUNT - updatedRowCount; i < ROW_COUNT; i++) {
+            assertTrue(dbChanges.containsKey(i + 1));
+            SourceRecord record = dbChanges.get(i + 1);
+            final int value = ((Struct) record.value()).getStruct("after").getInt32(valueFieldName());
+            assertEquals(i, value);
+            final String c = ((Struct) record.value()).getStruct("after").getString("c");
+            assertEquals("c", c);
+        }
+    }
+
+    @Test
+    public void columnNullabilityChanges() throws Exception {
+        Print.enable();
+
+        populateTable();
+        final Configuration config = config().build();
+        startAndConsumeTillEnd(connectorClass(), config);
+        waitForConnectorToStart();
+
+        waitForAvailableRecords(1, TimeUnit.SECONDS);
+        // there shouldn't be any snapshot records
+        assertNoRecordsToConsume();
+        sendAdHocSnapshotSignal();
+
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.setAutoCommit(false);
+            connection.execute(alterColumnSetNotNullStatement(tableName(), "aa", "INTEGER"));
+            connection.commit();
+
+            connection.execute(alterColumnDropNotNullStatement(tableName(), "aa", "INTEGER"));
+            connection.commit();
+
+            for (int i = 0; i < ROW_COUNT; i++) {
+                connection.executeWithoutCommitting(String.format("INSERT INTO %s (pk, aa) VALUES (%s, null)",
+                        tableName(),
+                        i + ROW_COUNT + 1));
+            }
+            connection.commit();
+        }
+        final int expectedRecordCount = ROW_COUNT * 2;
+        final Map<Integer, SourceRecord> dbChanges = consumeRecordsMixedWithIncrementalSnapshot(expectedRecordCount);
+
+        for (int i = 0; i < ROW_COUNT; i++) {
+            SourceRecord record = dbChanges.get(i + 1);
+            final int value = ((Struct) record.value()).getStruct("after").getInt32(valueFieldName());
+            assertEquals(i, value);
+        }
+
+        for (int i = ROW_COUNT; i < 2 * ROW_COUNT; i++) {
+            SourceRecord record = dbChanges.get(i + 1);
+            final Integer value = ((Struct) record.value()).getStruct("after").getInt32(valueFieldName());
+            assertNull(value);
+        }
+    }
+
+    @Test
+    public void columnDefaultChanges() throws Exception {
+        Print.enable();
+
+        populateTable();
+        final Configuration config = config().build();
+        startAndConsumeTillEnd(connectorClass(), config);
+        waitForConnectorToStart();
+
+        waitForAvailableRecords(1, TimeUnit.SECONDS);
+        // there shouldn't be any snapshot records
+        assertNoRecordsToConsume();
+
+        sendAdHocSnapshotSignal();
+
+        final int expectedRecordCount = ROW_COUNT * 4;
+        try (JdbcConnection connection = databaseConnection()) {
+            connection.setAutoCommit(false);
+            connection.execute(alterColumnSetDefaultStatement(tableName(), "aa", "INTEGER", "-6"));
+            connection.commit();
+
+            for (int i = 0; i < ROW_COUNT; i++) {
+                connection.executeWithoutCommitting(String.format("INSERT INTO %s (pk) VALUES (%s)",
+                        tableName(),
+                        i + ROW_COUNT + 1));
+            }
+            connection.commit();
+
+            connection.executeWithoutCommitting(alterColumnDropDefaultStatement(tableName(), "aa", "INTEGER"));
+            connection.executeWithoutCommitting(alterColumnSetDefaultStatement(tableName(), "aa", "INTEGER", "-9"));
+            connection.commit();
+            for (int i = 0; i < ROW_COUNT; i++) {
+                connection.executeWithoutCommitting(String.format("INSERT INTO %s (pk) VALUES (%s)",
+                        tableName(),
+                        i + 2 * ROW_COUNT + 1));
+            }
+            connection.commit();
+
+            connection.executeWithoutCommitting(alterColumnDropDefaultStatement(tableName(), "aa", "INTEGER"));
+            connection.commit();
+            for (int i = 0; i < ROW_COUNT; i++) {
+                connection.executeWithoutCommitting(String.format("INSERT INTO %s (pk) VALUES (%s)",
+                        tableName(),
+                        i + 3 * ROW_COUNT + 1));
+            }
+            connection.commit();
+        }
+        final Map<Integer, SourceRecord> dbChanges = consumeRecordsMixedWithIncrementalSnapshot(expectedRecordCount);
+
+        for (int i = 0; i < ROW_COUNT; i++) {
+            SourceRecord record = dbChanges.get(i + 1);
+            final Struct after = ((Struct) record.value()).getStruct("after");
+            final int value = after.getInt32(valueFieldName());
+            assertEquals(i, value);
+        }
+
+        for (int i = ROW_COUNT; i < 2 * ROW_COUNT; i++) {
+            SourceRecord record = dbChanges.get(i + 1);
+            final Struct after = ((Struct) record.value()).getStruct("after");
+            final Integer value = after.getInt32(valueFieldName());
+            assertNotNull("value is null at pk=" + (i + 1), value);
+            assertEquals(String.format("value is %d at pk = %d, expected -6", value, i + 1), -6, value, 0);
+        }
+
+        for (int i = 2 * ROW_COUNT; i < 3 * ROW_COUNT; i++) {
+            SourceRecord record = dbChanges.get(i + 1);
+            final Struct after = ((Struct) record.value()).getStruct("after");
+            final Integer value = after.getInt32(valueFieldName());
+            assertNotNull("value is null at pk=" + (i + 1), value);
+            assertEquals(String.format("value is %d at pk = %d, expected -9", value, i + 1), -9, value, 0);
+        }
+
+        for (int i = 3 * ROW_COUNT; i < 4 * ROW_COUNT; i++) {
+            SourceRecord record = dbChanges.get(i + 1);
+            final Struct after = ((Struct) record.value()).getStruct("after");
+            final Integer value = after.getInt32(valueFieldName());
+            assertNull("value is not null at pk=" + (i + 1), value);
+        }
+    }
+
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4196

Blocked by https://issues.redhat.com/browse/DBZ-4197 to make the schema changes integration tests pass faster. Temporarily included DBZ-4197 related commit to this PR

#### Implementation: 

When incremental snapshot queries a database for the next chunk of rows, the rows have the table’s current schema. However, if the binlog stream is behind the in-memory representation the table’s schema may be different from the current schema. For connectors with historized schema the solution is to wait for the connector to receive the DDL event in the binlog stream and update the in-memory representation of the table’s schema. After that, the connector can use the cached table’s structure to produce the correct incremental snapshot chunk events.

In order to detect schema changes during the incremental snapshot, each chunk’s schema needs to be compared against the table’s schema saved in the incremental snapshot context. 

To capture the table’s schema at the beginning of the incremental snapshot the connector queries the database for the table’s schema between low and high watermarks just like it would query an incremental snapshot chunk. As soon as the connector gets a window close event from the binlog it means that the in-memory representation of the table’s schema is up to date with the schema that was captured at the beginning of the incremental snapshot. The connector queries the database one more time to verify that the table's schema didn’t change since the initial schema capture. If the schema has changed, then the process of capturing the incremental snapshot schema is repeated.
<img width="1209" alt="1" src="https://user-images.githubusercontent.com/553032/138471504-cb223299-b57f-4224-b796-8daf661ccfc2.png">

If the schema is the same then it gets marked as verified and is used for comparisons during the following chunks selections.

<img width="1178" alt="2" src="https://user-images.githubusercontent.com/553032/138533269-82dbc755-13f3-4a7e-86de-e669ac15df59.png">

When a chunk’s schema doesn’t match the schema saved in incremental snapshot context the connector drops the selected chunk, updates incremental snapshot schema in the snapshot context and re-reads the chunk after the current window is closed and the in-memory table’s schema is guaranteed to be updated with the DDL from the binlog stream.

<img width="1268" alt="3" src="https://user-images.githubusercontent.com/553032/138533306-f13412d3-ab5e-4d49-b4ac-8c240649a533.png">

_Since the incremental snapshot events are created during the pause in binlog processing and added into the binlog stream only after the window close event it’s possible that some binlog events preceding the chunk events have a more recent database schema than incremental snapshot events. If it’s critical to keep the schema change consistency in the binlog stream, then it can be achieved by triggering chunk re-read on DDL events in historized connectors._
