### PR TITLE
DBZ-4309 Avoid calling 'LoggerFactory.getLogger(getClass())' for each new instance of the RelationalChangeRecordEmitter

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
@@ -20,6 +20,8 @@ import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.postgresql.core.BaseConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.connection.ReplicationMessage;
@@ -45,6 +47,8 @@ import io.debezium.util.Strings;
  * @author Horia Chiorean (hchiorea@redhat.com), Jiri Pechanec
  */
 public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresChangeRecordEmitter.class);
 
     private final ReplicationMessage message;
     private final PostgresSchema schema;
@@ -215,14 +219,14 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
         final Column tableColumn = table.columnWithName(columnName);
 
         if (tableColumn == null) {
-            logger.warn(
+            LOGGER.warn(
                     "Internal schema is out-of-sync with incoming decoder events; column {} will be omitted from the change event.",
                     columnName);
             return -1;
         }
         int position = tableColumn.position() - 1;
         if (position < 0 || position >= values.length) {
-            logger.warn(
+            LOGGER.warn(
                     "Internal schema is out-of-sync with incoming decoder events; column {} will be omitted from the change event.",
                     columnName);
             return -1;
@@ -231,15 +235,15 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
     }
 
     private Optional<DataCollectionSchema> newTable(TableId tableId) {
-        logger.debug("Schema for table '{}' is missing", tableId);
+        LOGGER.debug("Schema for table '{}' is missing", tableId);
         refreshTableFromDatabase(tableId);
         final TableSchema tableSchema = schema.schemaFor(tableId);
         if (tableSchema == null) {
-            logger.warn("cannot load schema for table '{}'", tableId);
+            LOGGER.warn("cannot load schema for table '{}'", tableId);
             return Optional.empty();
         }
         else {
-            logger.debug("refreshed DB schema to include table '{}'", tableId);
+            LOGGER.debug("refreshed DB schema to include table '{}'", tableId);
             return Optional.of(tableSchema);
         }
     }
@@ -276,7 +280,7 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
         if (msgHasMissingColumns || msgHasAdditionalColumns) {
             // the table metadata has less or more columns than the event, which means the table structure has changed,
             // so we need to trigger a refresh...
-            logger.info("Different column count {} present in the server message as schema in memory contains {}; refreshing table schema",
+            LOGGER.info("Different column count {} present in the server message as schema in memory contains {}; refreshing table schema",
                     replicationColumnCount,
                     tableColumnCount);
             return true;
@@ -288,7 +292,7 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
             String columnName = message.getName();
             Column column = table.columnWithName(columnName);
             if (column == null) {
-                logger.info("found new column '{}' present in the server message which is not part of the table metadata; refreshing table schema", columnName);
+                LOGGER.info("found new column '{}' present in the server message which is not part of the table metadata; refreshing table schema", columnName);
                 return true;
             }
             else {
@@ -297,7 +301,7 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
                 if (localType != incomingType) {
                     final int incomingRootType = message.getType().getRootType().getOid();
                     if (localType != incomingRootType) {
-                        logger.info("detected new type for column '{}', old type was {} ({}), new type is {} ({}); refreshing table schema", columnName, localType,
+                        LOGGER.info("detected new type for column '{}', old type was {} ({}), new type is {} ({}); refreshing table schema", columnName, localType,
                                 column.typeName(),
                                 incomingType, message.getType().getName());
                         return true;
@@ -307,21 +311,21 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
                     final int localLength = column.length();
                     final int incomingLength = message.getTypeMetadata().getLength();
                     if (localLength != incomingLength) {
-                        logger.info("detected new length for column '{}', old length was {}, new length is {}; refreshing table schema", columnName, localLength,
+                        LOGGER.info("detected new length for column '{}', old length was {}, new length is {}; refreshing table schema", columnName, localLength,
                                 incomingLength);
                         return true;
                     }
                     final int localScale = column.scale().orElseGet(() -> 0);
                     final int incomingScale = message.getTypeMetadata().getScale();
                     if (localScale != incomingScale) {
-                        logger.info("detected new scale for column '{}', old scale was {}, new scale is {}; refreshing table schema", columnName, localScale,
+                        LOGGER.info("detected new scale for column '{}', old scale was {}, new scale is {}; refreshing table schema", columnName, localScale,
                                 incomingScale);
                         return true;
                     }
                     final boolean localOptional = column.isOptional();
                     final boolean incomingOptional = message.isOptional();
                     if (localOptional != incomingOptional) {
-                        logger.info("detected new optional status for column '{}', old value was {}, new value is {}; refreshing table schema", columnName, localOptional,
+                        LOGGER.info("detected new optional status for column '{}', old value was {}, new value is {}; refreshing table schema", columnName, localOptional,
                                 incomingOptional);
                         return true;
                     }
@@ -345,8 +349,8 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
 
         List<String> toastableColumns = schema.getToastableColumnsForTableId(table.id());
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("msg columns: '{}' --- missing columns: '{}' --- toastableColumns: '{}",
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("msg columns: '{}' --- missing columns: '{}' --- toastableColumns: '{}",
                     String.join(",", msgColumnNames),
                     String.join(",", missingColumnNames),
                     String.join(",", toastableColumns));
@@ -384,7 +388,7 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter {
         while (itPkCandidates.hasNext()) {
             final String candidateName = itPkCandidates.next();
             if (!combinedTable.hasUniqueValues() && combinedTable.columnWithName(candidateName) == null) {
-                logger.error("Potentional inconsistency in key for message {}", columns);
+                LOGGER.error("Potentional inconsistency in key for message {}", columns);
                 itPkCandidates.remove();
             }
         }

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalChangeRecordEmitter.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalChangeRecordEmitter.java
@@ -27,10 +27,12 @@ import io.debezium.util.Clock;
  */
 public abstract class RelationalChangeRecordEmitter extends AbstractChangeRecordEmitter<TableSchema> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(RelationalChangeRecordEmitter.class);
+    // for backwards compat with connectors in other repos
+    protected final Logger logger = LOGGER;
+
     public static final String PK_UPDATE_OLDKEY_FIELD = "__debezium.oldkey";
     public static final String PK_UPDATE_NEWKEY_FIELD = "__debezium.newkey";
-
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     public RelationalChangeRecordEmitter(Partition partition, OffsetContext offsetContext, Clock clock) {
         super(partition, offsetContext, clock);
@@ -72,7 +74,7 @@ public abstract class RelationalChangeRecordEmitter extends AbstractChangeRecord
 
         if (skipEmptyMessages() && (newColumnValues == null || newColumnValues.length == 0)) {
             // This case can be hit on UPDATE / DELETE when there's no primary key defined while using certain decoders
-            logger.warn("no new values found for table '{}' from create message at '{}'; skipping record", tableSchema, getOffset().getSourceInfo());
+            LOGGER.warn("no new values found for table '{}' from create message at '{}'; skipping record", tableSchema, getOffset().getSourceInfo());
             return;
         }
         receiver.changeRecord(getPartition(), tableSchema, Operation.CREATE, newKey, envelope, getOffset(), null);
@@ -102,7 +104,7 @@ public abstract class RelationalChangeRecordEmitter extends AbstractChangeRecord
         Struct oldValue = tableSchema.valueFromColumnData(oldColumnValues);
 
         if (skipEmptyMessages() && (newColumnValues == null || newColumnValues.length == 0)) {
-            logger.warn("no new values found for table '{}' from update message at '{}'; skipping record", tableSchema, getOffset().getSourceInfo());
+            LOGGER.warn("no new values found for table '{}' from update message at '{}'; skipping record", tableSchema, getOffset().getSourceInfo());
             return;
         }
         // some configurations does not provide old values in case of updates
@@ -134,7 +136,7 @@ public abstract class RelationalChangeRecordEmitter extends AbstractChangeRecord
         Struct oldValue = tableSchema.valueFromColumnData(oldColumnValues);
 
         if (skipEmptyMessages() && (oldColumnValues == null || oldColumnValues.length == 0)) {
-            logger.warn("no old values found for table '{}' from delete message at '{}'; skipping record", tableSchema, getOffset().getSourceInfo());
+            LOGGER.warn("no old values found for table '{}' from delete message at '{}'; skipping record", tableSchema, getOffset().getSourceInfo());
             return;
         }
 


### PR DESCRIPTION
Added a way to avoid that by overriding `getLogger()`; default behavior is the same to avoid build breaks in case I missed some other connectors (db2?) / connectors in other repos

Fixes: https://issues.redhat.com/browse/DBZ-4309