### PR TITLE
DBZ-4077 Fix NPE with Oracle test suite

### DIFF
--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -183,6 +183,7 @@ public class TestHelper {
         jdbcConfiguration.forEach(
                 (field, value) -> builder.with(OracleConnectorConfig.DATABASE_CONFIG_PREFIX + field, value));
 
+        builder.with(OracleConnectorConfig.SERVER_NAME, SERVER_NAME);
         return builder;
     }
 
@@ -196,6 +197,7 @@ public class TestHelper {
         jdbcConfiguration.forEach(
                 (field, value) -> builder.with(OracleConnectorConfig.DATABASE_CONFIG_PREFIX + field, value));
 
+        builder.with(OracleConnectorConfig.SERVER_NAME, SERVER_NAME);
         return builder;
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4077

The Oracle test suite failed with a NPE after the introduction of the DBZ-4077 code changes to main.  This PR supplements the original work by addressing the NPE failure.