### PR TITLE
DBZ-4423 Reimplemented method duration to be twice as fast as before.

### DIFF
--- a/debezium-core/src/main/java/io/debezium/util/Strings.java
+++ b/debezium-core/src/main/java/io/debezium/util/Strings.java
@@ -752,29 +752,19 @@ public final class Strings {
      * <dt>SS</dt>
      * <dd>is the number of seconds written in 2 digits (e.g., "09")</dd>
      * <dt>mmm</dt>
-     * <dd>is the fractional part of seconds, written with 1-3 digits (any trailing zeros are dropped)</dd>
+     * <dd>is the fractional part of seconds, written with 3 digits</dd>
      * </dl>
      *
      * @param durationInMillis the duration in milliseconds
      * @return the readable duration.
      */
     public static String duration(long durationInMillis) {
-        // Calculate how many seconds, and don't lose any information ...
-        BigDecimal bigSeconds = BigDecimal.valueOf(Math.abs(durationInMillis)).divide(new BigDecimal(1000));
-        // Calculate the minutes, and round to lose the seconds
-        int minutes = bigSeconds.intValue() / 60;
-        // Remove the minutes from the seconds, to just have the remainder of seconds
-        double dMinutes = minutes;
-        double seconds = bigSeconds.doubleValue() - dMinutes * 60;
-        // Now compute the number of full hours, and change 'minutes' to hold the remaining minutes
-        int hours = minutes / 60;
-        minutes = minutes - (hours * 60);
-
-        // Format the string, and have at least 2 digits for the hours, minutes and whole seconds,
-        // and between 3 and 6 digits for the fractional part of the seconds...
-        String result = new DecimalFormat("######00").format(hours) + ':' + new DecimalFormat("00").format(minutes) + ':'
-                + new DecimalFormat("00.0##").format(seconds);
-        return result;
+        long seconds = durationInMillis / 1000;
+        long s = seconds % 60;
+        long m = (seconds / 60) % 60;
+        long h = (seconds / (60 * 60));
+        long q = durationInMillis % 1000;
+        return String.format("%02d:%02d:%02d.%03d",h,m,s,q);
     }
 
     /**


### PR DESCRIPTION
I compared the two implementations using the following code snippet where duration1() is the old implementation and duration2() the new implementation:

     long x0 = java.lang.System.nanoTime();
     for (int i=0; i!=1000000; i++) {
         duration1(millis);
     }
     long x1 = java.lang.System.nanoTime() - x0;
     System.out.println(x1/1000000);

     long x2 = java.lang.System.nanoTime();
     for (int i=0; i!=1000000; i++) {
         duration2(millis);
     }
     long x3 = java.lang.System.nanoTime() - x2;
     System.out.println(x3/1000000);
     
Old impl, execution time for 1 million iterations: 4291 milliseconds
New impl, execution time for 1 million iterations: 2111 milliseconds