### PR TITLE
DBZ-4561: Add flush table[s] grammer for all open tables

### DIFF
--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -1855,8 +1855,8 @@ flushOption
         | USER_RESOURCES | TABLES (WITH READ LOCK)?
        )                                                            #simpleFlushOption
     | RELAY LOGS channelOption?                                     #channelFlushOption
-    | TABLES tables flushTableOption?                               #tableFlushOption
-    | TABLE tables flushTableOption?                                #tableFlushOption
+    | TABLES tables? flushTableOption?                              #tableFlushOption
+    | TABLE tables? flushTableOption?                               #tableFlushOption
     ;
 
 flushTableOption

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_flush.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_flush.sql
@@ -4,12 +4,14 @@ flush local hosts;
 flush hosts, status;
 
 -- Table flushing
+flush tables;
 flush local tables Foo;
 flush tables Foo, Bar;
 flush tables Foo, Bar for export;
 flush tables Foo, Bar with read lock;
 
 -- 'FLUSH TABLE' is an alias for 'FLUSH TABLES' (https://dev.mysql.com/doc/refman/8.0/en/flush.html)
+flush table;
 flush local table Foo;
 flush TABLE Foo, Bar;
 flush table Foo, Bar for export;


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/DBZ-4561

According to the [documentation of MySQL](https://dev.mysql.com/doc/refman/8.0/en/flush.html#flush-tables) `FLUSH TABLE` and `FLUSH TABLES` can be used without listing tables, which means all open tables will be flushed.