### PR TITLE
DBZ-4501 Null out incremental snapshot event's query field

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -218,6 +218,15 @@ public class MySqlReadOnlyIncrementalSnapshotChangeEventSource<T extends DataCol
         }
     }
 
+    @Override
+    protected void sendEvent(Partition partition, EventDispatcher<T> dispatcher, OffsetContext offsetContext, Object[] row) throws InterruptedException {
+        SourceInfo sourceInfo = ((MySqlOffsetContext) offsetContext).getSource();
+        String query = sourceInfo.getQuery();
+        sourceInfo.setQuery(null);
+        super.sendEvent(partition, dispatcher, offsetContext, row);
+        sourceInfo.setQuery(query);
+    }
+
     public void rereadChunk() throws InterruptedException {
         if (context == null) {
             return;

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/ReadOnlyIncrementalSnapshotIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/ReadOnlyIncrementalSnapshotIT.java
@@ -78,6 +78,7 @@ public class ReadOnlyIncrementalSnapshotIT extends IncrementalSnapshotIT {
                 .with(MySqlConnectorConfig.READ_ONLY_CONNECTION, true)
                 .with(KafkaSignalThread.SIGNAL_TOPIC, getSignalsTopic())
                 .with(KafkaSignalThread.BOOTSTRAP_SERVERS, kafka.brokerList())
+                .with(MySqlConnectorConfig.INCLUDE_SQL_QUERY, true)
                 .with(RelationalDatabaseConnectorConfig.MSG_KEY_COLUMNS, String.format("%s:%s", DATABASE.qualifiedTableName("a42"), "pk1,pk2,pk3,pk4"));
     }
 

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotWithSchemaChangesSupportTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotWithSchemaChangesSupportTest.java
@@ -46,7 +46,7 @@ public abstract class AbstractIncrementalSnapshotWithSchemaChangesSupportTest<T 
 
     @Test
     public void schemaChanges() throws Exception {
-        Print.enable();
+        // Testing.Print.enable();
 
         populateTable();
         startConnector();
@@ -87,7 +87,7 @@ public abstract class AbstractIncrementalSnapshotWithSchemaChangesSupportTest<T 
 
     @Test
     public void renameTable() throws Exception {
-        Print.enable();
+        // Testing.Print.enable();
 
         populateTable();
         final String newTable = "new_table";
@@ -141,7 +141,7 @@ public abstract class AbstractIncrementalSnapshotWithSchemaChangesSupportTest<T 
 
     @Test
     public void columnNullabilityChanges() throws Exception {
-        Print.enable();
+        // Testing.Print.enable();
 
         populateTable();
         final Configuration config = config().build();
@@ -186,7 +186,7 @@ public abstract class AbstractIncrementalSnapshotWithSchemaChangesSupportTest<T 
 
     @Test
     public void columnDefaultChanges() throws Exception {
-        Print.enable();
+        // Testing.Print.enable();
 
         populateTable();
         final Configuration config = config().build();


### PR DESCRIPTION
The `source.query` field must be null in the read-only incremental snapshot events