### PR TITLE
DBZ-4536 Make OracleErrorHandler more flexible of retriable errors

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleErrorHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleErrorHandler.java
@@ -7,6 +7,8 @@ package io.debezium.connector.oracle;
 
 import java.io.IOException;
 import java.sql.SQLRecoverableException;
+import java.util.ArrayList;
+import java.util.List;
 
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.pipeline.ErrorHandler;
@@ -20,29 +22,74 @@ import oracle.net.ns.NetException;
  */
 public class OracleErrorHandler extends ErrorHandler {
 
+    private static final String NO_MORE_DATA_TO_READ_FROM_SOCKET = "NO MORE DATA TO READ FROM SOCKET";
+
+    private static final List<String> retryOracleErrors = new ArrayList<>();
+    static {
+        retryOracleErrors.add("ORA-03135"); // connection lost
+        retryOracleErrors.add("ORA-12543"); // TNS:destination host unreachable
+        retryOracleErrors.add("ORA-00604"); // error occurred at recursive SQL level 1
+        retryOracleErrors.add("ORA-01089"); // Oracle immediate shutdown in progress
+        retryOracleErrors.add("ORA-01333"); // Failed to establish LogMiner dictionary
+        retryOracleErrors.add("ORA-01284"); // Redo/Archive log cannot be opened, likely locked
+        retryOracleErrors.add("ORA-26653"); // Apply DBZXOUT did not start properly and is currently in state INITIALI
+        retryOracleErrors.add("ORA-01291"); // missing logfile
+        retryOracleErrors.add("ORA-01327"); // failed to exclusively lock system dictionary as required BUILD
+        retryOracleErrors.add("ORA-04030"); // out of process memory
+    }
+
     public OracleErrorHandler(String logicalName, ChangeEventQueue<?> queue) {
         super(OracleConnector.class, logicalName, queue);
     }
 
     @Override
     protected boolean isRetriable(Throwable throwable) {
-        if (throwable.getMessage() == null || throwable.getCause() == null) {
-            return false;
+        // Always retry any recoverable error
+        if (throwable instanceof SQLRecoverableException) {
+            return true;
         }
 
-        return throwable.getMessage().startsWith("ORA-03135") || // connection lost
-                throwable.getMessage().startsWith("ORA-12543") || // TNS:destination host unreachable
-                throwable.getMessage().startsWith("ORA-00604") || // error occurred at recursive SQL level 1
-                throwable.getMessage().startsWith("ORA-01089") || // Oracle immediate shutdown in progress
-                throwable.getMessage().startsWith("ORA-01333") || // Failed to establish LogMiner dictionary
-                throwable.getMessage().startsWith("ORA-01284") || // Redo/Archive log cannot be opened, likely locked
-                throwable.getMessage().startsWith("ORA-26653") || // Apply DBZXOUT did not start properly and is currently in state INITIALI
-                throwable.getMessage().startsWith("ORA-01291") || // missing logfile
-                throwable.getMessage().startsWith("ORA-01327") || // failed to exclusively lock system dictionary as required BUILD
-                throwable.getMessage().startsWith("ORA-04030") || // out of process memory
-                throwable.getCause() instanceof IOException ||
-                throwable instanceof SQLRecoverableException ||
-                throwable.getMessage().toUpperCase().contains("NO MORE DATA TO READ FROM SOCKET") ||
-                (throwable.getCause() != null && throwable.getCause().getCause() instanceof NetException);
+        // If message is provided, check if it starts with a given Oracle error that's considered flagged for retry
+        if (isRetriableByMessageContents(throwable.getMessage())) {
+            return true;
+        }
+
+        // If there is a cause, inspect the cause, and its message details
+        if (throwable.getCause() != null) {
+            final Throwable cause = throwable.getCause();
+            if (cause instanceof IOException || cause instanceof SQLRecoverableException) {
+                return true;
+            }
+
+            if (isRetriableByMessageContents(cause.getMessage())) {
+                return true;
+            }
+        }
+
+        return isNestedNetException(throwable);
+    }
+
+    private boolean isRetriableByMessageContents(String message) {
+        if (message == null || message.length() == 0) {
+            return false;
+        }
+        // Check Oracle error codes
+        for (String errorCode : retryOracleErrors) {
+            if (message.startsWith(errorCode)) {
+                return true;
+            }
+        }
+        // Check specific Oracle message texts
+        return message.toUpperCase().contains(NO_MORE_DATA_TO_READ_FROM_SOCKET);
+    }
+
+    private boolean isNestedNetException(Throwable throwable) {
+        while (throwable != null) {
+            if (throwable.getCause() != null && throwable.getCause() instanceof NetException) {
+                return true;
+            }
+            throwable = throwable.getCause();
+        }
+        return false;
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4536

This rework addressed two problems.  

The first was that the `OracleErrorHandler` would not trigger retrying an error if the exception had no cause, which isn't necessarily always going to be the case.  If the raised error had the desired text in terms of either the error code or contained some text we deem retriable, then we should have allowed the error handler to proceed even if no cause was in the stack.

I took this a step further and applied the error code and text inspection to both the top-level and the cause (if available) portions of the stack trace.  In addition, I also changed the `NetException` check to be applied to each portion of the stack trace since this is often a deep exception thrown by the driver and could be n-levels deep in the stack trace.