### PR TITLE
DBZ-4295: Update Vitess version to 12.0.0

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -341,6 +341,7 @@ Wout Scheepers
 Xiao Fu
 Xiaopu Zhu
 Xuan Shen
+Yang Wu
 Yang Yang
 yangsanity
 Yilong Chang

--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -24,7 +24,7 @@
         <version.jetty>9.4.12.v20180830</version.jetty>
 
         <!-- Vitess dependencies -->
-        <version.vitess.grpc>9.0.0</version.vitess.grpc>
+        <version.vitess.grpc>12.0.0</version.vitess.grpc>
         <version.gson>2.7</version.gson>
         <version.grpc>1.33.0</version.grpc>
         <version.joda>2.10.1</version.joda>

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -103,3 +103,4 @@ PlugaruT,Plugaru Tudor
 lujiefsi,陆杰
 ahodavdekar,Abhishek Hodavdekar
 josetesan,Jose Luis
+yw,Yang Wu


### PR DESCRIPTION
Prerequisite for https://issues.redhat.com/browse/DBZ-4295