### PR TITLE
DBZ-4245: Handle SQL Server connection errors during database state transition

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
@@ -32,6 +32,8 @@ public class SqlServerErrorHandler extends ErrorHandler {
                         || throwable.getMessage().contains("Connection timed out (Write failed)")
                         || throwable.getMessage().contains("The connection has been closed.")
                         || throwable.getMessage().contains("The connection is closed.")
+                        || throwable.getMessage().contains("The login failed.")
+                        || throwable.getMessage().contains("Try the statement later.")
                         || throwable.getMessage().contains("Connection reset")
                         || throwable.getMessage().contains("SHUTDOWN is in progress")
                         || throwable.getMessage().contains("The server failed to resume the transaction")


### PR DESCRIPTION
See [DBZ-4245](https://issues.redhat.com/browse/DBZ-4245).

Automated testing of this scenario is non-trivial but should be possible. Hence, marking this as a draft.