### PR TITLE
DBZ-3992, DBZ-4273: Improve capture instance instrospection logic

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeTable.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeTable.java
@@ -32,7 +32,7 @@ public class SqlServerChangeTable extends ChangeTable {
     /**
      * A LSN to which the data in the change table are relevant
      */
-    private Lsn stopLsn;
+    private Lsn stopLsn = Lsn.NULL;
 
     /**
      * List of columns captured by the CDC table.
@@ -40,16 +40,15 @@ public class SqlServerChangeTable extends ChangeTable {
     @Immutable
     private final List<String> capturedColumns;
 
-    public SqlServerChangeTable(TableId sourceTableId, String captureInstance, int changeTableObjectId, Lsn startLsn, Lsn stopLsn,
+    public SqlServerChangeTable(TableId sourceTableId, String captureInstance, int changeTableObjectId, Lsn startLsn,
                                 List<String> capturedColumns) {
         super(captureInstance, sourceTableId, resolveChangeTableId(sourceTableId, captureInstance), changeTableObjectId);
         this.startLsn = startLsn;
-        this.stopLsn = stopLsn;
         this.capturedColumns = capturedColumns != null ? Collections.unmodifiableList(capturedColumns) : Collections.emptyList();
     }
 
-    public SqlServerChangeTable(String captureInstance, int changeTableObjectId, Lsn startLsn, Lsn stopLsn) {
-        this(null, captureInstance, changeTableObjectId, startLsn, stopLsn, null);
+    public SqlServerChangeTable(String captureInstance, int changeTableObjectId, Lsn startLsn) {
+        this(null, captureInstance, changeTableObjectId, startLsn, null);
     }
 
     public Lsn getStartLsn() {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -13,15 +13,16 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -71,9 +72,20 @@ public class SqlServerConnection extends JdbcConnection {
     private static final String GET_ALL_CHANGES_FOR_TABLE = "SELECT *# FROM [#db].cdc.[fn_cdc_get_all_changes_#](?, ?, N'all update old') order by [__$start_lsn] ASC, [__$seqval] ASC, [__$operation] ASC";
     private final String get_all_changes_for_table;
     protected static final String LSN_TIMESTAMP_SELECT_STATEMENT = "TODATETIMEOFFSET([#db].sys.fn_cdc_map_lsn_to_time([__$start_lsn]), DATEPART(TZOFFSET, SYSDATETIMEOFFSET()))";
-    private static final String GET_CHANGE_TABLES = "EXEC [#db].sys.sp_cdc_help_change_data_capture";
+
+    /**
+     * Queries the list of captured column names and their change table identifiers in the given database.
+     */
+    private static final String GET_CAPTURED_COLUMNS = "SELECT object_id, column_name" +
+            " FROM [#db].cdc.captured_columns" +
+            " ORDER BY object_id, column_id";
+
+    /**
+     * Queries the list of capture instances in the given database.
+     */
+    private static final String GET_CHANGE_TABLES = "SELECT s.name AS source_schema, o.name AS source_table, ct.capture_instance, ct.object_id, ct.start_lsn FROM [#db].cdc.change_tables ct INNER JOIN [#db].sys.objects o ON ct.source_object_id = o.object_id INNER JOIN [#db].sys.schemas s ON s.schema_id = o.schema_id";
+
     private static final String GET_NEW_CHANGE_TABLES = "SELECT * FROM [#db].cdc.change_tables WHERE start_lsn BETWEEN ? AND ?";
-    private static final Pattern BRACKET_PATTERN = Pattern.compile("[\\[\\]]");
     private static final String OPENING_QUOTING_CHARACTER = "[";
     private static final String CLOSING_QUOTING_CHARACTER = "]";
 
@@ -364,17 +376,31 @@ public class SqlServerConnection extends JdbcConnection {
     }
 
     public List<SqlServerChangeTable> getChangeTables(String databaseName) throws SQLException {
+        Map<Integer, List<String>> columns = queryAndMap(
+                replaceDatabaseNamePlaceholder(GET_CAPTURED_COLUMNS, databaseName),
+                rs -> {
+                    Map<Integer, List<String>> result = new HashMap<>();
+                    while (rs.next()) {
+                        int changeTableObjectId = rs.getInt(1);
+                        if (!result.containsKey(changeTableObjectId)) {
+                            result.put(changeTableObjectId, new LinkedList<>());
+                        }
+
+                        result.get(changeTableObjectId).add(rs.getString(2));
+                    }
+                    return result;
+                });
         return queryAndMap(replaceDatabaseNamePlaceholder(GET_CHANGE_TABLES, databaseName), rs -> {
             final List<SqlServerChangeTable> changeTables = new ArrayList<>();
             while (rs.next()) {
+                int changeTableObjectId = rs.getInt(4);
                 changeTables.add(
                         new SqlServerChangeTable(
                                 new TableId(databaseName, rs.getString(1), rs.getString(2)),
                                 rs.getString(3),
-                                rs.getInt(4),
-                                Lsn.valueOf(rs.getBytes(6)),
-                                Arrays.asList(BRACKET_PATTERN.matcher(Optional.ofNullable(rs.getString(15)).orElse(""))
-                                        .replaceAll("").split(", "))));
+                                changeTableObjectId,
+                                Lsn.valueOf(rs.getBytes(5)),
+                                columns.get(changeTableObjectId)));
             }
             return changeTables;
         });

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnection.java
@@ -373,7 +373,6 @@ public class SqlServerConnection extends JdbcConnection {
                                 rs.getString(3),
                                 rs.getInt(4),
                                 Lsn.valueOf(rs.getBytes(6)),
-                                Lsn.valueOf(rs.getBytes(7)),
                                 Arrays.asList(BRACKET_PATTERN.matcher(Optional.ofNullable(rs.getString(15)).orElse(""))
                                         .replaceAll("").split(", "))));
             }
@@ -395,8 +394,7 @@ public class SqlServerConnection extends JdbcConnection {
                         changeTables.add(new SqlServerChangeTable(
                                 rs.getString(4),
                                 rs.getInt(1),
-                                Lsn.valueOf(rs.getBytes(5)),
-                                Lsn.valueOf(rs.getBytes(6))));
+                                Lsn.valueOf(rs.getBytes(5))));
                     }
                     return changeTables;
                 });

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
@@ -197,7 +197,7 @@ public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChange
                     false);
 
             // Save changeTables for sql select later.
-            changeTables = jdbcConnection.listOfChangeTables(snapshotContext.partition.getDatabaseName()).stream()
+            changeTables = jdbcConnection.getChangeTables(snapshotContext.partition.getDatabaseName()).stream()
                     .collect(Collectors.toMap(SqlServerChangeTable::getSourceTableId, changeTable -> changeTable,
                             (changeTable1, changeTable2) -> changeTable1.getStartLsn().compareTo(changeTable2.getStartLsn()) > 0
                                     ? changeTable1

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerChangeTableSetIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerChangeTableSetIT.java
@@ -172,25 +172,48 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
     }
 
     @Test
-    public void addColumnToTableEndOfBatch() throws Exception {
-        addColumnToTable(true);
+    public void addColumnToTableEndOfBatchWithoutLsnLimit() throws Exception {
+        final Configuration config = TestHelper.defaultConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
+                .build();
+        addColumnToTable(config, true);
     }
 
     @Test
-    public void addColumnToTableMiddleOfBatch() throws Exception {
-        addColumnToTable(false);
+    @FixFor("DBZ-3992")
+    public void addColumnToTableEndOfBatchWithLsnLimit() throws Exception {
+        final Configuration config = TestHelper.defaultConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
+                .with(SqlServerConnectorConfig.MAX_TRANSACTIONS_PER_ITERATION, 1)
+                .build();
+        addColumnToTable(config, true);
     }
 
-    private void addColumnToTable(boolean pauseAfterCaptureChange) throws Exception {
+    @Test
+    public void addColumnToTableMiddleOfBatchWithoutLsnLimit() throws Exception {
+        final Configuration config = TestHelper.defaultConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
+                .build();
+        addColumnToTable(config, false);
+    }
+
+    @Test
+    @FixFor("DBZ-3992")
+    public void addColumnToTableMiddleOfBatchWithLsnLimit() throws Exception {
+        final Configuration config = TestHelper.defaultConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
+                .with(SqlServerConnectorConfig.MAX_TRANSACTIONS_PER_ITERATION, 1)
+                .build();
+        addColumnToTable(config, true);
+    }
+
+    private void addColumnToTable(Configuration config, boolean pauseAfterCaptureChange) throws Exception {
         final int RECORDS_PER_TABLE = 5;
         final int TABLES = 2;
         final int ID_START_1 = 10;
         final int ID_START_2 = 100;
         final int ID_START_3 = 1000;
         final int ID_START_4 = 10000;
-        final Configuration config = TestHelper.defaultConfig()
-                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
-                .build();
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
@@ -203,7 +203,7 @@ public class SqlServerConnectionIT {
                     "varbinary_column", "image_column");
 
             SqlServerChangeTable changeTable = new SqlServerChangeTable(new TableId("testDB", "dbo", "table_with_defaults"),
-                    null, 0, null, null, capturedColumns);
+                    null, 0, null, capturedColumns);
             Table table = connection.getTableSchemaFromTable(TestHelper.TEST_DATABASE, changeTable);
 
             TableSchemaBuilder tableSchemaBuilder = new TableSchemaBuilder(
@@ -373,7 +373,7 @@ public class SqlServerConnectionIT {
                             "real_column");
 
             SqlServerChangeTable changeTable = new SqlServerChangeTable(new TableId("testDB", "dbo", "table_with_defaults"),
-                    null, 0, null, null, capturedColumns);
+                    null, 0, null, capturedColumns);
             Table table = connection.getTableSchemaFromTable(TestHelper.TEST_DATABASE, changeTable);
 
             TableSchemaBuilder tableSchemaBuilder = new TableSchemaBuilder(

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -762,7 +762,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
             // verify pre-snapshot inserts have succeeded
             Map<String, Boolean> resultMap = new HashMap<>();
-            connection.listOfChangeTables(TestHelper.TEST_DATABASE).forEach(ct -> {
+            connection.getChangeTables(TestHelper.TEST_DATABASE).forEach(ct -> {
                 final String tableName = ct.getChangeTableId().table();
                 if (tableName.endsWith("dbo_" + tableaCT) || tableName.endsWith("dbo_" + tablebCT)) {
                     try {

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TransactionMetadataIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TransactionMetadataIT.java
@@ -153,7 +153,7 @@ public class TransactionMetadataIT extends AbstractConnectorTest {
                     return false;
                 }
 
-                for (SqlServerChangeTable ct : connection.listOfChangeTables(TestHelper.TEST_DATABASE)) {
+                for (SqlServerChangeTable ct : connection.getChangeTables(TestHelper.TEST_DATABASE)) {
                     final String tableName = ct.getChangeTableId().table();
                     if (tableName.endsWith("dbo_" + connection.getNameOfChangeTable("tablea"))) {
                         try {

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -461,7 +461,7 @@ public class TestHelper {
                             return false;
                         }
 
-                        for (SqlServerChangeTable ct : connection.listOfChangeTables(TEST_DATABASE)) {
+                        for (SqlServerChangeTable ct : connection.getChangeTables(TEST_DATABASE)) {
                             final String ctTableName = ct.getChangeTableId().table();
                             if (ctTableName.endsWith("dbo_" + connection.getNameOfChangeTable(tableName))) {
                                 try {
@@ -516,7 +516,7 @@ public class TestHelper {
                             return false;
                         }
 
-                        for (SqlServerChangeTable ct : connection.listOfChangeTables(TEST_DATABASE)) {
+                        for (SqlServerChangeTable ct : connection.getChangeTables(TEST_DATABASE)) {
                             final String ctTableName = ct.getChangeTableId().table();
                             if (ctTableName.endsWith(connection.getNameOfChangeTable(captureInstanceName))) {
                                 try {


### PR DESCRIPTION
This pull request contains fixes for [DBZ-3992](https://issues.redhat.com/browse/DBZ-3992) and [DBZ-4273](https://issues.redhat.com/browse/DBZ-4273). Although the two issues are unrelated, fixing them requires changing the same code, so it makes sense to combine their fixes together.

The root cause of [DBZ-3992](https://issues.redhat.com/browse/DBZ-3992) (SQL Server fails to read CDC events if there is a schema change ahead) is that the connector tries to use all available capture instances for a table, even though the newest one doesn't contain the changes that fall into the currently processed LSN interval (only applicable if `max.iteration.transactions` is configured).

```
CI  |                                                               LSNs      
------------------------------------------------------------------------->
ci1 |  A                                                            NULL
    |  |----------------------------------------------------------------
    |
ci2 |           B                                                   NULL
    |           |-------------------------------------------------------
    |
ci3 |                                  C                            NULL
    |                                  |--------------------------------
    |                ^-----------^
    |                X           Y

ci1, ci2, ci3 : capture instances
X             : "from" LSN
Y             : "to" LSN
[X, Y]        : current LSN interval with size of "max.iteration.transactions"
```

Here we expect only ci1 and ci2 capture instances to be selected but we get all three. The solution is to consider the capture instance's start LSN in the `GET_LIST_OF_CDC_ENABLED_TABLES` query.

Additionally ([DBZ-4273](https://issues.redhat.com/browse/DBZ-4273)), the connector doesn't expect multiple capture instances with the same start LSN for the same schema. In this case, the behavior of the connector is undefined.

## Key changes

### Do not use `cdc.change_tables.end_lsn`

According to the [documentation](https://docs.microsoft.com/en-us/sql/relational-databases/system-tables/cdc-change-tables-transact-sql?view=sql-server-2016), it's always NULL. The code still uses `SqlServerChangeTable#stopLsn` and its accessors in order to artificially set the stop LSN of the current capture instance to the start LSN of the future one. It would make sense to rework this logic but this is out of the scope of this pull request.

### Use `cdc.change_tables` instead of `sys.sp_cdc_help_change_data_capture`

Despite the [documentation](https://docs.microsoft.com/en-us/sql/relational-databases/system-tables/cdc-change-tables-transact-sql?view=sql-server-2016) suggesting to use the stored procedure, there are reasons to use the table:
1. The stored procedure doesn't allow filtering capture instances by start LSN.
2. There doesn't seem to be an easy way to implement a query like `SELECT * FROM (EXEC stored_procedure)`.

Additionally, the call to the stored procedure is much more expensive than the SQL query. This difference is insignificant given that schema changes are rare but is worth mentioning.

### Deduplicate capture instances by `create_date`

There are multiple places in the code where capture instances are compared by the start LSN. Adding comparison by the creation date is possible but would require changes in multiple places and result in the oldest one being discarded anyway. It's easier to filter it out at the query level.

## Testing considerations
1. The changes for [DBZ-3992](https://issues.redhat.com/browse/DBZ-3992) are covered by new tests. Additionally, now the entire test suite passes with `MAX_TRANSACTIONS_PER_ITERATION` set to `1`.
2. Automated testing of [DBZ-4273](https://issues.redhat.com/browse/DBZ-4273) is challenging. First, the setup procedure is time-consuming since it depends on periodic background jobs owned by the SQL Server. Second, the issue is not always reproducible, so a passing test won't mean that the issue doesn't exist. Automated testing might be reconsidered if the data structures for managing capture instances are redesigned. E.g., instead of `HashSet<SqlServerChangeTable>` a more specialized structure with ordering guarantees is used.