### PR TITLE
DBZ-4552 Modify link format to eliminate upstream Antora build error

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2394,7 +2394,7 @@ By default, no operations are skipped.
 
 |[[sqlserver-property-signal-data-collection]]<<sqlserver-property-signal-data-collection,`+signal.data.collection+`>>
 |No default value
-| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}debezium-signaling-enabling-signaling[signals] to the connector. +
+| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector. +
 Use the following format to specify the collection name: +
 `_<databaseName>_._<schemaName>_._<tableName>_`
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
@@ -69,7 +69,7 @@ The snapshot process reads the first and last primary key values and uses those 
 Based on the number of entries in the {data-collection}, and the configured chunk size, {prodname} divides the {data-collection} into chunks, and proceeds to snapshot each chunk, in succession, one at a time.
 
 Currently, the `execute-snapshot` action type triggers xref:{link-signalling}#debezium-signaling-incremental-snapshots[incremental snapshots] only.
-For more information, see xref:{link-{context}-connector}#{context}-incremental-snapshots[Incremental snapshots].
+For more information, see xref:#{context}-incremental-snapshots[Incremental snapshots].
 ////
 .Prerequisites
 


### PR DESCRIPTION
[DBZ-4553](https://issues.redhat.com/browse/DBZ-4552)

@Naros alerted me that a link in a shared file that I created for DBZ-3457 was generating multiple errors in the upstream Antora build that were not present in my local Antora build when I submitted PR #3057 last month. 

Changed the link format and tested that it works in both Antora and in the downstream build. 

Also fixed an unrelated error in `sqlserver.adoc` that resulted from a missing `#` in a property link.

Please backport this change to 1.7 and 1.8. 