### PR TITLE
DBZ-2363 (follow up)

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/LogicalDecodingMessageIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/LogicalDecodingMessageIT.java
@@ -247,8 +247,13 @@ public class LogicalDecodingMessageIT extends AbstractConnectorTest {
         List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("message"));
         assertThat(recordsForTopic).hasSize(3);
 
+        assertThat(((Struct) recordsForTopic.get(0).key()).getString("prefix")).isEqualTo("included_prefix");
         assertThat(getPrefix(recordsForTopic.get(0))).isEqualTo("included_prefix");
+
+        assertThat(((Struct) recordsForTopic.get(1).key()).getString("prefix")).isEqualTo("prefix:included");
         assertThat(getPrefix(recordsForTopic.get(1))).isEqualTo("prefix:included");
+
+        assertThat(((Struct) recordsForTopic.get(2).key()).getString("prefix")).isEqualTo("another_included");
         assertThat(getPrefix(recordsForTopic.get(2))).isEqualTo("another_included");
     }
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -206,7 +206,7 @@ The message contains a logical representation of the table schema.
   ...
   },
   "payload": {
-        "source": {  // <1>
+        "source": {  //<1>
         "version": "{debezium-version}",
         "connector": "mysql",
         "name": "dbserver1",
@@ -223,19 +223,19 @@ The message contains a logical representation of the table schema.
         "thread": null,
         "query": null
     },
-    "databaseName": "inventory", // <2>
+    "databaseName": "inventory", //<2>
     "schemaName": null,
-    "ddl": "ALTER TABLE customers ADD COLUMN middle_name VARCHAR(2000)", // <3>
-    "tableChanges": [  // <4>
+    "ddl": "ALTER TABLE customers ADD COLUMN middle_name VARCHAR(2000)", //<3>
+    "tableChanges": [  //<4>
         {
-        "type": "ALTER", // <5>
-        "id": "\"inventory\".\"customers\"",  // <6>
-        "table": { // <7>
+        "type": "ALTER", //<5>
+        "id": "\"inventory\".\"customers\"",  //<6>
+        "table": { //<7>
             "defaultCharsetName": "latin1",
-            "primaryKeyColumnNames": [  // <8>
+            "primaryKeyColumnNames": [  //<8>
                 "id"
             ],
-            "columns": [ // <9>
+            "columns": [ //<9>
                 {
                 "name": "id",
                 "jdbcType": 4,

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1187,7 +1187,8 @@ when those events are read from different partitions.
 This event type is only supported through the `pgoutput` plugin on Postgres 14+ (link:https://www.postgresql.org/docs/14/protocol-logicalrep-message-formats.html[Postgres Documentation])
 ====
 
-A  _message_ event signals that a generic logical decoding message has been inserted directly into the WAL typically with the `pg_logical_emit_message` function. The message key is `null` in this case.
+A  _message_ event signals that a generic logical decoding message has been inserted directly into the WAL typically with the `pg_logical_emit_message` function.
+The message key is a `Struct` with a single field named `prefix` in this case, carrying the prefix specified when inserting the message.
 The message value looks like this for transactional messages:
 
 [source,json,indent=0,subs="+attributes"]


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2363

@lairen, @jpechane, this uses the prefix as message key, allowing for consistent ordering of all logical messages with the same prefix, which seems like a sensible behavior, allowing to partition the messages topic, too.