### PR TITLE
DBZ-4354 Fix incorrect command for copying connector plug-in files

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1645,24 +1645,23 @@ For more information, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOp
 │   ├── ...
 ----
 
-.. Create a Docker file that uses `{DockerKafkaConnect}` as the base image.
-For example, from a terminal window, enter the following, replacing `my-plugins` with the name of your plug-ins directory:
+.. Create a `Dockerfile` that uses `{DockerKafkaConnect}` as the base image.
+For example, from a terminal window, enter the following command:
 +
 [source,shell,subs="+attributes,+quotes"]
 ----
 cat <<EOF >debezium-container-for-db2.yaml // <1>
 FROM {DockerKafkaConnect}
 USER root:root
-COPY ./_<my-plugins>_/ /opt/kafka/plugins/ // <2>
+COPY ./debezium-connector-db2/ /opt/kafka/plugins/debezium-connector-db2
 USER 1001
 EOF
 ----
 <1> You can specify any file name that you want.
-<2> Replace `my-plugins` with the name of your plug-ins directory.
 +
-The command creates a Docker file with the name `debezium-container-for-db2.yaml` in the current directory.
+The command creates a `Dockerfile` with the name `debezium-container-for-db2.yaml` in the current directory.
 
-.. Build the container image from the `debezium-container-for-db2.yaml` Docker file that you created in the previous step.
+.. Build the container image from the `debezium-container-for-db2.yaml` `Dockerfile` that you created in the previous step.
 From the directory that contains the file, open a terminal window and enter one of the following commands:
 +
 [source,shell,options="nowrap"]

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -946,24 +946,23 @@ You then create two custom resources (CRs):
 │   ├── ...
 ----
 
-.. Create a Docker file that uses `{DockerKafkaConnect}` as the base image.
-For example, from a terminal window, enter the following, replacing `my-plugins` with the name of your plug-ins directory:
+.. Create a `Dockerfile` that uses `{DockerKafkaConnect}` as the base image.
+For example, from a terminal window, enter the following command:
 +
 [source,shell,subs="+attributes,+quotes"]
 ----
 cat <<EOF >debezium-container-for-mongodb.yaml // <1>
 FROM {DockerKafkaConnect}
 USER root:root
-COPY ./_<my-plugins>_/ /opt/kafka/plugins/ // <2>
+COPY ./debezium-connector-mongodb/ /opt/kafka/plugins/debezium-connector-mongodb/
 USER 1001
 EOF
 ----
 <1> You can specify any file name that you want.
-<2> Replace `my-plugins` with the name of your plug-ins directory.
 +
-The command creates a Docker file with the name `debezium-container-for-mongodb.yaml` in the current directory.
+The command creates a `Dockerfile` with the name `debezium-container-for-mongodb.yaml` in the current directory.
 
-.. Build the container image from the `debezium-container-for-mongodb.yaml` Docker file that you created in the previous step.
+.. Build the container image from the `debezium-container-for-mongodb.yaml` `Dockerfile` that you created in the previous step.
 From the directory that contains the file, open a terminal window and enter one of the following commands:
 +
 [source,shell,options="nowrap"]

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2024,24 +2024,23 @@ For more information, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOp
 │   ├── ...
 ----
 
-.. Create a Docker file that uses `{DockerKafkaConnect}` as the base image.
-For example, from a terminal window, enter the following, replacing `my-plugins` with the name of your plug-ins directory:
+.. Create a `Dockerfile` that uses `{DockerKafkaConnect}` as the base image.
+For example, from a terminal window, enter the following command:
 +
 [source,shell,subs="+attributes,+quotes"]
 ----
 cat <<EOF >debezium-container-for-mysql.yaml // <1>
 FROM {DockerKafkaConnect}
 USER root:root
-COPY ./_<my-plugins>_/ /opt/kafka/plugins/ // <2>
+COPY ./debezium-connector-mysql/ /opt/kafka/plugins/debezium-connector-mysql
 USER 1001
 EOF
 ----
 <1> You can specify any file name that you want.
-<2> Replace `my-plugins` with the name of your plug-ins directory.
 +
-The command creates a Docker file with the name `debezium-container-for-mysql.yaml` in the current directory.
+The command creates a `Dockerfile` with the name `debezium-container-for-mysql.yaml` in the current directory.
 
-.. Build the container image from the `debezium-container-for-mysql.yaml` Docker file that you created in the previous step.
+.. Build the container image from the `debezium-container-for-mysql.yaml` `Dockerfile` that you created in the previous step.
 From the directory that contains the file, open a terminal window and enter one of the following commands:
 +
 [source,shell,options="nowrap"]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -175,7 +175,7 @@ The payload of a schema change event message includes the following elements:
 
 `ddl`:: Provides the SQL `CREATE`, `ALTER`, or `DROP` statement that results in the schema change.
 `databaseName`:: The name of the database to which the statements are applied.
-The value of `databaseName` serves as the message key. 
+The value of `databaseName` serves as the message key.
 `tableChanges`::  A structured representation of the entire table schema after the schema change.
 The `tableChanges` field contains an array that includes entries for each column of the table.
 Because the structured representation presents data in JSON or Avro format, consumers can easily read messages without first processing them through a DDL parser.
@@ -1684,24 +1684,23 @@ For more information, see {link-prefix}:{link-oracle-connector}#obtaining-the-or
 │   ├── ...
 ----
 
-.. Create a Dockerfile that uses `{DockerKafkaConnect}` as the base image.
-For example, from a terminal window, enter the following, replacing `my-plugins` with the name of your plug-ins directory:
+.. Create a `Dockerfile` that uses `{DockerKafkaConnect}` as the base image.
+For example, from a terminal window, enter the following command:
 +
 [source,shell,subs="+attributes,+quotes"]
 ----
 cat <<EOF >debezium-container-for-oracle.yaml // <1>
 FROM {DockerKafkaConnect}
 USER root:root
-COPY ./_<my-plugins>_/ /opt/kafka/plugins/ // <2>
+COPY ./debezium-connector-oracle/ /opt/kafka/plugins/debezium-connector-oracle
 USER 1001
 EOF
 ----
 <1> You can specify any file name that you want.
-<2> Replace `my-plugins` with the name of your plug-ins directory.
 +
-The command creates a Docker file with the name `debezium-container-for-oracle.yaml` in the current directory.
+The command creates a `Dockerfile` with the name `debezium-container-for-oracle.yaml` in the current directory.
 
-.. Build the container image from the `debezium-container-for-oracle.yaml` Docker file that you created in the previous step.
+.. Build the container image from the `debezium-container-for-oracle.yaml` `Dockerfile` that you created in the previous step.
 From the directory that contains the file, open a terminal window and enter one of the following commands:
 +
 [source,shell,options="nowrap"]

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2366,24 +2366,23 @@ Apply this CR to the same OpenShift instance where you applied the `KafkaConnect
 │   ├── ...
 ----
 
-.. Create a Docker file that uses `{DockerKafkaConnect}` as the base image.
-For example, from a terminal window, enter the following, replacing `my-plugins` with the name of your plug-ins directory:
+.. Create a `Dockerfile` that uses `{DockerKafkaConnect}` as the base image.
+For example, from a terminal window, enter the following command:
 +
 [source,shell,subs="+attributes,+quotes"]
 ----
 cat <<EOF >debezium-container-for-postgresql.yaml // <1>
 FROM {DockerKafkaConnect}
 USER root:root
-COPY ./_<my-plugins>_/ /opt/kafka/plugins/ // <2>
+COPY ./debezium-connector-postgres/ /opt/kafka/plugins/debezium-connector-postgres
 USER 1001
 EOF
 ----
 <1> You can specify any file name that you want.
-<2> Replace `my-plugins` with the name of your plug-ins directory.
 +
-The command creates a Docker file with the name `debezium-container-for-postgresql.yaml` in the current directory.
+The command creates a `Dockerfile` with the name `debezium-container-for-postgresql.yaml` in the current directory.
 
-.. Build the container image from the `debezium-container-for-postgresql.yaml` Docker file that you created in the previous step.
+.. Build the container image from the `debezium-container-for-postgresql.yaml` `Dockerfile` that you created in the previous step.
 From the directory that contains the file, open a terminal window and enter one of the following commands:
 +
 [source,shell,options="nowrap"]

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -209,7 +209,7 @@ Messages that the connector sends to the schema change topic contain a payload, 
 The payload of a schema change event message includes the following elements:
 
 `databaseName`:: The name of the database to which the statements are applied.
-The value of `databaseName` serves as the message key. 
+The value of `databaseName` serves as the message key.
 `tableChanges`::  A structured representation of the entire table schema after the schema change.
 The `tableChanges` field contains an array that includes entries for each column of the table.
 Because the structured representation presents data in JSON or Avro format, consumers can easily read messages without first processing them through a DDL parser.
@@ -1725,24 +1725,23 @@ You then need to create the following custom resources (CRs):
 │   ├── ...
 ----
 
-.. Create a Docker file that uses `{DockerKafkaConnect}` as the base image.
-For example, from a terminal window, enter the following, replacing `my-plugins` with the name of your plug-ins directory:
+.. Create a `Dockerfile` that uses `{DockerKafkaConnect}` as the base image.
+For example, from a terminal window, enter the following command:
 +
 [source,shell,subs="+attributes,+quotes"]
 ----
 cat <<EOF >debezium-container-for-sqlserver.yaml // <1>
 FROM {DockerKafkaConnect}
 USER root:root
-COPY ./_<my-plugins>_/ /opt/kafka/plugins/ // <2>
+COPY ./debezium-connector-sqlserver/ /opt/kafka/plugins/debezium-connector-sqlserver
 USER 1001
 EOF
 ----
 <1> You can specify any file name that you want.
-<2> Replace `my-plugins` with the name of your plug-ins directory.
 +
-The command creates a Docker file with the name `debezium-container-for-sqlserver.yaml` in the current directory.
+The command creates a `Dockerfile` with the name `debezium-container-for-sqlserver.yaml` in the current directory.
 
-.. Build the container image from the `debezium-container-for-sqlserver.yaml` Docker file that you created in the previous step.
+.. Build the container image from the `debezium-container-for-sqlserver.yaml` `Dockerfile` that you created in the previous step.
 From the directory that contains the file, open a terminal window and enter one of the following commands:
 +
 [source,shell,options="nowrap"]


### PR DESCRIPTION
[DBZ-4354](https://issues.redhat.com/browse/DBZ-4354)

This change corrects errors in the legacy instructions for creating the Dockerfile for deploying a connector, and also includes some minor related language and formatting edits. The change affects all of the connectors that are included in the RHI product and is confined to the content that is conditionalized for downstream use. The changes are not rendered in the community version of the documentation. 

Note that the change has implications for the downstream-only Getting Started and OCP installation guides, which are maintained in a separate repo. I'll address those changes separately.

I'd like to merge this change in before completing the work on DBZ-3991 to incorporate the instructions based on the updated Strimzi/Streams deployment mechanism.