### PR TITLE
DBZ-4137 Postgres defaults handling misses decimal mode configuration and cannot handle numerics with default NULL values

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -103,15 +103,15 @@ public class PostgresConnection extends JdbcConnection {
      * @param config {@link Configuration} instance, may not be null.
      * @param typeRegistry an existing/already-primed {@link TypeRegistry} instance
      */
-    public PostgresConnection(Configuration config, TypeRegistry typeRegistry) {
-        super(config, FACTORY, PostgresConnection::validateServerVersion, PostgresConnection::defaultSettings, "\"", "\"");
+    public PostgresConnection(PostgresConnectorConfig config, TypeRegistry typeRegistry) {
+        super(config.getJdbcConfig(), FACTORY, PostgresConnection::validateServerVersion, PostgresConnection::defaultSettings, "\"", "\"");
         if (Objects.isNull(typeRegistry)) {
             this.typeRegistry = null;
             this.defaultValueConverter = null;
         }
         else {
             this.typeRegistry = typeRegistry;
-            final PostgresValueConverter valueConverter = PostgresValueConverter.of(new PostgresConnectorConfig(config), this.getDatabaseCharset(), typeRegistry);
+            final PostgresValueConverter valueConverter = PostgresValueConverter.of(config, this.getDatabaseCharset(), typeRegistry);
             this.defaultValueConverter = new PostgresDefaultValueConverter(valueConverter, this.getTimestampUtils());
         }
     }
@@ -123,7 +123,7 @@ public class PostgresConnection extends JdbcConnection {
      * @param config {@link Configuration} instance, may not be null.
      */
     public PostgresConnection(Configuration config) {
-        this(config, (TypeRegistry) null);
+        this(config, null);
     }
 
     /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresDefaultValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresDefaultValueConverter.java
@@ -86,6 +86,9 @@ class PostgresDefaultValueConverter {
         try {
             Object rawDefaultValue = mapper.parse(defaultValue);
             Object convertedDefaultValue = convertDefaultValue(rawDefaultValue, column);
+            if (convertedDefaultValue == null) {
+                return Optional.empty();
+            }
             if (convertedDefaultValue instanceof Struct) {
                 // Workaround for KAFKA-12694
                 LOGGER.warn("Struct can't be used as default value for column '{}', will use null instead.", column.name());
@@ -124,6 +127,17 @@ class PostgresDefaultValueConverter {
         return defaultValue;
     }
 
+    private static DefaultValueMapper parseNullDefault(DefaultValueMapper mapper) {
+        return x -> {
+            if (x.startsWith("NULL::")) {
+                return null;
+            }
+            else {
+                return mapper.parse(x);
+            }
+        };
+    }
+
     private static Map<String, DefaultValueMapper> createDefaultValueMappers(TimestampUtils timestampUtils) {
         final Map<String, DefaultValueMapper> result = new HashMap<>();
 
@@ -137,21 +151,21 @@ class PostgresDefaultValueConverter {
         }); // Sample values: `B'1'::"bit"`, `B'11'::"bit"`
         result.put("varbit", v -> extractDefault(v, "0")); // Sample value: B'110'::"bit"
 
-        result.put("bool", v -> Boolean.parseBoolean(extractDefault(v, "false"))); // Sample value: true
+        result.put("bool", parseNullDefault(v -> Boolean.parseBoolean(extractDefault(v, "false")))); // Sample value: true
 
         result.put("bpchar", v -> extractDefault(v, "")); // Sample value: 'abcd'::bpchar
         result.put("varchar", v -> extractDefault(v, "")); // Sample value: `abcde'::character varying
         result.put("text", v -> extractDefault(v, "")); // Sample value: 'asdf'::text
 
-        result.put("numeric", v -> new BigDecimal(extractDefault(v, "0.0"))); // Sample value: 12345.67891
-        result.put("float4", v -> Float.parseFloat(extractDefault(v, "0.0"))); // Sample value: 1.234
-        result.put("float8", v -> Double.parseDouble(extractDefault(v, "0.0"))); // Sample values: `1.234`, `'12345678901234567890'::numeric`
-        result.put("int2", v -> Short.parseShort(extractDefault(v, "0"))); // Sample value: 32767
-        result.put("int4", v -> Integer.parseInt(extractDefault(v, "0"))); // Sample value: 123
-        result.put("serial", v -> Integer.parseInt(extractDefault(v, "0")));
-        result.put("int8", v -> Long.parseLong(extractDefault(v, "0"))); // Sample values: `123`, `'9223372036854775807'::bigint`
-        result.put("bigserial", v -> Long.parseLong(extractDefault(v, "0")));
-        result.put("smallserial", v -> Short.parseShort(extractDefault(v, "0")));
+        result.put("numeric", parseNullDefault(v -> new BigDecimal(extractDefault(v, "0.0")))); // Sample value: 12345.67891
+        result.put("float4", parseNullDefault(v -> Float.parseFloat(extractDefault(v, "0.0")))); // Sample value: 1.234
+        result.put("float8", parseNullDefault(v -> Double.parseDouble(extractDefault(v, "0.0")))); // Sample values: `1.234`, `'12345678901234567890'::numeric`
+        result.put("int2", parseNullDefault(v -> Short.parseShort(extractDefault(v, "0")))); // Sample value: 32767
+        result.put("int4", parseNullDefault(v -> Integer.parseInt(extractDefault(v, "0")))); // Sample value: 123
+        result.put("serial", parseNullDefault(v -> Integer.parseInt(extractDefault(v, "0"))));
+        result.put("int8", parseNullDefault(v -> Long.parseLong(extractDefault(v, "0")))); // Sample values: `123`, `'9223372036854775807'::bigint`
+        result.put("bigserial", parseNullDefault(v -> Long.parseLong(extractDefault(v, "0"))));
+        result.put("smallserial", parseNullDefault(v -> Short.parseShort(extractDefault(v, "0"))));
 
         result.put("json", v -> extractDefault(v, "{}")); // Sample value: '{}'::json
         result.put("jsonb", v -> extractDefault(v, "{}")); // Sample value: '{}'::jsonb

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -110,7 +110,7 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
 
     public PgOutputMessageDecoder(MessageDecoderContext decoderContext) {
         this.decoderContext = decoderContext;
-        this.connection = new PostgresConnection(decoderContext.getConfig().getJdbcConfig(), decoderContext.getSchema().getTypeRegistry());
+        this.connection = new PostgresConnection(decoderContext.getConfig(), decoderContext.getSchema().getTypeRegistry());
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresDefaultValueConverterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresDefaultValueConverterIT.java
@@ -17,13 +17,16 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.postgresql.PostgresValueConverter;
 import io.debezium.connector.postgresql.TestHelper;
 import io.debezium.connector.postgresql.TypeRegistry;
 import io.debezium.doc.FixFor;
+import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.junit.SkipTestRule;
 import io.debezium.relational.Column;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
 
 public class PostgresDefaultValueConverterIT {
     @Rule
@@ -32,6 +35,19 @@ public class PostgresDefaultValueConverterIT {
     @Before
     public void before() throws SQLException {
         TestHelper.dropAllSchemas();
+    }
+
+    public static JdbcConfiguration getJdbcConfig(RelationalDatabaseConnectorConfig.DecimalHandlingMode mode) {
+        return JdbcConfiguration.copy(Configuration.fromSystemProperties("database."))
+                .withDefault(JdbcConfiguration.DATABASE, "postgres")
+                .withDefault(JdbcConfiguration.HOSTNAME, "localhost")
+                .withDefault(JdbcConfiguration.PORT, 5432)
+                .withDefault(JdbcConfiguration.USER, "postgres")
+                .withDefault(JdbcConfiguration.PASSWORD, "postgres")
+                .with(PostgresConnectorConfig.MAX_RETRIES, 2)
+                .with(PostgresConnectorConfig.RETRY_DELAY_MS, 2000)
+                .with(PostgresConnectorConfig.DECIMAL_HANDLING_MODE, mode)
+                .build();
     }
 
     private static final String TEST_SERVER = "test_server";
@@ -43,6 +59,28 @@ public class PostgresDefaultValueConverterIT {
             postgresConnectorConfig,
             Charset.defaultCharset(),
             new TypeRegistry(postgresConnection));
+
+    @Test
+    @FixFor("DBZ-4137")
+    public void numericDefaultAsDecimal() {
+        final PostgresConnection postgresConnection = TestHelper.create();
+        final PostgresConnectorConfig postgresConnectorConfig = new PostgresConnectorConfig(defaultJdbcConfig());
+        final PostgresValueConverter postgresValueConverter = PostgresValueConverter.of(
+                postgresConnectorConfig,
+                Charset.defaultCharset(),
+                new TypeRegistry(postgresConnection));
+
+        final PostgresDefaultValueConverter postgresDefaultValueConverter = new PostgresDefaultValueConverter(
+                postgresValueConverter, postgresConnection.getTimestampUtils());
+
+        final Column NumericalColumn = Column.editor().type("numeric", "numeric(19, 4)")
+                .jdbcType(Types.NUMERIC).defaultValue("NULL::numeric").optional(true).create();
+        final Optional<Object> numericalConvertedValue = postgresDefaultValueConverter.parseDefaultValue(
+                NumericalColumn,
+                (String) NumericalColumn.defaultValue());
+
+        Assert.assertEquals(numericalConvertedValue, Optional.empty());
+    }
 
     @Test
     @FixFor("DBZ-3989")


### PR DESCRIPTION
See https://issues.redhat.com/browse/DBZ-4137 for details.

Two problems in handling of the defaults in the postgres connector:
1. "NULL::...." values for numeric/int/.. values were not handled
2. Inconsistent internal configuration if the decimal handling monee was not default (aka precise). `PgOutputMessageDecoder` passed jdbcConfig to `PostgresConnection`, JdbcConfig drops non-jdbc parameters but passes type check. As result, PostgresValueConverter was created with default (precise) mode even if other places used double. 