### PR TITLE
DBZ-4423 Micro-optimizing Strings::duration()

### DIFF
--- a/debezium-core/src/main/java/io/debezium/util/Strings.java
+++ b/debezium-core/src/main/java/io/debezium/util/Strings.java
@@ -9,7 +9,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.text.DecimalFormat;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -759,22 +758,58 @@ public final class Strings {
      * @return the readable duration.
      */
     public static String duration(long durationInMillis) {
-        // Calculate how many seconds, and don't lose any information ...
-        BigDecimal bigSeconds = BigDecimal.valueOf(Math.abs(durationInMillis)).divide(new BigDecimal(1000));
-        // Calculate the minutes, and round to lose the seconds
-        int minutes = bigSeconds.intValue() / 60;
-        // Remove the minutes from the seconds, to just have the remainder of seconds
-        double dMinutes = minutes;
-        double seconds = bigSeconds.doubleValue() - dMinutes * 60;
-        // Now compute the number of full hours, and change 'minutes' to hold the remaining minutes
-        int hours = minutes / 60;
-        minutes = minutes - (hours * 60);
+        long seconds = durationInMillis / 1000;
+        long s = seconds % 60;
+        long m = (seconds / 60) % 60;
+        long h = (seconds / (60 * 60));
+        long q = durationInMillis % 1000;
 
-        // Format the string, and have at least 2 digits for the hours, minutes and whole seconds,
-        // and between 3 and 6 digits for the fractional part of the seconds...
-        String result = new DecimalFormat("######00").format(hours) + ':' + new DecimalFormat("00").format(minutes) + ':'
-                + new DecimalFormat("00.0##").format(seconds);
-        return result;
+        StringBuilder result = new StringBuilder(15);
+
+        if (h < 10) {
+            result.append("0");
+        }
+
+        result.append(h).append(":");
+
+        if (m < 10) {
+            result.append("0");
+        }
+
+        result.append(m).append(":");
+
+        if (s < 10) {
+            result.append("0");
+        }
+
+        result.append(s).append(".");
+
+        if (q == 0) {
+            result.append("0");
+            return result.toString();
+        }
+        else if (q < 10) {
+            result.append("00");
+        }
+        else if (q < 100) {
+            result.append("0");
+        }
+
+        result.append(q);
+
+        int length = result.length();
+
+        if (result.charAt(length - 1) == '0') {
+            if (result.charAt(length - 2) == '0') {
+                return result.substring(0, length - 2);
+            }
+            else {
+                return result.substring(0, length - 1);
+            }
+        }
+        else {
+            return result.toString();
+        }
     }
 
     /**

--- a/debezium-core/src/test/java/io/debezium/util/StringsTest.java
+++ b/debezium-core/src/test/java/io/debezium/util/StringsTest.java
@@ -384,6 +384,21 @@ public class StringsTest {
         assertThat(Strings.isNullOrBlank("not blank")).isFalse();
     }
 
+    @Test
+    public void durationToString() {
+        assertThat(Strings.duration(0)).isEqualTo("00:00:00.0");
+        assertThat(Strings.duration(1)).isEqualTo("00:00:00.001");
+        assertThat(Strings.duration(10)).isEqualTo("00:00:00.01");
+        assertThat(Strings.duration(100)).isEqualTo("00:00:00.1");
+        assertThat(Strings.duration(1_000)).isEqualTo("00:00:01.0");
+        assertThat(Strings.duration(60_000)).isEqualTo("00:01:00.0");
+        assertThat(Strings.duration(61_010)).isEqualTo("00:01:01.01");
+        assertThat(Strings.duration(3_600_000)).isEqualTo("01:00:00.0");
+        assertThat(Strings.duration(36_000_000)).isEqualTo("10:00:00.0");
+        assertThat(Strings.duration(540_000_000)).isEqualTo("150:00:00.0");
+        assertThat(Strings.duration(541_934_321)).isEqualTo("150:32:14.321");
+    }
+
     protected void assertReplacement(String before, Map<String, String> replacements, String after) {
         String result = Strings.replaceVariables(before, replacements::get);
         assertThat(result).isEqualTo(after);

--- a/debezium-microbenchmark/src/main/java/io/debezium/performance/core/DurationToStringPerf.java
+++ b/debezium-microbenchmark/src/main/java/io/debezium/performance/core/DurationToStringPerf.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.performance.core;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.debezium.util.Strings;
+
+@Fork(1)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode({ Mode.AverageTime })
+public class DurationToStringPerf {
+
+    private long durationInMillis;
+
+    @Setup
+    public void prepare() {
+        durationInMillis = ThreadLocalRandom.current().nextLong(100_000_000);
+    }
+
+    @Benchmark
+    public void duration(Blackhole blackhole) {
+        blackhole.consume(Strings.duration(durationInMillis));
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4423

Not that it matters in the large scheme of things, but the implementation of this method was really itching me. JMH numbers before and after:

```
Benchmark                       (value)  Mode  Cnt     Score     Error  Units
DurationToStringPerf.before      3750520  avgt    5  3155,963 ± 149,810  ns/op
DurationToStringPerf.after       3750520  avgt    5    38,933 ±   4,301  ns/op
```