### PR TITLE
DBZ-4063 Script/Action to check for missing commits by branch

### DIFF
--- a/.github/workflows/missing-commits-by-issue-key.yml
+++ b/.github/workflows/missing-commits-by-issue-key.yml
@@ -1,0 +1,21 @@
+name: Missing commits check
+
+on:
+  workflow_dispatch:
+    inputs:
+      fixed_version:
+        description: 'The Jira fixed version (e.g. 1.8.0.Final)'
+        required: true
+      branch_name:
+        description: 'The branch to be inspected (e.g. main or 1.8)'
+        required: true
+
+jobs:
+  script:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout action
+        uses: actions/checkout@v1
+      - name: Run script
+        run: |
+          ./github-support/list-missing-commits-by-issue-key.sh ${{ github.event.inputs.fixed_version }} ${{ github.event.inputs.branch_name }}

--- a/.github/workflows/missing-commits-by-issue-key.yml
+++ b/.github/workflows/missing-commits-by-issue-key.yml
@@ -6,8 +6,11 @@ on:
       fixed_version:
         description: 'The Jira fixed version (e.g. 1.8.0.Final)'
         required: true
-      branch_name:
-        description: 'The branch to be inspected (e.g. main or 1.8)'
+      from_tag:
+        description: 'The tag to start from (e.g. v1.8.0.CR1)'
+        required: true
+      to_tag:
+        description: 'The tag to end at (e.g. v1.8.0.Final)'
         required: true
 
 jobs:
@@ -18,4 +21,4 @@ jobs:
         uses: actions/checkout@v1
       - name: Run script
         run: |
-          ./github-support/list-missing-commits-by-issue-key.sh ${{ github.event.inputs.fixed_version }} ${{ github.event.inputs.branch_name }}
+          ./github-support/list-missing-commits-by-issue-key.sh ${{ github.event.inputs.fixed_version }} ${{ github.event.inputs.from_tag }} ${{ github.event.inputs.to_tag }}

--- a/github-support/list-missing-commits-by-issue-key.sh
+++ b/github-support/list-missing-commits-by-issue-key.sh
@@ -4,11 +4,14 @@ set -ouo > /dev/null 2>&1
 
 if [ $# -eq 0 ]; then
   echo "No parameters provided."
-  echo "Syntax: ./list-missing-commits-by-issue-key.sh <fix-version> <branch-name>"
+  echo "Syntax: ./list-missing-commits-by-issue-key.sh <fix-version> <since-tag-name> <to-tag-name>"
   echo ""
-  echo "  fix-version : The Jira version for which issues will be compared against the Git history"
-  echo "  branch-name : The local GitHub branch that should be inspected for the commits"
-  echo "                Be sure you have synchronized your local repository!"
+  echo "  fix-version    : The Jira version for which issues will be compared against the Git history"
+  echo "  since-tag-name : The starting tag to begin inspecting Git history from"
+  echo "  to-tag-name    : The ending tag to stop inspecting Git history to"
+  echo ""
+  echo "An example of comparing the issues in Jira for 1.8.0.CR1 with Git history would be:"
+  echo "  ./list-missing-commits-by-issue-key.sh 1.8.0.CR1 v1.8.0.Beta1 v1.8.0.CR1"
   echo ""
   exit 1
 fi

--- a/github-support/list-missing-commits-by-issue-key.sh
+++ b/github-support/list-missing-commits-by-issue-key.sh
@@ -14,57 +14,82 @@ if [ $# -eq 0 ]; then
 fi
 
 FIX_VERSION=$1
-BRANCH_NAME=$2
+SINCE_TAG_NAME=$2
+TO_TAG_NAME=$3
 
-DIR="$HOME/debezium-backports"
+DIR="$HOME/debezium-issues"
 
 mkdir -p $DIR
 
 JIRA_URL="https://issues.redhat.com"
 PROJECT_NAME="Debezium"
+GITHUB_REPO_URL="https://api.github.com/repos/debezium"
+EXCLUDED_JIRA_COMPONENTS="examples,website,user-interface-frontend"
 
 ISSUE_KEYS="$DIR/debezium-version-issue-keys.txt"
-GIT_HISTORY="$DIR/debezium-git-history-issue-key.txt"
+GIT_HISTORY_PREFIX="$DIR/git-history"
+ISSUE_CHECK="$DIR/issue-check.txt"
 SCRIPT_OUTPUT_BAD="$DIR/debezium-backport-results-not-exists.txt"
 SCRIPT_OUTPUT_OK="$DIR/debezium-backport-results-found.txt"
 
-# Get all issue keys that are part of the fixed version
-echo "Getting issues from Jira for project $PROJECT_NAME and version $FIX_VERSION"
-curl --silent -X "GET" "$JIRA_URL/rest/api/2/search?jql=project=$PROJECT_NAME%20and%20fixVersion=$FIX_VERSION" | jq -r '.issues[].key' > "$ISSUE_KEYS" 2> /dev/null
+# Repositories to check for existence of commits
+declare -a DEBEZIUM_REPOS=("debezium" "debezium-connector-db2" "debezium-connector-cassandra" "debezium-connector-vitess" "docker-images")
 
-# Read each issue key and verify that at least one commit exists on the specified branch
+# Obtain all issue keys that are part of the fixed version
+echo "Getting issues from Jira for project $PROJECT_NAME and version $FIX_VERSION"
+echo "  components excluded: $EXCLUDED_JIRA_COMPONENTS"
+echo ""
+curl --silent -X "GET" "$JIRA_URL/rest/api/2/search?jql=project=$PROJECT_NAME%20and%20fixVersion=$FIX_VERSION%20and%20component%20not%20in%20($EXCLUDED_JIRA_COMPONENTS)" | jq -r '.issues[].key' > "$ISSUE_KEYS" 2> /dev/null
+
+# Obtain all history between tags for each repository
+for REPO in "${DEBEZIUM_REPOS[@]}";
+do
+  echo "Getting git history for repository $REPO"
+  GIT_HISTORY_FILE="$GIT_HISTORY_PREFIX-$REPO.txt"
+  curl --silent -X "GET" "${GITHUB_REPO_URL}/$REPO/compare/$SINCE_TAG_NAME...$TO_TAG_NAME" | jq ".commits[] | .commit.message" > "$GIT_HISTORY_FILE"
+done
+
+echo ""
+echo "Fix Version : $FIX_VERSION"
+echo "Comparing   : $SINCE_TAG_NAME ... $TO_TAG_NAME"
+
+# Read each issue key and verify that at least one commit in one repository exists for the key
 while IFS=" " read -r ISSUE_KEY
 do
-  git --no-pager log --all --decorate=short --pretty=oneline --grep="$ISSUE_KEY" "$BRANCH_NAME" > "$GIT_HISTORY"
-  if [ -s "$GIT_HISTORY" ]; then
-    # The file isn't empty, so the issue key was found
-    echo "$ISSUE_KEY - $JIRA_URL/browse/$ISSUE_KEY" >> "$SCRIPT_OUTPUT_OK"
-  else
-    # The file is empty, backport does not exist
+  # Iterate each repository history file
+  ISSUE_KEY_FOUND=0
+  for REPO in "${DEBEZIUM_REPOS[@]}";
+  do
+    GIT_HISTORY_FILE="$GIT_HISTORY_PREFIX-$REPO.txt"
+    cat "$GIT_HISTORY_FILE" | grep "$ISSUE_KEY" > "$ISSUE_CHECK"
+    if [ -s "$ISSUE_CHECK" ]; then
+      # The file isn't empty, so the issue key was found
+      ISSUE_KEY_FOUND=1
+    fi
+  done
+
+  if [ $ISSUE_KEY_FOUND -eq 0 ]; then
+    # Issue key was not found
     echo "$ISSUE_KEY - $JIRA_URL/browse/$ISSUE_KEY" >> "$SCRIPT_OUTPUT_BAD"
+  else
+    # Issue key was found
+    echo "$ISSUE_KEY - $JIRA_URL/browse/$ISSUE_KEY" >> "$SCRIPT_OUTPUT_OK"
   fi
+
 done < $ISSUE_KEYS
 
 echo ""
-echo ""
-
-echo "Git Branch  : $BRANCH_NAME"
-echo "Fix Version : $FIX_VERSION"
-
-echo ""
-echo "Issues found:"
-echo "-----------------------------------"
+echo "Issues found: "
+echo "--------------------------------------------------------"
 if [ -s "$SCRIPT_OUTPUT_OK" ]; then
   cat "$SCRIPT_OUTPUT_OK"
 fi
 
 echo ""
-
-echo "Issues not found:"
-echo "-----------------------------------"
-if [ -s "$SCRIPT_OUTPUT_OK" ]; then
+echo "Issues not found: "
+echo "--------------------------------------------------------"
+if [ -s "$SCRIPT_OUTPUT_BAD" ]; then
   cat "$SCRIPT_OUTPUT_BAD"
 fi
-echo ""
 
 rm -rf $DIR

--- a/github-support/list-missing-commits-by-issue-key.sh
+++ b/github-support/list-missing-commits-by-issue-key.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -ouo > /dev/null 2>&1
+
+if [ $# -eq 0 ]; then
+  echo "No parameters provided."
+  echo "Syntax: ./list-missing-commits-by-issue-key.sh <fix-version> <branch-name>"
+  echo ""
+  echo "  fix-version : The Jira version for which issues will be compared against the Git history"
+  echo "  branch-name : The local GitHub branch that should be inspected for the commits"
+  echo "                Be sure you have synchronized your local repository!"
+  echo ""
+  exit 1
+fi
+
+FIX_VERSION=$1
+BRANCH_NAME=$2
+
+DIR="$HOME/debezium-backports"
+
+mkdir -p $DIR
+
+JIRA_URL="https://issues.redhat.com"
+PROJECT_NAME="Debezium"
+
+ISSUE_KEYS="$DIR/debezium-version-issue-keys.txt"
+GIT_HISTORY="$DIR/debezium-git-history-issue-key.txt"
+SCRIPT_OUTPUT_BAD="$DIR/debezium-backport-results-not-exists.txt"
+SCRIPT_OUTPUT_OK="$DIR/debezium-backport-results-found.txt"
+
+# Get all issue keys that are part of the fixed version
+echo "Getting issues from Jira for project $PROJECT_NAME and version $FIX_VERSION"
+curl --silent -X "GET" "$JIRA_URL/rest/api/2/search?jql=project=$PROJECT_NAME%20and%20fixVersion=$FIX_VERSION" | jq -r '.issues[].key' > "$ISSUE_KEYS" 2> /dev/null
+
+# Read each issue key and verify that at least one commit exists on the specified branch
+while IFS=" " read -r ISSUE_KEY
+do
+  git --no-pager log --all --decorate=short --pretty=oneline --grep="$ISSUE_KEY" "$BRANCH_NAME" > "$GIT_HISTORY"
+  if [ -s "$GIT_HISTORY" ]; then
+    # The file isn't empty, so the issue key was found
+    echo "$ISSUE_KEY - $JIRA_URL/browse/$ISSUE_KEY" >> "$SCRIPT_OUTPUT_OK"
+  else
+    # The file is empty, backport does not exist
+    echo "$ISSUE_KEY - $JIRA_URL/browse/$ISSUE_KEY" >> "$SCRIPT_OUTPUT_BAD"
+  fi
+done < $ISSUE_KEYS
+
+echo ""
+echo ""
+
+echo "Git Branch  : $BRANCH_NAME"
+echo "Fix Version : $FIX_VERSION"
+
+echo ""
+echo "Issues found:"
+echo "-----------------------------------"
+if [ -s "$SCRIPT_OUTPUT_OK" ]; then
+  cat "$SCRIPT_OUTPUT_OK"
+fi
+
+echo ""
+
+echo "Issues not found:"
+echo "-----------------------------------"
+if [ -s "$SCRIPT_OUTPUT_OK" ]; then
+  cat "$SCRIPT_OUTPUT_BAD"
+fi
+echo ""
+
+rm -rf $DIR


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4063

So in testing this PR, I found that depending on the changes in a particular release, there may always be some issues reported as not being part of the branch; such as the following:

1. Commits made to community lead repositories but associated with the fix version
2. Commits made to internal / private repositories but associated with the fix version

For now, I didn't address these in the script.  For (1), we would need to improve the script to not only look at the main repository but to also checkout the sibling repositories and run separate iterations of the jira/git comparison per repository.  For (2), I'm not sure exactly if there is a way forward with those cases.

@gunnarmorling @jpechane thoughts?