### PR TITLE
WIP: DBZ-3457 Edit incremental snapshot doc for downstream use

### DIFF
--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -2540,7 +2540,6 @@ public class OracleConnectorIT extends AbstractConnectorTest {
             waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
 
             SourceRecords records = consumeRecordsByTopic(1);
-            System.out.println(records.topics());
             assertThat(records.recordsForTopic("server1.DEBEZIUM.DBZ3611")).hasSize(1);
 
             SourceRecord record = records.recordsForTopic("server1.DEBEZIUM.DBZ3611").get(0);
@@ -2551,7 +2550,9 @@ public class OracleConnectorIT extends AbstractConnectorTest {
             waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
 
             connection.execute("INSERT INTO dbz3611 values (2, 'streaming')");
-            waitForCurrentScnToHaveBeenSeenByConnector();
+
+            records = consumeRecordsByTopic(1);
+            assertThat(records.recordsForTopic("server1.DEBEZIUM.DBZ3611")).hasSize(1);
 
             assertNoRecordsToConsume();
         }
@@ -2586,7 +2587,6 @@ public class OracleConnectorIT extends AbstractConnectorTest {
             waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
 
             SourceRecords records = consumeRecordsByTopic(1);
-            System.out.println(records.topics());
             assertThat(records.recordsForTopic("server1.DEBEZIUM.DBZ3611")).hasSize(1);
 
             SourceRecord record = records.recordsForTopic("server1.DEBEZIUM.DBZ3611").get(0);
@@ -2597,7 +2597,9 @@ public class OracleConnectorIT extends AbstractConnectorTest {
             waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
 
             connection.execute("INSERT INTO dbz3611 values (2, 'streaming')");
-            waitForCurrentScnToHaveBeenSeenByConnector();
+
+            records = consumeRecordsByTopic(1);
+            assertThat(records.recordsForTopic("server1.DEBEZIUM.DBZ3611")).hasSize(1);
 
             assertNoRecordsToConsume();
         }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -73,7 +73,7 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
                 x -> !(x.startsWith(DatabaseHistory.CONFIGURATION_FIELD_PREFIX_STRING) || x.equals(HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY.name())))
                 .subset("database.", true);
         dataConnection = new SqlServerConnection(jdbcConfig, connectorConfig.getSourceTimestampMode(), valueConverters, () -> getClass().getClassLoader(),
-                connectorConfig.getSkippedOperations(), connectorConfig.isMultiPartitionModeEnabled());
+                connectorConfig.getSkippedOperations(), connectorConfig.isMultiPartitionModeEnabled(), connectorConfig.getOptionRecompile());
         metadataConnection = new SqlServerConnection(jdbcConfig, connectorConfig.getSourceTimestampMode(), valueConverters, () -> getClass().getClassLoader(),
                 connectorConfig.getSkippedOperations(), connectorConfig.isMultiPartitionModeEnabled());
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/IncrementalSnapshotWithRecompileIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/IncrementalSnapshotWithRecompileIT.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import java.sql.SQLException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+
+import io.debezium.config.Configuration.Builder;
+import io.debezium.connector.sqlserver.SqlServerConnectorConfig.SnapshotMode;
+import io.debezium.connector.sqlserver.util.TestHelper;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.junit.SkipTestRule;
+import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotTest;
+import io.debezium.util.Testing;
+
+public class IncrementalSnapshotWithRecompileIT extends AbstractIncrementalSnapshotTest<SqlServerConnector> {
+
+    private SqlServerConnection connection;
+
+    @Rule
+    public SkipTestRule skipRule = new SkipTestRule();
+
+    @Before
+    public void before() throws SQLException {
+        TestHelper.createTestDatabase();
+        connection = TestHelper.testConnectionWithOptionRecompile();
+        connection.execute(
+                "CREATE TABLE a (pk int primary key, aa int)",
+                "CREATE TABLE debezium_signal (id varchar(64), type varchar(32), data varchar(2048))");
+        TestHelper.enableTableCdc(connection, "debezium_signal");
+
+        initializeConnectorTestFramework();
+        Testing.Files.delete(TestHelper.DB_HISTORY_PATH);
+    }
+
+    @After
+    public void after() throws SQLException {
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    @Override
+    protected void populateTable() throws SQLException {
+        super.populateTable();
+        TestHelper.enableTableCdc(connection, "a");
+    }
+
+    @Override
+    protected Class<SqlServerConnector> connectorClass() {
+        return SqlServerConnector.class;
+    }
+
+    @Override
+    protected JdbcConnection databaseConnection() {
+        return connection;
+    }
+
+    @Override
+    protected String topicName() {
+        return "server1.dbo.a";
+    }
+
+    @Override
+    protected String tableName() {
+        return "testDB.dbo.a";
+    }
+
+    @Override
+    protected String signalTableName() {
+        return "dbo.debezium_signal";
+    }
+
+    @Override
+    protected Builder config() {
+        return TestHelper.defaultConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
+                .with(SqlServerConnectorConfig.SIGNAL_DATA_COLLECTION, "testDB.dbo.debezium_signal")
+                .with(SqlServerConnectorConfig.INCREMENTAL_SNAPSHOT_OPTION_RECOMPILE, true);
+    }
+}

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -244,6 +244,17 @@ public class TestHelper {
                 Collections.emptySet(), true);
     }
 
+    public static SqlServerConnection testConnectionWithOptionRecompile() {
+        Configuration config = defaultJdbcConfig()
+                .edit()
+                .with(JdbcConfiguration.ON_CONNECT_STATEMENTS, "USE [" + TEST_DATABASE + "]")
+                .build();
+
+        return new SqlServerConnection(config, SourceTimestampMode.getDefaultMode(),
+                new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE, null), () -> TestHelper.class.getClassLoader(),
+                Collections.emptySet(), true, true);
+    }
+
     /**
      * Enables CDC for a given database, if not already enabled.
      *

--- a/debezium-core/src/main/java/io/debezium/relational/history/AbstractDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/AbstractDatabaseHistory.java
@@ -45,7 +45,7 @@ public abstract class AbstractDatabaseHistory implements DatabaseHistory {
             .withDefault(false)
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
-            .withDescription("Prefer DDL for schema reovery in case logica schema is present")
+            .withDescription("Prefer DDL for schema recovery in case logical schema is present")
             .withInvisibleRecommender()
             .withNoValidation();
 

--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -1,5 +1,7 @@
+// Category: debezium-using
+// Type: assembly
 [id="sending-signals-to-a-debezium-connector"]
-= Sending signals to a Debezium connector
+= Sending signals to a {prodname} connector
 
 :toc:
 :toc-placement: macro
@@ -8,155 +10,213 @@
 :source-highlighter: highlight.js
 
 toc::[]
-
+ifdef::[community]
 [NOTE]
 ====
 This feature is currently in incubating state, i.e. exact semantics, configuration options etc. may change in future revisions, based on the feedback we receive. Please let us know if you encounter any problems while using this extension.
 ====
 
 == Overview
-Sometimes it is necessary for the user to modify a connector behaviour or trigger a one-time action (e.g. snapshot of a single table).
-To fulfill such needs {prodname} provides a mechanism how to send a signal to a {prodname} connector to trigger an action.
-As it might be necessary to synchronize such an action with the dataflow the signal is implemented as a write to a data collection.
+endif::[community]
 
-Signalling is disabled by default.
-The name of the signalling data collection must be set via connector configuration parameter to enable the function.
-The signalling data collection must be *explictly* added among captured data collections, i.e., included in the `table.include.list` parameter.
+ifdef::[product]
+[IMPORTANT]
+====
+Signaling is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::[product]
 
-.Connector configuration
-[cols="3,9",options="header"]
-|===
-|Parameter |  Description
+The {prodname} signaling mechanism provides a way to modify the behavior of a connector, or to trigger a one-time action, such as initiating an xref:debezium-signaling-ad-hoc-snapshots[ad hoc snapshot] of a table.
+To trigger a connector to perform a specified action, you issue a SQL command to add a signal message to a specialized signaling table, also referred to as a signaling data collection.
+The signaling table, which you create on the source database, is designated exclusively for communicating with {prodname}.
+When {prodname} detects that a new xref:debezium-signaling-example-of-a-logging-signal-record[logging record] or xref:debezium-signaling-example-of-an-ad-hoc-signal-record[ad hoc snapshot record] is added to the signaling table, it reads the signal, and initiates the requested operation.
 
-|`signal.data.collection`
-|Fully-qualified name of data collection. +
-The name format is connector specific, e.g. `"some_schema.debezium_signals"` in case of the {prodname} Postgres connector. +
-For SQL Server it should be formatted as `"some_database.some_schema.debezium_signals"`.
+Signaling is available for use with the following {prodname} connectors:
 
-|===
+* Db2
+* MySQL
+ifdef::[community]
+* Oracle
+endif::[community]
+* PostgreSQL
+* SQL Server
 
 
-=== Data collection structure
+// Type: procedure
+// Title: Enabling {prodname} signaling
+[id="debezium-signaling-enabling-signaling"]
+== Enabling signaling
 
-The signalling data collection must conform to a required format:
-It must contain three fields;
-the naming of the fields is arbitrary and only order of the field is important.
-It is recommended but not mandatory to use the field names as defined in the table below:
+By default, the {prodname} signaling mechanism is disabled.
+You must explicitly enable signaling for each connector that you want to use it with.
 
-.Signalling data collection structure
+.Procedure
+
+. On the source database, create a signaling data collection table for sending signals to the connector
+  For information about the required structure of the signaling data collection, see xref:{link-signalling}#debezium-signaling-data-collection-structure[Structure of a signaling data collection].
+
+. On source databases that implement a native change data capture (CDC) mechanism, such as Db2 or SQL Server, enable CDC for the signaling table.
+
+. Add the name of the signaling data collection to the {prodname} connector configuration. +
+  In the connector configuration, add the property `signal.data.collection`, and set its value to the fully-qualified name of the signaling data collection that you created in Step 1.
+  Use one of the following fully-qualified name formats depending on your connector:
+
+
+ifdef::[community]
+Db2, Oracle, or PostgreSQL:: `_<schemaName>_._<tableName>_`
+endif::[community]
+ifdef::[product]
+Db2 or PostgreSQL:: `_<schemaName>_._<tableName>_`
+endif::product[]
+MySQL:: `_<databaseName>_._<tableName>_`
+SQL Server:: `_<databaseName>_._<schemaName>_._<tableName>_` +
+ +
+For example, `inventory.debezium_signals`. +
+ +
+For more information about setting the `signal.data.collection` property, see the table of configuration properties for your connector.
+. Add the signaling table to the list of tables to monitor. +
+  In the configuration for the {prodname} connector, add the name of the data collection that you created in Step 1 to the `table.include.list` property. +
+ +
+For more information about the `table.include.list` property, see the table of configuration properties for your connector.
+
+// Type: reference
+// ModuleID: debezium-signaling-required-structure-of-a-signaling-data-collection
+// Title: Required structure of a {prodname} signaling data collection
+[id="debezium-signaling-data-collection-structure"]
+=== Structure of a signaling data collection
+
+A signaling data collection, or signaling table, stores signals that users send to trigger a connector to perform a specified operation.
+
+Records in a signaling tables must conform to the following standard format.
+
+* Contain three fields (columns).
+* Fields are arranged in a specific order, as shown in xref:debezium-signaling-required-structure-of-a-signaling-data-collection[Table 1].
++
+NOTE: The column names in a data collection are arbitrary.
+The following table provides suggested column names.
+If you use a different naming scheme, ensure that the values in each field are consistent with the intended content.
+
+[id="debezium-signaling-required-structure-of-a-signaling-data-collection"]
+.Required structure of a signaling data collection
 [cols="1,1,9",options="header"]
 |===
 |Column | Type | Description
 
-|`id`
-|`string` +
+|`id` +
 (required)
-|A unique identifier of this signal instance. +
-It can be used for logging, debugging or deduplication.
-Usually an UUID string.
+|`string`
 
-|`type`
-|`string` +
+|An arbitrary unique string that identifies a signal instance. +
+You assign an `id` to each signal that you submit to the signaling table. +
+Typically the ID is a UUID string. +
+You can use signal instances for logging, debugging, or de-duplication. +
+// When {prodname} runs the requested operation, it generates a signal message with an arbitrary `id` string that is unrelated to the string in the submitted signal.
+
+|`type` +
 (required)
-|The type of the signal to be sent. +
-There are signals common for all connectors or specific to a subset of connectors.
+|`string`
 
-|`data`
-|`string` +
+|Specifies the type of signal to send. +
+You can use some signal types with any connector for which signaling is available, while other signal types are available for specific connectors only.
+
+|`data` +
 (optional)
-|JSON formatted parameters that are passed to a signal action. +
-Each signal has its own expected set of data.
+|`string`
+
+|Specifies JSON-formatted parameters to pass to a signal action. +
+Each signal type requires a specific set of data.
 
 |===
 
-Such table could be created with a DDL command similar to:
+// Type: procedure
+// Title: Creating a {prodname} signaling data collection
+[id="debezium-signaling-creating-a-signal-data-collection"]
+=== Creating a signaling data collection
 
+You create a signaling table by submitting a standard SQL DDL query to the source database.
+
+.Prerequisites
+
+* You have sufficient access privileges to create a table on the target database.
+
+.Procedure
+
+* Submit a SQL query to the source database to create a table that is consistent with the xref:debezium-signaling-required-structure-of-a-signaling-data-collection[required structure], as shown in the following example: +
+
+[source,sql, options="nowrap" subs="+quotes"]
+----
+CREATE TABLE _<tableName>_ (id VARCHAR(_<varcharValue>_) PRIMARY KEY, type VARCHAR(__<varcharValue>__) NOT NULL, data VARCHAR(_<varcharValue>_) NULL);
+----
+
+[NOTE]
+====
+The space that you allocate to the `id` variable must be sufficient to accommodate the size of the ID strings of signals sent to the signaling table. +
+If the size of an ID exceeds the available space, the connector cannot process the signal.
+====
+
+The following example shows a `CREATE TABLE` command that creates a three-column `debezium_signal` table: +
+ +
 [source,sql]
 ----
 CREATE TABLE debezium_signal (id VARCHAR(42) PRIMARY KEY, type VARCHAR(32) NOT NULL, data VARCHAR(2048) NULL);
 ----
 
-.Example of a signal record
-[cols="1,9",options="header"]
+// Type: concept
+// ModuleID: debezium-signaling-types-of-signal-actions
+// Title: Types of {prodname} signal actions
+== Signal actions
+
+You can use signaling to initiate the following actions:
+
+* xref:debezium-signaling-logging[Add messages to the log].
+* xref:debezium-signaling-triggering-incremental-snapshots[Trigger ad hoc snapshots].
+
+You can use the preceding signals with all of the {prodname} connectors that are compatible with signaling.
+
+// Type: concept
+[id="debezium-signaling-logging"]
+=== Logging signals
+
+You can request a connector to add an entry to the log by creating a signaling table entry with the `log` signal type.
+After processing the signal, the connector prints the specified message to the log.
+Optionally, you can configure the signal so that the resulting message includes the streaming coordinates.
+
+[id="debezium-signaling-example-of-a-logging-record"]
+.Example of a signaling record for adding a log message
+[cols="1,9,9",options="header"]
 |===
-|Column | Value
+|Column | Value | Description
 
 |id
 |`924e3ff8-2245-43ca-ba77-2af9af02fa07`
+|
 
 |type
 |`log`
+|The action type of the signal.
 
 |data
 |`{"message": "Signal message at offset {}"}`
-
+| The `message` parameter specifies the string to print to the log. +
+If you add a placeholder (`{}`) to the message, it is replaced with streaming coordinates.
 |===
 
+// Type: concept
+[id="debezium-signaling-ad-hoc-snapshots"]
+=== Ad hoc snapshot signals
 
-== Signal Actions
+You can request a connector to initiate an ad hoc snapshot by creating a signaling table entry with the `execute-snapshot` signal type.
+After processing the signal, the connector runs the requested snapshot operation.
 
-These signals are common to all connectors
+Unlike the initial snapshot that a connector runs after it first starts, an ad hoc snapshot occurs during runtime, after the connector has already begun to stream change events from a database.
+You can initiate ad hoc snapshots at any time.
 
-=== Logging
-
-The type of the logging action is `log`.
-It will print a provided message to the log optionally including streaming position.
-
-.Action parameters
-[cols="1,9",options="header"]
-|===
-|Name | Description
-
-|message
-|The string printed to the log. +
-If a placeholder `{}` is added to the message it will be replaced with streaming coordinates.
-
-|===
-
-.Example of a logging record
-[cols="1,9",options="header"]
-|===
-|Column | Value
-
-|id
-|`924e3ff8-2245-43ca-ba77-2af9af02fa07`
-
-|type
-|`log`
-
-|data
-|`{"message": "Signal message at offset {}"}`
-
-|===
-
-
-=== Triggering an Incremental Snapshot
-*Available for MySQL, PostgresSQL, Oracle, SQL Server and Db2 connectors*
-
-The type of the action is `execute-snapshot`.
-It will start an incremental snapshot operation. The operation first reads the first and last primary key values and use those as start and end point for each table.
-
-==== Optional Connector Configuration
-`incremental.snapshot.chunk.size`: Integer value. The number of rows collected at each fetch operation on the database.
-
-
-.Action parameters
-[cols="3,9",options="header", source, adoc]
-|===
-|Name | Description
-
-|data-collections
-a|The list of data collections to be snapshoted. +
-Formatting should be: +
-
-* MySQL: `"some_database.some_table"`
-* PostgresSQL and Db2: `"some_schema.some_table"`
-* SQL Server: `"some_database.some_schema.some_table"`
-* Oracle: `"some_schema.some_table"`
-
-|===
-
-.Example of executing an incremental snapshot
+[id="debezium-signaling-example-of-an-ad-hoc-signal-record"]
+.Example of an ad hoc snapshot signal record
 [cols="1,9",options="header"]
 |===
 |Column | Value
@@ -171,3 +231,49 @@ Formatting should be: +
 |`{"data-collections": ["public.MyFirstTable", "public.MySecondTable"]}`
 
 |===
+
+Currently, the `execute-snapshot` action type triggers xref:debezium-signaling-incremental-snapshots[incremental snapshots] only.
+
+For more information about ad hoc snapshots, see the _Snapshots_ topic in the documentation for your connector.
+
+.Additional resources
+
+* xref:{link-db2-connector}#{db2}-ad-hoc-snapshots[Db2 connector ad hoc snapshots]
+* xref:{link-mysql-connector}#{mysql}-ad-hoc-snapshots[MySQL connector ad hoc snapshots]
+ifdef::[community]
+* xref:{link-oracle-connector}#{oracle}-ad-hoc-snapshots[Oracle connector ad hoc snapshots]
+endif::[community]
+* xref:{link-postgresql-connector}#{postgresql}-ad-hoc-snapshots[PostgreSQL connector ad hoc snapshots]
+* xref:{link-sqlserver-connector}#{sqlserver}-ad-hoc-snapshots[SQL Server connector ad hoc snapshots]
+
+// Type: concept
+[id="debezium-signaling-incremental-snapshots"]
+==== Incremental snapshots
+
+Incremental snapshots are a specific type of ad hoc snapshot.
+In an incremental snapshot, the connector captures the baseline state of the tables that you specify, similar to an initial snapshot.
+However, unlike an initial snapshot, an incremental snapshot captures tables in chunks, rather than all at once.
+The connector uses a watermarking method to track the progress of the snapshot.
+
+By capturing the initial state of the specified tables in chunks rather than in a single monolithic operation, incremental snapshots provide the following advantages over the initial snapshot process:
+
+* While the connector captures the baseline state of the specified tables, streaming of near real-time events from the transaction log continues uninterrupted.
+* If the incremental snapshot process is interrupted, it can be resumed from the point at which it stopped.
+* You can initiate an incremental snapshot at any time.
+
+The incremental snapshot concurrently captures events records directly from tables and from the transaction log.
+All of the records for a specified table are streamed to the same destination Kafka topic, both for the `READ`events that connector obtains through the snapshot process and the `UPDATE` and `DELETE` records that it captures from the transaction log.
+For each snapshot chunk, {prodname} buffers the two sets of records in memory and then compares the records that have the same primary key.
+The connector writes only the most recent version of a record to the destination topic. 
+
+For more information about incremental snapshots, see the _Snapshots_ topic in the documentation for your connector.
+
+.Additional resources
+
+* xref:{link-db2-connector}#{db2}-incremental-snapshots[Db2 connector incremental snapshots]
+* xref:{link-mysql-connector}#{mysql}-incremental-snapshots[MySQL connector incremental snapshots]
+ifdef::[community]
+* xref:{link-oracle-connector}#{oracle}-incremental-snapshots[Oracle connector incremental snapshots]
+endif::[community]
+* xref:{link-postgresql-connector}#{postgresql}-incremental-snapshots[PostgreSQL connector incremental snapshots]
+* xref:{link-sqlserver-connector}#{sqlserver}-incremental-snapshots[SQL Server connector incremental snapshots]

--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -62,9 +62,12 @@ You must explicitly enable signaling for each connector that you want to use it 
 . On source databases that implement a native change data capture (CDC) mechanism, such as Db2 or SQL Server, enable CDC for the signaling table.
 
 . Add the name of the signaling data collection to the {prodname} connector configuration. +
-  In the connector configuration, add the property `signal.data.collection`, and set its value to the fully-qualified name of the signaling data collection that you created in Step 1.
-  Use one of the following fully-qualified name formats depending on your connector:
-
+  In the connector configuration, add the property `signal.data.collection`, and set its value to the fully-qualified name of the signaling data collection that you created in Step 1. +
+ +
+For example, `signal.data.collection = inventory.debezium_signals`. +
+ +
+The format for the fully-qualified name of the signaling collection depends on which connector you use. +
+See the following list to find the naming format to use with your connector:
 
 ifdef::[community]
 Db2, Oracle, or PostgreSQL:: `_<schemaName>_._<tableName>_`
@@ -74,8 +77,6 @@ Db2 or PostgreSQL:: `_<schemaName>_._<tableName>_`
 endif::product[]
 MySQL:: `_<databaseName>_._<tableName>_`
 SQL Server:: `_<databaseName>_._<schemaName>_._<tableName>_` +
- +
-For example, `inventory.debezium_signals`. +
  +
 For more information about setting the `signal.data.collection` property, see the table of configuration properties for your connector.
 . Add the signaling table to the list of tables to monitor. +
@@ -90,15 +91,10 @@ For more information about the `table.include.list` property, see the table of c
 === Structure of a signaling data collection
 
 A signaling data collection, or signaling table, stores signals that users send to trigger a connector to perform a specified operation.
-
-Records in a signaling tables must conform to the following standard format.
+The structure of the signaling table must conform to the following standard format.
 
 * Contain three fields (columns).
 * Fields are arranged in a specific order, as shown in xref:debezium-signaling-required-structure-of-a-signaling-data-collection[Table 1].
-+
-NOTE: The column names in a data collection are arbitrary.
-The following table provides suggested column names.
-If you use a different naming scheme, ensure that the values in each field are consistent with the intended content.
 
 [id="debezium-signaling-required-structure-of-a-signaling-data-collection"]
 .Required structure of a signaling data collection
@@ -132,6 +128,10 @@ Each signal type requires a specific set of data.
 
 |===
 
+NOTE: The column names in a data collection are arbitrary.
+The preceding table provides suggested column names.
+If you use a different naming scheme, ensure that the values in each field are consistent with the intended content.
+
 // Type: procedure
 // Title: Creating a {prodname} signaling data collection
 [id="debezium-signaling-creating-a-signal-data-collection"]
@@ -146,20 +146,17 @@ You create a signaling table by submitting a standard SQL DDL query to the sourc
 .Procedure
 
 * Submit a SQL query to the source database to create a table that is consistent with the xref:debezium-signaling-required-structure-of-a-signaling-data-collection[required structure], as shown in the following example: +
-
-[source,sql, options="nowrap" subs="+quotes"]
-----
-CREATE TABLE _<tableName>_ (id VARCHAR(_<varcharValue>_) PRIMARY KEY, type VARCHAR(__<varcharValue>__) NOT NULL, data VARCHAR(_<varcharValue>_) NULL);
-----
+ +
+`CREATE TABLE _<tableName>_ (id VARCHAR(_<varcharValue>_) PRIMARY KEY, type VARCHAR(__<varcharValue>__) NOT NULL, data VARCHAR(_<varcharValue>_) NULL);` +
 
 [NOTE]
 ====
-The space that you allocate to the `id` variable must be sufficient to accommodate the size of the ID strings of signals sent to the signaling table. +
+Allocate enough space in the `VARCHAR` parameter for the `id` variable to accommodate the size of the ID strings of signals sent to the signaling table. +
 If the size of an ID exceeds the available space, the connector cannot process the signal.
 ====
 
-The following example shows a `CREATE TABLE` command that creates a three-column `debezium_signal` table: +
- +
+The following example shows a `CREATE TABLE` command that creates a three-column `debezium_signal` table:
+
 [source,sql]
 ----
 CREATE TABLE debezium_signal (id VARCHAR(42) PRIMARY KEY, type VARCHAR(32) NOT NULL, data VARCHAR(2048) NULL);
@@ -264,7 +261,7 @@ By capturing the initial state of the specified tables in chunks rather than in 
 The incremental snapshot concurrently captures events records directly from tables and from the transaction log.
 All of the records for a specified table are streamed to the same destination Kafka topic, both for the `READ`events that connector obtains through the snapshot process and the `UPDATE` and `DELETE` records that it captures from the transaction log.
 For each snapshot chunk, {prodname} buffers the two sets of records in memory and then compares the records that have the same primary key.
-The connector writes only the most recent version of a record to the destination topic. 
+The connector writes only the most recent version of a record to the destination topic.
 
 For more information about incremental snapshots, see the _Snapshots_ topic in the documentation for your connector.
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -123,6 +123,16 @@ The level of the lock is determined by the `snapshot.isolation.mode` connector  
 .. Emits each _read_ event to the Kafka topic that has the same name as the table.
 . Records the successful completion of the snapshot in the connector offsets.
 
+// Type: concept
+// ModuleID: debezium-{context}-ad-hoc-snapshots
+[id="{context}-ad-hoc-snapshot"]
+==== Ad hoc snapshots
+include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
+
+// Type: concept
+// ModuleID: debezium-{context}-incremental-snapshots
+[id="{context}-incremental-snapshots"]
+==== Incremental snapshots
 include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
 
 // Type: concept
@@ -2149,6 +2159,41 @@ Heartbeat messages are useful when there are many updates in a database that is 
 |`__debezium-heartbeat`
 |Specifies the prefix for the name of the topic to which the connector sends heartbeat messages. The format for this topic name is  `<heartbeat.topics.prefix>.<server.name>`.
 
+|[[db2-property-incremental-snapshot-chunk-size]]<<db2-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
+|1024
+|The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
+The value determines the number of rows that the snapshot collects during each fetch operation on the database.
+Increasing the chunk size causes the snapshot to run a smaller total number of larger snapshot queries.
+An increased chunk size requires a greater amount of memory to buffer the data.
+Test different chunk size values to determine the value that works best in your environment.
+ifdef::[product]
+[IMPORTANT]
+====
+Incremental snapshots is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::[product]
+
+|[[db2-property-signal-data-collection]]<<db2-property-signal-data-collection,`+signal.data.collection+`>>
+|No default value
+a|Fully-qualified name of the data collection that is used to send signals to the connector. +
+Use the following format to specify the collection name: +
+`_<schemaName>_._<tableName>_`
+
+ifdef::[product]
+[IMPORTANT]
+====
+Signaling is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::[product]
+
 |[[db2-property-snapshot-delay-ms]]<<db2-property-snapshot-delay-ms, `+snapshot.delay.ms+`>>
 |No default
 |An interval in milliseconds that the connector should wait before performing a snapshot when the connector starts. If you are starting multiple connectors in a cluster, this property is useful for avoiding snapshot interruptions, which might cause re-balancing of connectors.
@@ -2213,11 +2258,6 @@ In the resulting snapshot, the connector includes only the records for which `de
 | comma-separated list of operation types that will be skipped during streaming.
 The operations include: `c` for inserts/create, `u` for updates, and `d` for deletes.
 By default, no operations are skipped.
-
-|[[db2-property-signal-data-collection]]<<db2-property-signal-data-collection, `+signal.data.collection+`>>
-|No default
-| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}[signals] to the connector.
-The name format is _schema-name.table-name_.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2163,9 +2163,9 @@ Heartbeat messages are useful when there are many updates in a database that is 
 |1024
 |The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
 The value determines the number of rows that the snapshot collects during each fetch operation on the database.
-Increasing the chunk size causes the snapshot to run a smaller total number of larger snapshot queries.
-An increased chunk size requires a greater amount of memory to buffer the data.
-Test different chunk size values to determine the value that works best in your environment.
+Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
+However, larger chunk sizes also require more memory to buffer the snapshot data.
+Adjust the chunk size to a value that provides the best performance in your environment.
 ifdef::[product]
 [IMPORTANT]
 ====

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2664,9 +2664,9 @@ endif::community[]
 |1024
 |The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
 The value determines the number of rows that the snapshot collects during each fetch operation on the database.
-Increasing the chunk size causes the snapshot to run a smaller total number of larger snapshot queries.
-An increased chunk size requires a greater amount of memory to buffer the data.
-Test different chunk size values to determine the value that works best in your environment.
+Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
+However, larger chunk sizes also require more memory to buffer the snapshot data.
+Adjust the chunk size to a value that provides the best performance in your environment.
 
 ifdef::[product]
 [IMPORTANT]

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -481,30 +481,47 @@ a|Records the completed snapshot in the connector offsets.
 
 |===
 
+// Type: concept
+// ModuleID: debezium-{context}-ad-hoc-snapshots
+[id="{context}-ad-hoc-snapshot"]
+==== Ad hoc snapshots
 include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
 
-==== Read-only Incremental snapshot
+// Type: concept
+// ModuleID: debezium-{context}-incremental-snapshots
+[id="{context}-incremental-snapshots"]
+==== Incremental snapshots
+include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
 
-The MySql connector supports Incremental snapshot with read-only connection to the database.
-It's achieved by using executed GTID set as high and low watermarks.
-The state of chunk's window gets updated by comparing GTIDs of binlog events or server's heartbeats against low and high watermarks.
 
-To switch to read-only implementation set {link-prefix}:{link-mysql-connector}#mysql-property-read-only[read.only] to `true`.
+// Type: concept
+// ModuleID: debezium-{context}-read-only-incremental-snapshots
+[id="{context-read-only-incremental-snapshots"]
+==== Read-only incremental snapshots
+
+The MySQL connector allows for running incremental snapshots with a read-only connection to the database.
+To run an incremental snapshot with read-only access, the connector uses the executed global transaction IDs (GTID) set as high and low watermarks.
+The state of a chunk's window is updated by comparing the GTIDs of binary log (binlog) events or the server's heartbeats against low and high watermarks.
+
+To switch to a read-only implementation, set the value of the {link-prefix}:{link-mysql-connector}#mysql-property-read-only[`read.only`] property to `true`.
 
 .Prerequisites
 
-* {link-prefix}:{link-mysql-connector}#enable-mysql-gtids[`enable-mysql-gtids`]
-* If connector is reading from a replica, then for multithreaded replicas (replicas on which `replica_parallel_workers` is set to a value greater than 0)
-it's required to set `replica_preserve_commit_order=1` or `slave_preserve_commit_order=1`
+* {link-prefix}:{link-mysql-connector}#enable-mysql-gtids[Enable MySQL GTIDs].
+* If the connector reads from a multi-threaded replica (that is, a replica for which the value of `replica_parallel_workers` is greater than `0`)
+you must set one of the following options:
 
-==== Ad-hoc read-only Incremental snapshot
+** `replica_preserve_commit_order=ON`
+** `slave_preserve_commit_order=ON`
 
-An alternative way to {link-prefix}:{link-signalling}[signalling table] mechanism to execute a new snapshot when the MySQL connection is read-only is to send a message to the Kafka topic configured with
-{link-prefix}:{link-mysql-connector}#mysql-property-signal-kafka-topic[signal.kafka.topic] property.
+==== Ad hoc read-only incremental snapshots
 
-The key of the Kafka message has to match the connector's name.
+When the MySQL connection is read-only, the {link-prefix}:{link-signalling}[signaling table] mechanism can also run a snapshot by sending a message to the Kafka topic that is specified in
+the {link-prefix}:{link-mysql-connector}#mysql-property-signal-kafka-topic[signal.kafka.topic] property.
 
-The value is a json with `type` and `data` fields.
+The key of the Kafka message must match the name of the connector.
+
+The value is a JSON object with `type` and `data` fields.
 
 The signal type is `execute-snapshot` and the `data` field must have the following fields:
 
@@ -527,20 +544,23 @@ The format of the names is the same as for {link-prefix}:#{context}-property-sig
 
 An example of the execute-snapshot Kafka message:
 
+----
 Key = `test_connector`
 
 Value = `{"type":"execute-snapshot","data": {"data-collections": ["schema1.table1", "schema1.table2"], "type": "INCREMENTAL"}}`
+----
 
 ifdef::community[]
 
 // Type: continue
 [id="mysql-snapshot-events"]
 === Operation type for snapshot events
-The MySql connector emits snapshot events using the "r" operation type (`READ`). In case you want the connector to emit snapshot events as "c" events (`CREATE`, as done incorrectly in earlier versions), this can be achieved using a Simple Message Transforms (SMT).
-Configure the Debezium `ReadToInsertEvent` SMT by adding the SMT configuration details to your connector’s configuration.
+The MySQL connector emits snapshot events using the "r" operation type (`READ`).
+If you prefer that the connector emits snapshot events as "c" events (`CREATE`), you can configure the {prodname} `ReadToInsertEvent` single message transform (SMT) to modify the event type.
 
-An example of the configuration is this:
+The following example shows how to configure the SMT:
 
+.Example: Using the `ReadToInsertEvent` SMT to change the type of snapshot events
 ----
 transforms=snapshotasinsert,...
 transforms.snapshotasinsert.type=io.debezium.connector.mysql.transforms.ReadToInsertEvent
@@ -2639,6 +2659,43 @@ If the size of the transaction is larger than the buffer then {prodname} must re
  +
 NOTE: This feature is incubating. Feedback is encouraged. It is expected that this feature is not completely polished.
 endif::community[]
+
+|[[mysql-property-incremental-snapshot-chunk-size]]<<mysql-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
+|1024
+|The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
+The value determines the number of rows that the snapshot collects during each fetch operation on the database.
+Increasing the chunk size causes the snapshot to run a smaller total number of larger snapshot queries.
+An increased chunk size requires a greater amount of memory to buffer the data.
+Test different chunk size values to determine the value that works best in your environment.
+
+ifdef::[product]
+[IMPORTANT]
+====
+Incremental snapshots is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::[product]
+
+|[[mysql-property-signal-data-collection]]<<mysql-property-signal-data-collection,`+signal.data.collection+`>>
+|No default value
+a|Fully-qualified name of the data collection that is used to send signals to the connector. +
+Use the following format to specify the collection name: +
+`_<databaseName>_._<tableName>_`
+
+ifdef::[product]
+[IMPORTANT]
+====
+Signaling is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::[product]
+
 |[[mysql-property-snapshot-mode]]<<mysql-property-snapshot-mode, `+snapshot.mode+`>>
 |`initial`
 |Specifies the criteria for running a snapshot when the connector starts. Possible settings are: +
@@ -2770,11 +2827,6 @@ endif::community[]
 |No default
 |Comma-separated list of operation types to skip during streaming. The following values are possible: `c` for inserts/create, `u` for updates, `d` for deletes. By default, no operations are skipped.
 
-|[[mysql-property-signal-data-collection]]<<mysql-property-signal-data-collection, `+signal.data.collection+`>>
-|No default
-| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}[signals] to the connector.
-The name format is _database-name.table-name_.
-
 |[[mysql-property-read-only]]<<mysql-property-read-only, `+read.only+`>>
 |`false`
 |Switch to alternative incremental snapshot watermarks implementation to avoid writes to signal data collection
@@ -2794,9 +2846,9 @@ The name format is _database-name.table-name_.
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 
 [id="debezium-{context}-connector-kafka-signals-configuration-properties"]
-==== {prodname} connector kafka signals configuration properties
+==== {prodname} connector Kafka signals configuration properties
 
-When MySQL connector is configured as read-only the alternative for the signalling table is the signals Kafka topic.
+When the MySQL connector is configured as read-only, the alternative for the signaling table is the signals Kafka topic.
 
 {prodname} provides a set of `signal.*` properties that control how the connector interacts with the Kafka signals topic.
 
@@ -2808,7 +2860,7 @@ The following table describes the `signal` properties.
 |Property |Default |Description
 |[[{context}-property-signal-kafka-topic]]<<{context}-property-signal-kafka-topic, `+signal.kafka.topic+`>>
 |
-|The name of the Kafka topic that connector monitors for ad-hoc signals.
+|The name of the Kafka topic that the connector monitors for ad hoc signals.
 
 |[[{context}-property-signal-kafka-bootstrap-servers]]<<{context}-property-signal-kafka-bootstrap-servers, `+signal.kafka.bootstrap.servers+`>>
 |

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2048,9 +2048,9 @@ ifdef::[community]
 |1024
 |The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
 The value determines the number of rows that the snapshot collects during each fetch operation on the database.
-Increasing the chunk size causes the snapshot to run a smaller total number of larger snapshot queries.
-An increased chunk size requires a greater amount of memory to buffer the data.
-Test different chunk size values to determine the value that works best in your environment.
+Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
+However, larger chunk sizes also require more memory to buffer the snapshot data.
+Adjust the chunk size to a value that provides the best performance in your environment.
 endif::[community[]
 ////
 ifdef::[product]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -118,7 +118,19 @@ Note this mode is only safe to be used when it is guaranteed that no schema chan
 
 |===
 
+ifdef::community[]
+// Type: concept
+// ModuleID: debezium-{context}-ad-hoc-snapshots
+[id="{context}-ad-hoc-snapshot"]
+==== Ad hoc snapshots
 include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
+
+// Type: concept
+// ModuleID: debezium-{context}-incremental-snapshots
+[id="{context}-incremental-snapshots"]
+==== Incremental snapshots
+include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
+endif::community[]
 
 // Type: concept
 // ModuleID: default-names-of-kafka-topics-that-receive-debezium-oracle-change-event-records
@@ -170,7 +182,7 @@ The payload of a schema change event message includes the following elements:
 
 `ddl`:: Provides the SQL `CREATE`, `ALTER`, or `DROP` statement that results in the schema change.
 `databaseName`:: The name of the database to which the statements are applied.
-The value of `databaseName` serves as the message key. 
+The value of `databaseName` serves as the message key.
 `tableChanges`::  A structured representation of the entire table schema after the schema change.
 The `tableChanges` field contains an array that includes entries for each column of the table.
 Because the structured representation presents data in JSON or Avro format, consumers can easily read messages without first processing them through a DDL parser.
@@ -1967,7 +1979,7 @@ Information about the properties is organized as follows:
 * xref:debezium-{context}-connector-pass-through-database-driver-configuration-properties[Pass-through database driver properties] that control the behavior of the database driver.
 
 [id="required-debezium-{context}-connector-configuration-properties"]
-==== Required {prodname} Oracle connector configuration properties
+==== {prodname} Oracle connector configuration properties
 The following configuration properties are _required_ unless a default value is available.
 
 [cols="30%a,25%a,45%a"]
@@ -2031,7 +2043,49 @@ You can set the following values:
 
 `logminer`(default):: The connector uses the native Oracle LogMiner API.
 `xstream`:: The connector uses the Oracle XStreams API.
+ifdef::[community]
+|[[oracle-property-incremental-snapshot-chunk-size]]<<oracle-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
+|1024
+|The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
+The value determines the number of rows that the snapshot collects during each fetch operation on the database.
+Increasing the chunk size causes the snapshot to run a smaller total number of larger snapshot queries.
+An increased chunk size requires a greater amount of memory to buffer the data.
+Test different chunk size values to determine the value that works best in your environment.
+endif::[community[]
+////
+ifdef::[product]
+[IMPORTANT]
+====
+Incremental snapshots is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::[product]
+////
 
+ifdef::[community]
+|[[oracle-property-signal-data-collection]]<<oracle-property-signal-data-collection,`+signal.data.collection+`>>
+|No default value
+a|Fully-qualified name of the data collection that is used to send signals to the connector. +
+Use the following format to specify the collection name: +
+`_<schemaName>_._<tableName>_`
+
+endif::[community[]
+
+////
+ifdef::[product]
+[IMPORTANT]
+====
+Signaling is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::[product]
+////
 |[[oracle-property-snapshot-mode]]<<oracle-property-snapshot-mode, `+snapshot.mode+`>>
 |_initial_
 |Specifies the mode that the connector uses to take snapshots of a captured table.
@@ -2796,7 +2850,7 @@ The Oracle connector automatically tracks and applies table schema changes by pa
 If the DDL parser encounters an incompatible statement, if needed, the connector provides an alternative way to apply the schema change.
 
 By default, the connector stops when it encountered a DDL statement that it cannot parse.
-You can use {prodname} link:/documentation/reference/configuration/signalling[signalling] to trigger the update of the database schema from such DDL statements.
+You can use {prodname} link:/documentation/reference/configuration/signalling[signaling] to trigger the update of the database schema from such DDL statements.
 
 The type of the schema update action is `schema-changes`.
 This action updates the schema of all tables enumerated in the signal parameters.

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2798,9 +2798,9 @@ The following _advanced_ configuration properties have defaults that work in mos
 |1024
 |The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
 The value determines the number of rows that the snapshot collects during each fetch operation on the database.
-Increasing the chunk size causes the snapshot to run a smaller total number of larger snapshot queries.
-An increased chunk size requires a greater amount of memory to buffer the data.
-Test different chunk size values to determine the value that works best in your environment.
+Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
+However, larger chunk sizes also require more memory to buffer the snapshot data.
+Adjust the chunk size to a value that provides the best performance in your environment.
 
 ifdef::[product]
 [IMPORTANT]

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -163,6 +163,16 @@ endif::community[]
 
 |===
 
+// Type: concept
+// ModuleID: debezium-{context}-ad-hoc-snapshots
+[id="{context}-ad-hoc-snapshot"]
+==== Ad hoc snapshots
+include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
+
+// Type: concept
+// ModuleID: debezium-{context}-incremental-snapshots
+[id="{context}-incremental-snapshots"]
+==== Incremental snapshots
 include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
 
 ifdef::community[]
@@ -2784,6 +2794,43 @@ The following _advanced_ configuration properties have defaults that work in mos
 |Default
 |Description
 
+|[[postgresql-property-incremental-snapshot-chunk-size]]<<postgresql-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
+|1024
+|The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
+The value determines the number of rows that the snapshot collects during each fetch operation on the database.
+Increasing the chunk size causes the snapshot to run a smaller total number of larger snapshot queries.
+An increased chunk size requires a greater amount of memory to buffer the data.
+Test different chunk size values to determine the value that works best in your environment.
+
+ifdef::[product]
+[IMPORTANT]
+====
+Incremental snapshots is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::[product]
+
+|[[postgresql-property-signal-data-collection]]<<postgresql-property-signal-data-collection,`+signal.data.collection+`>>
+|No default value
+a|Fully-qualified name of the data collection that is used to send signals to the connector. +
+Use the following format to specify the collection name: +
+`_<schemaName>_._<tableName>_`
+
+ifdef::[product]
+[IMPORTANT]
+====
+Signaling is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::[product]
+
+
 |[[postgresql-property-snapshot-mode]]<<postgresql-property-snapshot-mode, `+snapshot.mode+`>>
 |`initial`
 |Specifies the criteria for performing a snapshot when the connector starts: +
@@ -2982,11 +3029,6 @@ If the setting of `toasted.value.placeholder` starts with the `hex:` prefix it i
 |A comma-separated list of operation types that will be skipped during streaming.
 The operations include: `c` for inserts/create, `u` for updates, and `d` for deletes.
 By default, no operations are skipped.
-
-|[[postgresql-property-signal-data-collection]]<<postgresql-property-signal-data-collection, `+signal.data.collection+`>>
-|No default
-|Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}[signals] to the connector.
-The name format is _schema-name.table-name_.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -131,6 +131,16 @@ The level of the lock is determined by `snapshot.isolation.mode` configuration o
 The resulting initial snapshot captures the current state of each row in the tables that are enabled for CDC.
 From this baseline state, the connector captures subsequent changes as they occur.
 
+// Type: concept
+// ModuleID: debezium-{context}-ad-hoc-snapshots
+[id="{context}-ad-hoc-snapshot"]
+==== Ad hoc snapshots
+include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
+
+// Type: concept
+// ModuleID: debezium-{context}-incremental-snapshots
+[id="{context}-incremental-snapshots"]
+==== Incremental snapshots
 include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
 
 // Type: concept
@@ -196,7 +206,7 @@ Messages that the connector sends to the schema change topic contain a payload, 
 The payload of a schema change event message includes the following elements:
 
 `databaseName`:: The name of the database to which the statements are applied.
-The value of `databaseName` serves as the message key. 
+The value of `databaseName` serves as the message key.
 `tableChanges`::  A structured representation of the entire table schema after the schema change.
 The `tableChanges` field contains an array that includes entries for each column of the table.
 Because the structured representation presents data in JSON or Avro format, consumers can easily read messages without first processing them through a DDL parser.
@@ -2203,6 +2213,42 @@ The following _advanced_ configuration properties have good defaults that will w
 |Default
 |Description
 
+|[[sqlserver-property-incremental-snapshot-chunk-size]]<<sqlserver-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
+|1024
+|The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
+The value determines the number of rows that the snapshot collects during each fetch operation on the database.
+Increasing the chunk size causes the snapshot to run a smaller total number of larger snapshot queries.
+An increased chunk size requires a greater amount of memory to buffer the data.
+Test different chunk size values to determine the value that works best in your environment.
+
+ifdef::[product]
+[IMPORTANT]
+====
+Incremental snapshots is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::[product]
+
+|[[sqlserver-property-signal-data-collection]]<<sqlserver-property-signal-data-collection,`+signal.data.collection+`>>
+|No default value
+a|Fully-qualified name of the data collection that is used to send signals to the connector. +
+Use the following format to specify the collection name: +
+`_<databaseName>_._<schemaName>_._<tableName>_`
+
+ifdef::[product]
+[IMPORTANT]
+====
+Signaling is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::[product]
+
 |[[sqlserver-property-snapshot-mode]]<<sqlserver-property-snapshot-mode, `+snapshot.mode+`>>
 |_initial_
 |A mode for taking an initial snapshot of the structure and optionally data of captured tables.
@@ -2361,11 +2407,6 @@ See {link-prefix}:{link-sqlserver-connector}#sqlserver-transaction-metadata[Tran
 | comma-separated list of operation types that will be skipped during streaming.
 The operations include: `c` for inserts/create, `u` for updates, and `d` for deletes.
 By default, no operations are skipped.
-
-|[[sqlserver-property-signal-data-collection]]<<sqlserver-property-signal-data-collection, `+signal.data.collection+`>>
-|No default
-| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}[signals] to the connector.
-The name format is _database_name.schema-name.table-name_.
 
 |[[sqlserver-property-max-iteration-transactions]]<<sqlserver-property-max-iteration-transactions, `+max.iteration.transactions+`>>
 |0

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2413,6 +2413,10 @@ By default, no operations are skipped.
 |Specifies the maximum number of transactions per iteration to be used to reduce the memory footprint when streaming changes from multiple tables in a database.
 When set to `0` (the default), the connector uses the current maximum LSN as the range to fetch changes from.
 When set to a value greater than zero, the connector uses the n-th LSN specified by this setting as the range to fetch changes from.
+
+|[[sqlserver-property-incremental-snapshot-option-recompile]]<<sqlserver-property-incremental-snapshot-option-recompile, `+incremental.snapshot.option.recompile+`>>
+|`false`
+|Uses OPTION(RECOMPILE) query option to all SELECT statements used during an incremental snapshot. This can help to solve parameter sniffing issues that may occur but can cause increased CPU load on the source database, depending on the frequency of query execution.
 |===
 
 [id="debezium-{context}-connector-database-history-configuration-properties"]

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2217,9 +2217,9 @@ The following _advanced_ configuration properties have good defaults that will w
 |1024
 |The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
 The value determines the number of rows that the snapshot collects during each fetch operation on the database.
-Increasing the chunk size causes the snapshot to run a smaller total number of larger snapshot queries.
-An increased chunk size requires a greater amount of memory to buffer the data.
-Test different chunk size values to determine the value that works best in your environment.
+Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
+However, larger chunk sizes also require more memory to buffer the snapshot data.
+Adjust the chunk size to a value that provides the best performance in your environment.
 
 ifdef::[product]
 [IMPORTANT]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-ad-hoc-snapshots.adoc
@@ -1,0 +1,135 @@
+ifdef::[community]
+[NOTE]
+====
+This feature is currently in incubating state, i.e. exact semantics, configuration options etc. may change in future revisions, based on the feedback we receive.
+Please let us know if you encounter any problems while using this extension.
+====
+endif::[community]
+
+ifdef::[product]
+[IMPORTANT]
+====
+The use of ad hoc snapshots is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::[product]
+
+//You can run an ad hoc snapshot to refresh data in a topic in cases where the initial snapshot is damaged or incomplete.
+//For, example, a new snapshot might be warranted if any of the following events occur in the database:
+//* The database is restored from a backup, or requires repairs related to downstream data loss or corruption.
+//* A subset of data requires repair, for example, if a specific set of rows becomes corrupted in the downstream topic.
+
+//You initiate an ad hoc snapshot by sending a message that specifies the action type `execute-snapshot` to the signaling database.
+//When the connector processes the message, it triggers the snapshot operation.
+//The operation reads the first and last primary key values and uses those values as the start and end point for each table.
+////
+The ad hoc snapshot process differs from the initial snapshot process in the following ways:
+
+Can be triggered while the connector is running.
+Can run concurrently with streaming. Ability to re-bootstrap previously snapshotted tables by generating a new snapshot.
+Can be resumed when interrupted by a connector restart.
+Can adapt to updates in the filter configuration (include/exclude lists for captured tables)
+
+Typically, it not necessary for an applications to have access to the entire data history of a database all at once.
+Instead, they require the data to be delivered at an unspecific point of time.
+This leads to the idea of incremental snapshotting, where the snapshot is taken in parallel with streaming.
+The result will be that the streaming will be executed from start and the snapshotting will be executed in chunks, which would allow resuming of snapshot in the middle of execution.
+Signals serve as triggers to perform some action.
+You run a SQL query to insert signals into the database. When the connector reads the new signal record, the connector performs the specified action.
+////
+
+By default, a connector runs an initial snapshot operation only after it starts for the first time.
+Following this initial snapshot, the snapshot process is not repeated, and the connector captures data for subsequent change events through streaming only.
+
+However, in some situations the data that the connector obtained during the initial snapshot might become stale, lost, or incomplete.
+To provide a mechanism for recapturing table data, {prodname} includes an option to perform ad hoc snapshots.
+The following changes in a database might be cause for performing an ad hoc snapshot:
+
+* The connector configuration is modified to capture a different set of tables.
+* Kafka topics are deleted and must be rebuilt.
+* Data corruption occurs due to a configuration error or some other problem.
+
+You can re-run a snapshot for a table for which you previously captured a snapshot by initiating a so-called _ad-hoc snapshot_.
+Ad hoc snapshots require the use of {link-prefix}:{link-signalling}#sending-signals-to-a-debezium-connector[signaling tables].
+You initiate an ad hoc snapshot by sending a signal request to the {prodname} signaling table.
+
+When you initiate an ad hoc snapshot of an existing table, the connector appends content to the topic that already exists for the table.
+It does not create a new topic, unless the topic was removed.
+// To enable {prodname} to create topics automatically, xref:{link-topic-auto-creation}#customizing-debezium-automatically-created-topics[automatic topic creation] must be enabled.
+////
+For each signal record that you send to the table, you specify a name,
+Incremental snapshotting in Debezium is available in form of ad-hoc snapshots.
+Rather than configuring the connector to run a snapshot, you send a snapshot signal that triggers the connector to run a snapshot of a set of tables.
+The signal for triggering an ad hoc snapshot is called `execute-snapshot` and it uses the following message format:
+
+{"data-collections": ["<table-id-1>", "<table-id-2>", "<table-id-3>", ...]}
+
+After you request an ad hoc table snapshot, {prodname} completes the following tasks:
+
+* Obtains the largest primary key in the table; this is the snapshot endpoint, and its value is stored in the connector offsets
+* Splits the table into chunks based on the primary key’s total order.
+* Performs a snapshot of the table data in chunks - no lengthy process at the connector start, and also in case of crashes or a controlled termination of the connector, the snapshotting can be resumed since the last completed chunk.
+The default chunk size is 1,024. You can specify a different chunk size in the `incremental.snapshot.chunk.size` configuration property.
+* After the connector queries a chunk, it selects the next set of records based on the configured chunk size, whose primary keys are larger than the last one from the previous chunk (or the first primary key for the first chunk) and which are smaller or equal to the recorded maximum primary key.
+The chunk size specifies the number of rows that the snapshot collects during each fetch operation on the database.
+ You can increase the value for efficiency purposes (a smaller total number of snapshot queries will be executed), but this should be balanced with the increased memory consumption needed for the buffer. It is recommended to do some experimentation in your own environment to identify the setting working best for your situation.
+////
+
+Each signal specifies the tables to include in the snapshot.
+An ad hoc snapshot can recapture the entire contents of the database, or capture only a subset of the tables in the database.
+
+Ad hoc snapshots are available for the following {prodname} connectors:
+
+* Db2
+* MySQL
+* Oracle
+* PostgreSQL
+* SQL Server
+
+You specify the tables to capture by listing them in a signal message that you send to the signaling table.
+The signal is named `execute-snapshot` and accepts messages in the following format:
+
+.Example of an ad hoc snapshot signal record
+[cols="2,2,6",options="header"]
+|===
+|Field | Default | Value
+
+|`type`
+|`incremental`
+| Specifies the type of snapshot that you want to run. +
+Currently, you can request only xref:{context}-incremental-snapshots[`incremental` snapshots]. 
+
+
+|`data-collections`
+|_N/A_
+| An array that contains the fully-qualified names of the tables to be snapshotted. +
+The format of the names is the same as for {link-prefix}:{context}-property-signal-data-collection[signal.data.collection] configuration option.
+
+|===
+
+==== Triggering an ad hoc snapshot
+
+Send a message to the signaling database that specifies the action type `execute-snapshot`.
+After the connector processes the message, it starts the snapshot operation.
+The operation reads the first and last primary key values and uses those values as the start and end point for each table.
+
+You initiate an ad hoc snapshot by adding a signaling table entry with the `execute-snapshot` signal type.
+
+Currently, the `execute-snapshot` action type triggers xref:debezium-signaling-incremental-snapshots[incremental snapshots] only.
+
+.Prerequisites
+
+* xref:{link-signalling}#debezium-enabling-signaling"[Signaling is enabled].
+
+An example of the signal to be triggered is this:
+
+[source,sql,indent=0,subs="+attributes"]
+----
+INSERT INTO myschema.debezium_signal VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.table1", "schema1.table2"]}')
+----
+// `"INSERT INTO _<schema>_.debezium_signal VALUES ('signal-1', 'execute-snapshot', '{\"data-collections\": [\"inventory.orders\"]}')"`
+// In this release, ad hoc snapshots are limited to `"type": "incremental"`.
+//Because `incremental` is the default type.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-ad-hoc-snapshots.adoc
@@ -112,11 +112,10 @@ The format of the names is the same as for {link-prefix}:{context}-property-sign
 
 ==== Triggering an ad hoc snapshot
 
-Send a message to the signaling database that specifies the action type `execute-snapshot`.
+You initiate an ad hoc snapshot by adding a signaling table entry with the `execute-snapshot` signal type.
 After the connector processes the message, it starts the snapshot operation.
 The operation reads the first and last primary key values and uses those values as the start and end point for each table.
 
-You initiate an ad hoc snapshot by adding a signaling table entry with the `execute-snapshot` signal type.
 
 Currently, the `execute-snapshot` action type triggers xref:debezium-signaling-incremental-snapshots[incremental snapshots] only.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-incremental-snapshot.adoc
@@ -1,108 +1,203 @@
-[[{context}-adhoc-snapshot]]
-
-= Ad-hoc snapshot
-
+ifdef::[community]
 [NOTE]
 ====
-This feature is currently in incubating state, i.e. exact semantics, configuration options etc. may change in future revisions, based on the feedback we receive.
+This feature is currently in incubating state. The exact semantics, configuration options, and so forth is subject to change in future revisions, based on the feedback we receive.
 Please let us know if you encounter any problems while using this extension.
 ====
+endif::[community]
 
-When the initial snapshot is completed then it is not executed again as further data are acquired via streaming.
+ifdef::[product]
+[IMPORTANT]
+====
+The use of incremental snapshots is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::[product]
+To enable greater flexibility in managing snapshots, {prodname} includes a supplementary snapshot mechanism, known as _incremental snapshotting_.
+//a snapshot of a set of tables during the streaming phase without interrupting the streaming
+Unlike an initial snapshot, which must capture the full state of a database all at once, during an incremental snapshot {prodname} captures data in a series of configurable chunks.
+Watermarks track the progress of the capture process.
+If the the snapshot is interrupted, it refers to the watermarks to determine which tables have been snapshot and which have not. 
+In this way, the snapshot can resume from the point at which it stops, rather than repeating the capture process from the beginning.
+You can pause and resume incremental snapshots at any time.
+This ability to pause and resume snapshots is especially useful when capturing databases that include large tables.
 
-Sometimes it would be really useful to re-execute a snapshot, either completely, or for only a subset of tables.
-Examples for such use cases include:
+Because an incremental snapshot captures tables in piecemeal fashion, event streaming is not postponed for the entire time that it takes for the snapshot to complete.   
+Depending on the size and number of the tables to be captured, an initial snapshot of a large data set might require hours, or even days, to complete.  
+//Change data streaming runs continuously together with snapshotting
+With an incremental snapshot, the capture of real-time events can continue in parallel with snapshot operations on select rows.
+Neither operation blocks the other.
+That is, the connector can begin or continue to stream change events while the snapshot runs.
 
-* a new table was added into the list of captured tables
-* some of the topics were deleted and their content needs to be rebuilt
-* the data were corrupted due to a configuration error
+You cannot pause the operation and you cannot stream data from the transaction log until the operation completes.
 
-Debezium can be requested via the {link-prefix}:{link-signalling}[signalling table] mechanism to execute a new snapshot of a defined list of tables.
-The signal is named `execute-snapshot` and accepts messages in the following format:
+//The initial snapshot that a {prodname} connector performs on a database is essential for establishing the current baseline for the database.
+//However, the following constraints are associated with the initial snapshot process:
 
-.Example of a signal record
-[cols="2,2,6",options="header"]
+* 
+* If an initial snapshot is interrupted, you cannot resume progress from the point at which the process stopped. 
+Data captured by the interrupted snapshot process is discarded, and the snapshot process must be restarted from the beginning.
+////
+.Resumable
+
+You can pause and resume snapshots for large tables so that a snapshot operation is not required to capture the full state at once and you can resume the process at any time without the need to restart the capture from the beginning.
+////
+
+
+
+
+//Implements a watermark-based approach that provides for capturing the full state of a database by .
+The default chunk size for incremental snapshots is 1KB.
+You can configure the chunk size  xref:{context}-property-incremental-snapshot-chunk-size[`incremental.snapshot.chunk.size`].
+
+* The initial snapshot captures data from a table, only if the table exists before the snapshot begins.
+If you add tables to the configuration of a running connector, by modifying the include/exclude lists, {prodname} does not include these tables in the snapshot.
+As a result, the data in the Kafka topics for these tables is no longer synchronized to the current state of the database.
+
+Streamed events and snapshot events from the table are interspersed in the topic.
+
+You can trigger incremental snapshots at any time and you can repeat them as needed.
+
+Currently, the only way to perform an incremental snapshot, is to initiate it as an {link-prefix}:#{context}-ad-hoc-snapshot[ad hoc snapshot].
+
+For more information about enabling signaling, see xref:{link-signalling}#sending-signals-to-a-debezium-connector[Sending signals to a {prodname} connector].
+
+
+
+ifdef::[community]
+Incremental snapshots are based on the link:https://github.com/debezium/debezium-design-documents/blob/main/DDD-3.md[DDD-3] design document.
+endif::[community]
+
+The incremental snapshot preserves the chronology of events so that earlier versions of a row do not overwrite later versions.
+//{prodname} must maintain the chronology of the `READ` events that originate from the snapshot process alongside of any `UPDATE` or `DELETE` events that originate from the streaming process.
+
+During an incremental snapshot, {prodname} reads the initial state of each table row directly from the source table and writes the data to Kafka as a `READ` event. 
+At the same time, the streaming process continues to capture change events that occur in each source table.
+If a streamed event modifies an existing row, {prodname} captures the changes as `UPDATE` or `DELETE` events. 
+//Because of the way that the incremental snapshot captures tables in chunks, it's possible that an `UPDATE` or `DELETE` event that modifies a row might be written to the destination Kafka topic before the snapshot process captures the row. 
+Because of the way that the incremental snapshot captures tables in chunks, the connector might encounter `UPDATE` or `DELETE` events that modify a row before it captures the snapshot `READ` event that represents the row's initial state.
+To maintain the chronology of events when `UPDATE` or `DELETE` events are received out of sequence, {prodname} first records the snapshot `READ` events for each chunk into a buffer. 
+It then performs a deduplication step to resolve conflicts among event entries.
+
+For a specified chunk, if `UPDATE` or `DELETE` events exist for a corresponding `READ` event (that is, the events share a primary key), then {prodname} applies the following rules to disposition the `READ` event:   
+
+* If a `DELETE` event arrives before a corresponding `READ` event, the connector discards the `READ` event from the buffer.
+* If an `UPDATE` event arrives before a corresponding `READ` event, the connector either discards the `READ` event or delivers it with the updated value.
+
+The connector repeats the process for each snapshot chunk.
+
+.Triggering an incremental snapshot
+
+You trigger an incremental snapshot by sending a snapshot signal (`execute-snapshot`) to a designated signaling table.
+You send the signal by submitting it in a SQL `INSERT` query to the table.
+After {prodname} detects the change to the table, it captures the change event, which triggers it to initiate the requested operation.
+//When {prodname} receives the `execute-snapshot` signal, it runs a snapshot operation to capture data from the specified tables.
+
+.Prerequisites
+
+* xref:{link-signalling}#debezium-enabling-signaling"[Signaling is enabled]. +
+
+////
+See the following properties for more information:
+** xref:{context}-property-signal-data-collection[`signal.data.collection`]
+** xref:{context}-property-incremental-snapshot-chunk-size[incremental.snapshot.chunk.size]
+////
+
+.Procedure
+
+Compose a SQL query to send an ad hoc snapshot request to the signaling database.  
+//The query specifies the kind of operation that you want the connector to run. +
+//Currently, for snapshots operations, the only valid option is the default value, `incremental`. +
+//If you do not specify a value, the connector runs an incremental snapshot.
+
+
+.Example of sending a SQL command to initiate an incremental snapshot
+[source,sql,indent=0,subs="+attributes"]
+----
+INSERT INTO myschema.debezium_signal (id,`type`,`data`) VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.table1", "schema1.table2"],"type":"INCREMENTAL"}');
+----
+
+|==
+
+[cols="1,9",options="header"]
 |===
-|Field | Default | Value
+|Column | Value
 
-|`type`
-|`incremental`
-| The type of the snapshot to be executed. Currently only `incremental` is supported. +
-See the next section for more details.
+|id
+|`d139b9b7-7777-4547-917d-e1775ea61d41`
 
-|`data-collections`
-|_N/A_
-| An array of qualified names of table to be snapshotted. +
-The format of the names is the same as for {link-prefix}:#{context}-property-signal-data-collection[signal.data.collection] configuration option.
+|type
+|`execute-snapshot`
+
+|data
+|`{"data-collections": ["public.MyFirstTable", "public.MySecondTable"]}`
 
 |===
 
-An example of the signal to be triggered is this:
+
+The values of the `id`,`type`, and `data` fields in the command correspond to the xref:debezium-signaling-required-structure-of-a-signaling-data-collection[fields of the signaling table].
+
+
+For example,
 
 [source,sql,indent=0,subs="+attributes"]
 ----
-INSERT INTO myschema.debezium_signal VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.table1", "schema1.table2"]}')
+INSERT INTO _<schema>_.dbz_signal VALUES ('signal-1', 'execute-snapshot', '{\"data-collections\": [\"inventory.orders\"],"type":"INCREMENTAL"}');
 ----
 
-[[{context}-incremental-snapshot]]
+The following example, shows the JSON for an incremental snapshot event that is captured by a connector.
 
-= Incremental snapshot
-
-[NOTE]
-====
-This feature is currently in incubating state, i.e. exact semantics, configuration options etc. may change in future revisions, based on the feedback we receive.
-Please let us know if you encounter any problems while using this extension.
-====
-
-Initial snapshots are a great way to obtain a consistent set of all data stored in a database upfront.
-But there are also some downsides to this approach, though:
-
-* For larger datasets it can take very long to complete; hours or even days
-* The snapshot must be completed before the start of streaming
-* Snapshots are not resumable
-If a snapshot hasn't been completed when the connector gets stopped or restarted, the snapshot must be restarted from scratch
-* New tables that are added among the captured ones later are not snapshotted.
-
-To mitigate these issues, a new mechanism called _incremental snapshotting_ has been introduced.
-
-[NOTE]
-====
-Incremental snapshots can be started current only as {link-prefix}:#{context}-adhoc-snapshot[an ad-hoc snapshot].
-====
-
-[NOTE]
-====
-Configuration option {link-prefix}:#{context}-property-signal-data-collection[signal.data.collection] must be set.
-====
-
-Incremental snapshot is based on link:https://github.com/debezium/debezium-design-documents/blob/main/DDD-3.md[DDD-3] design document.
-In this case the table is snapshotted in chunks and streaming and snapshot events are blended together.
-The snaphot events are still denoted using operation `r` and the `snapshot` field in `source` info block is set to `incremental`.
-
-.Example
+.Example: Incremental snapshot event message
 [source,json,index=0]
 ----
 {
-   "before":null,
-   "after": {
-      "pk":"1",
-      "value":"New data"
-   },
-   "source": {
-...
-      "snapshot":"incremental"
-   },
-   "op":"r",
-   "ts_ms":"1620393591654",
-   "transaction":null
+    "before":null,
+    "after": {
+        "pk":"1",
+        "value":"New data"
+    },
+    "source": {
+        ...
+        "snapshot":"incremental" <1>
+    },
+    "op":"r", <2>
+    "ts_ms":"1620393591654",
+    "transaction":null
 }
 ----
+[cols="1,1,4",options="header"]
+|===
+|Item |Field name |Description
+|1
+|`snapshot`
+|Specifies the type of snapshot operation to run. +
+Currently, the only valid option is the default value, `incremental`. +
+Specifying a `type` value in the SQL query that you submit to the signaling table is optional. +
+If you do not specify a value, the connector runs an incremental snapshot.
 
-The incremental snapshot events should be understood in a different way than events from an initial snapshot.
-The `read` events should be understood like a materialization of data in a certain period of time.
-This means that event semantics differ between initial and incremental snapshots:
+|2
+|`op`
+|Specifies the event type. +
+The value for snapshot events is `r`, signifying a `READ` operation.
 
-* `update` and `delete` events can arrive before `read` events
-* if `delete` event arrives first then `read` event is never delivered
-* if `update` event arrives first then `read` event will either not be delivered at all or it will be delivered with the updated value
+|===
 
+////
+.Descriptions of fields in a SQL command for sending an incremental snapshot signal to the signaling table
+[cols="1,4",options="header"]
+|===
+|Field |Description
+
+|`id`
+| An arbitrary string that that you assign to identify a signal request. +
+WHen {prodname} runs the requested snapshot, it generates its own `id` string as a watermarking signal.
+
+|`type`
+| Specifies the kind of snapshot operation that you want the connector to run. +
+Currently, the only valid option is the default value, `incremental`. +
+Specifying a `type` value is optional. +
+If you do not specify a value, the connector runs an incremental snapshot.
+////

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-incremental-snapshot.adoc
@@ -16,51 +16,28 @@ This Technology Preview feature provides early access to upcoming product innova
 For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====
 endif::[product]
-To enable greater flexibility in managing snapshots, {prodname} includes a supplementary snapshot mechanism, known as _incremental snapshotting_.
-//a snapshot of a set of tables during the streaming phase without interrupting the streaming
-Unlike an initial snapshot, which must capture the full state of a database all at once, during an incremental snapshot {prodname} captures data in a series of configurable chunks.
-Watermarks track the progress of the capture process.
-If the the snapshot is interrupted, it refers to the watermarks to determine which tables have been snapshot and which have not. 
-In this way, the snapshot can resume from the point at which it stops, rather than repeating the capture process from the beginning.
-You can pause and resume incremental snapshots at any time.
-This ability to pause and resume snapshots is especially useful when capturing databases that include large tables.
-
-Because an incremental snapshot captures tables in piecemeal fashion, event streaming is not postponed for the entire time that it takes for the snapshot to complete.   
-Depending on the size and number of the tables to be captured, an initial snapshot of a large data set might require hours, or even days, to complete.  
-//Change data streaming runs continuously together with snapshotting
-With an incremental snapshot, the capture of real-time events can continue in parallel with snapshot operations on select rows.
-Neither operation blocks the other.
-That is, the connector can begin or continue to stream change events while the snapshot runs.
-
-You cannot pause the operation and you cannot stream data from the transaction log until the operation completes.
-
-//The initial snapshot that a {prodname} connector performs on a database is essential for establishing the current baseline for the database.
-//However, the following constraints are associated with the initial snapshot process:
-
-* 
-* If an initial snapshot is interrupted, you cannot resume progress from the point at which the process stopped. 
-Data captured by the interrupted snapshot process is discarded, and the snapshot process must be restarted from the beginning.
-////
-.Resumable
-
-You can pause and resume snapshots for large tables so that a snapshot operation is not required to capture the full state at once and you can resume the process at any time without the need to restart the capture from the beginning.
-////
-
-
-
-
-//Implements a watermark-based approach that provides for capturing the full state of a database by .
-The default chunk size for incremental snapshots is 1KB.
+To provide flexibility in managing snapshots, {prodname} includes a supplementary snapshot mechanism, known as _incremental snapshotting_.
+Incremental snapshots enable you to capture a snapshot of a set of tables for a running connector.
+Unlike an initial snapshot, which must capture the full state of a database all at once, during an incremental snapshot {prodname} captures data in a phases, in a series of configurable chunks.
+The default chunk size for incremental snapshots is 1 KB.
 You can configure the chunk size  xref:{context}-property-incremental-snapshot-chunk-size[`incremental.snapshot.chunk.size`].
 
-* The initial snapshot captures data from a table, only if the table exists before the snapshot begins.
-If you add tables to the configuration of a running connector, by modifying the include/exclude lists, {prodname} does not include these tables in the snapshot.
-As a result, the data in the Kafka topics for these tables is no longer synchronized to the current state of the database.
+Watermarks track the progress of the capture process, allowing you to pause and resume snapshots without losing data.
+If the the snapshot is interrupted, it refers to the watermarks to determine which tables have been snapshot and which have not.
+In this way, the snapshot can resume from the point at which it stops, rather than repeating the capture process from the beginning as happens after an initial snapshot is stopped. 
 
-Streamed events and snapshot events from the table are interspersed in the topic.
+This phased approach to capturing data allows for the snapshot to run in parallel with streamed data capture.
+Neither operation blocks the other.
+Change data streaming runs continuously throughout the snapshot.
+This contrasts with an initial snapshot, in which streaming is postponed until the snapshot completes. 
+The ability to stream data during the snapshot, and to pause and resume snapshots on demand is especially useful when capturing databases that include large tables.
+In a database that includes many large tables, an initial snapshot of a large data set might require hours, or even days, to complete.
+
+Incremental snapshot provide a mechanism for capturing tables that are created after you initialize the connector.
+You can modify the `include` list in the connector configuration to specify new tables to capture, and then run an incremental snapshot. 
+The snapshot captures the new tables and resynchronize data in the Kafka topics for these tables with the current state of the database.
 
 You can trigger incremental snapshots at any time and you can repeat them as needed.
-
 Currently, the only way to perform an incremental snapshot, is to initiate it as an {link-prefix}:#{context}-ad-hoc-snapshot[ad hoc snapshot].
 
 For more information about enabling signaling, see xref:{link-signalling}#sending-signals-to-a-debezium-connector[Sending signals to a {prodname} connector].
@@ -71,18 +48,23 @@ ifdef::[community]
 Incremental snapshots are based on the link:https://github.com/debezium/debezium-design-documents/blob/main/DDD-3.md[DDD-3] design document.
 endif::[community]
 
-The incremental snapshot preserves the chronology of events so that earlier versions of a row do not overwrite later versions.
+When you run an incremental snapshot, {prodname} continues to capture records related to ongoing table changes along with the snapshot records that it captures directly from source tables. 
+During the window for capturing a table chunk, {prodname} compares the primary key of each table record in the snapshot to the keys  
+of the `UPDATE` or `DELETE` event records that the connector obtains by streaming.
+The state of an event that the connector captureds through the streaming process might be in conflict with the state represented by the snapshot process.
+might be the incremental snapshot captures the table chunk that includes the "initial" state of that record,  tracks the event chronology so that earlier versions of a row do not overwrite later versions.
+//In general, `READ` events represent the state of the record at an arbitrary point of time, rather than the initial state of the record in a table 
 //{prodname} must maintain the chronology of the `READ` events that originate from the snapshot process alongside of any `UPDATE` or `DELETE` events that originate from the streaming process.
 
-During an incremental snapshot, {prodname} reads the initial state of each table row directly from the source table and writes the data to Kafka as a `READ` event. 
+During an incremental snapshot, {prodname} reads the initial state of each table row directly from the source table and writes the data to Kafka as a `READ` event.
 At the same time, the streaming process continues to capture change events that occur in each source table.
-If a streamed event modifies an existing row, {prodname} captures the changes as `UPDATE` or `DELETE` events. 
-//Because of the way that the incremental snapshot captures tables in chunks, it's possible that an `UPDATE` or `DELETE` event that modifies a row might be written to the destination Kafka topic before the snapshot process captures the row. 
+If a streamed event modifies an existing row, {prodname} captures the changes as `UPDATE` or `DELETE` events.
+//Because of the way that the incremental snapshot captures tables in chunks, it's possible that an `UPDATE` or `DELETE` event that modifies a row might be written to the destination Kafka topic before the snapshot process captures the row.
 Because of the way that the incremental snapshot captures tables in chunks, the connector might encounter `UPDATE` or `DELETE` events that modify a row before it captures the snapshot `READ` event that represents the row's initial state.
-To maintain the chronology of events when `UPDATE` or `DELETE` events are received out of sequence, {prodname} first records the snapshot `READ` events for each chunk into a buffer. 
+To maintain the chronology of events when `UPDATE` or `DELETE` events are received out of sequence, {prodname} first records the snapshot `READ` events for each chunk into a buffer.
 It then performs a deduplication step to resolve conflicts among event entries.
 
-For a specified chunk, if `UPDATE` or `DELETE` events exist for a corresponding `READ` event (that is, the events share a primary key), then {prodname} applies the following rules to disposition the `READ` event:   
+For a specified chunk, if `UPDATE` or `DELETE` events exist for a corresponding `READ` event (that is, the events share a primary key), then {prodname} applies the following rules to disposition the `READ` event:
 
 * If a `DELETE` event arrives before a corresponding `READ` event, the connector discards the `READ` event from the buffer.
 * If an `UPDATE` event arrives before a corresponding `READ` event, the connector either discards the `READ` event or delivers it with the updated value.
@@ -108,7 +90,7 @@ See the following properties for more information:
 
 .Procedure
 
-Compose a SQL query to send an ad hoc snapshot request to the signaling database.  
+Compose a SQL query to send an ad hoc snapshot request to the signaling database.
 //The query specifies the kind of operation that you want the connector to run. +
 //Currently, for snapshots operations, the only valid option is the default value, `incremental`. +
 //If you do not specify a value, the connector runs an incremental snapshot.


### PR DESCRIPTION
[DBZ-3457](https://issues.redhat.com/browse/DBZ-3457)

Still have further work to do on this, but `signalling.adoc` is now relatively complete. 

I split the shared partial file `ref-connector-incremental-snapshot.adoc` in two, creating a second file `ref-connector-ad-hoc-snapshots.adoc`. This was necessary because the shared file contained multiple headings, which would not play nicely after annotations are added to incorporate the content downstream. The headings for each file are now moved to the containing connector files, so that the shared files contain content only. Neither shared file is complete yet, and sections in both files are commented out. 

In addition to the  changes to add headings for the ad hoc and incremental snapshot sections to the files for each of the SQL-based connectors docs, I also incorporated the signaling and incremental snapshot properties into connector configuration tables.