### PR TITLE
DBZ-3552 Allow usage of payload custom types

### DIFF
--- a/debezium-quarkus-outbox/deployment/src/main/java/io/debezium/outbox/quarkus/deployment/DebeziumOutboxConfig.java
+++ b/debezium-quarkus-outbox/deployment/src/main/java/io/debezium/outbox/quarkus/deployment/DebeziumOutboxConfig.java
@@ -199,6 +199,12 @@ public class DebeziumOutboxConfig {
          */
         @ConfigItem
         public Optional<String> converter;
+
+        /**
+         * The column's explicit type definition class
+         */
+        @ConfigItem
+        public Optional<String> explicitType;
     }
 
     @ConfigGroup

--- a/debezium-quarkus-outbox/deployment/src/main/java/io/debezium/outbox/quarkus/deployment/DebeziumOutboxConfig.java
+++ b/debezium-quarkus-outbox/deployment/src/main/java/io/debezium/outbox/quarkus/deployment/DebeziumOutboxConfig.java
@@ -201,10 +201,10 @@ public class DebeziumOutboxConfig {
         public Optional<String> converter;
 
         /**
-         * The column's explicit type definition class
+         * The column's type definition class
          */
         @ConfigItem
-        public Optional<String> explicitType;
+        public Optional<String> type;
     }
 
     @ConfigGroup

--- a/debezium-quarkus-outbox/deployment/src/main/java/io/debezium/outbox/quarkus/deployment/OutboxEventHbmWriter.java
+++ b/debezium-quarkus-outbox/deployment/src/main/java/io/debezium/outbox/quarkus/deployment/OutboxEventHbmWriter.java
@@ -162,9 +162,9 @@ public class OutboxEventHbmWriter {
         attribute.setName("payload");
         attribute.setNotNull(false);
 
-        if (config.payload.explicitType.isPresent()) {
-            LOGGER.infof("Using payload explicit type: %s", config.payload.explicitType.get());
-            attribute.setTypeAttribute(config.payload.explicitType.get());
+        if (config.payload.type.isPresent()) {
+            LOGGER.infof("Using payload type: %s", config.payload.type.get());
+            attribute.setTypeAttribute(config.payload.type.get());
         }
         else if (config.payload.converter.isPresent()) {
             LOGGER.infof("Using payload attribute converter: %s", config.payload.converter.get());

--- a/debezium-quarkus-outbox/integration-tests/src/main/resources/application.properties
+++ b/debezium-quarkus-outbox/integration-tests/src/main/resources/application.properties
@@ -7,3 +7,10 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.hibernate-orm.log.sql=true
 pull.pause.timeout=120
 quarkus.debezium-outbox.remove-after-insert=false
+
+# Example of defining a PostgreSQL JSONB payload type
+# Note that any custom types like those specified below are not included automatically, and they must
+# be added to your application's dependencies allowing their usage at runtime.
+#
+#quarkus.debezium-outbox.payload.column-definition=JSONB
+#quarkus.debezium-outbox.payload.explicit-type=com.vladmihalcea.hibernate.type.json.JsonNodeBinaryType

--- a/debezium-quarkus-outbox/integration-tests/src/main/resources/application.properties
+++ b/debezium-quarkus-outbox/integration-tests/src/main/resources/application.properties
@@ -13,4 +13,4 @@ quarkus.debezium-outbox.remove-after-insert=false
 # be added to your application's dependencies allowing their usage at runtime.
 #
 #quarkus.debezium-outbox.payload.column-definition=JSONB
-#quarkus.debezium-outbox.payload.explicit-type=com.vladmihalcea.hibernate.type.json.JsonNodeBinaryType
+#quarkus.debezium-outbox.payload.type=com.vladmihalcea.hibernate.type.json.JsonNodeBinaryType

--- a/debezium-quarkus-outbox/integration-tests/src/test/java/io/debezium/outbox/quarkus/it/AbstractOutboxTest.java
+++ b/debezium-quarkus-outbox/integration-tests/src/test/java/io/debezium/outbox/quarkus/it/AbstractOutboxTest.java
@@ -9,14 +9,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.math.BigInteger;
-import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Map;
 import java.util.UUID;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
-import javax.persistence.Query;
 
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.metamodel.spi.MetamodelImplementor;
@@ -57,18 +55,16 @@ public abstract class AbstractOutboxTest {
     }
 
     @Test
+    @SuppressWarnings("rawtypes")
     public void firedEventGetsPersistedInOutboxTable() {
         myService.doSomething();
 
-        Query q = entityManager
-                .createNativeQuery("SELECT CAST(id as varchar), aggregateId, aggregateType, type, timestamp, payload FROM OutboxEvent");
-        Object[] row = (Object[]) q.getSingleResult();
-
-        assertNotNull(UUID.fromString((String) row[0]));
-        assertEquals(BigInteger.valueOf(1L), row[1]);
-        assertEquals("MyOutboxEvent", row[2]);
-        assertEquals("SomeType", row[3]);
-        assertTrue(((Timestamp) row[4]).toInstant().isBefore(Instant.now()));
-        assertEquals("Some amazing payload", row[5]);
+        final Map row = (Map) entityManager.createQuery("FROM OutboxEvent").getSingleResult();
+        assertNotNull(row.get("id"));
+        assertEquals(1L, row.get("aggregateId"));
+        assertEquals("MyOutboxEvent", row.get("aggregateType"));
+        assertEquals("SomeType", row.get("type"));
+        assertTrue(((Instant) row.get("timestamp")).isBefore(Instant.now()));
+        assertEquals("Some amazing payload", row.get("payload"));
     }
 }

--- a/debezium-quarkus-outbox/integration-tests/src/test/java/io/debezium/outbox/quarkus/it/OutboxTest.java
+++ b/debezium-quarkus-outbox/integration-tests/src/test/java/io/debezium/outbox/quarkus/it/OutboxTest.java
@@ -9,14 +9,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.math.BigInteger;
-import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.UUID;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
-import javax.persistence.Query;
 
 import org.junit.jupiter.api.Test;
 
@@ -40,19 +37,17 @@ public class OutboxTest extends AbstractOutboxTest {
 
     @Override
     @Test
+    @SuppressWarnings("rawtypes")
     public void firedEventGetsPersistedInOutboxTable() {
         myService.doSomething();
 
-        Query q = entityManager
-                .createNativeQuery("SELECT CAST(id as varchar), aggregateId, aggregateType, type, timestamp, payload, tracingspancontext FROM OutboxEvent");
-        Object[] row = (Object[]) q.getSingleResult();
-
-        assertNotNull(UUID.fromString((String) row[0]));
-        assertEquals(BigInteger.valueOf(1L), row[1]);
-        assertEquals("MyOutboxEvent", row[2]);
-        assertEquals("SomeType", row[3]);
-        assertTrue(((Timestamp) row[4]).toInstant().isBefore(Instant.now()));
-        assertEquals("Some amazing payload", row[5]);
-        assertNotNull(row[6]);
+        final Map row = (Map) entityManager.createQuery("FROM OutboxEvent").getSingleResult();
+        assertNotNull(row.get("id"));
+        assertEquals(1L, row.get("aggregateId"));
+        assertEquals("MyOutboxEvent", row.get("aggregateType"));
+        assertEquals("SomeType", row.get("type"));
+        assertTrue(((Instant) row.get("timestamp")).isBefore(Instant.now()));
+        assertEquals("Some amazing payload", row.get("payload"));
+        assertNotNull(row.get("tracingspancontext"));
     }
 }

--- a/documentation/modules/ROOT/pages/integrations/outbox.adoc
+++ b/documentation/modules/ROOT/pages/integrations/outbox.adoc
@@ -239,8 +239,8 @@ for example, `com.company.TheAttributeConverter`
 |string
 |
 
-|[[quarkus-debezium-outbox-payload-explicit-type]]<<quarkus-debezium-outbox-payload-explicit-type,`+quarkus.debezium-outbox.payload.explicit-type+`>>::
-A fully-qualified class name of the explicit type of the payload. +
+|[[quarkus-debezium-outbox-payload-type]]<<quarkus-debezium-outbox-payload-type,`+quarkus.debezium-outbox.payload.type+`>>::
+A fully-qualified class name of a Hibernate https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#basic-custom-type[user type] implementation. +
 for example, `io.company.types.JsonNodeBinaryType`
 |string
 |

--- a/documentation/modules/ROOT/pages/integrations/outbox.adoc
+++ b/documentation/modules/ROOT/pages/integrations/outbox.adoc
@@ -239,6 +239,12 @@ for example, `com.company.TheAttributeConverter`
 |string
 |
 
+|[[quarkus-debezium-outbox-payload-explicit-type]]<<quarkus-debezium-outbox-payload-explicit-type,`+quarkus.debezium-outbox.payload.explicit-type+`>>::
+A fully-qualified class name of the explicit type of the payload. +
+for example, `io.company.types.JsonNodeBinaryType`
+|string
+|
+
 |[[quarkus-debezium-outbox-tracingspancontext-name]]<<quarkus-debezium-outbox-tracingspancontext-name,`+quarkus.debezium-outbox.tracingspancontext.name+`>>::
 The column name for the tracing span context column.
 |string


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3552

This PR extends the capabilities of the `payload` field by allowing users to define a custom user-defined type handler that can be used to bridge the transformation of the payload value between the Java representation and that of the database.  This normally can be done using a JPA attribute converter; however, there are pre-existing user-defined type implementations that also do this in "Hibernate terms" and so the new `quarkus.debezium-outbox.payload.explicit-type` configuration property enables this usage.