### PR TITLE
DBZ-4385 Truncate support for Oracle

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/BaseChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/BaseChangeRecordEmitter.java
@@ -5,11 +5,14 @@
  */
 package io.debezium.connector.oracle;
 
+import org.apache.kafka.connect.data.Struct;
+
 import io.debezium.data.Envelope.Operation;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
 import io.debezium.relational.RelationalChangeRecordEmitter;
 import io.debezium.relational.Table;
+import io.debezium.relational.TableSchema;
 import io.debezium.util.Clock;
 
 /**
@@ -25,5 +28,10 @@ public abstract class BaseChangeRecordEmitter<T> extends RelationalChangeRecordE
     }
 
     abstract protected Operation getOperation();
+
+    protected void emitTruncateRecord(Receiver receiver, TableSchema tableSchema) throws InterruptedException {
+        Struct envelope = tableSchema.getEnvelopeSchema().truncate(getOffset().getSourceInfo(), getClock().currentTimeAsInstant());
+        receiver.changeRecord(getPartition(), tableSchema, Operation.TRUNCATE, null, envelope, getOffset(), null);
+    }
 
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/OracleDdlParserListener.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/OracleDdlParserListener.java
@@ -35,6 +35,7 @@ public class OracleDdlParserListener extends PlSqlParserBaseListener implements 
         listeners.add(new AlterTableParserListener(catalogName, schemaName, parser, listeners));
         listeners.add(new DropTableParserListener(catalogName, schemaName, parser));
         listeners.add(new CommentParserListener(catalogName, schemaName, parser));
+        listeners.add(new TruncateTableParserListener(catalogName, schemaName, parser));
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/TruncateTableParserListener.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/TruncateTableParserListener.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.antlr.listener;
+
+import io.debezium.connector.oracle.antlr.OracleDdlParser;
+import io.debezium.ddl.parser.oracle.generated.PlSqlParser;
+import io.debezium.relational.TableId;
+
+/**
+ * This class is parsing Oracle truncate table statements.
+ */
+public class TruncateTableParserListener extends BaseParserListener {
+
+    private final String catalogName;
+    private final String schemaName;
+    private final OracleDdlParser parser;
+
+    TruncateTableParserListener(final String catalogName, final String schemaName, final OracleDdlParser parser) {
+        this.catalogName = catalogName;
+        this.schemaName = schemaName;
+        this.parser = parser;
+    }
+
+    @Override
+    public void enterTruncate_table(final PlSqlParser.Truncate_tableContext ctx) {
+        TableId tableId = new TableId(catalogName, schemaName, getTableName(ctx.tableview_name()));
+        parser.signalTruncateTable(tableId, ctx);
+        super.enterTruncate_table(ctx);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerChangeRecordEmitter.java
@@ -19,20 +19,24 @@ import io.debezium.util.Clock;
  */
 public class LogMinerChangeRecordEmitter extends BaseChangeRecordEmitter<Object> {
 
-    private final EventType eventType;
+    private final Operation operation;
     private final Object[] oldValues;
     private final Object[] newValues;
 
-    public LogMinerChangeRecordEmitter(Partition partition, OffsetContext offset, EventType eventType, Object[] oldValues,
+    public LogMinerChangeRecordEmitter(Partition partition, OffsetContext offset, Operation operation, Object[] oldValues,
                                        Object[] newValues, Table table, Clock clock) {
         super(partition, offset, table, clock);
-        this.eventType = eventType;
         this.oldValues = oldValues;
         this.newValues = newValues;
+        this.operation = operation;
     }
 
-    @Override
-    protected Operation getOperation() {
+    public LogMinerChangeRecordEmitter(Partition partition, OffsetContext offset, EventType eventType, Object[] oldValues,
+                                       Object[] newValues, Table table, Clock clock) {
+        this(partition, offset, getOperation(eventType), oldValues, newValues, table, clock);
+    }
+
+    private static Operation getOperation(EventType eventType) {
         switch (eventType) {
             case INSERT:
                 return Operation.CREATE;
@@ -44,6 +48,11 @@ public class LogMinerChangeRecordEmitter extends BaseChangeRecordEmitter<Object>
             default:
                 throw new DebeziumException("Unsupported operation type: " + eventType);
         }
+    }
+
+    @Override
+    protected Operation getOperation() {
+        return operation;
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/TruncateEvent.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/TruncateEvent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.oracle.logminer.events;
+
+import java.time.Instant;
+
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntry;
+import io.debezium.relational.TableId;
+
+public class TruncateEvent extends DmlEvent {
+    public TruncateEvent(LogMinerEventRow row, LogMinerDmlEntry dmlEntry) {
+        super(row, dmlEntry);
+    }
+
+    public TruncateEvent(EventType eventType, Scn scn, TableId tableId, String rowId, String rsId,
+                         Instant changeTime, LogMinerDmlEntry dmlEntry) {
+        super(eventType, scn, tableId, rowId, rsId, changeTime, dmlEntry);
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlEntryImpl.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlEntryImpl.java
@@ -50,6 +50,10 @@ public class LogMinerDmlEntryImpl implements LogMinerDmlEntry {
         return new LogMinerDmlEntryImpl(EventType.DELETE, new Object[0], oldColumnValues);
     }
 
+    public static LogMinerDmlEntry forValuelessDdl() {
+        return new LogMinerDmlEntryImpl(EventType.DDL, new Object[0], new Object[0]);
+    }
+
     public static LogMinerDmlEntry forLobLocator(Object[] newColumnValues) {
         // TODO: can that copy be avoided?
         final Object[] oldColumnValues = Arrays.copyOf(newColumnValues, newColumnValues.length);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/TruncateReceiver.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/TruncateReceiver.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.oracle.logminer.processor;
+
+public interface TruncateReceiver {
+    void processTruncateEvent();
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/marshalling/LogMinerEventMarshaller.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/marshalling/LogMinerEventMarshaller.java
@@ -16,6 +16,6 @@ import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
  * @author Chris Cranford
  */
 @AutoProtoSchemaBuilder(includeClasses = { LogMinerEventAdapter.class, DmlEventAdapter.class, SelectLobLocatorEventAdapter.class, LobWriteEventAdapter.class,
-        LobEraseEventAdapter.class, LogMinerDmlEntryImplAdapter.class }, schemaFilePath = "/")
+        LobEraseEventAdapter.class, LogMinerDmlEntryImplAdapter.class, TruncateEventAdapter.class }, schemaFilePath = "/")
 public interface LogMinerEventMarshaller extends SerializationContextInitializer {
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/marshalling/TruncateEventAdapter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/marshalling/TruncateEventAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.processor.infinispan.marshalling;
+
+import java.time.Instant;
+
+import org.infinispan.protostream.annotations.ProtoAdapter;
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.logminer.events.EventType;
+import io.debezium.connector.oracle.logminer.events.TruncateEvent;
+import io.debezium.connector.oracle.logminer.parser.LogMinerDmlEntryImpl;
+import io.debezium.relational.TableId;
+
+@ProtoAdapter(TruncateEvent.class)
+public class TruncateEventAdapter extends LogMinerEventAdapter {
+
+    /**
+     * A ProtoStream factory that creates {@link TruncateEvent} instances.
+     *
+     * @param eventType the event type
+     * @param scn the system change number, must not be {@code null}
+     * @param tableId the fully-qualified table name
+     * @param rowId the Oracle row-id the change is associated with
+     * @param rsId the Oracle rollback segment identifier
+     * @param changeTime the time the change occurred
+     * @param entry the parsed SQL statement entry
+     * @return the constructed DmlEvent
+     */
+    @ProtoFactory
+    public TruncateEvent factory(int eventType, String scn, String tableId, String rowId, String rsId, String changeTime, LogMinerDmlEntryImpl entry) {
+        return new TruncateEvent(EventType.from(eventType), Scn.valueOf(scn), TableId.parse(tableId), rowId, rsId, Instant.parse(changeTime), entry);
+    }
+
+    /**
+     * A ProtoStream handler to extract the {@code entry} field from the {@link TruncateEvent}.
+     *
+     * @param event the event instance, must not be {@code null}
+     * @return the LogMinerDmlEntryImpl instance
+     */
+    @ProtoField(number = 7, required = true)
+    public LogMinerDmlEntryImpl getEntry(TruncateEvent event) {
+        return (LogMinerDmlEntryImpl) event.getDmlEntry();
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamChangeRecordEmitter.java
@@ -43,6 +43,8 @@ public class XStreamChangeRecordEmitter extends BaseChangeRecordEmitter<ColumnVa
                 return Operation.DELETE;
             case RowLCR.UPDATE:
                 return Operation.UPDATE;
+            case "TRUNCATE TABLE":
+                return Operation.TRUNCATE;
             default:
                 throw new IllegalArgumentException("Received event of unexpected command type: " + lcr);
         }

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -774,6 +774,7 @@ public abstract class CommonConnectorConfig {
                 case "c":
                 case "u":
                 case "d":
+                case "t":
                     continue;
                 default:
                     problems.accept(field, operation, "Invalid operation");

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1008,6 +1008,80 @@ The message value must be set to `null` to instruct Kafka to remove _all message
 To make this possible, by default, {prodname}'s Oracle connector always follows a _delete_ event with a special _tombstone_ event that has the same key but `null` value.
 You can change the default behavior by setting the connector property xref:oracle-property-tombstones-on-delete[`tombstones.on.delete`].
 
+// Type: continue
+[[oracle-truncate-events]]
+=== _truncate_ events
+
+A  _truncate_ change event signals that a table has been truncated.
+The message key is `null` in this case, the message value looks like this:
+
+[source,json,indent=0,subs="+attributes"]
+----
+{
+    "schema": { ... },
+    "payload": {
+        "before": null,
+        "after": null,
+        "source": { // <1>
+            "version": "{debezium-version}",
+            "connector": "oracle",
+            "name": "oracle_server",
+            "ts_ms": 1638974535000,
+            "snapshot": "false",
+            "db": "ORCLPDB1",
+            "sequence": null,
+            "schema": "DEBEZIUM",
+            "table": "TEST_TABLE",
+            "txId": "02000a0037030000",
+            "scn": "13234397",
+            "commit_scn": "13271102",
+            "lcr_position": null
+        },
+        "op": "t", // <2>
+        "ts_ms": 1638974558961, // <3>
+        "transaction": null
+    }
+}
+----
+
+.Descriptions of _truncate_ event value fields
+[cols="1,2,7",options="header"]
+|===
+|Item |Field name |Description
+
+|1
+|`source`
+a|Mandatory field that describes the source metadata for the event. In a _truncate_ event value, the `source` field structure is the same as for _create_, _update_, and _delete_ events for the same table, provides this metadata:
+
+* {prodname} version
+* Connector type and name
+* Database and table that contains the new row
+* Schema name
+* If the event was part of a snapshot (always `false` for _truncate_ events)
+* ID of the transaction in which the operation was performed
+* SCN of the operation
+* Timestamp for when the change was made in the database
+
+|2
+|`op`
+a|Mandatory string that describes the type of operation. The `op` field value is `t`, signifying that this table was truncated.
+
+|3
+|`ts_ms`
+a|Optional field that displays the time at which the connector processed the event. The time is based on the system clock in the JVM running the Kafka Connect task.  +
++
+In the `source` object, `ts_ms` indicates the time that the change was made in the database. By comparing the value for `payload.source.ts_ms` with the value for `payload.ts_ms`, you can determine the lag between the source database update and {prodname}.
+
+|===
+
+Note that since _truncate_ events represent a change made to an entire table and don't have a message key,
+unless you're working with topics with a single partition,
+there are no ordering guarantees for the change events pertaining to a table (_create_, _update_, etc.) and _truncate_ events for that table.
+For instance a consumer may receive an _update_ event only after a _truncate_ event for that table,
+when those events are read from different partitions.
+
+If _truncate_ events are not desired, they can be filtered out with the xref:oracle-property-skipped-operations[`skipped.operations`] option.
+
 // Type: reference
 // ModuleID: how-debezium-oracle-connectors-map-data-types
 // Title: How {prodname} Oracle connectors map data types
@@ -2620,6 +2694,7 @@ You can configure the connector to skip the following types of operations:
 * `c` (insert/create)
 * `u` (update)
 * `d` (delete)
+* `t` (truncate)
 
 By default, no operations are skipped.
 


### PR DESCRIPTION
WIP since I'd like to have some feedback on the current approach. Oracle treats truncate events as DDL statements, but to align with other connectors (I looked at postgres), I twisted the logic to emit this as a DML truncate event.