### PR TITLE
Dbz 3991 reflect new streams deployment mechanism in connector docs

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -42,9 +42,7 @@ ifdef::community[]
 * MongoDB
 endif::community[]
 * MySQL
-ifdef::community[]
 * Oracle
-endif::community[]
 * PostgreSQL
 * SQL Server
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -6,6 +6,8 @@
 :context: db2
 :data-collection: table
 :mbean-name: {context}
+:connector-file: {context}
+:connector-class: Db2Connector
 ifdef::community[]
 
 :toc:
@@ -1611,15 +1613,24 @@ You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and Ope
 endif::community[]
 
 ifdef::product[]
-To deploy a {prodname} Db2 connector, you add the connector files to Kafka Connect, create a custom container to run the connector, and then add the connector configuration to your container.
-For details about deploying the {prodname} Db2 connector, see the following topics:
+You can use either of the following methods to deploy a {prodname} connector:
 
-* xref:deploying-debezium-db2-connectors[]
+* xref:debezium-{context}-using-streams-to-deploy-a-connector[Use {StreamsName} to automatically create a container image that includes the connector plug-in]
++ This is the preferred method.
+* xref:deploying-debezium-{context}-connectors[Build a custom Kafka Connect container image from a Dockerfile].
+
+include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc[leveloffset=+1]
+
+include::{partialsdir}/modules/all-connectors/proc-connector-streams-deployment.adoc[leveloffset=+1]
+
+
+.Additional resources
+
 * xref:descriptions-of-debezium-db2-connector-configuration-properties[]
 
 // Type: procedure
 // ModuleID: deploying-debezium-db2-connectors
-=== Deploying {prodname} Db2 connectors
+=== Deploying a {prodname} Db2 connector by building a custom Kafka Connect container image from a Dockerfile
 
 To deploy a {prodname} Db2 connector, you must build a custom Kafka Connect container image that contains the {prodname} connector archive, and then push this container image to a container registry.
 You then need to create the following custom resources (CRs):
@@ -1657,7 +1668,7 @@ For more information, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOp
 │   ├── ...
 ----
 
-.. Create a Docker file that uses `{DockerKafkaConnect}` as the base image.
+.. Create a Dockerfile that uses `{DockerKafkaConnect}` as the base image.
 For example, from a terminal window, enter the following, replacing `my-plugins` with the name of your plug-ins directory:
 +
 [source,shell,subs="+attributes,+quotes"]
@@ -1672,7 +1683,7 @@ EOF
 <1> You can specify any file name that you want.
 <2> Replace `my-plugins` with the name of your plug-ins directory.
 +
-The command creates a Docker file with the name `debezium-container-for-db2.yaml` in the current directory.
+The command creates a Dockerfile with the name `debezium-container-for-db2.yaml` in the current directory.
 
 .. Build the container image from the `debezium-container-for-db2.yaml` Docker file that you created in the previous step.
 From the directory that contains the file, open a terminal window and enter one of the following commands:
@@ -1812,32 +1823,9 @@ oc apply -f inventory-connector.yaml
 +
 The preceding command registers `inventory-connector` and the connector starts to run against the `mydatabase` database as defined in the `KafkaConnector` CR.
 
-. Verify that the connector was created and has started:
-.. Display the Kafka Connect log output to verify that the connector was created and has started to capture changes in the specified database:
-+
-[source,shell,options="nowrap"]
-----
-oc logs $(oc get pods -o name -l strimzi.io/cluster=my-connect-cluster)
-----
-
-.. Review the log output to verify that {prodname} performs the initial snapshot.
-The log displays output that is similar to the following messages:
-+
-[source,shell,options="nowrap"]
-----
-... INFO Starting snapshot for ...
-... INFO Snapshot is using user 'debezium' ...
-----
-+
-If the connector starts correctly without errors, it creates a topic for each table whose changes the connector is capturing.
-For the example CR, there would be a topic for the table specified in the `include.list` property.
-Downstream applications can subscribe to these topics.
-
-.. Verify that the connector created the topics by running the following command:
-+
-[source,shell,options="nowrap"]
-----
-oc get kafkatopics
+[id="verifying-that-the-debezium-{context}-connector-is-running"]
+== Verifying that the connector is running
+include::{partialsdir}/modules/all-connectors/proc-verifying-that-the-debezium-{context}-connector-is-running.adoct kafkatopics
 ----
 endif::product[]
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1640,6 +1640,7 @@ include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.a
 include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[]
 
 For information about verifying the connector deployment, see xref:verifying-that-the-debezium-db2-connector-is-running[Verifying that the {prodname} Db2 connector is running].
+
 // Type: procedure
 // ModuleID: deploying-debezium-db2-connectors
 === Deploying a {prodname} Db2 connector by building a custom Kafka Connect container image from a Dockerfile

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1639,8 +1639,6 @@ include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.a
 
 include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[]
 
-For information about verifying the connector deployment, see xref:verifying-that-the-debezium-db2-connector-is-running[Verifying that the {prodname} Db2 connector is running].
-
 // Type: procedure
 // ModuleID: deploying-debezium-db2-connectors
 === Deploying a {prodname} Db2 connector by building a custom Kafka Connect container image from a Dockerfile

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -8,6 +8,7 @@
 :mbean-name: {context}
 :connector-file: {context}
 :connector-class: Db2Connector
+:connector-name: Db2
 ifdef::community[]
 
 :toc:
@@ -1615,13 +1616,20 @@ endif::community[]
 ifdef::product[]
 You can use either of the following methods to deploy a {prodname} connector:
 
-* xref:debezium-{context}-using-streams-to-deploy-a-connector[Use {StreamsName} to automatically create a container image that includes the connector plug-in]
+* xref:openshift-streams-db2-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
 + This is the preferred method.
-* xref:deploying-debezium-{context}-connectors[Build a custom Kafka Connect container image from a Dockerfile].
+* xref:deploying-debezium-db2-connectors[Build a custom Kafka Connect container image from a Dockerfile].
 
-include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc[leveloffset=+1]
 
-include::{partialsdir}/modules/all-connectors/proc-connector-streams-deployment.adoc[leveloffset=+1]
+// Type: concept
+[id="openshift-streams-db2-connector-deployment"]
+=== Db2 connector deployment using {StreamsName}
+include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc
+
+// Type: procedure
+[id="using-streams-to-deploy-debezium-db2-connectors"]
+=== Using {StreamsName} to deploy a {prodname} Db2 connector
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
 
 
 .Additional resources
@@ -1823,10 +1831,6 @@ oc apply -f inventory-connector.yaml
 +
 The preceding command registers `inventory-connector` and the connector starts to run against the `mydatabase` database as defined in the `KafkaConnector` CR.
 
-[id="verifying-that-the-debezium-{context}-connector-is-running"]
-== Verifying that the connector is running
-include::{partialsdir}/modules/all-connectors/proc-verifying-that-the-debezium-{context}-connector-is-running.adoct kafkatopics
-----
 endif::product[]
 
 ifdef::community[]
@@ -1904,6 +1908,14 @@ endif::community[]
 When the connector starts, it {link-prefix}:{link-db2-connector}#db2-snapshots[performs a consistent snapshot] of the Db2 database tables that the connector is configured to capture changes for.
 The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
 
+ifdef::product[]
+// Type: procedure
+[id="verifying-that-the-debezium-db2-connector-is-running"]
+=== Verifying that the {prodname} Db2 connector is running
+
+include::{partialsdir}/modules/all-connectors/proc-verifying-the-debezium-connector-deployment.adoc
+
+endif::[product]
 // Type: reference
 // Title: Description of {prodname} Db2 connector configuration properties
 // ModuleID: descriptions-of-debezium-db2-connector-configuration-properties
@@ -2245,12 +2257,12 @@ endif::product[]
 [id="debezium-{context}-connector-database-history-configuration-properties"]
 ==== {prodname} connector database history configuration properties
 
-include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
+include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
 
 [id="debezium-{context}-connector-pass-through-database-driver-configuration-properties"]
 ==== {prodname} connector pass-through database driver configuration properties
 
-include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-database-driver-configuration-properties.adoc[leveloffset=+1]
+include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-database-driver-configuration-properties.adoc
 
 // Type: assembly
 // ModuleID: monitoring-debezium-db2-connector-performance
@@ -2272,9 +2284,9 @@ The {prodname} Db2 connector provides three types of metrics that are in additio
 [[db2-snapshot-metrics]]
 === Snapshot metrics
 
-include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
+include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[
 
-include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc[leveloffset=+1]
+include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc
 
 // Type: reference
 // ModuleID: monitoring-debezium-db2-connector-record-streaming
@@ -2282,7 +2294,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-increment
 [[db2-streaming-metrics]]
 === Streaming metrics
 
-include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
+include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc
 
 // Type: reference
 // ModuleID: monitoring-debezium-db2-connector-schema-history
@@ -2290,7 +2302,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming
 [[db2-schema-history-metrics]]
 === Schema history metrics
 
-include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc[leveloffset=+1]
+include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc
 
 // Type: reference
 // ModuleID: managing-debezium-db2-connectors

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1652,13 +1652,13 @@ After you apply the `KafkaConnector` resource to deploy the connector, the conne
 [id="openshift-streams-db2-connector-deployment"]
 === Db2 connector deployment using {StreamsName}
 
-include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc[]
+include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc[leveloffset=+1]
 
 // Type: procedure
 [id="using-streams-to-deploy-debezium-db2-connectors"]
 === Using {StreamsName} to deploy a {prodname} Db2 connector
 
-include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[]
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[leveloffset=+1]
 
 // Type: procedure
 // ModuleID: deploying-debezium-db2-connectors

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1614,27 +1614,27 @@ You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and Ope
 endif::community[]
 
 ifdef::product[]
-You can use either of the following methods to deploy a {prodname} connector:
+You can use either of the following methods to deploy a {prodname} Db2 connector:
 
 * xref:openshift-streams-db2-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
 + This is the preferred method.
 * xref:deploying-debezium-db2-connectors[Build a custom Kafka Connect container image from a Dockerfile].
 
+.Additional resources
+
+* xref:descriptions-of-debezium-db2-connector-configuration-properties[]
 
 // Type: concept
 [id="openshift-streams-db2-connector-deployment"]
 === Db2 connector deployment using {StreamsName}
+
 include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc
 
 // Type: procedure
 [id="using-streams-to-deploy-debezium-db2-connectors"]
 === Using {StreamsName} to deploy a {prodname} Db2 connector
+
 include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
-
-
-.Additional resources
-
-* xref:descriptions-of-debezium-db2-connector-configuration-properties[]
 
 // Type: procedure
 // ModuleID: deploying-debezium-db2-connectors
@@ -1905,7 +1905,7 @@ endif::community[]
 
 .Results
 
-When the connector starts, it {link-prefix}:{link-db2-connector}#db2-snapshots[performs a consistent snapshot] of the Db2 database tables that the connector is configured to capture changes for.
+After the connector starts, it {link-prefix}:{link-db2-connector}#db2-snapshots[performs a consistent snapshot] of the Db2 database tables that the connector is configured to capture changes for.
 The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
 
 ifdef::product[]
@@ -1913,9 +1913,9 @@ ifdef::product[]
 [id="verifying-that-the-debezium-db2-connector-is-running"]
 === Verifying that the {prodname} Db2 connector is running
 
-include::{partialsdir}/modules/all-connectors/proc-verifying-the-debezium-connector-deployment.adoc
-
+include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
 endif::[product]
+
 // Type: reference
 // Title: Description of {prodname} Db2 connector configuration properties
 // ModuleID: descriptions-of-debezium-db2-connector-configuration-properties

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1620,6 +1620,9 @@ You can use either of the following methods to deploy a {prodname} Db2 connector
 + This is the preferred method.
 * xref:deploying-debezium-db2-connectors[Build a custom Kafka Connect container image from a Dockerfile].
 
+The {prodname} Db2 connector requires the Db2 JDBC driver to connect to Db2 databases.
+For information about how to obtain the driver, see xref:obtaining-the-db2-jdbc-driver[Obtaining the Db2 JDBC driver].
+
 .Additional resources
 
 * xref:descriptions-of-debezium-db2-connector-configuration-properties[]
@@ -1660,6 +1663,8 @@ Apply this CR to the same OpenShift instance where you applied the `KafkaConnect
 For more information, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOpenShift}].
 
 * Podman or Docker is installed.
+
+* You obtained the required link:https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads[JDBC driver for Db2].
 
 * You have an account and permissions to create and manage containers in the container registry (such as `quay.io` or `docker.io`) to which you plan to add the container that will run your Debezium connector.
 
@@ -1831,6 +1836,25 @@ oc apply -f inventory-connector.yaml
 ----
 +
 The preceding command registers `inventory-connector` and the connector starts to run against the `mydatabase` database as defined in the `KafkaConnector` CR.
+
+// Type: procedure
+[id="obtaining-the-db2-jdbc-driver"]
+=== Obtaining the Db2 JDBC driver
+
+Due to licensing requirements, the Db2 JDBC driver file is not included in the {prodname} Db2 connector archive.
+Regardless of the deployment method that you use, you must download the driver file to complete the deployment.
+
+* If you xref:deploying-debezium-db2-connectors[use a Dockerfile to build the connector], download the required driver file directly from IBM and add it to your Kafka Connect environment.
+
+The following steps describe how to download the driver and add it your your environment.
+
+.Procedure
+
+. From a browser, download the the driver for your version of Db2 from the link:https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads[IBM Support site].
+If you xref:openshift-streams-db2-connector-deployment[use {StreamsName} to add the connector to your Kafka Connect image], deploy the driver to a Maven repository or to another HTTP server, and then add the artifact URL to the `KafkaConnect` custom resource.
+. Copy the downloaded file to the directory that stores the {prodname} Db2 connector files, for example, `_<kafka_home>_/libs` directory.
++
+When you apply the `KafkaConnector` resource to deploy the connector, the connector is configured to use the specified driver.
 
 endif::product[]
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1627,6 +1627,27 @@ For information about how to obtain the driver, see xref:obtaining-the-db2-jdbc-
 
 * xref:descriptions-of-debezium-db2-connector-configuration-properties[]
 
+// Type: procedure
+[id="obtaining-the-db2-jdbc-driver"]
+=== Obtaining the Db2 JDBC driver
+
+Due to licensing requirements, the Db2 JDBC driver file is not included in the {prodname} Db2 connector archive.
+Regardless of the deployment method that you use, you must download the driver file to complete the deployment.
+
+The following steps describe how to obtain the driver and use it your your environment.
+
+.Procedure
+
+. From a browser, navigate to the link:https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads[IBM Support site] and download the JDBC driver that matches your version of Db2.
+
+* If you xref:deploying-debezium-db2-connectors[use a Dockerfile to build the connector], copy the downloaded file to the directory that contains the {prodname} Db2 connector files, for example, `_<kafka_home>_/libs` directory.
+
+* If you xref:openshift-streams-db2-connector-deployment[use {StreamsName} to add the connector to your Kafka Connect image]:
+.. Deploy the driver to a Maven repository or to another HTTP server that is available to your OpenShift cluster.
+.. Add the artifact URL to the `KafkaConnect` custom resource.
+
+After you apply the `KafkaConnector` resource to deploy the connector, the connector is configured to use the specified driver.
+
 // Type: concept
 [id="openshift-streams-db2-connector-deployment"]
 === Db2 connector deployment using {StreamsName}
@@ -1836,24 +1857,6 @@ oc apply -f inventory-connector.yaml
 +
 The preceding command registers `inventory-connector` and the connector starts to run against the `mydatabase` database as defined in the `KafkaConnector` CR.
 
-// Type: procedure
-[id="obtaining-the-db2-jdbc-driver"]
-=== Obtaining the Db2 JDBC driver
-
-Due to licensing requirements, the Db2 JDBC driver file is not included in the {prodname} Db2 connector archive.
-Regardless of the deployment method that you use, you must download the driver file to complete the deployment.
-
-* If you xref:deploying-debezium-db2-connectors[use a Dockerfile to build the connector], download the required driver file directly from IBM and add it to your Kafka Connect environment.
-
-The following steps describe how to download the driver and add it your your environment.
-
-.Procedure
-
-. From a browser, download the the driver for your version of Db2 from the link:https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads[IBM Support site].
-If you xref:openshift-streams-db2-connector-deployment[use {StreamsName} to add the connector to your Kafka Connect image], deploy the driver to a Maven repository or to another HTTP server, and then add the artifact URL to the `KafkaConnect` custom resource.
-. Copy the downloaded file to the directory that stores the {prodname} Db2 connector files, for example, `_<kafka_home>_/libs` directory.
-+
-When you apply the `KafkaConnector` resource to deploy the connector, the connector is configured to use the specified driver.
 
 endif::product[]
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1628,14 +1628,15 @@ You can use either of the following methods to deploy a {prodname} Db2 connector
 [id="openshift-streams-db2-connector-deployment"]
 === Db2 connector deployment using {StreamsName}
 
-include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc
+include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc[]
 
 // Type: procedure
 [id="using-streams-to-deploy-debezium-db2-connectors"]
 === Using {StreamsName} to deploy a {prodname} Db2 connector
 
-include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[]
 
+For information about verifying the connector deployment, see xref:verifying-that-the-debezium-db2-connector-is-running[Verifying that the {prodname} Db2 connector is running].
 // Type: procedure
 // ModuleID: deploying-debezium-db2-connectors
 === Deploying a {prodname} Db2 connector by building a custom Kafka Connect container image from a Dockerfile
@@ -1913,8 +1914,8 @@ ifdef::product[]
 [id="verifying-that-the-debezium-db2-connector-is-running"]
 === Verifying that the {prodname} Db2 connector is running
 
-include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
-endif::[product]
+include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc[leveloffset=+1]
+endif::product[]
 
 // Type: reference
 // Title: Description of {prodname} Db2 connector configuration properties
@@ -1928,9 +1929,9 @@ Information about the properties is organized as follows:
 
 * xref:db2-required-configuration-properties[Required configuration properties]
 * xref:db2-advanced-configuration-properties[Advanced configuration properties]
-* xref:debezium-{context}-connector-database-history-configuration-properties[Database history connector configuration properties] that control how {prodname} processes events that it reads from the database history topic.
-** xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties]
-* xref:debezium-{context}-connector-pass-through-database-driver-configuration-properties[Pass-through database driver properties] that control the behavior of the database driver.
+* xref:debezium-db2-connector-database-history-configuration-properties[Database history connector configuration properties] that control how {prodname} processes events that it reads from the database history topic.
+** xref:debezium-db2-connector-pass-through-database-driver-configuration-properties[Pass-through database history properties]
+* xref:debezium-db2-connector-pass-through-database-driver-configuration-properties[Pass-through database driver properties] that control the behavior of the database driver.
 
 
 [id="db2-required-configuration-properties"]
@@ -2254,15 +2255,15 @@ endif::product[]
 
 |===
 
-[id="debezium-{context}-connector-database-history-configuration-properties"]
+[id="debezium-db2-connector-database-history-configuration-properties"]
 ==== {prodname} connector database history configuration properties
 
-include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 
-[id="debezium-{context}-connector-pass-through-database-driver-configuration-properties"]
+[id="debezium-db2-connector-pass-through-database-driver-configuration-properties"]
 ==== {prodname} connector pass-through database driver configuration properties
 
-include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-database-driver-configuration-properties.adoc
+include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-database-driver-configuration-properties.adoc[leveloffset=+1]
 
 // Type: assembly
 // ModuleID: monitoring-debezium-db2-connector-performance
@@ -2284,9 +2285,9 @@ The {prodname} Db2 connector provides three types of metrics that are in additio
 [[db2-snapshot-metrics]]
 === Snapshot metrics
 
-include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[
+include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
-include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc
+include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc[leveloffset=+1]
 
 // Type: reference
 // ModuleID: monitoring-debezium-db2-connector-record-streaming
@@ -2294,7 +2295,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-increment
 [[db2-streaming-metrics]]
 === Streaming metrics
 
-include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc
+include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 
 // Type: reference
 // ModuleID: monitoring-debezium-db2-connector-schema-history
@@ -2302,7 +2303,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming
 [[db2-schema-history-metrics]]
 === Schema history metrics
 
-include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc
+include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-schema-history-metrics.adoc[leveloffset=+1]
 
 // Type: reference
 // ModuleID: managing-debezium-db2-connectors

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1068,19 +1068,21 @@ You can use either of the following methods to deploy a {prodname} MongoDB conne
 
 .Additional resources
 
-* xref:descriptions-of-debezium-mongodb-connector-configuration-properties[]
+* xref:mongodb-connector-properties[]
 
 // Type: concept
 [id="openshift-streams-mongodb-connector-deployment"]
 === MongoDB connector deployment using {StreamsName}
 
-include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc
+include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc[leveloffset=+1]
 
 // Type: procedure
 [id="using-streams-to-deploy-debezium-mongodb-connectors"]
 === Using {StreamsName} to deploy a {prodname} MongoDB connector
 
-include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[leveloffset=+1]
+
+For information about verifying the connector deployment, see xref:verifying-that-the-debezium-mongodb-connector-is-running[Verifying that the {prodname} MongoDB connector is running].
 
 // Type: procedure
 [id="deploying-debezium-mongodb-connectors"]
@@ -1306,9 +1308,9 @@ After the connector starts, it completes the following actions:
 ifdef::product[]
 // Type: procedure
 [id="verifying-that-the-debezium-mongodb-connector-is-running"]
-== Verifying that the {prodname} MongoDB connector is running
+=== Verifying that the {prodname} MongoDB connector is running
 
-include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
+include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc[leveloffset=+1]
 endif::product[]
 
 // Type: reference

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -8,6 +8,7 @@
 :mbean-name: {context}
 :connector-file: {context}
 :connector-class: MongoDb
+:connector-name: MongoDB
 ifdef::community[]
 
 :toc:

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1060,15 +1060,31 @@ The {prodname} xref:tutorial.adoc[tutorial] walks you through using these images
 endif::community[]
 
 ifdef::product[]
-To deploy a {prodname} MongoDB connector, add the connector files to Kafka Connect, create a custom container to run the connector, and add the connector configuration to your container.
-Details are in the following topics:
+You can use either of the following methods to deploy a {prodname} MongoDB connector:
 
-* xref:deploying-debezium-mongodb-connectors[]
-* xref:mongodb-connector-properties[]
+* xref:openshift-streams-mongodb-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
++ This is the preferred method.
+* xref:deploying-debezium-mongodb-connectors[Build a custom Kafka Connect container image from a Dockerfile].
+
+.Additional resources
+
+* xref:descriptions-of-debezium-mongodb-connector-configuration-properties[]
+
+// Type: concept
+[id="openshift-streams-mongodb-connector-deployment"]
+=== MongoDB connector deployment using {StreamsName}
+
+include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc
+
+// Type: procedure
+[id="using-streams-to-deploy-debezium-mongodb-connectors"]
+=== Using {StreamsName} to deploy a {prodname} MongoDB connector
+
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
 
 // Type: procedure
 [id="deploying-debezium-mongodb-connectors"]
-=== Deploying {prodname} MongoDB connectors
+=== Deploying a {prodname} MongoDB connector by building a custom Kafka Connect container image from a Dockerfile
 
 To deploy a {prodname} MongoDB connector, you must build a custom Kafka Connect container image that contains the {prodname} connector archive and then push this container image to a container registry.
 You then create two custom resources (CRs):
@@ -1219,11 +1235,6 @@ oc apply -f inventory-connector.yaml
 +
 The preceding command registers `inventory-connector` and the connector starts to run against the `inventory` collection as defined in the `KafkaConnector` CR.
 
-[id="verifying-that-the-debezium-{context}-connector-is-running"]
-== Verifying that the connector is running
-include::{partialsdir}/modules/all-connectors/proc-verifying-that-the-debezium-{context}-connector-is-running.adoc
-endif::product[]
-
 ifdef::community[]
 [[mongodb-example-configuration]]
 === MongoDB connector configuration example
@@ -1285,12 +1296,20 @@ To start running a {prodname} MongoDB connector, create a connector configuratio
 endif::community[]
 
 .Results
-When the connector starts, it completes the following actions:
+After the connector starts, it completes the following actions:
 
 * {link-prefix}:{link-mongodb-connector}#mongodb-performing-a-snapshot[Performs a consistent snapshot] of the collections in your MongoDB replica sets.
 * Reads the oplogs/change streams for the replica sets.
 * Produces change events for every inserted, updated, and deleted document.
 * Streams change event records to Kafka topics.
+
+ifdef::product[]
+// Type: procedure
+[id="verifying-that-the-debezium-mongodb-connector-is-running"]
+== Verifying that the {prodname} MongoDB connector is running
+
+include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
+endif::product[]
 
 // Type: reference
 // Title: Description of {prodname} Db2 connector configuration properties

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -6,6 +6,8 @@
 :context: mongodb
 :data-collection: collection
 :mbean-name: {context}
+:connector-file: {context}
+:connector-class: MongoDb
 ifdef::community[]
 
 :toc:
@@ -1102,7 +1104,7 @@ You then create two custom resources (CRs):
 │   ├── ...
 ----
 
-.. Create a Docker file that uses `{DockerKafkaConnect}` as the base image.
+.. Create a Dockerfile that uses `{DockerKafkaConnect}` as the base image.
 For example, from a terminal window, enter the following, replacing `my-plugins` with the name of your plug-ins directory:
 +
 [source,shell,subs="+attributes,+quotes"]
@@ -1117,7 +1119,7 @@ EOF
 <1> You can specify any file name that you want.
 <2> Replace `my-plugins` with the name of your plug-ins directory.
 +
-The command creates a Docker file with the name `debezium-container-for-mongodb.yaml` in the current directory.
+The command creates a Dockerfile with the name `debezium-container-for-mongodb.yaml` in the current directory.
 
 .. Build the container image from the `debezium-container-for-mongodb.yaml` Docker file that you created in the previous step.
 From the directory that contains the file, open a terminal window and enter one of the following commands:
@@ -1216,33 +1218,9 @@ oc apply -f inventory-connector.yaml
 +
 The preceding command registers `inventory-connector` and the connector starts to run against the `inventory` collection as defined in the `KafkaConnector` CR.
 
-. Verify that the connector was created and has started:
-.. Display the Kafka Connect log output to verify that the connector was created and has started to capture changes in the specified database:
-+
-[source,shell,options="nowrap"]
-----
-oc logs $(oc get pods -o name -l strimzi.io/cluster=my-connect-cluster)
-----
-
-.. Review the log output to verify that {prodname} performs the initial snapshot.
-The log displays output that is similar to the following messages:
-+
-[source,shell,options="nowrap"]
-----
-... INFO Starting snapshot for ...
-... INFO Snapshot is using user 'debezium' ...
-----
-+
-If the connector starts correctly without errors, it creates a topic for each collection from which the connector captures changes.
-For the CR in the preceding example, there would be a topic for the collection specified in the `collection.include.list` property.
-Downstream applications can subscribe to the topics that the connector creates.
-
-.. Verify that the connector created topics by running the following command:
-+
-[source,shell,options="nowrap"]
-----
-oc get kafkatopics
-----
+[id="verifying-that-the-debezium-{context}-connector-is-running"]
+== Verifying that the connector is running
+include::{partialsdir}/modules/all-connectors/proc-verifying-that-the-debezium-{context}-connector-is-running.adoc
 endif::product[]
 
 ifdef::community[]

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1082,8 +1082,6 @@ include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.a
 
 include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[leveloffset=+1]
 
-For information about verifying the connector deployment, see xref:verifying-that-the-debezium-mongodb-connector-is-running[Verifying that the {prodname} MongoDB connector is running].
-
 // Type: procedure
 [id="deploying-debezium-mongodb-connectors"]
 === Deploying a {prodname} MongoDB connector by building a custom Kafka Connect container image from a Dockerfile

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2022,8 +2022,6 @@ include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.a
 === Using {StreamsName} to deploy a {prodname} MySQL connector
 include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[leveloffset=+1]
 
-For information about verifying the connector deployment, see xref:verifying-that-the-debezium-mysql-connector-is-running[Verifying that the {prodname} MySQL connector is running].
-
 // Type: procedure
 // ModuleID: deploying-debezium-mysql-connectors
 === Deploying {prodname} MySQL connectors by building a custom Kafka Connect container image from a Dockerfile

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -8,6 +8,7 @@
 :mbean-name: {context}
 :connector-file: {context}
 :connector-class: MySql
+:connector-name: MySQL
 ifdef::community[]
 :toc:
 :toc-placement: macro
@@ -2000,16 +2001,33 @@ You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and Ope
 endif::community[]
 
 ifdef::product[]
-To deploy a {prodname} MySQL connector, you add the connector files to Kafka Connect, create a custom container to run the connector, and then add the connector configuration to your container.
-For details about deploying the {prodname} MySQL connector, see the following topics:
+You can use either of the following methods to deploy a {prodname} MySQL connector:
 
-* xref:deploying-debezium-mysql-connectors[]
+* xref:using-streams-to-deploy-a-debezium-mysql-connector[Use {StreamsName} to automatically create an image that includes the connector plug-in].
++
+This is the preferred method.
+* xref:deploying-debezium-mysql-connectors[Build a custom Kafka Connect container image from a Dockerfile].
+
+.Additional resources
+
 * xref:descriptions-of-debezium-mysql-connector-configuration-properties[]
+
+// Type: concept
+[id="openshift-streams-mysql-connector-deployment"]
+=== MySQL connector deployment using {StreamsName}
+include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc
+
+//Type: procedure
+[id="using-streams-to-deploy-debezium-mysql-connectors"]
+=== Using {StreamsName} to deploy a {prodname} MySQL connector
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
 
 // Type: procedure
 // ModuleID: deploying-debezium-mysql-connectors
 === Deploying {prodname} MySQL connectors
 
+
+//To deploy a {prodname} MySQL connector, you add the connector files to Kafka Connect, create a custom container to run the connector, and then add the connector configuration to your container.
 To deploy a {prodname} MySQL connector, you must build a custom Kafka Connect container image that contains the {prodname} connector archive, and then push this container image to a container registry.
 You then need to create the following custom resources (CRs):
 
@@ -2203,9 +2221,6 @@ oc apply -f inventory-connector.yaml
 +
 The preceding command registers `inventory-connector` and the connector starts to run against the `inventory` database as defined in the `KafkaConnector` CR.
 
-[id="verifying-that-the-debezium-{context}-connector-is-running"]
-== Verifying that the connector is running
-include::{partialsdir}/modules/all-connectors/proc-verifying-that-the-debezium-{context}-connector-is-running.adoc
 endif::product[]
 
 ifdef::community[]
@@ -2282,6 +2297,15 @@ endif::community[]
 .Results
 When the connector starts, it {link-prefix}:{link-mysql-connector}#mysql-snapshots[performs a consistent snapshot] of the MySQL databases that the connector is configured for.
 The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
+
+ifdef::product[]
+// Type: procedure
+[id="verifying-that-the-debezium-mysql-connector-is-running"]
+=== Verifying that the {prodname} MySQL connector is running
+
+include::{partialsdir}/modules/all-connectors/proc-verifying-the-debezium-connector-deployment.adoc
+
+endif::[product]
 
 // Type: reference
 // Title: Description of {prodname} MySQL connector configuration properties

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2280,6 +2280,7 @@ The service records the configuration and starts one connector task that perform
 
 [[mysql-adding-configuration]]
 === Adding connector configuration
+
 To start running a MySQL connector, configure a connector configuration, and add the configuration to your Kafka Connect cluster.
 
 .Prerequisites
@@ -2295,7 +2296,7 @@ To start running a MySQL connector, configure a connector configuration, and add
 endif::community[]
 
 .Results
-When the connector starts, it {link-prefix}:{link-mysql-connector}#mysql-snapshots[performs a consistent snapshot] of the MySQL databases that the connector is configured for.
+After the connector starts, it {link-prefix}:{link-mysql-connector}#mysql-snapshots[performs a consistent snapshot] of the MySQL databases that the connector is configured for.
 The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
 
 ifdef::product[]
@@ -2304,7 +2305,6 @@ ifdef::product[]
 === Verifying that the {prodname} MySQL connector is running
 
 include::{partialsdir}/modules/all-connectors/proc-verifying-the-debezium-connector-deployment.adoc
-
 endif::[product]
 
 // Type: reference

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -6,6 +6,8 @@
 :context: mysql
 :data-collection: table
 :mbean-name: {context}
+:connector-file: {context}
+:connector-class: MySql
 ifdef::community[]
 :toc:
 :toc-placement: macro
@@ -2044,7 +2046,7 @@ For more information, see link:{LinkDeployStreamsOpenShift}[{NameDeployStreamsOp
 │   ├── ...
 ----
 
-.. Create a Docker file that uses `{DockerKafkaConnect}` as the base image.
+.. Create a Dockerfile that uses `{DockerKafkaConnect}` as the base image.
 For example, from a terminal window, enter the following, replacing `my-plugins` with the name of your plug-ins directory:
 +
 [source,shell,subs="+attributes,+quotes"]
@@ -2059,7 +2061,7 @@ EOF
 <1> You can specify any file name that you want.
 <2> Replace `my-plugins` with the name of your plug-ins directory.
 +
-The command creates a Docker file with the name `debezium-container-for-mysql.yaml` in the current directory.
+The command creates a Dockerfile with the name `debezium-container-for-mysql.yaml` in the current directory.
 
 .. Build the container image from the `debezium-container-for-mysql.yaml` Docker file that you created in the previous step.
 From the directory that contains the file, open a terminal window and enter one of the following commands:
@@ -2201,33 +2203,9 @@ oc apply -f inventory-connector.yaml
 +
 The preceding command registers `inventory-connector` and the connector starts to run against the `inventory` database as defined in the `KafkaConnector` CR.
 
-. Verify that the connector was created and has started:
-.. Display the Kafka Connect log output to verify that the connector was created and has started to capture changes in the specified database:
-+
-[source,shell,options="nowrap"]
-----
-oc logs $(oc get pods -o name -l strimzi.io/cluster=my-connect-cluster)
-----
-
-.. Review the log output to verify that {prodname} performs the initial snapshot.
-The log displays output that is similar to the following messages:
-+
-[source,shell,options="nowrap"]
-----
-... INFO Starting snapshot for ...
-... INFO Snapshot is using user 'debezium' ...
-----
-+
-If the connector starts correctly without errors, it creates a topic for each table whose changes the connector is capturing.
-For the example CR, there would be a topic for the table specified in the `include.list` property.
-Downstream applications can subscribe to these topics.
-
-.. Verify that the connector created the topics by running the following command:
-+
-[source,shell,options="nowrap"]
-----
-oc get kafkatopics
-----
+[id="verifying-that-the-debezium-{context}-connector-is-running"]
+== Verifying that the connector is running
+include::{partialsdir}/modules/all-connectors/proc-verifying-that-the-debezium-{context}-connector-is-running.adoc
 endif::product[]
 
 ifdef::community[]

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2028,8 +2028,6 @@ For information about verifying the connector deployment, see xref:verifying-tha
 // ModuleID: deploying-debezium-mysql-connectors
 === Deploying {prodname} MySQL connectors by building a custom Kafka Connect container image from a Dockerfile
 
-
-//To deploy a {prodname} MySQL connector, you add the connector files to Kafka Connect, create a custom container to run the connector, and then add the connector configuration to your container.
 To deploy a {prodname} MySQL connector, you must build a custom Kafka Connect container image that contains the {prodname} connector archive, and then push this container image to a container registry.
 You then need to create the following custom resources (CRs):
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2003,7 +2003,7 @@ endif::community[]
 ifdef::product[]
 You can use either of the following methods to deploy a {prodname} MySQL connector:
 
-* xref:using-streams-to-deploy-a-debezium-mysql-connector[Use {StreamsName} to automatically create an image that includes the connector plug-in].
+* xref:openshift-streams-mysql-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
 +
 This is the preferred method.
 * xref:deploying-debezium-mysql-connectors[Build a custom Kafka Connect container image from a Dockerfile].
@@ -2015,16 +2015,18 @@ This is the preferred method.
 // Type: concept
 [id="openshift-streams-mysql-connector-deployment"]
 === MySQL connector deployment using {StreamsName}
-include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc
+include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc[leveloffset=+1]
 
 //Type: procedure
-[id="using-streams-to-deploy-debezium-mysql-connectors"]
+[id="using-streams-to-deploy-a-debezium-mysql-connector"]
 === Using {StreamsName} to deploy a {prodname} MySQL connector
-include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[leveloffset=+1]
+
+For information about verifying the connector deployment, see xref:verifying-that-the-debezium-mysql-connector-is-running[Verifying that the {prodname} MySQL connector is running].
 
 // Type: procedure
 // ModuleID: deploying-debezium-mysql-connectors
-=== Deploying {prodname} MySQL connectors
+=== Deploying {prodname} MySQL connectors by building a custom Kafka Connect container image from a Dockerfile
 
 
 //To deploy a {prodname} MySQL connector, you add the connector files to Kafka Connect, create a custom container to run the connector, and then add the connector configuration to your container.
@@ -2304,7 +2306,7 @@ ifdef::product[]
 [id="verifying-that-the-debezium-mysql-connector-is-running"]
 === Verifying that the {prodname} MySQL connector is running
 
-include::{partialsdir}/modules/all-connectors/proc-verifying-the-debezium-connector-deployment.adoc
+include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
 endif::[product]
 
 // Type: reference
@@ -2836,7 +2838,7 @@ endif::product[]
 |Controls the name of the topic to which the connector sends transaction metadata messages. The placeholder `${database.server.name}` can be used for referring to the connector's logical name; defaults to `${database.server.name}.transaction`, for example `dbserver1.transaction`.
 |===
 
-[id="debezium-{context}-connector-database-history-configuration-properties"]
+[id="debezium-mysql-connector-database-history-configuration-properties"]
 ==== {prodname} connector database history configuration properties
 
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -34,10 +34,11 @@ ifdef::product[]
 
 [IMPORTANT]
 ====
-The {prodname} Oracle connector is a Developer Preview feature.
-Developer Preview features provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
-A Developer Preview feature is not supported with Red Hat production service-level agreements (SLAs) and it might not be functionally complete; therefore, Red Hat does not recommend implementing any Developer Preview features in production environments.
-If you need assistance with this feature, you can engage with the https://debezium.io/community/[{prodname} community].
+{prodname} Oracle connector is a Technology Preview feature only.
+Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete.
+Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[https://access.redhat.com/support/offerings/techpreview].
+====
 ====
 
 Information and procedures for using a {prodname} Oracle connector are organized as follows:

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1674,8 +1674,6 @@ include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.a
 
 include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[leveloffset=+1]
 
-For information about verifying the connector deployment, see xref:verifying-that-the-debezium-oracle-connector-is-running[Verifying that the {prodname} Oracle connector is running].
-
 // Type: procedure
 [id="deploying-debezium-oracle-connectors"]
 === Deploying a {prodname} Oracle connector by building a custom Kafka Connect container image from a Dockerfile

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2133,6 +2133,7 @@ ifdef::product[]
 === Verifying that the {prodname} Oracle connector is running
 
 include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc[leveloffset=+1]
+
 endif::product[]
 
 // Type: reference

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1655,7 +1655,8 @@ You can use either of the following methods to deploy a {prodname} Oracle connec
 + This is the preferred method.
 * xref:deploying-debezium-oracle-connectors[Build a custom Kafka Connect container image from a Dockerfile].
 
-Regardless of which method you use, you must first xref:obtaining-the-oracle-jdbc-driver[obtain the Oracle JDBC driver].
+The {prodname} Oracle connector requires the Oracle JDBC driver (ojdbc8.jar) to connect to Oracle databases.
+For information about how to obtain the driver, see xref:obtaining-the-oracle-jdbc-driver[Obtaining the Oracle JDBC driver].
 
 .Additional resources
 
@@ -1702,7 +1703,7 @@ You then need to create the following custom resources (CRs):
 * You have an account and permissions to create and manage containers in the container registry (such as `quay.io` or `docker.io`) to which you plan to add the container that will run your {prodname} connector.
 
 * You have a copy of the Oracle JDBC driver.
-Due to licensing requirements, the {prodname} Oracle connector does not include the required JDBC driver files.
+Due to licensing requirements, the {prodname} Oracle connector does not include the required driver file.
 +
 For more information, see {link-prefix}:{link-oracle-connector}#obtaining-the-oracle-jdbc-driver[Obtaining the Oracle JDBC driver].
 
@@ -1876,27 +1877,46 @@ oc apply -f inventory-connector.yaml
 +
 The preceding command registers `inventory-connector` and the connector starts to run against the `server1` database as defined in the `KafkaConnector` CR.
 
+// Type: procedure
+[id="obtaining-the-oracle-jdbc-driver"]
+=== Obtaining the Oracle JDBC driver
+
+Due to licensing requirements, the required driver file is not included in the {prodname} Oracle connector archive.
+Regardless of which deployment method that you use, you have obtain the Oracle JDBC driver to complete the deployment.
+
+There are two methods for obtaining the driver, depending on the deployment method that you use.
+
+* If you xref:openshift-streams-oracle-connector-deployment[use {StreamsName} to add the connector to your Kafka Connect image], add an artifact reference to the `KafkaConnect` custom resource and then add the location of the artifact as the `url` value.
+* If you xref:deploying-debezium-oracle-connectors[use a Dockerfile to build the connector], download the required driver file directly from Oracle and add it to your Kafka Connect environment.
+
+The following steps describe how to make the driver and available in your environment.
+
+.Procedure
+
+. Complete one of the following procedures, depending on your deployment type:
+** If you use {StreamsName} to deploy the connector:
+.. Navigate to link:https://repo1.maven.org/maven2/com/oracle/database/jdbc/[Maven Central] and locate the `ojdbc8.jar` file for your release of Oracle Database.
+.. In the YAML for the `KafkaConnector` custom resource (CR), add the URL path for the driver to the `artifacts.url` field for the `debezium-connector-oracle` artifact.
++
+For more information about the YAML file for the `KafkaConnector` CR, see xref:openshift-streams-oracle-connector-deployment[Using {StreamsName} to deploy a {prodname} Oracle connector].
+
+** If you use a Dockerfile to deploy the connector:
+.. From a browser, navigate to the link:https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html[Oracle JDBC and UCP Downloads page].
+.. Locate and download the `ojdbc8.jar` driver file for your version of Oracle Database.
+.. Copy the downloaded file to the directory that stores the {prodname} Oracle connector files, for example, `_<kafka_home>_/libs`.
++
+When the connector starts, it is automatically configured to use the specified driver.
 endif::product[]
 
-// Type: procedure
-// Title: Obtaining the Oracle JDBC driver
-// ModuleID: obtaining-the-oracle-jdbc-driver
+ifdef::community[]
 [id="obtaining-oracle-jdbc-driver-and-xstreams-api-files"]
 === Obtaining the Oracle JDBC driver and XStream API files
 
 The {prodname} Oracle connector requires the Oracle JDBC driver (`ojdbc8.jar`) to connect to Oracle databases.
-ifdef::community[]
 If the connector uses XStreams to access the database, you must also have the XStream API (`xstreams.jar`).
 Licensing requirements prohibit {prodname} from including these files in the Oracle connector archive.
 However, the required files are available for free download as part of the Oracle Instant Client.
 The following steps describe how to download the Oracle Instant Client and extract the required files.
-
-endif::community[]
-ifdef::product[]
-Due to licensing requirements, the required driver file is not included in the {prodname} Oracle connector archive.
-You must download the required driver file directly from Oracle and add it to your Kafka Connect environment.
-The following steps describe how to download the Oracle Instant Client and extract the driver.
-endif::product[]
 
 .Procedure
 
@@ -1925,7 +1945,6 @@ instantclient_21_1/
 
 ----
 
-ifdef::community[]
 . Copy the `ojdbc8.jar` and `xstreams.jar` files, and add them to the `_<kafka_home>_/libs` directory, for example, `kafka/libs`.
 +
 [NOTE]
@@ -1941,13 +1960,7 @@ LD_LIBRARY_PATH=/path/to/instant_client/
 ----
 +
 The `LD_LIBRARY_PATH` environment variable is not required if you run the Oracle LogMiner implementation.
-endif::community[]
-ifdef::product[]
- Copy the `ojdbc8.jar` file to the `_<kafka_home>_/libs` directory.
-endif::product[]
 
-
-ifdef::community[]
 [[oracle-example-configuration]]
 === {prodname} Oracle connector configuration
 
@@ -2132,13 +2145,13 @@ The {prodname} Oracle connector has numerous configuration properties that you c
 Many properties have default values.
 Information about the properties is organized as follows:
 
-* xref:required-debezium-{context}-connector-configuration-properties[Required {prodname} Oracle connector configuration properties]
-* xref:debezium-{context}-connector-database-history-configuration-properties[Database history connector configuration properties] that control how {prodname} processes events that it reads from the database history topic.
-** xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties]
-* xref:debezium-{context}-connector-pass-through-database-driver-configuration-properties[Pass-through database driver properties] that control the behavior of the database driver.
+* xref:required-debezium-oracle-connector-configuration-properties[Required {prodname} Oracle connector configuration properties]
+* xref:debezium-oracle-connector-database-history-configuration-properties[Database history connector configuration properties] that control how {prodname} processes events that it reads from the database history topic.
+** xref:oracle-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties]
+* xref:debezium-oracle-connector-pass-through-database-driver-configuration-properties[Pass-through database driver properties] that control the behavior of the database driver.
 
 [id="required-debezium-{context}-connector-configuration-properties"]
-==== Required {prodname} Oracle connector configuration properties
+=== Required {prodname} Oracle connector configuration properties
 The following configuration properties are _required_ unless a default value is available.
 
 [cols="30%a,25%a,45%a"]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1660,89 +1660,23 @@ Regardless of which method you use, you must first xref:obtaining-the-oracle-jdb
 .Additional resources
 
 * xref:descriptions-of-debezium-oracle-connector-configuration-properties[]
-endif::product[]
+
+// Type: concept
+[id="openshift-streams-oracle-connector-deployment"]
+=== {prodname} Oracle connector deployment using {StreamsName}
+
+include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc[leveloffset=+1]
 
 // Type: procedure
-// Title: Obtaining the Oracle JDBC driver
-// ModuleID: obtaining-the-oracle-jdbc-driver
-[id="obtaining-oracle-jdbc-driver-and-xstreams-api-files"]
-=== Obtaining the Oracle JDBC driver and XStream API files
+[id="using-streams-to-deploy-debezium-oracle-connectors"]
+=== Using {StreamsName} to deploy a {prodname} Oracle connector
 
-The {prodname} Oracle connector requires the Oracle JDBC driver (`ojdbc8.jar`) to connect to Oracle databases.
-ifdef::community[]
-If the connector uses XStreams to access the database, you must also have the XStream API (`xstreams.jar`).
-Licensing requirements prohibit {prodname} from including these files in the Oracle connector archive.
-However, the required files are available for free download as part of the Oracle Instant Client.
-The following steps describe how to download the Oracle Instant Client and extract the required files.
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[leveloffset=+1]
 
-endif::community[]
-ifdef::product[]
-Due to licensing requirements, the required driver file is not included in the {prodname} Oracle connector archive.
-You must download the required driver file directly from Oracle and add it to your Kafka Connect environment.
-The following steps describe how to download the Oracle Instant Client and extract the driver.
-endif::product[]
-
-.Procedure
-
-. From a browser, download the https://www.oracle.com/database/technologies/instant-client/downloads.html[Oracle Instant Client package] for your operating system.
-
-. Extract the archive and then open the `instantclient___<version>__` directory.
-+
-For example:
-+
-[source]
-----
-instantclient_21_1/
-├── adrci
-├── BASIC_LITE_LICENSE
-├── BASIC_LITE_README
-├── genezi
-├── libclntshcore.so -> libclntshcore.so.21.1
-├── libclntshcore.so.12.1 -> libclntshcore.so.21.1
-
-...
-
-├── ojdbc8.jar
-├── ucp.jar
-├── uidrvci
-└── xstreams.jar
-
-----
-
-ifdef::community[]
-. Copy the `ojdbc8.jar` and `xstreams.jar` files, and add them to the `_<kafka_home>_/libs` directory, for example, `kafka/libs`.
-+
-[NOTE]
-====
-In environments that use the Oracle LogMiner implementation, copy only the `ojdbc8.jar` file.
-The `xstreams.jar` file is only required in environments that use the Oracle XStreams implementation.
-====
-. If you are using the XStreams implementation, create an environment variable, `LD_LIBRARY_PATH`, and set its value to the path to the Instant Client directory, for example:
-+
-[source,bash,indent=0]
-----
-LD_LIBRARY_PATH=/path/to/instant_client/
-----
-+
-The `LD_LIBRARY_PATH` environment variable is not required if you run the Oracle LogMiner implementation.
-endif::community[]
-ifdef::product[]
- Copy the `ojdbc8.jar` file to the `_<kafka_home>_/libs` directory.
-
- // Type: concept
- [id="openshift-streams-oracle-connector-deployment"]
- === Oracle connector deployment using {StreamsName}
-
- include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc
-
- // Type: procedure
- [id="using-streams-to-deploy-debezium-oracle-connectors"]
- === Using {StreamsName} to deploy a {prodname} Oracle connector
-
- include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
+For information about verifying the connector deployment, see xref:verifying-that-the-debezium-oracle-connector-is-running[Verifying that the {prodname} Oracle connector is running].
 
 // Type: procedure
-// ModuleID: deploying-debezium-oracle-server-connectors
+[id="deploying-debezium-oracle-connectors"]
 === Deploying a {prodname} Oracle connector by building a custom Kafka Connect container image from a Dockerfile
 
 To deploy a {prodname} Oracle connector, you must build a custom Kafka Connect container image that contains the {prodname} connector archive, and then push this container image to a container registry.
@@ -1756,7 +1690,7 @@ You then need to create the following custom resources (CRs):
 * A `KafkaConnector` CR that defines your {prodname} Oracle connector.
   Apply this CR to the same OpenShift instance where you apply the `KafkaConnect` CR.
 
-  .Prerequisites
+.Prerequisites
 
 * Oracle Database is running and you completed the steps to {LinkDebeziumUserGuide}#setting-up-oracle-for-use-with-the-debezium-oracle-connector[set up Oracle to work with a {prodname} connector].
 
@@ -1944,6 +1878,75 @@ The preceding command registers `inventory-connector` and the connector starts t
 
 endif::product[]
 
+// Type: procedure
+// Title: Obtaining the Oracle JDBC driver
+// ModuleID: obtaining-the-oracle-jdbc-driver
+[id="obtaining-oracle-jdbc-driver-and-xstreams-api-files"]
+=== Obtaining the Oracle JDBC driver and XStream API files
+
+The {prodname} Oracle connector requires the Oracle JDBC driver (`ojdbc8.jar`) to connect to Oracle databases.
+ifdef::community[]
+If the connector uses XStreams to access the database, you must also have the XStream API (`xstreams.jar`).
+Licensing requirements prohibit {prodname} from including these files in the Oracle connector archive.
+However, the required files are available for free download as part of the Oracle Instant Client.
+The following steps describe how to download the Oracle Instant Client and extract the required files.
+
+endif::community[]
+ifdef::product[]
+Due to licensing requirements, the required driver file is not included in the {prodname} Oracle connector archive.
+You must download the required driver file directly from Oracle and add it to your Kafka Connect environment.
+The following steps describe how to download the Oracle Instant Client and extract the driver.
+endif::product[]
+
+.Procedure
+
+. From a browser, download the https://www.oracle.com/database/technologies/instant-client/downloads.html[Oracle Instant Client package] for your operating system.
+
+. Extract the archive and then open the `instantclient___<version>__` directory.
++
+For example:
++
+[source]
+----
+instantclient_21_1/
+├── adrci
+├── BASIC_LITE_LICENSE
+├── BASIC_LITE_README
+├── genezi
+├── libclntshcore.so -> libclntshcore.so.21.1
+├── libclntshcore.so.12.1 -> libclntshcore.so.21.1
+
+...
+
+├── ojdbc8.jar
+├── ucp.jar
+├── uidrvci
+└── xstreams.jar
+
+----
+
+ifdef::community[]
+. Copy the `ojdbc8.jar` and `xstreams.jar` files, and add them to the `_<kafka_home>_/libs` directory, for example, `kafka/libs`.
++
+[NOTE]
+====
+In environments that use the Oracle LogMiner implementation, copy only the `ojdbc8.jar` file.
+The `xstreams.jar` file is only required in environments that use the Oracle XStreams implementation.
+====
+. If you are using the XStreams implementation, create an environment variable, `LD_LIBRARY_PATH`, and set its value to the path to the Instant Client directory, for example:
++
+[source,bash,indent=0]
+----
+LD_LIBRARY_PATH=/path/to/instant_client/
+----
++
+The `LD_LIBRARY_PATH` environment variable is not required if you run the Oracle LogMiner implementation.
+endif::community[]
+ifdef::product[]
+ Copy the `ojdbc8.jar` file to the `_<kafka_home>_/libs` directory.
+endif::product[]
+
+
 ifdef::community[]
 [[oracle-example-configuration]]
 === {prodname} Oracle connector configuration
@@ -2112,17 +2115,18 @@ After the connector starts, it {link-prefix}:{link-oracle-connector}#oracle-snap
 The connector then starts generating data change events for row-level operations and streaming the change event records to Kafka topics.
 
 ifdef::product[]
+// Type: procedure
 [id="verifying-that-the-debezium-oracle-connector-is-running"]
-== Verifying that the {prodname} Oracle connector is running
+=== Verifying that the {prodname} Oracle connector is running
 
-include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
+include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc[leveloffset=+1]
 endif::product[]
 
 // Type: reference
 // Title: Descriptions of {prodname} Oracle connector configuration properties
 // ModuleID: descriptions-of-debezium-oracle-connector-configuration-properties
 [[oracle-connector-properties]]
-=== Connector properties
+== Connector properties
 
 The {prodname} Oracle connector has numerous configuration properties that you can use to achieve the right connector behavior for your application.
 Many properties have default values.
@@ -2725,13 +2729,12 @@ Adjust the chunk size to a value that provides the best performance in your envi
 
 |===
 
-[id="debezium-{context}-connector-database-history-configuration-properties"]
-==== {prodname} connector database history configuration properties
+[id="debezium-oracle-connector-database-history-configuration-properties"]
+==== {prodname} Oracle connector database history configuration properties
+include::../../partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 
-include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
-
-[id="debezium-{context}-connector-pass-through-database-driver-configuration-properties"]
-==== {prodname} connector pass-through database driver configuration properties
+[id="debezium-oracle-connector-pass-through-database-driver-configuration-properties"]
+==== {prodname} Oracle connector pass-through database driver configuration properties
 
 include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-database-driver-configuration-properties.adoc[leveloffset=+1]
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1649,11 +1649,16 @@ For more information, see {link-prefix}:{link-oracle-connector}#obtaining-oracle
 endif::community[]
 
 ifdef::product[]
-To deploy a {prodname} Oracle connector, you add the connector files to Kafka Connect, create a custom container to run the connector, and then add connector configuration to your container.
-For details about deploying the {prodname} Oracle connector, see the following topics:
+You can use either of the following methods to deploy a {prodname} Oracle connector:
 
-* xref:obtaining-the-oracle-jdbc-driver[]
-* xref:deploying-debezium-oracle-server-connectors[]
+* xref:openshift-streams-oracle-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
++ This is the preferred method.
+* xref:deploying-debezium-oracle-connectors[Build a custom Kafka Connect container image from a Dockerfile].
+
+Regardless of which method you use, you must first xref:obtaining-the-oracle-jdbc-driver[obtain the Oracle JDBC driver].
+
+.Additional resources
+
 * xref:descriptions-of-debezium-oracle-connector-configuration-properties[]
 endif::product[]
 
@@ -1704,7 +1709,6 @@ instantclient_21_1/
 
 ----
 
-
 ifdef::community[]
 . Copy the `ojdbc8.jar` and `xstreams.jar` files, and add them to the `_<kafka_home>_/libs` directory, for example, `kafka/libs`.
 +
@@ -1725,9 +1729,21 @@ endif::community[]
 ifdef::product[]
  Copy the `ojdbc8.jar` file to the `_<kafka_home>_/libs` directory.
 
+ // Type: concept
+ [id="openshift-streams-oracle-connector-deployment"]
+ === Oracle connector deployment using {StreamsName}
+
+ include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc
+
+ // Type: procedure
+ [id="using-streams-to-deploy-debezium-oracle-connectors"]
+ === Using {StreamsName} to deploy a {prodname} Oracle connector
+
+ include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
+
 // Type: procedure
 // ModuleID: deploying-debezium-oracle-server-connectors
-=== Deploying {prodname} Oracle connectors
+=== Deploying a {prodname} Oracle connector by building a custom Kafka Connect container image from a Dockerfile
 
 To deploy a {prodname} Oracle connector, you must build a custom Kafka Connect container image that contains the {prodname} connector archive, and then push this container image to a container registry.
 You then need to create the following custom resources (CRs):
@@ -1926,10 +1942,6 @@ oc apply -f inventory-connector.yaml
 +
 The preceding command registers `inventory-connector` and the connector starts to run against the `server1` database as defined in the `KafkaConnector` CR.
 
-[id="verifying-that-the-debezium-{context}-connector-is-running"]
-== Verifying that the connector is running
-include::{partialsdir}/modules/all-connectors/proc-verifying-that-the-debezium-{context}-connector-is-running.adoc
-
 endif::product[]
 
 ifdef::community[]
@@ -2096,8 +2108,15 @@ endif::community[]
 
 .Results
 
-When the connector starts, it {link-prefix}:{link-oracle-connector}#oracle-snapshots[performs a consistent snapshot] of the Oracle databases that the connector is configured for.
+After the connector starts, it {link-prefix}:{link-oracle-connector}#oracle-snapshots[performs a consistent snapshot] of the Oracle databases that the connector is configured for.
 The connector then starts generating data change events for row-level operations and streaming the change event records to Kafka topics.
+
+ifdef::product[]
+[id="verifying-that-the-debezium-oracle-connector-is-running"]
+== Verifying that the {prodname} Oracle connector is running
+
+include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
+endif::product[]
 
 // Type: reference
 // Title: Descriptions of {prodname} Oracle connector configuration properties

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -6,6 +6,7 @@
 :context: oracle
 :data-collection: table
 :mbean-name: {context}
+:connector-file: {context}
 ifdef::community[]
 :toc:
 :toc-placement: macro
@@ -1783,7 +1784,7 @@ EOF
 <1> You can specify any file name that you want.
 <2> Replace `my-plugins` with the name of your plug-ins directory.
 +
-The command creates a Docker file with the name `debezium-container-for-oracle.yaml` in the current directory.
+The command creates a Dockerfile with the name `debezium-container-for-oracle.yaml` in the current directory.
 
 .. Build the container image from the `debezium-container-for-oracle.yaml` Docker file that you created in the previous step.
 From the directory that contains the file, open a terminal window and enter one of the following commands:
@@ -1924,32 +1925,9 @@ oc apply -f inventory-connector.yaml
 +
 The preceding command registers `inventory-connector` and the connector starts to run against the `server1` database as defined in the `KafkaConnector` CR.
 
-. Verify that the connector was created and has started:
-.. Display the Kafka Connect log output to verify that the connector was created and has started to capture changes in the specified database:
-+
-[source,shell,options="nowrap"]
-----
-oc logs $(oc get pods -o name -l strimzi.io/cluster=my-connect-cluster)
-----
-
-.. Review the log output to verify that {prodname} performs the initial snapshot.
-The log displays output that is similar to the following messages:
-+
-[source,shell,options="nowrap"]
-----
-... INFO Starting snapshot for ...
-... INFO Snapshot is using user 'c##dbzuser' ...
-----
-+
-If the connector starts correctly without errors, it creates a topic for each table whose changes the connector is capturing.
-Downstream applications can subscribe to these topics.
-
-.. Verify that the connector created the topics by running the following command:
-+
-[source,shell,options="nowrap"]
-----
-oc get kafkatopics
-----
+[id="verifying-that-the-debezium-{context}-connector-is-running"]
+== Verifying that the connector is running
+include::{partialsdir}/modules/all-connectors/proc-verifying-that-the-debezium-{context}-connector-is-running.adoc
 
 endif::product[]
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -7,6 +7,7 @@
 :data-collection: table
 :mbean-name: {context}
 :connector-file: {context}
+:connector-name: Oracle
 ifdef::community[]
 :toc:
 :toc-placement: macro

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2348,13 +2348,13 @@ You can use either of the following methods to deploy a {prodname} PostgreSQL co
 [id="openshift-streams-postgresql-connector-deployment"]
 === PostgreSQL connector deployment using {StreamsName}
 
-include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc
+include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adocleveloffset=+1]
 
 // Type: procedure
 [id="using-streams-to-deploy-debezium-postgresql-connectors"]
 === Using {StreamsName} to deploy a {prodname} PostgreSQL connector
 
-include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adocleveloffset=+1]
 
 // Type: procedure
 [id="deploying-debezium-postgresql-connectors"]
@@ -2522,9 +2522,6 @@ oc apply -f fulfillment-connector.yaml
 +
 This registers `fulfillment-connector` and the connector starts to run against the `sampledb` database as defined in the `KafkaConnector` CR.
 
-[id="verifying-that-the-debezium-{context}-connector-is-running"]
-== Verifying that the connector is running
-include::{partialsdir}/modules/all-connectors/proc-verifying-that-the-debezium-{context}-connector-is-running.adoc
 endif::product[]
 
 ifdef::community[]
@@ -2607,8 +2604,8 @@ ifdef::product[]
 [id="verifying-that-the-debezium-postgresql-connector-is-running"]
 === Verifying that the {prodname} PostgreSQL connector is running
 
-include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
-endif::[product]
+include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adocleveloffset=+1]
+endif::product[]
 
 // Type: reference
 // Title: Description of {prodname} PostgreSQL connector configuration properties

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -6,6 +6,8 @@
 :context: postgresql
 :data-collection: table
 :mbean-name: postgres
+:connector-file: postgres
+:connector-class: Postgres
 ifdef::community[]
 
 :toc:
@@ -2378,7 +2380,7 @@ Apply this CR to the same OpenShift instance where you applied the `KafkaConnect
 │   ├── ...
 ----
 
-.. Create a Docker file that uses `{DockerKafkaConnect}` as the base image.
+.. Create a Dockerfile that uses `{DockerKafkaConnect}` as the base image.
 For example, from a terminal window, enter the following, replacing `my-plugins` with the name of your plug-ins directory:
 +
 [source,shell,subs="+attributes,+quotes"]
@@ -2393,7 +2395,7 @@ EOF
 <1> You can specify any file name that you want.
 <2> Replace `my-plugins` with the name of your plug-ins directory.
 +
-The command creates a Docker file with the name `debezium-container-for-postgresql.yaml` in the current directory.
+The command creates a Dockerfile with the name `debezium-container-for-postgresql.yaml` in the current directory.
 
 .. Build the container image from the `debezium-container-for-postgresql.yaml` Docker file that you created in the previous step.
 From the directory that contains the file, open a terminal window and enter one of the following commands:
@@ -2504,34 +2506,9 @@ oc apply -f fulfillment-connector.yaml
 +
 This registers `fulfillment-connector` and the connector starts to run against the `sampledb` database as defined in the `KafkaConnector` CR.
 
-. Verify that the connector was created and has started:
-.. Display the Kafka Connect log output to verify that the connector was created and has started to capture changes in the specified database:
-+
-[source,shell,options="nowrap"]
-----
-oc logs $(oc get pods -o name -l strimzi.io/cluster=my-connect-cluster)
-----
-
-.. Review the log output to verify that {prodname} performs the initial snapshot.
-The log displays output that is similar to the following messages:
-+
-[source,shell,options="nowrap"]
-----
-... INFO Starting snapshot for ...
-... INFO Snapshot is using user 'debezium' ...
-----
-+
-If the connector starts correctly without errors, it creates a topic for each table whose changes the connector is capturing.
-For the example CR, there would be a topic for each table in the `public` schema.
-Downstream applications can subscribe to these topics.
-
-.. Verify that the connector created the topics by running the following command:
-+
-[source,shell,options="nowrap"]
-----
-oc get kafkatopics
-----
-
+[id="verifying-that-the-debezium-{context}-connector-is-running"]
+== Verifying that the connector is running
+include::{partialsdir}/modules/all-connectors/proc-verifying-that-the-debezium-{context}-connector-is-running.adoc
 endif::product[]
 
 ifdef::community[]

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -462,7 +462,7 @@ Following is an example of a message:
     "aa": "1"
   },
   "source": {
-...
+   ...
   },
   "op": "c",
   "ts_ms": "1580390884335",
@@ -1776,7 +1776,7 @@ When the `dhstore.handling.mode` property is set to `json` (the default), the co
 |`STRING`
 |`io.debezium.data.Json` +
  +
-Example: output representation using the JSON converter is `{\"key\" : \"val\"}`
+Example: output representation using the JSON converter is ``{"key" : "val"}``
 
 |`HSTORE`
 |`MAP`
@@ -2334,16 +2334,31 @@ If you are working with immutable containers, see link:https://hub.docker.com/r/
 endif::community[]
 
 ifdef::product[]
-To deploy a {prodname} PostgreSQL connector, add the connector files to Kafka Connect, create a custom container to run the connector, and add connector configuration to your container. Details are in the following topics:
+You can use either of the following methods to deploy a {prodname} PostgreSQL connector:
 
-* xref:deploying-debezium-postgresql-connectors[]
+* xref:openshift-streams-postgresql-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
++ This is the preferred method.
+* xref:deploying-debezium-postgresql-connectors[Build a custom Kafka Connect container image from a Dockerfile].
+
+.Additional resources
+
 * xref:descriptions-of-debezium-postgresql-connector-configuration-properties[]
 
+// Type: concept
+[id="openshift-streams-postgresql-connector-deployment"]
+=== PostgreSQL connector deployment using {StreamsName}
+
+include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc
+
 // Type: procedure
-// ModuleID: deploying-debezium-postgresql-connectors
-// Title: Deploying {prodname} PostgreSQL connectors
-[[postgresql-deploying-a-connector]]
-=== Deploying connectors
+[id="using-streams-to-deploy-debezium-postgresql-connectors"]
+=== Using {StreamsName} to deploy a {prodname} PostgreSQL connector
+
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
+
+// Type: procedure
+[id="deploying-debezium-postgresql-connectors"]
+=== Deploying a {prodname} PostgreSQL connector by building a custom Kafka Connect container image from a Dockerfile
 
 To deploy a {prodname} PostgreSQL connector, you need to build a custom Kafka Connect container image that contains the {prodname} connector archive and push this container image to a container registry.
 You then need to create two custom resources (CRs):
@@ -2566,6 +2581,7 @@ The service records the configuration and starts one connector task that perform
 === Adding connector configuration
 
 To run a {prodname} PostgreSQL connector, create a connector configuration and add the configuration to your Kafka Connect cluster.
+
 .Prerequisites
 
 * {link-prefix}:{link-postgresql-connector}#postgresql-server-configuration[PostgreSQL is configured to support logical replication].
@@ -2584,8 +2600,15 @@ endif::community[]
 
 .Results
 
-When the connector starts, it {link-prefix}:{link-postgresql-connector}#postgresql-snapshots[performs a consistent snapshot] of the PostgreSQL server databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
+After the connector starts, it {link-prefix}:{link-postgresql-connector}#postgresql-snapshots[performs a consistent snapshot] of the PostgreSQL server databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
 
+ifdef::product[]
+// Type: procedure
+[id="verifying-that-the-debezium-postgresql-connector-is-running"]
+=== Verifying that the {prodname} PostgreSQL connector is running
+
+include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
+endif::[product]
 
 // Type: reference
 // Title: Description of {prodname} PostgreSQL connector configuration properties

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -8,6 +8,7 @@
 :mbean-name: postgres
 :connector-file: postgres
 :connector-class: Postgres
+:connector-name: PostgreSQL
 ifdef::community[]
 
 :toc:

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2348,13 +2348,13 @@ You can use either of the following methods to deploy a {prodname} PostgreSQL co
 [id="openshift-streams-postgresql-connector-deployment"]
 === PostgreSQL connector deployment using {StreamsName}
 
-include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adocleveloffset=+1]
+include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc[leveloffset=+1]
 
 // Type: procedure
 [id="using-streams-to-deploy-debezium-postgresql-connectors"]
 === Using {StreamsName} to deploy a {prodname} PostgreSQL connector
 
-include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adocleveloffset=+1]
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[leveloffset=+1]
 
 // Type: procedure
 [id="deploying-debezium-postgresql-connectors"]
@@ -2604,7 +2604,7 @@ ifdef::product[]
 [id="verifying-that-the-debezium-postgresql-connector-is-running"]
 === Verifying that the {prodname} PostgreSQL connector is running
 
-include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adocleveloffset=+1]
+include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc[leveloffset=+1]
 endif::product[]
 
 // Type: reference

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1912,6 +1912,7 @@ The preceding command registers `fulfillment-connector` and the connector starts
 
 [id="verifying-that-the-debezium-sqlserver-connector-is-running"]
 === Verifying that the {prodname} SQL Server connector is running
+
 include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc[leveloffset=+1]
 
 endif::product[]

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -9,6 +9,7 @@
 :mbean-name: sql_server
 :connector-file: {context}
 :connector-class: SqlServer
+:connector-name: SQL Server
 ifdef::community[]
 
 :toc:

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -7,6 +7,8 @@
 :context: sqlserver
 :data-collection: table
 :mbean-name: sql_server
+:connector-file: {context}
+:connector-class: SqlServer
 ifdef::community[]
 
 :toc:
@@ -1695,7 +1697,7 @@ For details about deploying the {prodname} SQL Server connector, see the followi
 * xref:descriptions-of-debezium-sql-server-connector-configuration-properties[]
 
 // Type: procedure
-// ModuleID: deploying-debezium-sql-server-connectors
+// ModuleID: deploying-debezium-sqlserver-connectors
 [[sql-server-deploying-a-connector]]
 === Deploying {prodname} SQL Server connectors
 
@@ -1735,7 +1737,7 @@ You then need to create the following custom resources (CRs):
 │   ├── ...
 ----
 
-.. Create a Docker file that uses `{DockerKafkaConnect}` as the base image.
+.. Create a Dockerfile that uses `{DockerKafkaConnect}` as the base image.
 For example, from a terminal window, enter the following, replacing `my-plugins` with the name of your plug-ins directory:
 +
 [source,shell,subs="+attributes,+quotes"]
@@ -1750,7 +1752,7 @@ EOF
 <1> You can specify any file name that you want.
 <2> Replace `my-plugins` with the name of your plug-ins directory.
 +
-The command creates a Docker file with the name `debezium-container-for-sqlserver.yaml` in the current directory.
+The command creates a Dockerfile with the name `debezium-container-for-sqlserver.yaml` in the current directory.
 
 .. Build the container image from the `debezium-container-for-sqlserver.yaml` Docker file that you created in the previous step.
 From the directory that contains the file, open a terminal window and enter one of the following commands:
@@ -1891,33 +1893,9 @@ oc apply -f fulfillment-connector.yaml
 +
 The preceding command registers `fulfillment-connector` and the connector starts to run against the `testDB` database as defined in the `KafkaConnector` CR.
 
-. Verify that the connector was created and has started:
-.. Display the Kafka Connect log output to verify that the connector was created and has started to capture changes in the specified database:
-+
-[source,shell,options="nowrap"]
-----
-oc logs $(oc get pods -o name -l strimzi.io/cluster=my-connect-cluster)
-----
-
-.. Review the log output to verify that {prodname} performs the initial snapshot.
-The log displays output that is similar to the following messages:
-+
-[source,shell,options="nowrap"]
-----
-... INFO Starting snapshot for ...
-... INFO Snapshot is using user 'debezium' ...
-----
-+
-If the connector starts correctly without errors, it creates a topic for each table whose changes the connector is capturing.
-For the example CR, there would be a topic for the table specified in the `include.list` property.
-Downstream applications can subscribe to these topics.
-
-.. Verify that the connector created the topics by running the following command:
-+
-[source,shell,options="nowrap"]
-----
-oc get kafkatopics
-----
+[id="verifying-that-the-debezium-{context}-connector-is-running"]
+== Verifying that the connector is running
+include::{partialsdir}/modules/all-connectors/proc-verifying-that-the-debezium-{context}-connector-is-running.adoc
 
 endif::product[]
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1691,16 +1691,38 @@ You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and Ope
 endif::community[]
 
 ifdef::product[]
+You can use either of the following methods to deploy a {prodname} SQL Server connector:
+
+* xref:openshift-streams-sqlserver-connector-deployment[Use {StreamsName} to automatically create an image that includes the connector plug-in].
++ This is the preferred method.
+* xref:deploying-debezium-sqlserver-connectors[Build a custom Kafka Connect container image from a Dockerfile].
+
+.Additional resources
+
+* xref:descriptions-of-debezium-sqlserver-connector-configuration-properties[]
+
+// Type: concept
+[id="openshift-streams-sqlserver-connector-deployment"]
+=== SQL Server connector deployment using {StreamsName}
+
+include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc[leveloffset=+1]
+
+// Type: procedure
+[id="using-streams-to-deploy-debezium-sqlserver-connectors"]
+=== Using {StreamsName} to deploy a {prodname} SQL Server connector
+
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[leveloffset=+1]
+
 To deploy a {prodname} SQL Server connector, you add the connector files to Kafka Connect, create a custom container to run the connector, and then add connector configuration to your container.
 For details about deploying the {prodname} SQL Server connector, see the following topics:
 
-* xref:deploying-debezium-sql-server-connectors[]
-* xref:descriptions-of-debezium-sql-server-connector-configuration-properties[]
+* xref:deploying-debezium-sqlserver-connectors[]
+* xref:descriptions-of-debezium-sqlserver-connector-configuration-properties[]
 
 // Type: procedure
 // ModuleID: deploying-debezium-sqlserver-connectors
 [[sql-server-deploying-a-connector]]
-=== Deploying {prodname} SQL Server connectors
+=== Deploying a {prodname} SQL Server connector by building a custom Kafka Connect container image from a Dockerfile
 
 To deploy a {prodname} SQL Server connector, you must build a custom Kafka Connect container image that contains the {prodname} connector archive, and then push this container image to a container registry.
 You then need to create the following custom resources (CRs):
@@ -1894,9 +1916,9 @@ oc apply -f fulfillment-connector.yaml
 +
 The preceding command registers `fulfillment-connector` and the connector starts to run against the `testDB` database as defined in the `KafkaConnector` CR.
 
-[id="verifying-that-the-debezium-{context}-connector-is-running"]
-== Verifying that the connector is running
-include::{partialsdir}/modules/all-connectors/proc-verifying-that-the-debezium-{context}-connector-is-running.adoc
+[id="verifying-that-the-debezium-sqlserver-connector-is-running"]
+=== Verifying that the connector is running
+include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc[leveloffset=+1]
 
 endif::product[]
 
@@ -1976,7 +1998,7 @@ The connector then starts generating data change events for row-level operations
 
 // Type: reference
 // Title: Descriptions of {prodname} SQL Server connector configuration properties
-// ModuleID: descriptions-of-debezium-sql-server-connector-configuration-properties
+// ModuleID: descriptions-of-debezium-sqlserver-connector-configuration-properties
 [[sqlserver-connector-properties]]
 === Connector properties
 
@@ -1985,13 +2007,13 @@ Many properties have default values.
 
 Information about the properties is organized as follows:
 
-* xref:{context}-required-connector-configuration-properties[Required connector configuration properties]
-* xref:{context}-advanced-connector-configuration-properties[Advanced connector configuration properties]
-* xref:debezium-{context}-connector-database-history-configuration-properties[Database history connector configuration properties] that control how {prodname} processes events that it reads from the database history topic.
-** xref:{context}-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties]
-* xref:debezium-{context}-connector-pass-through-database-driver-configuration-properties[Pass-through database driver properties] that control the behavior of the database driver.
+* xref:sqlserver-required-connector-configuration-properties[Required connector configuration properties]
+* xref:sqlserver-advanced-connector-configuration-properties[Advanced connector configuration properties]
+* xref:debezium-sqlserver-connector-database-history-configuration-properties[Database history connector configuration properties] that control how {prodname} processes events that it reads from the database history topic.
+** xref:sqlserver-pass-through-database-history-properties-for-configuring-producer-and-consumer-clients[Pass-through database history properties]
+* xref:debezium-sqlserver-connector-pass-through-database-driver-configuration-properties[Pass-through database driver properties] that control the behavior of the database driver.
 
-[id="{context}-required-connector-configuration-properties"]
+[id="sqlserver-required-connector-configuration-properties"]
 ==== Required {prodname} SQL Server connector configuration properties
 
 The following configuration properties are _required_ unless a default value is available.
@@ -2398,13 +2420,13 @@ When set to a value greater than zero, the connector uses the n-th LSN specified
 |Uses OPTION(RECOMPILE) query option to all SELECT statements used during an incremental snapshot. This can help to solve parameter sniffing issues that may occur but can cause increased CPU load on the source database, depending on the frequency of query execution.
 |===
 
-[id="debezium-{context}-connector-database-history-configuration-properties"]
-==== {prodname} connector database history configuration properties
+[id="debezium-sqlserver-connector-database-history-configuration-properties"]
+==== {prodname} SQL Server connector database history configuration properties
 
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 
-[id="debezium-{context}-connector-pass-through-database-driver-configuration-properties"]
-==== {prodname} connector pass-through database driver configuration properties
+[id="debezium-sqlserver-connector-pass-through-database-driver-configuration-properties"]
+==== {prodname} SQL Server connector pass-through database driver configuration properties
 
 include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-database-driver-configuration-properties.adoc[leveloffset=+1]
 
@@ -2589,14 +2611,14 @@ GO
 The {prodname} SQL Server connector provides three types of metrics that are in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect provide.
 The connector provides the following metrics:
 
-* {link-prefix}:{link-sqlserver-connector}#sqlserver-snapshot-metrics[Snapshot metrics] for monitoring the connector when performing snapshots.
-* {link-prefix}:{link-sqlserver-connector}#sqlserver-streaming-metrics[Streaming metrics] for monitoring the connector when reading CDC table data.
-* {link-prefix}:{link-sqlserver-connector}#sqlserver-schema-history-metrics[Schema history metrics] for monitoring the status of the connector's schema history.
+* xref:sqlserver-connector-snapshot-metrics[Snapshot metrics] for monitoring the connector when performing snapshots.
+* xref:sqlserver-connector-streaming-metrics[Streaming metrics] for monitoring the connector when reading CDC table data.
+* xref:sqlserver-connector-schema-history-metrics[Schema history metrics] for monitoring the status of the connector's schema history.
 
 For information about how to expose the preceding metrics through JMX, see the {link-prefix}:{link-debezium-monitoring}[{prodname} monitoring documentation].
 
 // Type: reference
-// ModuleID: debezium-sql-server-connector-snapshot-metrics
+// ModuleID: debezium-sqlserver-connector-snapshot-metrics
 // Title: {prodname} SQL Server connector snapshot metrics
 [[sqlserver-snapshot-metrics]]
 === Snapshot metrics
@@ -2606,7 +2628,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc[leveloffset=+1]
 
 // Type: reference
-// ModuleID: debezium-sql-server-connector-streaming-metrics
+// ModuleID: debezium-sqlserver-connector-streaming-metrics
 // Title: {prodname} SQL Server connector streaming metrics
 [[sqlserver-streaming-metrics]]
 === Streaming metrics
@@ -2614,7 +2636,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-increment
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 
 // Type: reference
-// ModuleID: debezium-sql-server-connector-schema-history-metrics
+// ModuleID: debezium-sqlserver-connector-schema-history-metrics
 // Title: {prodname} SQL Server connector schema history metrics
 [[sqlserver-schema-history-metrics]]
 === Schema history metrics

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2611,9 +2611,9 @@ GO
 The {prodname} SQL Server connector provides three types of metrics that are in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect provide.
 The connector provides the following metrics:
 
-* xref:sqlserver-connector-snapshot-metrics[Snapshot metrics] for monitoring the connector when performing snapshots.
-* xref:sqlserver-connector-streaming-metrics[Streaming metrics] for monitoring the connector when reading CDC table data.
-* xref:sqlserver-connector-schema-history-metrics[Schema history metrics] for monitoring the status of the connector's schema history.
+* xref:debezium-sqlserver-connector-snapshot-metrics[Snapshot metrics] for monitoring the connector when performing snapshots.
+* xref:debezium-sqlserver-connector-streaming-metrics[Streaming metrics] for monitoring the connector when reading CDC table data.
+* xref:debezium-sqlserver-connector-schema-history-metrics[Schema history metrics] for monitoring the status of the connector's schema history.
 
 For information about how to expose the preceding metrics through JMX, see the {link-prefix}:{link-debezium-monitoring}[{prodname} monitoring documentation].
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1713,12 +1713,6 @@ include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.a
 
 include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[leveloffset=+1]
 
-To deploy a {prodname} SQL Server connector, you add the connector files to Kafka Connect, create a custom container to run the connector, and then add connector configuration to your container.
-For details about deploying the {prodname} SQL Server connector, see the following topics:
-
-* xref:deploying-debezium-sqlserver-connectors[]
-* xref:descriptions-of-debezium-sqlserver-connector-configuration-properties[]
-
 // Type: procedure
 // ModuleID: deploying-debezium-sqlserver-connectors
 [[sql-server-deploying-a-connector]]
@@ -1917,7 +1911,7 @@ oc apply -f fulfillment-connector.yaml
 The preceding command registers `fulfillment-connector` and the connector starts to run against the `testDB` database as defined in the `KafkaConnector` CR.
 
 [id="verifying-that-the-debezium-sqlserver-connector-is-running"]
-=== Verifying that the connector is running
+=== Verifying that the {prodname} SQL Server connector is running
 include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deployment.adoc[leveloffset=+1]
 
 endif::product[]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
@@ -1,25 +1,3 @@
-////
-
-//Include in the deployment section that is conditionalized for [product]
-// You can use either of the following methods to deploy a {prodname} connector:
-//* Use {StreamsName} to automatically create a container image that includes the connector plug-in  This is the preferred method. [Links to Overview topic, which follows]
-//* Build a custom Kafka Connect container image from a Dockerfile.
-
-//.Additional resources
-//[Links to connector configuration properties]
-
-// Set the type to concept
-//(// Type: concept
-// Set the following ID
-//[id="overview-of-using-streams-to-deploy-a-debezium-<context>-connector"]
-The ID should explicitly specify the connector type vs. using the {context} variable
-// Add the following heading in the connector file.
-//=== Overview of using {StreamsName} to deploy a {prodname} {connector-name} connector
-// Follow the title with the following INCLUDE statement
-//include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc[leveloffset=+1]
-
-////
-
 Beginning with {prodname} 1.6, the preferred method for deploying a {prodname} connector is to use {StreamsName} to build a Kafka Connect container image that includes the connector plug-in.
 
 During the deployment process, you create and use the following custom resources (CRs):

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
@@ -1,0 +1,36 @@
+//Include in the deployment section that is conditionalized for [product]
+// Add under a concept heading in the connector file.
+
+Beginning with {prodname} 1.6, the preferred method for deploying a {prodname} connector is to create a `KafkaConnect` custom resource CR that includes the connector configuration,
+and then to use {StreamsName} to build a Kafka Connect container image that includes the connector plug-in automatically.
+You then apply a `KafkaConnector` CR to deploy the connector.
+
+To specify the connector to incorporate into the Kafka Connect image, you add it to the `build.plugins` configuration of the `KafkaConnect` custom resource,
+alongside the standard Kafka Connect configuration properties, such as the number of replicas and the name of the Kafka Connect server.
+
+You also add a `spec.build.output` parameter in the CR to specify where to store the resulting Kafka Connect container image.
+Container images can be stored in a Docker repository, or in an OpenShift ImageStream.
+To store images in an ImageStream, you must create the ImageStream manually before you deploy Kafka Connect.
+
+//For {StreamsName} to create the new image automatically, the build configuration requires `output` properties that specify a container registry to store the container newly built image, and `plugins` properties that list the connector plug-ins and their artifacts to add to the image.
+//You specify the connectors to include by adding the list of connector plug-ins and their artifacts to the `.spec.build.plugins` section of the `KafkaConnect` custom resource.
+
+When you build the Kafka Connect image, {kafka-streams} downloads the connector plug-in artifacts that you specify, and incorporates them into the `KafkaConnect` image.
+Optionally, for each connector plug-in, you can include other components that you want to use with the connector.
+For example, you can integrate service registry artifacts or the Debezium scripting component with a connector.
+
+After the Kafka Connect pod that contains your connector starts, you can start the connector by creating a `KafkaConnector` resource.
+The KafkaConnector CR specifies the connector configuration, which includes the following connection and deployment details:
+
+* Name of the cluster where you want to deploy the connector.
+* The database server name.
+* Host address and port for connecting to the database
+* The database account and password that the connector uses to connect to the database.
+
+NOTE: If you use a `KafkaConnect` resource to create a cluster, afterwards you cannot use the Kafka Connect REST API to create or update connectors.
+You can still use the REST API to retrieve information.
+
+.Additional resources
+
+* link:{LinkStreamsOpenShift}#proc-kafka-connect-config-str[Configuring Kafka Connect] in {NameStreamsOpenShift}.
+* link:{LinkDeployStreamsOpenShift}#creating-new-image-using-kafka-connect-build-str[Creating a new container image automatically using {StreamsName} in {NameDeployStreamsOpenShift}].

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
@@ -1,31 +1,43 @@
+////
+
 //Include in the deployment section that is conditionalized for [product]
-// Add under a concept heading in the connector file.
+// You can use either of the following methods to deploy a {prodname} connector:
+//* Use {StreamsName} to automatically create a container image that includes the connector plug-in  This is the preferred method. [Links to Overview topic, which follows]
+//* Build a custom Kafka Connect container image from a Dockerfile.
 
-Beginning with {prodname} 1.6, the preferred method for deploying a {prodname} connector is to create a `KafkaConnect` custom resource CR that includes the connector configuration,
-and then to use {StreamsName} to build a Kafka Connect container image that includes the connector plug-in automatically.
-You then apply a `KafkaConnector` CR to deploy the connector.
+//.Additional resources
+//[Links to connector configuration properties]
 
-To specify the connector to incorporate into the Kafka Connect image, you add it to the `build.plugins` configuration of the `KafkaConnect` custom resource,
-alongside the standard Kafka Connect configuration properties, such as the number of replicas and the name of the Kafka Connect server.
+// Set the type to concept
+//(// Type: concept
+// Set the following ID
+//[id="overview-of-using-streams-to-deploy-a-debezium-<context>-connector"]
+The ID should explicitly specify the connector type vs. using the {context} variable
+// Add the following heading in the connector file.
+//=== Overview of using {StreamsName} to deploy a {prodname} {connector-name} connector
+// Follow the title with the following INCLUDE statement
+//include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc[leveloffset=+1]
 
-You also add a `spec.build.output` parameter in the CR to specify where to store the resulting Kafka Connect container image.
-Container images can be stored in a Docker repository, or in an OpenShift ImageStream.
-To store images in an ImageStream, you must create the ImageStream manually before you deploy Kafka Connect.
+////
 
-//For {StreamsName} to create the new image automatically, the build configuration requires `output` properties that specify a container registry to store the container newly built image, and `plugins` properties that list the connector plug-ins and their artifacts to add to the image.
-//You specify the connectors to include by adding the list of connector plug-ins and their artifacts to the `.spec.build.plugins` section of the `KafkaConnect` custom resource.
+Beginning with {prodname} 1.6, the preferred method for deploying a {prodname} connector is to use {StreamsName} to build a Kafka Connect container image that includes the connector plug-in.
 
-When you build the Kafka Connect image, {kafka-streams} downloads the connector plug-in artifacts that you specify, and incorporates them into the `KafkaConnect` image.
-Optionally, for each connector plug-in, you can include other components that you want to use with the connector.
-For example, you can integrate service registry artifacts or the Debezium scripting component with a connector.
+During the deployment process, you create and use the following custom resources (CRs):
 
-After the Kafka Connect pod that contains your connector starts, you can start the connector by creating a `KafkaConnector` resource.
-The KafkaConnector CR specifies the connector configuration, which includes the following connection and deployment details:
+* A `KafkaConnect` CR that defines your Kafka Connect instance and includes information about the connector artifacts needs to include in the image.
+* A `KafkaConnector` CR that provides details that include information the connector uses to access the source database.
+  After {kafka-streams} starts the Kafka Connect pod, you start the connector by applying the `KafkaConnector` CR.
 
-* Name of the cluster where you want to deploy the connector.
-* The database server name.
-* Host address and port for connecting to the database
-* The database account and password that the connector uses to connect to the database.
+In the build specification for the Kafka Connect image, you can specify the connectors that are available to deploy.
+For each connector plug-in, you can also specify other components that you want to make available for deployment.
+For example, you can add {registry} artifacts, or the {prodname} scripting component.
+When {kafka-streams} builds the Kafka Connect image, it downloads the specified artifacts, and incorporates them into the image.
+
+The `spec.build.output` parameter in the `KafkaConnect` CR specifies where to store the resulting Kafka Connect container image.
+Container images can be stored in a Docker registry, or in an OpenShift ImageStream.
+To store images in an ImageStream, you must create the ImageStream before you deploy Kafka Connect.
+ImageStreams are not created automatically.
+
 
 NOTE: If you use a `KafkaConnect` resource to create a cluster, afterwards you cannot use the Kafka Connect REST API to create or update connectors.
 You can still use the REST API to retrieve information.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
@@ -1,4 +1,4 @@
-Beginning with {prodname} 1.6, the preferred method for deploying a {prodname} connector is to use {StreamsName} to build a Kafka Connect container image that includes the connector plug-in.
+Beginning with {prodname} 1.7, the preferred method for deploying a {prodname} connector is to use {StreamsName} to build a Kafka Connect container image that includes the connector plug-in.
 
 During the deployment process, you create and use the following custom resources (CRs):
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
@@ -1,28 +1,32 @@
 
 ////
-Add this content to the deployment section that is conditionalized for [product]
+Add the content in this file to the part of the Deployment section in each connector file that is conditionalized for [product]
 
-{prodname} provides the following methods for deploying a {prodname} connector:
 You can use either of the following methods to deploy a {prodname} connector:
 
-Confirm whether it's necessary to obtain JDBC drivers for Db2 and Oracle.
-The current downstream doc doesn't explicitly mention obtaining the Db2 driver. Is it part of the RH package?
-
-
 * xref:debezium-{context}-using-streams-to-deploy-a-connector[Use {StreamsName} to automatically create a container image that includes the connector plug-in]
-
++ This is the preferred method.
 * xref:deploying-debezium-{context}-connectors[Build a custom Kafka Connect container image from a Dockerfile].
+
+include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc[leveloffset=+1]
+
+include::{partialsdir}/modules/all-connectors/proc-connector-streams-deployment.adoc[leveloffset=+1]
+
+
+For Db2 and Oracle, customer must obtain JDBC drivers.
+WHere to insert that content.
+In the current downstream Db2 doc there's no mention of obtaining the Db2 driver, although the information is part of the upstream doc.
 
 // Insert the following anchor ID and title immediately after the bulleted list and add the connector name in place of <database>
 [id="using-streams-to-deploy-a-debezium-{context}-connector"]
-=== Using {StreamsName} to deploy a {prodname} <database> connector
+=== Using {StreamsName} to deploy a {prodname} {connector-name} connector
 // Follow the title with the following INCLUDE statement
 
 include::{partialsdir}/modules/all-connectors/proc-{context}-debezium-using-streams-to-deploy-a-connector.adoc
 ////
 
 When deploying {prodname} connectors on OpenShift, it's no longer necessary to first build your own Kafka Connect image.
-Rather, the preferred method for deploying connectors on OpenShift is to use a build configuration in {kafka-streams} to automatically build a Kafka Connect container image that includes the {prodname} connector plug-ins that you want to use.
+Instead, the preferred method for deploying connectors on OpenShift is to use a build configuration in {kafka-streams} to automatically build a Kafka Connect container image that includes the {prodname} connector plug-ins that you want to use.
 
 During the build process, the {kafka-streams} Operator transforms input parameters in a `KafkaConnect` custom resource, including {prodname} connector definitions, into a Kafka Connect container image.
 The build downloads the necessary artifacts from the Red Hat Maven repository or another configured HTTP server.
@@ -30,30 +34,27 @@ The newly created container is pushed to the container repository that is specif
 After {StreamsName} builds the Kafka Connect image, you create `KafkaConnector` custom resources to start the connectors that included in the build.
 
 .Prerequisites
-* You have administrator (?) access to an OpenShift cluster on which the cluster Operator is installed.
-* The {StreamsName} Operator is deployed and {StreamsName} is running.
-* A Kafka cluster is deployed as documented in link:{LinkDeployStreamsOpenShift}#kafka-cluster-str[{NameDeployStreamsOpenShift}].
+* You have access to an OpenShift cluster on which the cluster Operator is installed.
+* The {StreamsName} Operator is running.
+* An Apache Kafka cluster is deployed as documented in link:{LinkDeployStreamsOpenShift}#kafka-cluster-str[{NameDeployStreamsOpenShift}].
 * You have a {prodnamefull} license.
-* The OpenShift `oc` CLI client is installed.
-* You have access to the OpenShift Container Platform web console.
-* A source database is running on a server that is available to the OpenShift cluster.
-* You have one of the following:
-To store the build image for the connnector as a container in a container registry such as `quay.io` or `docker.io`::
+* The OpenShift `oc` CLI client is installed or you have access to the OpenShift Container Platform web console.
+* Depending on how you intend to store the Kafka Connect build image, you need registry permissions or you must create an ImageStream resource:
+To store the build image in an image registry, such as quay.io or Docker Hub:::
 +
-** An account and permissions to create and manage containers in the container registry.
-To store the build image for the connector as a native OpenShift ImageStream::
+** An account and permissions to create and manage images in the registry.
+To store the build image as a native OpenShift ImageStream::
 +
 ** An link:https://docs.openshift.com/container-platform/latest/openshift_images/images-understand.html#images-imagestream-use_images-understand[ImageStream] resource is deployed to the cluster.
 You must explicitly create an ImageStream for the cluster.
-ImageStreams are not created by default.
-
+ImageStreams are not available by default.
 
 .Procedure
 
 . Log in to the OpenShift cluster.
 . Create a new {prodname} `KafkaConnect` custom resource (CR) for the connector.
 For example, create a `KafkaConnect` CR that specifies the `metadata.annotations` and `spec.build` properties as shown xref:debezium-connector-deployment-kafka-connect-custom-resource[Example 1, window="_blank" rel="noopener noreferrer"].
-Save the file with the name `dbz-connect.yaml`.
+Save the file with a name such as `dbz-connect.yaml`.
 +
 [id="debezium-connector-deployment-kafka-connect-custom-resource"]
 .A `dbz-inventory-connector.yaml` file that defines a `KafkaConnect` custom resource that includes a {prodname} connector
@@ -76,9 +77,9 @@ spec:
       - name: debezium-connector-{connector-file}
         artifacts:
         - type: zip // <6>
-          url: {red-hat-maven-repository}/debezium/debezium-connector-{connector-file}/{debezium-version}-redhat-_<build_number>_/{debezium-version}-.zip  // <7>
+          url: {red-hat-maven-repository}/debezium/debezium-connector-{connector-file}/{debezium-version}-redhat-_<build_number>_/debezium-connector-{connector-file}-{debezium-version}.zip  // <7>
         - type: zip
-          url: {red-hat-maven-repository}/apicurio/apicurio-registry-distro-connect-converter/{registry-version}/apicurio-registry-distro-connect-converter-{registry-version}-converter.zip
+          url: {red-hat-maven-repository}/apicurio/apicurio-registry-distro-connect-converter/{registry-version}-redhat-_<build-number>_/apicurio-registry-distro-connect-converter-{registry-version}-redhat-_<build-number>.zip
         - type: zip
           url: {red-hat-maven-repository}/debezium/debezium-scripting/{debezium-version}/debezium-scripting-{debezium-version}.zip
 
@@ -93,28 +94,28 @@ spec:
 | Sets the `strimzi.io/use-connector-resources` annotation to `"true"` to enable the Cluster Operator to use `KafkaConnector` resources to configure connectors in this Kafka Connect cluster.
 
 |2
-|The `spec.build` configuration specifies where to output the container image and which plug-ins. The build configuration specifies the output location for storing the Kafka Connect image after it is built, and lists the plug-ins to include .
+|The `spec.build` configuration specifies where to store the build image and lists the plug-ins to include in the image, along with the location of the plug-in artifacts.
 
 |3
 |The `build.output` specifies the registry in which the newly built image is stored.
 
 |4
 |Specifies the name and image name for the image output.
-Valid values for `output.type` are `docker` to push into a container registry like Docker Hub or Quay, or `ImageStream` to push the image to an internal OpenShift registry.
-An ImageStream resource must be deployed to the cluster if you want to store the build image as a native OpenShift ImageStream rather than storing the image in a docker container.
+Valid values for `output.type` are `docker` to push into a container registry like Docker Hub or Quay, or `imagestream` to push the image to an internal OpenShift ImageStream.
+To use an ImageStream, an ImageStream resource must be deployed to the cluster.
 For more information about specifying the `build.output` in the KafkaConnect configuration, see the link:{LinkStreamsOpenShift}#type-Build-reference[{StreamsName} Build schema reference documentation].
 
 |5
 |The `plugins` configuration lists all of the connectors that you want to include in the Kafka Connect image.
-For each entry in the list you specify a plug-in `name`, and provide type and location information for the `artifacts` that are required to build the connector.
-Optionally, for each connector plug-in, you can include other components that you want to use with the connector.
-For example, you can add service registry artifacts, or the Debezium scripting component if you want to use these with a connector.
+For each entry in the list, specify a plug-in `name`, and information for about the artifacts that are required to build the connector.
+Optionally, for each connector plug-in, you can include other components that you want to be available for use with the connector.
+For example, you can add Service Registry artifacts, or the {prodname} scripting component.
 
 |6
 |The value of `artifacts.type` specifies the file type of the artifact specified in the `artifacts.url`.
 Valid types are `zip`, `tgz`, or `jar`.
-{prodname} connector archives are provided in `zip` file format.
-JDBC driver files are in JAR format.
+{prodname} connector archives are provided in `.zip` file format.
+JDBC driver files are in `.jar` format.
 The `type` value must match the type of the file that is referenced in the `url` field.
 
 |7
@@ -132,12 +133,11 @@ oc create -f dbz-connect.yaml
 ----
 +
 Based on the configuration specified in the custom resource, the Streams Operator prepares a Kafka Connect image to deploy. +
-After the build completes, it pushes the image to the specified container registry or ImageStream.
-A Kafka Connect pod is started.
-The pod includes the connectors that you listed in the configuration.
+After the build completes, the Operator pushes the image to the specified registry or ImageStream, and starts the Kafka Connect cluster.
+The connector artifacts that you listed in the configuration are available in the cluster.
 
-. After the Kafka Connect connect pod starts, create a `KafkaConnector` resource to start the connector. +
-For example, create the following `KafkaConnector` CR and save it as `{context}-inventory-connector.yaml`
+. Create a `KafkaConnector` resource to define an instance of each connector that you want to deploy. +
+For example, create the following `KafkaConnector` CR, and save it as `{context}-inventory-connector.yaml`
 +
 [id="debezium-connector-deployment-kafkaconnector-custom-resource"]
 .A `{context}-inventory-connector.yaml` file that defines the `KafkaConnector` custom resource for a {prodname} connector
@@ -210,6 +210,22 @@ The namespace is also used in the names of related Kafka Connect schemas, and th
 |The list of tables from which the connector captures change events.
 
 |===
+
+. Create the connector resource by running the following command:
++
+[source,shell,options="nowrap"]
+----
+oc create -n <namespace> -f _<kafkaConnector>_.yaml
+----
++
+For example,
++
+[source,shell,options="nowrap"]
+----
+oc create -n debezium-docs -f dbz-connect.yaml
+----
 +
 The connector is registered to the Kafka Connect cluster and starts to run against the database that is specified by `spec.config.database.dbname` in the `KafkaConnector` CR.
 After the connector pod is ready, {prodname} is running.
+
+For information about verifying the connector, see xref:[Verifying the connector deployment]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
@@ -1,0 +1,215 @@
+
+////
+Add this content to the deployment section that is conditionalized for [product]
+
+{prodname} provides the following methods for deploying a {prodname} connector:
+You can use either of the following methods to deploy a {prodname} connector:
+
+Confirm whether it's necessary to obtain JDBC drivers for Db2 and Oracle.
+The current downstream doc doesn't explicitly mention obtaining the Db2 driver. Is it part of the RH package?
+
+
+* xref:debezium-{context}-using-streams-to-deploy-a-connector[Use {StreamsName} to automatically create a container image that includes the connector plug-in]
+
+* xref:deploying-debezium-{context}-connectors[Build a custom Kafka Connect container image from a Dockerfile].
+
+// Insert the following anchor ID and title immediately after the bulleted list and add the connector name in place of <database>
+[id="using-streams-to-deploy-a-debezium-{context}-connector"]
+=== Using {StreamsName} to deploy a {prodname} <database> connector
+// Follow the title with the following INCLUDE statement
+
+include::{partialsdir}/modules/all-connectors/proc-{context}-debezium-using-streams-to-deploy-a-connector.adoc
+////
+
+When deploying {prodname} connectors on OpenShift, it's no longer necessary to first build your own Kafka Connect image.
+Rather, the preferred method for deploying connectors on OpenShift is to use a build configuration in {kafka-streams} to automatically build a Kafka Connect container image that includes the {prodname} connector plug-ins that you want to use.
+
+During the build process, the {kafka-streams} Operator transforms input parameters in a `KafkaConnect` custom resource, including {prodname} connector definitions, into a Kafka Connect container image.
+The build downloads the necessary artifacts from the Red Hat Maven repository or another configured HTTP server.
+The newly created container is pushed to the container repository that is specified in `.spec.build.output`, and is used to deploy a Kafka Connect pod.
+After {StreamsName} builds the Kafka Connect image, you create `KafkaConnector` custom resources to start the connectors that included in the build.
+
+.Prerequisites
+* You have administrator (?) access to an OpenShift cluster on which the cluster Operator is installed.
+* The {StreamsName} Operator is deployed and {StreamsName} is running.
+* A Kafka cluster is deployed as documented in link:{LinkDeployStreamsOpenShift}#kafka-cluster-str[{NameDeployStreamsOpenShift}].
+* You have a {prodnamefull} license.
+* The OpenShift `oc` CLI client is installed.
+* You have access to the OpenShift Container Platform web console.
+* A source database is running on a server that is available to the OpenShift cluster.
+* You have one of the following:
+To store the build image for the connnector as a container in a container registry such as `quay.io` or `docker.io`::
++
+** An account and permissions to create and manage containers in the container registry.
+To store the build image for the connector as a native OpenShift ImageStream::
++
+** An link:https://docs.openshift.com/container-platform/latest/openshift_images/images-understand.html#images-imagestream-use_images-understand[ImageStream] resource is deployed to the cluster.
+You must explicitly create an ImageStream for the cluster.
+ImageStreams are not created by default.
+
+
+.Procedure
+
+. Log in to the OpenShift cluster.
+. Create a new {prodname} `KafkaConnect` custom resource (CR) for the connector.
+For example, create a `KafkaConnect` CR that specifies the `metadata.annotations` and `spec.build` properties as shown xref:debezium-connector-deployment-kafka-connect-custom-resource[Example 1, window="_blank" rel="noopener noreferrer"].
+Save the file with the name `dbz-connect.yaml`.
++
+[id="debezium-connector-deployment-kafka-connect-custom-resource"]
+.A `dbz-inventory-connector.yaml` file that defines a `KafkaConnect` custom resource that includes a {prodname} connector
+=====================================================================
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnect
+metadata:
+    name: debezium-kafka-connect-cluster
+    annotations:
+        strimzi.io/use-connector-resources: "true" // <1>
+spec:
+    version: 3.00
+    build: // <2>
+      output: // <3>
+      type: imagestream  // <4>
+      image: debezium-streams-connect:latest
+      plugins: // <5>
+      - name: debezium-connector-{connector-file}
+        artifacts:
+        - type: zip // <6>
+          url: {red-hat-maven-repository}/debezium/debezium-connector-{connector-file}/{debezium-version}-redhat-_<build_number>_/{debezium-version}-.zip  // <7>
+        - type: zip
+          url: {red-hat-maven-repository}/apicurio/apicurio-registry-distro-connect-converter/{registry-version}/apicurio-registry-distro-connect-converter-{registry-version}-converter.zip
+        - type: zip
+          url: {red-hat-maven-repository}/debezium/debezium-scripting/{debezium-version}/debezium-scripting-{debezium-version}.zip
+
+  bootstrapServers: debezium-kafka-cluster-kafka-bootstrap:9093
+----
+.Descriptions of Kafka Connect configuration settings
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+| Sets the `strimzi.io/use-connector-resources` annotation to `"true"` to enable the Cluster Operator to use `KafkaConnector` resources to configure connectors in this Kafka Connect cluster.
+
+|2
+|The `spec.build` configuration specifies where to output the container image and which plug-ins. The build configuration specifies the output location for storing the Kafka Connect image after it is built, and lists the plug-ins to include .
+
+|3
+|The `build.output` specifies the registry in which the newly built image is stored.
+
+|4
+|Specifies the name and image name for the image output.
+Valid values for `output.type` are `docker` to push into a container registry like Docker Hub or Quay, or `ImageStream` to push the image to an internal OpenShift registry.
+An ImageStream resource must be deployed to the cluster if you want to store the build image as a native OpenShift ImageStream rather than storing the image in a docker container.
+For more information about specifying the `build.output` in the KafkaConnect configuration, see the link:{LinkStreamsOpenShift}#type-Build-reference[{StreamsName} Build schema reference documentation].
+
+|5
+|The `plugins` configuration lists all of the connectors that you want to include in the Kafka Connect image.
+For each entry in the list you specify a plug-in `name`, and provide type and location information for the `artifacts` that are required to build the connector.
+Optionally, for each connector plug-in, you can include other components that you want to use with the connector.
+For example, you can add service registry artifacts, or the Debezium scripting component if you want to use these with a connector.
+
+|6
+|The value of `artifacts.type` specifies the file type of the artifact specified in the `artifacts.url`.
+Valid types are `zip`, `tgz`, or `jar`.
+{prodname} connector archives are provided in `zip` file format.
+JDBC driver files are in JAR format.
+The `type` value must match the type of the file that is referenced in the `url` field.
+
+|7
+|The value of `artifacts.url` specifies the address of an HTTP server, such as a Maven repository, that stores the file for the connector artifact.
+The OpenShift cluster must have access to the specified server.
+
+|===
+=====================================================================
+
+. Apply the `KafkaConnect` build specification to the OpenShift cluster by entering the following command:
++
+[source,shell,options="nowrap"]
+----
+oc create -f dbz-connect.yaml
+----
++
+Based on the configuration specified in the custom resource, the Streams Operator prepares a Kafka Connect image to deploy. +
+After the build completes, it pushes the image to the specified container registry or ImageStream.
+A Kafka Connect pod is started.
+The pod includes the connectors that you listed in the configuration.
+
+. After the Kafka Connect connect pod starts, create a `KafkaConnector` resource to start the connector. +
+For example, create the following `KafkaConnector` CR and save it as `{context}-inventory-connector.yaml`
++
+[id="debezium-connector-deployment-kafkaconnector-custom-resource"]
+.A `{context}-inventory-connector.yaml` file that defines the `KafkaConnector` custom resource for a {prodname} connector
+=====================================================================
+
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnector
+metadata:
+  labels:
+    strimzi.io/cluster: debezium-kafka-connect-cluster
+  name: inventory-connector-{context} // <1>
+spec:
+  class: io.debezium.connector.{context}.{connector-class}Connector // <2>
+  tasksMax: 1  // <3>
+  config:  // <4>
+    database.history.kafka.bootstrap.servers: 'debezium-kafka-cluster-kafka-bootstrap.debezium.svc.cluster.local:9092'
+    database.history.kafka.topic: schema-changes.inventory
+    database.hostname: {context}.debezium-{context}.svc.cluster.local // <5>
+    database.port: 3306   // <6>
+    database.user: debezium  // <7>
+    database.password: dbz  // <8>
+    database.dbname: mydatabase // <9>
+    database.server.name: inventory_connector_{context} // <10>
+    database.include.list: public.inventory  // <11>
+----
+
+=====================================================================
++
+.Descriptions of connector configuration settings
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|The name of the connector to register with the Kafka Connect cluster.
+
+|2
+|The name of the connector class.
+
+|3
+|The number of tasks that can operate concurrently.
+
+|4
+|The connector’s configuration.
+
+|5
+|The address of the host database instance.
+
+|6
+|The port number of the database instance.
+
+|7
+|The name of the user account through which {prodname} connects to the database.
+
+|8
+|The password for the database user account.
+
+|9
+|The name of the database to capture changes from.
+
+|10
+|The logical name of the database instance or cluster. +
+The specified name must be formed only from alphanumeric characters or underscores. +
+Because the logical name is used as the prefix for any Kafka topics that receive change events from this connector, the name must be unique among the connectors in the cluster. +
+The namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the {link-prefix}:{link-avro-serialization}[Avro connector].
+
+|11
+|The list of tables from which the connector captures change events.
+
+|===
++
+The connector is registered to the Kafka Connect cluster and starts to run against the database that is specified by `spec.config.database.dbname` in the `KafkaConnector` CR.
+After the connector pod is ready, {prodname} is running.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
@@ -31,7 +31,7 @@ Save the file with a name such as `dbz-connect.yaml`.
 +
 .A `dbz-inventory-connector.yaml` file that defines a `KafkaConnect` custom resource that includes a {prodname} connector
 =====================================================================
-[source,yaml,subs="+attributes"]
+[source,yaml,subs="+attributes,+quotes"]
 ----
 apiVersion: {KafkaConnectApiVersion}
 kind: KafkaConnect
@@ -49,11 +49,11 @@ spec:
       - name: debezium-connector-{connector-file}
         artifacts:
         - type: zip // <6>
-          url: {red-hat-maven-repository}/debezium/debezium-connector-{connector-file}/{debezium-version}-redhat-_<build_number>_/debezium-connector-{connector-file}-{debezium-version}.zip  // <7>
+          url: {red-hat-maven-repository}debezium/debezium-connector-{connector-file}/{debezium-version}-redhat-__<build_number>__/debezium-connector-{connector-file}-{debezium-version}.zip  // <7>
         - type: zip
-          url: {red-hat-maven-repository}/apicurio/apicurio-registry-distro-connect-converter/{registry-version}-redhat-_<build-number>_/apicurio-registry-distro-connect-converter-{registry-version}-redhat-_<build-number>.zip
+          url: {red-hat-maven-repository}apicurio/apicurio-registry-distro-connect-converter/{registry-version}-redhat-_<build-number>_/apicurio-registry-distro-connect-converter-{registry-version}-redhat-_<build-number>_.zip
         - type: zip
-          url: {red-hat-maven-repository}/debezium/debezium-scripting/{debezium-version}/debezium-scripting-{debezium-version}.zip
+          url: {red-hat-maven-repository}debezium/debezium-scripting/{debezium-version}/debezium-scripting-{debezium-version}.zip
 
   bootstrapServers: debezium-kafka-cluster-kafka-bootstrap:9093
 ----
@@ -198,3 +198,5 @@ oc create -n debezium-docs -f dbz-connect.yaml
 +
 The connector is registered to the Kafka Connect cluster and starts to run against the database that is specified by `spec.config.database.dbname` in the `KafkaConnector` CR.
 After the connector pod is ready, {prodname} is running.
+
+You are now ready to xref:verifying-that-the-debezium-{context}-connector-is-running[verify the {prodname}{connector-name} deployment].

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
@@ -3,7 +3,7 @@ Instead, the preferred method for deploying connectors on OpenShift is to use a 
 
 During the build process, the {kafka-streams} Operator transforms input parameters in a `KafkaConnect` custom resource, including {prodname} connector definitions, into a Kafka Connect container image.
 The build downloads the necessary artifacts from the Red Hat Maven repository or another configured HTTP server.
-The newly created container is pushed to the container repository that is specified in `.spec.build.output`, and is used to deploy a Kafka Connect pod.
+The newly created container is pushed to the container registry that is specified in `.spec.build.output`, and is used to deploy a Kafka Connect pod.
 After {StreamsName} builds the Kafka Connect image, you create `KafkaConnector` custom resources to start the connectors that included in the build.
 
 .Prerequisites

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
@@ -199,4 +199,4 @@ oc create -n debezium-docs -f dbz-connect.yaml
 The connector is registered to the Kafka Connect cluster and starts to run against the database that is specified by `spec.config.database.dbname` in the `KafkaConnector` CR.
 After the connector pod is ready, {prodname} is running.
 
-You are now ready to xref:verifying-that-the-debezium-{context}-connector-is-running[verify the {prodname}{connector-name} deployment].
+You are now ready to xref:verifying-that-the-debezium-{context}-connector-is-running[verify the {prodname} {connector-name} deployment].

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
@@ -1,30 +1,3 @@
-
-////
-Add the content in this file to the part of the Deployment section in each connector file that is conditionalized for [product]
-
-You can use either of the following methods to deploy a {prodname} connector:
-
-* xref:debezium-{context}-using-streams-to-deploy-a-connector[Use {StreamsName} to automatically create a container image that includes the connector plug-in]
-+ This is the preferred method.
-* xref:deploying-debezium-{context}-connectors[Build a custom Kafka Connect container image from a Dockerfile].
-
-include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.adoc[leveloffset=+1]
-
-include::{partialsdir}/modules/all-connectors/proc-connector-streams-deployment.adoc[leveloffset=+1]
-
-
-For Db2 and Oracle, customer must obtain JDBC drivers.
-WHere to insert that content.
-In the current downstream Db2 doc there's no mention of obtaining the Db2 driver, although the information is part of the upstream doc.
-
-// Insert the following anchor ID and title immediately after the bulleted list and add the connector name in place of <database>
-[id="using-streams-to-deploy-a-debezium-{context}-connector"]
-=== Using {StreamsName} to deploy a {prodname} {connector-name} connector
-// Follow the title with the following INCLUDE statement
-
-include::{partialsdir}/modules/all-connectors/proc-{context}-debezium-using-streams-to-deploy-a-connector.adoc
-////
-
 When deploying {prodname} connectors on OpenShift, it's no longer necessary to first build your own Kafka Connect image.
 Instead, the preferred method for deploying connectors on OpenShift is to use a build configuration in {kafka-streams} to automatically build a Kafka Connect container image that includes the {prodname} connector plug-ins that you want to use.
 
@@ -40,11 +13,11 @@ After {StreamsName} builds the Kafka Connect image, you create `KafkaConnector` 
 * You have a {prodnamefull} license.
 * The OpenShift `oc` CLI client is installed or you have access to the OpenShift Container Platform web console.
 * Depending on how you intend to store the Kafka Connect build image, you need registry permissions or you must create an ImageStream resource:
-To store the build image in an image registry, such as quay.io or Docker Hub:::
 +
+To store the build image in an image registry, such as Red Hat Quay.io or Docker Hub::
 ** An account and permissions to create and manage images in the registry.
+
 To store the build image as a native OpenShift ImageStream::
-+
 ** An link:https://docs.openshift.com/container-platform/latest/openshift_images/images-understand.html#images-imagestream-use_images-understand[ImageStream] resource is deployed to the cluster.
 You must explicitly create an ImageStream for the cluster.
 ImageStreams are not available by default.
@@ -53,10 +26,9 @@ ImageStreams are not available by default.
 
 . Log in to the OpenShift cluster.
 . Create a new {prodname} `KafkaConnect` custom resource (CR) for the connector.
-For example, create a `KafkaConnect` CR that specifies the `metadata.annotations` and `spec.build` properties as shown xref:debezium-connector-deployment-kafka-connect-custom-resource[Example 1, window="_blank" rel="noopener noreferrer"].
+For example, create a `KafkaConnect` CR that specifies the `metadata.annotations` and `spec.build` properties, as shown in the following example.
 Save the file with a name such as `dbz-connect.yaml`.
 +
-[id="debezium-connector-deployment-kafka-connect-custom-resource"]
 .A `dbz-inventory-connector.yaml` file that defines a `KafkaConnect` custom resource that includes a {prodname} connector
 =====================================================================
 [source,yaml,subs="+attributes"]
@@ -139,7 +111,6 @@ The connector artifacts that you listed in the configuration are available in th
 . Create a `KafkaConnector` resource to define an instance of each connector that you want to deploy. +
 For example, create the following `KafkaConnector` CR, and save it as `{context}-inventory-connector.yaml`
 +
-[id="debezium-connector-deployment-kafkaconnector-custom-resource"]
 .A `{context}-inventory-connector.yaml` file that defines the `KafkaConnector` custom resource for a {prodname} connector
 =====================================================================
 
@@ -213,9 +184,9 @@ The namespace is also used in the names of related Kafka Connect schemas, and th
 
 . Create the connector resource by running the following command:
 +
-[source,shell,options="nowrap"]
+[source,shell,options="nowrap", subs="+attributes,+quotes"]
 ----
-oc create -n <namespace> -f _<kafkaConnector>_.yaml
+oc create -n __<namespace>__ -f __<kafkaConnector>__.yaml
 ----
 +
 For example,
@@ -227,5 +198,3 @@ oc create -n debezium-docs -f dbz-connect.yaml
 +
 The connector is registered to the Kafka Connect cluster and starts to run against the database that is specified by `spec.config.database.dbname` in the `KafkaConnector` CR.
 After the connector pod is ready, {prodname} is running.
-
-For information about verifying the connector, see xref:[Verifying the connector deployment]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
@@ -48,33 +48,9 @@ Labels:       strimzi.io/cluster=debezium-kafka-connect-cluster
 Annotations:  <none>
 API Version:  kafka.strimzi.io/v1beta2
 Kind:         KafkaConnector
-Metadata:
-  Creation Timestamp:  2021-12-08T16:20:30Z
-  Generation:          1
-  Managed Fields:
-    API Version:  kafka.strimzi.io/v1beta2
-    Fields Type:  FieldsV1
-    fieldsV1:
-      f:status:
-        f:conditions:
-        f:topics:
-    Manager:         okhttp
-    Operation:       Update
-    Time:            2021-12-08T17:41:34Z
-  Resource Version:  996714
-  Self Link:         /apis/kafka.strimzi.io/v1beta2/namespaces/debezium/kafkaconnectors/inventory-connector-{context}
-  UID:               53390480-9e04-4415-8999-43bc9d072d54
-Spec:
-  Class:  io.debezium.connector.{context}.{connector-class}Connector
-  Config:
-    database.history.kafka.bootstrap.servers:  debezium-kafka-cluster-kafka-bootstrap.debezium.svc.cluster.local:9092
-    database.history.kafka.topic:              schema-changes.inventory
-    database.hostname:                         {context}.debezium-{context}.svc.cluster.local
-    database.password:                         xxx
-    database.port:                             3306
-    database.server.name:                      inventory_connector_{context}
-    database.user:                             debezium
-  Tasks Max:                                   1
+
+...
+
 Status:
   Conditions:
     Last Transition Time:  2021-12-08T17:41:34.897153Z

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
@@ -1,3 +1,10 @@
+////
+Insert this content after the legacy deployment instructions, in place of the verification steps.
+// Add the following ID and title
+// [id="verifying-that-the-debezium-<connector-name>-connector-is-running"]
+// == Verifying that the {prodname}{connector-name} connector is running
+//include::{partialsdir}/modules/all-connectors/proc-verifying-the-debezium-connector-deployment.adoc
+////
 If the connector starts correctly without errors, it creates a topic for each table that the connector is configured to capture.
 Downstream applications can subscribe to these topics to retrieve information events that occur in the source database.
 
@@ -17,7 +24,7 @@ To verify that the connector is running, perform the following operations from t
 * From the OpenShift Container Platform web console:
 .. Navigate to *Home -> Search*.
 .. On the *Search* page, click *Resources* to open the *Select Resource* box, and then type `*KafkaConnector*`.
-.. From the *KafkaConnectors* list, click the name of the connector that you want to check, for example *inventory-connector-mysql*.
+.. From the *KafkaConnectors* list, click the name of the connector that you want to check, for example *inventory-connector-{context}*.
 .. In the *Conditions* section, verify that the values in the *Type* and *Status* columns are set to *Ready* and *True*.
 +
 * From a terminal window:
@@ -30,17 +37,18 @@ oc describe KafkaConnector _<connector-name>_ -n _<project>_
 +
 For example,
 +
-[source,shell,options="nowrap"]
+[source,shell,options="nowrap",subs="+attributes,quotes"]
 ----
-oc describe KafkaConnector inventory-connector-mysql -n debezium
+oc describe KafkaConnector inventory-connector-{context} -n debezium
 ----
 +
 The command returns status information that is similar to the following output:
 +
 .`KafkaConnector` resource status
 ======================================
+[source,shell,options="nowrap",subs="+attributes,quotes"]
 ----
-Name:         inventory-connector-mysql
+Name:         inventory-connector-{context}
 Namespace:    debezium
 Labels:       strimzi.io/cluster=debezium-kafka-connect-cluster
 Annotations:  <none>
@@ -60,17 +68,17 @@ Metadata:
     Operation:       Update
     Time:            2021-12-08T17:41:34Z
   Resource Version:  996714
-  Self Link:         /apis/kafka.strimzi.io/v1beta2/namespaces/debezium/kafkaconnectors/inventory-connector-mysql
+  Self Link:         /apis/kafka.strimzi.io/v1beta2/namespaces/debezium/kafkaconnectors/inventory-connector-{context}
   UID:               53390480-9e04-4415-8999-43bc9d072d54
 Spec:
-  Class:  io.debezium.connector.mysql.MySqlConnector
+  Class:  io.debezium.connector.{context}.{connector-class}Connector
   Config:
     database.history.kafka.bootstrap.servers:  debezium-kafka-cluster-kafka-bootstrap.debezium.svc.cluster.local:9092
     database.history.kafka.topic:              schema-changes.inventory
-    database.hostname:                         mysql.debezium-mysql.svc.cluster.local
+    database.hostname:                         {context}.debezium-{context}.svc.cluster.local
     database.password:                         xxx
     database.port:                             3306
-    database.server.name:                      inventory_connector_mysql
+    database.server.name:                      inventory_connector_{context}
     database.user:                             debezium
   Tasks Max:                                   1
 Status:
@@ -82,7 +90,7 @@ Status:
     Connector:
       State:      RUNNING
       worker_id:  10.131.1.124:8083
-    Name:         inventory-connector-mysql
+    Name:         inventory-connector-{context}
     Tasks:
       Id:               0
       State:            RUNNING
@@ -91,13 +99,13 @@ Status:
   Observed Generation:  1
   Tasks Max:            1
   Topics:
-    inventory_connector_mysql
-    inventory_connector_mysql.inventory.addresses
-    inventory_connector_mysql.inventory.customers
-    inventory_connector_mysql.inventory.geom
-    inventory_connector_mysql.inventory.orders
-    inventory_connector_mysql.inventory.products
-    inventory_connector_mysql.inventory.products_on_hand
+    inventory_connector_{context}
+    inventory_connector_{context}.inventory.addresses
+    inventory_connector_{context}.inventory.customers
+    inventory_connector_{context}.inventory.geom
+    inventory_connector_{context}.inventory.orders
+    inventory_connector_{context}.inventory.products
+    inventory_connector_{context}.inventory.products_on_hand
 Events:  <none>
 ----
 ======================================
@@ -106,7 +114,7 @@ Events:  <none>
   * From the OpenShift Container Platform web console.
   .. Navigate to *Home -> Search*.
   .. On the *Search* page, click *Resources* to open the *Select Resource* box, and then type `*KafkaTopic*`.
-  .. From the *KafkaTopics* list, click the name of the topic that you want to check, for example, *inventory-connector-mysql.inventory.orders---ac5e98ac6a5d91e04d8ec0dc9078a1ece439081d*.
+  .. From the *KafkaTopics* list, click the name of the topic that you want to check, for example, *inventory-connector-{context}.inventory.orders---ac5e98ac6a5d91e04d8ec0dc9078a1ece439081d*.
   .. In the *Conditions* section, verify that the values in the *Type* and *Status* columns are set to *Ready* and *True*.
   * From a terminal window:
   .. Enter the following command:
@@ -120,20 +128,20 @@ The command returns status information that is similar to the following output:
 +
 .`KafkaTopic` resource status
 ======================================
-[source,options="nowrap"]
+[source,options="nowrap",subs="+attributes"]
 ----
 NAME                                                                                                   CLUSTER             PARTITIONS   REPLICATION FACTOR   READY
 connect-cluster-configs                                                                           debezium-kafka-cluster   1            1                    True
 connect-cluster-offsets                                                                           debezium-kafka-cluster   25           1                    True
 connect-cluster-status                                                                            debezium-kafka-cluster   5            1                    True
 consumer-offsets---84e7a678d08f4bd226872e5cdd4eb527fadc1c6a                                       debezium-kafka-cluster   50           1                    True
-inventory-connector-mysql---a96f69b23d6118ff415f772679da623fbbb99421                              debezium-kafka-cluster   1            1                    True
-inventory-connector-mysql.inventory.addresses---1b6beaf7b2eb57d177d92be90ca2b210c9a56480          debezium-kafka-cluster   1            1                    True
-inventory-connector-mysql.inventory.customers---9931e04ec92ecc0924f4406af3fdace7545c483b          debezium-kafka-cluster   1            1                    True
-inventory-connector-mysql.inventory.geom---9f7e136091f071bf49ca59bf99e86c713ee58dd5               debezium-kafka-cluster   1            1                    True
-inventory-connector-mysql.inventory.orders---ac5e98ac6a5d91e04d8ec0dc9078a1ece439081d             debezium-kafka-cluster   1            1                    True
-inventory-connector-mysql.inventory.products---df0746db116844cee2297fab611c21b56f82dcef           debezium-kafka-cluster   1            1                    True
-inventory-connector-mysql.inventory.products-on-hand---8649e0f17ffcc9212e266e31a7aeea4585e5c6b5   debezium-kafka-cluster   1            1                    True
+inventory-connector-{context}---a96f69b23d6118ff415f772679da623fbbb99421                              debezium-kafka-cluster   1            1                    True
+inventory-connector-{context}.inventory.addresses---1b6beaf7b2eb57d177d92be90ca2b210c9a56480          debezium-kafka-cluster   1            1                    True
+inventory-connector-{context}.inventory.customers---9931e04ec92ecc0924f4406af3fdace7545c483b          debezium-kafka-cluster   1            1                    True
+inventory-connector-{context}.inventory.geom---9f7e136091f071bf49ca59bf99e86c713ee58dd5               debezium-kafka-cluster   1            1                    True
+inventory-connector-{context}.inventory.orders---ac5e98ac6a5d91e04d8ec0dc9078a1ece439081d             debezium-kafka-cluster   1            1                    True
+inventory-connector-{context}.inventory.products---df0746db116844cee2297fab611c21b56f82dcef           debezium-kafka-cluster   1            1                    True
+inventory-connector-{context}.inventory.products-on-hand---8649e0f17ffcc9212e266e31a7aeea4585e5c6b5   debezium-kafka-cluster   1            1                    True
 schema-changes.inventory                                                                          debezium-kafka-cluster   1            1                    True
 strimzi-store-topic---effb8e3e057afce1ecf67c3f5d8e4e3ff177fc55                                    debezium-kafka-cluster   1            1                    True
 strimzi-topic-operator-kstreams-topic-store-changelog---b75e702040b99be8a9263134de3507fc0cc4017b  debezium-kafka-cluster   1            1                    True
@@ -155,23 +163,24 @@ oc exec -n __<project>__  -it _<kafka-cluster>_ -- /opt/kafka/bin/kafka-console-
 +
 For example,
 +
+[source,shell,options="nowrap",subs="+attributes,quotes"]
 ----
  oc exec -n debezium  -it debezium-kafka-cluster-kafka-0 -- /opt/kafka/bin/kafka-console-consumer.sh \
 >     --bootstrap-server localhost:9092 \
 >     --from-beginning \
 >     --property print.key=true \
->     --topic=inventory_connector_mysql.inventory.products_on_hand
+>     --topic=inventory_connector_{context}.inventory.products_on_hand
 ----
 +
-The format for specifying the topic name is the same as the `oc describe` command returns in Step 1, for example, `inventory_connector_mysql.inventory.addresses`.
+The format for specifying the topic name is the same as the `oc describe` command returns in Step 1, for example, `inventory_connector_{context}.inventory.addresses`.
 +
 For each event in the topic, the command returns information that is similar to the following output:
 +
 .Content of a {prodname} change event
 ======================================
-[source,subs="+quotes"]
+[source,subs="+attributes,quotes"]
 ----
-{"schema":{"type":"struct","fields":[{"type":"int32","optional":false,"field":"product_id"}],"optional":false,"name":"inventory_connector_mysql.inventory.products_on_hand.Key"},"payload":{"product_id":101}}	{"schema":{"type":"struct","fields":[{"type":"struct","fields":[{"type":"int32","optional":false,"field":"product_id"},{"type":"int32","optional":false,"field":"quantity"}],"optional":true,"name":"inventory_connector_mysql.inventory.products_on_hand.Value","field":"before"},{"type":"struct","fields":[{"type":"int32","optional":false,"field":"product_id"},{"type":"int32","optional":false,"field":"quantity"}],"optional":true,"name":"inventory_connector_mysql.inventory.products_on_hand.Value","field":"after"},{"type":"struct","fields":[{"type":"string","optional":false,"field":"version"},{"type":"string","optional":false,"field":"connector"},{"type":"string","optional":false,"field":"name"},{"type":"int64","optional":false,"field":"ts_ms"},{"type":"string","optional":true,"name":"io.debezium.data.Enum","version":1,"parameters":{"allowed":"true,last,false"},"default":"false","field":"snapshot"},{"type":"string","optional":false,"field":"db"},{"type":"string","optional":true,"field":"sequence"},{"type":"string","optional":true,"field":"table"},{"type":"int64","optional":false,"field":"server_id"},{"type":"string","optional":true,"field":"gtid"},{"type":"string","optional":false,"field":"file"},{"type":"int64","optional":false,"field":"pos"},{"type":"int32","optional":false,"field":"row"},{"type":"int64","optional":true,"field":"thread"},{"type":"string","optional":true,"field":"query"}],"optional":false,"name":"io.debezium.connector.mysql.Source","field":"source"},{"type":"string","optional":false,"field":"op"},{"type":"int64","optional":true,"field":"ts_ms"},{"type":"struct","fields":[{"type":"string","optional":false,"field":"id"},{"type":"int64","optional":false,"field":"total_order"},{"type":"int64","optional":false,"field":"data_collection_order"}],"optional":true,"field":"transaction"}],"optional":false,"name":**"inventory_connector_mysql.inventory.products_on_hand.Envelope"**},*"payload"*:{*"before"*:**null**,*"after"*:{*"product_id":101,"quantity":3*},"source":{"version":"1.6.4.Final-redhat-00001","connector":"mysql","name":"inventory_connector_mysql","ts_ms":1638985247805,"snapshot":"true","db":"inventory","sequence":null,"table":"products_on_hand","server_id":0,"gtid":null,"file":"mysql-bin.000003","pos":156,"row":0,"thread":null,"query":null},*"op"*:**"r"**,"ts_ms":1638985247805,"transaction":null}}
+{"schema":{"type":"struct","fields":[{"type":"int32","optional":false,"field":"product_id"}],"optional":false,"name":"inventory_connector_{context}.inventory.products_on_hand.Key"},"payload":{"product_id":101}}	{"schema":{"type":"struct","fields":[{"type":"struct","fields":[{"type":"int32","optional":false,"field":"product_id"},{"type":"int32","optional":false,"field":"quantity"}],"optional":true,"name":"inventory_connector_{context}.inventory.products_on_hand.Value","field":"before"},{"type":"struct","fields":[{"type":"int32","optional":false,"field":"product_id"},{"type":"int32","optional":false,"field":"quantity"}],"optional":true,"name":"inventory_connector_{context}.inventory.products_on_hand.Value","field":"after"},{"type":"struct","fields":[{"type":"string","optional":false,"field":"version"},{"type":"string","optional":false,"field":"connector"},{"type":"string","optional":false,"field":"name"},{"type":"int64","optional":false,"field":"ts_ms"},{"type":"string","optional":true,"name":"io.debezium.data.Enum","version":1,"parameters":{"allowed":"true,last,false"},"default":"false","field":"snapshot"},{"type":"string","optional":false,"field":"db"},{"type":"string","optional":true,"field":"sequence"},{"type":"string","optional":true,"field":"table"},{"type":"int64","optional":false,"field":"server_id"},{"type":"string","optional":true,"field":"gtid"},{"type":"string","optional":false,"field":"file"},{"type":"int64","optional":false,"field":"pos"},{"type":"int32","optional":false,"field":"row"},{"type":"int64","optional":true,"field":"thread"},{"type":"string","optional":true,"field":"query"}],"optional":false,"name":"io.debezium.connector.{context}.Source","field":"source"},{"type":"string","optional":false,"field":"op"},{"type":"int64","optional":true,"field":"ts_ms"},{"type":"struct","fields":[{"type":"string","optional":false,"field":"id"},{"type":"int64","optional":false,"field":"total_order"},{"type":"int64","optional":false,"field":"data_collection_order"}],"optional":true,"field":"transaction"}],"optional":false,"name":**"inventory_connector_{context}.inventory.products_on_hand.Envelope"**},*"payload"*:{*"before"*:**null**,*"after"*:{*"product_id":101,"quantity":3*},"source":{"version":"{debezium-version}-redhat-00001","connector":"{context}","name":"inventory_connector_{context}","ts_ms":1638985247805,"snapshot":"true","db":"inventory","sequence":null,"table":"products_on_hand","server_id":0,"gtid":null,"file":"{context}-bin.000003","pos":156,"row":0,"thread":null,"query":null},*"op"*:**"r"**,"ts_ms":1638985247805,"transaction":null}}
 ----
 ======================================
 +

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
@@ -1,0 +1,180 @@
+If the connector starts correctly without errors, it creates a topic for each table that the connector is configured to capture.
+Downstream applications can subscribe to these topics to retrieve information events that occur in the source database.
+
+To verify that the connector is running, perform the following operations from the OpenShift Container Platform web console, or through the OpenShift CLI tool (oc):
+
+* Verify the connector status.
+* Verify that the connector generates topics.
+* Verify that topics are populated with events for read operations ("op":"r") that the connector generates during the initial snapshot of each table.
+*
+.Prerequisites
+* A {prodname} connector is deployed to {StreamsName} on OpenShift.
+* The OpenShift `oc` CLI client is installed.
+* You have access to the OpenShift Container Platform web console.
+
+.Procedure
+. Check the status of the `KafkaConnector` resource by using one of the following methods:
+* From the OpenShift Container Platform web console:
+.. Navigate to *Home -> Search*.
+.. On the *Search* page, click *Resources* to open the *Select Resource* box, and then type `*KafkaConnector*`.
+.. From the *KafkaConnectors* list, click the name of the connector that you want to check, for example *inventory-connector-mysql*.
+.. In the *Conditions* section, verify that the values in the *Type* and *Status* columns are set to *Ready* and *True*.
++
+* From a terminal window:
+.. Enter the following command:
++
+[source,shell,options="nowrap",subs="+attributes,quotes"]
+----
+oc describe KafkaConnector _<connector-name>_ -n _<project>_
+----
++
+For example,
++
+[source,shell,options="nowrap"]
+----
+oc describe KafkaConnector inventory-connector-mysql -n debezium
+----
++
+The command returns status information that is similar to the following output:
++
+.`KafkaConnector` resource status
+======================================
+----
+Name:         inventory-connector-mysql
+Namespace:    debezium
+Labels:       strimzi.io/cluster=debezium-kafka-connect-cluster
+Annotations:  <none>
+API Version:  kafka.strimzi.io/v1beta2
+Kind:         KafkaConnector
+Metadata:
+  Creation Timestamp:  2021-12-08T16:20:30Z
+  Generation:          1
+  Managed Fields:
+    API Version:  kafka.strimzi.io/v1beta2
+    Fields Type:  FieldsV1
+    fieldsV1:
+      f:status:
+        f:conditions:
+        f:topics:
+    Manager:         okhttp
+    Operation:       Update
+    Time:            2021-12-08T17:41:34Z
+  Resource Version:  996714
+  Self Link:         /apis/kafka.strimzi.io/v1beta2/namespaces/debezium/kafkaconnectors/inventory-connector-mysql
+  UID:               53390480-9e04-4415-8999-43bc9d072d54
+Spec:
+  Class:  io.debezium.connector.mysql.MySqlConnector
+  Config:
+    database.history.kafka.bootstrap.servers:  debezium-kafka-cluster-kafka-bootstrap.debezium.svc.cluster.local:9092
+    database.history.kafka.topic:              schema-changes.inventory
+    database.hostname:                         mysql.debezium-mysql.svc.cluster.local
+    database.password:                         xxx
+    database.port:                             3306
+    database.server.name:                      inventory_connector_mysql
+    database.user:                             debezium
+  Tasks Max:                                   1
+Status:
+  Conditions:
+    Last Transition Time:  2021-12-08T17:41:34.897153Z
+    Status:                True
+    Type:                  Ready
+  Connector Status:
+    Connector:
+      State:      RUNNING
+      worker_id:  10.131.1.124:8083
+    Name:         inventory-connector-mysql
+    Tasks:
+      Id:               0
+      State:            RUNNING
+      worker_id:        10.131.1.124:8083
+    Type:               source
+  Observed Generation:  1
+  Tasks Max:            1
+  Topics:
+    inventory_connector_mysql
+    inventory_connector_mysql.inventory.addresses
+    inventory_connector_mysql.inventory.customers
+    inventory_connector_mysql.inventory.geom
+    inventory_connector_mysql.inventory.orders
+    inventory_connector_mysql.inventory.products
+    inventory_connector_mysql.inventory.products_on_hand
+Events:  <none>
+----
+======================================
+
+. Verify that the connector created Kafka topics:
+  * From the OpenShift Container Platform web console.
+  .. Navigate to *Home -> Search*.
+  .. On the *Search* page, click *Resources* to open the *Select Resource* box, and then type `*KafkaTopic*`.
+  .. From the *KafkaTopics* list, click the name of the topic that you want to check, for example, *inventory-connector-mysql.inventory.orders---ac5e98ac6a5d91e04d8ec0dc9078a1ece439081d*.
+  .. In the *Conditions* section, verify that the values in the *Type* and *Status* columns are set to *Ready* and *True*.
+  * From a terminal window:
+  .. Enter the following command:
++
+[source,shell,options="nowrap"]
+----
+oc get kafkatopics
+----
++
+The command returns status information that is similar to the following output:
++
+.`KafkaTopic` resource status
+======================================
+[source,options="nowrap"]
+----
+NAME                                                                                                   CLUSTER             PARTITIONS   REPLICATION FACTOR   READY
+connect-cluster-configs                                                                           debezium-kafka-cluster   1            1                    True
+connect-cluster-offsets                                                                           debezium-kafka-cluster   25           1                    True
+connect-cluster-status                                                                            debezium-kafka-cluster   5            1                    True
+consumer-offsets---84e7a678d08f4bd226872e5cdd4eb527fadc1c6a                                       debezium-kafka-cluster   50           1                    True
+inventory-connector-mysql---a96f69b23d6118ff415f772679da623fbbb99421                              debezium-kafka-cluster   1            1                    True
+inventory-connector-mysql.inventory.addresses---1b6beaf7b2eb57d177d92be90ca2b210c9a56480          debezium-kafka-cluster   1            1                    True
+inventory-connector-mysql.inventory.customers---9931e04ec92ecc0924f4406af3fdace7545c483b          debezium-kafka-cluster   1            1                    True
+inventory-connector-mysql.inventory.geom---9f7e136091f071bf49ca59bf99e86c713ee58dd5               debezium-kafka-cluster   1            1                    True
+inventory-connector-mysql.inventory.orders---ac5e98ac6a5d91e04d8ec0dc9078a1ece439081d             debezium-kafka-cluster   1            1                    True
+inventory-connector-mysql.inventory.products---df0746db116844cee2297fab611c21b56f82dcef           debezium-kafka-cluster   1            1                    True
+inventory-connector-mysql.inventory.products-on-hand---8649e0f17ffcc9212e266e31a7aeea4585e5c6b5   debezium-kafka-cluster   1            1                    True
+schema-changes.inventory                                                                          debezium-kafka-cluster   1            1                    True
+strimzi-store-topic---effb8e3e057afce1ecf67c3f5d8e4e3ff177fc55                                    debezium-kafka-cluster   1            1                    True
+strimzi-topic-operator-kstreams-topic-store-changelog---b75e702040b99be8a9263134de3507fc0cc4017b  debezium-kafka-cluster   1            1                    True
+----
+======================================
+
+. Check topic content.
++
+  * From a terminal window, enter the following command:
++
+[source,shell,options="nowrap",subs="+attributes,quotes"]
+----
+oc exec -n __<project>__  -it _<kafka-cluster>_ -- /opt/kafka/bin/kafka-console-consumer.sh \
+>     --bootstrap-server localhost:9092 \
+>     --from-beginning \
+>     --property print.key=true \
+>     --topic=_<topic-name_>
+----
++
+For example,
++
+----
+ oc exec -n debezium  -it debezium-kafka-cluster-kafka-0 -- /opt/kafka/bin/kafka-console-consumer.sh \
+>     --bootstrap-server localhost:9092 \
+>     --from-beginning \
+>     --property print.key=true \
+>     --topic=inventory_connector_mysql.inventory.products_on_hand
+----
++
+The format for specifying the topic name is the same as the `oc describe` command returns in Step 1, for example, `inventory_connector_mysql.inventory.addresses`.
++
+For each event in the topic, the command returns information that is similar to the following output:
++
+.Content of a {prodname} change event
+======================================
+[source,subs="+quotes"]
+----
+{"schema":{"type":"struct","fields":[{"type":"int32","optional":false,"field":"product_id"}],"optional":false,"name":"inventory_connector_mysql.inventory.products_on_hand.Key"},"payload":{"product_id":101}}	{"schema":{"type":"struct","fields":[{"type":"struct","fields":[{"type":"int32","optional":false,"field":"product_id"},{"type":"int32","optional":false,"field":"quantity"}],"optional":true,"name":"inventory_connector_mysql.inventory.products_on_hand.Value","field":"before"},{"type":"struct","fields":[{"type":"int32","optional":false,"field":"product_id"},{"type":"int32","optional":false,"field":"quantity"}],"optional":true,"name":"inventory_connector_mysql.inventory.products_on_hand.Value","field":"after"},{"type":"struct","fields":[{"type":"string","optional":false,"field":"version"},{"type":"string","optional":false,"field":"connector"},{"type":"string","optional":false,"field":"name"},{"type":"int64","optional":false,"field":"ts_ms"},{"type":"string","optional":true,"name":"io.debezium.data.Enum","version":1,"parameters":{"allowed":"true,last,false"},"default":"false","field":"snapshot"},{"type":"string","optional":false,"field":"db"},{"type":"string","optional":true,"field":"sequence"},{"type":"string","optional":true,"field":"table"},{"type":"int64","optional":false,"field":"server_id"},{"type":"string","optional":true,"field":"gtid"},{"type":"string","optional":false,"field":"file"},{"type":"int64","optional":false,"field":"pos"},{"type":"int32","optional":false,"field":"row"},{"type":"int64","optional":true,"field":"thread"},{"type":"string","optional":true,"field":"query"}],"optional":false,"name":"io.debezium.connector.mysql.Source","field":"source"},{"type":"string","optional":false,"field":"op"},{"type":"int64","optional":true,"field":"ts_ms"},{"type":"struct","fields":[{"type":"string","optional":false,"field":"id"},{"type":"int64","optional":false,"field":"total_order"},{"type":"int64","optional":false,"field":"data_collection_order"}],"optional":true,"field":"transaction"}],"optional":false,"name":**"inventory_connector_mysql.inventory.products_on_hand.Envelope"**},*"payload"*:{*"before"*:**null**,*"after"*:{*"product_id":101,"quantity":3*},"source":{"version":"1.6.4.Final-redhat-00001","connector":"mysql","name":"inventory_connector_mysql","ts_ms":1638985247805,"snapshot":"true","db":"inventory","sequence":null,"table":"products_on_hand","server_id":0,"gtid":null,"file":"mysql-bin.000003","pos":156,"row":0,"thread":null,"query":null},*"op"*:**"r"**,"ts_ms":1638985247805,"transaction":null}}
+----
+======================================
++
+In the preceding example, the `payload` value shows that the connector snapshot generated a read (`"op" ="r"`) event from the table `inventory.products_on_hand`.
+The `"before"` state of the `product_id` record is `null`, indicating that no previous value exists for the record.
+The `"after"` state shows a `quantity` of `3` for the item with `product_id` `101`.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
@@ -1,10 +1,3 @@
-////
-Insert this content after the legacy deployment instructions, in place of the verification steps.
-// Add the following ID and title
-// [id="verifying-that-the-debezium-<connector-name>-connector-is-running"]
-// == Verifying that the {prodname}{connector-name} connector is running
-//include::{partialsdir}/modules/all-connectors/proc-verifying-the-debezium-connector-deployment.adoc
-////
 If the connector starts correctly without errors, it creates a topic for each table that the connector is configured to capture.
 Downstream applications can subscribe to these topics to retrieve information events that occur in the source database.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-verifying-the-connector-deployment.adoc
@@ -1,13 +1,14 @@
 If the connector starts correctly without errors, it creates a topic for each table that the connector is configured to capture.
 Downstream applications can subscribe to these topics to retrieve information events that occur in the source database.
 
-To verify that the connector is running, perform the following operations from the OpenShift Container Platform web console, or through the OpenShift CLI tool (oc):
+To verify that the connector is running, you perform the following operations from the OpenShift Container Platform web console, or through the OpenShift CLI tool (oc):
 
 * Verify the connector status.
 * Verify that the connector generates topics.
 * Verify that topics are populated with events for read operations ("op":"r") that the connector generates during the initial snapshot of each table.
-*
+
 .Prerequisites
+
 * A {prodname} connector is deployed to {StreamsName} on OpenShift.
 * The OpenShift `oc` CLI client is installed.
 * You have access to the OpenShift Container Platform web console.


### PR DESCRIPTION
[DBZ-3991](https://issues.redhat.com/browse/DBZ-3991)

Adds instructions to the downstream docs for deploying connectors via the Streams deployment mechanism. The changes are not rendered in the upstream content. 
The change adds three shared files to the` /partials/modules/all-connectors` folder, and modifies the `product`-conditionalized content in the deployment sections of the six connector files that we use downstream. 

~I'm still working through one remaining downstream build issue. For some reason the Oracle deployment instructions don't build, but I can't see any differences in the structure compared to the other documents. 
@fbolton if you have a moment to take a look, it might be helpful.~ 

~Yet to do:~

~- Update the downstream steps for obtaining Oracle JDBC driver to point to the Maven site.~
~- Reconditionalize the steps for obtaining the JDBC drive for Db2 so that they are visible downstream.~

 
When this is ready, the changes should be backported to 1.7.  

Tested and built successfully in a local downstream build. Pending review, this is now complete.