### PR TITLE
DBZ-4257 Add additional catch block to catch exception while invoke select in snapshot phase.

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SnapshotReader.java
@@ -605,6 +605,9 @@ public class SnapshotReader extends AbstractReader {
                                         logger.info("Step {}: Stopping the snapshot due to thread interruption", stepNum);
                                         interrupted.set(true);
                                     }
+                                    catch (Exception e) {
+                                        logger.error("Aborting invoke " +  sql.get(), e);
+                                    }
                                 });
                             }
                             finally {


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4257

Add additional catch block to catch exception while invoke `select` in snapshot phase.