### PR TITLE
DBZ-4229 CREATE PROCEDURE DDL throws ParsingException

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -204,6 +204,22 @@ public class MySqlAntlrDdlParserTest {
     }
 
     @Test
+    @FixFor("DBZ-4229")
+    public void shouldProcessQueryWithoutFromStatement() {
+        String sp = "CREATE DEFINER=`system_user`@`%` PROCEDURE `update_order`(IN orderID bigint(11))\n" +
+                "BEGIN  insert into order_config(order_id, attribute, value, performer)\n" +
+                "    SELECT orderID, 'first_attr', 'true', 'AppConfig'\n" +
+                "    WHERE NOT EXISTS (select 1 from inventory.order_config t1 where t1.order_id = orderID and t1.attribute = 'first_attr') OR\n" +
+                "        EXISTS (select 1 from inventory.order_config p2 where p2.order_id = orderID and p2.attribute = 'first_attr' and p2.performer = 'AppConfig')\n" +
+                "    ON DUPLICATE KEY UPDATE value = 'true',\n" +
+                "                            performer = 'AppConfig'; -- Enable second_attr for order\n" +
+                "END";
+        parser.parse(sp, tables);
+        assertThat(((MySqlAntlrDdlParser) parser).getParsingExceptionsFromWalker().size()).isEqualTo(0);
+        assertThat(tables.size()).isEqualTo(0);
+    }
+
+    @Test
     @FixFor("DBZ-3020")
     public void shouldProcessExpressionWithDefault() {
         String ddl = "create table rack_shelf_bin ( id int unsigned not null auto_increment unique primary key, bin_volume decimal(20, 4) default (bin_len * bin_width * bin_height));";

--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -1076,7 +1076,7 @@ selectLinesInto
     ;
 
 fromClause
-    : FROM tableSources
+    : (FROM tableSources)?
       (WHERE whereExpr=expression)?
       (
         GROUP BY


### PR DESCRIPTION
The sp contains query statement which have `select` and `where` statements, but without`from` statment, cause this parser error.

sp:
CREATE DEFINER=`system_user`@`%` PROCEDURE `update_order`(IN orderID bigint(11))
BEGIN    insert into order_config(order_id, attribute, value, performer)
    **SELECT** orderID, 'first_attr', 'true', 'AppConfig'
    **WHERE** NOT EXISTS (select 1 from inventory.order_config t1 where t1.order_id = orderID and t1.attribute = 'first_attr') OR
        EXISTS (select 1 from inventory.order_config p2 where p2.order_id = orderID and p2.attribute = 'first_attr' and p2.performer = 'AppConfig')
    ON DUPLICATE KEY UPDATE value   = 'true',
                            performer   = 'AppConfig';    -- Enable second_attr for order
    insert into order_config(order_id, attribute, value, performer)
    select orderID, 'second_attr', 'true', 'AppConfig'
    WHERE NOT EXISTS (select 1 from inventory.order_config t1 where t1.order_id = orderID and t1.attribute = 'second_attr') OR
        EXISTS (select 1 from inventory.order_config p2 where p2.order_id = orderID and p2.attribute = 'second_attr' and p2.performer = 'AppConfig')
    ON DUPLICATE KEY UPDATE value   = 'true',
                            performer   = 'AppConfig';    -- Disable third_attr
    INSERT INTO order_config (order_id, attribute, value, customer_conf, is_large, type, performer)
    select orderID, 'third_attr', 'false', 1, 0, 3, 'AppConfig'
    WHERE NOT EXISTS (select 1 from inventory.order_config t1 where t1.order_id = orderID and t1.attribute = 'third_attr') OR
        EXISTS (select 1 from inventory.order_config p2 where p2.order_id = orderID and p2.attribute = 'third_attr' and p2.performer = 'AppConfig')
    ON DUPLICATE KEY UPDATE value   = 'false',
                            customer_conf = 1,
                            type        = 3,
                            is_large = 0,
                            performer   = 'AppConfig';
END
