### PR TITLE
Use default replication factor when lacking DescribeClusterDynamicConfiguration priv

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/KafkaDatabaseHistory.java
@@ -41,7 +41,6 @@ import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.ConfigResource;
-import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -520,11 +519,7 @@ public class KafkaDatabaseHistory extends AbstractDatabaseHistory {
                 return Short.parseShort(defaultReplicationFactorValue);
             }
         }
-        catch (ExecutionException ex) {
-            // ignore UnsupportedVersionException, e.g. due to older broker version
-            if (!(ex.getCause() instanceof UnsupportedVersionException)) {
-                throw ex;
-            }
+        catch (Exception ex) {
         }
 
         // Otherwise warn that no property was obtained and default it to 1 - users can increase this later if desired


### PR DESCRIPTION
This fix allows debezium to run against MSK IAM clusters that are lacking DescribeClusterDynamicConfiguration privilege.

Without this change, i get below error:
```
Caused by: java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.ClusterAuthorizationException: Cluster authorization failed.
 at org.apache.kafka.common.internals.KafkaFutureImpl.wrapAndThrow(KafkaFutureImpl.java:45)
 at org.apache.kafka.common.internals.KafkaFutureImpl.access$000(KafkaFutureImpl.java:32)
 at org.apache.kafka.common.internals.KafkaFutureImpl$SingleWaiter.await(KafkaFutureImpl.java:104)
 at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:272)
 at io.debezium.relational.history.KafkaDatabaseHistory.getKafkaBrokerConfig(KafkaDatabaseHistory.java:547)
 at io.debezium.relational.history.KafkaDatabaseHistory.getDefaultTopicReplicationFactor(KafkaDatabaseHistory.java:515)
 at io.debezium.relational.history.KafkaDatabaseHistory.initializeStorage(KafkaDatabaseHistory.java:498)
 ... 13 more
Caused by: org.apache.kafka.common.errors.ClusterAuthorizationException: Cluster authorization failed.



[2021-10-29 08:49:49,239] DEBUG [AdminClient clientId=my-pre-dbhistory] Sending DESCRIBE_CONFIGS request with header RequestHeader(apiKey=DESCRIBE_CONFIGS, apiVersion=4, clientId=my-pre-dbhistory, correlationId=5) and timeout 30000 to node 1: DescribeConfigsRequestData(resources=[DescribeConfigsResource(resourceType=4, resourceName='1', configurationKeys=null)], includeSynonyms=false, includeDocumentation=false) (org.apache.kafka.clients.NetworkClient:522)
[2021-10-29 08:49:49,247] DEBUG [AdminClient clientId=my-pre-dbhistory] Received DESCRIBE_CONFIGS response from node 1 for request with header RequestHeader(apiKey=DESCRIBE_CONFIGS, apiVersion=4, clientId=my-pre-dbhistory, correlationId=5): DescribeConfigsResponseData(throttleTimeMs=0, results=[DescribeConfigsResult(errorCode=31, errorMessage='Cluster authorization failed.', resourceType=4, resourceName='1', configs=[])]) (org.apache.kafka.clients.NetworkClient:880)
```