### PR TITLE
DBZ-4233 CHAR / NCHAR precision not derived from DDL

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/ColumnDefinitionParserListener.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/ColumnDefinitionParserListener.java
@@ -200,12 +200,20 @@ public class ColumnDefinitionParserListener extends BaseParserListener {
                         .jdbcType(Types.CHAR)
                         .type("CHAR")
                         .length(1);
+
+                if (precisionPart != null) {
+                    setPrecision(precisionPart, columnEditor);
+                }
             }
             else if (ctx.native_datatype_element().NCHAR() != null) {
                 columnEditor
                         .jdbcType(Types.NCHAR)
                         .type("NCHAR")
                         .length(1);
+
+                if (precisionPart != null) {
+                    setPrecision(precisionPart, columnEditor);
+                }
             }
             else if (ctx.native_datatype_element().BINARY_FLOAT() != null) {
                 columnEditor

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleDdlParserTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleDdlParserTest.java
@@ -70,9 +70,9 @@ public class OracleDdlParserTest {
         // nvarchar2(255)
         testColumn(table, "COL3", false, Types.NVARCHAR, "NVARCHAR2", 255, null, false, null);
         // char(4)
-        testColumn(table, "COL4", true, Types.CHAR, "CHAR", 1, null, true, null);
+        testColumn(table, "COL4", true, Types.CHAR, "CHAR", 4, null, true, null);
         // nchar(4)
-        testColumn(table, "COL5", true, Types.NCHAR, "NCHAR", 1, 0, true, null);
+        testColumn(table, "COL5", true, Types.NCHAR, "NCHAR", 4, 0, true, null);
         // float(126)
         testColumn(table, "COL6", true, Types.FLOAT, "FLOAT", 126, 0, true, null);
         // date


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4233

While working on DBZ-3710, I uncovered that we are not correctly deriving the length for CHAR and NCHAR data types when we parse a DDL statement.  This PR makes adjustments to the DDL parser code and adjusts the faulty test that masked the problem in the first place.