### PR TITLE
DBZ-4327 Add support for MongoDB 4.4

### DIFF
--- a/.github/workflows/mongodb-workflow.yml
+++ b/.github/workflows/mongodb-workflow.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version-mongo-server: ["4.0", "4.2", "5.0"]
+        version-mongo-server: ["4.0", "4.4", "5.0"]
     steps:
       - uses: actions/checkout@v2
       - name: Setup java 17

--- a/jenkins-jobs/job-dsl/connector_mongodb_matrix_test.groovy
+++ b/jenkins-jobs/job-dsl/connector_mongodb_matrix_test.groovy
@@ -7,7 +7,7 @@ matrixJob('connector-debezium-mongodb-matrix-test') {
     label('Slave')
 
     axes {
-        text('MONGODB_VERSION', '3.2', '3.4', '3.6', '4.0', '4.2')
+        text('MONGODB_VERSION', '3.2', '3.4', '3.6', '4.0', '4.2', '4.4', '5.0')
         label("Node", "Slave")
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4327

Requires https://github.com/debezium/docker-images/pull/272 and image 4.4 built and published to pass CI