### PR TITLE
DBZ-4131 Test with PostgreSQL 10 by default

### DIFF
--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -16,7 +16,7 @@
           Note that the `dockerhost.ip` property is computed from the IP address of DOCKER_HOST, which will
           work on all platforms. We'll set some of these as system properties during integration testing.
       -->
-        <version.postgres.server>9.6</version.postgres.server>
+        <version.postgres.server>10</version.postgres.server>
         <postgres.host>${docker.host.address}</postgres.host>
         <postgres.port>5432</postgres.port>
         <postgres.user>postgres</postgres.user>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4131

GH CI will use PostgreSQL 10 by default. Jenkins CI was not testing 9.6 so no changes are needed.