### PR TITLE
DBZ-4499 Enable Oracle connector to execute INITIAL_ONLY snapshot.mode

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -674,12 +674,12 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         /**
          * Perform a snapshot of data and schema upon initial startup of a connector and stop after initial consistent snapshot.
          */
-        INITIAL_ONLY("initial_only", true, false,false),
+        INITIAL_ONLY("initial_only", true, false, false),
 
         /**
          * Perform a snapshot of the schema but no data upon initial startup of a connector.
          */
-        SCHEMA_ONLY("schema_only", false, true,false),
+        SCHEMA_ONLY("schema_only", false, true, false),
 
         /**
          * Perform a snapshot of only the database schemas (without data) and then begin reading the redo log at the current redo log position.

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -669,12 +669,17 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         /**
          * Perform a snapshot of data and schema upon initial startup of a connector.
          */
-        INITIAL("initial", true, false),
+        INITIAL("initial", true, true, false),
+
+        /**
+         * Perform a snapshot of data and schema upon initial startup of a connector and stop after initial consistent snapshot.
+         */
+        INITIAL_ONLY("initial_only", true, false,false),
 
         /**
          * Perform a snapshot of the schema but no data upon initial startup of a connector.
          */
-        SCHEMA_ONLY("schema_only", false, false),
+        SCHEMA_ONLY("schema_only", false, true,false),
 
         /**
          * Perform a snapshot of only the database schemas (without data) and then begin reading the redo log at the current redo log position.
@@ -682,15 +687,17 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
          * This recovery option should be used with care as it assumes there have been no schema changes since the connector last stopped,
          * otherwise some events during the gap may be processed with an incorrect schema and corrupted.
          */
-        SCHEMA_ONLY_RECOVERY("schema_only_recovery", false, true);
+        SCHEMA_ONLY_RECOVERY("schema_only_recovery", false, true, true);
 
         private final String value;
         private final boolean includeData;
+        private final boolean shouldStream;
         private final boolean shouldSnapshotOnSchemaError;
 
-        private SnapshotMode(String value, boolean includeData, boolean shouldSnapshotOnSchemaError) {
+        private SnapshotMode(String value, boolean includeData, boolean shouldStream, boolean shouldSnapshotOnSchemaError) {
             this.value = value;
             this.includeData = includeData;
+            this.shouldStream = shouldStream;
             this.shouldSnapshotOnSchemaError = shouldSnapshotOnSchemaError;
         }
 
@@ -705,6 +712,13 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
          */
         public boolean includeData() {
             return includeData;
+        }
+
+        /**
+         * Whether the snapshot mode is followed by streaming.
+         */
+        public boolean shouldStream() {
+            return shouldStream;
         }
 
         /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -720,6 +720,6 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
 
     @Override
     public void commitOffset(Map<String, ?> offset) {
-        //do nothing
+        // nothing to do
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -107,10 +107,6 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
      */
     @Override
     public void execute(ChangeEventSourceContext context, OraclePartition partition, OracleOffsetContext offsetContext) {
-
-        /**
-         * check if the connector config has snapshot.mode = initial_only, return without initiaing streaming
-         */
         if (!connectorConfig.getSnapshotMode().shouldStream()) {
             LOGGER.info("Streaming is not enabled in current configuration");
             return;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -107,6 +107,14 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
      */
     @Override
     public void execute(ChangeEventSourceContext context, OraclePartition partition, OracleOffsetContext offsetContext) {
+
+        /**
+         * check if the connector config has snapshot.mode = initial_only, return without initiaing streaming
+         */
+        if (!connectorConfig.getSnapshotMode().shouldStream()) {
+            LOGGER.info("Streaming is not enabled in current configuration");
+            return;
+        }
         try {
             startScn = offsetContext.getScn();
 
@@ -716,6 +724,6 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
 
     @Override
     public void commitOffset(Map<String, ?> offset) {
-        // nothing to do
+        //do nothing
     }
 }

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -108,6 +108,9 @@ If the connector stops again for any reason, after it restarts, it resumes strea
 |The connector performs a database snapshot as described in the xref:default-workflow-for-performing-an-initial-snapshot[default workflow for creating an initial snapshot].
 After the snapshot completes, the connector begins to stream event records for subsequent database changes.
 
+|`initial_only`
+|The connector performs a database snapshot and stops before streaming any change event records, not allowing any subsequent change events to be captured.
+
 |`schema_only`
 |The connector captures the structure of all relevant tables, performing all of the steps described in the xref:default-workflow-for-performing-an-initial-snapshot[default snapshot workflow], except that it does not create `READ` events to represent the data set at the point of the connector's start-up (Step 6).
 
@@ -2206,8 +2209,11 @@ You can set the following values:
 |Specifies the mode that the connector uses to take snapshots of a captured table.
 You can set the following values:
 
-`initial`:: The snapshot includes the structure and data of captured tables.
+`initial`:: The snapshot includes the structure and data of a captured table.
 Specify this value to populate topics with a complete representation of the data from the captured tables.
+
+`initial_only`:: The snapshot includes the structure and data of captured tables.
+The connector performs an initial snapshot and then stops, without processing any subsequent changes.
 
 `schema_only`:: The snapshot includes only the structure of captured tables.
 Specify this value if you want the connector to capture data only for changes that occur after the snapshot.
@@ -2218,7 +2224,7 @@ You might set it periodically to "clean up" a database history topic that has be
 Database history topics require infinite retention.
 Note this mode is only safe to be used when it is guaranteed that no schema changes happened since the point in time the connector was shut down before and the point in time the snapshot is taken.
 
-After the snapshot is complete, the connector continues to read change events from the database's redo logs.
+After the snapshot is complete, the connector continues to read change events from the database's redo logs except in case of initial_only snapshot mode.
 
 |[[oracle-property-snapshot-locking-mode]]<<oracle-property-snapshot-locking-mode, `+snapshot.locking.mode+`>>
 |_shared_

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2209,10 +2209,10 @@ You can set the following values:
 |Specifies the mode that the connector uses to take snapshots of a captured table.
 You can set the following values:
 
-`initial`:: The snapshot includes the structure and data of a captured table.
+`initial`:: The snapshot includes the structure and data of the captured tables.
 Specify this value to populate topics with a complete representation of the data from the captured tables.
 
-`initial_only`:: The snapshot includes the structure and data of captured tables.
+`initial_only`:: The snapshot includes the structure and data of the captured tables.
 The connector performs an initial snapshot and then stops, without processing any subsequent changes.
 
 `schema_only`:: The snapshot includes only the structure of captured tables.
@@ -2224,7 +2224,7 @@ You might set it periodically to "clean up" a database history topic that has be
 Database history topics require infinite retention.
 Note this mode is only safe to be used when it is guaranteed that no schema changes happened since the point in time the connector was shut down before and the point in time the snapshot is taken.
 
-After the snapshot is complete, the connector continues to read change events from the database's redo logs except in case of initial_only snapshot mode.
+After the snapshot is complete, the connector continues to read change events from the database's redo logs except when `snapshot.mode` is configured as `initial_only`.
 
 |[[oracle-property-snapshot-locking-mode]]<<oracle-property-snapshot-locking-mode, `+snapshot.locking.mode+`>>
 |_shared_


### PR DESCRIPTION
**Jira ticket**: [DBZ-4499](https://issues.redhat.com/browse/DBZ-4499)

**Changes**
1) Added INITIAL_ONLY snapshot mode in OracleConnectorConfig.
2) Checking if the config has snapshot.mode set to INITIAL_ONLY, if yes then do not proceed with streaming.

**Notes for Reviewer**
As per the discussion in the [forum](https://debezium.zulipchat.com/#narrow/stream/302529-users/topic/Oracle.20snapshotting.20initial_only), commitOffsets implementation is not required.  