### PR TITLE
DBZ-3657: add null check when building array converters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ deploy/
 target/
 mods/
 *.swp
+.tags
 epom
 log
 npm-debug.log

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -280,6 +280,7 @@ Sagar Rao
 Sahan Dilshan
 René Kerner
 Rich O'Connell
+Richard Kolkovich
 Robert Coup
 Robert Roldan
 Ruslan Gibaiev

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -525,7 +525,11 @@ public class PostgresValueConverter extends JdbcValueConverters {
                 .length(column.length())
                 .create();
 
-        Schema elementSchema = schemaBuilder(elementColumn)
+        SchemaBuilder elementSchemaBuilder = schemaBuilder(elementColumn);
+        if (elementSchemaBuilder == null) {
+            return null;
+        }
+        Schema elementSchema = elementSchemaBuilder
                 .optional()
                 .build();
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -334,20 +334,38 @@ public class PostgresValueConverter extends JdbcValueConverters {
                 }
 
                 final PostgresType resolvedType = typeRegistry.get(oidValue);
+
                 if (resolvedType.isEnumType()) {
                     return io.debezium.data.Enum.builder(Strings.join(",", resolvedType.getEnumValues()));
                 }
-                else if (resolvedType.isArrayType() && resolvedType.getElementType().isEnumType()) {
-                    List<String> enumValues = resolvedType.getElementType().getEnumValues();
-                    return SchemaBuilder.array(io.debezium.data.Enum.builder(Strings.join(",", enumValues)));
-                }
+                else if (resolvedType.isArrayType()) {
+                    if (resolvedType.getElementType().isEnumType()) {
+                        List<String> enumValues = resolvedType.getElementType().getEnumValues();
+                        return SchemaBuilder.array(io.debezium.data.Enum.builder(Strings.join(",", enumValues)));
+                    }
+                    else {
+                        // unfortunately, this does not work for array columns of domain types; the element type will have a
+                        // non-matching JDBC id, resulting in no schema builder to be returned for those; the only way to export
+                        // them right now is via 'includeUnknownDatatypes'
+                        final SchemaBuilder jdbcSchemaBuilder = arrayElementSchema(column);
 
-                final SchemaBuilder jdbcSchemaBuilder = super.schemaBuilder(column);
-                if (jdbcSchemaBuilder == null) {
-                    return includeUnknownDatatypes ? binaryMode.getSchema() : null;
+                        if (jdbcSchemaBuilder != null) {
+                            return SchemaBuilder.array(jdbcSchemaBuilder);
+                        }
+                        else {
+                            return includeUnknownDatatypes ? SchemaBuilder.array(binaryMode.getSchema()) : null;
+                        }
+                    }
                 }
                 else {
-                    return jdbcSchemaBuilder;
+                    SchemaBuilder jdbcSchemaBuilder = super.schemaBuilder(column);
+
+                    if (jdbcSchemaBuilder != null) {
+                        return jdbcSchemaBuilder;
+                    }
+                    else {
+                        return includeUnknownDatatypes ? binaryMode.getSchema() : null;
+                    }
                 }
         }
     }
@@ -382,6 +400,24 @@ public class PostgresValueConverter extends JdbcValueConverters {
             default:
                 throw new IllegalArgumentException("Unknown decimalMode");
         }
+    }
+
+    private SchemaBuilder arrayElementSchema(Column column) {
+        PostgresType arrayType = typeRegistry.get(column.nativeType());
+        PostgresType elementType = arrayType.getElementType();
+        final String elementTypeName = elementType.getName();
+        final String elementColumnName = column.name() + "-element";
+        final Column elementColumn = Column.editor()
+                .name(elementColumnName)
+                .jdbcType(elementType.getJdbcId())
+                .nativeType(elementType.getOid())
+                .type(elementTypeName)
+                .optional(true)
+                .scale(column.scale().orElse(null))
+                .length(column.length())
+                .create();
+
+        return schemaBuilder(elementColumn);
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DomainTypesIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DomainTypesIT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.postgresql;
+
+import static io.debezium.junit.EqualityCheck.LESS_THAN;
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
+import io.debezium.doc.FixFor;
+import io.debezium.junit.SkipWhenDatabaseVersion;
+
+/**
+ * Integration test to verify behaviour of tables which include domain types
+ */
+@SkipWhenDatabaseVersion(check = LESS_THAN, major = 11, minor = 0, reason = "Domain type array columns not supported")
+public class DomainTypesIT extends AbstractRecordsProducerTest {
+
+    @Before
+    public void before() throws SQLException {
+        TestHelper.dropAllSchemas();
+        TestHelper.execute("CREATE SCHEMA domaintypes");
+        TestHelper.execute("CREATE DOMAIN nmtoken AS text CHECK (VALUE ~* '^[A-Z0-9\\.\\_\\-\\:]+$');");
+        TestHelper.execute("CREATE TABLE domaintypes.t1 (id serial primary key, token nmtoken, tokens nmtoken[]);");
+    }
+
+    @Test
+    @FixFor("DBZ-3657")
+    public void shouldNotChokeOnDomainTypes() throws Exception {
+        start(PostgresConnector.class, TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_ONLY)
+                .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "domaintypes")
+                .build());
+        assertConnectorIsRunning();
+
+        TestHelper.execute("INSERT INTO domaintypes.t1 (id, token, tokens) values (default, 'foo', '{\"bar\",\"baz\"}')");
+
+        final TestConsumer consumer = testConsumer(1, "domaintypes");
+        consumer.await(TestHelper.waitTimeForRecords() * 30, TimeUnit.SECONDS);
+        SourceRecord record = consumer.remove();
+        Struct value = (Struct) record.value();
+        Struct after = (Struct) value.get("after");
+        assertThat(after.get("token")).isEqualTo("foo");
+    }
+}

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -108,3 +108,4 @@ narcsfz,Yang Wu
 TomBillietKlarrio,Tom Billiet
 wndemon,魏南
 AChangFeng,胡琴
+sarumont,Richard Kolkovich


### PR DESCRIPTION
This resolves [DBZ-3657](https://issues.redhat.com/browse/DBZ-3657).

I have integration tests for the issue, but they utilize PG syntax that does not exist in 9.6. I have verified these manually by running ITs against my own PG database (v13). I can commit and add to this PR if there is a way to do that without breaking all the tests. :)