### PR TITLE
DBZ-4492: Add support for additional properties in metric name

### DIFF
--- a/debezium-core/src/main/java/io/debezium/connector/common/CdcSourceTaskContext.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/CdcSourceTaskContext.java
@@ -7,6 +7,7 @@ package io.debezium.connector.common;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import org.apache.kafka.connect.source.SourceTask;
@@ -31,6 +32,8 @@ public class CdcSourceTaskContext {
      * Obtains the data collections captured at the point of invocation.
      */
     private final Supplier<Collection<? extends DataCollectionId>> collectionsSupplier;
+
+    public static final Map<String, String> EMPTY_CONNECTOR_PROPERTIES = Collections.emptyMap();
 
     public CdcSourceTaskContext(String connectorType, String connectorName, Supplier<Collection<? extends DataCollectionId>> collectionsSupplier) {
         this.connectorType = connectorType;
@@ -84,5 +87,12 @@ public class CdcSourceTaskContext {
 
     public String getConnectorName() {
         return connectorName;
+    }
+
+    /**
+     * Return a map of connector properties as additional key properties in JMX metric name.
+     */
+    public Map<String, String> getConnectorProperties() {
+        return EMPTY_CONNECTOR_PROPERTIES;
     }
 }


### PR DESCRIPTION
Support passing connector-specific properties to the metric name
as additional key properties of the MBean's object name, via the task
context. This enables the JMX metric name to have other connector
properties than type, context and server, which can be used as tags
in the metrics reporter.

JIRA: https://issues.redhat.com/browse/DBZ-4492
