### PR TITLE
DBZ-4478: Partition-scoped metrics for the SQL Server connector

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeEventSourceFactory.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeEventSourceFactory.java
@@ -28,14 +28,15 @@ public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory
 
     private final MongoDbConnectorConfig configuration;
     private final ErrorHandler errorHandler;
-    private final EventDispatcher<CollectionId> dispatcher;
+    private final EventDispatcher<MongoDbPartition, CollectionId> dispatcher;
     private final Clock clock;
     private final ReplicaSets replicaSets;
     private final MongoDbTaskContext taskContext;
     private final MongoDbSchema schema;
 
-    public MongoDbChangeEventSourceFactory(MongoDbConnectorConfig configuration, ErrorHandler errorHandler, EventDispatcher<CollectionId> dispatcher,
-                                           Clock clock, ReplicaSets replicaSets, MongoDbTaskContext taskContext, MongoDbSchema schema) {
+    public MongoDbChangeEventSourceFactory(MongoDbConnectorConfig configuration, ErrorHandler errorHandler,
+                                           EventDispatcher<MongoDbPartition, CollectionId> dispatcher, Clock clock,
+                                           ReplicaSets replicaSets, MongoDbTaskContext taskContext, MongoDbSchema schema) {
         this.configuration = configuration;
         this.errorHandler = errorHandler;
         this.dispatcher = dispatcher;
@@ -46,7 +47,7 @@ public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory
     }
 
     @Override
-    public SnapshotChangeEventSource<MongoDbPartition, MongoDbOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
+    public SnapshotChangeEventSource<MongoDbPartition, MongoDbOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener<MongoDbPartition> snapshotProgressListener) {
         return new MongoDbSnapshotChangeEventSource(
                 configuration,
                 taskContext,
@@ -69,11 +70,11 @@ public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory
     }
 
     @Override
-    public Optional<IncrementalSnapshotChangeEventSource<? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(
-                                                                                                                              MongoDbOffsetContext offsetContext,
-                                                                                                                              SnapshotProgressListener snapshotProgressListener,
-                                                                                                                              DataChangeEventListener dataChangeEventListener) {
-        final MongoDbIncrementalSnapshotChangeEventSource<CollectionId> incrementalSnapshotChangeEventSource = new MongoDbIncrementalSnapshotChangeEventSource<CollectionId>(
+    public Optional<IncrementalSnapshotChangeEventSource<MongoDbPartition, ? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(
+                                                                                                                                                MongoDbOffsetContext offsetContext,
+                                                                                                                                                SnapshotProgressListener<MongoDbPartition> snapshotProgressListener,
+                                                                                                                                                DataChangeEventListener<MongoDbPartition> dataChangeEventListener) {
+        final MongoDbIncrementalSnapshotChangeEventSource incrementalSnapshotChangeEventSource = new MongoDbIncrementalSnapshotChangeEventSource(
                 configuration,
                 taskContext,
                 replicaSets,

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeSnapshotOplogRecordEmitter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeSnapshotOplogRecordEmitter.java
@@ -17,7 +17,6 @@ import io.debezium.data.Envelope.FieldName;
 import io.debezium.data.Envelope.Operation;
 import io.debezium.pipeline.AbstractChangeRecordEmitter;
 import io.debezium.pipeline.spi.OffsetContext;
-import io.debezium.pipeline.spi.Partition;
 import io.debezium.util.Clock;
 
 /**
@@ -25,7 +24,7 @@ import io.debezium.util.Clock;
  *
  * @author Chris Cranford
  */
-public class MongoDbChangeSnapshotOplogRecordEmitter extends AbstractChangeRecordEmitter<MongoDbCollectionSchema> {
+public class MongoDbChangeSnapshotOplogRecordEmitter extends AbstractChangeRecordEmitter<MongoDbPartition, MongoDbCollectionSchema> {
 
     private final Document oplogEvent;
 
@@ -47,7 +46,7 @@ public class MongoDbChangeSnapshotOplogRecordEmitter extends AbstractChangeRecor
         OPERATION_LITERALS = Collections.unmodifiableMap(literals);
     }
 
-    public MongoDbChangeSnapshotOplogRecordEmitter(Partition partition, OffsetContext offsetContext, Clock clock, Document oplogEvent, boolean isSnapshot) {
+    public MongoDbChangeSnapshotOplogRecordEmitter(MongoDbPartition partition, OffsetContext offsetContext, Clock clock, Document oplogEvent, boolean isSnapshot) {
         super(partition, offsetContext, clock);
         this.oplogEvent = oplogEvent;
         this.isSnapshot = isSnapshot;

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeStreamChangeRecordEmitter.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeStreamChangeRecordEmitter.java
@@ -20,7 +20,6 @@ import io.debezium.data.Envelope.FieldName;
 import io.debezium.data.Envelope.Operation;
 import io.debezium.pipeline.AbstractChangeRecordEmitter;
 import io.debezium.pipeline.spi.OffsetContext;
-import io.debezium.pipeline.spi.Partition;
 import io.debezium.util.Clock;
 
 /**
@@ -28,7 +27,7 @@ import io.debezium.util.Clock;
  *
  * @author Jiri Pechanec
  */
-public class MongoDbChangeStreamChangeRecordEmitter extends AbstractChangeRecordEmitter<MongoDbCollectionSchema> {
+public class MongoDbChangeStreamChangeRecordEmitter extends AbstractChangeRecordEmitter<MongoDbPartition, MongoDbCollectionSchema> {
 
     private final ChangeStreamDocument<Document> changeStreamEvent;
 
@@ -46,7 +45,8 @@ public class MongoDbChangeStreamChangeRecordEmitter extends AbstractChangeRecord
         OPERATION_LITERALS = Collections.unmodifiableMap(literals);
     }
 
-    public MongoDbChangeStreamChangeRecordEmitter(Partition partition, OffsetContext offsetContext, Clock clock, ChangeStreamDocument<Document> changeStreamEvent) {
+    public MongoDbChangeStreamChangeRecordEmitter(MongoDbPartition partition, OffsetContext offsetContext, Clock clock,
+                                                  ChangeStreamDocument<Document> changeStreamEvent) {
         super(partition, offsetContext, clock);
         this.changeStreamEvent = changeStreamEvent;
     }
@@ -57,27 +57,27 @@ public class MongoDbChangeStreamChangeRecordEmitter extends AbstractChangeRecord
     }
 
     @Override
-    protected void emitReadRecord(Receiver receiver, MongoDbCollectionSchema schema) throws InterruptedException {
+    protected void emitReadRecord(Receiver<MongoDbPartition> receiver, MongoDbCollectionSchema schema) throws InterruptedException {
         // TODO Handled in MongoDbChangeSnapshotOplogRecordEmitter
         // It might be worthy haveing three classes - one for Snapshot, one for oplog and one for change streams
     }
 
     @Override
-    protected void emitCreateRecord(Receiver receiver, MongoDbCollectionSchema schema) throws InterruptedException {
+    protected void emitCreateRecord(Receiver<MongoDbPartition> receiver, MongoDbCollectionSchema schema) throws InterruptedException {
         createAndEmitChangeRecord(receiver, schema);
     }
 
     @Override
-    protected void emitUpdateRecord(Receiver receiver, MongoDbCollectionSchema schema) throws InterruptedException {
+    protected void emitUpdateRecord(Receiver<MongoDbPartition> receiver, MongoDbCollectionSchema schema) throws InterruptedException {
         createAndEmitChangeRecord(receiver, schema);
     }
 
     @Override
-    protected void emitDeleteRecord(Receiver receiver, MongoDbCollectionSchema schema) throws InterruptedException {
+    protected void emitDeleteRecord(Receiver<MongoDbPartition> receiver, MongoDbCollectionSchema schema) throws InterruptedException {
         createAndEmitChangeRecord(receiver, schema);
     }
 
-    private void createAndEmitChangeRecord(Receiver receiver, MongoDbCollectionSchema schema) throws InterruptedException {
+    private void createAndEmitChangeRecord(Receiver<MongoDbPartition> receiver, MongoDbCollectionSchema schema) throws InterruptedException {
         final Object newKey = schema.keyFromDocument(changeStreamEvent.getDocumentKey());
         assert newKey != null;
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
@@ -129,7 +129,7 @@ public final class MongoDbConnectorTask extends BaseSourceTask<MongoDbPartition,
 
             final MongoDbEventMetadataProvider metadataProvider = new MongoDbEventMetadataProvider();
 
-            final EventDispatcher<CollectionId> dispatcher = new EventDispatcher<>(
+            final EventDispatcher<MongoDbPartition, CollectionId> dispatcher = new EventDispatcher<>(
                     connectorConfig,
                     taskContext.topicSelector(),
                     schema,

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSetPartition.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSetPartition.java
@@ -8,10 +8,9 @@ package io.debezium.connector.mongodb;
 import java.util.Map;
 import java.util.Objects;
 
-import io.debezium.pipeline.spi.Partition;
 import io.debezium.util.Collect;
 
-public class ReplicaSetPartition implements Partition {
+public class ReplicaSetPartition extends MongoDbPartition {
     private static final String SERVER_ID_KEY = "server_id";
     private static final String REPLICA_SET_NAME = "rs";
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/metrics/MongoDbChangeEventSourceMetricsFactory.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/metrics/MongoDbChangeEventSourceMetricsFactory.java
@@ -7,6 +7,7 @@ package io.debezium.connector.mongodb.metrics;
 
 import io.debezium.connector.base.ChangeEventQueueMetrics;
 import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.mongodb.MongoDbPartition;
 import io.debezium.pipeline.metrics.DefaultChangeEventSourceMetricsFactory;
 import io.debezium.pipeline.metrics.SnapshotChangeEventSourceMetrics;
 import io.debezium.pipeline.metrics.StreamingChangeEventSourceMetrics;
@@ -15,18 +16,18 @@ import io.debezium.pipeline.source.spi.EventMetadataProvider;
 /**
  * @author Chris Cranford
  */
-public class MongoDbChangeEventSourceMetricsFactory extends DefaultChangeEventSourceMetricsFactory {
+public class MongoDbChangeEventSourceMetricsFactory extends DefaultChangeEventSourceMetricsFactory<MongoDbPartition> {
     @Override
-    public <T extends CdcSourceTaskContext> SnapshotChangeEventSourceMetrics getSnapshotMetrics(T taskContext,
-                                                                                                ChangeEventQueueMetrics changeEventQueueMetrics,
-                                                                                                EventMetadataProvider eventMetadataProvider) {
+    public <T extends CdcSourceTaskContext> SnapshotChangeEventSourceMetrics<MongoDbPartition> getSnapshotMetrics(T taskContext,
+                                                                                                                  ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                                                  EventMetadataProvider eventMetadataProvider) {
         return new MongoDbSnapshotChangeEventSourceMetrics(taskContext, changeEventQueueMetrics, eventMetadataProvider);
     }
 
     @Override
-    public <T extends CdcSourceTaskContext> StreamingChangeEventSourceMetrics getStreamingMetrics(T taskContext,
-                                                                                                  ChangeEventQueueMetrics changeEventQueueMetrics,
-                                                                                                  EventMetadataProvider eventMetadataProvider) {
+    public <T extends CdcSourceTaskContext> StreamingChangeEventSourceMetrics<MongoDbPartition> getStreamingMetrics(T taskContext,
+                                                                                                                    ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                                                    EventMetadataProvider eventMetadataProvider) {
         return new MongoDbStreamingChangeEventSourceMetrics(taskContext, changeEventQueueMetrics, eventMetadataProvider);
     }
 }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/metrics/MongoDbSnapshotChangeEventSourceMetrics.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/metrics/MongoDbSnapshotChangeEventSourceMetrics.java
@@ -11,6 +11,7 @@ import io.debezium.annotation.ThreadSafe;
 import io.debezium.connector.base.ChangeEventQueueMetrics;
 import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.connector.mongodb.DisconnectEvent;
+import io.debezium.connector.mongodb.MongoDbPartition;
 import io.debezium.pipeline.ConnectorEvent;
 import io.debezium.pipeline.metrics.DefaultSnapshotChangeEventSourceMetrics;
 import io.debezium.pipeline.source.spi.EventMetadataProvider;
@@ -19,7 +20,8 @@ import io.debezium.pipeline.source.spi.EventMetadataProvider;
  * @author Chris Cranford
  */
 @ThreadSafe
-public class MongoDbSnapshotChangeEventSourceMetrics extends DefaultSnapshotChangeEventSourceMetrics implements MongoDbSnapshotChangeEventSourceMetricsMBean {
+public class MongoDbSnapshotChangeEventSourceMetrics extends DefaultSnapshotChangeEventSourceMetrics<MongoDbPartition>
+        implements MongoDbSnapshotChangeEventSourceMetricsMBean {
 
     private AtomicLong numberOfDisconnects = new AtomicLong();
 
@@ -34,7 +36,7 @@ public class MongoDbSnapshotChangeEventSourceMetrics extends DefaultSnapshotChan
     }
 
     @Override
-    public void onConnectorEvent(ConnectorEvent event) {
+    public void onConnectorEvent(MongoDbPartition partition, ConnectorEvent event) {
         if (event instanceof DisconnectEvent) {
             numberOfDisconnects.incrementAndGet();
         }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/metrics/MongoDbStreamingChangeEventSourceMetrics.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/metrics/MongoDbStreamingChangeEventSourceMetrics.java
@@ -11,6 +11,7 @@ import io.debezium.annotation.ThreadSafe;
 import io.debezium.connector.base.ChangeEventQueueMetrics;
 import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.connector.mongodb.DisconnectEvent;
+import io.debezium.connector.mongodb.MongoDbPartition;
 import io.debezium.connector.mongodb.PrimaryElectionEvent;
 import io.debezium.pipeline.ConnectorEvent;
 import io.debezium.pipeline.metrics.DefaultStreamingChangeEventSourceMetrics;
@@ -20,7 +21,8 @@ import io.debezium.pipeline.source.spi.EventMetadataProvider;
  * @author Chris Cranford
  */
 @ThreadSafe
-public class MongoDbStreamingChangeEventSourceMetrics extends DefaultStreamingChangeEventSourceMetrics implements MongoDbStreamingChangeEventSourceMetricsMBean {
+public class MongoDbStreamingChangeEventSourceMetrics extends DefaultStreamingChangeEventSourceMetrics<MongoDbPartition>
+        implements MongoDbStreamingChangeEventSourceMetricsMBean {
 
     private AtomicLong numberOfPrimaryElections = new AtomicLong();
     private AtomicLong numberOfDisconnects = new AtomicLong();
@@ -41,7 +43,7 @@ public class MongoDbStreamingChangeEventSourceMetrics extends DefaultStreamingCh
     }
 
     @Override
-    public void onConnectorEvent(ConnectorEvent event) {
+    public void onConnectorEvent(MongoDbPartition partition, ConnectorEvent event) {
         if (event instanceof PrimaryElectionEvent) {
             numberOfPrimaryElections.incrementAndGet();
         }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceMetricsFactory.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceMetricsFactory.java
@@ -15,7 +15,7 @@ import io.debezium.pipeline.source.spi.EventMetadataProvider;
 /**
  * @author Jiri Pechanec
  */
-public class MySqlChangeEventSourceMetricsFactory extends DefaultChangeEventSourceMetricsFactory {
+public class MySqlChangeEventSourceMetricsFactory extends DefaultChangeEventSourceMetricsFactory<MySqlPartition> {
 
     final MySqlStreamingChangeEventSourceMetrics streamingMetrics;
 
@@ -24,16 +24,16 @@ public class MySqlChangeEventSourceMetricsFactory extends DefaultChangeEventSour
     }
 
     @Override
-    public <T extends CdcSourceTaskContext> SnapshotChangeEventSourceMetrics getSnapshotMetrics(T taskContext,
-                                                                                                ChangeEventQueueMetrics changeEventQueueMetrics,
-                                                                                                EventMetadataProvider eventMetadataProvider) {
+    public <T extends CdcSourceTaskContext> SnapshotChangeEventSourceMetrics<MySqlPartition> getSnapshotMetrics(T taskContext,
+                                                                                                                ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                                                EventMetadataProvider eventMetadataProvider) {
         return new MySqlSnapshotChangeEventSourceMetrics((MySqlTaskContext) taskContext, changeEventQueueMetrics, eventMetadataProvider);
     }
 
     @Override
-    public <T extends CdcSourceTaskContext> StreamingChangeEventSourceMetrics getStreamingMetrics(T taskContext,
-                                                                                                  ChangeEventQueueMetrics changeEventQueueMetrics,
-                                                                                                  EventMetadataProvider eventMetadataProvider) {
+    public <T extends CdcSourceTaskContext> StreamingChangeEventSourceMetrics<MySqlPartition> getStreamingMetrics(T taskContext,
+                                                                                                                  ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                                                  EventMetadataProvider eventMetadataProvider) {
         return streamingMetrics;
     }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeRecordEmitter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeRecordEmitter.java
@@ -10,7 +10,6 @@ import java.io.Serializable;
 import io.debezium.data.Envelope;
 import io.debezium.data.Envelope.Operation;
 import io.debezium.pipeline.spi.OffsetContext;
-import io.debezium.pipeline.spi.Partition;
 import io.debezium.relational.RelationalChangeRecordEmitter;
 import io.debezium.util.Clock;
 
@@ -19,14 +18,15 @@ import io.debezium.util.Clock;
  *
  * @author Jiri Pechanec
  */
-public class MySqlChangeRecordEmitter extends RelationalChangeRecordEmitter {
+public class MySqlChangeRecordEmitter extends RelationalChangeRecordEmitter<MySqlPartition> {
 
     private final Envelope.Operation operation;
     private final OffsetContext offset;
     private final Object[] before;
     private final Object[] after;
 
-    public MySqlChangeRecordEmitter(Partition partition, OffsetContext offset, Clock clock, Envelope.Operation operation, Serializable[] before, Serializable[] after) {
+    public MySqlChangeRecordEmitter(MySqlPartition partition, OffsetContext offset, Clock clock, Envelope.Operation operation, Serializable[] before,
+                                    Serializable[] after) {
         super(partition, offset, clock);
         this.offset = offset;
         this.operation = operation;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -1048,7 +1048,8 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
                 TableFilter.fromPredicate(MySqlConnectorConfig::isNotBuiltInTable),
                 true,
                 DEFAULT_SNAPSHOT_FETCH_SIZE,
-                ColumnFilterMode.CATALOG);
+                ColumnFilterMode.CATALOG,
+                false);
 
         this.config = config;
         this.legacy = MySqlConnector.isLegacy(config.getString(io.debezium.connector.mysql.MySqlConnector.IMPLEMENTATION_PROP));

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -162,7 +162,7 @@ public class MySqlConnectorTask extends BaseSourceTask<MySqlPartition, MySqlOffs
                     });
         }
 
-        final EventDispatcher<TableId> dispatcher = new EventDispatcher<>(
+        final EventDispatcher<MySqlPartition, TableId> dispatcher = new EventDispatcher<>(
                 connectorConfig,
                 topicSelector,
                 schema,

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlPartition.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlPartition.java
@@ -49,10 +49,10 @@ public class MySqlPartition implements Partition {
         return "MySqlPartition [sourcePartition=" + getSourcePartition() + "]";
     }
 
-    static class Provider implements Partition.Provider<MySqlPartition> {
+    public static class Provider implements Partition.Provider<MySqlPartition> {
         private final MySqlConnectorConfig connectorConfig;
 
-        Provider(MySqlConnectorConfig connectorConfig) {
+        public Provider(MySqlConnectorConfig connectorConfig) {
             this.connectorConfig = connectorConfig;
         }
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
@@ -60,7 +60,7 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
     private final BlockingConsumer<Function<SourceRecord, SourceRecord>> lastEventProcessor;
 
     public MySqlSnapshotChangeEventSource(MySqlConnectorConfig connectorConfig, MySqlConnection connection,
-                                          MySqlDatabaseSchema schema, EventDispatcher<TableId> dispatcher, Clock clock,
+                                          MySqlDatabaseSchema schema, EventDispatcher<MySqlPartition, TableId> dispatcher, Clock clock,
                                           MySqlSnapshotChangeEventSourceMetrics metrics,
                                           BlockingConsumer<Function<SourceRecord, SourceRecord>> lastEventProcessor) {
         super(connectorConfig, connection, schema, dispatcher, clock, metrics);
@@ -73,7 +73,7 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
     }
 
     @Override
-    protected SnapshottingTask getSnapshottingTask(MySqlOffsetContext previousOffset) {
+    protected SnapshottingTask getSnapshottingTask(MySqlPartition partition, MySqlOffsetContext previousOffset) {
         boolean snapshotSchema = true;
         boolean snapshotData = true;
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSourceMetrics.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSourceMetrics.java
@@ -15,7 +15,7 @@ import io.debezium.pipeline.source.spi.EventMetadataProvider;
  * @author Randall Hauch
  *
  */
-class MySqlSnapshotChangeEventSourceMetrics extends DefaultSnapshotChangeEventSourceMetrics implements MySqlSnapshotChangeEventSourceMetricsMXBean {
+class MySqlSnapshotChangeEventSourceMetrics extends DefaultSnapshotChangeEventSourceMetrics<MySqlPartition> implements MySqlSnapshotChangeEventSourceMetricsMXBean {
 
     private final AtomicBoolean holdingGlobalLock = new AtomicBoolean();
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSourceMetrics.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSourceMetrics.java
@@ -21,7 +21,8 @@ import io.debezium.util.Collect;
 /**
  * @author Randall Hauch
  */
-public class MySqlStreamingChangeEventSourceMetrics extends DefaultStreamingChangeEventSourceMetrics implements MySqlStreamingChangeEventSourceMetricsMXBean {
+public class MySqlStreamingChangeEventSourceMetrics extends DefaultStreamingChangeEventSourceMetrics<MySqlPartition>
+        implements MySqlStreamingChangeEventSourceMetricsMXBean {
 
     private final BinaryLogClient client;
     private final BinaryLogClientStatistics stats;

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/MySqlSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/MySqlSchema.java
@@ -151,7 +151,8 @@ public class MySqlSchema extends RelationalDatabaseSchema {
                 return SourceInfo.isPositionAtOrBefore(recorded, desired, gtidFilter);
             }
         };
-        this.dbHistory.configure(dbHistoryConfig, historyComparator, new DatabaseHistoryMetrics(configuration), true); // validates
+        this.dbHistory.configure(dbHistoryConfig, historyComparator,
+                new DatabaseHistoryMetrics(configuration, false), true); // validates
     }
 
     private static MySqlValueConverters getValueConverters(MySqlConnectorConfig configuration) {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/Reader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/Reader.java
@@ -6,18 +6,21 @@
 package io.debezium.connector.mysql.legacy;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 
+import io.debezium.connector.mysql.MySqlPartition;
+
 /**
  * A component that reads a portion of the MySQL server history or current state.
  * <p>
- * A reader starts out in the {@link State#STOPPED stopped} state, and when {@link #start() started} transitions to a
+ * A reader starts out in the {@link State#STOPPED stopped} state, and when {@link #start(MySqlPartition)} () started} transitions to a
  * {@link State#RUNNING} state. The reader may either complete its work or be explicitly {@link #stop() stopped}, at which
  * point the reader transitions to a {@value State#STOPPING stopping} state until all already-generated {@link SourceRecord}s
  * are consumed by the client via the {@link #poll() poll} method. Only after all records are consumed does the reader
- * transition to the {@link State#STOPPED stopped} state and call the {@link #uponCompletion(Runnable)} method.
+ * transition to the {@link State#STOPPED stopped} state and call the {@link #uponCompletion(Consumer)} method.
  * <p>
  * See {@link ChainedReader} if multiple {@link Reader} implementations are to be run in-sequence while keeping the
  * correct start, stop, and completion semantics.
@@ -71,11 +74,11 @@ public interface Reader {
      *
      * @param handler the function; may not be null
      */
-    public void uponCompletion(Runnable handler);
+    public void uponCompletion(Consumer<MySqlPartition> handler);
 
     /**
      * Perform any initialization of the reader before being started. This method should be
-     * called exactly once before {@link #start()} is called, and it should block until all
+     * called exactly once before {@link #start(MySqlPartition)} ()} is called, and it should block until all
      * initialization is completed.
      */
     public default void initialize() {
@@ -99,7 +102,7 @@ public interface Reader {
      * <p>
      * This method does nothing if it is already running.
      */
-    public void start();
+    public void start(MySqlPartition partition);
 
     /**
      * Stop the reader from running and transition to the {@link State#STOPPING} state until all remaining records

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/ReaderMetricsMXBean.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/ReaderMetricsMXBean.java
@@ -5,13 +5,15 @@
  */
 package io.debezium.connector.mysql.legacy;
 
+import io.debezium.pipeline.metrics.traits.SchemaMetricsMXBean;
+
 /**
  * Metrics that are common for both snapshot and binlog readers
  *
  * @author Jiri Pechanec
  *
  */
-public interface ReaderMetricsMXBean {
+public interface ReaderMetricsMXBean extends SchemaMetricsMXBean {
 
     /**
      * @deprecated Superseded by the 'Captured Tables' metric. Use {@link #getCapturedTables()}.
@@ -19,7 +21,4 @@ public interface ReaderMetricsMXBean {
      */
     @Deprecated
     String[] getMonitoredTables();
-
-    String[] getCapturedTables();
-
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SnapshotReaderMetrics.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SnapshotReaderMetrics.java
@@ -8,13 +8,15 @@ package io.debezium.connector.mysql.legacy;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.debezium.connector.base.ChangeEventQueueMetrics;
+import io.debezium.connector.mysql.MySqlPartition;
 import io.debezium.pipeline.metrics.DefaultSnapshotChangeEventSourceMetrics;
 
 /**
  * @author Randall Hauch
  *
  */
-class SnapshotReaderMetrics extends DefaultSnapshotChangeEventSourceMetrics implements SnapshotReaderMetricsMXBean {
+class SnapshotReaderMetrics extends DefaultSnapshotChangeEventSourceMetrics<MySqlPartition>
+        implements SnapshotReaderMetricsMXBean {
 
     private final AtomicBoolean holdingGlobalLock = new AtomicBoolean();
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/TimedBlockingReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/TimedBlockingReader.java
@@ -12,6 +12,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.connector.mysql.MySqlPartition;
 import io.debezium.util.Clock;
 import io.debezium.util.Threads;
 import io.debezium.util.Threads.Timer;
@@ -38,8 +39,8 @@ public class TimedBlockingReader extends BlockingReader {
     }
 
     @Override
-    public void start() {
-        super.start();
+    public void start(MySqlPartition partition) {
+        super.start(partition);
         this.timer = Threads.timer(Clock.SYSTEM, timeout);
     }
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/BinlogReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/BinlogReaderIT.java
@@ -38,6 +38,7 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnector;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
+import io.debezium.connector.mysql.MySqlPartition;
 import io.debezium.connector.mysql.MySqlTestConnection;
 import io.debezium.connector.mysql.UniqueDatabase;
 import io.debezium.connector.mysql.legacy.AbstractReader.AcceptAllPredicate;
@@ -157,7 +158,8 @@ public class BinlogReaderIT {
         reader = new BinlogReader("binlog", context, new AcceptAllPredicate());
 
         // Start reading the binlog ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
 
         // Poll for records ...
         // Testing.Print.enable();
@@ -219,7 +221,8 @@ public class BinlogReaderIT {
         reader = new BinlogReader("binlog", context, new AcceptAllPredicate());
 
         // Start reading the binlog ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
 
         // Poll for records ...
         // Testing.Print.enable();
@@ -307,7 +310,8 @@ public class BinlogReaderIT {
         reader = new BinlogReader("binlog", context, new AcceptAllPredicate());
 
         // Start reading the binlog ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
 
         // Lets wait for at least 35 events to be filtered.
         final int expectedFilterCount = 35;
@@ -347,7 +351,8 @@ public class BinlogReaderIT {
         reader = new BinlogReader("binlog", context, new AcceptAllPredicate());
 
         // Start reading the binlog ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
 
         // Lets wait for at least 35 events to be filtered.
         final int expectedFilterCount = 35;
@@ -386,7 +391,8 @@ public class BinlogReaderIT {
         reader = new BinlogReader("binlog", context, new AcceptAllPredicate());
 
         // Start reading the binlog ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
 
         int expectedChanges = 1; // only 1 insert
 
@@ -429,7 +435,8 @@ public class BinlogReaderIT {
         reader = new BinlogReader("binlog", context, null);
 
         // Start reading the binlog ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
 
         int expectedChanges = 1; // only 1 insert
 
@@ -533,7 +540,8 @@ public class BinlogReaderIT {
         reader = new BinlogReader("binlog", context, null);
 
         // Start reading the binlog ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
     }
 
     @Test
@@ -556,7 +564,8 @@ public class BinlogReaderIT {
         reader = new BinlogReader("binlog", context, null);
 
         // Start reading the binlog ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
         String acceptedTlsVersion = context.getConnectionContext().getSessionVariableForSslVersion();
         assertEquals("TLSv1.2", acceptedTlsVersion);
     }
@@ -579,7 +588,8 @@ public class BinlogReaderIT {
         reader = new BinlogReader("binlog", context, null);
 
         // Start reading the binlog ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
 
         // Poll for records ...
         // Testing.Print.enable();
@@ -588,7 +598,7 @@ public class BinlogReaderIT {
         assertThat(consumed).isGreaterThanOrEqualTo(expected);
 
         reader.stop();
-        reader.start();
+        reader.start(partition);
         reader.context.dbSchema().applyDdl(context.source(), DATABASE.getDatabaseName(), "DROP TABLE customers", null);
         try (
                 final MySqlTestConnection db = MySqlTestConnection.forTestDatabase(DATABASE.getDatabaseName());

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/SnapshotReaderIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/legacy/SnapshotReaderIT.java
@@ -34,6 +34,7 @@ import io.debezium.config.Configuration;
 import io.debezium.config.Configuration.Builder;
 import io.debezium.connector.mysql.MySqlConnector;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.MySqlPartition;
 import io.debezium.connector.mysql.MySqlTestConnection;
 import io.debezium.connector.mysql.UniqueDatabase;
 import io.debezium.data.KeyValueStore;
@@ -135,11 +136,12 @@ public class SnapshotReaderIT {
         context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
         reader = new SnapshotReader("snapshot", context, useGlobalLock);
-        reader.uponCompletion(completed::countDown);
+        reader.uponCompletion((partition) -> completed.countDown());
         reader.generateReadEvents();
 
         // Start the snapshot ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
 
         // Poll for records ...
         // Testing.Print.enable();
@@ -262,8 +264,10 @@ public class SnapshotReaderIT {
         reader = new SnapshotReader("snapshot", context, true);
         reader.generateReadEvents();
 
+        MySqlPartition partition = new MySqlPartition("test");
+
         if (!MySqlTestConnection.isPerconaServer()) {
-            reader.start(); // Start the reader to avoid failure in the afterEach method.
+            reader.start(partition); // Start the reader to avoid failure in the afterEach method.
             return; // Skip these tests for non-Percona flavours of MySQL
         }
 
@@ -284,7 +288,7 @@ public class SnapshotReaderIT {
 
         // Start the snapshot ...
         boolean connectException = false;
-        reader.start();
+        reader.start(partition);
 
         List<SourceRecord> records = null;
         try {
@@ -309,10 +313,11 @@ public class SnapshotReaderIT {
         context.start();
         reader = new SnapshotReader("snapshot", context);
 
-        reader.uponCompletion(completed::countDown);
+        reader.uponCompletion((partition) -> completed.countDown());
         reader.generateReadEvents();
         // Start the snapshot ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
 
         // Poll for records ...
         // Testing.Print.enable();
@@ -360,11 +365,12 @@ public class SnapshotReaderIT {
         context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
         reader = new SnapshotReader("snapshot", context);
-        reader.uponCompletion(completed::countDown);
+        reader.uponCompletion((partition) -> completed.countDown());
         reader.generateReadEvents();
 
         // Start the snapshot ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
 
         // Poll for records ...
         // Testing.Print.enable();
@@ -460,11 +466,12 @@ public class SnapshotReaderIT {
         context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
         reader = new SnapshotReader("snapshot", context);
-        reader.uponCompletion(completed::countDown);
+        reader.uponCompletion((partition) -> completed.countDown());
         reader.generateReadEvents();
 
         // Start the snapshot ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
 
         // Poll for records ...
         // Testing.Print.enable();
@@ -490,11 +497,12 @@ public class SnapshotReaderIT {
         context.start();
         context.source().setBinlogStartPoint("binlog1", 555); // manually set for happy path testing
         reader = new SnapshotReader("snapshot", context);
-        reader.uponCompletion(completed::countDown);
+        reader.uponCompletion((partition) -> completed.countDown());
         reader.generateReadEvents();
 
         // Start the snapshot ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
 
         // Poll for records ...
         // Testing.Print.enable();
@@ -537,10 +545,11 @@ public class SnapshotReaderIT {
         context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
         reader = new SnapshotReader("snapshot", context);
-        reader.uponCompletion(completed::countDown);
+        reader.uponCompletion((partition) -> completed.countDown());
         reader.generateReadEvents();
         // Start the snapshot ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
         // Poll for records ...
         List<SourceRecord> records;
         LinkedHashSet<String> tablesInOrder = new LinkedHashSet<>();
@@ -565,10 +574,11 @@ public class SnapshotReaderIT {
         context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
         reader = new SnapshotReader("snapshot", context);
-        reader.uponCompletion(completed::countDown);
+        reader.uponCompletion((partition) -> completed.countDown());
         reader.generateReadEvents();
         // Start the snapshot ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
         // Poll for records ...
         List<SourceRecord> records;
         LinkedHashSet<String> tablesInOrder = new LinkedHashSet<>();
@@ -591,10 +601,11 @@ public class SnapshotReaderIT {
         context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
         reader = new SnapshotReader("snapshot", context);
-        reader.uponCompletion(completed::countDown);
+        reader.uponCompletion((partition) -> completed.countDown());
         reader.generateReadEvents();
         // Start the snapshot ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
         // Poll for records ...
         // Testing.Print.enable();
         List<SourceRecord> records;
@@ -628,11 +639,12 @@ public class SnapshotReaderIT {
         context = new MySqlTaskContext(config, new Filters.Builder(config).build());
         context.start();
         reader = new SnapshotReader("snapshot", context);
-        reader.uponCompletion(completed::countDown);
+        reader.uponCompletion((partition) -> completed.countDown());
         reader.generateReadEvents();
 
         // Start the snapshot ...
-        reader.start();
+        MySqlPartition partition = new MySqlPartition("test");
+        reader.start(partition);
 
         // Poll for records ...
         // Testing.Print.enable();

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
@@ -26,7 +26,7 @@ public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory<
     private final OracleConnectorConfig configuration;
     private final OracleConnection jdbcConnection;
     private final ErrorHandler errorHandler;
-    private final EventDispatcher<TableId> dispatcher;
+    private final EventDispatcher<OraclePartition, TableId> dispatcher;
     private final Clock clock;
     private final OracleDatabaseSchema schema;
     private final Configuration jdbcConfig;
@@ -34,7 +34,7 @@ public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory<
     private final OracleStreamingChangeEventSourceMetrics streamingMetrics;
 
     public OracleChangeEventSourceFactory(OracleConnectorConfig configuration, OracleConnection jdbcConnection,
-                                          ErrorHandler errorHandler, EventDispatcher<TableId> dispatcher, Clock clock, OracleDatabaseSchema schema,
+                                          ErrorHandler errorHandler, EventDispatcher<OraclePartition, TableId> dispatcher, Clock clock, OracleDatabaseSchema schema,
                                           Configuration jdbcConfig, OracleTaskContext taskContext,
                                           OracleStreamingChangeEventSourceMetrics streamingMetrics) {
         this.configuration = configuration;
@@ -49,7 +49,7 @@ public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory<
     }
 
     @Override
-    public SnapshotChangeEventSource<OraclePartition, OracleOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
+    public SnapshotChangeEventSource<OraclePartition, OracleOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener<OraclePartition> snapshotProgressListener) {
         return new OracleSnapshotChangeEventSource(configuration, jdbcConnection,
                 schema, dispatcher, clock, snapshotProgressListener);
     }
@@ -68,10 +68,10 @@ public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory<
     }
 
     @Override
-    public Optional<IncrementalSnapshotChangeEventSource<? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(
-                                                                                                                              OracleOffsetContext offsetContext,
-                                                                                                                              SnapshotProgressListener snapshotProgressListener,
-                                                                                                                              DataChangeEventListener dataChangeEventListener) {
+    public Optional<IncrementalSnapshotChangeEventSource<OraclePartition, ? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(
+                                                                                                                                               OracleOffsetContext offsetContext,
+                                                                                                                                               SnapshotProgressListener<OraclePartition> snapshotProgressListener,
+                                                                                                                                               DataChangeEventListener<OraclePartition> dataChangeEventListener) {
         // If no data collection id is provided, don't return an instance as the implementation requires
         // that a signal data collection id be provided to work.
         if (Strings.isNullOrEmpty(configuration.getSignalingDataCollectionId())) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceMetricsFactory.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceMetricsFactory.java
@@ -14,7 +14,7 @@ import io.debezium.pipeline.source.spi.EventMetadataProvider;
 /**
  * @author Chris Cranford
  */
-public class OracleChangeEventSourceMetricsFactory extends DefaultChangeEventSourceMetricsFactory {
+public class OracleChangeEventSourceMetricsFactory extends DefaultChangeEventSourceMetricsFactory<OraclePartition> {
 
     private final OracleStreamingChangeEventSourceMetrics streamingMetrics;
 
@@ -23,9 +23,9 @@ public class OracleChangeEventSourceMetricsFactory extends DefaultChangeEventSou
     }
 
     @Override
-    public <T extends CdcSourceTaskContext> StreamingChangeEventSourceMetrics getStreamingMetrics(T taskContext,
-                                                                                                  ChangeEventQueueMetrics changeEventQueueMetrics,
-                                                                                                  EventMetadataProvider eventMetadataProvider) {
+    public <T extends CdcSourceTaskContext> StreamingChangeEventSourceMetrics<OraclePartition> getStreamingMetrics(T taskContext,
+                                                                                                                   ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                                                   EventMetadataProvider eventMetadataProvider) {
         return streamingMetrics;
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -536,8 +536,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     private final int logMiningLogFileQueryMaxRetries;
 
     public OracleConnectorConfig(Configuration config) {
-        super(OracleConnector.class, config, config.getString(SERVER_NAME), new SystemTablesPredicate(config), x -> x.schema() + "." + x.table(), true,
-                ColumnFilterMode.SCHEMA);
+        super(OracleConnector.class, config, config.getString(SERVER_NAME), new SystemTablesPredicate(config),
+                x -> x.schema() + "." + x.table(), true, ColumnFilterMode.SCHEMA, false);
 
         this.databaseName = toUpperCase(config.getString(DATABASE_NAME));
         this.pdbName = toUpperCase(config.getString(PDB_NAME));

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -1000,7 +1000,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             public LogMinerEventProcessor createProcessor(ChangeEventSourceContext context,
                                                           OracleConnectorConfig connectorConfig,
                                                           OracleConnection connection,
-                                                          EventDispatcher<TableId> dispatcher,
+                                                          EventDispatcher<OraclePartition, TableId> dispatcher,
                                                           OraclePartition partition,
                                                           OracleOffsetContext offsetContext,
                                                           OracleDatabaseSchema schema,
@@ -1019,7 +1019,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             public LogMinerEventProcessor createProcessor(ChangeEventSourceContext context,
                                                           OracleConnectorConfig connectorConfig,
                                                           OracleConnection connection,
-                                                          EventDispatcher<TableId> dispatcher,
+                                                          EventDispatcher<OraclePartition, TableId> dispatcher,
                                                           OraclePartition partition,
                                                           OracleOffsetContext offsetContext,
                                                           OracleDatabaseSchema schema,
@@ -1034,7 +1034,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             public LogMinerEventProcessor createProcessor(ChangeEventSourceContext context,
                                                           OracleConnectorConfig connectorConfig,
                                                           OracleConnection connection,
-                                                          EventDispatcher<TableId> dispatcher,
+                                                          EventDispatcher<OraclePartition, TableId> dispatcher,
                                                           OraclePartition partition,
                                                           OracleOffsetContext offsetContext,
                                                           OracleDatabaseSchema schema,
@@ -1049,7 +1049,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             public LogMinerEventProcessor createProcessor(ChangeEventSourceContext context,
                                                           OracleConnectorConfig connectorConfig,
                                                           OracleConnection connection,
-                                                          EventDispatcher<TableId> dispatcher,
+                                                          EventDispatcher<OraclePartition, TableId> dispatcher,
                                                           OraclePartition partition,
                                                           OracleOffsetContext offsetContext,
                                                           OracleDatabaseSchema schema,
@@ -1065,7 +1065,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
          * Creates the buffer type's specific processor implementation
          */
         public abstract LogMinerEventProcessor createProcessor(ChangeEventSourceContext context, OracleConnectorConfig connectorConfig,
-                                                               OracleConnection connection, EventDispatcher<TableId> dispatcher, OraclePartition partition,
+                                                               OracleConnection connection, EventDispatcher<OraclePartition, TableId> dispatcher,
+                                                               OraclePartition partition,
                                                                OracleOffsetContext offsetContext, OracleDatabaseSchema schema,
                                                                OracleStreamingChangeEventSourceMetrics metrics);
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
@@ -86,7 +86,7 @@ public class OracleConnectorTask extends BaseSourceTask<OraclePartition, OracleO
 
         final OracleEventMetadataProvider metadataProvider = new OracleEventMetadataProvider();
 
-        EventDispatcher<TableId> dispatcher = new EventDispatcher<>(
+        EventDispatcher<OraclePartition, TableId> dispatcher = new EventDispatcher<>(
                 connectorConfig,
                 topicSelector,
                 schema,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -22,18 +22,18 @@ import io.debezium.util.Clock;
 /**
  * @author Chris Cranford
  */
-public class OracleSignalBasedIncrementalSnapshotChangeEventSource extends SignalBasedIncrementalSnapshotChangeEventSource<TableId> {
+public class OracleSignalBasedIncrementalSnapshotChangeEventSource extends SignalBasedIncrementalSnapshotChangeEventSource<OraclePartition, TableId> {
 
     private final String pdbName;
     private final OracleConnection connection;
 
     public OracleSignalBasedIncrementalSnapshotChangeEventSource(RelationalDatabaseConnectorConfig config,
                                                                  JdbcConnection jdbcConnection,
-                                                                 EventDispatcher<TableId> dispatcher,
+                                                                 EventDispatcher<OraclePartition, TableId> dispatcher,
                                                                  DatabaseSchema<?> databaseSchema,
                                                                  Clock clock,
-                                                                 SnapshotProgressListener progressListener,
-                                                                 DataChangeEventListener dataChangeEventListener) {
+                                                                 SnapshotProgressListener<OraclePartition> progressListener,
+                                                                 DataChangeEventListener<OraclePartition> dataChangeEventListener) {
         super(config, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener);
         this.pdbName = ((OracleConnectorConfig) config).getPdbName();
         this.connection = (OracleConnection) jdbcConnection;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -46,8 +46,8 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
     private final OracleDatabaseSchema databaseSchema;
 
     public OracleSnapshotChangeEventSource(OracleConnectorConfig connectorConfig, OracleConnection jdbcConnection,
-                                           OracleDatabaseSchema schema, EventDispatcher<TableId> dispatcher, Clock clock,
-                                           SnapshotProgressListener snapshotProgressListener) {
+                                           OracleDatabaseSchema schema, EventDispatcher<OraclePartition, TableId> dispatcher, Clock clock,
+                                           SnapshotProgressListener<OraclePartition> snapshotProgressListener) {
         super(connectorConfig, jdbcConnection, schema, dispatcher, clock, snapshotProgressListener);
 
         this.connectorConfig = connectorConfig;
@@ -56,7 +56,7 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
     }
 
     @Override
-    protected SnapshottingTask getSnapshottingTask(OracleOffsetContext previousOffset) {
+    protected SnapshottingTask getSnapshottingTask(OraclePartition partition, OracleOffsetContext previousOffset) {
         boolean snapshotSchema = true;
         boolean snapshotData = true;
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleStreamingChangeEventSourceMetrics.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleStreamingChangeEventSourceMetrics.java
@@ -31,7 +31,8 @@ import io.debezium.pipeline.source.spi.EventMetadataProvider;
  * The metrics implementation for Oracle connector streaming phase.
  */
 @ThreadSafe
-public class OracleStreamingChangeEventSourceMetrics extends DefaultStreamingChangeEventSourceMetrics implements OracleStreamingChangeEventSourceMetricsMXBean {
+public class OracleStreamingChangeEventSourceMetrics extends DefaultStreamingChangeEventSourceMetrics<OraclePartition>
+        implements OracleStreamingChangeEventSourceMetricsMXBean {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OracleStreamingChangeEventSourceMetrics.class);
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/StreamingAdapter.java
@@ -49,7 +49,7 @@ public interface StreamingAdapter {
     OffsetContext.Loader<OracleOffsetContext> getOffsetContextLoader();
 
     StreamingChangeEventSource<OraclePartition, OracleOffsetContext> getSource(OracleConnection connection,
-                                                                               EventDispatcher<TableId> dispatcher,
+                                                                               EventDispatcher<OraclePartition, TableId> dispatcher,
                                                                                ErrorHandler errorHandler, Clock clock,
                                                                                OracleDatabaseSchema schema,
                                                                                OracleTaskContext taskContext,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerAdapter.java
@@ -56,7 +56,7 @@ public class LogMinerAdapter extends AbstractStreamingAdapter {
 
     @Override
     public StreamingChangeEventSource<OraclePartition, OracleOffsetContext> getSource(OracleConnection connection,
-                                                                                      EventDispatcher<TableId> dispatcher,
+                                                                                      EventDispatcher<OraclePartition, TableId> dispatcher,
                                                                                       ErrorHandler errorHandler,
                                                                                       Clock clock,
                                                                                       OracleDatabaseSchema schema,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -61,7 +61,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
     private static final String ALL_COLUMN_LOGGING = "ALL COLUMN LOGGING";
 
     private final OracleConnection jdbcConnection;
-    private final EventDispatcher<TableId> dispatcher;
+    private final EventDispatcher<OraclePartition, TableId> dispatcher;
     private final Clock clock;
     private final OracleDatabaseSchema schema;
     private final JdbcConfiguration jdbcConfiguration;
@@ -81,7 +81,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
     private List<BigInteger> currentRedoLogSequences;
 
     public LogMinerStreamingChangeEventSource(OracleConnectorConfig connectorConfig,
-                                              OracleConnection jdbcConnection, EventDispatcher<TableId> dispatcher,
+                                              OracleConnection jdbcConnection, EventDispatcher<OraclePartition, TableId> dispatcher,
                                               ErrorHandler errorHandler, Clock clock, OracleDatabaseSchema schema,
                                               Configuration jdbcConfig, OracleStreamingChangeEventSourceMetrics streamingMetrics) {
         this.jdbcConnection = jdbcConnection;
@@ -182,7 +182,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
 
                         if (context.isRunning()) {
                             startMiningSession(jdbcConnection, startScn, endScn);
-                            startScn = processor.process(startScn, endScn);
+                            startScn = processor.process(partition, startScn, endScn);
 
                             captureSessionMemoryStatistics(jdbcConnection);
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
@@ -64,7 +64,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
     private final OracleDatabaseSchema schema;
     private final OraclePartition partition;
     private final OracleOffsetContext offsetContext;
-    private final EventDispatcher<TableId> dispatcher;
+    private final EventDispatcher<OraclePartition, TableId> dispatcher;
     private final OracleStreamingChangeEventSourceMetrics metrics;
     private final LogMinerDmlParser dmlParser;
     private final SelectLobParser selectLobParser;
@@ -83,7 +83,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
                                           OracleDatabaseSchema schema,
                                           OraclePartition partition,
                                           OracleOffsetContext offsetContext,
-                                          EventDispatcher<TableId> dispatcher,
+                                          EventDispatcher<OraclePartition, TableId> dispatcher,
                                           OracleStreamingChangeEventSourceMetrics metrics) {
         this.context = context;
         this.connectorConfig = connectorConfig;
@@ -169,7 +169,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
     }
 
     @Override
-    public Scn process(Scn startScn, Scn endScn) throws SQLException, InterruptedException {
+    public Scn process(OraclePartition partition, Scn startScn, Scn endScn) throws SQLException, InterruptedException {
         counters.reset();
 
         try (PreparedStatement statement = createQueryStatement()) {
@@ -184,7 +184,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
                 metrics.setLastDurationOfBatchCapturing(Duration.between(queryStart, Instant.now()));
 
                 Instant startProcessTime = Instant.now();
-                processResults(resultSet);
+                processResults(this.partition, resultSet);
 
                 Duration totalTime = Duration.between(startProcessTime, Instant.now());
                 metrics.setLastCapturedDmlCount(counters.dmlCount);
@@ -235,10 +235,10 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
      * @throws SQLException if a database exception occurred
      * @throws InterruptedException if the dispatcher was interrupted sending an event
      */
-    protected void processResults(ResultSet resultSet) throws SQLException, InterruptedException {
+    protected void processResults(OraclePartition partition, ResultSet resultSet) throws SQLException, InterruptedException {
         while (context.isRunning() && hasNextWithMetricsUpdate(resultSet)) {
             counters.rows++;
-            processRow(LogMinerEventRow.fromResultSet(resultSet, getConfig().getCatalogName(), isTrxIdRawValue()));
+            processRow(partition, LogMinerEventRow.fromResultSet(resultSet, getConfig().getCatalogName(), isTrxIdRawValue()));
         }
     }
 
@@ -249,7 +249,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
      * @throws SQLException if a database exception occurred
      * @throws InterruptedException if the dispatcher was interrupted sending an event
      */
-    protected void processRow(LogMinerEventRow row) throws SQLException, InterruptedException {
+    protected void processRow(OraclePartition partition, LogMinerEventRow row) throws SQLException, InterruptedException {
         if (!row.getEventType().equals(EventType.MISSING_SCN)) {
             lastProcessedScn = row.getScn();
         }
@@ -268,7 +268,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
                 handleStart(row);
                 break;
             case COMMIT:
-                handleCommit(row);
+                handleCommit(partition, row);
                 break;
             case ROLLBACK:
                 handleRollback(row);
@@ -326,7 +326,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
      * @param row the result set row
      * @throws InterruptedException if the event dispatcher was interrupted sending events
      */
-    protected void handleCommit(LogMinerEventRow row) throws InterruptedException {
+    protected void handleCommit(OraclePartition partition, LogMinerEventRow row) throws InterruptedException {
         final String transactionId = row.getTransactionId();
         if (isRecentlyProcessed(transactionId)) {
             LOGGER.debug("\tTransaction is already committed, skipped.");
@@ -404,7 +404,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
                                 getSchema().tableFor(event.getTableId()),
                                 Clock.system());
                     }
-                    dispatcher.dispatchDataChangeEvent(event.getTableId(), logMinerChangeRecordEmitter);
+                    dispatcher.dispatchDataChangeEvent(partition, event.getTableId(), logMinerChangeRecordEmitter);
 
                 }
             }
@@ -839,7 +839,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
      */
     private Table dispatchSchemaChangeEventAndGetTableForNewCapturedTable(TableId tableId,
                                                                           OracleOffsetContext offsetContext,
-                                                                          EventDispatcher<TableId> dispatcher)
+                                                                          EventDispatcher<OraclePartition, TableId> dispatcher)
             throws SQLException, InterruptedException {
         LOGGER.info("Table '{}' is new and will now be captured.", tableId);
         offsetContext.event(tableId, Instant.now());

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/LogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/LogMinerEventProcessor.java
@@ -8,6 +8,7 @@ package io.debezium.connector.oracle.logminer.processor;
 import java.sql.SQLException;
 import java.time.Duration;
 
+import io.debezium.connector.oracle.OraclePartition;
 import io.debezium.connector.oracle.Scn;
 
 /**
@@ -23,7 +24,7 @@ public interface LogMinerEventProcessor extends AutoCloseable {
      * @param endScn the ending system change number, must not be {@code null}
      * @return the next iteration's starting system change number, never {@code null}
      */
-    Scn process(Scn startScn, Scn endScn) throws SQLException, InterruptedException;
+    Scn process(OraclePartition partition, Scn startScn, Scn endScn) throws SQLException, InterruptedException;
 
     /**
      * A callback for the event processor to abandon long running transactions.

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/AbstractInfinispanLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/AbstractInfinispanLogMinerEventProcessor.java
@@ -46,12 +46,12 @@ public abstract class AbstractInfinispanLogMinerEventProcessor extends AbstractL
     private final OracleStreamingChangeEventSourceMetrics metrics;
     private final OraclePartition partition;
     private final OracleOffsetContext offsetContext;
-    private final EventDispatcher<TableId> dispatcher;
+    private final EventDispatcher<OraclePartition, TableId> dispatcher;
 
     public AbstractInfinispanLogMinerEventProcessor(ChangeEventSourceContext context,
                                                     OracleConnectorConfig connectorConfig,
                                                     OracleConnection jdbcConnection,
-                                                    EventDispatcher<TableId> dispatcher,
+                                                    EventDispatcher<OraclePartition, TableId> dispatcher,
                                                     OraclePartition partition,
                                                     OracleOffsetContext offsetContext,
                                                     OracleDatabaseSchema schema,
@@ -105,13 +105,13 @@ public abstract class AbstractInfinispanLogMinerEventProcessor extends AbstractL
     }
 
     @Override
-    protected void processRow(LogMinerEventRow row) throws SQLException, InterruptedException {
+    protected void processRow(OraclePartition partition, LogMinerEventRow row) throws SQLException, InterruptedException {
         final String transactionId = row.getTransactionId();
         if (isRecentlyProcessed(transactionId)) {
             LOGGER.trace("Transaction {} has been seen by connector, skipped.", transactionId);
             return;
         }
-        super.processRow(row);
+        super.processRow(partition, row);
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/EmbeddedInfinispanLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/EmbeddedInfinispanLogMinerEventProcessor.java
@@ -63,7 +63,7 @@ public class EmbeddedInfinispanLogMinerEventProcessor extends AbstractInfinispan
     public EmbeddedInfinispanLogMinerEventProcessor(ChangeEventSourceContext context,
                                                     OracleConnectorConfig connectorConfig,
                                                     OracleConnection jdbcConnection,
-                                                    EventDispatcher<TableId> dispatcher,
+                                                    EventDispatcher<OraclePartition, TableId> dispatcher,
                                                     OraclePartition partition,
                                                     OracleOffsetContext offsetContext,
                                                     OracleDatabaseSchema schema,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/RemoteInfinispanLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/RemoteInfinispanLogMinerEventProcessor.java
@@ -70,7 +70,7 @@ public class RemoteInfinispanLogMinerEventProcessor extends AbstractInfinispanLo
     public RemoteInfinispanLogMinerEventProcessor(ChangeEventSourceContext context,
                                                   OracleConnectorConfig connectorConfig,
                                                   OracleConnection jdbcConnection,
-                                                  EventDispatcher<TableId> dispatcher,
+                                                  EventDispatcher<OraclePartition, TableId> dispatcher,
                                                   OraclePartition partition,
                                                   OracleOffsetContext offsetContext,
                                                   OracleDatabaseSchema schema,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/memory/MemoryLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/memory/MemoryLogMinerEventProcessor.java
@@ -48,7 +48,7 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
     private static final Logger LOGGER = LoggerFactory.getLogger(MemoryLogMinerEventProcessor.class);
 
     private final OracleConnection jdbcConnection;
-    private final EventDispatcher<TableId> dispatcher;
+    private final EventDispatcher<OraclePartition, TableId> dispatcher;
     private final OraclePartition partition;
     private final OracleOffsetContext offsetContext;
     private final OracleStreamingChangeEventSourceMetrics metrics;
@@ -67,7 +67,7 @@ public class MemoryLogMinerEventProcessor extends AbstractLogMinerEventProcessor
     public MemoryLogMinerEventProcessor(ChangeEventSourceContext context,
                                         OracleConnectorConfig connectorConfig,
                                         OracleConnection jdbcConnection,
-                                        EventDispatcher<TableId> dispatcher,
+                                        EventDispatcher<OraclePartition, TableId> dispatcher,
                                         OraclePartition partition,
                                         OracleOffsetContext offsetContext,
                                         OracleDatabaseSchema schema,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -52,7 +52,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
 
     private final OracleConnectorConfig connectorConfig;
     private final ErrorHandler errorHandler;
-    private final EventDispatcher<TableId> dispatcher;
+    private final EventDispatcher<OraclePartition, TableId> dispatcher;
     private final Clock clock;
     private final OracleDatabaseSchema schema;
     private final OraclePartition partition;
@@ -63,7 +63,8 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     private final Map<String, ChunkColumnValues> columnChunks;
     private RowLCR currentRow;
 
-    public LcrEventHandler(OracleConnectorConfig connectorConfig, ErrorHandler errorHandler, EventDispatcher<TableId> dispatcher, Clock clock,
+    public LcrEventHandler(OracleConnectorConfig connectorConfig, ErrorHandler errorHandler,
+                           EventDispatcher<OraclePartition, TableId> dispatcher, Clock clock,
                            OracleDatabaseSchema schema, OraclePartition partition, OracleOffsetContext offsetContext,
                            boolean tablenameCaseInsensitive, XstreamStreamingChangeEventSource eventSource,
                            OracleStreamingChangeEventSourceMetrics streamingMetrics) {
@@ -217,6 +218,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         }
 
         dispatcher.dispatchDataChangeEvent(
+                partition,
                 tableId,
                 new XStreamChangeRecordEmitter(partition, offsetContext, lcr, oldChunkValues, chunkValues,
                         schema.tableFor(tableId), clock));

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamAdapter.java
@@ -67,7 +67,7 @@ public class XStreamAdapter extends AbstractStreamingAdapter {
 
     @Override
     public StreamingChangeEventSource<OraclePartition, OracleOffsetContext> getSource(OracleConnection connection,
-                                                                                      EventDispatcher<TableId> dispatcher,
+                                                                                      EventDispatcher<OraclePartition, TableId> dispatcher,
                                                                                       ErrorHandler errorHandler,
                                                                                       Clock clock,
                                                                                       OracleDatabaseSchema schema,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -46,7 +46,7 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
 
     private final OracleConnectorConfig connectorConfig;
     private final OracleConnection jdbcConnection;
-    private final EventDispatcher<TableId> dispatcher;
+    private final EventDispatcher<OraclePartition, TableId> dispatcher;
     private final ErrorHandler errorHandler;
     private final Clock clock;
     private final OracleDatabaseSchema schema;
@@ -64,7 +64,7 @@ public class XstreamStreamingChangeEventSource implements StreamingChangeEventSo
     private final AtomicReference<PositionAndScn> lcrMessage = new AtomicReference<>();
 
     public XstreamStreamingChangeEventSource(OracleConnectorConfig connectorConfig, OracleConnection jdbcConnection,
-                                             EventDispatcher<TableId> dispatcher, ErrorHandler errorHandler,
+                                             EventDispatcher<OraclePartition, TableId> dispatcher, ErrorHandler errorHandler,
                                              Clock clock, OracleDatabaseSchema schema,
                                              OracleStreamingChangeEventSourceMetrics streamingMetrics) {
         this.connectorConfig = connectorConfig;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceCoordinator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceCoordinator.java
@@ -41,8 +41,8 @@ public class PostgresChangeEventSourceCoordinator extends ChangeEventSourceCoord
                                                 Class<? extends SourceConnector> connectorType,
                                                 CommonConnectorConfig connectorConfig,
                                                 PostgresChangeEventSourceFactory changeEventSourceFactory,
-                                                ChangeEventSourceMetricsFactory changeEventSourceMetricsFactory,
-                                                EventDispatcher<?> eventDispatcher, DatabaseSchema<?> schema,
+                                                ChangeEventSourceMetricsFactory<PostgresPartition> changeEventSourceMetricsFactory,
+                                                EventDispatcher<PostgresPartition, ?> eventDispatcher, DatabaseSchema<?> schema,
                                                 Snapshotter snapshotter, SlotState slotInfo) {
         super(previousOffsets, errorHandler, connectorType, connectorConfig, changeEventSourceFactory,
                 changeEventSourceMetricsFactory, eventDispatcher, schema);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFactory.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFactory.java
@@ -56,7 +56,7 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
     }
 
     @Override
-    public SnapshotChangeEventSource<PostgresPartition, PostgresOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
+    public SnapshotChangeEventSource<PostgresPartition, PostgresOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener<PostgresPartition> snapshotProgressListener) {
         return new PostgresSnapshotChangeEventSource(
                 configuration,
                 snapshotter,
@@ -84,10 +84,10 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
     }
 
     @Override
-    public Optional<IncrementalSnapshotChangeEventSource<? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(
-                                                                                                                              PostgresOffsetContext offsetContext,
-                                                                                                                              SnapshotProgressListener snapshotProgressListener,
-                                                                                                                              DataChangeEventListener dataChangeEventListener) {
+    public Optional<IncrementalSnapshotChangeEventSource<PostgresPartition, ? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(
+                                                                                                                                                 PostgresOffsetContext offsetContext,
+                                                                                                                                                 SnapshotProgressListener<PostgresPartition> snapshotProgressListener,
+                                                                                                                                                 DataChangeEventListener<PostgresPartition> dataChangeEventListener) {
         // If no data collection id is provided, don't return an instance as the implementation requires
         // that a signal data collection id be provided to work.
         if (Strings.isNullOrEmpty(configuration.getSignalingDataCollectionId())) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
@@ -29,7 +29,6 @@ import io.debezium.data.Envelope.Operation;
 import io.debezium.function.Predicates;
 import io.debezium.pipeline.spi.ChangeRecordEmitter;
 import io.debezium.pipeline.spi.OffsetContext;
-import io.debezium.pipeline.spi.Partition;
 import io.debezium.relational.Column;
 import io.debezium.relational.ColumnEditor;
 import io.debezium.relational.RelationalChangeRecordEmitter;
@@ -46,7 +45,7 @@ import io.debezium.util.Strings;
  *
  * @author Horia Chiorean (hchiorea@redhat.com), Jiri Pechanec
  */
-public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
+public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter<PostgresPartition> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgresChangeRecordEmitter.class);
 
@@ -59,7 +58,7 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
     private final boolean nullToastedValuesMissingFromOld;
     private final Map<String, Object> cachedOldToastedValues = new HashMap<>();
 
-    public PostgresChangeRecordEmitter(Partition partition, OffsetContext offset, Clock clock, PostgresConnectorConfig connectorConfig, PostgresSchema schema,
+    public PostgresChangeRecordEmitter(PostgresPartition partition, OffsetContext offset, Clock clock, PostgresConnectorConfig connectorConfig, PostgresSchema schema,
                                        PostgresConnection connection, TableId tableId,
                                        ReplicationMessage message) {
         super(partition, offset, clock);
@@ -92,7 +91,7 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
     }
 
     @Override
-    public void emitChangeRecords(DataCollectionSchema schema, Receiver receiver) throws InterruptedException {
+    public void emitChangeRecords(DataCollectionSchema schema, Receiver<PostgresPartition> receiver) throws InterruptedException {
         schema = synchronizeTableSchema(schema);
         super.emitChangeRecords(schema, receiver);
     }
@@ -257,7 +256,7 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
         }
     }
 
-    static Optional<DataCollectionSchema> updateSchema(TableId tableId, ChangeRecordEmitter changeRecordEmitter) {
+    static Optional<DataCollectionSchema> updateSchema(PostgresPartition partition, TableId tableId, ChangeRecordEmitter<PostgresPartition> changeRecordEmitter) {
         return ((PostgresChangeRecordEmitter) changeRecordEmitter).newTable(tableId);
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresEventDispatcher.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresEventDispatcher.java
@@ -31,7 +31,7 @@ import io.debezium.util.SchemaNameAdjuster;
  *
  * @author Lairen Hightower
  */
-public class PostgresEventDispatcher<T extends DataCollectionId> extends EventDispatcher<T> {
+public class PostgresEventDispatcher<T extends DataCollectionId> extends EventDispatcher<PostgresPartition, T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgresEventDispatcher.class);
     private final ChangeEventQueue<DataChangeEvent> queue;
     private final LogicalDecodingMessageMonitor logicalDecodingMessageMonitor;
@@ -54,7 +54,7 @@ public class PostgresEventDispatcher<T extends DataCollectionId> extends EventDi
 
     public PostgresEventDispatcher(PostgresConnectorConfig connectorConfig, TopicSelector<T> topicSelector,
                                    DatabaseSchema<T> schema, ChangeEventQueue<DataChangeEvent> queue, DataCollectionFilters.DataCollectionFilter<T> filter,
-                                   ChangeEventCreator changeEventCreator, InconsistentSchemaHandler<T> inconsistentSchemaHandler,
+                                   ChangeEventCreator changeEventCreator, InconsistentSchemaHandler<PostgresPartition, T> inconsistentSchemaHandler,
                                    EventMetadataProvider metadataProvider, Heartbeat customHeartbeat, SchemaNameAdjuster schemaNameAdjuster,
                                    JdbcConnection jdbcConnection) {
         super(connectorConfig, topicSelector, schema, queue, filter, changeEventCreator, inconsistentSchemaHandler, metadataProvider,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -28,7 +28,8 @@ import io.debezium.util.Clock;
  * 
  * @author Chris Cranford
  */
-public class PostgresSignalBasedIncrementalSnapshotChangeEventSource extends SignalBasedIncrementalSnapshotChangeEventSource<TableId> {
+public class PostgresSignalBasedIncrementalSnapshotChangeEventSource
+        extends SignalBasedIncrementalSnapshotChangeEventSource<PostgresPartition, TableId> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PostgresSignalBasedIncrementalSnapshotChangeEventSource.class);
 
@@ -37,11 +38,11 @@ public class PostgresSignalBasedIncrementalSnapshotChangeEventSource extends Sig
 
     public PostgresSignalBasedIncrementalSnapshotChangeEventSource(RelationalDatabaseConnectorConfig config,
                                                                    JdbcConnection jdbcConnection,
-                                                                   EventDispatcher<TableId> dispatcher,
+                                                                   EventDispatcher<PostgresPartition, TableId> dispatcher,
                                                                    DatabaseSchema<?> databaseSchema,
                                                                    Clock clock,
-                                                                   SnapshotProgressListener progressListener,
-                                                                   DataChangeEventListener dataChangeEventListener) {
+                                                                   SnapshotProgressListener<PostgresPartition> progressListener,
+                                                                   DataChangeEventListener<PostgresPartition> dataChangeEventListener) {
         super(config, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener);
         this.jdbcConnection = (PostgresConnection) jdbcConnection;
         this.schema = (PostgresSchema) databaseSchema;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -41,8 +41,10 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
     private final SlotState startingSlotInfo;
 
     public PostgresSnapshotChangeEventSource(PostgresConnectorConfig connectorConfig, Snapshotter snapshotter,
-                                             PostgresConnection jdbcConnection, PostgresSchema schema, EventDispatcher<TableId> dispatcher, Clock clock,
-                                             SnapshotProgressListener snapshotProgressListener, SlotCreationResult slotCreatedInfo, SlotState startingSlotInfo) {
+                                             PostgresConnection jdbcConnection, PostgresSchema schema, EventDispatcher<PostgresPartition, TableId> dispatcher,
+                                             Clock clock,
+                                             SnapshotProgressListener<PostgresPartition> snapshotProgressListener, SlotCreationResult slotCreatedInfo,
+                                             SlotState startingSlotInfo) {
         super(connectorConfig, jdbcConnection, schema, dispatcher, clock, snapshotProgressListener);
         this.connectorConfig = connectorConfig;
         this.jdbcConnection = jdbcConnection;
@@ -53,7 +55,7 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
     }
 
     @Override
-    protected SnapshottingTask getSnapshottingTask(PostgresOffsetContext previousOffset) {
+    protected SnapshottingTask getSnapshottingTask(PostgresPartition partition, PostgresOffsetContext previousOffset) {
         boolean snapshotSchema = true;
         boolean snapshotData = true;
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -265,6 +265,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                             tableId);
 
                     boolean dispatched = message.getOperation() != Operation.NOOP && dispatcher.dispatchDataChangeEvent(
+                            partition,
                             tableId,
                             new PostgresChangeRecordEmitter(
                                     partition,

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceCoordinator.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceCoordinator.java
@@ -45,7 +45,8 @@ public class SqlServerChangeEventSourceCoordinator extends ChangeEventSourceCoor
                                                  Class<? extends SourceConnector> connectorType,
                                                  CommonConnectorConfig connectorConfig,
                                                  ChangeEventSourceFactory<SqlServerPartition, SqlServerOffsetContext> changeEventSourceFactory,
-                                                 ChangeEventSourceMetricsFactory changeEventSourceMetricsFactory, EventDispatcher<?> eventDispatcher,
+                                                 ChangeEventSourceMetricsFactory<SqlServerPartition> changeEventSourceMetricsFactory,
+                                                 EventDispatcher<SqlServerPartition, ?> eventDispatcher,
                                                  DatabaseSchema<?> schema,
                                                  Clock clock) {
         super(previousOffsets, errorHandler, connectorType, connectorConfig, changeEventSourceFactory,
@@ -81,9 +82,7 @@ public class SqlServerChangeEventSourceCoordinator extends ChangeEventSourceCoor
             throws InterruptedException {
 
         // TODO: Determine how to do incremental snapshots with multiple partitions but for now just use the first offset
-        SqlServerOffsetContext offsetContext = streamingOffsets.getOffsets().values().stream().findFirst().get();
-
-        initStreamEvents(offsetContext);
+        initStreamEvents(streamingOffsets.getTheOnlyPartition(), streamingOffsets.getTheOnlyOffset());
         final Metronome metronome = Metronome.sleeper(pollInterval, clock);
 
         LOGGER.info("Starting streaming");

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
@@ -27,12 +27,13 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
     private final SqlServerConnection dataConnection;
     private final SqlServerConnection metadataConnection;
     private final ErrorHandler errorHandler;
-    private final EventDispatcher<TableId> dispatcher;
+    private final EventDispatcher<SqlServerPartition, TableId> dispatcher;
     private final Clock clock;
     private final SqlServerDatabaseSchema schema;
 
     public SqlServerChangeEventSourceFactory(SqlServerConnectorConfig configuration, SqlServerConnection dataConnection, SqlServerConnection metadataConnection,
-                                             ErrorHandler errorHandler, EventDispatcher<TableId> dispatcher, Clock clock, SqlServerDatabaseSchema schema) {
+                                             ErrorHandler errorHandler, EventDispatcher<SqlServerPartition, TableId> dispatcher, Clock clock,
+                                             SqlServerDatabaseSchema schema) {
         this.configuration = configuration;
         this.dataConnection = dataConnection;
         this.metadataConnection = metadataConnection;
@@ -43,7 +44,7 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
     }
 
     @Override
-    public SnapshotChangeEventSource<SqlServerPartition, SqlServerOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener) {
+    public SnapshotChangeEventSource<SqlServerPartition, SqlServerOffsetContext> getSnapshotChangeEventSource(SnapshotProgressListener<SqlServerPartition> snapshotProgressListener) {
         return new SqlServerSnapshotChangeEventSource(configuration, dataConnection, schema, dispatcher, clock,
                 snapshotProgressListener);
     }
@@ -61,16 +62,16 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
     }
 
     @Override
-    public Optional<IncrementalSnapshotChangeEventSource<? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(
-                                                                                                                              SqlServerOffsetContext offsetContext,
-                                                                                                                              SnapshotProgressListener snapshotProgressListener,
-                                                                                                                              DataChangeEventListener dataChangeEventListener) {
+    public Optional<IncrementalSnapshotChangeEventSource<SqlServerPartition, ? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(
+                                                                                                                                                  SqlServerOffsetContext offsetContext,
+                                                                                                                                                  SnapshotProgressListener<SqlServerPartition> snapshotProgressListener,
+                                                                                                                                                  DataChangeEventListener<SqlServerPartition> dataChangeEventListener) {
         // If no data collection id is provided, don't return an instance as the implementation requires
         // that a signal data collection id be provided to work.
         if (Strings.isNullOrEmpty(configuration.getSignalingDataCollectionId())) {
             return Optional.empty();
         }
-        final SignalBasedIncrementalSnapshotChangeEventSource<TableId> incrementalSnapshotChangeEventSource = new SignalBasedIncrementalSnapshotChangeEventSource<>(
+        final SignalBasedIncrementalSnapshotChangeEventSource<SqlServerPartition, TableId> incrementalSnapshotChangeEventSource = new SignalBasedIncrementalSnapshotChangeEventSource<>(
                 configuration,
                 dataConnection,
                 dispatcher,

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -384,7 +384,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
 
     public SqlServerConnectorConfig(Configuration config) {
         super(SqlServerConnector.class, config, config.getString(SERVER_NAME), new SystemTablesPredicate(), x -> x.schema() + "." + x.table(), true,
-                ColumnFilterMode.SCHEMA);
+                ColumnFilterMode.SCHEMA, config.hasKey(DATABASE_NAMES));
 
         final String databaseName = config.getString(DATABASE_NAME.name());
         final String databaseNames = config.getString(DATABASE_NAMES.name());

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -105,7 +105,7 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
 
         final SqlServerEventMetadataProvider metadataProvider = new SqlServerEventMetadataProvider();
 
-        final EventDispatcher<TableId> dispatcher = new EventDispatcher<>(
+        final EventDispatcher<SqlServerPartition, TableId> dispatcher = new EventDispatcher<>(
                 connectorConfig,
                 topicSelector,
                 schema,
@@ -121,7 +121,7 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
                 SqlServerConnector.class,
                 connectorConfig,
                 new SqlServerChangeEventSourceFactory(connectorConfig, dataConnection, metadataConnection, errorHandler, dispatcher, clock, schema),
-                new DefaultChangeEventSourceMetricsFactory(),
+                new DefaultChangeEventSourceMetricsFactory<>(),
                 dispatcher,
                 schema,
                 clock);

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -17,11 +17,13 @@ import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.connector.common.BaseSourceTask;
+import io.debezium.connector.sqlserver.metrics.SqlServerMetricsFactory;
 import io.debezium.pipeline.ChangeEventSourceCoordinator;
 import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.metrics.DefaultChangeEventSourceMetricsFactory;
+import io.debezium.pipeline.metrics.spi.ChangeEventSourceMetricsFactory;
 import io.debezium.pipeline.spi.Offsets;
 import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
@@ -121,7 +123,7 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
                 SqlServerConnector.class,
                 connectorConfig,
                 new SqlServerChangeEventSourceFactory(connectorConfig, dataConnection, metadataConnection, errorHandler, dispatcher, clock, schema),
-                new DefaultChangeEventSourceMetricsFactory<>(),
+                createChangeEventSourceMetricsFactory(connectorConfig.isMultiPartitionModeEnabled(), offsets),
                 dispatcher,
                 schema,
                 clock);
@@ -170,5 +172,15 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
     @Override
     protected Iterable<Field> getAllConfigurationFields() {
         return SqlServerConnectorConfig.ALL_FIELDS;
+    }
+
+    private ChangeEventSourceMetricsFactory<SqlServerPartition> createChangeEventSourceMetricsFactory(boolean multiPartitionMode,
+                                                                                                      Offsets<SqlServerPartition, SqlServerOffsetContext> offsets) {
+        if (multiPartitionMode) {
+            return new SqlServerMetricsFactory(offsets.getPartitions());
+        }
+        else {
+            return new DefaultChangeEventSourceMetricsFactory<>();
+        }
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerPartition.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerPartition.java
@@ -42,7 +42,7 @@ public class SqlServerPartition implements Partition {
     /**
      * Returns the SQL Server database name corresponding to the partition.
      */
-    String getDatabaseName() {
+    public String getDatabaseName() {
         return databaseName;
     }
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
@@ -45,8 +45,8 @@ public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChange
     private Map<TableId, SqlServerChangeTable> changeTables;
 
     public SqlServerSnapshotChangeEventSource(SqlServerConnectorConfig connectorConfig, SqlServerConnection jdbcConnection,
-                                              SqlServerDatabaseSchema schema, EventDispatcher<TableId> dispatcher, Clock clock,
-                                              SnapshotProgressListener snapshotProgressListener) {
+                                              SqlServerDatabaseSchema schema, EventDispatcher<SqlServerPartition, TableId> dispatcher, Clock clock,
+                                              SnapshotProgressListener<SqlServerPartition> snapshotProgressListener) {
         super(connectorConfig, jdbcConnection, schema, dispatcher, clock, snapshotProgressListener);
         this.connectorConfig = connectorConfig;
         this.jdbcConnection = jdbcConnection;
@@ -54,7 +54,7 @@ public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChange
     }
 
     @Override
-    protected SnapshottingTask getSnapshottingTask(SqlServerOffsetContext previousOffset) {
+    protected SnapshottingTask getSnapshottingTask(SqlServerPartition partition, SqlServerOffsetContext previousOffset) {
         boolean snapshotSchema = true;
         boolean snapshotData = true;
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -77,7 +77,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
      */
     private final SqlServerConnection metadataConnection;
 
-    private final EventDispatcher<TableId> dispatcher;
+    private final EventDispatcher<SqlServerPartition, TableId> dispatcher;
     private final ErrorHandler errorHandler;
     private final Clock clock;
     private final SqlServerDatabaseSchema schema;
@@ -88,8 +88,9 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
     private final Map<SqlServerPartition, SqlServerStreamingExecutionContext> streamingExecutionContexts;
 
     public SqlServerStreamingChangeEventSource(SqlServerConnectorConfig connectorConfig, SqlServerConnection dataConnection,
-                                               SqlServerConnection metadataConnection, EventDispatcher<TableId> dispatcher, ErrorHandler errorHandler, Clock clock,
-                                               SqlServerDatabaseSchema schema) {
+                                               SqlServerConnection metadataConnection,
+                                               EventDispatcher<SqlServerPartition, TableId> dispatcher,
+                                               ErrorHandler errorHandler, Clock clock, SqlServerDatabaseSchema schema) {
         this.connectorConfig = connectorConfig;
         this.dataConnection = dataConnection;
         this.metadataConnection = metadataConnection;
@@ -287,6 +288,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
 
                             dispatcher
                                     .dispatchDataChangeEvent(
+                                            partition,
                                             tableId,
                                             new SqlServerChangeRecordEmitter(
                                                     partition,

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/AbstractSqlServerPartitionMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/AbstractSqlServerPartitionMetrics.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver.metrics;
+
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.data.Envelope.Operation;
+import io.debezium.metrics.Metrics;
+import io.debezium.pipeline.ConnectorEvent;
+import io.debezium.pipeline.meters.CommonEventMeter;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.schema.DataCollectionId;
+
+/**
+ * Base implementation of partition-scoped multi-partition SQL Server connector metrics.
+ */
+abstract public class AbstractSqlServerPartitionMetrics extends Metrics implements SqlServerPartitionMetricsMXBean {
+
+    private final CommonEventMeter commonEventMeter;
+
+    AbstractSqlServerPartitionMetrics(CdcSourceTaskContext taskContext, Map<String, String> tags,
+                                      EventMetadataProvider metadataProvider) {
+        super(taskContext, tags);
+        this.commonEventMeter = new CommonEventMeter(taskContext.getClock(), metadataProvider);
+    }
+
+    @Override
+    public String getLastEvent() {
+        return commonEventMeter.getLastEvent();
+    }
+
+    @Override
+    public long getMilliSecondsSinceLastEvent() {
+        return commonEventMeter.getMilliSecondsSinceLastEvent();
+    }
+
+    @Override
+    public long getTotalNumberOfEventsSeen() {
+        return commonEventMeter.getTotalNumberOfEventsSeen();
+    }
+
+    @Override
+    public long getTotalNumberOfCreateEventsSeen() {
+        return commonEventMeter.getTotalNumberOfCreateEventsSeen();
+    }
+
+    @Override
+    public long getTotalNumberOfUpdateEventsSeen() {
+        return commonEventMeter.getTotalNumberOfUpdateEventsSeen();
+    }
+
+    @Override
+    public long getTotalNumberOfDeleteEventsSeen() {
+        return commonEventMeter.getTotalNumberOfDeleteEventsSeen();
+    }
+
+    @Override
+    public long getNumberOfEventsFiltered() {
+        return commonEventMeter.getNumberOfEventsFiltered();
+    }
+
+    @Override
+    public long getNumberOfErroneousEvents() {
+        return commonEventMeter.getNumberOfErroneousEvents();
+    }
+
+    /**
+     * Invoked if an event is processed for a captured table.
+     */
+    void onEvent(DataCollectionId source, OffsetContext offset, Object key, Struct value, Operation operation) {
+        commonEventMeter.onEvent(source, offset, key, value, operation);
+    }
+
+    /**
+     * Invoked for events pertaining to non-captured tables.
+     */
+    void onFilteredEvent(String event) {
+        commonEventMeter.onFilteredEvent();
+    }
+
+    /**
+     * Invoked for events pertaining to non-captured tables.
+     */
+    void onFilteredEvent(String event, Operation operation) {
+        commonEventMeter.onFilteredEvent(operation);
+    }
+
+    /**
+     * Invoked for events that cannot be processed.
+     */
+    void onErroneousEvent(String event) {
+        commonEventMeter.onErroneousEvent();
+    }
+
+    /**
+     * Invoked for events that cannot be processed.
+     */
+    void onErroneousEvent(String event, Operation operation) {
+        commonEventMeter.onErroneousEvent(operation);
+    }
+
+    /**
+     * Invoked for events that represent a connector event.
+     */
+    void onConnectorEvent(ConnectorEvent event) {
+    }
+
+    @Override
+    public void reset() {
+        commonEventMeter.reset();
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/AbstractSqlServerTaskMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/AbstractSqlServerTaskMetrics.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver.metrics;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.connector.base.ChangeEventQueueMetrics;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.sqlserver.SqlServerPartition;
+import io.debezium.data.Envelope.Operation;
+import io.debezium.metrics.Metrics;
+import io.debezium.pipeline.ConnectorEvent;
+import io.debezium.pipeline.metrics.ChangeEventSourceMetrics;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.schema.DataCollectionId;
+import io.debezium.util.Collect;
+
+/**
+ * Base implementation of task-scoped multi-partition SQL Server connector metrics.
+ */
+abstract class AbstractSqlServerTaskMetrics<B extends AbstractSqlServerPartitionMetrics> extends Metrics
+        implements ChangeEventSourceMetrics<SqlServerPartition>, SqlServerTaskMetricsMXBean {
+
+    private final ChangeEventQueueMetrics changeEventQueueMetrics;
+    private final Map<SqlServerPartition, B> beans = new HashMap<>();
+
+    AbstractSqlServerTaskMetrics(CdcSourceTaskContext taskContext,
+                                 String contextName,
+                                 ChangeEventQueueMetrics changeEventQueueMetrics,
+                                 Collection<SqlServerPartition> partitions,
+                                 Function<SqlServerPartition, B> beanFactory) {
+        super(taskContext, Collect.linkMapOf(
+                "server", taskContext.getConnectorName(),
+                "task", "0",
+                "context", contextName));
+        this.changeEventQueueMetrics = changeEventQueueMetrics;
+
+        for (SqlServerPartition partition : partitions) {
+            beans.put(partition, beanFactory.apply(partition));
+        }
+    }
+
+    @Override
+    public synchronized void register() {
+        super.register();
+        beans.values().forEach(Metrics::register);
+    }
+
+    @Override
+    public synchronized void unregister() {
+        beans.values().forEach(Metrics::unregister);
+        super.unregister();
+    }
+
+    @Override
+    public void reset() {
+        beans.values().forEach(B::reset);
+    }
+
+    @Override
+    public void onEvent(SqlServerPartition partition, DataCollectionId source, OffsetContext offset, Object key,
+                        Struct value, Operation operation) {
+        onPartitionEvent(partition, bean -> bean.onEvent(source, offset, key, value, operation));
+    }
+
+    @Override
+    public void onFilteredEvent(SqlServerPartition partition, String event) {
+        onPartitionEvent(partition, bean -> bean.onFilteredEvent(event));
+    }
+
+    @Override
+    public void onFilteredEvent(SqlServerPartition partition, String event, Operation operation) {
+        onPartitionEvent(partition, bean -> bean.onFilteredEvent(event, operation));
+    }
+
+    @Override
+    public void onErroneousEvent(SqlServerPartition partition, String event) {
+        onPartitionEvent(partition, bean -> bean.onErroneousEvent(event));
+    }
+
+    @Override
+    public void onErroneousEvent(SqlServerPartition partition, String event, Operation operation) {
+        onPartitionEvent(partition, bean -> bean.onErroneousEvent(event, operation));
+    }
+
+    @Override
+    public void onConnectorEvent(SqlServerPartition partition, ConnectorEvent event) {
+        onPartitionEvent(partition, bean -> bean.onConnectorEvent(event));
+    }
+
+    @Override
+    public int getQueueTotalCapacity() {
+        return changeEventQueueMetrics.totalCapacity();
+    }
+
+    @Override
+    public int getQueueRemainingCapacity() {
+        return changeEventQueueMetrics.remainingCapacity();
+    }
+
+    @Override
+    public long getMaxQueueSizeInBytes() {
+        return changeEventQueueMetrics.maxQueueSizeInBytes();
+    }
+
+    @Override
+    public long getCurrentQueueSizeInBytes() {
+        return changeEventQueueMetrics.currentQueueSizeInBytes();
+    }
+
+    protected void onPartitionEvent(SqlServerPartition partition, Consumer<B> handler) {
+        B bean = beans.get(partition);
+        if (bean == null) {
+            throw new IllegalArgumentException("MBean for partition " + partition + " are not registered");
+        }
+        handler.accept(bean);
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerMetricsFactory.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerMetricsFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver.metrics;
+
+import java.util.Collection;
+
+import io.debezium.connector.base.ChangeEventQueueMetrics;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.sqlserver.SqlServerPartition;
+import io.debezium.pipeline.metrics.SnapshotChangeEventSourceMetrics;
+import io.debezium.pipeline.metrics.StreamingChangeEventSourceMetrics;
+import io.debezium.pipeline.metrics.spi.ChangeEventSourceMetricsFactory;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+
+public class SqlServerMetricsFactory implements ChangeEventSourceMetricsFactory<SqlServerPartition> {
+
+    private final Collection<SqlServerPartition> partitions;
+
+    public SqlServerMetricsFactory(Collection<SqlServerPartition> partitions) {
+        this.partitions = partitions;
+    }
+
+    @Override
+    public <T extends CdcSourceTaskContext> SnapshotChangeEventSourceMetrics<SqlServerPartition> getSnapshotMetrics(T taskContext,
+                                                                                                                    ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                                                    EventMetadataProvider eventMetadataProvider) {
+        return new SqlServerSnapshotTaskMetrics(taskContext, changeEventQueueMetrics,
+                eventMetadataProvider, partitions);
+    }
+
+    @Override
+    public <T extends CdcSourceTaskContext> StreamingChangeEventSourceMetrics<SqlServerPartition> getStreamingMetrics(T taskContext,
+                                                                                                                      ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                                                      EventMetadataProvider eventMetadataProvider) {
+        return new SqlServerStreamingTaskMetrics(taskContext, changeEventQueueMetrics,
+                eventMetadataProvider, partitions);
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerPartitionMetricsMXBean.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerPartitionMetricsMXBean.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver.metrics;
+
+import io.debezium.pipeline.metrics.traits.CommonEventMetricsMXBean;
+import io.debezium.pipeline.metrics.traits.SchemaMetricsMXBean;
+
+/**
+ * Metrics scoped to a source partition that are common for both snapshot and streaming change event sources
+ */
+public interface SqlServerPartitionMetricsMXBean extends CommonEventMetricsMXBean, SchemaMetricsMXBean {
+
+    void reset();
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotPartitionMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotPartitionMetrics.java
@@ -3,33 +3,25 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.pipeline.metrics;
+package io.debezium.connector.sqlserver.metrics;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
-import io.debezium.annotation.ThreadSafe;
-import io.debezium.connector.base.ChangeEventQueueMetrics;
 import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.pipeline.meters.SnapshotMeter;
 import io.debezium.pipeline.source.spi.EventMetadataProvider;
-import io.debezium.pipeline.spi.Partition;
 import io.debezium.relational.TableId;
 import io.debezium.schema.DataCollectionId;
 
-/**
- * The default implementation of metrics related to the snapshot phase of a connector.
- *
- * @author Randall Hauch, Jiri Pechanec
- */
-@ThreadSafe
-public class DefaultSnapshotChangeEventSourceMetrics<P extends Partition> extends PipelineMetrics<P>
-        implements SnapshotChangeEventSourceMetrics<P>, SnapshotChangeEventSourceMetricsMXBean {
+class SqlServerSnapshotPartitionMetrics extends AbstractSqlServerPartitionMetrics
+        implements SqlServerSnapshotPartitionMetricsMXBean {
 
     private final SnapshotMeter snapshotMeter;
 
-    public <T extends CdcSourceTaskContext> DefaultSnapshotChangeEventSourceMetrics(T taskContext, ChangeEventQueueMetrics changeEventQueueMetrics,
-                                                                                    EventMetadataProvider metadataProvider) {
-        super(taskContext, "snapshot", changeEventQueueMetrics, metadataProvider);
+    SqlServerSnapshotPartitionMetrics(CdcSourceTaskContext taskContext, Map<String, String> tags,
+                                      EventMetadataProvider metadataProvider) {
+        super(taskContext, tags, metadataProvider);
         snapshotMeter = new SnapshotMeter(taskContext.getClock());
     }
 
@@ -63,48 +55,32 @@ public class DefaultSnapshotChangeEventSourceMetrics<P extends Partition> extend
         return snapshotMeter.getSnapshotDurationInSeconds();
     }
 
-    /**
-     * @deprecated Superseded by the 'Captured Tables' metric. Use {@link #getCapturedTables()}.
-     * Scheduled for removal in a future release.
-     */
-    @Override
-    @Deprecated
-    public String[] getMonitoredTables() {
-        return snapshotMeter.getCapturedTables();
-    }
-
     @Override
     public String[] getCapturedTables() {
         return snapshotMeter.getCapturedTables();
     }
 
-    @Override
-    public void monitoredDataCollectionsDetermined(P partition, Iterable<? extends DataCollectionId> dataCollectionIds) {
+    void monitoredDataCollectionsDetermined(Iterable<? extends DataCollectionId> dataCollectionIds) {
         snapshotMeter.monitoredDataCollectionsDetermined(dataCollectionIds);
     }
 
-    @Override
-    public void dataCollectionSnapshotCompleted(P partition, DataCollectionId dataCollectionId, long numRows) {
+    void dataCollectionSnapshotCompleted(DataCollectionId dataCollectionId, long numRows) {
         snapshotMeter.dataCollectionSnapshotCompleted(dataCollectionId, numRows);
     }
 
-    @Override
-    public void snapshotStarted(P partition) {
+    void snapshotStarted() {
         snapshotMeter.snapshotStarted();
     }
 
-    @Override
-    public void snapshotCompleted(P partition) {
+    void snapshotCompleted() {
         snapshotMeter.snapshotCompleted();
     }
 
-    @Override
-    public void snapshotAborted(P partition) {
+    void snapshotAborted() {
         snapshotMeter.snapshotAborted();
     }
 
-    @Override
-    public void rowsScanned(P partition, TableId tableId, long numRows) {
+    void rowsScanned(TableId tableId, long numRows) {
         snapshotMeter.rowsScanned(tableId, numRows);
     }
 
@@ -113,13 +89,11 @@ public class DefaultSnapshotChangeEventSourceMetrics<P extends Partition> extend
         return snapshotMeter.getRowsScanned();
     }
 
-    @Override
-    public void currentChunk(P partition, String chunkId, Object[] chunkFrom, Object[] chunkTo) {
+    void currentChunk(String chunkId, Object[] chunkFrom, Object[] chunkTo) {
         snapshotMeter.currentChunk(chunkId, chunkFrom, chunkTo);
     }
 
-    @Override
-    public void currentChunk(P partition, String chunkId, Object[] chunkFrom, Object[] chunkTo, Object[] tableTo) {
+    void currentChunk(String chunkId, Object[] chunkFrom, Object[] chunkTo, Object tableTo[]) {
         snapshotMeter.currentChunk(chunkId, chunkFrom, chunkTo, tableTo);
     }
 
@@ -150,7 +124,6 @@ public class DefaultSnapshotChangeEventSourceMetrics<P extends Partition> extend
 
     @Override
     public void reset() {
-        super.reset();
         snapshotMeter.reset();
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotPartitionMetricsMXBean.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotPartitionMetricsMXBean.java
@@ -3,12 +3,10 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.debezium.pipeline.metrics;
+package io.debezium.connector.sqlserver.metrics;
 
 import io.debezium.pipeline.metrics.traits.SnapshotMetricsMXBean;
 
-/**
- * @author Randall Hauch, Jiri Pechanec
- */
-public interface SnapshotChangeEventSourceMetricsMXBean extends ChangeEventSourceMetricsMXBean, SnapshotMetricsMXBean {
+public interface SqlServerSnapshotPartitionMetricsMXBean extends SnapshotMetricsMXBean,
+        SqlServerPartitionMetricsMXBean {
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotTaskMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotTaskMetrics.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver.metrics;
+
+import java.util.Collection;
+
+import io.debezium.connector.base.ChangeEventQueueMetrics;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.sqlserver.SqlServerPartition;
+import io.debezium.pipeline.metrics.SnapshotChangeEventSourceMetrics;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.relational.TableId;
+import io.debezium.schema.DataCollectionId;
+import io.debezium.util.Collect;
+
+class SqlServerSnapshotTaskMetrics extends AbstractSqlServerTaskMetrics<SqlServerSnapshotPartitionMetrics>
+        implements SnapshotChangeEventSourceMetrics<SqlServerPartition> {
+
+    SqlServerSnapshotTaskMetrics(CdcSourceTaskContext taskContext,
+                                 ChangeEventQueueMetrics changeEventQueueMetrics,
+                                 EventMetadataProvider metadataProvider,
+                                 Collection<SqlServerPartition> partitions) {
+        super(taskContext, "snapshot", changeEventQueueMetrics, partitions,
+                (SqlServerPartition partition) -> new SqlServerSnapshotPartitionMetrics(taskContext,
+                        Collect.linkMapOf(
+                                "server", taskContext.getConnectorName(),
+                                "task", "0",
+                                "context", "snapshot",
+                                "database", partition.getDatabaseName()),
+                        metadataProvider));
+    }
+
+    @Override
+    public void snapshotStarted(SqlServerPartition partition) {
+        onPartitionEvent(partition, SqlServerSnapshotPartitionMetrics::snapshotStarted);
+    }
+
+    @Override
+    public void monitoredDataCollectionsDetermined(SqlServerPartition partition, Iterable<? extends DataCollectionId> dataCollectionIds) {
+        onPartitionEvent(partition, bean -> bean.monitoredDataCollectionsDetermined(dataCollectionIds));
+    }
+
+    @Override
+    public void snapshotCompleted(SqlServerPartition partition) {
+        onPartitionEvent(partition, SqlServerSnapshotPartitionMetrics::snapshotCompleted);
+    }
+
+    @Override
+    public void snapshotAborted(SqlServerPartition partition) {
+        onPartitionEvent(partition, SqlServerSnapshotPartitionMetrics::snapshotAborted);
+    }
+
+    @Override
+    public void dataCollectionSnapshotCompleted(SqlServerPartition partition, DataCollectionId dataCollectionId, long numRows) {
+        onPartitionEvent(partition, bean -> bean.dataCollectionSnapshotCompleted(dataCollectionId, numRows));
+    }
+
+    @Override
+    public void rowsScanned(SqlServerPartition partition, TableId tableId, long numRows) {
+        onPartitionEvent(partition, bean -> bean.rowsScanned(tableId, numRows));
+    }
+
+    @Override
+    public void currentChunk(SqlServerPartition partition, String chunkId, Object[] chunkFrom, Object[] chunkTo) {
+        onPartitionEvent(partition, bean -> bean.currentChunk(chunkId, chunkFrom, chunkTo));
+    }
+
+    @Override
+    public void currentChunk(SqlServerPartition partition, String chunkId, Object[] chunkFrom, Object[] chunkTo, Object[] tableTo) {
+        onPartitionEvent(partition, bean -> bean.currentChunk(chunkId, chunkFrom, chunkTo, tableTo));
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingPartitionMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingPartitionMetrics.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver.metrics;
+
+import java.util.Map;
+
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.pipeline.meters.StreamingMeter;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+
+class SqlServerStreamingPartitionMetrics extends AbstractSqlServerPartitionMetrics
+        implements SqlServerStreamingPartitionMetricsMXBean {
+
+    private final StreamingMeter streamingMeter;
+
+    SqlServerStreamingPartitionMetrics(CdcSourceTaskContext taskContext,
+                                       Map<String, String> tags,
+                                       EventMetadataProvider metadataProvider) {
+        super(taskContext, tags, metadataProvider);
+        streamingMeter = new StreamingMeter(taskContext, metadataProvider);
+    }
+
+    @Override
+    public String[] getCapturedTables() {
+        return streamingMeter.getCapturedTables();
+    }
+
+    @Override
+    public long getMilliSecondsBehindSource() {
+        return streamingMeter.getMilliSecondsBehindSource();
+    }
+
+    @Override
+    public long getNumberOfCommittedTransactions() {
+        return streamingMeter.getNumberOfCommittedTransactions();
+    }
+
+    @Override
+    public Map<String, String> getSourceEventPosition() {
+        return streamingMeter.getSourceEventPosition();
+    }
+
+    @Override
+    public String getLastTransactionId() {
+        return streamingMeter.getLastTransactionId();
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        streamingMeter.reset();
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingPartitionMetricsMXBean.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingPartitionMetricsMXBean.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver.metrics;
+
+import io.debezium.pipeline.metrics.traits.StreamingMetricsMXBean;
+
+public interface SqlServerStreamingPartitionMetricsMXBean extends StreamingMetricsMXBean,
+        SqlServerPartitionMetricsMXBean {
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetrics.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver.metrics;
+
+import java.util.Collection;
+
+import io.debezium.connector.base.ChangeEventQueueMetrics;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.connector.sqlserver.SqlServerPartition;
+import io.debezium.pipeline.meters.ConnectionMeter;
+import io.debezium.pipeline.metrics.StreamingChangeEventSourceMetrics;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.util.Collect;
+
+class SqlServerStreamingTaskMetrics extends AbstractSqlServerTaskMetrics<SqlServerStreamingPartitionMetrics>
+        implements StreamingChangeEventSourceMetrics<SqlServerPartition>, SqlServerStreamingTaskMetricsMXBean {
+
+    private final ConnectionMeter connectionMeter;
+
+    SqlServerStreamingTaskMetrics(CdcSourceTaskContext taskContext,
+                                  ChangeEventQueueMetrics changeEventQueueMetrics,
+                                  EventMetadataProvider metadataProvider,
+                                  Collection<SqlServerPartition> partitions) {
+        super(taskContext, "streaming", changeEventQueueMetrics, partitions,
+                (SqlServerPartition partition) -> new SqlServerStreamingPartitionMetrics(taskContext,
+                        Collect.linkMapOf(
+                                "server", taskContext.getConnectorName(),
+                                "task", "0",
+                                "context", "streaming",
+                                "database", partition.getDatabaseName()),
+                        metadataProvider));
+        connectionMeter = new ConnectionMeter();
+    }
+
+    @Override
+    public boolean isConnected() {
+        return connectionMeter.isConnected();
+    }
+
+    @Override
+    public void connected(boolean connected) {
+        connectionMeter.connected(connected);
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetricsMXBean.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetricsMXBean.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver.metrics;
+
+import io.debezium.pipeline.metrics.traits.ConnectionMetricsMXBean;
+
+/**
+ * Metrics specific to streaming change event sources scoped to a connector task
+ */
+public interface SqlServerStreamingTaskMetricsMXBean extends ConnectionMetricsMXBean, SqlServerTaskMetricsMXBean {
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerTaskMetricsMXBean.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerTaskMetricsMXBean.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver.metrics;
+
+import io.debezium.pipeline.metrics.traits.QueueMetricsMXBean;
+
+/**
+ * Metrics scoped to a connector task that are common for both snapshot and streaming change event sources
+ */
+public interface SqlServerTaskMetricsMXBean extends QueueMetricsMXBean {
+
+    void reset();
+}

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -2528,7 +2528,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
 
-        TestHelper.waitForSnapshotToBeCompleted();
+        TestHelper.waitForDatabaseSnapshotToBeCompleted(TestHelper.TEST_DATABASE);
 
         final SourceRecords records = consumeRecordsByTopic(1);
         final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB.dbo.tablea");

--- a/debezium-core/src/main/java/io/debezium/metrics/Metrics.java
+++ b/debezium-core/src/main/java/io/debezium/metrics/Metrics.java
@@ -6,12 +6,15 @@
 package io.debezium.metrics;
 
 import java.lang.management.ManagementFactory;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
+import org.apache.kafka.common.utils.Sanitizer;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.util.Collect;
 
 /**
  * Base for metrics implementations.
@@ -37,8 +41,22 @@ public abstract class Metrics {
         this.name = metricName(taskContext.getConnectorType(), taskContext.getConnectorName(), contextName);
     }
 
-    protected Metrics(CommonConnectorConfig connectorConfig, String contextName) {
-        this.name = metricName(connectorConfig.getContextName(), connectorConfig.getLogicalName(), contextName);
+    protected Metrics(CdcSourceTaskContext taskContext, Map<String, String> tags) {
+        this.name = metricName(taskContext.getConnectorType(), tags);
+    }
+
+    protected Metrics(CommonConnectorConfig connectorConfig, String contextName, boolean multiPartitionMode) {
+        String connectorType = connectorConfig.getContextName();
+        String connectorName = connectorConfig.getLogicalName();
+        if (multiPartitionMode) {
+            this.name = metricName(connectorType, Collect.linkMapOf(
+                    "server", connectorName,
+                    "task", "0",
+                    "context", contextName));
+        }
+        else {
+            this.name = metricName(connectorType, connectorName, contextName);
+        }
     }
 
     /**
@@ -64,7 +82,7 @@ public abstract class Metrics {
      * Unregisters a metrics MBean from the platform MBean server.
      * The method is intentionally synchronized to prevent preemption between registration and unregistration.
      */
-    public final void unregister() {
+    public synchronized void unregister() {
         if (this.name != null && registered) {
             try {
                 final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
@@ -81,14 +99,19 @@ public abstract class Metrics {
         }
     }
 
+    protected ObjectName metricName(String connectorType, String connectorName, String contextName) {
+        return metricName(connectorType, Collect.linkMapOf("context", contextName, "server", connectorName));
+    }
+
     /**
      * Create a JMX metric name for the given metric.
-     * @param contextName the name of the context
      * @return the JMX metric name
-     * @throws MalformedObjectNameException if the name is invalid
      */
-    public ObjectName metricName(String connectorType, String connectorName, String contextName) {
-        final String metricName = "debezium." + connectorType.toLowerCase() + ":type=connector-metrics,context=" + contextName + ",server=" + connectorName;
+    protected ObjectName metricName(String connectorType, Map<String, String> tags) {
+        final String metricName = "debezium." + connectorType.toLowerCase() + ":type=connector-metrics,"
+                + tags.entrySet().stream()
+                        .map(e -> e.getKey() + "=" + Sanitizer.jmxSanitize(e.getValue()))
+                        .collect(Collectors.joining(","));
         try {
             return new ObjectName(metricName);
         }

--- a/debezium-core/src/main/java/io/debezium/pipeline/AbstractChangeRecordEmitter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/AbstractChangeRecordEmitter.java
@@ -17,13 +17,14 @@ import io.debezium.util.Clock;
  *
  * @author Chris Cranford
  */
-public abstract class AbstractChangeRecordEmitter<T extends DataCollectionSchema> implements ChangeRecordEmitter {
+public abstract class AbstractChangeRecordEmitter<P extends Partition, T extends DataCollectionSchema>
+        implements ChangeRecordEmitter<P> {
 
-    private final Partition partition;
+    private final P partition;
     private final OffsetContext offsetContext;
     private final Clock clock;
 
-    public AbstractChangeRecordEmitter(Partition partition, OffsetContext offsetContext, Clock clock) {
+    public AbstractChangeRecordEmitter(P partition, OffsetContext offsetContext, Clock clock) {
         this.partition = partition;
         this.offsetContext = offsetContext;
         this.clock = clock;
@@ -31,7 +32,7 @@ public abstract class AbstractChangeRecordEmitter<T extends DataCollectionSchema
 
     @Override
     @SuppressWarnings({ "unchecked" })
-    public void emitChangeRecords(DataCollectionSchema schema, Receiver receiver) throws InterruptedException {
+    public void emitChangeRecords(DataCollectionSchema schema, Receiver<P> receiver) throws InterruptedException {
         Operation operation = getOperation();
         switch (operation) {
             case CREATE:
@@ -52,7 +53,7 @@ public abstract class AbstractChangeRecordEmitter<T extends DataCollectionSchema
     }
 
     @Override
-    public Partition getPartition() {
+    public P getPartition() {
         return partition;
     }
 
@@ -74,7 +75,7 @@ public abstract class AbstractChangeRecordEmitter<T extends DataCollectionSchema
      * @param receiver the handler for which the emitted record should be dispatched
      * @param schema the schema
      */
-    protected abstract void emitReadRecord(Receiver receiver, T schema) throws InterruptedException;
+    protected abstract void emitReadRecord(Receiver<P> receiver, T schema) throws InterruptedException;
 
     /**
      * Emits change record(s) associated with an insert operation.
@@ -82,7 +83,7 @@ public abstract class AbstractChangeRecordEmitter<T extends DataCollectionSchema
      * @param receiver the handler for which the emitted record should be dispatched
      * @param schema the schema
      */
-    protected abstract void emitCreateRecord(Receiver receiver, T schema) throws InterruptedException;
+    protected abstract void emitCreateRecord(Receiver<P> receiver, T schema) throws InterruptedException;
 
     /**
      * Emits change record(s) associated with an update operation.
@@ -90,7 +91,7 @@ public abstract class AbstractChangeRecordEmitter<T extends DataCollectionSchema
      * @param receiver the handler for which the emitted record should be dispatched
      * @param schema the schema
      */
-    protected abstract void emitUpdateRecord(Receiver receiver, T schema) throws InterruptedException;
+    protected abstract void emitUpdateRecord(Receiver<P> receiver, T schema) throws InterruptedException;
 
     /**
      * Emits change record(s) associated with a delete operation.
@@ -98,5 +99,5 @@ public abstract class AbstractChangeRecordEmitter<T extends DataCollectionSchema
      * @param receiver the handler for which the emitted record should be dispatched
      * @param schema the schema
      */
-    protected abstract void emitDeleteRecord(Receiver receiver, T schema) throws InterruptedException;
+    protected abstract void emitDeleteRecord(Receiver<P> receiver, T schema) throws InterruptedException;
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -229,6 +229,7 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
     protected void streamingConnected(boolean status) {
         if (changeEventSourceMetricsFactory.connectionMetricHandledByCoordinator()) {
             streamingMetrics.connected(status);
+            LOGGER.info("Connected metrics set to '{}'", status);
         }
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -59,22 +59,23 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
     protected final Offsets<P, O> previousOffsets;
     protected final ErrorHandler errorHandler;
     protected final ChangeEventSourceFactory<P, O> changeEventSourceFactory;
-    protected final ChangeEventSourceMetricsFactory changeEventSourceMetricsFactory;
+    protected final ChangeEventSourceMetricsFactory<P> changeEventSourceMetricsFactory;
     protected final ExecutorService executor;
-    protected final EventDispatcher<?> eventDispatcher;
+    protected final EventDispatcher<P, ?> eventDispatcher;
     protected final DatabaseSchema<?> schema;
 
     private volatile boolean running;
     protected volatile StreamingChangeEventSource<P, O> streamingSource;
     protected final ReentrantLock commitOffsetLock = new ReentrantLock();
 
-    protected SnapshotChangeEventSourceMetrics snapshotMetrics;
-    protected StreamingChangeEventSourceMetrics streamingMetrics;
+    protected SnapshotChangeEventSourceMetrics<P> snapshotMetrics;
+    protected StreamingChangeEventSourceMetrics<P> streamingMetrics;
 
     public ChangeEventSourceCoordinator(Offsets<P, O> previousOffsets, ErrorHandler errorHandler, Class<? extends SourceConnector> connectorType,
                                         CommonConnectorConfig connectorConfig,
                                         ChangeEventSourceFactory<P, O> changeEventSourceFactory,
-                                        ChangeEventSourceMetricsFactory changeEventSourceMetricsFactory, EventDispatcher<?> eventDispatcher, DatabaseSchema<?> schema) {
+                                        ChangeEventSourceMetricsFactory<P> changeEventSourceMetricsFactory, EventDispatcher<P, ?> eventDispatcher,
+                                        DatabaseSchema<?> schema) {
         this.previousOffsets = previousOffsets;
         this.errorHandler = errorHandler;
         this.changeEventSourceFactory = changeEventSourceFactory;
@@ -167,22 +168,22 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
     }
 
     protected void streamEvents(ChangeEventSourceContext context, P partition, O offsetContext) throws InterruptedException {
-        initStreamEvents(offsetContext);
+        initStreamEvents(partition, offsetContext);
         LOGGER.info("Starting streaming");
         streamingSource.execute(context, partition, offsetContext);
         LOGGER.info("Finished streaming");
     }
 
-    protected void initStreamEvents(O offsetContext) throws InterruptedException {
+    protected void initStreamEvents(P partition, O offsetContext) throws InterruptedException {
         streamingSource = changeEventSourceFactory.getStreamingChangeEventSource();
         eventDispatcher.setEventListener(streamingMetrics);
         streamingConnected(true);
         streamingSource.init();
 
-        final Optional<IncrementalSnapshotChangeEventSource<? extends DataCollectionId>> incrementalSnapshotChangeEventSource = changeEventSourceFactory
+        final Optional<IncrementalSnapshotChangeEventSource<P, ? extends DataCollectionId>> incrementalSnapshotChangeEventSource = changeEventSourceFactory
                 .getIncrementalSnapshotChangeEventSource(offsetContext, snapshotMetrics, snapshotMetrics);
         eventDispatcher.setIncrementalSnapshotChangeEventSource(incrementalSnapshotChangeEventSource);
-        incrementalSnapshotChangeEventSource.ifPresent(x -> x.init(offsetContext));
+        incrementalSnapshotChangeEventSource.ifPresent(x -> x.init(partition, offsetContext));
     }
 
     public void commitOffset(Map<String, ?> offset) {

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/CommonEventMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/CommonEventMeter.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.meters;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.annotation.ThreadSafe;
+import io.debezium.data.Envelope.Operation;
+import io.debezium.pipeline.metrics.traits.CommonEventMetricsMXBean;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.schema.DataCollectionId;
+import io.debezium.util.Clock;
+
+/**
+ * Carries common event metrics.
+ */
+@ThreadSafe
+public class CommonEventMeter implements CommonEventMetricsMXBean {
+
+    protected final AtomicLong totalNumberOfEventsSeen = new AtomicLong();
+    protected final AtomicLong totalNumberOfCreateEventsSeen = new AtomicLong();
+    protected final AtomicLong totalNumberOfUpdateEventsSeen = new AtomicLong();
+    protected final AtomicLong totalNumberOfDeleteEventsSeen = new AtomicLong();
+    private final AtomicLong numberOfEventsFiltered = new AtomicLong();
+    protected final AtomicLong numberOfErroneousEvents = new AtomicLong();
+    protected final AtomicLong lastEventTimestamp = new AtomicLong(-1);
+    private volatile String lastEvent;
+
+    private final Clock clock;
+    private final EventMetadataProvider metadataProvider;
+
+    public CommonEventMeter(Clock clock, EventMetadataProvider metadataProvider) {
+        this.clock = clock;
+        this.metadataProvider = metadataProvider;
+    }
+
+    public void onEvent(DataCollectionId source, OffsetContext offset, Object key, Struct value, Operation operation) {
+        updateCommonEventMetrics(operation);
+        lastEvent = metadataProvider.toSummaryString(source, offset, key, value);
+    }
+
+    private void updateCommonEventMetrics() {
+        updateCommonEventMetrics(null);
+    }
+
+    private void updateCommonEventMetrics(Operation operation) {
+        totalNumberOfEventsSeen.incrementAndGet();
+        lastEventTimestamp.set(clock.currentTimeInMillis());
+
+        if (operation != null) {
+            switch (operation) {
+                case CREATE:
+                    totalNumberOfCreateEventsSeen.incrementAndGet();
+                    break;
+                case UPDATE:
+                    totalNumberOfUpdateEventsSeen.incrementAndGet();
+                    break;
+                case DELETE:
+                    totalNumberOfDeleteEventsSeen.incrementAndGet();
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    public void onFilteredEvent() {
+        numberOfEventsFiltered.incrementAndGet();
+        updateCommonEventMetrics();
+    }
+
+    public void onFilteredEvent(Operation operation) {
+        numberOfEventsFiltered.incrementAndGet();
+        updateCommonEventMetrics(operation);
+    }
+
+    public void onErroneousEvent() {
+        numberOfErroneousEvents.incrementAndGet();
+        updateCommonEventMetrics();
+    }
+
+    public void onErroneousEvent(Operation operation) {
+        numberOfErroneousEvents.incrementAndGet();
+        updateCommonEventMetrics(operation);
+    }
+
+    @Override
+    public String getLastEvent() {
+        return lastEvent;
+    }
+
+    @Override
+    public long getMilliSecondsSinceLastEvent() {
+        return (lastEventTimestamp.get() == -1) ? -1 : (clock.currentTimeInMillis() - lastEventTimestamp.get());
+    }
+
+    @Override
+    public long getTotalNumberOfEventsSeen() {
+        return totalNumberOfEventsSeen.get();
+    }
+
+    @Override
+    public long getTotalNumberOfCreateEventsSeen() {
+        return totalNumberOfCreateEventsSeen.get();
+    }
+
+    @Override
+    public long getTotalNumberOfUpdateEventsSeen() {
+        return totalNumberOfUpdateEventsSeen.get();
+    }
+
+    @Override
+    public long getTotalNumberOfDeleteEventsSeen() {
+        return totalNumberOfDeleteEventsSeen.get();
+    }
+
+    @Override
+    public long getNumberOfEventsFiltered() {
+        return numberOfEventsFiltered.get();
+    }
+
+    @Override
+    public long getNumberOfErroneousEvents() {
+        return numberOfErroneousEvents.get();
+    }
+
+    public void reset() {
+        totalNumberOfEventsSeen.set(0);
+        totalNumberOfCreateEventsSeen.set(0);
+        totalNumberOfUpdateEventsSeen.set(0);
+        totalNumberOfDeleteEventsSeen.set(0);
+        lastEventTimestamp.set(-1);
+        numberOfEventsFiltered.set(0);
+        numberOfErroneousEvents.set(0);
+        lastEvent = null;
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/ConnectionMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/ConnectionMeter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.meters;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.debezium.annotation.ThreadSafe;
+import io.debezium.pipeline.metrics.traits.ConnectionMetricsMXBean;
+
+/**
+ * Carries connection metrics.
+ */
+@ThreadSafe
+public class ConnectionMeter implements ConnectionMetricsMXBean {
+
+    private final AtomicBoolean connected = new AtomicBoolean();
+
+    @Override
+    public boolean isConnected() {
+        return this.connected.get();
+    }
+
+    public void connected(boolean connected) {
+        this.connected.set(connected);
+    }
+
+    public void reset() {
+        connected.set(false);
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/SnapshotMeter.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.meters;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.debezium.annotation.ThreadSafe;
+import io.debezium.pipeline.metrics.traits.SnapshotMetricsMXBean;
+import io.debezium.relational.TableId;
+import io.debezium.schema.DataCollectionId;
+import io.debezium.util.Clock;
+
+/**
+ * Carries snapshot metrics.
+ */
+@ThreadSafe
+public class SnapshotMeter implements SnapshotMetricsMXBean {
+
+    private final AtomicBoolean snapshotRunning = new AtomicBoolean();
+    private final AtomicBoolean snapshotCompleted = new AtomicBoolean();
+    private final AtomicBoolean snapshotAborted = new AtomicBoolean();
+    private final AtomicLong startTime = new AtomicLong();
+    private final AtomicLong stopTime = new AtomicLong();
+    private final ConcurrentMap<String, Long> rowsScanned = new ConcurrentHashMap<>();
+
+    private final ConcurrentMap<String, String> remainingTables = new ConcurrentHashMap<>();
+
+    private final AtomicReference<String> chunkId = new AtomicReference<>();
+    private final AtomicReference<Object[]> chunkFrom = new AtomicReference<>();
+    private final AtomicReference<Object[]> chunkTo = new AtomicReference<>();
+    private final AtomicReference<Object[]> tableFrom = new AtomicReference<>();
+    private final AtomicReference<Object[]> tableTo = new AtomicReference<>();
+
+    private final Set<String> capturedTables = Collections.synchronizedSet(new HashSet<>());
+
+    private final Clock clock;
+
+    public SnapshotMeter(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    public int getTotalTableCount() {
+        return this.capturedTables.size();
+    }
+
+    @Override
+    public int getRemainingTableCount() {
+        return this.remainingTables.size();
+    }
+
+    @Override
+    public boolean getSnapshotRunning() {
+        return this.snapshotRunning.get();
+    }
+
+    @Override
+    public boolean getSnapshotCompleted() {
+        return this.snapshotCompleted.get();
+    }
+
+    @Override
+    public boolean getSnapshotAborted() {
+        return this.snapshotAborted.get();
+    }
+
+    @Override
+    public long getSnapshotDurationInSeconds() {
+        final long startMillis = startTime.get();
+        if (startMillis <= 0L) {
+            return 0;
+        }
+        long stopMillis = stopTime.get();
+        if (stopMillis == 0L) {
+            stopMillis = clock.currentTimeInMillis();
+        }
+        return (stopMillis - startMillis) / 1000L;
+    }
+
+    @Override
+    public String[] getCapturedTables() {
+        return capturedTables.toArray(new String[0]);
+    }
+
+    public void monitoredDataCollectionsDetermined(Iterable<? extends DataCollectionId> dataCollectionIds) {
+        for (DataCollectionId dataCollectionId : dataCollectionIds) {
+            this.remainingTables.put(dataCollectionId.identifier(), "");
+            capturedTables.add(dataCollectionId.identifier());
+        }
+    }
+
+    public void dataCollectionSnapshotCompleted(DataCollectionId dataCollectionId, long numRows) {
+        rowsScanned.put(dataCollectionId.identifier(), numRows);
+        remainingTables.remove(dataCollectionId.identifier());
+    }
+
+    public void snapshotStarted() {
+        this.snapshotRunning.set(true);
+        this.snapshotCompleted.set(false);
+        this.snapshotAborted.set(false);
+        this.startTime.set(clock.currentTimeInMillis());
+        this.stopTime.set(0L);
+    }
+
+    public void snapshotCompleted() {
+        this.snapshotCompleted.set(true);
+        this.snapshotAborted.set(false);
+        this.snapshotRunning.set(false);
+        this.stopTime.set(clock.currentTimeInMillis());
+    }
+
+    public void snapshotAborted() {
+        this.snapshotCompleted.set(false);
+        this.snapshotAborted.set(true);
+        this.snapshotRunning.set(false);
+        this.stopTime.set(clock.currentTimeInMillis());
+    }
+
+    public void rowsScanned(TableId tableId, long numRows) {
+        rowsScanned.put(tableId.toString(), numRows);
+    }
+
+    @Override
+    public ConcurrentMap<String, Long> getRowsScanned() {
+        return rowsScanned;
+    }
+
+    public void currentChunk(String chunkId, Object[] chunkFrom, Object[] chunkTo) {
+        this.chunkId.set(chunkId);
+        this.chunkFrom.set(chunkFrom);
+        this.chunkTo.set(chunkTo);
+    }
+
+    public void currentChunk(String chunkId, Object[] chunkFrom, Object[] chunkTo, Object[] tableTo) {
+        currentChunk(chunkId, chunkFrom, chunkTo);
+        this.tableFrom.set(chunkFrom);
+        this.tableTo.set(tableTo);
+    }
+
+    @Override
+    public String getChunkId() {
+        return chunkId.get();
+    }
+
+    @Override
+    public String getChunkFrom() {
+        return arrayToString(chunkFrom.get());
+    }
+
+    @Override
+    public String getChunkTo() {
+        return arrayToString(chunkTo.get());
+    }
+
+    @Override
+    public String getTableFrom() {
+        return arrayToString(tableFrom.get());
+    }
+
+    @Override
+    public String getTableTo() {
+        return arrayToString(tableTo.get());
+    }
+
+    private String arrayToString(Object[] array) {
+        return (array == null) ? null : Arrays.toString(array);
+    }
+
+    public void reset() {
+        snapshotRunning.set(false);
+        snapshotCompleted.set(false);
+        snapshotAborted.set(false);
+        startTime.set(0);
+        stopTime.set(0);
+        rowsScanned.clear();
+        remainingTables.clear();
+        capturedTables.clear();
+        chunkId.set(null);
+        chunkFrom.set(null);
+        chunkTo.set(null);
+        tableFrom.set(null);
+        tableTo.set(null);
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/StreamingMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/StreamingMeter.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.meters;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.connect.data.Struct;
+
+import io.debezium.annotation.ThreadSafe;
+import io.debezium.connector.common.CdcSourceTaskContext;
+import io.debezium.pipeline.metrics.traits.StreamingMetricsMXBean;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.schema.DataCollectionId;
+
+/**
+ * Carries streaming metrics.
+ */
+@ThreadSafe
+public class StreamingMeter implements StreamingMetricsMXBean {
+
+    private final AtomicReference<Duration> lagBehindSource = new AtomicReference<>();
+    private final AtomicLong numberOfCommittedTransactions = new AtomicLong();
+    private final AtomicReference<Map<String, String>> sourceEventPosition = new AtomicReference<>(Collections.emptyMap());
+    private final AtomicReference<String> lastTransactionId = new AtomicReference<>();
+
+    private final CdcSourceTaskContext taskContext;
+    private final EventMetadataProvider metadataProvider;
+
+    public StreamingMeter(CdcSourceTaskContext taskContext, EventMetadataProvider metadataProvider) {
+        this.taskContext = taskContext;
+        this.metadataProvider = metadataProvider;
+    }
+
+    @Override
+    public String[] getCapturedTables() {
+        return taskContext.capturedDataCollections();
+    }
+
+    @Override
+    public Map<String, String> getSourceEventPosition() {
+        return sourceEventPosition.get();
+    }
+
+    @Override
+    public long getMilliSecondsBehindSource() {
+        Duration lag = lagBehindSource.get();
+        return lag != null ? lag.toMillis() : -1;
+    }
+
+    @Override
+    public long getNumberOfCommittedTransactions() {
+        return numberOfCommittedTransactions.get();
+    }
+
+    @Override
+    public String getLastTransactionId() {
+        return lastTransactionId.get();
+    }
+
+    public void onEvent(DataCollectionId source, OffsetContext offset, Object key, Struct value) {
+        final Instant eventTimestamp = metadataProvider.getEventTimestamp(source, offset, key, value);
+        if (eventTimestamp != null) {
+            lagBehindSource.set(Duration.between(eventTimestamp, Instant.now()));
+        }
+
+        final String transactionId = metadataProvider.getTransactionId(source, offset, key, value);
+        if (transactionId != null) {
+            if (!transactionId.equals(lastTransactionId.get())) {
+                lastTransactionId.set(transactionId);
+                numberOfCommittedTransactions.incrementAndGet();
+            }
+        }
+
+        final Map<String, String> eventSource = metadataProvider.getEventSourcePosition(source, offset, key, value);
+        if (eventSource != null) {
+            sourceEventPosition.set(eventSource);
+        }
+    }
+
+    public void reset() {
+        lagBehindSource.set(null);
+        numberOfCommittedTransactions.set(0);
+        sourceEventPosition.set(Collections.emptyMap());
+        lastTransactionId.set(null);
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/ChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/ChangeEventSourceMetrics.java
@@ -11,7 +11,7 @@ import io.debezium.pipeline.spi.Partition;
 /**
  * Common API for all change event source metrics regardless of the connector phase.
  */
-interface ChangeEventSourceMetrics<P extends Partition> extends DataChangeEventListener<P> {
+public interface ChangeEventSourceMetrics<P extends Partition> extends DataChangeEventListener<P> {
 
     void register();
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/ChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/ChangeEventSourceMetrics.java
@@ -6,11 +6,12 @@
 package io.debezium.pipeline.metrics;
 
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
+import io.debezium.pipeline.spi.Partition;
 
 /**
  * Common API for all change event source metrics regardless of the connector phase.
  */
-interface ChangeEventSourceMetrics extends DataChangeEventListener {
+interface ChangeEventSourceMetrics<P extends Partition> extends DataChangeEventListener<P> {
 
     void register();
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/ChangeEventSourceMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/ChangeEventSourceMetricsMXBean.java
@@ -5,28 +5,17 @@
  */
 package io.debezium.pipeline.metrics;
 
+import io.debezium.pipeline.metrics.traits.CommonEventMetricsMXBean;
+import io.debezium.pipeline.metrics.traits.QueueMetricsMXBean;
+import io.debezium.pipeline.metrics.traits.SchemaMetricsMXBean;
+
 /**
  * Metrics that are common for both snapshot and streaming change event sources
  *
  * @author Jiri Pechanec
  */
-public interface ChangeEventSourceMetricsMXBean {
-
-    String getLastEvent();
-
-    long getMilliSecondsSinceLastEvent();
-
-    long getTotalNumberOfEventsSeen();
-
-    long getTotalNumberOfCreateEventsSeen();
-
-    long getTotalNumberOfUpdateEventsSeen();
-
-    long getTotalNumberOfDeleteEventsSeen();
-
-    long getNumberOfEventsFiltered();
-
-    long getNumberOfErroneousEvents();
+public interface ChangeEventSourceMetricsMXBean extends CommonEventMetricsMXBean, QueueMetricsMXBean,
+        SchemaMetricsMXBean {
 
     /**
      * @deprecated Superseded by the 'Captured Tables' metric. Use {@link #getCapturedTables()}.
@@ -34,16 +23,6 @@ public interface ChangeEventSourceMetricsMXBean {
      */
     @Deprecated
     String[] getMonitoredTables();
-
-    String[] getCapturedTables();
-
-    int getQueueTotalCapacity();
-
-    int getQueueRemainingCapacity();
-
-    long getMaxQueueSizeInBytes();
-
-    long getCurrentQueueSizeInBytes();
 
     void reset();
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultChangeEventSourceMetricsFactory.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultChangeEventSourceMetricsFactory.java
@@ -9,22 +9,23 @@ import io.debezium.connector.base.ChangeEventQueueMetrics;
 import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.pipeline.metrics.spi.ChangeEventSourceMetricsFactory;
 import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.Partition;
 
 /**
  * @author Chris Cranford
  */
-public class DefaultChangeEventSourceMetricsFactory implements ChangeEventSourceMetricsFactory {
+public class DefaultChangeEventSourceMetricsFactory<P extends Partition> implements ChangeEventSourceMetricsFactory<P> {
     @Override
-    public <T extends CdcSourceTaskContext> SnapshotChangeEventSourceMetrics getSnapshotMetrics(T taskContext,
-                                                                                                ChangeEventQueueMetrics changeEventQueueMetrics,
-                                                                                                EventMetadataProvider eventMetadataProvider) {
-        return new DefaultSnapshotChangeEventSourceMetrics(taskContext, changeEventQueueMetrics, eventMetadataProvider);
+    public <T extends CdcSourceTaskContext> SnapshotChangeEventSourceMetrics<P> getSnapshotMetrics(T taskContext,
+                                                                                                   ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                                   EventMetadataProvider eventMetadataProvider) {
+        return new DefaultSnapshotChangeEventSourceMetrics<>(taskContext, changeEventQueueMetrics, eventMetadataProvider);
     }
 
     @Override
-    public <T extends CdcSourceTaskContext> StreamingChangeEventSourceMetrics getStreamingMetrics(T taskContext,
-                                                                                                  ChangeEventQueueMetrics changeEventQueueMetrics,
-                                                                                                  EventMetadataProvider eventMetadataProvider) {
-        return new DefaultStreamingChangeEventSourceMetrics(taskContext, changeEventQueueMetrics, eventMetadataProvider);
+    public <T extends CdcSourceTaskContext> StreamingChangeEventSourceMetrics<P> getStreamingMetrics(T taskContext,
+                                                                                                     ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                                     EventMetadataProvider eventMetadataProvider) {
+        return new DefaultStreamingChangeEventSourceMetrics<>(taskContext, changeEventQueueMetrics, eventMetadataProvider);
     }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
@@ -5,13 +5,7 @@
  */
 package io.debezium.pipeline.metrics;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.connect.data.Struct;
 
@@ -20,6 +14,8 @@ import io.debezium.connector.base.ChangeEventQueueMetrics;
 import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.data.Envelope.Operation;
 import io.debezium.pipeline.ConnectorEvent;
+import io.debezium.pipeline.meters.ConnectionMeter;
+import io.debezium.pipeline.meters.StreamingMeter;
 import io.debezium.pipeline.source.spi.EventMetadataProvider;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
@@ -34,20 +30,19 @@ import io.debezium.schema.DataCollectionId;
 public class DefaultStreamingChangeEventSourceMetrics<P extends Partition> extends PipelineMetrics<P>
         implements StreamingChangeEventSourceMetrics<P>, StreamingChangeEventSourceMetricsMXBean {
 
-    private final AtomicBoolean connected = new AtomicBoolean();
-    private final AtomicReference<Duration> lagBehindSource = new AtomicReference<>();
-    private final AtomicLong numberOfCommittedTransactions = new AtomicLong();
-    private final AtomicReference<Map<String, String>> sourceEventPosition = new AtomicReference<Map<String, String>>(Collections.emptyMap());
-    private final AtomicReference<String> lastTransactionId = new AtomicReference<>();
+    private final ConnectionMeter connectionMeter;
+    private final StreamingMeter streamingMeter;
 
     public <T extends CdcSourceTaskContext> DefaultStreamingChangeEventSourceMetrics(T taskContext, ChangeEventQueueMetrics changeEventQueueMetrics,
                                                                                      EventMetadataProvider metadataProvider) {
         super(taskContext, "streaming", changeEventQueueMetrics, metadataProvider);
+        streamingMeter = new StreamingMeter(taskContext, metadataProvider);
+        connectionMeter = new ConnectionMeter();
     }
 
     @Override
     public boolean isConnected() {
-        return this.connected.get();
+        return connectionMeter.isConnected();
     }
 
     /**
@@ -57,55 +52,37 @@ public class DefaultStreamingChangeEventSourceMetrics<P extends Partition> exten
     @Override
     @Deprecated
     public String[] getMonitoredTables() {
-        return taskContext.capturedDataCollections();
+        return streamingMeter.getCapturedTables();
     }
 
     @Override
     public String[] getCapturedTables() {
-        return taskContext.capturedDataCollections();
+        return streamingMeter.getCapturedTables();
     }
 
     public void connected(boolean connected) {
-        this.connected.set(connected);
+        connectionMeter.connected(connected);
     }
 
     @Override
     public Map<String, String> getSourceEventPosition() {
-        return sourceEventPosition.get();
+        return streamingMeter.getSourceEventPosition();
     }
 
     @Override
     public long getMilliSecondsBehindSource() {
-        Duration lag = lagBehindSource.get();
-        return lag != null ? lag.toMillis() : -1;
+        return streamingMeter.getMilliSecondsBehindSource();
     }
 
     @Override
     public long getNumberOfCommittedTransactions() {
-        return numberOfCommittedTransactions.get();
+        return streamingMeter.getNumberOfCommittedTransactions();
     }
 
     @Override
     public void onEvent(P partition, DataCollectionId source, OffsetContext offset, Object key, Struct value, Operation operation) {
         super.onEvent(partition, source, offset, key, value, operation);
-
-        final Instant eventTimestamp = metadataProvider.getEventTimestamp(source, offset, key, value);
-        if (eventTimestamp != null) {
-            lagBehindSource.set(Duration.between(eventTimestamp, Instant.now()));
-        }
-
-        final String transactionId = metadataProvider.getTransactionId(source, offset, key, value);
-        if (transactionId != null) {
-            if (!transactionId.equals(lastTransactionId.get())) {
-                lastTransactionId.set(transactionId);
-                numberOfCommittedTransactions.incrementAndGet();
-            }
-        }
-
-        final Map<String, String> eventSource = metadataProvider.getEventSourcePosition(source, offset, key, value);
-        if (eventSource != null) {
-            sourceEventPosition.set(eventSource);
-        }
+        streamingMeter.onEvent(source, offset, key, value);
     }
 
     @Override
@@ -114,16 +91,13 @@ public class DefaultStreamingChangeEventSourceMetrics<P extends Partition> exten
 
     @Override
     public String getLastTransactionId() {
-        return lastTransactionId.get();
+        return streamingMeter.getLastTransactionId();
     }
 
     @Override
     public void reset() {
         super.reset();
-        connected.set(false);
-        lagBehindSource.set(null);
-        numberOfCommittedTransactions.set(0);
-        sourceEventPosition.set(Collections.emptyMap());
-        lastTransactionId.set(null);
+        streamingMeter.reset();
+        connectionMeter.reset();
     }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
@@ -14,8 +14,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.connect.data.Struct;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.connector.base.ChangeEventQueueMetrics;
@@ -34,8 +32,6 @@ import io.debezium.schema.DataCollectionId;
 @ThreadSafe
 public class DefaultStreamingChangeEventSourceMetrics extends PipelineMetrics
         implements StreamingChangeEventSourceMetrics, StreamingChangeEventSourceMetricsMXBean {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultStreamingChangeEventSourceMetrics.class);
 
     private final AtomicBoolean connected = new AtomicBoolean();
     private final AtomicReference<Duration> lagBehindSource = new AtomicReference<>();
@@ -70,7 +66,6 @@ public class DefaultStreamingChangeEventSourceMetrics extends PipelineMetrics
 
     public void connected(boolean connected) {
         this.connected.set(connected);
-        LOGGER.info("Connected metrics set to '{}'", this.connected.get());
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/DefaultStreamingChangeEventSourceMetrics.java
@@ -22,6 +22,7 @@ import io.debezium.data.Envelope.Operation;
 import io.debezium.pipeline.ConnectorEvent;
 import io.debezium.pipeline.source.spi.EventMetadataProvider;
 import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Partition;
 import io.debezium.schema.DataCollectionId;
 
 /**
@@ -30,8 +31,8 @@ import io.debezium.schema.DataCollectionId;
  * @author Randall Hauch, Jiri Pechanec
  */
 @ThreadSafe
-public class DefaultStreamingChangeEventSourceMetrics extends PipelineMetrics
-        implements StreamingChangeEventSourceMetrics, StreamingChangeEventSourceMetricsMXBean {
+public class DefaultStreamingChangeEventSourceMetrics<P extends Partition> extends PipelineMetrics<P>
+        implements StreamingChangeEventSourceMetrics<P>, StreamingChangeEventSourceMetricsMXBean {
 
     private final AtomicBoolean connected = new AtomicBoolean();
     private final AtomicReference<Duration> lagBehindSource = new AtomicReference<>();
@@ -85,8 +86,8 @@ public class DefaultStreamingChangeEventSourceMetrics extends PipelineMetrics
     }
 
     @Override
-    public void onEvent(DataCollectionId source, OffsetContext offset, Object key, Struct value, Operation operation) {
-        super.onEvent(source, offset, key, value, operation);
+    public void onEvent(P partition, DataCollectionId source, OffsetContext offset, Object key, Struct value, Operation operation) {
+        super.onEvent(partition, source, offset, key, value, operation);
 
         final Instant eventTimestamp = metadataProvider.getEventTimestamp(source, offset, key, value);
         if (eventTimestamp != null) {
@@ -108,7 +109,7 @@ public class DefaultStreamingChangeEventSourceMetrics extends PipelineMetrics
     }
 
     @Override
-    public void onConnectorEvent(ConnectorEvent event) {
+    public void onConnectorEvent(P partition, ConnectorEvent event) {
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/PipelineMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/PipelineMetrics.java
@@ -5,8 +5,6 @@
  */
 package io.debezium.pipeline.metrics;
 
-import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.kafka.connect.data.Struct;
 
 import io.debezium.annotation.ThreadSafe;
@@ -15,12 +13,12 @@ import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.data.Envelope.Operation;
 import io.debezium.metrics.Metrics;
 import io.debezium.pipeline.ConnectorEvent;
+import io.debezium.pipeline.meters.CommonEventMeter;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.EventMetadataProvider;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
 import io.debezium.schema.DataCollectionId;
-import io.debezium.util.Clock;
 
 /**
  * Base for metrics implementations.
@@ -32,81 +30,44 @@ public abstract class PipelineMetrics<P extends Partition> extends Metrics
         implements DataChangeEventListener<P>, ChangeEventSourceMetricsMXBean {
 
     protected final EventMetadataProvider metadataProvider;
-    protected final AtomicLong totalNumberOfEventsSeen = new AtomicLong();
-    protected final AtomicLong totalNumberOfCreateEventsSeen = new AtomicLong();
-    protected final AtomicLong totalNumberOfUpdateEventsSeen = new AtomicLong();
-    protected final AtomicLong totalNumberOfDeleteEventsSeen = new AtomicLong();
-    private final AtomicLong numberOfEventsFiltered = new AtomicLong();
-    protected final AtomicLong numberOfErroneousEvents = new AtomicLong();
-    protected final AtomicLong lastEventTimestamp = new AtomicLong(-1);
-    private volatile String lastEvent;
 
-    protected final Clock clock;
     private final ChangeEventQueueMetrics changeEventQueueMetrics;
     protected final CdcSourceTaskContext taskContext;
+    private final CommonEventMeter commonEventMeter;
 
     protected <T extends CdcSourceTaskContext> PipelineMetrics(T taskContext, String contextName, ChangeEventQueueMetrics changeEventQueueMetrics,
                                                                EventMetadataProvider metadataProvider) {
         super(taskContext, contextName);
         this.taskContext = taskContext;
-        this.clock = taskContext.getClock();
         this.changeEventQueueMetrics = changeEventQueueMetrics;
         this.metadataProvider = metadataProvider;
+        this.commonEventMeter = new CommonEventMeter(taskContext.getClock(), metadataProvider);
     }
 
     @Override
-    public void onEvent(P partition, DataCollectionId source, OffsetContext offset, Object key, Struct value, Operation operation) {
-        updateCommonEventMetrics(operation);
-        lastEvent = metadataProvider.toSummaryString(source, offset, key, value);
-    }
-
-    private void updateCommonEventMetrics() {
-        updateCommonEventMetrics(null);
-    }
-
-    private void updateCommonEventMetrics(Operation operation) {
-        totalNumberOfEventsSeen.incrementAndGet();
-        lastEventTimestamp.set(clock.currentTimeInMillis());
-
-        if (operation != null) {
-            switch (operation) {
-                case CREATE:
-                    totalNumberOfCreateEventsSeen.incrementAndGet();
-                    break;
-                case UPDATE:
-                    totalNumberOfUpdateEventsSeen.incrementAndGet();
-                    break;
-                case DELETE:
-                    totalNumberOfDeleteEventsSeen.incrementAndGet();
-                    break;
-                default:
-                    break;
-            }
-        }
+    public void onEvent(P partition, DataCollectionId source, OffsetContext offset, Object key, Struct value,
+                        Operation operation) {
+        commonEventMeter.onEvent(source, offset, key, value, operation);
     }
 
     @Override
     public void onFilteredEvent(P partition, String event) {
-        numberOfEventsFiltered.incrementAndGet();
-        updateCommonEventMetrics();
+        commonEventMeter.onFilteredEvent();
     }
 
     @Override
     public void onFilteredEvent(P partition, String event, Operation operation) {
-        numberOfEventsFiltered.incrementAndGet();
-        updateCommonEventMetrics(operation);
+        commonEventMeter.onFilteredEvent(operation);
     }
 
     @Override
     public void onErroneousEvent(P partition, String event) {
-        numberOfErroneousEvents.incrementAndGet();
-        updateCommonEventMetrics();
+        commonEventMeter.onErroneousEvent();
     }
 
     @Override
     public void onErroneousEvent(P partition, String event, Operation operation) {
-        numberOfErroneousEvents.incrementAndGet();
-        updateCommonEventMetrics(operation);
+        commonEventMeter.onErroneousEvent(operation);
     }
 
     @Override
@@ -115,54 +76,47 @@ public abstract class PipelineMetrics<P extends Partition> extends Metrics
 
     @Override
     public String getLastEvent() {
-        return lastEvent;
+        return commonEventMeter.getLastEvent();
     }
 
     @Override
     public long getMilliSecondsSinceLastEvent() {
-        return (lastEventTimestamp.get() == -1) ? -1 : (clock.currentTimeInMillis() - lastEventTimestamp.get());
+        return commonEventMeter.getMilliSecondsSinceLastEvent();
     }
 
     @Override
     public long getTotalNumberOfEventsSeen() {
-        return totalNumberOfEventsSeen.get();
+        return commonEventMeter.getTotalNumberOfEventsSeen();
     }
 
     @Override
     public long getTotalNumberOfCreateEventsSeen() {
-        return totalNumberOfCreateEventsSeen.get();
+        return commonEventMeter.getTotalNumberOfCreateEventsSeen();
     }
 
     @Override
     public long getTotalNumberOfUpdateEventsSeen() {
-        return totalNumberOfUpdateEventsSeen.get();
+        return commonEventMeter.getTotalNumberOfUpdateEventsSeen();
     }
 
     @Override
     public long getTotalNumberOfDeleteEventsSeen() {
-        return totalNumberOfDeleteEventsSeen.get();
+        return commonEventMeter.getTotalNumberOfDeleteEventsSeen();
     }
 
     @Override
     public long getNumberOfEventsFiltered() {
-        return numberOfEventsFiltered.get();
+        return commonEventMeter.getNumberOfEventsFiltered();
     }
 
     @Override
     public long getNumberOfErroneousEvents() {
-        return numberOfErroneousEvents.get();
+        return commonEventMeter.getNumberOfErroneousEvents();
     }
 
     @Override
     public void reset() {
-        totalNumberOfEventsSeen.set(0);
-        totalNumberOfCreateEventsSeen.set(0);
-        totalNumberOfUpdateEventsSeen.set(0);
-        totalNumberOfDeleteEventsSeen.set(0);
-        lastEventTimestamp.set(-1);
-        numberOfEventsFiltered.set(0);
-        numberOfErroneousEvents.set(0);
-        lastEvent = null;
+        commonEventMeter.reset();
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/PipelineMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/PipelineMetrics.java
@@ -18,6 +18,7 @@ import io.debezium.pipeline.ConnectorEvent;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.EventMetadataProvider;
 import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Partition;
 import io.debezium.schema.DataCollectionId;
 import io.debezium.util.Clock;
 
@@ -27,7 +28,8 @@ import io.debezium.util.Clock;
  * @author Randall Hauch, Jiri Pechanec
  */
 @ThreadSafe
-public abstract class PipelineMetrics extends Metrics implements DataChangeEventListener, ChangeEventSourceMetricsMXBean {
+public abstract class PipelineMetrics<P extends Partition> extends Metrics
+        implements DataChangeEventListener<P>, ChangeEventSourceMetricsMXBean {
 
     protected final EventMetadataProvider metadataProvider;
     protected final AtomicLong totalNumberOfEventsSeen = new AtomicLong();
@@ -53,7 +55,7 @@ public abstract class PipelineMetrics extends Metrics implements DataChangeEvent
     }
 
     @Override
-    public void onEvent(DataCollectionId source, OffsetContext offset, Object key, Struct value, Operation operation) {
+    public void onEvent(P partition, DataCollectionId source, OffsetContext offset, Object key, Struct value, Operation operation) {
         updateCommonEventMetrics(operation);
         lastEvent = metadataProvider.toSummaryString(source, offset, key, value);
     }
@@ -84,31 +86,31 @@ public abstract class PipelineMetrics extends Metrics implements DataChangeEvent
     }
 
     @Override
-    public void onFilteredEvent(String event) {
+    public void onFilteredEvent(P partition, String event) {
         numberOfEventsFiltered.incrementAndGet();
         updateCommonEventMetrics();
     }
 
     @Override
-    public void onFilteredEvent(String event, Operation operation) {
+    public void onFilteredEvent(P partition, String event, Operation operation) {
         numberOfEventsFiltered.incrementAndGet();
         updateCommonEventMetrics(operation);
     }
 
     @Override
-    public void onErroneousEvent(String event) {
+    public void onErroneousEvent(P partition, String event) {
         numberOfErroneousEvents.incrementAndGet();
         updateCommonEventMetrics();
     }
 
     @Override
-    public void onErroneousEvent(String event, Operation operation) {
+    public void onErroneousEvent(P partition, String event, Operation operation) {
         numberOfErroneousEvents.incrementAndGet();
         updateCommonEventMetrics(operation);
     }
 
     @Override
-    public void onConnectorEvent(ConnectorEvent event) {
+    public void onConnectorEvent(P partition, ConnectorEvent event) {
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/SnapshotChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/SnapshotChangeEventSourceMetrics.java
@@ -6,9 +6,11 @@
 package io.debezium.pipeline.metrics;
 
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.pipeline.spi.Partition;
 
 /**
  * Metrics related to the snapshot phase of a connector.
  */
-public interface SnapshotChangeEventSourceMetrics extends ChangeEventSourceMetrics, SnapshotProgressListener {
+public interface SnapshotChangeEventSourceMetrics<P extends Partition> extends ChangeEventSourceMetrics<P>,
+        SnapshotProgressListener<P> {
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/StreamingChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/StreamingChangeEventSourceMetrics.java
@@ -6,9 +6,11 @@
 package io.debezium.pipeline.metrics;
 
 import io.debezium.pipeline.source.spi.StreamingProgressListener;
+import io.debezium.pipeline.spi.Partition;
 
 /**
  * Metrics related to the streaming phase of a connector.
  */
-public interface StreamingChangeEventSourceMetrics extends ChangeEventSourceMetrics, StreamingProgressListener {
+public interface StreamingChangeEventSourceMetrics<P extends Partition>
+        extends ChangeEventSourceMetrics<P>, StreamingProgressListener {
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/StreamingChangeEventSourceMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/StreamingChangeEventSourceMetricsMXBean.java
@@ -5,22 +5,14 @@
  */
 package io.debezium.pipeline.metrics;
 
-import java.util.Map;
+import io.debezium.pipeline.metrics.traits.ConnectionMetricsMXBean;
+import io.debezium.pipeline.metrics.traits.StreamingMetricsMXBean;
 
 /**
  * Metrics specific to streaming change event sources
  *
  * @author Randall Hauch, Jiri Pechanec
  */
-public interface StreamingChangeEventSourceMetricsMXBean extends ChangeEventSourceMetricsMXBean {
-
-    boolean isConnected();
-
-    long getMilliSecondsBehindSource();
-
-    long getNumberOfCommittedTransactions();
-
-    Map<String, String> getSourceEventPosition();
-
-    String getLastTransactionId();
+public interface StreamingChangeEventSourceMetricsMXBean extends ChangeEventSourceMetricsMXBean,
+        ConnectionMetricsMXBean, StreamingMetricsMXBean {
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/spi/ChangeEventSourceMetricsFactory.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/spi/ChangeEventSourceMetricsFactory.java
@@ -10,13 +10,14 @@ import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.pipeline.metrics.SnapshotChangeEventSourceMetrics;
 import io.debezium.pipeline.metrics.StreamingChangeEventSourceMetrics;
 import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.Partition;
 
 /**
  * A factory for creating {@link SnapshotChangeEventSourceMetrics} and {@link StreamingChangeEventSourceMetrics}.
  *
  * @author Chris Cranford
  */
-public interface ChangeEventSourceMetricsFactory {
+public interface ChangeEventSourceMetricsFactory<P extends Partition> {
 
     /**
      * Returns the snapshot change event source metrics.
@@ -30,8 +31,8 @@ public interface ChangeEventSourceMetricsFactory {
      *
      * @return a snapshot change event source metrics
      */
-    <T extends CdcSourceTaskContext> SnapshotChangeEventSourceMetrics getSnapshotMetrics(T taskContext, ChangeEventQueueMetrics changeEventQueueMetrics,
-                                                                                         EventMetadataProvider eventMetadataProvider);
+    <T extends CdcSourceTaskContext> SnapshotChangeEventSourceMetrics<P> getSnapshotMetrics(T taskContext, ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                            EventMetadataProvider eventMetadataProvider);
 
     /**
      * Returns the streaming change event source metrics.
@@ -45,8 +46,8 @@ public interface ChangeEventSourceMetricsFactory {
      *
      * @return a streaming change event source metrics
      */
-    <T extends CdcSourceTaskContext> StreamingChangeEventSourceMetrics getStreamingMetrics(T taskContext, ChangeEventQueueMetrics changeEventQueueMetrics,
-                                                                                           EventMetadataProvider eventMetadataProvider);
+    <T extends CdcSourceTaskContext> StreamingChangeEventSourceMetrics<P> getStreamingMetrics(T taskContext, ChangeEventQueueMetrics changeEventQueueMetrics,
+                                                                                              EventMetadataProvider eventMetadataProvider);
 
     default boolean connectionMetricHandledByCoordinator() {
         return true;

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/CommonEventMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/CommonEventMetricsMXBean.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.metrics.traits;
+
+/**
+ * Exposes common event metrics.
+ */
+public interface CommonEventMetricsMXBean {
+
+    String getLastEvent();
+
+    long getMilliSecondsSinceLastEvent();
+
+    long getTotalNumberOfEventsSeen();
+
+    long getTotalNumberOfCreateEventsSeen();
+
+    long getTotalNumberOfUpdateEventsSeen();
+
+    long getTotalNumberOfDeleteEventsSeen();
+
+    long getNumberOfEventsFiltered();
+
+    long getNumberOfErroneousEvents();
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/ConnectionMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/ConnectionMetricsMXBean.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.metrics.traits;
+
+/**
+ * Exposes connection metrics.
+ */
+public interface ConnectionMetricsMXBean {
+
+    boolean isConnected();
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/QueueMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/QueueMetricsMXBean.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.metrics.traits;
+
+/**
+ * Exposes queue metrics.
+ */
+public interface QueueMetricsMXBean {
+
+    int getQueueTotalCapacity();
+
+    int getQueueRemainingCapacity();
+
+    long getMaxQueueSizeInBytes();
+
+    long getCurrentQueueSizeInBytes();
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SchemaMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SchemaMetricsMXBean.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.metrics.traits;
+
+/**
+ * Exposes schema metrics.
+ */
+public interface SchemaMetricsMXBean {
+
+    String[] getCapturedTables();
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SnapshotMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/SnapshotMetricsMXBean.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.metrics.traits;
+
+import java.util.Map;
+
+/**
+ * Exposes snapshot metrics.
+ */
+public interface SnapshotMetricsMXBean extends SchemaMetricsMXBean {
+
+    int getTotalTableCount();
+
+    int getRemainingTableCount();
+
+    boolean getSnapshotRunning();
+
+    boolean getSnapshotCompleted();
+
+    boolean getSnapshotAborted();
+
+    long getSnapshotDurationInSeconds();
+
+    Map<String, Long> getRowsScanned();
+
+    String getChunkId();
+
+    String getChunkFrom();
+
+    String getChunkTo();
+
+    String getTableFrom();
+
+    String getTableTo();
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/StreamingMetricsMXBean.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/traits/StreamingMetricsMXBean.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.metrics.traits;
+
+import java.util.Map;
+
+/**
+ * Exposes streaming metrics.
+ */
+public interface StreamingMetricsMXBean extends SchemaMetricsMXBean {
+
+    String[] getCapturedTables();
+
+    Map<String, String> getSourceEventPosition();
+
+    long getMilliSecondsBehindSource();
+
+    long getNumberOfCommittedTransactions();
+
+    String getLastTransactionId();
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/Log.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/Log.java
@@ -9,8 +9,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.pipeline.signal.Signal.Payload;
+import io.debezium.pipeline.spi.Partition;
 
-public class Log implements Signal.Action {
+public class Log<P extends Partition> implements Signal.Action<P> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Log.class);
     private static final String FIELD_MESSAGE = "message";
@@ -18,7 +19,7 @@ public class Log implements Signal.Action {
     public static final String NAME = "log";
 
     @Override
-    public boolean arrived(Payload signalPayload) {
+    public boolean arrived(Payload<P> signalPayload) {
         final String message = signalPayload.data.getString(FIELD_MESSAGE);
         if (message == null || message.isEmpty()) {
             LOGGER.warn("Logging signal '{}' has arrived but the requested field '{}' is missing from data", signalPayload, FIELD_MESSAGE);

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/SchemaChanges.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/SchemaChanges.java
@@ -12,6 +12,7 @@ import io.debezium.DebeziumException;
 import io.debezium.document.Array;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.signal.Signal.Payload;
+import io.debezium.pipeline.spi.Partition;
 import io.debezium.relational.RelationalDatabaseSchema;
 import io.debezium.relational.TableId;
 import io.debezium.relational.history.JsonTableChangeSerializer;
@@ -21,7 +22,7 @@ import io.debezium.schema.DataCollectionId;
 import io.debezium.schema.SchemaChangeEvent;
 import io.debezium.schema.SchemaChangeEvent.SchemaChangeEventType;
 
-public class SchemaChanges implements Signal.Action {
+public class SchemaChanges<P extends Partition> implements Signal.Action<P> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SchemaChanges.class);
 
@@ -33,17 +34,17 @@ public class SchemaChanges implements Signal.Action {
 
     private final JsonTableChangeSerializer serializer;
     private final boolean useCatalogBeforeSchema;
-    private final EventDispatcher<TableId> dispatcher;
+    private final EventDispatcher<P, TableId> dispatcher;
 
     @SuppressWarnings("unchecked")
-    public SchemaChanges(EventDispatcher<? extends DataCollectionId> dispatcher, boolean useCatalogBeforeSchema) {
+    public SchemaChanges(EventDispatcher<P, ? extends DataCollectionId> dispatcher, boolean useCatalogBeforeSchema) {
         serializer = new JsonTableChangeSerializer();
         this.useCatalogBeforeSchema = useCatalogBeforeSchema;
-        this.dispatcher = (EventDispatcher<TableId>) dispatcher;
+        this.dispatcher = (EventDispatcher<P, TableId>) dispatcher;
     }
 
     @Override
-    public boolean arrived(Payload signalPayload) throws InterruptedException {
+    public boolean arrived(Payload<P> signalPayload) throws InterruptedException {
         final Array changes = signalPayload.data.getArray(FIELD_CHANGES);
         final String database = signalPayload.data.getString(FIELD_DATABASE);
         final String schema = signalPayload.data.getString(FIELD_SCHEMA);

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
@@ -43,16 +43,16 @@ public abstract class AbstractSnapshotChangeEventSource<P extends Partition, O e
     public static final Duration LOG_INTERVAL = Duration.ofMillis(10_000);
 
     private final CommonConnectorConfig connectorConfig;
-    private final SnapshotProgressListener snapshotProgressListener;
+    private final SnapshotProgressListener<P> snapshotProgressListener;
 
-    public AbstractSnapshotChangeEventSource(CommonConnectorConfig connectorConfig, SnapshotProgressListener snapshotProgressListener) {
+    public AbstractSnapshotChangeEventSource(CommonConnectorConfig connectorConfig, SnapshotProgressListener<P> snapshotProgressListener) {
         this.connectorConfig = connectorConfig;
         this.snapshotProgressListener = snapshotProgressListener;
     }
 
     @Override
     public SnapshotResult<O> execute(ChangeEventSourceContext context, P partition, O previousOffset) throws InterruptedException {
-        SnapshottingTask snapshottingTask = getSnapshottingTask(previousOffset);
+        SnapshottingTask snapshottingTask = getSnapshottingTask(partition, previousOffset);
         if (snapshottingTask.shouldSkipSnapshot()) {
             LOGGER.debug("Skipping snapshotting");
             return SnapshotResult.skipped(previousOffset);
@@ -72,7 +72,7 @@ public abstract class AbstractSnapshotChangeEventSource<P extends Partition, O e
         boolean completedSuccessfully = true;
 
         try {
-            snapshotProgressListener.snapshotStarted();
+            snapshotProgressListener.snapshotStarted(partition);
             return doExecute(context, previousOffset, ctx, snapshottingTask);
         }
         catch (InterruptedException e) {
@@ -89,10 +89,10 @@ public abstract class AbstractSnapshotChangeEventSource<P extends Partition, O e
             complete(ctx);
 
             if (completedSuccessfully) {
-                snapshotProgressListener.snapshotCompleted();
+                snapshotProgressListener.snapshotCompleted(partition);
             }
             else {
-                snapshotProgressListener.snapshotAborted();
+                snapshotProgressListener.snapshotAborted(partition);
             }
         }
     }
@@ -151,7 +151,7 @@ public abstract class AbstractSnapshotChangeEventSource<P extends Partition, O e
     /**
      * Returns the snapshotting task based on the previous offset (if available) and the connector's snapshotting mode.
      */
-    protected abstract SnapshottingTask getSnapshottingTask(O previousOffset);
+    protected abstract SnapshottingTask getSnapshottingTask(P partition, O previousOffset);
 
     /**
      * Prepares the taking of a snapshot and returns an initial {@link SnapshotContext}.

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/CloseIncrementalSnapshotWindow.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/CloseIncrementalSnapshotWindow.java
@@ -11,23 +11,24 @@ import org.slf4j.LoggerFactory;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.signal.Signal;
 import io.debezium.pipeline.signal.Signal.Payload;
+import io.debezium.pipeline.spi.Partition;
 import io.debezium.schema.DataCollectionId;
 
-public class CloseIncrementalSnapshotWindow implements Signal.Action {
+public class CloseIncrementalSnapshotWindow<P extends Partition> implements Signal.Action<P> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CloseIncrementalSnapshotWindow.class);
 
     public static final String NAME = "snapshot-window-close";
 
-    private final EventDispatcher<? extends DataCollectionId> dispatcher;
+    private final EventDispatcher<P, ? extends DataCollectionId> dispatcher;
 
-    public CloseIncrementalSnapshotWindow(EventDispatcher<? extends DataCollectionId> dispatcher) {
+    public CloseIncrementalSnapshotWindow(EventDispatcher<P, ? extends DataCollectionId> dispatcher) {
         this.dispatcher = dispatcher;
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
-    public boolean arrived(Payload signalPayload) throws InterruptedException {
+    public boolean arrived(Payload<P> signalPayload) throws InterruptedException {
         dispatcher.getIncrementalSnapshotChangeEventSource().closeWindow(signalPayload.partition, signalPayload.id,
                 signalPayload.offsetContext);
         return true;

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
@@ -18,26 +18,26 @@ import io.debezium.schema.DataCollectionId;
  *
  * @param <T> data collection id class
  */
-public interface IncrementalSnapshotChangeEventSource<T extends DataCollectionId> {
+public interface IncrementalSnapshotChangeEventSource<P extends Partition, T extends DataCollectionId> {
 
-    void closeWindow(Partition partition, String id, OffsetContext offsetContext) throws InterruptedException;
+    void closeWindow(P partition, String id, OffsetContext offsetContext) throws InterruptedException;
 
-    void processMessage(Partition partition, DataCollectionId dataCollectionId, Object key, OffsetContext offsetContext) throws InterruptedException;
+    void processMessage(P partition, DataCollectionId dataCollectionId, Object key, OffsetContext offsetContext) throws InterruptedException;
 
-    void init(OffsetContext offsetContext);
+    void init(P partition, OffsetContext offsetContext);
 
-    void addDataCollectionNamesToSnapshot(List<String> dataCollectionIds, OffsetContext offsetContext)
+    void addDataCollectionNamesToSnapshot(P partition, List<String> dataCollectionIds, OffsetContext offsetContext)
             throws InterruptedException;
 
-    default void processHeartbeat(Partition partition, OffsetContext offsetContext) throws InterruptedException {
+    default void processHeartbeat(P partition, OffsetContext offsetContext) throws InterruptedException {
     }
 
-    default void processFilteredEvent(Partition partition, OffsetContext offsetContext) throws InterruptedException {
+    default void processFilteredEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
     }
 
-    default void processTransactionStartedEvent(Partition partition, OffsetContext offsetContext) throws InterruptedException {
+    default void processTransactionStartedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
     }
 
-    default void processTransactionCommittedEvent(Partition partition, OffsetContext offsetContext) throws InterruptedException {
+    default void processTransactionCommittedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
     }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/OpenIncrementalSnapshotWindow.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/OpenIncrementalSnapshotWindow.java
@@ -10,8 +10,9 @@ import org.slf4j.LoggerFactory;
 
 import io.debezium.pipeline.signal.Signal;
 import io.debezium.pipeline.signal.Signal.Payload;
+import io.debezium.pipeline.spi.Partition;
 
-public class OpenIncrementalSnapshotWindow implements Signal.Action {
+public class OpenIncrementalSnapshotWindow<P extends Partition> implements Signal.Action<P> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenIncrementalSnapshotWindow.class);
 
@@ -21,7 +22,7 @@ public class OpenIncrementalSnapshotWindow implements Signal.Action {
     }
 
     @Override
-    public boolean arrived(Payload signalPayload) {
+    public boolean arrived(Payload<P> signalPayload) {
         signalPayload.offsetContext.getIncrementalSnapshotContext().openWindow(signalPayload.id);
         return true;
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeEventSourceFactory.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeEventSourceFactory.java
@@ -31,7 +31,7 @@ public interface ChangeEventSourceFactory<P extends Partition, O extends OffsetC
      *
      * @return A snapshot change event source
      */
-    SnapshotChangeEventSource<P, O> getSnapshotChangeEventSource(SnapshotProgressListener snapshotProgressListener);
+    SnapshotChangeEventSource<P, O> getSnapshotChangeEventSource(SnapshotProgressListener<P> snapshotProgressListener);
 
     /**
      * Returns a streaming change event source that starts streaming at the given offset.
@@ -49,9 +49,9 @@ public interface ChangeEventSourceFactory<P extends Partition, O extends OffsetC
      *
      * @return An incremental snapshot change event source
      */
-    default Optional<IncrementalSnapshotChangeEventSource<? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(O offsetContext,
-                                                                                                                               SnapshotProgressListener snapshotProgressListener,
-                                                                                                                               DataChangeEventListener dataChangeEventListener) {
+    default Optional<IncrementalSnapshotChangeEventSource<P, ? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(O offsetContext,
+                                                                                                                                  SnapshotProgressListener<P> snapshotProgressListener,
+                                                                                                                                  DataChangeEventListener<P> dataChangeEventListener) {
         return Optional.empty();
     }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/DataChangeEventListener.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/DataChangeEventListener.java
@@ -24,7 +24,7 @@ public interface DataChangeEventListener {
     /**
      * Invoked if an event is processed for a captured table.
      */
-    void onEvent(DataCollectionId source, OffsetContext offset, Object key, Struct value, Operation operation) throws InterruptedException;
+    void onEvent(DataCollectionId source, OffsetContext offset, Object key, Struct value, Operation operation);
 
     /**
      * Invoked for events pertaining to non-captured tables.

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/DataChangeEventListener.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/DataChangeEventListener.java
@@ -11,6 +11,7 @@ import io.debezium.data.Envelope.Operation;
 import io.debezium.pipeline.ConnectorEvent;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Partition;
 import io.debezium.schema.DataCollectionId;
 
 /**
@@ -19,61 +20,65 @@ import io.debezium.schema.DataCollectionId;
  * @author Jiri Pechanec
  *
  */
-public interface DataChangeEventListener {
+public interface DataChangeEventListener<P extends Partition> {
 
     /**
      * Invoked if an event is processed for a captured table.
      */
-    void onEvent(DataCollectionId source, OffsetContext offset, Object key, Struct value, Operation operation);
+    void onEvent(P partition, DataCollectionId source, OffsetContext offset, Object key, Struct value, Operation operation);
 
     /**
      * Invoked for events pertaining to non-captured tables.
      */
-    void onFilteredEvent(String event);
+    void onFilteredEvent(P partition, String event);
 
     /**
      * Invoked for events pertaining to non-captured tables.
      */
-    void onFilteredEvent(String event, Operation operation);
+    void onFilteredEvent(P partition, String event, Operation operation);
 
     /**
      * Invoked for events that cannot be processed.
      */
-    void onErroneousEvent(String event);
+    void onErroneousEvent(P partition, String event);
 
     /**
      * Invoked for events that cannot be processed.
      */
-    void onErroneousEvent(String event, Operation operation);
+    void onErroneousEvent(P partition, String event, Operation operation);
 
     /**
      * Invoked for events that represent a connector event.
      */
-    void onConnectorEvent(ConnectorEvent event);
+    void onConnectorEvent(P partition, ConnectorEvent event);
 
-    DataChangeEventListener NO_OP = new DataChangeEventListener() {
-        @Override
-        public void onFilteredEvent(String event) {
-        }
+    static <P extends Partition> DataChangeEventListener<P> NO_OP() {
+        return new DataChangeEventListener<P>() {
 
-        @Override
-        public void onFilteredEvent(String event, Operation operation) {
-        }
+            @Override
+            public void onFilteredEvent(P partition, String event) {
+            }
 
-        @Override
-        public void onErroneousEvent(String event) {
-        }
+            @Override
+            public void onFilteredEvent(P partition, String event, Operation operation) {
+            }
 
-        @Override
-        public void onErroneousEvent(String event, Operation operation) {
-        }
+            @Override
+            public void onErroneousEvent(P partition, String event) {
+            }
 
-        @Override
-        public void onConnectorEvent(ConnectorEvent event) {
-        }
+            @Override
+            public void onErroneousEvent(P partition, String event, Operation operation) {
+            }
 
-        @Override
-        public void onEvent(DataCollectionId source, OffsetContext offset, Object key, Struct value, Operation operation) {
-        }
-    };
+            @Override
+            public void onConnectorEvent(P partition, ConnectorEvent event) {
+            }
+
+            @Override
+            public void onEvent(P partition, DataCollectionId source, OffsetContext offset, Object key, Struct value,
+                                Operation operation) {
+            }
+        };
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/SnapshotProgressListener.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/SnapshotProgressListener.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.pipeline.source.spi;
 
+import io.debezium.pipeline.spi.Partition;
 import io.debezium.relational.TableId;
 import io.debezium.schema.DataCollectionId;
 
@@ -13,56 +14,58 @@ import io.debezium.schema.DataCollectionId;
  *
  * @author Jiri Pechanec
  */
-public interface SnapshotProgressListener {
+public interface SnapshotProgressListener<P extends Partition> {
 
-    void snapshotStarted();
+    void snapshotStarted(P partition);
 
-    void monitoredDataCollectionsDetermined(Iterable<? extends DataCollectionId> dataCollectionIds);
+    void monitoredDataCollectionsDetermined(P partition, Iterable<? extends DataCollectionId> dataCollectionIds);
 
-    void snapshotCompleted();
+    void snapshotCompleted(P partition);
 
-    void snapshotAborted();
+    void snapshotAborted(P partition);
 
-    void dataCollectionSnapshotCompleted(DataCollectionId dataCollectionId, long numRows);
+    void dataCollectionSnapshotCompleted(P partition, DataCollectionId dataCollectionId, long numRows);
 
-    void rowsScanned(TableId tableId, long numRows);
+    void rowsScanned(P partition, TableId tableId, long numRows);
 
-    void currentChunk(String chunkId, Object[] chunkFrom, Object[] chunkTo);
+    void currentChunk(P partition, String chunkId, Object[] chunkFrom, Object[] chunkTo);
 
-    void currentChunk(String chunkId, Object[] chunkFrom, Object[] chunkTo, Object tableTo[]);
+    void currentChunk(P partition, String chunkId, Object[] chunkFrom, Object[] chunkTo, Object[] tableTo);
 
-    public static SnapshotProgressListener NO_OP = new SnapshotProgressListener() {
+    static <P extends Partition> SnapshotProgressListener<P> NO_OP() {
+        return new SnapshotProgressListener<P>() {
 
-        @Override
-        public void snapshotStarted() {
-        }
+            @Override
+            public void snapshotStarted(P partition) {
+            }
 
-        @Override
-        public void rowsScanned(TableId tableId, long numRows) {
-        }
+            @Override
+            public void rowsScanned(P partition, TableId tableId, long numRows) {
+            }
 
-        @Override
-        public void monitoredDataCollectionsDetermined(Iterable<? extends DataCollectionId> dataCollectionIds) {
-        }
+            @Override
+            public void monitoredDataCollectionsDetermined(P partition, Iterable<? extends DataCollectionId> dataCollectionIds) {
+            }
 
-        @Override
-        public void dataCollectionSnapshotCompleted(DataCollectionId dataCollectionId, long numRows) {
-        }
+            @Override
+            public void dataCollectionSnapshotCompleted(P partition, DataCollectionId dataCollectionId, long numRows) {
+            }
 
-        @Override
-        public void snapshotCompleted() {
-        }
+            @Override
+            public void snapshotCompleted(P partition) {
+            }
 
-        @Override
-        public void snapshotAborted() {
-        }
+            @Override
+            public void snapshotAborted(P partition) {
+            }
 
-        @Override
-        public void currentChunk(String chunkId, Object[] chunkFrom, Object[] chunkTo) {
-        }
+            @Override
+            public void currentChunk(P partition, String chunkId, Object[] chunkFrom, Object[] chunkTo) {
+            }
 
-        @Override
-        public void currentChunk(String chunkId, Object[] chunkFrom, Object[] chunkTo, Object tableTo[]) {
-        }
-    };
+            @Override
+            public void currentChunk(P partition, String chunkId, Object[] chunkFrom, Object[] chunkTo, Object[] tableTo) {
+            }
+        };
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/ChangeRecordEmitter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/ChangeRecordEmitter.java
@@ -18,17 +18,17 @@ import io.debezium.schema.DataCollectionSchema;
  *
  * @author Gunnar Morling
  */
-public interface ChangeRecordEmitter {
+public interface ChangeRecordEmitter<P extends Partition> {
 
     /**
      * Emits the change record(s) corresponding to data change represented by this emitter.
      */
-    void emitChangeRecords(DataCollectionSchema schema, Receiver receiver) throws InterruptedException;
+    void emitChangeRecords(DataCollectionSchema schema, Receiver<P> receiver) throws InterruptedException;
 
     /**
      * Returns the partition of the change record(s) emitted.
      */
-    Partition getPartition();
+    P getPartition();
 
     /**
      * Returns the offset of the change record(s) emitted.
@@ -44,9 +44,9 @@ public interface ChangeRecordEmitter {
      * Callback passed to {@link ChangeRecordEmitter}s, allowing them to produce one
      * or more change records.
      */
-    public interface Receiver {
+    interface Receiver<P extends Partition> {
 
-        void changeRecord(Partition partition, DataCollectionSchema schema, Operation operation, Object key, Struct value,
+        void changeRecord(P partition, DataCollectionSchema schema, Operation operation, Object key, Struct value,
                           OffsetContext offset, ConnectHeaders headers)
                 throws InterruptedException;
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/spi/Offsets.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/spi/Offsets.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import io.debezium.DebeziumException;
 
@@ -35,6 +36,10 @@ public final class Offsets<P extends Partition, O extends OffsetContext> impleme
 
     public void resetOffset(P partition) {
         offsets.put(partition, null);
+    }
+
+    public Set<P> getPartitions() {
+        return offsets.keySet();
     }
 
     public Map<P, O> getOffsets() {

--- a/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
@@ -33,6 +33,7 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
     private boolean useCatalogBeforeSchema;
     private final String logicalName;
     private final Class<? extends SourceConnector> connectorClass;
+    private final boolean multiPartitionMode;
 
     /**
      * The database history class is hidden in the {@link #configDef()} since that is designed to work with a user interface,
@@ -62,27 +63,29 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
                     KafkaDatabaseHistory.KAFKA_QUERY_TIMEOUT_MS)
             .create();
 
-    protected HistorizedRelationalDatabaseConnectorConfig(Class<? extends SourceConnector> connectorClass, Configuration config, String logicalName,
+    protected HistorizedRelationalDatabaseConnectorConfig(Class<? extends SourceConnector> connectorClass,
+                                                          Configuration config, String logicalName,
                                                           TableFilter systemTablesFilter,
-                                                          boolean useCatalogBeforeSchema, int defaultSnapshotFetchSize, ColumnFilterMode columnFilterMode) {
+                                                          boolean useCatalogBeforeSchema,
+                                                          int defaultSnapshotFetchSize,
+                                                          ColumnFilterMode columnFilterMode,
+                                                          boolean multiPartitionMode) {
         super(config, logicalName, systemTablesFilter, TableId::toString, defaultSnapshotFetchSize, columnFilterMode);
         this.useCatalogBeforeSchema = useCatalogBeforeSchema;
         this.logicalName = logicalName;
         this.connectorClass = connectorClass;
-    }
-
-    protected HistorizedRelationalDatabaseConnectorConfig(Class<? extends SourceConnector> connectorClass, Configuration config, String logicalName,
-                                                          TableFilter systemTablesFilter, boolean useCatalogBeforeSchema, ColumnFilterMode columnFilterMode) {
-        this(connectorClass, config, logicalName, systemTablesFilter, useCatalogBeforeSchema, DEFAULT_SNAPSHOT_FETCH_SIZE, columnFilterMode);
+        this.multiPartitionMode = multiPartitionMode;
     }
 
     protected HistorizedRelationalDatabaseConnectorConfig(Class<? extends SourceConnector> connectorClass, Configuration config, String logicalName,
                                                           TableFilter systemTablesFilter, TableIdToStringMapper tableIdMapper,
-                                                          boolean useCatalogBeforeSchema, ColumnFilterMode columnFilterMode) {
+                                                          boolean useCatalogBeforeSchema, ColumnFilterMode columnFilterMode,
+                                                          boolean multiPartitionMode) {
         super(config, logicalName, systemTablesFilter, tableIdMapper, DEFAULT_SNAPSHOT_FETCH_SIZE, columnFilterMode);
         this.useCatalogBeforeSchema = useCatalogBeforeSchema;
         this.logicalName = logicalName;
         this.connectorClass = connectorClass;
+        this.multiPartitionMode = multiPartitionMode;
     }
 
     /**
@@ -106,7 +109,8 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
                 .build();
 
         HistoryRecordComparator historyComparator = getHistoryRecordComparator();
-        databaseHistory.configure(dbHistoryConfig, historyComparator, new DatabaseHistoryMetrics(this), useCatalogBeforeSchema); // validates
+        databaseHistory.configure(dbHistoryConfig, historyComparator,
+                new DatabaseHistoryMetrics(this, multiPartitionMode), useCatalogBeforeSchema); // validates
 
         return databaseHistory;
     }

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -60,13 +60,13 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
     private final RelationalDatabaseConnectorConfig connectorConfig;
     private final JdbcConnection jdbcConnection;
     private final RelationalDatabaseSchema schema;
-    protected final EventDispatcher<TableId> dispatcher;
+    protected final EventDispatcher<P, TableId> dispatcher;
     protected final Clock clock;
-    private final SnapshotProgressListener snapshotProgressListener;
+    private final SnapshotProgressListener<P> snapshotProgressListener;
 
     public RelationalSnapshotChangeEventSource(RelationalDatabaseConnectorConfig connectorConfig,
                                                JdbcConnection jdbcConnection, RelationalDatabaseSchema schema,
-                                               EventDispatcher<TableId> dispatcher, Clock clock, SnapshotProgressListener snapshotProgressListener) {
+                                               EventDispatcher<P, TableId> dispatcher, Clock clock, SnapshotProgressListener<P> snapshotProgressListener) {
         super(connectorConfig, snapshotProgressListener);
         this.connectorConfig = connectorConfig;
         this.jdbcConnection = jdbcConnection;
@@ -98,7 +98,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
             // Note that there's a minor race condition here: a new table matching the filters could be created between
             // this call and the determination of the initial snapshot position below; this seems acceptable, though
             determineCapturedTables(ctx);
-            snapshotProgressListener.monitoredDataCollectionsDetermined(ctx.capturedTables);
+            snapshotProgressListener.monitoredDataCollectionsDetermined(snapshotContext.partition, ctx.capturedTables);
 
             LOGGER.info("Snapshot step 3 - Locking captured tables {}", ctx.capturedTables);
 
@@ -290,7 +290,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
     private void createDataEvents(ChangeEventSourceContext sourceContext,
                                   RelationalSnapshotContext<P, O> snapshotContext)
             throws Exception {
-        SnapshotReceiver snapshotReceiver = dispatcher.getSnapshotChangeEventReceiver();
+        SnapshotReceiver<P> snapshotReceiver = dispatcher.getSnapshotChangeEventReceiver();
         tryStartingSnapshot(snapshotContext);
 
         final int tableCount = snapshotContext.capturedTables.size();
@@ -326,7 +326,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
      */
     private void createDataEventsForTable(ChangeEventSourceContext sourceContext,
                                           RelationalSnapshotContext<P, O> snapshotContext,
-                                          SnapshotReceiver snapshotReceiver, Table table, int tableOrder,
+                                          SnapshotReceiver<P> snapshotReceiver, Table table, int tableOrder,
                                           int tableCount)
             throws InterruptedException {
 
@@ -336,7 +336,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
         final Optional<String> selectStatement = determineSnapshotSelect(snapshotContext, table.id());
         if (!selectStatement.isPresent()) {
             LOGGER.warn("For table '{}' the select statement was not provided, skipping table", table.id());
-            snapshotProgressListener.dataCollectionSnapshotCompleted(table.id(), 0);
+            snapshotProgressListener.dataCollectionSnapshotCompleted(snapshotContext.partition, table.id(), 0);
             return;
         }
         LOGGER.info("\t For table '{}' using select statement: '{}'", table.id(), selectStatement.get());
@@ -370,14 +370,15 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
                             LOGGER.info("\t Exported {} records for table '{}' after {}", rows, table.id(),
                                     Strings.duration(stop - exportStart));
                         }
-                        snapshotProgressListener.rowsScanned(table.id(), rows);
+                        snapshotProgressListener.rowsScanned(snapshotContext.partition, table.id(), rows);
                         logTimer = getTableScanLogTimer();
                     }
 
                     if (snapshotContext.lastTable && snapshotContext.lastRecordInTable) {
                         lastSnapshotRecord(snapshotContext);
                     }
-                    dispatcher.dispatchSnapshotEvent(table.id(), getChangeRecordEmitter(snapshotContext, table.id(), row), snapshotReceiver);
+                    dispatcher.dispatchSnapshotEvent(snapshotContext.partition, table.id(),
+                            getChangeRecordEmitter(snapshotContext, table.id(), row), snapshotReceiver);
                 }
             }
             else if (snapshotContext.lastTable) {
@@ -386,7 +387,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
 
             LOGGER.info("\t Finished exporting {} records for table '{}'; total duration '{}'", rows,
                     table.id(), Strings.duration(clock.currentTimeInMillis() - exportStart));
-            snapshotProgressListener.dataCollectionSnapshotCompleted(table.id(), rows);
+            snapshotProgressListener.dataCollectionSnapshotCompleted(snapshotContext.partition, table.id(), rows);
         }
         catch (SQLException e) {
             throw new ConnectException("Snapshotting of table " + table.id() + " failed", e);
@@ -411,10 +412,10 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
     /**
      * Returns a {@link ChangeRecordEmitter} producing the change records for the given table row.
      */
-    protected ChangeRecordEmitter getChangeRecordEmitter(SnapshotContext<P, O> snapshotContext, TableId tableId,
-                                                         Object[] row) {
+    protected ChangeRecordEmitter<P> getChangeRecordEmitter(SnapshotContext<P, O> snapshotContext, TableId tableId,
+                                                            Object[] row) {
         snapshotContext.offset.event(tableId, getClock().currentTime());
-        return new SnapshotChangeRecordEmitter(snapshotContext.partition, snapshotContext.offset, row, getClock());
+        return new SnapshotChangeRecordEmitter<>(snapshotContext.partition, snapshotContext.offset, row, getClock());
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/relational/SnapshotChangeRecordEmitter.java
+++ b/debezium-core/src/main/java/io/debezium/relational/SnapshotChangeRecordEmitter.java
@@ -15,11 +15,11 @@ import io.debezium.util.Clock;
  *
  * @author Jiri Pechanec
  */
-public class SnapshotChangeRecordEmitter extends RelationalChangeRecordEmitter {
+public class SnapshotChangeRecordEmitter<P extends Partition> extends RelationalChangeRecordEmitter<P> {
 
     private final Object[] row;
 
-    public SnapshotChangeRecordEmitter(Partition partition, OffsetContext offset, Object[] row, Clock clock) {
+    public SnapshotChangeRecordEmitter(P partition, OffsetContext offset, Object[] row, Clock clock) {
         super(partition, offset, clock);
 
         this.row = row;

--- a/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistoryMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistoryMetrics.java
@@ -13,7 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.config.CommonConnectorConfig;
-import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.metrics.Metrics;
 import io.debezium.schema.DatabaseSchema;
 
@@ -46,12 +45,8 @@ public class DatabaseHistoryMetrics extends Metrics implements DatabaseHistoryLi
     private HistoryRecord lastAppliedChange;
     private HistoryRecord lastRecoveredChange;
 
-    protected <T extends CdcSourceTaskContext> DatabaseHistoryMetrics(T taskContext, String contextName) {
-        super(taskContext, contextName);
-    }
-
-    public DatabaseHistoryMetrics(CommonConnectorConfig connectorConfig) {
-        super(connectorConfig, CONTEXT_NAME);
+    public DatabaseHistoryMetrics(CommonConnectorConfig connectorConfig, boolean multiPartitionMode) {
+        super(connectorConfig, CONTEXT_NAME, multiPartitionMode);
     }
 
     @Override

--- a/debezium-core/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedSnapshotChangeEventSourceTest.java
+++ b/debezium-core/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedSnapshotChangeEventSourceTest.java
@@ -13,6 +13,7 @@ import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.pipeline.spi.Partition;
 import io.debezium.relational.Column;
 import io.debezium.relational.ColumnFilterMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
@@ -44,9 +45,9 @@ public class SignalBasedSnapshotChangeEventSourceTest {
 
     @Test
     public void testBuildQueryOnePkColumn() {
-        final SignalBasedIncrementalSnapshotChangeEventSource<TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
-                config(), new JdbcConnection(config().getConfig(), config -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP,
-                DataChangeEventListener.NO_OP);
+        final SignalBasedIncrementalSnapshotChangeEventSource<? extends Partition, TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
+                config(), new JdbcConnection(config().getConfig(), config -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP(),
+                DataChangeEventListener.NO_OP());
         final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
         source.setContext(context);
         final Column pk1 = Column.editor().name("pk1").create();
@@ -66,9 +67,9 @@ public class SignalBasedSnapshotChangeEventSourceTest {
 
     @Test
     public void testBuildQueryThreePkColumns() {
-        final SignalBasedIncrementalSnapshotChangeEventSource<TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
-                config(), new JdbcConnection(config().getConfig(), config -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP,
-                DataChangeEventListener.NO_OP);
+        final SignalBasedIncrementalSnapshotChangeEventSource<? extends Partition, TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
+                config(), new JdbcConnection(config().getConfig(), config -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP(),
+                DataChangeEventListener.NO_OP());
         final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
         source.setContext(context);
         final Column pk1 = Column.editor().name("pk1").create();
@@ -92,9 +93,9 @@ public class SignalBasedSnapshotChangeEventSourceTest {
 
     @Test
     public void testMaxQuery() {
-        final SignalBasedIncrementalSnapshotChangeEventSource<TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
-                config(), new JdbcConnection(config().getConfig(), config -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP,
-                DataChangeEventListener.NO_OP);
+        final SignalBasedIncrementalSnapshotChangeEventSource<? extends Partition, TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
+                config(), new JdbcConnection(config().getConfig(), config -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP(),
+                DataChangeEventListener.NO_OP());
         final Column pk1 = Column.editor().name("pk1").create();
         final Column pk2 = Column.editor().name("pk2").create();
         final Column val1 = Column.editor().name("val1").create();

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2071,6 +2071,7 @@ incompatible with the default configuration with no upgrade or downgrade path:
 * The connector will use different keys for its committed offset messages.
 * The SQL statements used in `snapshot.select.statement.overrides` will have to use the database name
   as part of the fully-qualified table name.
+* The structure of the exposed connector metrics will be different.
 
 |[[sqlserver-property-database-server-name]]<<sqlserver-property-database-server-name, `+database.server.name+`>>
 |No default


### PR DESCRIPTION
### Change summary

Introducing an absolutely separate API for multi-partition metrics would complicate a lot of code, so I decided to find a common ground. Below are the key steps.

#### Introduce interfaces and default implementations for change event source metrics 

See the details in [#3047](https://github.com/debezium/debezium/pull/3047).

### Add `P extends Partition` parameter to `io.debezium.pipeline.source.spi.*Listener` interfaces

All existing connectors are already aware of the `Partition` interface. Passing partition to the listeners won't require any fundamental rework of the existing connectors but at the same time will enable building single- and multi-partition metrics using the same API.

Technically, the `Partition` interface contains all the properties needed for exposing partition-scoped metrics but the interface stores them in a map without defining semantics for any of the properties. Since from the metrics perspective each property (e.g. server, database) has its own semantics, it's better to accept a parameterized type.

### Implement multi-partition metrics for SQL Server connector

In the single-partition mode, the SQL Server connector will use the default implementations of the metrics. This will provide a backward compatibility layer without any additional code.

In the multip-partition mode, it will use a separate metrics factory which will initialize multi-partition metrics. The metrics will have the following hierarchy:

1. The `Metrics` classes will act as multi-partition listeners and implement task-level MBean interfaces.
2. Internally, each metric will maintain a collection of task-scoped objects (currently called meters but we may think of a better name). Each object is in fact a group of atomic references which implements a single-partition listener API and a partition-level MBean.
3. When registering or unregistering, each `Metrics` class registers or unregisters itself and all internal objects.
4. Now, the default metrics can (and have been) reimplemented to delegate their implementation to the meter objects. This way, the same implementation is shared between the single- and multi-partition metrics.
5. As an intended side-effect, the integration tests that use a multi-partition configuration should use `TestHelper.waitForDatabaseSnapshotToBeCompleted(TestHelper.TEST_DATABASE)` to synchronize with the connector.

### Future scope

1. The existing single-partition and multi-partition `Snapshot` and `Streaming` MXBean interfaces can be replaced with combinations of smaller "meter" interfaces introduced above. For instance:
    * Single-partition streaming metrics = connection metrics (e.g. is connected) + streaming metrics (e.g. time behind source).
    * Multi-partition streaming task metrics = connection metrics; multi-partition partition metrics = streaming metrics.
2. The logic of building metric names could be extracted into a separate API. Otherwise, the code is quite complex and duplicated between the production code and tests.

**TODO**:
- [x] Update `debezium/debezium-connector-db2` (https://github.com/debezium/debezium-connector-db2/pull/42)
- [x] Update `debezium/debezium-connector-vitess` (https://github.com/debezium/debezium-connector-vitess/pull/64)