### PR TITLE
Dbz 3457 incremental snapshots make over

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -254,6 +254,7 @@ Currently, the `execute-snapshot` action triggers xref:debezium-signaling-increm
 
 For more information about ad hoc snapshots, see the _Snapshots_ topic in the documentation for your connector.
 
+
 .Additional resources
 
 * xref:{link-db2-connector}#db2-ad-hoc-snapshots[Db2 connector ad hoc snapshots]
@@ -267,9 +268,10 @@ endif::community[]
 * xref:{link-postgresql-connector}#postgresql-ad-hoc-snapshots[PostgreSQL connector ad hoc snapshots]
 * xref:{link-sqlserver-connector}#sqlserver-ad-hoc-snapshots[SQL Server connector ad hoc snapshots]
 
+
 // Type: concept
 [id="debezium-signaling-incremental-snapshots"]
-==== Incremental snapshots
+=== Incremental snapshots
 
 Incremental snapshots are a specific type of ad hoc snapshot.
 In an incremental snapshot, the connector captures the baseline state of the tables that you specify, similar to an initial snapshot.
@@ -281,7 +283,6 @@ By capturing the initial state of the specified tables in chunks rather than in 
 * While the connector captures the baseline state of the specified tables, streaming of near real-time events from the transaction log continues uninterrupted.
 * If the incremental snapshot process is interrupted, it can be resumed from the point at which it stopped.
 * You can initiate an incremental snapshot at any time.
-
 
 For more information about incremental snapshots, see the _Snapshots_ topic in the documentation for your connector.
 

--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -1,6 +1,8 @@
+// Category: debezium-using
+// Type: assembly
 [id="sending-signals-to-a-debezium-connector"]
-= Sending signals to a Debezium connector
-
+= Sending signals to a {prodname} connector
+ifdef::community[]
 :toc:
 :toc-placement: macro
 :linkattrs:
@@ -15,148 +17,214 @@ This feature is currently in incubating state, i.e. exact semantics, configurati
 ====
 
 == Overview
-Sometimes it is necessary for the user to modify a connector behaviour or trigger a one-time action (e.g. snapshot of a single table).
-To fulfill such needs {prodname} provides a mechanism how to send a signal to a {prodname} connector to trigger an action.
-As it might be necessary to synchronize such an action with the dataflow the signal is implemented as a write to a data collection.
+endif::community[]
 
-Signalling is disabled by default.
-The name of the signalling data collection must be set via connector configuration parameter to enable the function.
-The signalling data collection must be *explictly* added among captured data collections, i.e., included in the `table.include.list` parameter.
+ifdef::product[]
+[IMPORTANT]
+====
+Signaling is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::product[]
 
-.Connector configuration
-[cols="3,9",options="header"]
-|===
-|Parameter |  Description
+The {prodname} signaling mechanism provides a way to modify the behavior of a connector, or to trigger a one-time action, such as initiating an xref:debezium-signaling-ad-hoc-snapshots[ad hoc snapshot] of a table.
+To trigger a connector to perform a specified action, you issue a SQL command to add a signal message to a specialized signaling table, also referred to as a signaling data collection.
+The signaling table, which you create on the source database, is designated exclusively for communicating with {prodname}.
+When {prodname} detects that a new xref:debezium-signaling-example-of-a-logging-record[logging record] or xref:debezium-signaling-example-of-an-ad-hoc-signal-record[ad hoc snapshot record] is added to the signaling table, it reads the signal, and initiates the requested operation.
 
-|`signal.data.collection`
-|Fully-qualified name of data collection. +
-The name format is connector specific, e.g. `"some_schema.debezium_signals"` in case of the {prodname} Postgres connector. +
-For SQL Server it should be formatted as `"some_database.some_schema.debezium_signals"`.
+Signaling is available for use with the following {prodname} connectors:
 
-|===
+* Db2
+* MySQL
+ifdef::community[]
+* Oracle
+endif::community[]
+* PostgreSQL
+* SQL Server
 
 
-=== Data collection structure
+// Type: procedure
+// Title: Enabling {prodname} signaling
+[id="debezium-signaling-enabling-signaling"]
+== Enabling signaling
 
-The signalling data collection must conform to a required format:
-It must contain three fields;
-the naming of the fields is arbitrary and only order of the field is important.
-It is recommended but not mandatory to use the field names as defined in the table below:
+By default, the {prodname} signaling mechanism is disabled.
+You must explicitly enable signaling for each connector that you want to use it with.
 
-.Signalling data collection structure
+.Procedure
+
+. On the source database, create a signaling data collection table for sending signals to the connector.
+  For information about the required structure of the signaling data collection, see xref:debezium-signaling-data-collection-structure[Structure of a signaling data collection].
+
+. For source databases such as Db2 or SQL Server that implement a native change data capture (CDC) mechanism, enable CDC for the signaling table.
+
+. Add the name of the signaling data collection to the {prodname} connector configuration. +
+  In the connector configuration, add the property `signal.data.collection`, and set its value to the fully-qualified name of the signaling data collection that you created in Step 1. +
+ +
+For example, `signal.data.collection = inventory.debezium_signals`. +
+ +
+The format for the fully-qualified name of the signaling collection depends on the connector. +
+The following example shows the naming formats to use for each connector:
+
+ifdef::community[]
+Db2, Oracle, or PostgreSQL:: `_<schemaName>_._<tableName>_`
+endif::community[]
+ifdef::product[]
+Db2 or PostgreSQL:: `_<schemaName>_._<tableName>_`
+endif::product[]
+MySQL:: `_<databaseName>_._<tableName>_`
+SQL Server:: `_<databaseName>_._<schemaName>_._<tableName>_` +
+ +
+For more information about setting the `signal.data.collection` property, see the table of configuration properties for your connector.
+. Add the signaling table to the list of tables to monitor. +
+  In the configuration for the {prodname} connector, add the name of the data collection that you created in Step 1 to the `table.include.list` property. +
+ +
+For more information about the `table.include.list` property, see the table of configuration properties for your connector.
+
+// Type: reference
+// ModuleID: debezium-signaling-required-structure-of-a-signaling-data-collection
+// Title: Required structure of a {prodname} signaling data collection
+[id="debezium-signaling-data-collection-structure"]
+=== Structure of a signaling data collection
+
+A signaling data collection, or signaling table, stores signals that you send to a connector to trigger a specified operation.
+The structure of the signaling table must conform to the following standard format.
+
+* Contain three fields (columns).
+* Fields are arranged in a specific order, as shown in xref:debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[Table 1].
+
+.Structure of a signaling data collection
+[id="debezium-signaling-description-of-required-structure-of-a-signaling-data-collection"]
+.Required structure of a signaling data collection
 [cols="1,1,9",options="header"]
 |===
 |Column | Type | Description
 
-|`id`
-|`string` +
+|`id` +
 (required)
-|A unique identifier of this signal instance. +
-It can be used for logging, debugging or deduplication.
-Usually an UUID string.
+|`string`
 
-|`type`
-|`string` +
+|An arbitrary unique string that identifies a signal instance. +
+You assign an `id` to each signal that you submit to the signaling table. +
+Typically the ID is a UUID string. +
+You can use signal instances for logging, debugging, or de-duplication. +
+// When {prodname} runs the requested operation, it generates a signal message with an arbitrary `id` string that is unrelated to the string in the submitted signal.
+
+|`type` +
 (required)
-|The type of the signal to be sent. +
-There are signals common for all connectors or specific to a subset of connectors.
+|`string`
 
-|`data`
-|`string` +
+|Specifies the type of signal to send. +
+You can use some signal types with any connector for which signaling is available, while other signal types are available for specific connectors only.
+
+|`data` +
 (optional)
-|JSON formatted parameters that are passed to a signal action. +
-Each signal has its own expected set of data.
+|`string`
+
+|Specifies JSON-formatted parameters to pass to a signal action. +
+Each signal type requires a specific set of data.
 
 |===
 
-Such table could be created with a DDL command similar to:
+NOTE: The column names in a data collection are arbitrary.
+The column names in the preceding table are suggestions.
+If you use a different naming scheme, ensure that the values in each field are consistent with the intended content.
+
+// Type: procedure
+// Title: Creating a {prodname} signaling data collection
+[id="debezium-signaling-creating-a-signal-data-collection"]
+=== Creating a signaling data collection
+
+You create a signaling table by submitting a standard SQL DDL query to the source database.
+
+.Prerequisites
+
+* You have sufficient access privileges to create a table on the target database.
+
+.Procedure
+
+* Submit a SQL query to the source database to create a table that is consistent with the xref:debezium-signaling-required-structure-of-a-signaling-data-collection[required structure], as shown in the following example: +
+ +
+`CREATE TABLE _<tableName>_ (id VARCHAR(_<varcharValue>_) PRIMARY KEY, type VARCHAR(__<varcharValue>__) NOT NULL, data VARCHAR(_<varcharValue>_) NULL);` +
+
+[NOTE]
+====
+The amount of space that you allocate to the `VARCHAR` parameter of the `id` variable must be sufficient to accommodate the size of the ID strings of signals sent to the signaling table. +
+If the size of an ID exceeds the available space, the connector cannot process the signal.
+====
+
+The following example shows a `CREATE TABLE` command that creates a three-column `debezium_signal` table:
 
 [source,sql]
 ----
 CREATE TABLE debezium_signal (id VARCHAR(42) PRIMARY KEY, type VARCHAR(32) NOT NULL, data VARCHAR(2048) NULL);
 ----
 
-.Example of a signal record
-[cols="1,9",options="header"]
+// Type: concept
+// ModuleID: debezium-signaling-types-of-signal-actions
+// Title: Types of {prodname} signal actions
+== Signal actions
+
+You can use signaling to initiate the following actions:
+
+* xref:debezium-signaling-logging[Add messages to the log].
+* xref:debezium-signaling-ad-hoc-snapshots[Trigger ad hoc snapshots].
+
+Some signals are not compatible with all connectors.
+
+// Type: concept
+[id="debezium-signaling-logging"]
+=== Logging signals
+
+You can request a connector to add an entry to the log by creating a signaling table entry with the `log` signal type.
+After processing the signal, the connector prints the specified message to the log.
+Optionally, you can configure the signal so that the resulting message includes the streaming coordinates.
+
+[id="debezium-signaling-example-of-a-logging-record"]
+.Example of a signaling record for adding a log message
+[cols="1,9,9",options="header"]
 |===
-|Column | Value
+|Column | Value | Description
 
 |id
 |`924e3ff8-2245-43ca-ba77-2af9af02fa07`
+|
 
 |type
 |`log`
+|The action type of the signal.
 
 |data
 |`{"message": "Signal message at offset {}"}`
-
+| The `message` parameter specifies the string to print to the log. +
+If you add a placeholder (`{}`) to the message, it is replaced with streaming coordinates.
 |===
 
+// Type: concept
+[id="debezium-signaling-ad-hoc-snapshots"]
+=== Ad hoc snapshot signals
 
-== Signal Actions
+You can request a connector to initiate an ad hoc snapshot by creating a signaling table entry with the `execute-snapshot` signal type.
+After processing the signal, the connector runs the requested snapshot operation.
 
-These signals are common to all connectors
+Unlike the initial snapshot that a connector runs after it first starts, an ad hoc snapshot occurs during runtime, after the connector has already begun to stream change events from a database.
+You can initiate ad hoc snapshots at any time.
 
-=== Logging
+Ad hoc snapshots are available for the following {prodname} connectors:
 
-The type of the logging action is `log`.
-It will print a provided message to the log optionally including streaming position.
+* Db2
+* MySQL
+ifdef::community[]
+* Oracle
+endif::community[]
+* PostgreSQL
+* SQL Server
 
-.Action parameters
-[cols="1,9",options="header"]
-|===
-|Name | Description
-
-|message
-|The string printed to the log. +
-If a placeholder `{}` is added to the message it will be replaced with streaming coordinates.
-
-|===
-
-.Example of a logging record
-[cols="1,9",options="header"]
-|===
-|Column | Value
-
-|id
-|`924e3ff8-2245-43ca-ba77-2af9af02fa07`
-
-|type
-|`log`
-
-|data
-|`{"message": "Signal message at offset {}"}`
-
-|===
-
-
-=== Triggering an Incremental Snapshot
-*Available for MySQL, PostgresSQL, Oracle, SQL Server and Db2 connectors*
-
-The type of the action is `execute-snapshot`.
-It will start an incremental snapshot operation. The operation first reads the first and last primary key values and use those as start and end point for each table.
-
-==== Optional Connector Configuration
-`incremental.snapshot.chunk.size`: Integer value. The number of rows collected at each fetch operation on the database.
-
-
-.Action parameters
-[cols="3,9",options="header", source, adoc]
-|===
-|Name | Description
-
-|data-collections
-a|The list of data collections to be snapshoted. +
-Formatting should be: +
-
-* MySQL: `"some_database.some_table"`
-* PostgresSQL and Db2: `"some_schema.some_table"`
-* SQL Server: `"some_database.some_schema.some_table"`
-* Oracle: `"some_schema.some_table"`
-
-|===
-
-.Example of executing an incremental snapshot
+[id="debezium-signaling-example-of-an-ad-hoc-signal-record"]
+.Example of an ad hoc snapshot signal record
 [cols="1,9",options="header"]
 |===
 |Column | Value
@@ -171,3 +239,53 @@ Formatting should be: +
 |`{"data-collections": ["public.MyFirstTable", "public.MySecondTable"]}`
 
 |===
+
+Currently, the `execute-snapshot` action triggers xref:debezium-signaling-incremental-snapshots[incremental snapshots] only.
+
+For more information about ad hoc snapshots, see the _Snapshots_ topic in the documentation for your connector.
+
+.Additional resources
+
+* xref:{link-db2-connector}#db2-ad-hoc-snapshots[Db2 connector ad hoc snapshots]
+* xref:{link-mysql-connector}#mysql-ad-hoc-snapshots[MySQL connector ad hoc snapshots]
+ifdef::community[]
+* xref:{link-oracle-connector}#oracle-ad-hoc-snapshots[Oracle connector ad hoc snapshots]
+endif::community[]
+* xref:{link-postgresql-connector}#postgresql-ad-hoc-snapshots[PostgreSQL connector ad hoc snapshots]
+* xref:{link-sqlserver-connector}#sqlserver-ad-hoc-snapshots[SQL Server connector ad hoc snapshots]
+
+// Type: concept
+[id="debezium-signaling-incremental-snapshots"]
+==== Incremental snapshots
+
+Incremental snapshots are a specific type of ad hoc snapshot.
+In an incremental snapshot, the connector captures the baseline state of the tables that you specify, similar to an initial snapshot.
+However, unlike an initial snapshot, an incremental snapshot captures tables in chunks, rather than all at once.
+The connector uses a watermarking method to track the progress of the snapshot.
+
+By capturing the initial state of the specified tables in chunks rather than in a single monolithic operation, incremental snapshots provide the following advantages over the initial snapshot process:
+
+* While the connector captures the baseline state of the specified tables, streaming of near real-time events from the transaction log continues uninterrupted.
+* If the incremental snapshot process is interrupted, it can be resumed from the point at which it stopped.
+* You can initiate an incremental snapshot at any time.
+
+During the incremental snapshot process, the connector simultaneously captures two types of records from a data-collection.
+It captures snapshot records directly from the table as `READ` operations.
+Meanwhile, as users continue to update records in the data collection, the connector captures change event records based on these updates from the transaction log.
+These connector emits the records for these events as `UPDATE` or `DELETE` operations.
+For each data collection, the connector emits the records for these two types of events to a single destination Kafka topic.
+
+As {prodname} processes a snapshot chunk, it buffers the two sets of records in memory, comparing records that share the same primary key.
+When the connector detects records with the same primary key, it writes only the most recent version of a record to the destination topic.
+
+For more information about incremental snapshots, see the _Snapshots_ topic in the documentation for your connector.
+
+.Additional resources
+
+* xref:{link-db2-connector}#db2-incremental-snapshots[Db2 connector incremental snapshots]
+* xref:{link-mysql-connector}#mysql-incremental-snapshots[MySQL connector incremental snapshots]
+ifdef::community[]
+* xref:{link-oracle-connector}#oracle-incremental-snapshots[Oracle connector incremental snapshots]
+endif::community[]
+* xref:{link-postgresql-connector}#postgresql-incremental-snapshots[PostgreSQL connector incremental snapshots]
+* xref:{link-sqlserver-connector}#sqlserver-incremental-snapshots[SQL Server connector incremental snapshots]

--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -72,16 +72,15 @@ For example, `signal.data.collection = inventory.debezium_signals`. +
 The format for the fully-qualified name of the signaling collection depends on the connector. +
 The following example shows the naming formats to use for each connector:
 
-ifdef::community[]
-Db2, Oracle, or PostgreSQL:: `_<schemaName>_._<tableName>_`
-endif::community[]
-ifdef::product[]
-Db2 or PostgreSQL:: `_<schemaName>_._<tableName>_`
-endif::product[]
+Db2:: `_<schemaName>_._<tableName>_`
 ifdef::community[]
 MongoDB:: `_<databaseName>_._<collectionName>_`
 endif::community[]
 MySQL:: `_<databaseName>_._<tableName>_`
+ifdef::community[]
+Oracle:: `_<databaseName>_._<schemaName>_._<tableName>_`
+endif::community[]
+PostgreSQL:: `_<schemaName>_._<tableName>_`
 SQL Server:: `_<databaseName>_._<schemaName>_._<tableName>_` +
  +
 For more information about setting the `signal.data.collection` property, see the table of configuration properties for your connector.

--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -38,6 +38,9 @@ When {prodname} detects that a new xref:debezium-signaling-example-of-a-logging-
 Signaling is available for use with the following {prodname} connectors:
 
 * Db2
+ifdef::community[]
+* MongoDB
+endif::community[]
 * MySQL
 ifdef::community[]
 * Oracle
@@ -75,6 +78,9 @@ endif::community[]
 ifdef::product[]
 Db2 or PostgreSQL:: `_<schemaName>_._<tableName>_`
 endif::product[]
+ifdef::community[]
+MongoDB:: `_<databaseName>_._<collectionName>_`
+endif::community[]
 MySQL:: `_<databaseName>_._<tableName>_`
 SQL Server:: `_<databaseName>_._<schemaName>_._<tableName>_` +
  +
@@ -93,7 +99,7 @@ For more information about the `table.include.list` property, see the table of c
 A signaling data collection, or signaling table, stores signals that you send to a connector to trigger a specified operation.
 The structure of the signaling table must conform to the following standard format.
 
-* Contain three fields (columns).
+* Contains three fields (columns).
 * Fields are arranged in a specific order, as shown in xref:debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[Table 1].
 
 .Structure of a signaling data collection
@@ -101,7 +107,7 @@ The structure of the signaling table must conform to the following standard form
 .Required structure of a signaling data collection
 [cols="1,1,9",options="header"]
 |===
-|Column | Type | Description
+|Field | Type | Description
 
 |`id` +
 (required)
@@ -111,7 +117,8 @@ The structure of the signaling table must conform to the following standard form
 You assign an `id` to each signal that you submit to the signaling table. +
 Typically the ID is a UUID string. +
 You can use signal instances for logging, debugging, or de-duplication. +
-// When {prodname} runs the requested operation, it generates a signal message with an arbitrary `id` string that is unrelated to the string in the submitted signal.
+When a signal triggers {prodname} to perform an incremental snapshot, it generates a signal message with an arbitrary `id` string.
+The `id` string that the generated message contains is unrelated to the `id` string in the submitted signal.
 
 |`type` +
 (required)
@@ -129,9 +136,9 @@ Each signal type requires a specific set of data.
 
 |===
 
-NOTE: The column names in a data collection are arbitrary.
-The column names in the preceding table are suggestions.
-If you use a different naming scheme, ensure that the values in each field are consistent with the intended content.
+NOTE: The field names in a data collection are arbitrary.
+The preceding table provides suggested names.
+If you use a different naming convention, ensure that the values in each field are consistent with the expected content.
 
 // Type: procedure
 // Title: Creating a {prodname} signaling data collection
@@ -216,6 +223,9 @@ You can initiate ad hoc snapshots at any time.
 Ad hoc snapshots are available for the following {prodname} connectors:
 
 * Db2
+ifdef::community[]
+* MongoDB
+endif::community[]
 * MySQL
 ifdef::community[]
 * Oracle
@@ -247,6 +257,9 @@ For more information about ad hoc snapshots, see the _Snapshots_ topic in the do
 .Additional resources
 
 * xref:{link-db2-connector}#db2-ad-hoc-snapshots[Db2 connector ad hoc snapshots]
+ifdef::community[]
+* xref:{link-mongodb-connector}#mongodb-ad-hoc-snapshot[MongoDB connector ad hoc snapshots]
+endif::community[]
 * xref:{link-mysql-connector}#mysql-ad-hoc-snapshots[MySQL connector ad hoc snapshots]
 ifdef::community[]
 * xref:{link-oracle-connector}#oracle-ad-hoc-snapshots[Oracle connector ad hoc snapshots]
@@ -269,20 +282,15 @@ By capturing the initial state of the specified tables in chunks rather than in 
 * If the incremental snapshot process is interrupted, it can be resumed from the point at which it stopped.
 * You can initiate an incremental snapshot at any time.
 
-During the incremental snapshot process, the connector simultaneously captures two types of records from a data-collection.
-It captures snapshot records directly from the table as `READ` operations.
-Meanwhile, as users continue to update records in the data collection, the connector captures change event records based on these updates from the transaction log.
-These connector emits the records for these events as `UPDATE` or `DELETE` operations.
-For each data collection, the connector emits the records for these two types of events to a single destination Kafka topic.
-
-As {prodname} processes a snapshot chunk, it buffers the two sets of records in memory, comparing records that share the same primary key.
-When the connector detects records with the same primary key, it writes only the most recent version of a record to the destination topic.
 
 For more information about incremental snapshots, see the _Snapshots_ topic in the documentation for your connector.
 
 .Additional resources
 
 * xref:{link-db2-connector}#db2-incremental-snapshots[Db2 connector incremental snapshots]
+ifdef::community[]
+* xref:{link-mongodb-connector}#mongodb-incremental-snapshots[MongoDB connector incremental snapshots]
+endif::community[]
 * xref:{link-mysql-connector}#mysql-incremental-snapshots[MySQL connector incremental snapshots]
 ifdef::community[]
 * xref:{link-oracle-connector}#oracle-incremental-snapshots[Oracle connector incremental snapshots]

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2233,12 +2233,12 @@ By default, no operations are skipped.
 
 |[[db2-property-signal-data-collection]]<<db2-property-signal-data-collection, `+signal.data.collection+`>>
 |No default
-| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}[signals] to the connector.
+| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector.
 Use the following format to specify the collection name: +
 `_<schemaName>_._<tableName>_`
 
 ifdef::product[]
-xref:{link-signalling}#sending-signals-to-a-debezium-connector[Signaling] is a Technology Preview feature.
+Signaling is a Technology Preview feature.
 endif::product[]
 
 |[[db2-property-incremental-snapshot-chunk-size]]<<db2-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -128,12 +128,13 @@ The level of the lock is determined by the `snapshot.isolation.mode` connector  
 // ModuleID: debezium-db2-ad-hoc-snapshots
 [id="db2-ad-hoc-snapshots"]
 ==== Ad hoc snapshots
+
 include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
 
 // Type: concept
-// ModuleID: debezium-db2-incremental-snapshots
 [id="db2-incremental-snapshots"]
 ==== Incremental snapshots
+
 include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+3]
 
 [WARNING]
@@ -2248,7 +2249,7 @@ However, larger chunk sizes also require more memory to buffer the snapshot data
 Adjust the chunk size to a value that provides the best performance in your environment.
 
 ifdef::product[]
-xref:{link-db2-connector}#debezium-db2-incremental-snapshots[Incremental snapshots] is a Technology Preview feature.
+Incremental snapshots is a Technology Preview feature.
 endif::product[]
 
 |===

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -124,7 +124,17 @@ The level of the lock is determined by the `snapshot.isolation.mode` connector  
 .. Emits each _read_ event to the Kafka topic that has the same name as the table.
 . Records the successful completion of the snapshot in the connector offsets.
 
-include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
+// Type: concept
+// ModuleID: debezium-db2-ad-hoc-snapshots
+[id="db2-ad-hoc-snapshots"]
+==== Ad hoc snapshots
+include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
+
+// Type: concept
+// ModuleID: debezium-db2-incremental-snapshots
+[id="db2-incremental-snapshots"]
+==== Incremental snapshots
+include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+3]
 
 [WARNING]
 ====
@@ -2223,11 +2233,24 @@ By default, no operations are skipped.
 |[[db2-property-signal-data-collection]]<<db2-property-signal-data-collection, `+signal.data.collection+`>>
 |No default
 | Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}[signals] to the connector.
-The name format is _schema-name.table-name_.
+Use the following format to specify the collection name: +
+`_<schemaName>_._<tableName>_`
+
+ifdef::product[]
+xref:{link-signalling}#sending-signals-to-a-debezium-connector[Signaling] is a Technology Preview feature.
+endif::product[]
 
 |[[db2-property-incremental-snapshot-chunk-size]]<<db2-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
 |`1024`
-| The number of rows fetched from the database for each incremental snapshot iteration.
+||The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
+The value determines the number of rows that the snapshot collects during each fetch operation on the database.
+Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
+However, larger chunk sizes also require more memory to buffer the snapshot data.
+Adjust the chunk size to a value that provides the best performance in your environment.
+
+ifdef::product[]
+xref:debezium-db2-incremental-snapshots[Incremental snapshots] is a Technology Preview feature.
+endif::product[]
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2242,14 +2242,13 @@ endif::product[]
 
 |[[db2-property-incremental-snapshot-chunk-size]]<<db2-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
 |`1024`
-||The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
-The value determines the number of rows that the snapshot collects during each fetch operation on the database.
+|The maximum number of rows that the connector fetches and reads into memory during an incremental snapshot chunk.
 Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
 However, larger chunk sizes also require more memory to buffer the snapshot data.
 Adjust the chunk size to a value that provides the best performance in your environment.
 
 ifdef::product[]
-xref:debezium-db2-incremental-snapshots[Incremental snapshots] is a Technology Preview feature.
+xref:{link-db2-connector}#debezium-db2-incremental-snapshots[Incremental snapshots] is a Technology Preview feature.
 endif::product[]
 
 |===

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -222,7 +222,18 @@ If the connector is stopped before the tasks' snapshots are completed, upon rest
 Try to avoid task reassignment and reconfiguration while the connector is performing a snapshot of any replica sets. The connector does log messages with the progress of the snapshot. For utmost control, run a separate cluster of Kafka Connect for each connector.
 ====
 
-include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
+// Type: concept
+// ModuleID: debezium-mongodb-ad-hoc-snapshots
+[id="mongodb-ad-hoc-snapshots"]
+==== Ad hoc snapshots
+include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
+
+// Type: concept
+// ModuleID: debezium-mongodb-incremental-snapshots
+[id="mongodb-incremental-snapshots"]
+==== Incremental snapshots
+include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+3]
+
 
 [NOTE]
 ====

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -222,6 +222,7 @@ If the connector is stopped before the tasks' snapshots are completed, upon rest
 Try to avoid task reassignment and reconfiguration while the connector is performing a snapshot of any replica sets. The connector does log messages with the progress of the snapshot. For utmost control, run a separate cluster of Kafka Connect for each connector.
 ====
 
+ifdef::community[]
 // Type: concept
 // ModuleID: debezium-mongodb-ad-hoc-snapshots
 [id="mongodb-ad-hoc-snapshots"]
@@ -240,6 +241,8 @@ include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot
 Incremental snapshots are currently supported for single replica set deployments only.
 This limitation will be removed in the next version.
 ====
+
+endif::community[]
 
 // Type: concept
 // ModuleID: how-the-debezium-mongodb-connector-streams-change-event-records

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -207,7 +207,7 @@ The message contains a logical representation of the table schema.
   ...
   },
   "payload": {
-        "source": {  # (1)
+        "source": {  // (1)
         "version": "{debezium-version}",
         "connector": "mysql",
         "name": "dbserver1",
@@ -224,19 +224,19 @@ The message contains a logical representation of the table schema.
         "thread": null,
         "query": null
     },
-    "databaseName": "inventory", # (2)
+    "databaseName": "inventory", // (2)
     "schemaName": null,
-    "ddl": "ALTER TABLE customers ADD COLUMN middle_name VARCHAR(2000)", #(3)
-    "tableChanges": [ # (4)
+    "ddl": "ALTER TABLE customers ADD COLUMN middle_name VARCHAR(2000)", // (3)
+    "tableChanges": [ // (4)
         {
-        "type": "ALTER", # (5)
-        "id": "\"inventory\".\"customers\"",  # (6)
-        "table": { # (7)
+        "type": "ALTER", // (5)
+        "id": "\"inventory\".\"customers\"",  // (6)
+        "table": { // (7)
             "defaultCharsetName": "latin1",
-            "primaryKeyColumnNames": [  # (8)
+            "primaryKeyColumnNames": [  // (8)
                 "id"
             ],
-            "columns": [ # (9)
+            "columns": [ // (9)
                 {
                 "name": "id",
                 "jdbcType": 4,
@@ -482,21 +482,21 @@ a|Records the completed snapshot in the connector offsets.
 
 |===
 
-// Type: concept
-// ModuleID: debezium-mysql-ad-hoc-snapshots
+ifdef::community[]
+
+// ADD annotation onlyu after supported downstream: Type: concept
+// ADD annotation onlyu after supported downstream: ModuleID: debezium-mysql-ad-hoc-snapshots
 [id="mysql-ad-hoc-snapshots"]
 ==== Ad hoc snapshots
 include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
 
-// Type: concept
-// ModuleID: debezium-mysql-incremental-snapshots
+// ADD annotation only after supported downstream: Type: concept
+// ADD annotation only after supported downstream: ModuleID: debezium-mysql-incremental-snapshots
 [id="mysql-incremental-snapshots"]
 ==== Incremental snapshots
 include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+3]
-
-// Type: concept
-// ModuleID: debezium-mysql-read-only-incremental-snapshots
 [id="mysql-read-only-incremental-snapshots"]
+
 ==== Read-only incremental snapshots
 
 The MySQL connector allows for running incremental snapshots with a read-only connection to the database.
@@ -549,8 +549,6 @@ Key = `test_connector`
 
 Value = `{"type":"execute-snapshot","data": {"data-collections": ["schema1.table1", "schema1.table2"], "type": "INCREMENTAL"}}`
 ----
-
-ifdef::community[]
 
 // Type: continue
 [id="mysql-snapshot-events"]
@@ -2802,7 +2800,7 @@ Use the following format to specify the collection name: +
 `_<databaseName>_._<tableName>_`
 
 ifdef::product[]
-xref:{link-signalling}#sending-signals-to-a-debezium-connector[Signaling] is a Technology Preview feature.
+Signaling is a Technology Preview feature.
 endif::product[]
 
 |[[mysql-property-incremental-snapshot-allow-schema-changes]]<<mysql-property-incremental-snapshot-allow-schema-changes, `+incremental.snapshot.allow.schema.changes+`>>
@@ -2813,14 +2811,13 @@ Note that changes to a primary key are not supported and can cause incorrect res
 
 |[[mysql-property-incremental-snapshot-chunk-size]]<<mysql-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
 |`1024`
-|The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
-The value determines the number of rows that the snapshot collects during each fetch operation on the database.
+|The maximum number of rows that the connector fetches and reads into memory during an incremental snapshot chunk.
 Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
 However, larger chunk sizes also require more memory to buffer the snapshot data.
 Adjust the chunk size to a value that provides the best performance in your environment.
 
 ifdef::product[]
-xref:debezium-mysql-incremental-snapshots[Incremental snapshots] is a Technology Preview feature.
+Incremental snapshots is a Technology Preview feature.
 endif::product[]
 
 |[[mysql-property-read-only]]<<mysql-property-read-only, `+read.only+`>>

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2796,7 +2796,7 @@ endif::community[]
 
 |[[mysql-property-signal-data-collection]]<<mysql-property-signal-data-collection,`+signal.data.collection+`>>
 |No default value
-|Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}[signals] to the connector. +
+|Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector. +
 Use the following format to specify the collection name: +
 `_<databaseName>_._<tableName>_`
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -207,7 +207,7 @@ The message contains a logical representation of the table schema.
   ...
   },
   "payload": {
-        "source": {  //<1>
+        "source": {  # (1)
         "version": "{debezium-version}",
         "connector": "mysql",
         "name": "dbserver1",
@@ -224,19 +224,19 @@ The message contains a logical representation of the table schema.
         "thread": null,
         "query": null
     },
-    "databaseName": "inventory", //<2>
+    "databaseName": "inventory", # (2)
     "schemaName": null,
-    "ddl": "ALTER TABLE customers ADD COLUMN middle_name VARCHAR(2000)", //<3>
-    "tableChanges": [  //<4>
+    "ddl": "ALTER TABLE customers ADD COLUMN middle_name VARCHAR(2000)", #(3)
+    "tableChanges": [ # (4)
         {
-        "type": "ALTER", //<5>
-        "id": "\"inventory\".\"customers\"",  //<6>
-        "table": { //<7>
+        "type": "ALTER", # (5)
+        "id": "\"inventory\".\"customers\"",  # (6)
+        "table": { # (7)
             "defaultCharsetName": "latin1",
-            "primaryKeyColumnNames": [  //<8>
+            "primaryKeyColumnNames": [  # (8)
                 "id"
             ],
-            "columns": [ //<9>
+            "columns": [ # (9)
                 {
                 "name": "id",
                 "jdbcType": 4,
@@ -482,30 +482,46 @@ a|Records the completed snapshot in the connector offsets.
 
 |===
 
-include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
+// Type: concept
+// ModuleID: debezium-mysql-ad-hoc-snapshots
+[id="mysql-ad-hoc-snapshots"]
+==== Ad hoc snapshots
+include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
 
-==== Read-only Incremental snapshot
+// Type: concept
+// ModuleID: debezium-mysql-incremental-snapshots
+[id="mysql-incremental-snapshots"]
+==== Incremental snapshots
+include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+3]
 
-The MySql connector supports Incremental snapshot with read-only connection to the database.
-It's achieved by using executed GTID set as high and low watermarks.
-The state of chunk's window gets updated by comparing GTIDs of binlog events or server's heartbeats against low and high watermarks.
+// Type: concept
+// ModuleID: debezium-mysql-read-only-incremental-snapshots
+[id="mysql-read-only-incremental-snapshots"]
+==== Read-only incremental snapshots
 
-To switch to read-only implementation set {link-prefix}:{link-mysql-connector}#mysql-property-read-only[read.only] to `true`.
+The MySQL connector allows for running incremental snapshots with a read-only connection to the database.
+To run an incremental snapshot with read-only access, the connector uses the executed global transaction IDs (GTID) set as high and low watermarks.
+The state of a chunk's window is updated by comparing the GTIDs of binary log (binlog) events or the server's heartbeats against low and high watermarks.
+
+To switch to a read-only implementation, set the value of the {link-prefix}:{link-mysql-connector}#mysql-property-read-only[`read.only`] property to `true`.
 
 .Prerequisites
 
-* {link-prefix}:{link-mysql-connector}#enable-mysql-gtids[`enable-mysql-gtids`]
-* If connector is reading from a replica, then for multithreaded replicas (replicas on which `replica_parallel_workers` is set to a value greater than 0)
-it's required to set `replica_preserve_commit_order=1` or `slave_preserve_commit_order=1`
+* xref:enable-mysql-gtids[Enable MySQL GTIDs].
+* If the connector reads from a multi-threaded replica (that is, a replica for which the value of `replica_parallel_workers` is greater than `0`)
+you must set one of the following options:
 
-==== Ad-hoc read-only Incremental snapshot
+** `replica_preserve_commit_order=ON`
+** `slave_preserve_commit_order=ON`
 
-An alternative way to {link-prefix}:{link-signalling}[signalling table] mechanism to execute a new snapshot when the MySQL connection is read-only is to send a message to the Kafka topic configured with
-{link-prefix}:{link-mysql-connector}#mysql-property-signal-kafka-topic[signal.kafka.topic] property.
+==== Ad hoc read-only incremental snapshots
 
-The key of the Kafka message has to match the connector's name.
+When the MySQL connection is read-only, the {link-prefix}:{link-signalling}[signaling table] mechanism can also run a snapshot by sending a message to the Kafka topic that is specified in
+the {link-prefix}:{link-mysql-connector}#mysql-property-signal-kafka-topic[signal.kafka.topic] property.
 
-The value is a json with `type` and `data` fields.
+The key of the Kafka message must match the name of the connector.
+
+The value is a JSON object with `type` and `data` fields.
 
 The signal type is `execute-snapshot` and the `data` field must have the following fields:
 
@@ -528,20 +544,24 @@ The format of the names is the same as for {link-prefix}:#{context}-property-sig
 
 An example of the execute-snapshot Kafka message:
 
+----
 Key = `test_connector`
 
 Value = `{"type":"execute-snapshot","data": {"data-collections": ["schema1.table1", "schema1.table2"], "type": "INCREMENTAL"}}`
+----
 
 ifdef::community[]
 
 // Type: continue
 [id="mysql-snapshot-events"]
-=== Operation type for snapshot events
-The MySql connector emits snapshot events using the "r" operation type (`READ`). In case you want the connector to emit snapshot events as "c" events (`CREATE`, as done incorrectly in earlier versions), this can be achieved using a Simple Message Transforms (SMT).
-Configure the Debezium `ReadToInsertEvent` SMT by adding the SMT configuration details to your connector’s configuration.
+=== Operation type of snapshot events
 
-An example of the configuration is this:
+The MySQL connector emits snapshot events as `READ` operations `("op" : "r")`.
+If you prefer that the connector emits snapshot events as `CREATE` (`c`) events, configure the {prodname} `ReadToInsertEvent` single message transform (SMT) to modify the event type.
 
+The following example shows how to configure the SMT:
+
+.Example: Using the `ReadToInsertEvent` SMT to change the type of snapshot events
 ----
 transforms=snapshotasinsert,...
 transforms.snapshotasinsert.type=io.debezium.connector.mysql.transforms.ReadToInsertEvent
@@ -2640,6 +2660,7 @@ If the size of the transaction is larger than the buffer then {prodname} must re
  +
 NOTE: This feature is incubating. Feedback is encouraged. It is expected that this feature is not completely polished.
 endif::community[]
+
 |[[mysql-property-snapshot-mode]]<<mysql-property-snapshot-mode, `+snapshot.mode+`>>
 |`initial`
 |Specifies the criteria for running a snapshot when the connector starts. Possible settings are: +
@@ -2670,7 +2691,10 @@ a|Controls whether and how long the connector holds the global MySQL read lock, 
 
 |[[mysql-property-snapshot-include-collection-list]]<<mysql-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>
 | All tables specified in `table.include.list`
-|An optional, comma-separated list of regular expressions that match names of schemas specified in `table.include.list` for which you *want* to take the snapshot.
+|An optional, comma-separated list of regular expressions that match the fully-qualified names (`_<databaseName>.<tableName>_`) of the tables to include in a snapshot.
+The specified items must be named in the connector's xref:mysql-property-table-include-list[`table.include.list`] property.
+This property takes effect only if the connector's `snapshot.mode` property is set to a value other than `never`. +
+This property does not affect the behavior of xref:mysql-incremental-snapshots[incremental snapshots].
 
 |[[mysql-property-snapshot-select-statement-overrides]]<<mysql-property-snapshot-select-statement-overrides, `+snapshot.select.statement.overrides+`>>
 |No default
@@ -2771,10 +2795,15 @@ endif::community[]
 |No default
 |Comma-separated list of operation types to skip during streaming. The following values are possible: `c` for inserts/create, `u` for updates, `d` for deletes. By default, no operations are skipped.
 
-|[[mysql-property-signal-data-collection]]<<mysql-property-signal-data-collection, `+signal.data.collection+`>>
-|No default
-| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}[signals] to the connector.
-The name format is _database-name.table-name_.
+|[[mysql-property-signal-data-collection]]<<mysql-property-signal-data-collection,`+signal.data.collection+`>>
+|No default value
+|Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}[signals] to the connector. +
+Use the following format to specify the collection name: +
+`_<databaseName>_._<tableName>_`
+
+ifdef::product[]
+xref:{link-signalling}#sending-signals-to-a-debezium-connector[Signaling] is a Technology Preview feature.
+endif::product[]
 
 |[[mysql-property-incremental-snapshot-allow-schema-changes]]<<mysql-property-incremental-snapshot-allow-schema-changes, `+incremental.snapshot.allow.schema.changes+`>>
 |`false`
@@ -2784,7 +2813,15 @@ Note that changes to a primary key are not supported and can cause incorrect res
 
 |[[mysql-property-incremental-snapshot-chunk-size]]<<mysql-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
 |`1024`
-| The number of rows fetched from the database for each incremental snapshot iteration.
+|The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
+The value determines the number of rows that the snapshot collects during each fetch operation on the database.
+Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
+However, larger chunk sizes also require more memory to buffer the snapshot data.
+Adjust the chunk size to a value that provides the best performance in your environment.
+
+ifdef::product[]
+xref:debezium-mysql-incremental-snapshots[Incremental snapshots] is a Technology Preview feature.
+endif::product[]
 
 |[[mysql-property-read-only]]<<mysql-property-read-only, `+read.only+`>>
 |`false`
@@ -2805,9 +2842,9 @@ Note that changes to a primary key are not supported and can cause incorrect res
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 
 [id="debezium-{context}-connector-kafka-signals-configuration-properties"]
-==== {prodname} connector kafka signals configuration properties
+==== {prodname} connector Kafka signals configuration properties
 
-When MySQL connector is configured as read-only the alternative for the signalling table is the signals Kafka topic.
+When the MySQL connector is configured as read-only, the alternative for the signaling table is the signals Kafka topic.
 
 {prodname} provides a set of `signal.*` properties that control how the connector interacts with the Kafka signals topic.
 
@@ -2819,7 +2856,7 @@ The following table describes the `signal` properties.
 |Property |Default |Description
 |[[{context}-property-signal-kafka-topic]]<<{context}-property-signal-kafka-topic, `+signal.kafka.topic+`>>
 |
-|The name of the Kafka topic that connector monitors for ad-hoc signals.
+|The name of the Kafka topic that the connector monitors for ad hoc signals.
 
 |[[{context}-property-signal-kafka-bootstrap-servers]]<<{context}-property-signal-kafka-bootstrap-servers, `+signal.kafka.bootstrap.servers+`>>
 |

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -145,7 +145,7 @@ When the connector restarts after having crashed or been stopped gracefully, the
 The connector rebuilds the table structures that existed at this point in time by reading the database history Kafka topic and parsing all DDL statements up to the point in the binlog where the connector is starting.
 
 This database history topic is for connector use only.
-The connector can optionally {link-prefix}:{link-mysql-connector}#mysql-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
+The connector can optionally xref:mysql-schema-change-topic[emit schema change events to a different topic that is intended for consumer applications].
 
 When the MySQL connector captures changes in a table to which a schema change tool such as `gh-ost` or `pt-online-schema-change` is applied, there are helper tables created during the migration process.
 The connector needs to be configured to capture change to these helper tables.
@@ -482,21 +482,22 @@ a|Records the completed snapshot in the connector offsets.
 
 |===
 
-ifdef::community[]
-
-// ADD annotation onlyu after supported downstream: Type: concept
-// ADD annotation onlyu after supported downstream: ModuleID: debezium-mysql-ad-hoc-snapshots
+// Type: concept
+// ModuleID: debezium-mysql-ad-hoc-snapshots
 [id="mysql-ad-hoc-snapshots"]
 ==== Ad hoc snapshots
 include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
 
-// ADD annotation only after supported downstream: Type: concept
-// ADD annotation only after supported downstream: ModuleID: debezium-mysql-incremental-snapshots
+
+
+// Type: concept
 [id="mysql-incremental-snapshots"]
 ==== Incremental snapshots
 include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+3]
-[id="mysql-read-only-incremental-snapshots"]
 
+
+ifdef::community[]
+[id="mysql-read-only-incremental-snapshots"]
 ==== Read-only incremental snapshots
 
 The MySQL connector allows for running incremental snapshots with a read-only connection to the database.
@@ -2692,7 +2693,7 @@ a|Controls whether and how long the connector holds the global MySQL read lock, 
 |An optional, comma-separated list of regular expressions that match the fully-qualified names (`_<databaseName>.<tableName>_`) of the tables to include in a snapshot.
 The specified items must be named in the connector's xref:mysql-property-table-include-list[`table.include.list`] property.
 This property takes effect only if the connector's `snapshot.mode` property is set to a value other than `never`. +
-This property does not affect the behavior of xref:mysql-incremental-snapshots[incremental snapshots].
+This property does not affect the behavior of incremental snapshots.
 
 |[[mysql-property-snapshot-select-statement-overrides]]<<mysql-property-snapshot-select-statement-overrides, `+snapshot.select.statement.overrides+`>>
 |No default

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2712,13 +2712,11 @@ You can configure the connector to skip the following types of operations:
 
 By default, no operations are skipped.
 
-
 |[[oracle-property-signal-data-collection]]<<oracle-property-signal-data-collection,`+signal.data.collection+`>>
 |No default value
-a|Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}[signals] to the connector. +
+a|Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector. +
 Use the following format to specify the collection name: +
-`_<schemaName>_._<tableName>_`
-
+`_<databaseName>_._<schemaName>_._<tableName>_`
 
 |[[oracle-property-incremental-snapshot-chunk-size]]<<oracle-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
 |`1024`

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -119,7 +119,17 @@ Note this mode is only safe to be used when it is guaranteed that no schema chan
 
 |===
 
-include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
+// Type: concept
+// ModuleID: debezium-oracle-ad-hoc-snapshots
+[id="oracle-ad-hoc-snapshots"]
+==== Ad hoc snapshots
+include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
+
+// Type: concept
+// ModuleID: debezium-oracle-incremental-snapshots
+[id="oracle-incremental-snapshots"]
+==== Incremental snapshots
+include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+3]
 
 [WARNING]
 ====
@@ -176,7 +186,7 @@ The payload of a schema change event message includes the following elements:
 
 `ddl`:: Provides the SQL `CREATE`, `ALTER`, or `DROP` statement that results in the schema change.
 `databaseName`:: The name of the database to which the statements are applied.
-The value of `databaseName` serves as the message key. 
+The value of `databaseName` serves as the message key.
 `tableChanges`::  A structured representation of the entire table schema after the schema change.
 The `tableChanges` field contains an array that includes entries for each column of the table.
 Because the structured representation presents data in JSON or Avro format, consumers can easily read messages without first processing them through a DDL parser.
@@ -2224,7 +2234,11 @@ You can set the following values:
 
 |[[oracle-property-snapshot-include-collection-list]]<<oracle-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>
 | All tables specified in `table.include.list`
-|An optional, comma-separated list of regular expressions that match names of fully-qualified table names (`_<schemaName>_._<tableName>_`) included in `table.include.list` for which you want to take the snapshot.
+|An optional, comma-separated list of regular expressions that match the fully-qualified names (`_<schemaName>_._<tableName>_`) of the tables to include in a snapshot.
+The specified items must be named in the connector's xref:{context}-property-table-include-list[`table.include.list`] property.
+This property takes effect only if the connector's `snapshot.mode` property is set to a value other than `never`. +
+
+This property does not affect the behavior of xref:oracle-incremental-snapshots[incremental snapshots].
 
 |[[oracle-property-snapshot-select-statement-overrides]]<<oracle-property-snapshot-select-statement-overrides, `+snapshot.select.statement.overrides+`>>
 |No default
@@ -2534,17 +2548,17 @@ Use the `log.mining.buffer.location` property to define the location for storing
 |[[oracle-property-log-mining-buffer-infinispan-cache-transactions]]<<oracle-property-log-mining-buffer-infinispan-cache-transactions, `+log.mining.buffer.infinispan.cache.transactions+`>>
 |No default
 |The XML configuration for the Infinispan transaction cache.
-See xref:oracle-event-buffering-infinispan[Infinispan event buffering] for more details.
+For more information, see xref:oracle-event-buffering-infinispan[Infinispan event buffering].
 
 |[[oracle-property-log-mining-buffer-infinispan-cache-events]]<<oracle-property-log-mining-buffer-infinispan-cache-events, `+log.mining.buffer.infinispan.cache.events+`>>
 |No default
 |The XML configuration for the Infinispan events cache.
-See xref:oracle-event-buffering-infinispan[Infinispan event buffering] for more details.
+For more information, see xref:oracle-event-buffering-infinispan[Infinispan event buffering].
 
 |[[oracle-property-log-mining-buffer-infinispan-cache-processed-transactions]]<<oracle-property-log-mining-buffer-infinispan-cache-processed-transactions, `+log.mining.buffer.infinispan.cache.processed_transactions+`>>
 |No default
 |The XML configuration for the Infinispan processed transactions cache.
-See xref:oracle-event-buffering-infinispan[Infinispan event buffering] for more details.
+For more information, see xref:oracle-event-buffering-infinispan[Infinispan event buffering].
 
 |[[oracle-property-log-mining-buffer-infinispan-cache-schema-changes]]<<oracle-property-log-mining-buffer-infinispan-cache-schema-changes, `+log.mining.buffer.infinispan.cache.schema_changes+`>>
 |No default
@@ -2699,14 +2713,21 @@ You can configure the connector to skip the following types of operations:
 
 By default, no operations are skipped.
 
-|[[oracle-property-signal-data-collection]]<<oracle-property-signal-data-collection, `+signal.data.collection+`>>
-|No default
-| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}[signals] to the connector.
-The name format is _database_name.schema-name.table-name_.
+
+|[[oracle-property-signal-data-collection]]<<oracle-property-signal-data-collection,`+signal.data.collection+`>>
+|No default value
+a|Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}[signals] to the connector. +
+Use the following format to specify the collection name: +
+`_<schemaName>_._<tableName>_`
+
 
 |[[oracle-property-incremental-snapshot-chunk-size]]<<oracle-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
 |`1024`
-| The number of rows fetched from the database for each incremental snapshot iteration.
+|The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
+The value determines the number of rows that the snapshot collects during each fetch operation on the database.
+Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
+However, larger chunk sizes also require more memory to buffer the snapshot data.
+Adjust the chunk size to a value that provides the best performance in your environment.
 
 |===
 
@@ -2995,8 +3016,8 @@ ifdef::community[]
 The Oracle connector automatically tracks and applies table schema changes by parsing DDL from the redo logs.
 If the DDL parser encounters an incompatible statement, if needed, the connector provides an alternative way to apply the schema change.
 
-By default, the connector stops when it encountered a DDL statement that it cannot parse.
-You can use {prodname} link:/documentation/reference/configuration/signalling[signalling] to trigger the update of the database schema from such DDL statements.
+By default, the connector stops when it encounters a DDL statement that it cannot parse.
+You can use {prodname} link:/documentation/reference/configuration/signalling[signaling] to trigger the update of the database schema from such DDL statements.
 
 The type of the schema update action is `schema-changes`.
 This action updates the schema of all tables enumerated in the signal parameters.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -126,7 +126,6 @@ Note this mode is only safe to be used when it is guaranteed that no schema chan
 include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
 
 // Type: concept
-// ModuleID: debezium-oracle-incremental-snapshots
 [id="oracle-incremental-snapshots"]
 ==== Incremental snapshots
 include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+3]
@@ -2238,7 +2237,7 @@ You can set the following values:
 The specified items must be named in the connector's xref:{context}-property-table-include-list[`table.include.list`] property.
 This property takes effect only if the connector's `snapshot.mode` property is set to a value other than `never`. +
 
-This property does not affect the behavior of xref:oracle-incremental-snapshots[incremental snapshots].
+This property does not affect the behavior of incremental snapshots.
 
 |[[oracle-property-snapshot-select-statement-overrides]]<<oracle-property-snapshot-select-statement-overrides, `+snapshot.select.statement.overrides+`>>
 |No default

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2723,8 +2723,7 @@ Use the following format to specify the collection name: +
 
 |[[oracle-property-incremental-snapshot-chunk-size]]<<oracle-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
 |`1024`
-|The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
-The value determines the number of rows that the snapshot collects during each fetch operation on the database.
+|The maximum number of rows that the connector fetches and reads into memory during an incremental snapshot chunk.
 Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
 However, larger chunk sizes also require more memory to buffer the snapshot data.
 Adjust the chunk size to a value that provides the best performance in your environment.

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3166,7 +3166,7 @@ Use the following format to specify the collection name: +
 `_<schemaName>_._<tableName>_` +
 
 ifdef::product[]
-xref:{link-signalling}#sending-signals-to-a-debezium-connector[Signaling] is a Technology Preview feature.
+Signaling is a Technology Preview feature.
 endif::product[]
 
 |[[postgresql-property-incremental-snapshot-chunk-size]]<<postgresql-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -171,7 +171,6 @@ endif::community[]
 include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
 
 // Type: concept
-// ModuleID: debezium-postgresql-incremental-snapshots
 [id="postgresql-incremental-snapshots"]
 ==== Incremental snapshots
 include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+1]
@@ -2979,7 +2978,8 @@ endif::community[]
 |An optional, comma-separated list of regular expressions that match the fully-qualified names (`_<schemaName>.<tableName>_`) of the tables to include in a snapshot.
 The specified items must be named in the connector's xref:{context}-property-table-include-list[`table.include.list`] property.
 This property takes effect only if the connector's `snapshot.mode` property is set to a value other than `never`. +
-This property does not affect the behavior of xref:postgresql-ad-hoc-snapshots[incremental snapshots].
+
+This property does not affect the behavior of incremental snapshots.
 
 |[[postgresql-property-snapshot-lock-timeout-ms]]<<postgresql-property-snapshot-lock-timeout-ms, `+snapshot.lock.timeout.ms+`>>
 |`10000`
@@ -3177,7 +3177,7 @@ However, larger chunk sizes also require more memory to buffer the snapshot data
 Adjust the chunk size to a value that provides the best performance in your environment.
 
 ifdef::product[]
-xref:debezium-postgresql-incremental-snapshots[Incremental snapshots] is a Technology Preview feature.
+Incremental snapshots is a Technology Preview feature.
 endif::product[]
 
 |===

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -164,7 +164,17 @@ endif::community[]
 
 |===
 
-include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
+// Type: concept
+// ModuleID: debezium-postgresql-ad-hoc-snapshots
+[id="postgresql-ad-hoc-snapshots"]
+==== Ad hoc snapshots
+include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
+
+// Type: concept
+// ModuleID: debezium-postgresql-incremental-snapshots
+[id="postgresql-incremental-snapshots"]
+==== Incremental snapshots
+include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+1]
 
 [WARNING]
 ====
@@ -2963,9 +2973,14 @@ ifdef::community[]
 |No default
 | A full Java class name that is an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. Required when the `snapshot.mode` property is set to `custom`. See {link-prefix}:{link-postgresql-connector}#postgresql-custom-snapshot[custom snapshotter SPI].
 endif::community[]
+
 |[[postgresql-property-snapshot-include-collection-list]]<<postgresql-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>
 | All tables specified in `table.include.list`
-|An optional, comma-separated list of regular expressions that match names of schemas specified in `table.include.list` for which you *want* to take the snapshot when the `snapshot.mode` is not `never`
+|An optional, comma-separated list of regular expressions that match the fully-qualified names (`_<schemaName>.<tableName>_`) of the tables to include in a snapshot.
+The specified items must be named in the connector's xref:{context}-property-table-include-list[`table.include.list`] property.
+This property takes effect only if the connector's `snapshot.mode` property is set to a value other than `never`. +
+This property does not affect the behavior of xref:postgresql-ad-hoc-snapshots[incremental snapshots].
+
 |[[postgresql-property-snapshot-lock-timeout-ms]]<<postgresql-property-snapshot-lock-timeout-ms, `+snapshot.lock.timeout.ms+`>>
 |`10000`
 |Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. {link-prefix}:{link-postgresql-connector}#postgresql-snapshots[How the connector performs snapshots] provides details.
@@ -3144,14 +3159,27 @@ If the setting of `unavailable.value.placeholder` starts with the `hex:` prefix 
 The operations include: `c` for inserts/create, `u` for updates, and `d` for deletes.
 By default, no operations are skipped.
 
-|[[postgresql-property-signal-data-collection]]<<postgresql-property-signal-data-collection, `+signal.data.collection+`>>
-|No default
-|Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}[signals] to the connector.
-The name format is _schema-name.table-name_.
+|[[postgresql-property-signal-data-collection]]<<postgresql-property-signal-data-collection,`+signal.data.collection+`>>
+|No default value
+|Fully-qualified name of the data collection that is used to send signals to the connector. +
+Use the following format to specify the collection name: +
+`_<schemaName>_._<tableName>_` +
+
+ifdef::product[]
+xref:{link-signalling}#sending-signals-to-a-debezium-connector[Signaling] is a Technology Preview feature.
+endif::product[]
 
 |[[postgresql-property-incremental-snapshot-chunk-size]]<<postgresql-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
-|`1024`
-| The number of rows fetched from the database for each incremental snapshot iteration.
+|1024
+|The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
+The value determines the number of rows that the snapshot collects during each fetch operation on the database. +
+Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
+However, larger chunk sizes also require more memory to buffer the snapshot data.
+Adjust the chunk size to a value that provides the best performance in your environment.
+
+ifdef::product[]
+xref:debezium-postgresql-incremental-snapshots[Incremental snapshots] is a Technology Preview feature.
+endif::product[]
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3171,8 +3171,7 @@ endif::product[]
 
 |[[postgresql-property-incremental-snapshot-chunk-size]]<<postgresql-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
 |1024
-|The maximum size, in bytes, of each chunk that the connector queries and reads into memory during an incremental snapshot.
-The value determines the number of rows that the snapshot collects during each fetch operation on the database. +
+|The maximum number of rows that the connector fetches and reads into memory during an incremental snapshot chunk.
 Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
 However, larger chunk sizes also require more memory to buffer the snapshot data.
 Adjust the chunk size to a value that provides the best performance in your environment.

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -139,7 +139,6 @@ From this baseline state, the connector captures subsequent changes as they occu
 include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
 
 // Type: concept
-// ModuleID: debezium-sqlserver-incremental-snapshots
 [id="sqlserver-incremental-snapshots"]
 ==== Incremental snapshots
 include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+3]
@@ -2238,7 +2237,8 @@ The following values are supported:
 |An optional, comma-separated list of regular expressions that match the fully-qualified names (`_<dbName>_._<schemaName>_._<tableName>_`) of the tables to include in a snapshot.
 The specified items must be named in the connector's xref:{context}-property-table-include-list[`table.include.list`] property.
 This property takes effect only if the connector's `snapshot.mode` property is set to a value other than `never`. +
-This property does not affect the behavior of xref:{link-sqlserver-connector}#sqlserver-incremental-snapshots[incremental snapshots].
+
+This property does not affect the behavior of incremental snapshots.
 
 |[[sqlserver-property-snapshot-isolation-mode]]<<sqlserver-property-snapshot-isolation-mode, `+snapshot.isolation.mode+`>>
 |_repeatable_read_

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2403,7 +2403,10 @@ Note that changes to a primary key are not supported and can cause incorrect res
 
 |[[sqlserver-property-incremental-snapshot-chunk-size]]<<sqlserver-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
 |`1024`
-| The number of rows fetched from the database for each incremental snapshot iteration.
+|The maximum number of rows that the connector fetches and reads into memory during an incremental snapshot chunk.
+Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
+However, larger chunk sizes also require more memory to buffer the snapshot data.
+Adjust the chunk size to a value that provides the best performance in your environment.
 
 |[[sqlserver-property-max-iteration-transactions]]<<sqlserver-property-max-iteration-transactions, `+max.iteration.transactions+`>>
 |0

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2387,12 +2387,12 @@ By default, no operations are skipped.
 
 |[[sqlserver-property-signal-data-collection]]<<sqlserver-property-signal-data-collection,`+signal.data.collection+`>>
 |No default value
-| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}[signals] to the connector. +
+| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}debezium-signaling-enabling-signaling[signals] to the connector. +
 Use the following format to specify the collection name: +
 `_<databaseName>_._<schemaName>_._<tableName>_`
 
 ifdef::product[]
-xref:{link-signalling}#sending-signals-to-a-debezium-connector[Signaling] is a Technology Preview feature.
+Signaling is a Technology Preview feature.
 endif::product[]
 
 |[[sqlserver-property-incremental-snapshot-allow-schema-changes]]<<sqlserver-property-incremental-snapshot-allow-schema-changes, `+incremental.snapshot.allow.schema.changes+`>>

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -132,7 +132,17 @@ The level of the lock is determined by `snapshot.isolation.mode` configuration o
 The resulting initial snapshot captures the current state of each row in the tables that are enabled for CDC.
 From this baseline state, the connector captures subsequent changes as they occur.
 
-include::{partialsdir}/modules/all-connectors/ref-connector-incremental-snapshot.adoc[leveloffset=+3]
+// Type: concept
+// ModuleID: debezium-sqlserver-ad-hoc-snapshots
+[id="sqlserver-ad-hoc-snapshots"]
+==== Ad hoc snapshots
+include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
+
+// Type: concept
+// ModuleID: debezium-sqlserver-incremental-snapshots
+[id="sqlserver-incremental-snapshots"]
+==== Incremental snapshots
+include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+3]
 
 [WARNING]
 ====
@@ -210,7 +220,7 @@ Messages that the connector sends to the schema change topic contain a payload, 
 The payload of a schema change event message includes the following elements:
 
 `databaseName`:: The name of the database to which the statements are applied.
-The value of `databaseName` serves as the message key. 
+The value of `databaseName` serves as the message key.
 `tableChanges`::  A structured representation of the entire table schema after the schema change.
 The `tableChanges` field contains an array that includes entries for each column of the table.
 Because the structured representation presents data in JSON or Avro format, consumers can easily read messages without first processing them through a DDL parser.
@@ -2225,7 +2235,10 @@ The following values are supported:
 
 |[[sqlserver-property-snapshot-include-collection-list]]<<sqlserver-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>
 | All tables specified in `table.include.list`
-|An optional, comma-separated list of regular expressions that match names of *fully-qualified* table names (`<db-name>.<schema-name>.<name>`) included in `table.include.list` for which you *want* to take the snapshot.
+|An optional, comma-separated list of regular expressions that match the fully-qualified names (`_<dbName>_._<schemaName>_._<tableName>_`) of the tables to include in a snapshot.
+The specified items must be named in the connector's xref:{context}-property-table-include-list[`table.include.list`] property.
+This property takes effect only if the connector's `snapshot.mode` property is set to a value other than `never`. +
+This property does not affect the behavior of xref:{link-sqlserver-connector}#sqlserver-incremental-snapshots[incremental snapshots].
 
 |[[sqlserver-property-snapshot-isolation-mode]]<<sqlserver-property-snapshot-isolation-mode, `+snapshot.isolation.mode+`>>
 |_repeatable_read_
@@ -2360,7 +2373,7 @@ endif::community[]
 |`${database.server.name}.transaction`
 |Controls the name of the topic to which the connector sends transaction metadata messages. The placeholder `${database.server.name}` can be used for referring to the connector's logical name; defaults to `${database.server.name}.transaction`, for example `dbserver1.transaction`.
 
-See {link-prefix}:{link-sqlserver-connector}#sqlserver-transaction-metadata[Transaction Metadata] for additional details.
+For more information, see xref:sqlserver-transaction-metadata[Transaction Metadata].
 
 |[[sqlserver-property-retriable-restart-connector-wait-ms]]<<sqlserver-property-retriable-restart-connector-wait-ms, `+retriable.restart.connector.wait.ms+`>> +
 |10000 (10 seconds)
@@ -2372,10 +2385,15 @@ See {link-prefix}:{link-sqlserver-connector}#sqlserver-transaction-metadata[Tran
 The operations include: `c` for inserts/create, `u` for updates, and `d` for deletes.
 By default, no operations are skipped.
 
-|[[sqlserver-property-signal-data-collection]]<<sqlserver-property-signal-data-collection, `+signal.data.collection+`>>
-|No default
-| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}[signals] to the connector.
-The name format is _database_name.schema-name.table-name_.
+|[[sqlserver-property-signal-data-collection]]<<sqlserver-property-signal-data-collection,`+signal.data.collection+`>>
+|No default value
+| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}[signals] to the connector. +
+Use the following format to specify the collection name: +
+`_<databaseName>_._<schemaName>_._<tableName>_`
+
+ifdef::product[]
+xref:{link-signalling}#sending-signals-to-a-debezium-connector[Signaling] is a Technology Preview feature.
+endif::product[]
 
 |[[sqlserver-property-incremental-snapshot-allow-schema-changes]]<<sqlserver-property-incremental-snapshot-allow-schema-changes, `+incremental.snapshot.allow.schema.changes+`>>
 |`false`

--- a/documentation/modules/ROOT/pages/features.adoc
+++ b/documentation/modules/ROOT/pages/features.adoc
@@ -14,12 +14,12 @@ Unlike other approaches, such as polling or dual writes,
 log-based CDC as implemented by {prodname}:
 
 * Ensures that *all data changes are captured*.
-* Produces change events with a *very low delay* while avoiding increased CPU usage required for frequent polling. For example, for MySQL or PostgreSQL, the delay is in the millisecond range. 
+* Produces change events with a *very low delay* while avoiding increased CPU usage required for frequent polling. For example, for MySQL or PostgreSQL, the delay is in the millisecond range.
 * Requires *no changes to your data model*, such as a "Last Updated" column.
 * Can *capture deletes*.
 * Can *capture old record state and additional metadata* such as transaction ID and causing query, depending on the database's capabilities and configuration.
 
-link:https://debezium.io/blog/2018/07/19/advantages-of-log-based-change-data-capture/[Five Advantages of Log-Based Change Data Capture] is a blog post that provides more details. 
+link:https://debezium.io/blog/2018/07/19/advantages-of-log-based-change-data-capture/[Five Advantages of Log-Based Change Data Capture] is a blog post that provides more details.
 
 {prodname} connectors capture data changes with a range of related capabilities and options:
 
@@ -27,7 +27,15 @@ link:https://debezium.io/blog/2018/07/19/advantages-of-log-based-change-data-cap
 * *Filters:* you can configure the set of captured schemas, tables and columns with include/exclude list filters.
 * *Masking:* the values from specific columns can be masked, for example, when they contain sensitive data.
 * *Monitoring:* most connectors can be monitored by using JMX.
+ifdef::community[]
 * Ready-to-use *message transformations* for message routing, filtering, event flattening, and more; see xref:transformations/index.adoc[Transformations] for an overview of all the SMTs coming with {prodname}.
+endif::community[]
+ifdef::product[]
+* Ready-to-use *single message transformations (SMTs)* for message routing, filtering, event flattening, and more.
+  For more an overview of the SMTs that {prodname} provides, see xref:applying-transformations-to-modify-messages-exchanged-with-kafka[Applying transformations to modify messages exchanged with Apache Kafka].
+
+The documentation for each connector provides details about the connectors features and configuration options.
+endif::product[]
 
 ifdef::community[]
 See the {link-prefix}:{link-connectors}[connector documentation] for a list of all supported databases and detailed information about the features and configuration options of each connector.
@@ -35,7 +43,3 @@ See the {link-prefix}:{link-connectors}[connector documentation] for a list of a
 {prodname} can also be used as xref:development/engine.adoc[library embedded] into your JVM-based applications;
 via xref:operations/debezium-server.adoc[Debezium Server], you can emit change events to messaging infrastructure like Amazon Kinesis, Google Cloud Pub/Sub, Apache Pulsar, etc.
 endif::community[]
-
-ifdef::product[]
-The documentation for each connector provides details about the connectors features and configuration options. 
-endif::product[]

--- a/documentation/modules/ROOT/pages/features.adoc
+++ b/documentation/modules/ROOT/pages/features.adoc
@@ -32,7 +32,7 @@ ifdef::community[]
 endif::community[]
 ifdef::product[]
 * Ready-to-use *single message transformations (SMTs)* for message routing, filtering, event flattening, and more.
-  For more an overview of the SMTs that {prodname} provides, see xref:applying-transformations-to-modify-messages-exchanged-with-kafka[Applying transformations to modify messages exchanged with Apache Kafka].
+  For more information about the SMTs that {prodname} provides, see xref:applying-transformations-to-modify-messages-exchanged-with-kafka[Applying transformations to modify messages exchanged with Apache Kafka].
 
 The documentation for each connector provides details about the connectors features and configuration options.
 endif::product[]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
@@ -69,7 +69,8 @@ The snapshot process reads the first and last primary key values and uses those 
 Based on the number of entries in the {data-collection}, and the configured chunk size, {prodname} divides the {data-collection} into chunks, and proceeds to snapshot each chunk, in succession, one at a time.
 
 Currently, the `execute-snapshot` action type triggers xref:{link-signalling}#debezium-signaling-incremental-snapshots[incremental snapshots] only.
-
+For more information, see xref:{link-{context}-connector}#{context}-incremental-snapshots[Incremental snapshots].
+////
 .Prerequisites
 
 * xref:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled].
@@ -89,5 +90,4 @@ For example:
 ----
 INSERT INTO myschema.debezium_signal VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.table1", "schema2.table2"]}')
 ----
-
-//For more information, see xref:{context}-incremental-snapshots[Incremental snapshots].
+////

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
@@ -1,0 +1,93 @@
+ifdef::community[]
+[NOTE]
+====
+This feature is currently in incubating state, i.e. exact semantics, configuration options etc. may change in future revisions, based on the feedback we receive.
+Please let us know if you encounter any problems while using this extension.
+====
+endif::community[]
+
+ifdef::product[]
+[IMPORTANT]
+====
+The use of ad hoc snapshots is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::product[]
+
+By default, a connector runs an initial snapshot operation only after it starts for the first time.
+Following this initial snapshot, under normal circumstances, the connector does not repeat the snapshot process.
+Any future change event data that the connector captures comes in through the streaming process only.
+
+However, in some situations the data that the connector obtained during the initial snapshot might become stale, lost, or incomplete.
+To provide a mechanism for recapturing {data-collection} data, {prodname} includes an option to perform ad hoc snapshots.
+The following changes in a database might be cause for performing an ad hoc snapshot:
+
+* The connector configuration is modified to capture a different set of {data-collection}s.
+* Kafka topics are deleted and must be rebuilt.
+* Data corruption occurs due to a configuration error or some other problem.
+
+You can re-run a snapshot for a {data-collection} for which you previously captured a snapshot by initiating a so-called _ad-hoc snapshot_.
+Ad hoc snapshots require the use of {link-prefix}:{link-signalling}#sending-signals-to-a-debezium-connector[signaling {data-collection}s].
+You initiate an ad hoc snapshot by sending a signal request to the {prodname} signaling {data-collection}.
+
+When you initiate an ad hoc snapshot of an existing {data-collection}, the connector appends content to the topic that already exists for the {data-collection}.
+If a previously existing topic was removed, {prodname} can create a topic automatically if xref:{link-topic-auto-creation}#customizing-debezium-automatically-created-topics[automatic topic creation] is enabled.
+
+Ad hoc snapshot signals specify the {data-collection}s to include in the snapshot.
+The snapshot can capture the entire contents of the database, or capture only a subset of the {data-collection}s in the database.
+
+You specify the {data-collection}s to capture by sending an `execute-snapshot` message to the signaling {data-collection}.
+Set the type of the `execute-snapshot` signal to `incremental`, and provide the names of the {data-collection}s to include in the snapshot, as described in the following table:
+
+.Example of an ad hoc `execute-snapshot` signal record
+[cols="2,2,6",options="header"]
+|===
+|Field | Default | Value
+
+|`type`
+|`incremental`
+| Specifies the type of snapshot that you want to run. +
+Setting the type is optional.
+Currently, you can request only `incremental` snapshots.
+
+
+|`data-collections`
+|_N/A_
+| An array that contains the fully-qualified names of the {data-collection} to be snapshotted. +
+The format of the names is the same as for the `signal.data.collection` configuration option.
+
+|===
+
+.Triggering an ad hoc snapshot
+
+You initiate an ad hoc snapshot by adding an entry with the `execute-snapshot` signal type to the signaling {data-collection}.
+After the connector processes the message, it begins the snapshot operation.
+The snapshot process reads the first and last primary key values and uses those values as the start and end point for each {data-collection}.
+Based on the number of entries in the {data-collection}, and the configured chunk size, {prodname} divides the {data-collection} into chunks, and proceeds to snapshot each chunk, in succession, one at a time.
+
+Currently, the `execute-snapshot` action type triggers xref:{link-signalling}#debezium-signaling-incremental-snapshots[incremental snapshots] only.
+
+.Prerequisites
+
+* xref:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled].
+
+.Procedure
+
+* Trigger a snapshot by submitting a SQL query to add a signal to the signaling {data-collection} that uses the following format:
++
+[source,sql,subs="+attributes,+quotes"]
+----
+INSERT INTO _<signalingCollection>_ VALUES('_<signalName>_','_<signalType>_', '{"data-collections": ["_<dataCollection>_","_<dataCollectionN>_"]}')
+----
++
+For example:
++
+[source,sql]
+----
+INSERT INTO myschema.debezium_signal VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.table1", "schema2.table2"]}')
+----
+
+//For more information, see xref:{context}-incremental-snapshots[Incremental snapshots].

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
@@ -47,25 +47,24 @@ As a snapshot proceeds, it’s likely that other processes continue to access th
 To reflect such changes, `INSERT`, `UPDATE`, or `DELETE` operations are committed to the transaction log as per usual.
 Similarly, the ongoing {prodname} streaming process continues to detect these change events and emits corresponding change event records to Kafka.
 
-.How {prodname} resolves conflicts among records with the same primary key
+.How {prodname} resolves collisions among records with the same primary key
 In some cases, the `UPDATE` or `DELETE` events that the streaming process emits are received out of sequence.
 That is, the streaming process might emit an event that modifies a {data-collection} row before the snapshot captures the chunk that contains the `READ` event for that row.
 When the snapshot eventually emits the corresponding `READ` event for the row, its value is already superseded.
-To ensure that incremental snapshot events that arrive out of sequence are processed in the correct logical order, {prodname} employs a buffering scheme for resolving conflicts.
-Only after conflicts between the snapshot events and the streamed events are resolved does {prodname} emit an event record to Kafka.
+To ensure that incremental snapshot events that arrive out of sequence are processed in the correct logical order, {prodname} employs a buffering scheme for resolving collisions.
+Only after collisions between the snapshot events and the streamed events are resolved does {prodname} emit an event record to Kafka.
 
 .Snapshot window
-To assist in resolving conflicts between late-arriving `READ` events and streamed events that modify the same {data-collection} row, {prodname} employs a so-called _snapshot window_.
+To assist in resolving collisions between late-arriving `READ` events and streamed events that modify the same {data-collection} row, {prodname} employs a so-called _snapshot window_.
 The snapshot windows demarcates the interval during which an incremental snapshot captures data for a specified {data-collection} chunk.
 Before the snapshot window for a chunk opens, {prodname} follows its usual behavior and emits events from the transaction log directly downstream to the target Kafka topic.
-But from the moment that the snapshot for a particular chunk opens, until it closes, {prodname} performs a de-duplication step to resolve potential conflicts among events.
+But from the moment that the snapshot for a particular chunk opens, until it closes, {prodname} performs a de-duplication step to resolve collisions between events that have the same primary key..
 
-During the snapshot window for a {data-collection} chunk, the incremental snapshot sends the `READ` events that it captures from a {data-collection} to a memory buffer.
-Next, it examines the events that the streaming process emits from the transaction log.
-Events that are not related to records that already exist in the {data-collection} are sent to Kafka.
-But for events that modify existing records in the {data-collection}, {prodname} searches the buffer for a `READ` event that has a matching primary key.
-Any matching `READ` events in the buffer are dropped, because the corresponding transaction log events logically supersede them.
-The transaction log event for the record is then emitted to Kafka.
+As {prodname} processes a snapshot chunk, it delivers `READ` events that the incremental snapshot process captures to a memory buffer.
+Meanwhile, as users commit changes for ongoing database operations to the transaction log, the {prodname} streaming process continues to emit change events for these operations.
+As {prodname} processes each event, it compares its primary key to the keys of the events in the buffer.
+If no match is found, the streamed event is sent directly to Kafka.
+If the key of a streamed event matches the key of a buffered event, {prodname} drops the `READ` event in the buffer, because the streamed transaction log events logically supersede it.
 After the snapshot window for the chunk closes, the buffer contains only `READ` events for which no related transaction log events exist.
 {prodname} emits these remaining `READ` events to the {data-collection}'s Kafka topic.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
@@ -1,0 +1,177 @@
+ifdef::community[]
+[NOTE]
+====
+This feature is currently in incubating state. The exact semantics, configuration options, and so forth is subject to change in future revisions, based on the feedback we receive.
+Please let us know if you encounter any problems while using this extension.
+====
+endif::community[]
+
+ifdef::product[]
+[IMPORTANT]
+====
+The use of incremental snapshots is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::product[]
+To provide flexibility in managing snapshots, {prodname} includes a supplementary snapshot mechanism, known as _incremental snapshotting_.
+Incremental snapshots rely on the {prodname} mechanism for xref:{link-signalling}#sending-signals-to-a-debezium-connector[sending signals to a {prodname} connector].
+ifdef::community[]
+Incremental snapshots are based on the link:https://github.com/debezium/debezium-design-documents/blob/main/DDD-3.md[DDD-3] design document.
+endif::community[]
+
+In an incremental snapshot, instead of capturing the full state of a database all at once, as in an initial snapshot, {prodname} captures each {data-collection} in phases, in a series of configurable chunks.
+You can specify the {data-collection}s that you want the snapshot to capture and the xref:{context}-property-incremental-snapshot-chunk-size[size of each chunk].
+The chunk size determines the number of rows that the snapshot collects during each fetch operation on the database.
+The default chunk size for incremental snapshots is 1 KB.
+
+As an incremental snapshot proceeds, {prodname} uses watermarks to track its progress, maintaining a record of each {data-collection} row that it captures.
+This phased approach to capturing data provides the following advantages over the standard initial snapshot process:
+
+* You can run incremental snapshots in parallel with streamed data capture, instead of postponing streaming until the snapshot completes.
+  The connector continues to capture near real-time events from the change log throughout the snapshot process, and neither operation blocks the other.
+* If the progress of an incremental snapshot is interrupted, you can resume it without losing any data.
+  After the process resumes, the snapshot begins at the point where it stopped, rather than recapturing the {data-collection} from the beginning.
+* You can run an incremental snapshot on demand at any time, and repeat the process as needed to adapt to database updates.
+  For example, you might re-run a snapshot after you modify the connector configuration to add a {data-collection} to its xref:{context}-property-table-include-list[`table.include.list`] property.
+
+.Incremental snapshot process
+When you run an incremental snapshot, {prodname} sorts each {data-collection} by primary key and then splits the {data-collection} into chunks based on the xref:{context}-property-incremental-snapshot-chunk-size[configured chunk size].
+Working chunk by chunk, it then captures each {data-collection} row in a chunk.
+For each row that it captures, the snapshot emits a `READ` event.
+That event represents the value of the row when the snapshot for the chunk began.
+
+As a snapshot proceeds, it’s likely that other processes continue to access the database, potentially modifying {data-collection} records.
+To reflect such changes, `INSERT`, `UPDATE`, or `DELETE` operations are committed to the transaction log as per usual.
+Similarly, the ongoing {prodname} streaming process continues to detect these change events and emits corresponding change event records to Kafka.
+
+.How {prodname} resolves conflicts among records with the same primary key
+In some cases, the `UPDATE` or `DELETE` events that the streaming process emits are received out of sequence.
+That is, the streaming process might emit an event that modifies a {data-collection} row before the snapshot captures the chunk that contains the `READ` event for that row.
+When the snapshot eventually emits the corresponding `READ` event for the row, its value is already superseded.
+To ensure that incremental snapshot events that arrive out of sequence are processed in the correct logical order, {prodname} employs a buffering scheme for resolving conflicts.
+Only after conflicts between the snapshot events and the streamed events are resolved does {prodname} emit an event record to Kafka.
+
+.Snapshot window
+To assist in resolving conflicts between late-arriving `READ` events and streamed events that modify the same {data-collection} row, {prodname} employs a so-called _snapshot window_.
+The snapshot windows demarcates the interval during which an incremental snapshot captures data for a specified {data-collection} chunk.
+Before the snapshot window for a chunk opens, {prodname} follows its usual behavior and emits events from the transaction log directly downstream to the target Kafka topic.
+But from the moment that the snapshot for a particular chunk opens, until it closes, {prodname} performs a de-duplication step to resolve potential conflicts among events.
+
+During the snapshot window for a {data-collection} chunk, the incremental snapshot sends the `READ` events that it captures from a {data-collection} to a memory buffer.
+Next, it examines the events that the streaming process emits from the transaction log.
+Events that are not related to records that already exist in the {data-collection} are sent to Kafka.
+But for events that modify existing records in the {data-collection}, {prodname} searches the buffer for a `READ` event that has a matching primary key.
+Any matching `READ` events in the buffer are dropped, because the corresponding transaction log events logically supersede them.
+The transaction log event for the record is then emitted to Kafka.
+After the snapshot window for the chunk closes, the buffer contains only `READ` events for which no related transaction log events exist.
+{prodname} emits these remaining `READ` events to the {data-collection}'s Kafka topic.
+
+The connector repeats the process for each snapshot chunk.
+
+.Triggering an incremental snapshot
+
+Currently, the only way to initiate an incremental snapshot is to send an xref:{link-signalling}#debezium-signaling-ad-hoc-snapshots[ad hoc snapshot signal] to the signaling {data-collection} on the source database.
+You submit signals to the {data-collection} as SQL `INSERT` queries.
+After {prodname} detects the change in the signaling {data-collection}, it reads the signal, and runs the requested snapshot operation.
+
+The query that you submit specifies the {data-collection}s to include in the snapshot, and, optionally, specifies the kind of snapshot operation.
+Currently, the only valid option for snapshots operations is the default value, `incremental`.
+
+To specify the {data-collection}s to include in the snapshot, provide a `data-collections` array that lists the {data-collection}s, for example, +
+`{"data-collections": ["public.MyFirstTable", "public.MySecondTable"]}` +
+
+The `data-collections` array for an incremental snapshot signal has no default value.
+If the `data-collections` array  is empty, {prodname} detects that no action is required and does not perform a snapshot.
+
+.Prerequisites
+
+* xref:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled]. +
+** A signaling data collection exists on the source database and the connector is configured to capture it.
+** The signaling data collection is specified in the xref:{context}-property-signal-data-collection[`signal.data.collection`] property.
+
+.Procedure
+
+. Send a SQL query to add the ad hoc incremental snapshot request to the signaling {data-collection}:
++
+[source,sql,indent=0,subs="+attributes"]
+----
+INSERT INTO _<signalTable>_ (id, type, data) VALUES (_'<id>'_, _'<snapshotType>'_, '{"data-collections": ["_<tableName>_","_<tableName>_"],"type":"_<snapshotType>_"}');
+----
++
+For example,
++
+[source,sql,indent=0,subs="+attributes"]
+----
+INSERT INTO myschema.debezium_signal (id, type, data) VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.table1", "schema2.table2"],"type":"incremental"}');
+----
+The values of the `id`,`type`, and `data` parameters in the command correspond to the xref:{link-signalling}#debezium-signaling-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
++
+The following {data-collection} describes the these parameters:
++
+.Descriptions of fields in a SQL command for sending an incremental snapshot signal to the signaling {data-collection}
+[cols="1,4",options="header"]
+|===
+|Value |Description
+
+|`myschema.debezium_signal`
+|Specifies the fully-qualified name of the signaling {data-collection} on the source database
+
+|`ad-hoc-1`
+| The `id` parameter specifies an arbitrary string that is assigned as the `id` identifier for the signal request. +
+Use this string to identify logging messages to entries in the signaling {data-collection}.
+{prodname} does not use this string.
+Rather, during the snapshot, {prodname} generates its own `id` string as a watermarking signal.
+
+|`execute-snapshot`
+| Specifies `type` parameter specifies the operation that the signal is intended to trigger. +
+
+|`data-collections`
+|A required component of the `data` field of a signal that specifies an array of {data-collection} names to include in the snapshot. +
+The array lists {data-collection}s by their fully-qualified names, using the same format as you use to specify the name of the connector's signaling {data-collection} in the xref:{context}-property-signal-data-collection[`signal.data.collection`] configuration property.
+
+|`incremental`
+|An optional `type` component of the `data` field of a signal that specifies the kind of snapshot operation to run. +
+Currently, the only valid option is the default value, `incremental`. +
+Specifying a `type` value in the SQL query that you submit to the signaling {data-collection} is optional. +
+If you do not specify a value, the connector runs an incremental snapshot.
+|===
+
+The following example, shows the JSON for an incremental snapshot event that is captured by a connector.
+
+.Example: Incremental snapshot event message
+[source,json,index=0]
+----
+{
+    "before":null,
+    "after": {
+        "pk":"1",
+        "value":"New data"
+    },
+    "source": {
+        ...
+        "snapshot":"incremental" <1>
+    },
+    "op":"r", <2>
+    "ts_ms":"1620393591654",
+    "transaction":null
+}
+----
+[cols="1,1,4",options="header"]
+|===
+|Item |Field name |Description
+|1
+|`snapshot`
+|Specifies the type of snapshot operation to run. +
+Currently, the only valid option is the default value, `incremental`. +
+Specifying a `type` value in the SQL query that you submit to the signaling {data-collection} is optional. +
+If you do not specify a value, the connector runs an incremental snapshot.
+
+|2
+|`op`
+|Specifies the event type. +
+The value for snapshot events is `r`, signifying a `READ` operation.
+
+|===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
@@ -16,6 +16,7 @@ This Technology Preview feature provides early access to upcoming product innova
 For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====
 endif::product[]
+
 To provide flexibility in managing snapshots, {prodname} includes a supplementary snapshot mechanism, known as _incremental snapshotting_.
 Incremental snapshots rely on the {prodname} mechanism for xref:{link-signalling}#sending-signals-to-a-debezium-connector[sending signals to a {prodname} connector].
 ifdef::community[]
@@ -60,11 +61,14 @@ The snapshot windows demarcates the interval during which an incremental snapsho
 Before the snapshot window for a chunk opens, {prodname} follows its usual behavior and emits events from the transaction log directly downstream to the target Kafka topic.
 But from the moment that the snapshot for a particular chunk opens, until it closes, {prodname} performs a de-duplication step to resolve collisions between events that have the same primary key..
 
-As {prodname} processes a snapshot chunk, it delivers `READ` events that the incremental snapshot process captures to a memory buffer.
-Meanwhile, as users commit changes for ongoing database operations to the transaction log, the {prodname} streaming process continues to emit change events for these operations.
-As {prodname} processes each event, it compares its primary key to the keys of the events in the buffer.
-If no match is found, the streamed event is sent directly to Kafka.
-If the key of a streamed event matches the key of a buffered event, {prodname} drops the `READ` event in the buffer, because the streamed transaction log events logically supersede it.
+For each data collection, the {prodname} emits two types of events, and stores the records for them both in a single destination Kafka topic.
+The snapshot records that it  captures directly from a table are emitted as `READ` operations.
+Meanwhile, as users continue to update records in the data collection, and the transaction log is updated to reflect each commit, {prodname} emits `UPDATE` or `DELETE` operations for each change.
+
+As the snapshot window opens, and {prodname} begins processing a snapshot chunk, it delivers snapshot records to a memory buffer.
+During the snapshot windows, the primary keys of the `READ` events in the buffer are compared to the primary keys of the incoming streamed events.
+If no match is found, the streamed event record is sent directly to Kafka.
+If {prodname} detects a match, it discards the buffered `READ` event, and writes the streamed record to the destination topic, because the streamed event logically supersede the static snapshot event.
 After the snapshot window for the chunk closes, the buffer contains only `READ` events for which no related transaction log events exist.
 {prodname} emits these remaining `READ` events to the {data-collection}'s Kafka topic.
 
@@ -83,7 +87,7 @@ To specify the {data-collection}s to include in the snapshot, provide a `data-co
 `{"data-collections": ["public.MyFirstTable", "public.MySecondTable"]}` +
 
 The `data-collections` array for an incremental snapshot signal has no default value.
-If the `data-collections` array  is empty, {prodname} detects that no action is required and does not perform a snapshot.
+If the `data-collections` array is empty, {prodname} detects that no action is required and does not perform a snapshot.
 
 .Prerequisites
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/obs_ref-connector-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/obs_ref-connector-incremental-snapshot.adoc
@@ -114,4 +114,3 @@ This means that event semantics differ between initial and incremental snapshots
 * `update` and `delete` events can arrive before `read` events
 * if `delete` event arrives first then `read` event is never delivered
 * if `update` event arrives first then `read` event will either not be delivered at all or it will be delivered with the updated value
-

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc
@@ -26,7 +26,9 @@ The connector also provides the following additional snapshot metrics when an in
 
 |===
 
+ifdef::product[]
 [IMPORTANT]
 ====
 Incremental snapshots is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[https://access.redhat.com/support/offerings/techpreview].
 ====
+endif::product[]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc
@@ -25,3 +25,8 @@ The connector also provides the following additional snapshot metrics when an in
 |The upper bound of the primary key set of the currently snapshotted table.
 
 |===
+
+[IMPORTANT]
+====
+Incremental snapshots is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[https://access.redhat.com/support/offerings/techpreview].
+====


### PR DESCRIPTION
[DBZ-3457](https://issues.redhat.com/browse/DBZ-3457)

Supersedes earlier PRs #2923 and #2954.

This change describes the Ad hoc and Incremental snapshot processes, together with how to use the signaling mechanism to trigger the connector to perform operations.

The changes include:
 
* Updates and restructures the upstream content. 
* Refactors the original `ref-connector-incremental-snapshot.adoc` file into two files to create a separate `con-connector-incremental-snapshot.adoc` and  `con-ad-hoc-snapshots.adoc` files.
* Rearranges and consolidates content from the original Signaling and Incremental snapshots files to reduce redundancy.
* Incorporates content from the Incremental snapshots blog post by @jpechane, and the 1.6.x release announcements by Jiri and @Naros.
* Fixes ID conflicts, broken links, and other issues that prevented the downstream content from building.

Although the MongoDB content is not being used in the current downstream release, due to the changes to the formerly single shared file, I updated the file reference to prevent the `include` statement from failing.

Please verify that all of the necessary content is preserved, and that I've correctly captured the intended sense.

Tested in local Antora and downstream builds.