### PR TITLE
DBZ-4331 Avoid holding metadata lock in R/O incremental snapshots

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -177,14 +177,7 @@ public class MySqlReadOnlyIncrementalSnapshotChangeEventSource<T extends DataCol
     }
 
     protected void updateLowWatermark() {
-        try {
-            getExecutedGtidSet(getContext()::setLowWatermark);
-            // it is required that the chunk selection sees the changes that are committed before its execution
-            jdbcConnection.commit();
-        }
-        catch (SQLException e) {
-            throw new DebeziumException(e);
-        }
+        getExecutedGtidSet(getContext()::setLowWatermark);
     }
 
     protected void updateHighWatermark() {
@@ -205,6 +198,7 @@ public class MySqlReadOnlyIncrementalSnapshotChangeEventSource<T extends DataCol
                     }
                 }
             });
+            jdbcConnection.commit();
         }
         catch (SQLException e) {
             throw new DebeziumException(e);


### PR DESCRIPTION
SHOW MASTER STATUS query used for watermarks in read-only incremental snapshot is holding on to a table metadata lock
Cases test timeout in https://github.com/debezium/debezium/pull/2925
Closes https://issues.redhat.com/browse/DBZ-4331