### PR TITLE
DBZ-4063 Script/Action to check for missing commits by branch

### DIFF
--- a/.github/workflows/missing-commits-by-issue-key.yml
+++ b/.github/workflows/missing-commits-by-issue-key.yml
@@ -1,5 +1,9 @@
 name: Missing commits check
 
+# The Jira access token for performing authenticated queries requires that the variable
+# be passed to the workflow using WEBHOOK_TOKEN so that it can be properly masked. It
+# is currently the only way to do this reliably with GitHub Actions.
+
 on:
   workflow_dispatch:
     inputs:
@@ -12,6 +16,9 @@ on:
       to_tag:
         description: 'The tag to end at (e.g. v1.8.0.Final)'
         required: true
+      WEBHOOK_TOKEN:
+        description: 'Your JIRA access token'
+        required: true
 
 jobs:
   script:
@@ -20,5 +27,10 @@ jobs:
       - name: Checkout action
         uses: actions/checkout@v1
       - name: Run script
+        env:
+          FIXED_VERSION: ${{ github.event.inputs.fixed_version }}
+          FROM_TAG: ${{ github.event.inputs.from_tag }}
+          TO_TAG: ${{ github.event.inputs.to_tag }}
+          WEBHOOK_TOKEN: ${{ github.event.inputs.WEBHOOK_TOKEN }}
         run: |
-          ./github-support/list-missing-commits-by-issue-key.sh ${{ github.event.inputs.fixed_version }} ${{ github.event.inputs.from_tag }} ${{ github.event.inputs.to_tag }}
+          ./github-support/list-missing-commits-by-issue-key.sh $FIXED_VERSION $FROM_TAG $TO_TAG $WEBHOOK_TOKEN

--- a/.github/workflows/missing-commits-by-issue-key.yml
+++ b/.github/workflows/missing-commits-by-issue-key.yml
@@ -1,0 +1,24 @@
+name: Missing commits check
+
+on:
+  workflow_dispatch:
+    inputs:
+      fixed_version:
+        description: 'The Jira fixed version (e.g. 1.8.0.Final)'
+        required: true
+      from_tag:
+        description: 'The tag to start from (e.g. v1.8.0.CR1)'
+        required: true
+      to_tag:
+        description: 'The tag to end at (e.g. v1.8.0.Final)'
+        required: true
+
+jobs:
+  script:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout action
+        uses: actions/checkout@v1
+      - name: Run script
+        run: |
+          ./github-support/list-missing-commits-by-issue-key.sh ${{ github.event.inputs.fixed_version }} ${{ github.event.inputs.from_tag }} ${{ github.event.inputs.to_tag }}

--- a/github-support/list-missing-commits-by-issue-key.sh
+++ b/github-support/list-missing-commits-by-issue-key.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -ouo > /dev/null 2>&1
+
+if [ $# -eq 0 ]; then
+  echo "No parameters provided."
+  echo "Syntax: ./list-missing-commits-by-issue-key.sh <fix-version> <since-tag-name> <to-tag-name>"
+  echo ""
+  echo "  fix-version    : The Jira version for which issues will be compared against the Git history"
+  echo "  since-tag-name : The starting tag to begin inspecting Git history from"
+  echo "  to-tag-name    : The ending tag to stop inspecting Git history to"
+  echo ""
+  echo "An example of comparing the issues in Jira for 1.8.0.CR1 with Git history would be:"
+  echo "  ./list-missing-commits-by-issue-key.sh 1.8.0.CR1 v1.8.0.Beta1 v1.8.0.CR1"
+  echo ""
+  exit 1
+fi
+
+FIX_VERSION=$1
+SINCE_TAG_NAME=$2
+TO_TAG_NAME=$3
+
+DIR="$HOME/debezium-issues"
+
+mkdir -p $DIR
+
+JIRA_URL="https://issues.redhat.com"
+PROJECT_NAME="Debezium"
+GITHUB_REPO_URL="https://api.github.com/repos/debezium"
+EXCLUDED_JIRA_COMPONENTS="examples,website,user-interface-frontend"
+
+ISSUE_KEYS="$DIR/debezium-version-issue-keys.txt"
+GIT_HISTORY_PREFIX="$DIR/git-history"
+ISSUE_CHECK="$DIR/issue-check.txt"
+SCRIPT_OUTPUT_BAD="$DIR/debezium-backport-results-not-exists.txt"
+SCRIPT_OUTPUT_OK="$DIR/debezium-backport-results-found.txt"
+
+# Repositories to check for existence of commits
+declare -a DEBEZIUM_REPOS=("debezium" "debezium-connector-db2" "debezium-connector-cassandra" "debezium-connector-vitess" "docker-images")
+
+# Obtain all issue keys that are part of the fixed version
+echo "Getting issues from Jira for project $PROJECT_NAME and version $FIX_VERSION"
+echo "  components excluded: $EXCLUDED_JIRA_COMPONENTS"
+echo ""
+curl --silent -X "GET" "$JIRA_URL/rest/api/2/search?jql=project=$PROJECT_NAME%20and%20fixVersion=$FIX_VERSION%20and%20component%20not%20in%20($EXCLUDED_JIRA_COMPONENTS)" | jq -r '.issues[].key' > "$ISSUE_KEYS" 2> /dev/null
+
+# Obtain all history between tags for each repository
+for REPO in "${DEBEZIUM_REPOS[@]}";
+do
+  echo "Getting git history for repository $REPO"
+  GIT_HISTORY_FILE="$GIT_HISTORY_PREFIX-$REPO.txt"
+  curl --silent -X "GET" "${GITHUB_REPO_URL}/$REPO/compare/$SINCE_TAG_NAME...$TO_TAG_NAME" | jq ".commits[] | .commit.message" > "$GIT_HISTORY_FILE"
+done
+
+echo ""
+echo "Fix Version : $FIX_VERSION"
+echo "Comparing   : $SINCE_TAG_NAME ... $TO_TAG_NAME"
+
+# Read each issue key and verify that at least one commit in one repository exists for the key
+while IFS=" " read -r ISSUE_KEY
+do
+  # Iterate each repository history file
+  ISSUE_KEY_FOUND=0
+  for REPO in "${DEBEZIUM_REPOS[@]}";
+  do
+    GIT_HISTORY_FILE="$GIT_HISTORY_PREFIX-$REPO.txt"
+    cat "$GIT_HISTORY_FILE" | grep "$ISSUE_KEY" > "$ISSUE_CHECK"
+    if [ -s "$ISSUE_CHECK" ]; then
+      # The file isn't empty, so the issue key was found
+      ISSUE_KEY_FOUND=1
+    fi
+  done
+
+  if [ $ISSUE_KEY_FOUND -eq 0 ]; then
+    # Issue key was not found
+    echo "$ISSUE_KEY - $JIRA_URL/browse/$ISSUE_KEY" >> "$SCRIPT_OUTPUT_BAD"
+  else
+    # Issue key was found
+    echo "$ISSUE_KEY - $JIRA_URL/browse/$ISSUE_KEY" >> "$SCRIPT_OUTPUT_OK"
+  fi
+
+done < $ISSUE_KEYS
+
+echo ""
+echo "Issues found: "
+echo "--------------------------------------------------------"
+if [ -s "$SCRIPT_OUTPUT_OK" ]; then
+  cat "$SCRIPT_OUTPUT_OK"
+fi
+
+echo ""
+echo "Issues not found: "
+echo "--------------------------------------------------------"
+if [ -s "$SCRIPT_OUTPUT_BAD" ]; then
+  cat "$SCRIPT_OUTPUT_BAD"
+fi
+
+rm -rf $DIR

--- a/github-support/list-missing-commits-by-issue-key.sh
+++ b/github-support/list-missing-commits-by-issue-key.sh
@@ -9,6 +9,7 @@ if [ $# -eq 0 ]; then
   echo "  fix-version    : The Jira version for which issues will be compared against the Git history"
   echo "  since-tag-name : The starting tag to begin inspecting Git history from"
   echo "  to-tag-name    : The ending tag to stop inspecting Git history to"
+  echo "  jira-token     : Your Jira access token for authentication"
   echo ""
   echo "An example of comparing the issues in Jira for 1.8.0.CR1 with Git history would be:"
   echo "  ./list-missing-commits-by-issue-key.sh 1.8.0.CR1 v1.8.0.Beta1 v1.8.0.CR1"
@@ -19,6 +20,7 @@ fi
 FIX_VERSION=$1
 SINCE_TAG_NAME=$2
 TO_TAG_NAME=$3
+JIRA_TOKEN=$4
 
 DIR="$HOME/debezium-issues"
 
@@ -42,7 +44,7 @@ declare -a DEBEZIUM_REPOS=("debezium" "debezium-connector-db2" "debezium-connect
 echo "Getting issues from Jira for project $PROJECT_NAME and version $FIX_VERSION"
 echo "  components excluded: $EXCLUDED_JIRA_COMPONENTS"
 echo ""
-curl --silent -X "GET" "$JIRA_URL/rest/api/2/search?jql=project=$PROJECT_NAME%20and%20fixVersion=$FIX_VERSION%20and%20component%20not%20in%20($EXCLUDED_JIRA_COMPONENTS)" | jq -r '.issues[].key' > "$ISSUE_KEYS" 2> /dev/null
+curl --silent -X "GET" -H "Authorization: Bearer ${JIRA_TOKEN}" "$JIRA_URL/rest/api/2/search?jql=project=$PROJECT_NAME%20and%20fixVersion=$FIX_VERSION%20and%20component%20not%20in%20($EXCLUDED_JIRA_COMPONENTS)" | jq -r '.issues[].key' > "$ISSUE_KEYS" 2> /dev/null
 
 # Obtain all history between tags for each repository
 for REPO in "${DEBEZIUM_REPOS[@]}";

--- a/jenkins-jobs/pipelines/release-pipeline.groovy
+++ b/jenkins-jobs/pipelines/release-pipeline.groovy
@@ -333,6 +333,17 @@ node('Slave') {
             }
         }
 
+        stage('Check missing backports') {
+            if (!DRY_RUN) {
+                dir(DEBEZIUM_DIR) {
+                    def rc = sh(script: "github-support/list-missing-commits-by-issue-key.sh", returnStatus: true)
+                    if (rc != 0) {
+                        error "Error, there are some missing backport commits."
+                    }
+                }
+            }
+        }
+
         stage('Check Jira') {
             if (!DRY_RUN) {
                 unresolvedIssues = unresolvedIssuesFromJira()


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4063, this supersedes #3035.  

At first, I tried making some correlations between components and repositories but that quickly became unwieldy.  I decided to take a more practical approach and examine each repository to verify at least one commit for the issue key exists.  If one commit is found, we add the issue to the "found" output; if not it gets added to the "not found" output.

In testing this I did notice the following using 1.8.0.CR1 as the fix version and the span of v1.8.0.Beta1 to v1.8.0.CR1 tags:

[DBZ-4391](https://issues.redhat.com/browse/DBZ-4391) - Not found; incorporated by DBZ-4389 but DBZ-4391 not in commit message.
[DBZ-4249](https://issues.redhat.com/browse/DBZ-4249) - Jira has it marked in 1.8.0.CR1; was part of 1.8.0.Beta1.
[DBZ-4127](https://issues.redhat.com/browse/DBZ-4127) - Jira has it marked in 1.8.0.CR1; was part of 1.8.0.Beta1.

Unfortunately or fortunately (depending on how you look at it); there are going to possibly be these types of corner cases but this script can't really solve every possibility but we knew that going into this.