### PR TITLE
DBZ-2975: Move the poll interval logic to the SqlServerChangeEventSourceCoordinator.

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceCoordinator.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceCoordinator.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.connect.source.SourceConnector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.pipeline.ChangeEventSourceCoordinator;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.metrics.spi.ChangeEventSourceMetricsFactory;
+import io.debezium.pipeline.source.spi.ChangeEventSource;
+import io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContext;
+import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
+import io.debezium.pipeline.source.spi.SnapshotChangeEventSource;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.pipeline.spi.SnapshotResult;
+import io.debezium.schema.DatabaseSchema;
+import io.debezium.util.Clock;
+import io.debezium.util.LoggingContext;
+import io.debezium.util.Metronome;
+
+/**
+ * Coordinates one or more {@link ChangeEventSource}s and executes them in order. Extends the base
+ * {@link ChangeEventSourceCoordinator} to support snapshotting and streaming of multiple partitions.
+ */
+public class SqlServerChangeEventSourceCoordinator extends ChangeEventSourceCoordinator<SqlServerPartition, SqlServerOffsetContext> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerChangeEventSourceCoordinator.class);
+
+    private final Clock clock;
+    private final Duration pollInterval;
+
+    public SqlServerChangeEventSourceCoordinator(Offsets<SqlServerPartition, SqlServerOffsetContext> previousOffsets, ErrorHandler errorHandler,
+                                                 Class<? extends SourceConnector> connectorType,
+                                                 CommonConnectorConfig connectorConfig,
+                                                 ChangeEventSourceFactory<SqlServerPartition, SqlServerOffsetContext> changeEventSourceFactory,
+                                                 ChangeEventSourceMetricsFactory changeEventSourceMetricsFactory, EventDispatcher<?> eventDispatcher,
+                                                 DatabaseSchema<?> schema,
+                                                 Clock clock) {
+        super(previousOffsets, errorHandler, connectorType, connectorConfig, changeEventSourceFactory,
+                changeEventSourceMetricsFactory, eventDispatcher, schema);
+        this.clock = clock;
+        this.pollInterval = connectorConfig.getPollInterval();
+    }
+
+    @Override
+    protected void executeChangeEventSources(CdcSourceTaskContext taskContext, SnapshotChangeEventSource<SqlServerPartition, SqlServerOffsetContext> snapshotSource,
+                                             Offsets<SqlServerPartition, SqlServerOffsetContext> previousOffsets,
+                                             AtomicReference<LoggingContext.PreviousContext> previousLogContext,
+                                             ChangeEventSourceContext context)
+            throws InterruptedException {
+        Offsets<SqlServerPartition, SqlServerOffsetContext> streamingOffsets = Offsets.of(new HashMap<>());
+
+        for (Map.Entry<SqlServerPartition, SqlServerOffsetContext> entry : previousOffsets) {
+            SqlServerPartition partition = entry.getKey();
+            SqlServerOffsetContext previousOffset = entry.getValue();
+
+            SnapshotResult<SqlServerOffsetContext> snapshotResult = doSnapshot(snapshotSource, context, partition, previousOffset);
+
+            if (snapshotResult.isCompletedOrSkipped()) {
+                streamingOffsets.getOffsets().put(partition, snapshotResult.getOffset());
+            }
+        }
+
+        previousLogContext.set(taskContext.configureLoggingContext("streaming"));
+        streamEvents(context, streamingOffsets);
+    }
+
+    private void streamEvents(ChangeEventSourceContext context, Offsets<SqlServerPartition, SqlServerOffsetContext> streamingOffsets)
+            throws InterruptedException {
+
+        // TODO: Determine how to do incremental snapshots with multiple partitions but for now just use the first offset
+        SqlServerOffsetContext offsetContext = streamingOffsets.getOffsets().values().stream().findFirst().get();
+
+        initStreamEvents(offsetContext);
+        final Metronome metronome = Metronome.sleeper(pollInterval, clock);
+
+        LOGGER.info("Starting streaming");
+
+        while (context.isRunning()) {
+            boolean streamedEvents = false;
+            for (Map.Entry<SqlServerPartition, SqlServerOffsetContext> entry : streamingOffsets) {
+                SqlServerPartition partition = entry.getKey();
+                SqlServerOffsetContext previousOffset = entry.getValue();
+
+                if (context.isRunning()) {
+                    if (streamingSource.executeIteration(context, partition, previousOffset)) {
+                        streamedEvents = true;
+                    }
+                }
+            }
+
+            if (!streamedEvents) {
+                metronome.pause();
+            }
+        }
+
+        LOGGER.info("Finished streaming");
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -115,7 +115,7 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
                 metadataProvider,
                 schemaNameAdjuster);
 
-        ChangeEventSourceCoordinator<SqlServerPartition, SqlServerOffsetContext> coordinator = new ChangeEventSourceCoordinator<>(
+        ChangeEventSourceCoordinator<SqlServerPartition, SqlServerOffsetContext> coordinator = new SqlServerChangeEventSourceCoordinator(
                 offsets,
                 errorHandler,
                 SqlServerConnector.class,
@@ -123,7 +123,8 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
                 new SqlServerChangeEventSourceFactory(connectorConfig, dataConnection, metadataConnection, errorHandler, dispatcher, clock, schema),
                 new DefaultChangeEventSourceMetricsFactory(),
                 dispatcher,
-                schema);
+                schema,
+                clock);
 
         coordinator.start(taskContext, this.queue, metadataProvider);
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingExecutionContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingExecutionContext.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Keeps track of the current execution context a partition has while streaming events.
+ *
+ * @author Jacob Gminder
+ *
+ */
+public class SqlServerStreamingExecutionContext {
+    private final Queue<SqlServerChangeTable> schemaChangeCheckpoints;
+    private final AtomicReference<SqlServerChangeTable[]> tablesSlot;
+    private TxLogPosition lastProcessedPosition;
+    private final AtomicBoolean changesStoppedBeingMonotonic;
+    private boolean shouldIncreaseFromLsn;
+
+    public SqlServerStreamingExecutionContext(PriorityQueue<SqlServerChangeTable> schemaChangeCheckpoints, AtomicReference<SqlServerChangeTable[]> tablesSlot,
+                                              TxLogPosition changePosition, AtomicBoolean changesStoppedBeingMonotonic, boolean snapshotCompleted) {
+        this.schemaChangeCheckpoints = schemaChangeCheckpoints;
+        this.tablesSlot = tablesSlot;
+        this.changesStoppedBeingMonotonic = changesStoppedBeingMonotonic;
+        this.shouldIncreaseFromLsn = snapshotCompleted;
+        this.lastProcessedPosition = changePosition;
+    }
+
+    public void setShouldIncreaseFromLsn(boolean shouldIncreaseFromLsn) {
+        this.shouldIncreaseFromLsn = shouldIncreaseFromLsn;
+    }
+
+    public Queue<SqlServerChangeTable> getSchemaChangeCheckpoints() {
+        return schemaChangeCheckpoints;
+    }
+
+    public AtomicReference<SqlServerChangeTable[]> getTablesSlot() {
+        return tablesSlot;
+    }
+
+    public TxLogPosition getLastProcessedPosition() {
+        return lastProcessedPosition;
+    }
+
+    public void setLastProcessedPosition(TxLogPosition lastProcessedPosition) {
+        this.lastProcessedPosition = lastProcessedPosition;
+    }
+
+    public AtomicBoolean getChangesStoppedBeingMonotonic() {
+        return changesStoppedBeingMonotonic;
+    }
+
+    public boolean getShouldIncreaseFromLsn() {
+        return shouldIncreaseFromLsn;
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/StreamingChangeEventSource.java
@@ -43,6 +43,26 @@ public interface StreamingChangeEventSource<P extends Partition, O extends Offse
     void execute(ChangeEventSourceContext context, P partition, O offsetContext) throws InterruptedException;
 
     /**
+     * Executes this source for a single execution iteration. This is useful for iterating over multiple partitions and performing
+     * an action if events were processed. For example, pausing a connector once no events were produced after iterating over all
+     * partitions. Implementations should regularly check via the given context if they should stop. If that's
+     * the case, they should abort their processing and perform any clean-up needed, such as rolling back pending
+     * transactions, releasing locks etc.
+     *
+     * @param context
+     *            contextual information for this source's execution
+     * @param partition
+     *            the source partition from which the changes should be streamed
+     * @param offsetContext
+     * @return true if events were processed during the iteration or false otherwise.
+     * @throws InterruptedException
+     *             in case the snapshot was aborted before completion
+     */
+    default boolean executeIteration(ChangeEventSourceContext context, P partition, O offsetContext) throws InterruptedException {
+        throw new UnsupportedOperationException("Currently unsupported by the connector");
+    }
+
+    /**
      * Commits the given offset with the source database. Used by some connectors
      * like Postgres and Oracle to indicate how far the source TX log can be
      * discarded.


### PR DESCRIPTION
This moves the poll interval logic of the `SqlServerStreamingChangeEventSource` to a new `SqlServerChangeEventSourceCoordinator` class in order to support iterating over multiple partitions.