### PR TITLE
DBZ-4461 Add documentation for postgres bytea_output

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1421,9 +1421,9 @@ The string representation of the interval value that follows the pattern `P<year
 |`BYTES` or `STRING`
 |n/a +
  +
-Either the raw bytes (the default), a base64-encoded string, or a hex-encoded string, based on the connector's {link-prefix}:{link-postgresql-connector}#postgresql-property-binary-handling-mode[binary handling mode] setting. +
+Either the raw bytes (the default), a base64-encoded string, or a hex-encoded string, based on the connector's xref:postgresql-property-binary-handling-mode[binary handling mode] setting. +
  +
-Debezium only supports Postgres `bytea_output` configuration of value `hex`.
+Debezium only supports Postgres `bytea_output` configuration of value `hex`. See this link:https://www.postgresql.org/docs/current/datatype-binary.html[documentation on Postgres binary data types].
 
 |`JSON`, `JSONB`
 |`STRING`

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1421,7 +1421,9 @@ The string representation of the interval value that follows the pattern `P<year
 |`BYTES` or `STRING`
 |n/a +
  +
-Either the raw bytes (the default), a base64-encoded string, or a hex-encoded string, based on the connector's {link-prefix}:{link-postgresql-connector}#postgresql-property-binary-handling-mode[binary handling mode] setting.
+Either the raw bytes (the default), a base64-encoded string, or a hex-encoded string, based on the connector's {link-prefix}:{link-postgresql-connector}#postgresql-property-binary-handling-mode[binary handling mode] setting. +
+ +
+Debezium only supports Postgres `bytea_output` configuration of value `hex`.
 
 |`JSON`, `JSONB`
 |`STRING`


### PR DESCRIPTION
@gunnarmorling @jpechane adding docs for `bytea_output`. Should I also add something on the `binary.handling.mode` configuration table row?

https://issues.redhat.com/browse/DBZ-4461