### PR TITLE
DBZ-1539 Add interval.handling.mode to oracle connector

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -317,6 +317,7 @@ Thomas Prelle
 Thomas Thornton
 Tin Nguyen
 Tom Bentley
+Tom Billiet
 Tomaz Lemos Fernandes
 Tommy Karlsson
 Tony Rizko

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
@@ -37,6 +37,7 @@ import io.debezium.jdbc.ResultReceiver;
 import io.debezium.relational.Column;
 import io.debezium.relational.ValueConverter;
 import io.debezium.time.Date;
+import io.debezium.time.Interval;
 import io.debezium.time.MicroDuration;
 import io.debezium.time.ZonedTimestamp;
 import io.debezium.util.NumberConversions;
@@ -106,9 +107,11 @@ public class OracleValueConverters extends JdbcValueConverters {
     private static final Pattern TO_TIMESTAMP = Pattern.compile("TO_TIMESTAMP\\('(.*)'\\)", Pattern.CASE_INSENSITIVE);
     private static final Pattern TO_TIMESTAMP_TZ = Pattern.compile("TO_TIMESTAMP_TZ\\('(.*)'\\)", Pattern.CASE_INSENSITIVE);
     private static final Pattern TO_DATE = Pattern.compile("TO_DATE\\('(.*)',[ ]*'(.*)'\\)", Pattern.CASE_INSENSITIVE);
+    private static final BigDecimal MICROSECONDS_PER_SECOND = new BigDecimal(1_000_000);
 
     private final OracleConnection connection;
     private final boolean lobEnabled;
+    private final OracleConnectorConfig.IntervalHandlingMode intervalHandlingMode;
     private final byte[] unavailableValuePlaceholderBinary;
     private final String unavailableValuePlaceholderString;
 
@@ -116,6 +119,7 @@ public class OracleValueConverters extends JdbcValueConverters {
         super(config.getDecimalMode(), config.getTemporalPrecisionMode(), ZoneOffset.UTC, null, null, null);
         this.connection = connection;
         this.lobEnabled = config.isLobEnabled();
+        this.intervalHandlingMode = config.getIntervalHandlingMode();
         this.unavailableValuePlaceholderBinary = config.getUnavailableValuePlaceholder();
         this.unavailableValuePlaceholderString = new String(config.getUnavailableValuePlaceholder());
     }
@@ -144,7 +148,7 @@ public class OracleValueConverters extends JdbcValueConverters {
                 return ZonedTimestamp.builder();
             case OracleTypes.INTERVALYM:
             case OracleTypes.INTERVALDS:
-                return MicroDuration.builder();
+                return intervalHandlingMode == OracleConnectorConfig.IntervalHandlingMode.STRING ? Interval.builder() : MicroDuration.builder();
             case Types.STRUCT:
                 return SchemaBuilder.string();
             default: {
@@ -651,7 +655,13 @@ public class OracleValueConverters extends JdbcValueConverters {
         return convertValue(column, fieldDefn, data, NumberConversions.LONG_FALSE, (r) -> {
             if (data instanceof Number) {
                 // we expect to get back from the plugin a double value
-                r.deliver(((Number) data).longValue());
+                final long micros = ((Number) data).longValue();
+                if (intervalHandlingMode == OracleConnectorConfig.IntervalHandlingMode.STRING) {
+                    r.deliver(Interval.toIsoString(0, 0, 0, 0, 0, new BigDecimal(micros).divide(MICROSECONDS_PER_SECOND)));
+                }
+                else {
+                    r.deliver(micros);
+                }
             }
             else if (data instanceof INTERVALYM) {
                 convertOracleIntervalYearMonth(data, r);
@@ -677,8 +687,13 @@ public class OracleValueConverters extends JdbcValueConverters {
             if (interval.charAt(i) == '-') {
                 final int year = sign * Integer.parseInt(interval.substring(start, i));
                 final int month = sign * Integer.parseInt(interval.substring(i + 1, interval.length()));
-                r.deliver(MicroDuration.durationMicros(year, month, 0, 0,
-                        0, 0, MicroDuration.DAYS_PER_MONTH_AVG));
+                if (intervalHandlingMode == OracleConnectorConfig.IntervalHandlingMode.STRING) {
+                    r.deliver(Interval.toIsoString(year, month, 0, 0, 0, BigDecimal.ZERO));
+                }
+                else {
+                    r.deliver(MicroDuration.durationMicros(year, month, 0, 0,
+                            0, 0, MicroDuration.DAYS_PER_MONTH_AVG));
+                }
             }
         }
     }
@@ -687,7 +702,13 @@ public class OracleValueConverters extends JdbcValueConverters {
         return convertValue(column, fieldDefn, data, NumberConversions.LONG_FALSE, (r) -> {
             if (data instanceof Number) {
                 // we expect to get back from the plugin a double value
-                r.deliver(((Number) data).longValue());
+                final long micros = ((Number) data).longValue();
+                if (intervalHandlingMode == OracleConnectorConfig.IntervalHandlingMode.STRING) {
+                    r.deliver(Interval.toIsoString(0, 0, 0, 0, 0, new BigDecimal(micros).divide(MICROSECONDS_PER_SECOND)));
+                }
+                else {
+                    r.deliver(micros);
+                }
             }
             else if (data instanceof INTERVALDS) {
                 convertOracleIntervalDaySecond(data, r);
@@ -706,15 +727,28 @@ public class OracleValueConverters extends JdbcValueConverters {
         final Matcher m = INTERVAL_DAY_SECOND_PATTERN.matcher(interval);
         if (m.matches()) {
             final int sign = "-".equals(m.group(1)) ? -1 : 1;
-            r.deliver(MicroDuration.durationMicros(
-                    0,
-                    0,
-                    sign * Integer.valueOf(m.group(2)),
-                    sign * Integer.valueOf(m.group(3)),
-                    sign * Integer.valueOf(m.group(4)),
-                    sign * Integer.valueOf(m.group(5)),
-                    sign * Integer.valueOf(Strings.pad(m.group(6), 6, '0')),
-                    MicroDuration.DAYS_PER_MONTH_AVG));
+            if (intervalHandlingMode == OracleConnectorConfig.IntervalHandlingMode.STRING) {
+                double seconds = (double) (sign * Integer.parseInt(m.group(5)))
+                        + (double) Integer.parseInt(Strings.pad(m.group(6), 6, '0')) / 1_000_000D;
+                r.deliver(Interval.toIsoString(
+                        0,
+                        0,
+                        sign * Integer.valueOf(m.group(2)),
+                        sign * Integer.valueOf(m.group(3)),
+                        sign * Integer.valueOf(m.group(4)),
+                        BigDecimal.valueOf(seconds)));
+            }
+            else {
+                r.deliver(MicroDuration.durationMicros(
+                        0,
+                        0,
+                        sign * Integer.valueOf(m.group(2)),
+                        sign * Integer.valueOf(m.group(3)),
+                        sign * Integer.valueOf(m.group(4)),
+                        sign * Integer.valueOf(m.group(5)),
+                        sign * Integer.valueOf(Strings.pad(m.group(6), 6, '0')),
+                        MicroDuration.DAYS_PER_MONTH_AVG));
+            }
         }
     }
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1258,13 +1258,21 @@ Represents the number of milliseconds past epoch, and does not include timezone 
 |`FLOAT64`
 |`io.debezium.time.MicroDuration` +
  +
-The number of micro seconds for a time interval using the `365.25 / 12.0` formula for days per month average.
+The number of micro seconds for a time interval using the `365.25 / 12.0` formula for days per month average. +
+ +
+`io.debezium.time.Interval` (when `interval.handling.mode` is set to `string`) +
+ +
+The string representation of the interval value that follows the pattern `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`, for example,  `P1Y2M3DT4H5M6.78S`.
 
 |`INTERVAL YEAR[(M)] TO MONTH`
 |`FLOAT64`
 |`io.debezium.time.MicroDuration` +
  +
-The number of micro seconds for a time interval using the `365.25 / 12.0` formula for days per month average.
+The number of micro seconds for a time interval using the `365.25 / 12.0` formula for days per month average. +
+ +
+`io.debezium.time.Interval` (when `interval.handling.mode` is set to `string`) +
+ +
+The string representation of the interval value that follows the pattern `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`, for example,  `P1Y2M3DT4H5M6.78S`.
 
 |`TIMESTAMP(0 - 3)`
 |`INT64`
@@ -1316,13 +1324,21 @@ Represents the number of days since the epoch.
 |`FLOAT64`
 |`io.debezium.time.MicroDuration` +
  +
-The number of micro seconds for a time interval using the `365.25 / 12.0` formula for days per month average.
+The number of micro seconds for a time interval using the `365.25 / 12.0` formula for days per month average. +
+ +
+`io.debezium.time.Interval` (when `interval.handling.mode` is set to `string`) +
+ +
+The string representation of the interval value that follows the pattern `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`, for example,  `P1Y2M3DT4H5M6.78S`.
 
 |`INTERVAL YEAR[(M)] TO MONTH`
 |`FLOAT64`
 |`io.debezium.time.MicroDuration` +
  +
-The number of micro seconds for a time interval using the `365.25 / 12.0` formula for days per month average.
+The number of micro seconds for a time interval using the `365.25 / 12.0` formula for days per month average. +
+ +
+`io.debezium.time.Interval` (when `interval.handling.mode` is set to `string`) +
+ +
+The string representation of the interval value that follows the pattern `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`, for example,  `P1Y2M3DT4H5M6.78S`.
 
 |`TIMESTAMP(0 - 3)`
 |`INT64`
@@ -2254,6 +2270,14 @@ You can set one of the following options:
 `string`:: Encodes values as formatted strings.
   Using the `string` option is easier to consume, but results in a loss of semantic information about the real type.
   For more information, see <<oracle-decimal-types>>.
+
+|[[oracle-property-interval-handling-mode]]<<oracle-property-interval-handling-mode, `+interval.handling.mode+`>>
+|`numeric`
+| Specifies how the connector should handle values for `interval` columns: +
+ +
+`numeric` represents intervals using approximate number of microseconds. +
+ +
+`string` represents intervals exactly by using the string pattern representation `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`. For example: `P1Y2M3DT4H5M6.78S`.
 
 |[[oracle-property-event-processing-failure-handling-mode]]<<oracle-property-event-processing-failure-handling-mode, `+event.processing.failure.handling.mode+`>>
 |`fail`

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -104,3 +104,4 @@ lujiefsi,陆杰
 ahodavdekar,Abhishek Hodavdekar
 josetesan,Jose Luis
 yw,Yang Wu
+TomBillietKlarrio,Tom Billiet


### PR DESCRIPTION
Improves interval type support to be able to send interval types as a string.

https://issues.redhat.com/browse/DBZ-1539