### PR TITLE
DBZ-4473 Remove unused brackets in MySqlParser

### DIFF
--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -2165,7 +2165,7 @@ convertedDataType
       | typeName=(DATE | DATETIME | TIME | JSON | INT | INTEGER)
       | typeName=DECIMAL lengthTwoOptionalDimension?
       | (SIGNED | UNSIGNED) INTEGER?
-    ) (ARRAY)?
+    ) ARRAY?
     ;
 
 lengthOneDimension


### PR DESCRIPTION
Refer https://issues.redhat.com/browse/DBZ-4473
Have removed in upstream grammars-v4