### PR TITLE
DBZ-4518 Make kafka query timeout configurable

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -377,3 +377,4 @@ Zoran Regvart
 Ünal Sürmeli
 魏南
 胡琴
+Snigdhajyoti Ghosh

--- a/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/HistorizedRelationalDatabaseConnectorConfig.java
@@ -58,7 +58,8 @@ public abstract class HistorizedRelationalDatabaseConnectorConfig extends Relati
                     KafkaDatabaseHistory.BOOTSTRAP_SERVERS,
                     KafkaDatabaseHistory.TOPIC,
                     KafkaDatabaseHistory.RECOVERY_POLL_ATTEMPTS,
-                    KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS)
+                    KafkaDatabaseHistory.RECOVERY_POLL_INTERVAL_MS,
+                    KafkaDatabaseHistory.KAFKA_QUERY_TIMEOUT_MS)
             .create();
 
     protected HistorizedRelationalDatabaseConnectorConfig(Class<? extends SourceConnector> connectorClass, Configuration config, String logicalName,

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -18,6 +18,10 @@ The following table describes the `database.history` properties for configuring 
 |`100`
 |An integer value that specifies the maximum number of milliseconds the connector should wait during startup/recovery while polling for persisted data. The default is 100ms.
 
+|[[{context}-property-database-history-kafka-query-timeout-ms]]<<{context}-property-database-history-kafka-query-timeout-ms, `+database.history.kafka.query.timeout.ms+`>>
+|`3000`
+|An integer value that specifies the maximum number of milliseconds the connector should wait while fetching cluster information using Kafka admin client.
+
 |[[{context}-property-database-history-kafka-recovery-attempts]]<<{context}-property-database-history-kafka-recovery-attempts, `+database.history.kafka.recovery.attempts+`>>
 |`4`
 |The maximum number of times that the connector should try to read persisted history data before the connector recovery fails with an error. The maximum amount of time to wait after receiving no data is `recovery.attempts` x `recovery.poll.interval.ms`.

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -112,3 +112,4 @@ sarumont,Richard Kolkovich
 poonam-meghnani,Poonam Meghnani
 Oscar,Oscar Romero
 nathan-smit-1,Nathan Smit
+snigdhasjg,Snigdhajyoti Ghosh


### PR DESCRIPTION
When creating history topic, debezium core module's KafkaDatabaseHistory class make an API call using KafkaAdminClient to get broker default replication factor.

The call can get timed-out if there are SSL encryption and SASL validation happens on server side while creating connection.

The aim here is to make timeout configurable.