### PR TITLE
DBZ-4107 Incremental snapshot doesn't work without primary key

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -13,7 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
-import io.debezium.config.CommonConnectorConfig;
 import io.debezium.connector.mysql.signal.ExecuteSnapshotKafkaSignal;
 import io.debezium.connector.mysql.signal.KafkaSignalThread;
 import io.debezium.jdbc.JdbcConnection;
@@ -23,6 +22,7 @@ import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.schema.DataCollectionId;
 import io.debezium.schema.DatabaseSchema;
 import io.debezium.util.Clock;
@@ -81,9 +81,11 @@ public class MySqlReadOnlyIncrementalSnapshotChangeEventSource<T extends DataCol
     private final String showMasterStmt = "SHOW MASTER STATUS";
     private final KafkaSignalThread<T> kafkaSignal;
 
-    public MySqlReadOnlyIncrementalSnapshotChangeEventSource(CommonConnectorConfig config, JdbcConnection jdbcConnection,
+    public MySqlReadOnlyIncrementalSnapshotChangeEventSource(RelationalDatabaseConnectorConfig config,
+                                                             JdbcConnection jdbcConnection,
                                                              EventDispatcher<T> dispatcher,
-                                                             DatabaseSchema<?> databaseSchema, Clock clock,
+                                                             DatabaseSchema<?> databaseSchema,
+                                                             Clock clock,
                                                              SnapshotProgressListener progressListener,
                                                              DataChangeEventListener dataChangeEventListener) {
         super(config, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener);

--- a/debezium-connector-mysql/src/test/resources/ddl/incremental_snapshot_test.sql
+++ b/debezium-connector-mysql/src/test/resources/ddl/incremental_snapshot_test.sql
@@ -12,6 +12,23 @@ CREATE TABLE b (
   aa INTEGER
 ) AUTO_INCREMENT = 1;
 
+CREATE TABLE a4 (
+  pk1 integer,
+  pk2 integer,
+  pk3 integer,
+  pk4 integer,
+  aa integer,
+  PRIMARY KEY(pk1, pk2, pk3, pk4)
+);
+
+CREATE TABLE a42 (
+  pk1 integer,
+  pk2 integer,
+  pk3 integer,
+  pk4 integer,
+  aa integer
+);
+
 CREATE TABLE debezium_signal (
   id varchar(64),
   type varchar(32),

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -8,13 +8,13 @@ package io.debezium.connector.oracle;
 import java.sql.SQLException;
 
 import io.debezium.DebeziumException;
-import io.debezium.config.CommonConnectorConfig;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
 import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
 import io.debezium.schema.DatabaseSchema;
 import io.debezium.util.Clock;
@@ -27,7 +27,7 @@ public class OracleSignalBasedIncrementalSnapshotChangeEventSource extends Signa
     private final String pdbName;
     private final OracleConnection connection;
 
-    public OracleSignalBasedIncrementalSnapshotChangeEventSource(CommonConnectorConfig config,
+    public OracleSignalBasedIncrementalSnapshotChangeEventSource(RelationalDatabaseConnectorConfig config,
                                                                  JdbcConnection jdbcConnection,
                                                                  EventDispatcher<TableId> dispatcher,
                                                                  DatabaseSchema<?> databaseSchema,

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedIncrementalSnapshotChangeEventSource.java
@@ -11,13 +11,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.annotation.NotThreadSafe;
-import io.debezium.config.CommonConnectorConfig;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.schema.DataCollectionId;
 import io.debezium.schema.DatabaseSchema;
 import io.debezium.util.Clock;
@@ -28,8 +28,10 @@ public class SignalBasedIncrementalSnapshotChangeEventSource<T extends DataColle
     private static final Logger LOGGER = LoggerFactory.getLogger(SignalBasedIncrementalSnapshotChangeEventSource.class);
     private final String signalWindowStatement;
 
-    public SignalBasedIncrementalSnapshotChangeEventSource(CommonConnectorConfig config, JdbcConnection jdbcConnection,
-                                                           EventDispatcher<T> dispatcher, DatabaseSchema<?> databaseSchema, Clock clock,
+    public SignalBasedIncrementalSnapshotChangeEventSource(RelationalDatabaseConnectorConfig config,
+                                                           JdbcConnection jdbcConnection,
+                                                           EventDispatcher<T> dispatcher, DatabaseSchema<?> databaseSchema,
+                                                           Clock clock,
                                                            SnapshotProgressListener progressListener,
                                                            DataChangeEventListener dataChangeEventListener) {
         super(config, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener);

--- a/debezium-core/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedSnapshotChangeEventSourceTest.java
+++ b/debezium-core/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedSnapshotChangeEventSourceTest.java
@@ -8,22 +8,23 @@ package io.debezium.pipeline.source.snapshot.incremental;
 import org.fest.assertions.Assertions;
 import org.junit.Test;
 
-import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.relational.Column;
+import io.debezium.relational.ColumnFilterMode;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 
 public class SignalBasedSnapshotChangeEventSourceTest {
 
-    protected CommonConnectorConfig config() {
-        return new CommonConnectorConfig(
-                Configuration.create().with(CommonConnectorConfig.SIGNAL_DATA_COLLECTION, "debezium.signal").build(),
-                "core", 0) {
+    protected RelationalDatabaseConnectorConfig config() {
+        return new RelationalDatabaseConnectorConfig(
+                Configuration.create().with(RelationalDatabaseConnectorConfig.SIGNAL_DATA_COLLECTION, "debezium.signal").build(),
+                "core", null, null, 0, ColumnFilterMode.CATALOG) {
             @Override
             protected SourceInfoStructMaker<?> getSourceInfoStructMaker(Version version) {
                 return null;


### PR DESCRIPTION
Refer the discussion from [DBZ-4107](https://issues.redhat.com/browse/DBZ-4107?filter=12358727)

I have implemented the [option 1] to support incremental snapshot for without pk tables, add the method getKeyMapper() instead of "table.primaryKeyColumns()" in AbstractIncrementalSnapshotChangeEventSource.

@jpechane, feel free to help review this code changes.