### PR TITLE
DBZ-4544 Change tests to JUnit 5

### DIFF
--- a/.github/workflows/testing-workflow.yml
+++ b/.github/workflows/testing-workflow.yml
@@ -59,4 +59,4 @@ jobs:
       - name: Run Formatting and Import Order Checks
         run: mvn clean install -DskipTests=true -DskipITs=true -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       - name: Build Debezium Testing
-        run: mvn clean install -B -pl debezium-testing -am -Passembly -Dcheckstyle.skip=true -Dformat.skip=true -Drevapi.skip -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+        run: mvn clean install -B -pl debezium-testing,debezium-testing/debezium-testing-testcontainers -am -Passembly -Dcheckstyle.skip=true -Dformat.skip=true -Drevapi.skip -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/ApicurioRegistryTest.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/ApicurioRegistryTest.java
@@ -25,9 +25,9 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.rnorth.ducttape.unreliables.Unreliables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,7 +67,7 @@ public class ApicurioRegistryTest {
             .enableApicurioConverters()
             .dependsOn(kafkaContainer);
 
-    @BeforeClass
+    @BeforeAll
     public static void startContainers() {
         Startables.deepStart(Stream.of(
                 apicurioContainer, kafkaContainer, postgresContainer, debeziumContainer)).join();
@@ -257,7 +257,7 @@ public class ApicurioRegistryTest {
         return apicurioUrl;
     }
 
-    @AfterClass
+    @AfterAll
     public static void stopContainers() {
         try {
             if (postgresContainer != null) {

--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/ConnectorConfigurationTest.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/ConnectorConfigurationTest.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.JsonNode;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;

--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/DebeziumContainerTest.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/DebeziumContainerTest.java
@@ -25,9 +25,9 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.awaitility.Awaitility;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.rnorth.ducttape.unreliables.Unreliables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +63,7 @@ public class DebeziumContainerTest {
             .withLogConsumer(new Slf4jLogConsumer(LOGGER))
             .dependsOn(kafkaContainer);
 
-    @BeforeClass
+    @BeforeAll
     public static void startContainers() {
         Startables.deepStart(Stream.of(
                 kafkaContainer, postgresContainer, debeziumContainer)).join();
@@ -171,7 +171,7 @@ public class DebeziumContainerTest {
         }
     }
 
-    @AfterClass
+    @AfterAll
     public static void stopContainers() {
         try {
             if (postgresContainer != null) {


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4544

`debezium-testing-testcontainers` module provides services also for Quarkus based modules. It means it brings JUnit 5.
The test in the module are written in JUnit 4 but surefire chooses launcher for JUnit 5 as it is present on classpath.

There are mutiple solutions to this issue

1) exclude JUnit 5 from quarkus dependencies. The problem is that every consumer of this module would need to explicitly reintroduce them.
2) Split the module for tests and test infra structure
3) Change the tests to use JUnit 5

I've opted for the last option. We are using JUnit 5 in other modules too so it is not a precedent. The tests to change were just few and other two options would just bring complications for no gain.