### PR TITLE
Fix DBZ-4413 MongoDB Extract Document State SMT overwrites id field

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,18 @@ See [PostgreSQL on Amazon RDS](debezium-connector-postgres/RDS.md) for details o
 
     $ mvn clean install -pl debezium-connector-oracle -Poracle -Dinstantclient.dir=<path-to-instantclient> -Ddatabase.pdb.name=
 
+### Running the tests for MongoDB with oplog capturing from an IDE
+
+When running the test without maven, please make sure you pass the correct parameters to the execution. Look for the correct parameters in `.github/workflows/mongodb-oplog-workflow.yml` and
+append them to the JVM execution parameters, prefixing them with `debezium.test`. As the execution will happen outside of the lifecycle execution, you need to start the MongoDB container manually
+from the MongoDB connector directory
+
+    $ mvn docker:start -B -am -Passembly -Dcheckstyle.skip=true -Dformat.skip=true -Drevapi.skip -Dcapture.mode=oplog -Dversion.mongo.server=3.6 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dcapture.mode=oplog -Dmongo.server=3.6
+
+The relevant portion of the line will look similar to the following:
+
+    java -ea -Ddebezium.test.capture.mode=oplog -Ddebezium.test.version.mongo.server=3.6 -Djava.awt.headless=true -Dconnector.mongodb.members.auto.discover=false -Dconnector.mongodb.name=mongo1 -DskipLongRunningTests=true [...]
+
 ## Contributing
 
 The Debezium community welcomes anyone that wants to help out in any way, whether that includes reporting problems, helping with documentation, or contributing code changes to fix bugs, add tests, or implement new features. See [this document](CONTRIBUTE.md) for details.

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentState.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentState.java
@@ -408,11 +408,10 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
             // In case of a full update we can use the whole Document as it is
             // see https://docs.mongodb.com/manual/reference/method/db.collection.update/#replace-a-document-entirely
             valueDocument = document;
-            valueDocument.remove("_id");
         }
 
-        if (!valueDocument.containsKey("id")) {
-            valueDocument.append("id", keyDocument.get("id"));
+        if (!valueDocument.containsKey("_id")) {
+            valueDocument.append("_id", keyDocument.get("id"));
         }
 
         if (flattenStruct) {
@@ -425,11 +424,7 @@ public class ExtractNewDocumentState<R extends ConnectRecord<R>> implements Tran
     }
 
     private BsonDocument getInsertDocument(R record, BsonDocument key) {
-        BsonDocument valueDocument = BsonDocument.parse(record.value().toString());
-        valueDocument.remove("_id");
-        valueDocument.append("id", key.get("id"));
-
-        return valueDocument;
+        return BsonDocument.parse(record.value().toString());
     }
 
     private Headers makeHeaders(List<FieldReference> additionalHeaders, Struct originalRecordValue) {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTestIT.java
@@ -116,7 +116,7 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
 
         // Test insert
         primary().execute("insert", client -> {
-            long timestamp = ZonedDateTime.of(2020, 1, 28, 10, 00, 33, 0, ZoneId.of("UTC")).toEpochSecond();
+            long timestamp = ZonedDateTime.of(2020, 1, 28, 10, 0, 33, 0, ZoneId.of("UTC")).toEpochSecond();
             client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
                     .insertOne(Document.parse(
                             "{"
@@ -136,16 +136,16 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
         final SourceRecord transformedInsert = transformation.apply(insertRecord);
         final Struct transformedInsertValue = (Struct) transformedInsert.value();
 
-        assertThat(transformedInsert.valueSchema().field("id").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
+        assertThat(transformedInsert.valueSchema().field("_id").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
         assertThat(transformedInsert.valueSchema().field("dataStr").schema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
         assertThat(transformedInsert.valueSchema().field("dataInt").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
         assertThat(transformedInsert.valueSchema().field("dataLong").schema()).isEqualTo(Schema.OPTIONAL_INT64_SCHEMA);
-        assertThat(transformedInsertValue.get("id")).isEqualTo(1);
+        assertThat(transformedInsertValue.get("_id")).isEqualTo(1);
         assertThat(transformedInsertValue.get("dataStr")).isEqualTo("hello");
         assertThat(transformedInsertValue.get("dataInt")).isEqualTo(123);
         assertThat(transformedInsertValue.get("dataLong")).isEqualTo(80_000_000_000l);
         assertThat(transformedInsertValue.get("dataDate")).isEqualTo(Date.from(Instant.from(ZonedDateTime.of(2020, 1, 27, 10, 47, 12, 311000000, ZoneId.of("UTC")))));
-        assertThat(transformedInsertValue.get("dataTimestamp")).isEqualTo(Date.from(Instant.from(ZonedDateTime.of(2020, 1, 28, 10, 00, 33, 0, ZoneId.of("UTC")))));
+        assertThat(transformedInsertValue.get("dataTimestamp")).isEqualTo(Date.from(Instant.from(ZonedDateTime.of(2020, 1, 28, 10, 0, 33, 0, ZoneId.of("UTC")))));
 
         // Test update
         primary().execute("update", client -> {
@@ -166,9 +166,9 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
         final SourceRecord transformedUpdate = transformation.apply(updateRecord);
         final Struct transformedUpdateValue = (Struct) transformedUpdate.value();
 
-        assertThat(transformedUpdate.valueSchema().field("id").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
+        assertThat(transformedUpdate.valueSchema().field("_id").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
         assertThat(transformedUpdate.valueSchema().field("dataStr").schema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(1);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
         assertThat(transformedUpdateValue.get("dataStr")).isEqualTo("bye");
 
         // Test Update Multiple Fields
@@ -184,10 +184,10 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
         final SourceRecord transformedMultipleUpdate = transformation.apply(updateMultipleRecord);
         final Struct transformedMultipleUpdateValue = (Struct) transformedMultipleUpdate.value();
 
-        assertThat(transformedMultipleUpdate.valueSchema().field("id").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
+        assertThat(transformedMultipleUpdate.valueSchema().field("_id").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
         assertThat(transformedMultipleUpdate.valueSchema().field("newStr").schema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
         assertThat(transformedMultipleUpdate.valueSchema().field("dataInt").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
-        assertThat(transformedMultipleUpdateValue.get("id")).isEqualTo(1);
+        assertThat(transformedMultipleUpdateValue.get("_id")).isEqualTo(1);
         assertThat(transformedMultipleUpdateValue.get("newStr")).isEqualTo("hello");
         assertThat(transformedMultipleUpdateValue.get("dataInt")).isEqualTo(456);
 
@@ -204,8 +204,8 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
         final SourceRecord transformedUnsetUpdate = transformation.apply(updateUnsetRecord);
         final Struct transformedUnsetUpdateValue = (Struct) transformedUnsetUpdate.value();
 
-        assertThat(transformedUnsetUpdate.valueSchema().field("id").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
-        assertThat(transformedUnsetUpdateValue.get("id")).isEqualTo(1);
+        assertThat(transformedUnsetUpdate.valueSchema().field("_id").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
+        assertThat(transformedUnsetUpdateValue.get("_id")).isEqualTo(1);
         if (TestHelper.isOplogCaptureMode()) {
             assertThat(transformedUnsetUpdate.valueSchema().field("newStr").schema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
         }
@@ -232,9 +232,9 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
         final SourceRecord transformedFullUpdate = transformation.apply(FullUpdateRecord);
         final Struct transformedFullUpdateValue = (Struct) transformedFullUpdate.value();
 
-        assertThat(transformedFullUpdate.valueSchema().field("id").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
+        assertThat(transformedFullUpdate.valueSchema().field("_id").schema()).isEqualTo(Schema.OPTIONAL_INT32_SCHEMA);
         assertThat(transformedFullUpdate.valueSchema().field("dataStr").schema()).isEqualTo(Schema.OPTIONAL_STRING_SCHEMA);
-        assertThat(transformedFullUpdateValue.get("id")).isEqualTo(1);
+        assertThat(transformedFullUpdateValue.get("_id")).isEqualTo(1);
         assertThat(transformedFullUpdateValue.get("dataStr")).isEqualTo("Hi again");
 
         // Test Delete
@@ -469,12 +469,12 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
         assertThat(value.schema().name()).isEqualTo(SERVER_NAME + "." + DB_NAME + "." + getCollectionName());
         assertThat(value.schema()).isSameAs(transformed.valueSchema());
         assertThat(value.get("name")).isEqualTo("Sally");
-        assertThat(value.get("id")).isEqualTo(objId.toString());
+        assertThat(value.get("_id")).isEqualTo(objId.toString());
         assertThat(value.get("phone")).isEqualTo(123L);
         assertThat(value.get("active")).isEqualTo(true);
         assertThat(value.get("scores")).isEqualTo(Arrays.asList(1.2, 3.4, 5.6));
 
-        assertThat(value.schema().field("id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        assertThat(value.schema().field("_id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("name").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("phone").schema()).isEqualTo(SchemaBuilder.OPTIONAL_INT64_SCHEMA);
         assertThat(value.schema().field("active").schema()).isEqualTo(SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA);
@@ -520,12 +520,12 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
 
         // and then assert value and its schema
         assertThat(value.schema()).isSameAs(transformed.valueSchema());
-        assertThat(((Struct) value.get("id")).get("company")).isEqualTo(32);
-        assertThat(((Struct) value.get("id")).get("dept")).isEqualTo("home improvement");
+        assertThat(((Struct) value.get("_id")).get("company")).isEqualTo(32);
+        assertThat(((Struct) value.get("_id")).get("dept")).isEqualTo("home improvement");
         assertThat(value.get("name")).isEqualTo("Sally");
 
-        assertThat(value.schema().field("id").schema().field("company").schema()).isEqualTo(SchemaBuilder.OPTIONAL_INT32_SCHEMA);
-        assertThat(value.schema().field("id").schema().field("dept").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        assertThat(value.schema().field("_id").schema().field("company").schema()).isEqualTo(SchemaBuilder.OPTIONAL_INT32_SCHEMA);
+        assertThat(value.schema().field("_id").schema().field("dept").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("name").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().fields()).hasSize(2);
     }
@@ -588,9 +588,9 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
         // and then assert value and its schema
         assertThat(value.schema()).isSameAs(transformed.valueSchema());
         assertThat(value.get("name")).isEqualTo("Sally");
-        assertThat(value.get("id")).isEqualTo(objId.toString());
+        assertThat(value.get("_id")).isEqualTo(objId.toString());
 
-        assertThat(value.schema().field("id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        assertThat(value.schema().field("_id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("name").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().fields()).hasSize(2);
     }
@@ -1074,11 +1074,11 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
         // and then assert value and its schema
         assertThat(value.schema()).isSameAs(transformed.valueSchema());
         assertThat(value.get("name")).isEqualTo("Sally");
-        assertThat(value.get("id")).isEqualTo(objId.toString());
+        assertThat(value.get("_id")).isEqualTo(objId.toString());
         assertThat(value.get("address")).isEqualTo(new Struct(value.schema().field("address").schema())
                 .put("street", "Morris Park Ave").put("zipcode", "10462"));
 
-        assertThat(value.schema().field("id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        assertThat(value.schema().field("_id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("name").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("address").schema()).isEqualTo(
                 SchemaBuilder.struct()
@@ -1129,11 +1129,11 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
         // and then assert value and its schema
         assertThat(value.schema()).isSameAs(transformed.valueSchema());
         assertThat(value.get("name")).isEqualTo("Sally");
-        assertThat(value.get("id")).isEqualTo(objId.toString());
+        assertThat(value.get("_id")).isEqualTo(objId.toString());
         assertThat(value.get("address_street")).isEqualTo("Morris Park Ave");
         assertThat(value.get("address_zipcode")).isEqualTo("10462");
 
-        assertThat(value.schema().field("id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        assertThat(value.schema().field("_id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("name").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("address_street").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("address_zipcode").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
@@ -1180,11 +1180,11 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
         // and then assert value and its schema
         assertThat(value.schema()).isSameAs(transformed.valueSchema());
         assertThat(value.get("name")).isEqualTo("Sally");
-        assertThat(value.get("id")).isEqualTo(objId.toString());
+        assertThat(value.get("_id")).isEqualTo(objId.toString());
         assertThat(value.get("address-street")).isEqualTo("Morris Park Ave");
         assertThat(value.get("address-zipcode")).isEqualTo("10462");
 
-        assertThat(value.schema().field("id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        assertThat(value.schema().field("_id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("name").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("address-street").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("address-zipcode").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
@@ -1247,12 +1247,12 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
 
         // and then assert value and its schema
         assertThat(value.schema()).isSameAs(transformed.valueSchema());
-        assertThat(value.get("id")).isEqualTo(objId.toString());
+        assertThat(value.get("_id")).isEqualTo(objId.toString());
         assertThat(value.get("address-city")).isEqualTo("Canberra");
         assertThat(value.get("address-name")).isEqualTo("James");
         assertThat(value.get("address-city2-part")).isEqualTo(3);
 
-        assertThat(value.schema().field("id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        assertThat(value.schema().field("_id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("address-city").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("address-name").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("address-city2-part").schema()).isEqualTo(SchemaBuilder.OPTIONAL_INT32_SCHEMA);
@@ -1518,10 +1518,10 @@ public class ExtractNewDocumentStateTestIT extends AbstractExtractNewDocumentSta
 
         // and then assert value and its schema
         assertThat(value.schema()).isSameAs(transformed.valueSchema());
-        assertThat(value.get("id")).isEqualTo(objId.toString());
+        assertThat(value.get("_id")).isEqualTo(objId.toString());
         assertThat(value.get("a")).isEqualTo(22);
 
-        assertThat(value.schema().field("id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+        assertThat(value.schema().field("_id").schema()).isEqualTo(SchemaBuilder.OPTIONAL_STRING_SCHEMA);
         assertThat(value.schema().field("a").schema()).isEqualTo(SchemaBuilder.OPTIONAL_INT32_SCHEMA);
 
         if (TestHelper.isOplogCaptureMode()) {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UpdateOperators/ExtractNewDocumentStateArrayOperatorTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UpdateOperators/ExtractNewDocumentStateArrayOperatorTestIT.java
@@ -41,10 +41,10 @@ public class ExtractNewDocumentStateArrayOperatorTestIT extends AbstractExtractN
         final Struct transformedUpdateValue = (Struct) transformedUpdate.value();
         final Schema valueSchema = transformedUpdate.valueSchema();
 
-        VerifyRecord.assertConnectSchemasAreEqual("id", valueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", valueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
         VerifyRecord.assertConnectSchemasAreEqual("dataArrayOfStr", valueSchema.field("dataArrayOfStr").schema(),
                 SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build());
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(1);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
         assertThat(transformedUpdateValue.get("dataArrayOfStr")).isEqualTo(Arrays.asList("a", "c", "e", "b"));
     }
 
@@ -60,10 +60,10 @@ public class ExtractNewDocumentStateArrayOperatorTestIT extends AbstractExtractN
         final Struct transformedUpdateValue = (Struct) transformedUpdate.value();
         final Schema valueSchema = transformedUpdate.valueSchema();
 
-        VerifyRecord.assertConnectSchemasAreEqual("id", valueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", valueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
         VerifyRecord.assertConnectSchemasAreEqual("dataArrayOfStr", valueSchema.field("dataArrayOfStr").schema(),
                 SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build());
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(1);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
         assertThat(transformedUpdateValue.get("dataArrayOfStr")).isEqualTo(Arrays.asList("c", "e"));
     }
 
@@ -79,10 +79,10 @@ public class ExtractNewDocumentStateArrayOperatorTestIT extends AbstractExtractN
         final Struct transformedUpdateValue = (Struct) transformedUpdate.value();
         final Schema valueSchema = transformedUpdate.valueSchema();
 
-        VerifyRecord.assertConnectSchemasAreEqual("id", valueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", valueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
         VerifyRecord.assertConnectSchemasAreEqual("dataArrayOfStr", valueSchema.field("dataArrayOfStr").schema(),
                 SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build());
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(1);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
         assertThat(transformedUpdateValue.get("dataArrayOfStr")).isEqualTo(Arrays.asList("a", "e"));
     }
 
@@ -98,10 +98,10 @@ public class ExtractNewDocumentStateArrayOperatorTestIT extends AbstractExtractN
         final Struct transformedUpdateValue = (Struct) transformedUpdate.value();
         final Schema valueSchema = transformedUpdate.valueSchema();
 
-        VerifyRecord.assertConnectSchemasAreEqual("id", valueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", valueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
         VerifyRecord.assertConnectSchemasAreEqual("dataArrayOfStr", valueSchema.field("dataArrayOfStr").schema(),
                 SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build());
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(1);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
         assertThat(transformedUpdateValue.get("dataArrayOfStr")).isEqualTo(Arrays.asList("a", "e"));
     }
 
@@ -118,8 +118,8 @@ public class ExtractNewDocumentStateArrayOperatorTestIT extends AbstractExtractN
         final Schema valueSchema = transformedUpdate.valueSchema();
 
         // Operations which include items to arrays result in a new field where the structure looks like "FIELD_NAME.ARRAY_INDEX"
-        VerifyRecord.assertConnectSchemasAreEqual("id", valueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(1);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", valueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
         if (TestHelper.isOplogCaptureMode()) {
             VerifyRecord.assertConnectSchemasAreEqual("dataArrayOfStr.3", valueSchema.field("dataArrayOfStr.3").schema(), Schema.OPTIONAL_STRING_SCHEMA);
             assertThat(transformedUpdateValue.get("dataArrayOfStr.3")).isEqualTo("g");

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UpdateOperators/ExtractNewDocumentStateUpdateBitOperatorTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UpdateOperators/ExtractNewDocumentStateUpdateBitOperatorTestIT.java
@@ -37,9 +37,9 @@ public class ExtractNewDocumentStateUpdateBitOperatorTestIT extends AbstractExtr
         final Struct transformedUpdateValue = (Struct) transformedUpdate.value();
         final Schema valueSchema = transformedUpdate.valueSchema();
 
-        VerifyRecord.assertConnectSchemasAreEqual("id", valueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", valueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
         VerifyRecord.assertConnectSchemasAreEqual("dataInt", valueSchema.field("dataInt").schema(), Schema.OPTIONAL_INT32_SCHEMA);
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(1);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
         assertThat(transformedUpdateValue.get("dataInt")).isEqualTo(114);
     }
 
@@ -55,9 +55,9 @@ public class ExtractNewDocumentStateUpdateBitOperatorTestIT extends AbstractExtr
         final Struct transformedUpdateValue = (Struct) transformedUpdate.value();
         final Schema valueSchema = transformedUpdate.valueSchema();
 
-        VerifyRecord.assertConnectSchemasAreEqual("id", valueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", valueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
         VerifyRecord.assertConnectSchemasAreEqual("dataInt", valueSchema.field("dataInt").schema(), Schema.OPTIONAL_INT32_SCHEMA);
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(1);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
         assertThat(transformedUpdateValue.get("dataInt")).isEqualTo(1019);
     }
 
@@ -73,9 +73,9 @@ public class ExtractNewDocumentStateUpdateBitOperatorTestIT extends AbstractExtr
         final Struct transformedUpdateValue = (Struct) transformedUpdate.value();
         final Schema valueSchema = transformedUpdate.valueSchema();
 
-        VerifyRecord.assertConnectSchemasAreEqual("id", valueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", valueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
         VerifyRecord.assertConnectSchemasAreEqual("dataInt", valueSchema.field("dataInt").schema(), Schema.OPTIONAL_INT32_SCHEMA);
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(1);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
         assertThat(transformedUpdateValue.get("dataInt")).isEqualTo(20);
     }
 }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UpdateOperators/ExtractNewDocumentStateUpdateFieldOperatorTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UpdateOperators/ExtractNewDocumentStateUpdateFieldOperatorTestIT.java
@@ -45,9 +45,9 @@ public class ExtractNewDocumentStateUpdateFieldOperatorTestIT extends AbstractEx
         final Struct transformedUpdateValue = (Struct) transformedUpdate.value();
         final Schema valueSchema = transformedUpdate.valueSchema();
 
-        VerifyRecord.assertConnectSchemasAreEqual("id", valueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", valueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
         VerifyRecord.assertConnectSchemasAreEqual("dataInt", valueSchema.field("dataInt").schema(), Schema.OPTIONAL_INT32_SCHEMA);
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(1);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
         assertThat(transformedUpdateValue.get("dataInt")).isEqualTo(246);
         if (TestHelper.isOplogCaptureMode()) {
             VerifyRecord.assertConnectSchemasAreEqual("nested.dataInt", valueSchema.field("nested.dataInt").schema(), Schema.OPTIONAL_INT32_SCHEMA);
@@ -72,9 +72,9 @@ public class ExtractNewDocumentStateUpdateFieldOperatorTestIT extends AbstractEx
         final Struct transformedUpdateValue = (Struct) transformedUpdate.value();
         final Schema valueSchema = transformedUpdate.valueSchema();
 
-        VerifyRecord.assertConnectSchemasAreEqual("id", valueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", valueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
         VerifyRecord.assertConnectSchemasAreEqual("dataInt", valueSchema.field("dataInt").schema(), Schema.OPTIONAL_INT32_SCHEMA);
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(1);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
         assertThat(transformedUpdateValue.get("dataInt")).isEqualTo(122);
         if (TestHelper.isOplogCaptureMode()) {
             // Since 124 > 123 we should expect "nested.dataInt" to not be present
@@ -97,8 +97,8 @@ public class ExtractNewDocumentStateUpdateFieldOperatorTestIT extends AbstractEx
         final Struct transformedUpdateValue = (Struct) transformedUpdate.value();
         final Schema valueSchema = transformedUpdate.valueSchema();
 
-        VerifyRecord.assertConnectSchemasAreEqual("id", valueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(1);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", valueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
         if (TestHelper.isOplogCaptureMode()) {
             // Since 122 < 123 we should expect "dataInt" to not be present
             assertThat(valueSchema.field("dataInt")).isNull();
@@ -123,10 +123,10 @@ public class ExtractNewDocumentStateUpdateFieldOperatorTestIT extends AbstractEx
         final Struct transformedUpdateValue = (Struct) transformedUpdate.value();
         final Schema valueSchema = transformedUpdate.valueSchema();
 
-        VerifyRecord.assertConnectSchemasAreEqual("id", valueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", valueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
         VerifyRecord.assertConnectSchemasAreEqual("dataInt", valueSchema.field("dataInt").schema(), Schema.OPTIONAL_INT32_SCHEMA);
         VerifyRecord.assertConnectSchemasAreEqual("nonExistentField", valueSchema.field("nonExistentField").schema(), Schema.OPTIONAL_INT32_SCHEMA);
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(1);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
         assertThat(transformedUpdateValue.get("dataInt")).isEqualTo(369);
         assertThat(transformedUpdateValue.get("nonExistentField")).isEqualTo(0);
         if (TestHelper.isOplogCaptureMode()) {
@@ -152,9 +152,9 @@ public class ExtractNewDocumentStateUpdateFieldOperatorTestIT extends AbstractEx
         final Struct transformedUpdateValue = (Struct) transformedUpdate.value();
         final Schema valueSchema = transformedUpdate.valueSchema();
 
-        VerifyRecord.assertConnectSchemasAreEqual("id", valueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", valueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
         VerifyRecord.assertConnectSchemasAreEqual("dataIntNewName", valueSchema.field("dataIntNewName").schema(), Schema.OPTIONAL_INT32_SCHEMA);
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(1);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
         assertThat(transformedUpdateValue.get("dataIntNewName")).isEqualTo(123);
 
         if (TestHelper.isOplogCaptureMode()) {
@@ -182,10 +182,10 @@ public class ExtractNewDocumentStateUpdateFieldOperatorTestIT extends AbstractEx
         final Struct transformedUpdateValue = (Struct) transformedUpdate.value();
         final Schema valueSchema = transformedUpdate.valueSchema();
 
-        VerifyRecord.assertConnectSchemasAreEqual("id", valueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", valueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
         VerifyRecord.assertConnectSchemasAreEqual("dataStr", valueSchema.field("dataStr").schema(), Schema.OPTIONAL_STRING_SCHEMA);
         VerifyRecord.assertConnectSchemasAreEqual("newDataInt", valueSchema.field("newDataInt").schema(), Schema.OPTIONAL_INT32_SCHEMA);
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(1);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
         assertThat(transformedUpdateValue.get("dataStr")).isEqualTo("Setting new value");
         assertThat(transformedUpdateValue.get("newDataInt")).isEqualTo(456);
     }
@@ -209,9 +209,9 @@ public class ExtractNewDocumentStateUpdateFieldOperatorTestIT extends AbstractEx
         final Struct transformedUpsertValue = (Struct) transformedUpsert.value();
         final Schema upsertValueSchema = transformedUpsert.valueSchema();
 
-        VerifyRecord.assertConnectSchemasAreEqual("id", upsertValueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", upsertValueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
         VerifyRecord.assertConnectSchemasAreEqual("onlySetIfInsertDataInt", upsertValueSchema.field("onlySetIfInsertDataInt").schema(), Schema.OPTIONAL_INT32_SCHEMA);
-        assertThat(transformedUpsertValue.get("id")).isEqualTo(2);
+        assertThat(transformedUpsertValue.get("_id")).isEqualTo(2);
         assertThat(transformedUpsertValue.get("onlySetIfInsertDataInt")).isEqualTo(789);
 
         // Execute a new Upsert with the same ID to ensure the field "onlySetIfInsertDataInt" doesn't change its value
@@ -225,9 +225,9 @@ public class ExtractNewDocumentStateUpdateFieldOperatorTestIT extends AbstractEx
         final Struct transformedUpdateValue = (Struct) transformedUpdate.value();
         final Schema updateValueSchema = transformedUpdate.valueSchema();
 
-        VerifyRecord.assertConnectSchemasAreEqual("id", updateValueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", updateValueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
         VerifyRecord.assertConnectSchemasAreEqual("newField", updateValueSchema.field("newField").schema(), Schema.OPTIONAL_INT32_SCHEMA);
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(2);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(2);
         assertThat(transformedUpdateValue.get("newField")).isEqualTo(456);
         if (TestHelper.isOplogCaptureMode()) {
             // Ensure on the second update the field is not set
@@ -252,8 +252,8 @@ public class ExtractNewDocumentStateUpdateFieldOperatorTestIT extends AbstractEx
         final Struct transformedUpdateValue = (Struct) transformedUpdate.value();
         final Schema valueSchema = transformedUpdate.valueSchema();
 
-        VerifyRecord.assertConnectSchemasAreEqual("id", valueSchema.field("id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
-        assertThat(transformedUpdateValue.get("id")).isEqualTo(1);
+        VerifyRecord.assertConnectSchemasAreEqual("_id", valueSchema.field("_id").schema(), Schema.OPTIONAL_INT32_SCHEMA);
+        assertThat(transformedUpdateValue.get("_id")).isEqualTo(1);
 
         if (TestHelper.isOplogCaptureMode()) {
             // Unset fields come as null value


### PR DESCRIPTION
As discussed here: https://issues.redhat.com/browse/DBZ-4413