### PR TITLE
DBZ-4254 fixing several anchors in documentation

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -187,7 +187,7 @@ You can configure a {prodname} Db2 connector to produce schema change events tha
 * A table is removed from capture mode.
 * During a {link-prefix}:{link-db2-connector}#db2-schema-evolution[database schema update], there is a change in the schema for a table that is in capture mode.
 
-The connector writes schema change events to a Kafka schema change topic that has the name `_<serverName>_` where `_<serverName>_` is the logical server name that is specified in the xref:mysql-property-database-server-name[`database.server.name`] connector configuration property.
+The connector writes schema change events to a Kafka schema change topic that has the name `_<serverName>_` where `_<serverName>_` is the logical server name that is specified in the xref:db2-property-database-server-name[`database.server.name`] connector configuration property.
 Messages that the connector sends to the schema change topic contain a payload that includes the following elements:
 
 `databaseName`:: The name of the database to which the statements are applied.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -148,7 +148,7 @@ fulfillment.inventory.customers
 fulfillment.inventory.products
 ----
 
-The connector applies similar naming conventions to label its internal database history topics, xref:about-the-debezium-oracle-connector-schema-change-topic[schema change topics], and xref:oracle-transaction-metadata[transaction metadata topics].
+The connector applies similar naming conventions to label its internal database history topics, xref:oracle-schema-change-topic[schema change topics], and xref:oracle-transaction-metadata[transaction metadata topics].
 
 If the default topic name do not meet your requirements, you can configure custom topic names.
 To configure custom topic names, you specify regular expressions in the logical topic routing SMT.
@@ -2855,7 +2855,7 @@ Instead, it contains the complete new schema structure.
 
 |===
 
-After the `schema-changes` signal is inserted, the connector must be restarted with an altered configuration that includes specifying the  <<oracle-property-database-history-skip-unparseable-ddl, `+database.history.skip.unparseable.ddl+`>> option as `true`.
+After the `schema-changes` signal is inserted, the connector must be restarted with an altered configuration that includes specifying the  <<{context}-property-database-history-skip-unparseable-ddl, `+database.history.skip.unparseable.ddl+`>> option as `true`.
 After the connector's commit SCN advances beyond the DDL change, to prevent unparseable DDL statements from being skipped unexpectedly, return the connector configuration to its previous state.
 
 .Example of a logging record
@@ -3176,12 +3176,13 @@ This error means that the connector has attempted to execute an operation that m
 To resolve this, the IOT name used in the SQL operation should be replaced with the parent index-organized table name.
 To determine the parent index-organized table name, use the following SQL:
 
-```
+[source,sql]
+----
 SELECT IOT_NAME
   FROM DBA_TABLES
  WHERE OWNER='<tablespace-owner>'
    AND TABLE_NAME='<iot-table-name-that-failed>'
-```
+----
 
 The connector's `table.include.list` or `table.exclude.list` configuration options should then be adjusted to explicitly include or exclude the appropriate tables to avoid the connector from attempting to capture changes from the child index-organized table.
 

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -386,7 +386,7 @@ Pub/Sub exposes a set of REST APIs and provides a (not-only) Java SDK that is us
 |
 |Must be set to `pubsub`.
 
-|[[pubsub-project-id]]<<pubsub-project.id, `debezium.sink.pubsub.project.id`>>
+|[[pubsub-project-id]]<<pubsub-project-id, `debezium.sink.pubsub.project.id`>>
 |_system-wide default project id_
 |A project name in which the target topics are created.
 

--- a/documentation/modules/ROOT/pages/operations/embedded.adoc
+++ b/documentation/modules/ROOT/pages/operations/embedded.adoc
@@ -63,7 +63,7 @@ The remainder of this document describes embedding the MySQL connector in your a
 
 Your application needs to set up an embedded engine for each connector instance you want to run. The `io.debezium.embedded.EmbeddedEngine` class serves as an easy-to-use wrapper around any standard Kafka Connect connector and completely manages the connector's lifecycle. Basically, you create the `EmbeddedEngine` with a configuration (perhaps loaded from a properties file) that defines the environment for both the engine and the connector. You also provide the engine with a function that it will call for every data change event produced by the connector.
 
-Here's an example of code that configures and runs an embedded xref:connectors/mysql[MySQL connector]:
+Here's an example of code that configures and runs an embedded xref:connectors/mysql.adoc[MySQL connector]:
 
 [source,java,indent=0]
 ----

--- a/documentation/modules/ROOT/pages/transformations/content-based-routing.adoc
+++ b/documentation/modules/ROOT/pages/transformations/content-based-routing.adoc
@@ -168,7 +168,7 @@ Because the structure of these other messages differs from the structure of the 
 You can use one of the following methods to configure the connector to apply the SMT selectively:
 
 * {link-prefix}:{link-smt-predicates}#applying-transformation-selectively[Configure an SMT predicate for the transformation].
-* Use the xref:filter-topic-regex[topic.regex] configuration option for the SMT.
+* Use the xref:transformations/filtering.adoc#filter-topic-regex[topic.regex] configuration option for the SMT.
 
 // Type: reference
 // ModuleID: configuration-of-content-based-routing-conditions-for-other-scripting-languages


### PR DESCRIPTION
Also changing listing format from Markdown to AsciiDoc style. All xrefs to files should have the .adoc extension (will be required by Antora v3)