### PR TITLE
DBZ-4409 Removing Gson from BOM

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -24,7 +24,6 @@
 
         <!-- Vitess dependencies -->
         <version.vitess.grpc>12.0.0</version.vitess.grpc>
-        <version.gson>2.7</version.gson>
         <version.grpc>1.33.0</version.grpc>
         <version.joda>2.10.1</version.joda>
         <version.google.protos>1.17.0</version.google.protos>
@@ -359,11 +358,6 @@
                 <groupId>io.vitess</groupId>
                 <artifactId>vitess-grpc-client</artifactId>
                 <version>${version.vitess.grpc}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>${version.gson}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4409

Hey @jpechane, do we BOM-manage versions of solely transitive dependencies? Gson isn't used by any Debezium connector as of this change (there's a corresponding PR for the Vitess connector which replaces the only existing usage with Jackson), so we don't really need this any longer.

Gson is a transitive dependency of the Vitess GRPC client though (and in fact the version we managed here doesn't match the actual definition). So I am leaning towards removing it, but I'm wondering whether we did have a policy to manage _all_ dependencies showing up in the dependency tree, no matter whether directly used or only transitively used. If we want to keep managing it, the version should be updated to what's actually used by the client.


WDYT?

// CC @sonne5 @shichao-an @jeffchao