### PR TITLE
DBZ-3635 Allow fetching of transaction logs to be retried.

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -396,7 +396,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     "bigger than log.mining.scn.gap.detection.gap.size.min, and the time difference of current SCN and previous end SCN is smaller than " +
                     " this value, consider it a SCN gap.");
 
-    public static final Field LOG_MINING_LOG_FILE_QUERY_MAX_RETRIES = Field.create("log.mining.log.file.query.max.retries")
+    public static final Field LOG_MINING_LOG_FILE_QUERY_MAX_RETRIES = Field.createInternal("log.mining.log.file.query.max.retries")
             .withDisplayName("Maximum number of retries to get logs before throwing an exception")
             .withType(Type.INT)
             .withWidth(Width.SHORT)

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
@@ -26,6 +26,8 @@ import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
 import io.debezium.connector.oracle.Scn;
 import io.debezium.relational.Column;
 import io.debezium.relational.Table;
+import io.debezium.util.Clock;
+import io.debezium.util.Metronome;
 import io.debezium.util.Strings;
 
 /**
@@ -44,37 +46,60 @@ public class LogMinerHelper {
      * @param archiveLogRetention the duration that archive logs will be mined
      * @param archiveLogOnlyMode true to mine only archive lgos, false to mine all available logs
      * @param archiveDestinationName configured archive log destination name to use, may be {@code null}
+     * @param maxRetries the number of retry attempts before giving up and throwing an exception about log state
      * @throws SQLException if anything unexpected happens
      */
     // todo: check RAC resiliency
-    public static void setLogFilesForMining(OracleConnection connection, Scn lastProcessedScn, Duration archiveLogRetention, boolean archiveLogOnlyMode,
-                                            String archiveDestinationName)
-            throws SQLException {
+    public static void setLogFilesForMining(OracleConnection connection, Scn lastProcessedScn, Duration archiveLogRetention,
+                                            boolean archiveLogOnlyMode, String archiveDestinationName, int maxRetries)
+            throws SQLException, InterruptedException {
         removeLogFilesFromMining(connection);
 
-        List<LogFile> logFilesForMining = getLogFilesForOffsetScn(connection, lastProcessedScn, archiveLogRetention, archiveLogOnlyMode, archiveDestinationName);
-        if (!logFilesForMining.stream().anyMatch(l -> l.getFirstScn().compareTo(lastProcessedScn) <= 0)) {
-            Scn minScn = logFilesForMining.stream()
-                    .map(LogFile::getFirstScn)
-                    .min(Scn::compareTo)
-                    .orElse(Scn.NULL);
+        // Restrict max attempts to 0 or greater values (sanity-check)
+        // the code will do at least 1 attempt and up to maxAttempts extra polls based on configuration
+        final int maxAttempts = Math.max(maxRetries, 0);
 
-            if ((minScn.isNull() || logFilesForMining.isEmpty()) && archiveLogOnlyMode) {
-                throw new DebeziumException("The log.mining.archive.log.only mode was recently enabled and the offset SCN " +
-                        lastProcessedScn + "is not yet in any available archive logs. " +
-                        "Please perform an Oracle log switch and restart the connector.");
+        // We perform a retry algorithm here as there is a race condition where Oracle may update the V$LOG table
+        // but the V$ARCHIVED_LOG lags behind and a single-shot SQL query may return an inconsistent set of results
+        // due to Oracle performing the operation non-atomically.
+        final Metronome metronome = Metronome.sleeper(Duration.ofSeconds(1), Clock.SYSTEM);
+        List<LogFile> logFilesForMining = new ArrayList<>();
+        for (int attempt = 0; attempt <= maxAttempts; ++attempt) {
+            logFilesForMining.addAll(getLogFilesForOffsetScn(connection, lastProcessedScn, archiveLogRetention,
+                    archiveLogOnlyMode, archiveDestinationName));
+            if (hasNoLogFilesStartingBeforeScn(logFilesForMining, lastProcessedScn)) {
+                LOGGER.debug("No logs available yet...");
+                logFilesForMining.clear();
+                metronome.pause();
+                continue;
             }
-            throw new IllegalStateException("None of log files contains offset SCN: " + lastProcessedScn + ", re-snapshot is required.");
+
+            List<String> logFilesNames = logFilesForMining.stream().map(LogFile::getFileName).collect(Collectors.toList());
+            for (String file : logFilesNames) {
+                LOGGER.trace("Adding log file {} to mining session", file);
+                String addLogFileStatement = SqlUtils.addLogFileStatement("DBMS_LOGMNR.ADDFILE", file);
+                executeCallableStatement(connection, addLogFileStatement);
+            }
+
+            LOGGER.debug("Last mined SCN: {}, Log file list to mine: {}", lastProcessedScn, logFilesNames);
+            return;
         }
 
-        List<String> logFilesNames = logFilesForMining.stream().map(LogFile::getFileName).collect(Collectors.toList());
-        for (String file : logFilesNames) {
-            LOGGER.trace("Adding log file {} to mining session", file);
-            String addLogFileStatement = SqlUtils.addLogFileStatement("DBMS_LOGMNR.ADDFILE", file);
-            executeCallableStatement(connection, addLogFileStatement);
+        final Scn minScn = getMinimumScn(logFilesForMining);
+        if ((minScn.isNull() || logFilesForMining.isEmpty()) && archiveLogOnlyMode) {
+            throw new DebeziumException("The log.mining.archive.log.only mode was recently enabled and the offset SCN " +
+                    lastProcessedScn + "is not yet in any available archive logs. " +
+                    "Please perform an Oracle log switch and restart the connector.");
         }
+        throw new IllegalStateException("None of log files contains offset SCN: " + lastProcessedScn + ", re-snapshot is required.");
+    }
 
-        LOGGER.debug("Last mined SCN: {}, Log file list to mine: {}", lastProcessedScn, logFilesNames);
+    private static boolean hasNoLogFilesStartingBeforeScn(List<LogFile> logs, Scn scn) {
+        return logs.stream().noneMatch(l -> l.getFirstScn().compareTo(scn) <= 0);
+    }
+
+    private static Scn getMinimumScn(List<LogFile> logs) {
+        return logs.stream().map(LogFile::getFirstScn).min(Scn::compareTo).orElse(Scn.NULL);
     }
 
     static void logWarn(OracleStreamingChangeEventSourceMetrics streamingMetrics, String format, Object... args) {
@@ -98,8 +123,8 @@ public class LogMinerHelper {
      * @return list of log files
      * @throws SQLException if a database exception occurs
      */
-    public static List<LogFile> getLogFilesForOffsetScn(OracleConnection connection, Scn offsetScn, Duration archiveLogRetention, boolean archiveLogOnlyMode,
-                                                        String archiveDestinationName)
+    public static List<LogFile> getLogFilesForOffsetScn(OracleConnection connection, Scn offsetScn, Duration archiveLogRetention,
+                                                        boolean archiveLogOnlyMode, String archiveDestinationName)
             throws SQLException {
         LOGGER.trace("Getting logs to be mined for offset scn {}", offsetScn);
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/LogMinerHelperIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/LogMinerHelperIT.java
@@ -90,7 +90,7 @@ public class LogMinerHelperIT extends AbstractConnectorTest {
     public void shouldSetCorrectLogFiles() throws Exception {
         List<Scn> oneDayArchivedNextScn = getOneDayArchivedLogNextScn(conn);
         Scn oldestArchivedScn = getOldestArchivedScn(oneDayArchivedNextScn);
-        LogMinerHelper.setLogFilesForMining(conn, oldestArchivedScn, Duration.ofHours(0L), false, null);
+        LogMinerHelper.setLogFilesForMining(conn, oldestArchivedScn, Duration.ofHours(0L), false, null, 0);
 
         List<LogFile> files = LogMinerHelper.getLogFilesForOffsetScn(conn, oldestArchivedScn, Duration.ofHours(0L), false, null);
         assertThat(files.size()).isEqualTo(getNumberOfAddedLogFiles(conn));

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2517,6 +2517,13 @@ endif::community[]
 |`10000`
 |The number of content records that the connector fetches from the LogMiner content view.
 
+|[[oracle-property-log-mining-log-file-query-max-retries]]<<oracle-property-log-mining-log-file-query-max-retries, `+log.mining.log.file.query.max.retries+`>>
+|`5`
+|The number of additional query attempts the connector will make to get a list of transaction logs based on the current offset SCN. +
+ +
+There is a small window where Oracle may update several transaction log-based metadata tables in a non-atomic way and cause the connector to believe a log may not be available while it transitions from redo to archive.
+To safeguard against this problem, this property specifies the number of retry attempts that should be performed before throwing an exception.
+
 |[[oracle-property-log-mining-archive-log-hours]]<<oracle-property-log-mining-archive-log-hours, `+log.mining.archive.log.hours+`>>
 |`0`
 |The number of hours in the past from SYSDATE to mine archive logs.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2517,13 +2517,6 @@ endif::community[]
 |`10000`
 |The number of content records that the connector fetches from the LogMiner content view.
 
-|[[oracle-property-log-mining-log-file-query-max-retries]]<<oracle-property-log-mining-log-file-query-max-retries, `+log.mining.log.file.query.max.retries+`>>
-|`5`
-|The number of additional query attempts the connector will make to get a list of transaction logs based on the current offset SCN. +
- +
-There is a small window where Oracle may update several transaction log-based metadata tables in a non-atomic way and cause the connector to believe a log may not be available while it transitions from redo to archive.
-To safeguard against this problem, this property specifies the number of retry attempts that should be performed before throwing an exception.
-
 |[[oracle-property-log-mining-archive-log-hours]]<<oracle-property-log-mining-archive-log-hours, `+log.mining.archive.log.hours+`>>
 |`0`
 |The number of hours in the past from SYSDATE to mine archive logs.


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3635

There exists a small potential race condition where logs transition from `ONLINE` to `ARCHIVE` non-atomically and during this transition, the query used by the connector to get a list of logs to be mined may throw a false-positive error indicating that no log exists based on the SCN value.  This is because the query doesn't contain a record that contains the SCN as we would expect since it has been removed from the `ONLINE` table but Oracle hasn't yet inserted it into the `ARCHIVE` table.

To address the race condition, this PR introduces a configurable option called `log.mining.log.file.query.max.retries`.  This will be the basis for the number of attempts that the connector will retry to get a list of logs from these two tables that contain the offset SCN before the connector throws a hard fault that no logs contain the SCN.

