### PR TITLE
DBZ-4541: Promote failure to register metrics to exception

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/BinlogReader.java
@@ -320,12 +320,12 @@ public class BinlogReader extends AbstractReader {
 
     @Override
     protected void doInitialize() {
-        metrics.register(logger);
+        metrics.register();
     }
 
     @Override
     public void doDestroy() {
-        metrics.unregister(logger);
+        metrics.unregister();
     }
 
     @Override

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SnapshotReader.java
@@ -111,12 +111,12 @@ public class SnapshotReader extends AbstractReader {
 
     @Override
     protected void doInitialize() {
-        metrics.register(logger);
+        metrics.register();
     }
 
     @Override
     public void doDestroy() {
-        metrics.unregister(logger);
+        metrics.unregister();
     }
 
     /**

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
@@ -15,6 +15,7 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import java.util.Iterator;
 
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -51,6 +52,8 @@ public class LogMinerQueryBuilderTest {
 
     private static final String OPERATION_CODES_LOB_ENABLED = "(1,2,3,9,10,11,29)";
     private static final String OPERATION_CODES_LOB_DISABLED = "(1,2,3)";
+
+    private OracleDatabaseSchema schema;
 
     /**
      * A template that defines the expected SQL output when the configuration specifies
@@ -92,12 +95,24 @@ public class LogMinerQueryBuilderTest {
             "${tablePredicate}" +
             "))";
 
+    @After
+    public void after() {
+        if (schema != null) {
+            try {
+                schema.close();
+            }
+            finally {
+                schema = null;
+            }
+        }
+    }
+
     @Test
     @FixFor("DBZ-3009")
     public void testLogMinerQueryWithNoFilters() {
         Configuration config = TestHelper.defaultConfig().build();
         OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
-        OracleDatabaseSchema schema = createSchema(connectorConfig);
+        schema = createSchema(connectorConfig);
 
         String result = LogMinerQueryBuilder.build(connectorConfig, schema);
         assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schema, null, null));
@@ -181,7 +196,7 @@ public class LogMinerQueryBuilderTest {
     private void assertQueryWithConfig(Field field, Object fieldValue, String schemaValue, String tableValue) {
         Configuration config = TestHelper.defaultConfig().with(field, fieldValue).build();
         OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
-        OracleDatabaseSchema schema = createSchema(connectorConfig);
+        schema = createSchema(connectorConfig);
 
         String result = LogMinerQueryBuilder.build(connectorConfig, schema);
         assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schema, schemaValue, tableValue));
@@ -208,7 +223,7 @@ public class LogMinerQueryBuilderTest {
     private void assertQueryWithConfig(Field field1, Object fieldValue1, Field field2, Object fieldValue2, String schemaValue, String tableValue) {
         Configuration config = TestHelper.defaultConfig().with(field1, fieldValue1).with(field2, fieldValue2).build();
         OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
-        OracleDatabaseSchema schema = createSchema(connectorConfig);
+        schema = createSchema(connectorConfig);
 
         String result = LogMinerQueryBuilder.build(connectorConfig, schema);
         assertThat(result).isEqualTo(resolveLogMineryContentQueryFromTemplate(connectorConfig, schema, schemaValue, tableValue));

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/processor/AbstractProcessorUnitTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/processor/AbstractProcessorUnitTest.java
@@ -18,6 +18,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -85,6 +86,18 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
         this.connection = createOracleConnection();
         this.schema = createOracleDatabaseSchema();
         this.metrics = createMetrics(schema);
+    }
+
+    @After
+    public void after() {
+        if (schema != null) {
+            try {
+                schema.close();
+            }
+            finally {
+                schema = null;
+            }
+        }
     }
 
     protected abstract Configuration.Builder getConfig();

--- a/debezium-core/src/main/java/io/debezium/metrics/Metrics.java
+++ b/debezium-core/src/main/java/io/debezium/metrics/Metrics.java
@@ -14,6 +14,7 @@ import javax.management.ObjectName;
 
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.debezium.annotation.ThreadSafe;
 import io.debezium.config.CommonConnectorConfig;
@@ -26,6 +27,8 @@ import io.debezium.connector.common.CdcSourceTaskContext;
  */
 @ThreadSafe
 public abstract class Metrics {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Metrics.class);
 
     private final ObjectName name;
     private volatile boolean registered = false;
@@ -42,11 +45,11 @@ public abstract class Metrics {
      * Registers a metrics MBean into the platform MBean server.
      * The method is intentionally synchronized to prevent preemption between registration and unregistration.
      */
-    public synchronized void register(Logger logger) {
+    public synchronized void register() {
         try {
             final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
             if (mBeanServer == null) {
-                logger.info("JMX not supported, bean '{}' not registered");
+                LOGGER.info("JMX not supported, bean '{}' not registered");
                 return;
             }
             mBeanServer.registerMBean(this, name);
@@ -61,12 +64,12 @@ public abstract class Metrics {
      * Unregisters a metrics MBean from the platform MBean server.
      * The method is intentionally synchronized to prevent preemption between registration and unregistration.
      */
-    public final void unregister(Logger logger) {
+    public final void unregister() {
         if (this.name != null && registered) {
             try {
                 final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
                 if (mBeanServer == null) {
-                    logger.debug("JMX not supported, bean '{}' not registered");
+                    LOGGER.debug("JMX not supported, bean '{}' not registered");
                     return;
                 }
                 mBeanServer.unregisterMBean(name);

--- a/debezium-core/src/main/java/io/debezium/metrics/Metrics.java
+++ b/debezium-core/src/main/java/io/debezium/metrics/Metrics.java
@@ -49,14 +49,14 @@ public abstract class Metrics {
         try {
             final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
             if (mBeanServer == null) {
-                LOGGER.info("JMX not supported, bean '{}' not registered");
+                LOGGER.info("JMX not supported, bean '{}' not registered", name);
                 return;
             }
             mBeanServer.registerMBean(this, name);
             registered = true;
         }
         catch (JMException e) {
-            logger.warn("Unable to register the MBean '{}': {}", name, e.getMessage());
+            throw new RuntimeException("Unable to register the MBean '" + name + "'", e);
         }
     }
 
@@ -69,13 +69,14 @@ public abstract class Metrics {
             try {
                 final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
                 if (mBeanServer == null) {
-                    LOGGER.debug("JMX not supported, bean '{}' not registered");
+                    LOGGER.debug("JMX not supported, bean '{}' not registered", name);
                     return;
                 }
                 mBeanServer.unregisterMBean(name);
+                registered = false;
             }
             catch (JMException e) {
-                logger.warn("Unable to unregister the MBean '{}': {}", name, e.getMessage());
+                throw new RuntimeException("Unable to unregister the MBean '" + name + "'", e);
             }
         }
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -97,8 +97,8 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
             executor.submit(() -> {
                 try {
                     previousLogContext.set(taskContext.configureLoggingContext("snapshot"));
-                    snapshotMetrics.register(LOGGER);
-                    streamingMetrics.register(LOGGER);
+                    snapshotMetrics.register();
+                    streamingMetrics.register();
                     LOGGER.info("Metrics registered");
 
                     ChangeEventSourceContext context = new ChangeEventSourceContextImpl();
@@ -213,8 +213,8 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
             }
         }
         finally {
-            snapshotMetrics.unregister(LOGGER);
-            streamingMetrics.unregister(LOGGER);
+            snapshotMetrics.unregister();
+            streamingMetrics.unregister();
         }
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/metrics/ChangeEventSourceMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/metrics/ChangeEventSourceMetrics.java
@@ -5,8 +5,6 @@
  */
 package io.debezium.pipeline.metrics;
 
-import org.slf4j.Logger;
-
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 
 /**
@@ -14,7 +12,7 @@ import io.debezium.pipeline.source.spi.DataChangeEventListener;
  */
 interface ChangeEventSourceMetrics extends DataChangeEventListener {
 
-    void register(Logger logger);
+    void register();
 
-    void unregister(Logger logger);
+    void unregister();
 }

--- a/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistoryMetrics.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistoryMetrics.java
@@ -97,13 +97,13 @@ public class DatabaseHistoryMetrics extends Metrics implements DatabaseHistoryLi
     @Override
     public void started() {
         status = DatabaseHistoryStatus.RUNNING;
-        register(LOGGER);
+        register();
     }
 
     @Override
     public void stopped() {
         status = DatabaseHistoryStatus.STOPPED;
-        unregister(LOGGER);
+        unregister();
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/schema/DatabaseSchema.java
+++ b/debezium-core/src/main/java/io/debezium/schema/DatabaseSchema.java
@@ -13,11 +13,9 @@ package io.debezium.schema;
  * @param <I>
  *            The type of {@link DataCollectionId} used by a given implementation
  */
-public interface DatabaseSchema<I extends DataCollectionId> {
+public interface DatabaseSchema<I extends DataCollectionId> extends AutoCloseable {
 
     String NO_CAPTURED_DATA_COLLECTIONS_WARNING = "After applying the include/exclude list filters, no changes will be captured. Please check your configuration!";
-
-    void close();
 
     DataCollectionSchema schemaFor(I id);
 


### PR DESCRIPTION
See [DBZ-4541](https://issues.redhat.com/browse/DBZ-4541).

1. Make `DatabaseSchema` extend `AutoCloseable`. This isn't strictly necessary but allows writing less code.
2. Maintain a single schema instance in the tests for the MySQL and Oracle connectors. Multiple schema instances can no longer co-exist in a single process since they would use the same metrics name.

Additionally, remove the `logger` parameter from the `Metrics#register` and `unregister` methods as suggested in https://github.com/debezium/debezium/pull/3047#discussion_r783075907.