### PR TITLE
DBZ-3938 Add config database among builtins

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Filters.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Filters.java
@@ -20,7 +20,7 @@ import io.debezium.util.Collect;
  */
 public final class Filters {
 
-    protected static final Set<String> BUILT_IN_DB_NAMES = Collect.unmodifiableSet("local", "admin");
+    protected static final Set<String> BUILT_IN_DB_NAMES = Collect.unmodifiableSet("local", "admin", "config");
 
     private final Predicate<String> databaseFilter;
     private final Predicate<CollectionId> collectionFilter;


### PR DESCRIPTION
The `config` database was not include among builtins albeit it should. It was not a problem for earlier MongoDB versions but version 5.0 contains collections there that require special privileges so it is necessary to get rid of it.