### PR TITLE
DBZ-4367: LogMiner start mining from oldest pending TX instead of snapshot SCN

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -243,7 +243,7 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
                 ResultSet rs = statement.executeQuery(txQuery.toString())) {
             while (rs.next()) {
                 byte[] txid = rs.getBytes(1);
-                Long scn = rs.getLong(2);
+                String scn = rs.getString(2);
                 transactions.put(HexConverter.convertToHexString(txid), Scn.valueOf(scn));
             }
         }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -9,7 +9,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Savepoint;
 import java.sql.Statement;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -28,6 +30,7 @@ import io.debezium.relational.TableId;
 import io.debezium.schema.SchemaChangeEvent;
 import io.debezium.schema.SchemaChangeEvent.SchemaChangeEventType;
 import io.debezium.util.Clock;
+import io.debezium.util.HexConverter;
 
 /**
  * A {@link StreamingChangeEventSource} for Oracle.
@@ -150,9 +153,16 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
             currentScn = jdbcConnection.getCurrentScn();
         } while (areSameTimestamp(latestTableDdlScn.orElse(null), currentScn));
 
+        // Record the starting SCNs for all currently in-progress transactions.
+        // We should mine from the oldest still-reachable start SCN, but only for those transactions.
+        // For everything else, we mine only from the snapshot SCN forward.
+        Map<String, Scn> snapshotPendingTransactions = getSnapshotPendingTransactions(currentScn);
+
         ctx.offset = OracleOffsetContext.create()
                 .logicalName(connectorConfig)
                 .scn(currentScn)
+                .snapshotScn(currentScn)
+                .snapshotPendingTransactions(snapshotPendingTransactions)
                 .transactionContext(new TransactionContext())
                 .incrementalSnapshotContext(new SignalBasedIncrementalSnapshotContext<>())
                 .build();
@@ -218,6 +228,31 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
             }
             throw e;
         }
+    }
+
+    /**
+     * Returns a map of transaction id to start SCN for all ongoing transactions before snapshotSCN.
+     */
+    private Map<String, Scn> getSnapshotPendingTransactions(final Scn snapshotSCN) throws SQLException {
+        StringBuilder txQuery = new StringBuilder("SELECT XID, START_SCN FROM V$TRANSACTION WHERE START_SCN < ");
+        txQuery.append(snapshotSCN.toString());
+
+        Map<String, Scn> transactions = new HashMap<>();
+
+        try (Statement statement = jdbcConnection.connection().createStatement();
+                ResultSet rs = statement.executeQuery(txQuery.toString())) {
+            while (rs.next()) {
+                byte[] txid = rs.getBytes(1);
+                Long scn = rs.getLong(2);
+                transactions.put(HexConverter.convertToHexString(txid), Scn.valueOf(scn));
+            }
+        }
+        catch (SQLException e) {
+            LOGGER.warn("Could not query the V$TRANSACTION view: {}", e);
+            throw e;
+        }
+
+        return transactions;
     }
 
     @Override

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerOracleOffsetContextLoader.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerOracleOffsetContextLoader.java
@@ -33,7 +33,10 @@ public class LogMinerOracleOffsetContextLoader implements OffsetContext.Loader<O
 
         Scn scn = OracleOffsetContext.getScnFromOffsetMapByKey(offset, SourceInfo.SCN_KEY);
         Scn commitScn = OracleOffsetContext.getScnFromOffsetMapByKey(offset, SourceInfo.COMMIT_SCN_KEY);
-        return new OracleOffsetContext(connectorConfig, scn, commitScn, null, snapshot, snapshotCompleted, TransactionContext.load(offset),
+        Map<String, Scn> snapshotPendingTransactions = OracleOffsetContext.loadSnapshotPendingTransactions(offset);
+        Scn snapshotScn = OracleOffsetContext.loadSnapshotScn(offset);
+        return new OracleOffsetContext(connectorConfig, scn, commitScn, null, snapshotScn, snapshotPendingTransactions, snapshot, snapshotCompleted,
+                TransactionContext.load(offset),
                 SignalBasedIncrementalSnapshotContext.load(offset));
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -113,54 +113,15 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
             return;
         }
         try {
-            Scn firstScn = getFirstScnInLogs(jdbcConnection);
             startScn = offsetContext.getScn();
             snapshotScn = offsetContext.getSnapshotScn();
+            Scn firstScn = getFirstScnInLogs(jdbcConnection);
             if (startScn.compareTo(snapshotScn) == 0) {
                 // This is the initial run of the streaming change event source.
                 // We need to compute the correct start offset for mining. That is not the snapshot offset,
                 // but the start offset of the oldest transaction that was still pending when the snapshot
                 // was taken.
-                Map<String, Scn> snapshotPendingTransactions = offsetContext.getSnapshotPendingTransactions();
-                if (snapshotPendingTransactions == null || snapshotPendingTransactions.isEmpty()) {
-                    // no pending transactions, we can start mining from the snapshot SCN
-                    startScn = snapshotScn;
-                }
-                else {
-                    // find the oldest transaction we can still fully process, and start from there.
-                    Scn minScn = snapshotScn;
-                    for (Map.Entry<String, Scn> entry : snapshotPendingTransactions.entrySet()) {
-                        String transactionId = entry.getKey();
-                        Scn scn = entry.getValue();
-                        LOGGER.info("Transaction {} was pending across snapshot boundary. Start SCN = {}, snapshot SCN = {}", transactionId, scn, startScn);
-                        if (scn.compareTo(firstScn) < 0) {
-                            LOGGER.warn(
-                                    "Transaction {} was still ongoing while snapshot was taken, but is no longer completely recorded in the archive logs. Events will be lost. Oldest SCN = {}, TX start SCN = {}",
-                                    transactionId, firstScn, scn);
-                            minScn = firstScn;
-                        }
-                        else if (scn.compareTo(minScn) < 0) {
-                            minScn = scn;
-                        }
-                    }
-
-                    // Make sure the commit SCN is at least the snapshot SCN - 1.
-                    // This ensures we'll never emit events for transactions that were complete before the snapshot was
-                    // taken.
-                    Scn originalCommitScn = offsetContext.getCommitScn();
-                    if (originalCommitScn == null || originalCommitScn.compareTo(snapshotScn) < 0) {
-                        LOGGER.info("Setting commit SCN to {} (snapshot SCN - 1) to ensure we don't double-emit events from pre-snapshot transactions.",
-                                snapshotScn.subtract(Scn.valueOf(1)));
-                        offsetContext.setCommitScn(snapshotScn.subtract(Scn.valueOf(1)));
-                    }
-
-                    // set start SCN to minScn
-                    if (minScn.compareTo(startScn) < 0) {
-                        LOGGER.info("Resetting start SCN from {} (snapshot SCN) to {} (start of oldest complete pending transaction)", startScn, minScn);
-                        startScn = minScn.subtract(Scn.valueOf(1));
-                    }
-                }
-                offsetContext.setScn(snapshotScn);
+                computeStartScnForFirstMiningSession(offsetContext, firstScn);
             }
 
             try (LogWriterFlushStrategy flushStrategy = resolveFlushStrategy()) {
@@ -238,6 +199,63 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
             LOGGER.info("Streaming metrics dump: {}", streamingMetrics.toString());
             LOGGER.info("Offsets: {}", offsetContext);
         }
+    }
+
+    /**
+     * Computes the start SCN for the first mining session.
+     *
+     * Normally, this would be the snapshot SCN, but if there were pending transactions at the time 
+     * the snapshot was taken, we'd miss the events in those transactions that have an SCN smaller
+     * than the snapshot SCN.
+     *
+     * @param offsetContext the offset context
+     * @param firstScn the oldest SCN still available in the REDO logs
+     */
+    private void computeStartScnForFirstMiningSession(OracleOffsetContext offsetContext, Scn firstScn) {
+        // This is the initial run of the streaming change event source.
+        // We need to compute the correct start offset for mining. That is not the snapshot offset,
+        // but the start offset of the oldest transaction that was still pending when the snapshot
+        // was taken.
+        Map<String, Scn> snapshotPendingTransactions = offsetContext.getSnapshotPendingTransactions();
+        if (snapshotPendingTransactions == null || snapshotPendingTransactions.isEmpty()) {
+            // no pending transactions, we can start mining from the snapshot SCN
+            startScn = snapshotScn;
+        }
+        else {
+            // find the oldest transaction we can still fully process, and start from there.
+            Scn minScn = snapshotScn;
+            for (Map.Entry<String, Scn> entry : snapshotPendingTransactions.entrySet()) {
+                String transactionId = entry.getKey();
+                Scn scn = entry.getValue();
+                LOGGER.info("Transaction {} was pending across snapshot boundary. Start SCN = {}, snapshot SCN = {}", transactionId, scn, startScn);
+                if (scn.compareTo(firstScn) < 0) {
+                    LOGGER.warn(
+                            "Transaction {} was still ongoing while snapshot was taken, but is no longer completely recorded in the archive logs. Events will be lost. Oldest SCN in logs = {}, TX start SCN = {}",
+                            transactionId, firstScn, scn);
+                    minScn = firstScn;
+                }
+                else if (scn.compareTo(minScn) < 0) {
+                    minScn = scn;
+                }
+            }
+
+            // Make sure the commit SCN is at least the snapshot SCN - 1.
+            // This ensures we'll never emit events for transactions that were complete before the snapshot was
+            // taken.
+            Scn originalCommitScn = offsetContext.getCommitScn();
+            if (originalCommitScn == null || originalCommitScn.compareTo(snapshotScn) < 0) {
+                LOGGER.info("Setting commit SCN to {} (snapshot SCN - 1) to ensure we don't double-emit events from pre-snapshot transactions.",
+                        snapshotScn.subtract(Scn.valueOf(1)));
+                offsetContext.setCommitScn(snapshotScn.subtract(Scn.valueOf(1)));
+            }
+
+            // set start SCN to minScn
+            if (minScn.compareTo(startScn) < 0) {
+                LOGGER.info("Resetting start SCN from {} (snapshot SCN) to {} (start of oldest complete pending transaction)", startScn, minScn);
+                startScn = minScn.subtract(Scn.valueOf(1));
+            }
+        }
+        offsetContext.setScn(startScn);
     }
 
     private void captureSessionMemoryStatistics(OracleConnection connection) throws SQLException {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -77,6 +77,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
 
     private Scn startScn;
     private Scn endScn;
+    private Scn snapshotScn;
     private List<BigInteger> currentRedoLogSequences;
 
     public LogMinerStreamingChangeEventSource(OracleConnectorConfig connectorConfig,
@@ -112,10 +113,58 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
             return;
         }
         try {
+            Scn firstScn = getFirstScnInLogs(jdbcConnection);
             startScn = offsetContext.getScn();
+            snapshotScn = offsetContext.getSnapshotScn();
+            if (startScn.compareTo(snapshotScn) == 0) {
+                // This is the initial run of the streaming change event source.
+                // We need to compute the correct start offset for mining. That is not the snapshot offset,
+                // but the start offset of the oldest transaction that was still pending when the snapshot
+                // was taken.
+                Map<String, Scn> snapshotPendingTransactions = offsetContext.getSnapshotPendingTransactions();
+                if (snapshotPendingTransactions == null || snapshotPendingTransactions.isEmpty()) {
+                    // no pending transactions, we can start mining from the snapshot SCN
+                    startScn = snapshotScn;
+                }
+                else {
+                    // find the oldest transaction we can still fully process, and start from there.
+                    Scn minScn = snapshotScn;
+                    for (Map.Entry<String, Scn> entry : snapshotPendingTransactions.entrySet()) {
+                        String transactionId = entry.getKey();
+                        Scn scn = entry.getValue();
+                        LOGGER.info("Transaction {} was pending across snapshot boundary. Start SCN = {}, snapshot SCN = {}", transactionId, scn, startScn);
+                        if (scn.compareTo(firstScn) < 0) {
+                            LOGGER.warn(
+                                    "Transaction {} was still ongoing while snapshot was taken, but is no longer completely recorded in the archive logs. Events will be lost. Oldest SCN = {}, TX start SCN = {}",
+                                    transactionId, firstScn, scn);
+                            minScn = firstScn;
+                        }
+                        else if (scn.compareTo(minScn) < 0) {
+                            minScn = scn;
+                        }
+                    }
+
+                    // Make sure the commit SCN is at least the snapshot SCN - 1.
+                    // This ensures we'll never emit events for transactions that were complete before the snapshot was
+                    // taken.
+                    Scn originalCommitScn = offsetContext.getCommitScn();
+                    if (originalCommitScn == null || originalCommitScn.compareTo(snapshotScn) < 0) {
+                        LOGGER.info("Setting commit SCN to {} (snapshot SCN - 1) to ensure we don't double-emit events from pre-snapshot transactions.",
+                                snapshotScn.subtract(Scn.valueOf(1)));
+                        offsetContext.setCommitScn(snapshotScn.subtract(Scn.valueOf(1)));
+                    }
+
+                    // set start SCN to minScn
+                    if (minScn.compareTo(startScn) < 0) {
+                        LOGGER.info("Resetting start SCN from {} (snapshot SCN) to {} (start of oldest complete pending transaction)", startScn, minScn);
+                        startScn = minScn.subtract(Scn.valueOf(1));
+                    }
+                }
+                offsetContext.setScn(snapshotScn);
+            }
 
             try (LogWriterFlushStrategy flushStrategy = resolveFlushStrategy()) {
-                if (!isContinuousMining && startScn.compareTo(getFirstScnInLogs(jdbcConnection)) < 0) {
+                if (!isContinuousMining && startScn.compareTo(firstScn) < 0) {
                     throw new DebeziumException(
                             "Online REDO LOG files or archive log files do not contain the offset scn " + startScn + ".  Please perform a new snapshot.");
                 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
@@ -257,7 +257,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
         if (row.getScn().compareTo(offsetContext.getSnapshotScn()) < 0) {
             Map<String, Scn> snapshotPendingTransactions = offsetContext.getSnapshotPendingTransactions();
             if (snapshotPendingTransactions == null || !snapshotPendingTransactions.containsKey(row.getTransactionId())) {
-                LOGGER.info("Skipping event {} (SCN {}) because it is already encompassed by the initial snapshot", row.getEventType(), row.getScn());
+                LOGGER.debug("Skipping event {} (SCN {}) because it is already encompassed by the initial snapshot", row.getEventType(), row.getScn());
                 return;
             }
         }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import javax.management.JMException;
 import javax.management.MBeanServer;
@@ -50,6 +51,8 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
@@ -84,6 +87,7 @@ import io.debezium.util.Testing;
  * @author Gunnar Morling
  */
 public class OracleConnectorIT extends AbstractConnectorTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OracleConnectorIT.class);
 
     private static final long MICROS_PER_SECOND = TimeUnit.SECONDS.toMicros(1);
     private static final String SNAPSHOT_COMPLETED_KEY = "snapshot_completed";
@@ -2961,6 +2965,174 @@ public class OracleConnectorIT extends AbstractConnectorTest {
         stopConnector();
     }
 
+    @Test
+    @FixFor("DBZ-4367")
+    public void shouldCaptureChangesForTransactionsAcrossSnapshotBoundary() throws Exception {
+        TestHelper.dropTable(connection, "DBZ4367");
+        try {
+            connection.execute("CREATE TABLE DBZ4367 (ID number(9, 0), DATA varchar2(50))");
+            TestHelper.streamTable(connection, "DBZ4367");
+
+            connection.execute("INSERT INTO DBZ4367 (ID, DATA) VALUES (1, 'pre-snapshot pre TX')");
+            connection.executeWithoutCommitting("INSERT INTO DBZ4367 (ID, DATA) VALUES (2, 'pre-snapshot in TX')");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ4367")
+                    .build();
+            start(OracleConnector.class, config);
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            connection.executeWithoutCommitting("INSERT INTO DBZ4367 (ID, DATA) VALUES (3, 'post-snapshot in TX')");
+            connection.executeWithoutCommitting("COMMIT");
+            connection.execute("INSERT INTO DBZ4367 (ID, DATA) VALUES (4, 'post snapshot post TX')");
+
+            SourceRecords records = consumeRecordsByTopic(4);
+            List<Integer> ids = records.recordsForTopic("server1.DEBEZIUM.DBZ4367").stream()
+                    .map(r -> getAfter(r).getInt32("ID"))
+                    .collect(Collectors.toList());
+            assertThat(ids).containsOnly(1, 2, 3, 4);
+            assertThat(ids).doesNotHaveDuplicates();
+            assertThat(ids).hasSize(4);
+        }
+        finally {
+            stopConnector();
+            TestHelper.dropTable(connection, "DBZ4367");
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-4367")
+    public void shouldCaptureChangesForTransactionsAcrossSnapshotBoundaryWithoutDuplicatingSnapshottedChanges() throws Exception {
+        OracleConnection secondConnection = TestHelper.testConnection();
+        TestHelper.dropTable(connection, "DBZ4367");
+        try {
+            connection.execute("CREATE TABLE DBZ4367 (ID number(9, 0), DATA varchar2(50))");
+            TestHelper.streamTable(connection, "DBZ4367");
+
+            connection.execute("INSERT INTO DBZ4367 (ID, DATA) VALUES (1, 'pre-snapshot pre TX')");
+            connection.executeWithoutCommitting("INSERT INTO DBZ4367 (ID, DATA) VALUES (2, 'pre-snapshot in TX')");
+            secondConnection.execute("INSERT INTO DBZ4367 (ID, DATA) VALUES (3, 'pre-snapshot in another TX')");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ4367")
+                    .build();
+            start(OracleConnector.class, config);
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            SourceRecords records = consumeRecordsByTopic(2);
+            List<Integer> ids = records.recordsForTopic("server1.DEBEZIUM.DBZ4367").stream()
+                    .map(r -> getAfter(r).getInt32("ID"))
+                    .collect(Collectors.toList());
+            assertThat(ids).containsOnly(1, 3);
+            assertThat(ids).doesNotHaveDuplicates();
+            assertThat(ids).hasSize(2);
+
+            connection.executeWithoutCommitting("INSERT INTO DBZ4367 (ID, DATA) VALUES (4, 'post-snapshot in TX')");
+            connection.executeWithoutCommitting("COMMIT");
+            connection.execute("INSERT INTO DBZ4367 (ID, DATA) VALUES (5, 'post snapshot post TX')");
+
+            records = consumeRecordsByTopic(3);
+            ids = records.recordsForTopic("server1.DEBEZIUM.DBZ4367").stream()
+                    .map(r -> getAfter(r).getInt32("ID"))
+                    .collect(Collectors.toList());
+            assertThat(ids).containsOnly(2, 4, 5);
+            assertThat(ids).doesNotHaveDuplicates();
+            assertThat(ids).hasSize(3);
+        }
+        finally {
+            stopConnector();
+            TestHelper.dropTable(connection, "DBZ4367");
+            secondConnection.close();
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-4367")
+    public void shouldCaptureChangesForTransactionsAcrossSnapshotBoundaryWithoutReemittingDDLChanges() throws Exception {
+        OracleConnection secondConnection = TestHelper.testConnection();
+        TestHelper.dropTable(connection, "DBZ4367");
+        TestHelper.dropTable(connection, "DBZ4367_EXTRA");
+        try {
+            connection.execute("CREATE TABLE DBZ4367 (ID number(9, 0), DATA varchar2(50))");
+            TestHelper.streamTable(connection, "DBZ4367");
+            connection.execute("CREATE TABLE DBZ4367_EXTRA (ID number(9, 0), DATA varchar2(50))");
+            TestHelper.streamTable(connection, "DBZ4367_EXTRA");
+
+            // some transactions that are complete pre-snapshot
+            connection.execute("INSERT INTO DBZ4367 (ID, DATA) VALUES (1, 'pre-snapshot pre TX')");
+            connection.execute("INSERT INTO DBZ4367_EXTRA (ID, DATA) VALUES (100, 'second table, pre-snapshot pre TX')");
+
+            // this is a transaction that spans the snapshot boundary, changes should be streamed
+            connection.executeWithoutCommitting("INSERT INTO DBZ4367 (ID, DATA) VALUES (2, 'pre-snapshot in TX')");
+            // pre-snapshot DDL, should not be emitted in the streaming phase
+            secondConnection.execute("ALTER TABLE DBZ4367_EXTRA ADD DATA2 VARCHAR2(50) DEFAULT 'default2'");
+            secondConnection.execute("ALTER TABLE DBZ4367_EXTRA ADD DATA3 VARCHAR2(50) DEFAULT 'default3'");
+            secondConnection.execute("INSERT INTO DBZ4367_EXTRA (ID, DATA, DATA2, DATA3) VALUES (150, 'second table, with outdated schema', 'something', 'something')");
+            secondConnection.execute("ALTER TABLE DBZ4367_EXTRA DROP COLUMN DATA3");
+            connection.executeWithoutCommitting("INSERT INTO DBZ4367_EXTRA (ID, DATA, DATA2) VALUES (200, 'second table, pre-snapshot in TX', 'something')");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ4367,DEBEZIUM\\.DBZ4367_EXTRA")
+                    .with(OracleConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
+                    .build();
+            start(OracleConnector.class, config);
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            SourceRecords records;
+            List<SourceRecord> ddls;
+            List<Integer> ids;
+
+            // we expect two DDL records (synthetic CREATEs for the final table structure) and three DML records (one for each insert)
+            records = consumeRecordsByTopic(5);
+            ddls = records.ddlRecordsForDatabase("ORCLPDB1");
+            ddls.forEach(r -> assertThat(((Struct) r.value()).getString("ddl")).contains("CREATE TABLE"));
+            assertThat(ddls).hasSize(2);
+            ids = records.recordsForTopic("server1.DEBEZIUM.DBZ4367").stream()
+                    .map(r -> getAfter(r).getInt32("ID"))
+                    .collect(Collectors.toList());
+            assertThat(ids).containsExactly(1);
+            ids = records.recordsForTopic("server1.DEBEZIUM.DBZ4367_EXTRA").stream()
+                    .map(r -> getAfter(r).getInt32("ID"))
+                    .collect(Collectors.toList());
+            assertThat(ids).containsOnly(100, 150);
+            assertThat(ids).doesNotHaveDuplicates();
+            assertThat(ids).hasSize(2);
+
+            connection.executeWithoutCommitting("INSERT INTO DBZ4367 (ID, DATA) VALUES (3, 'post-snapshot in TX')");
+            connection.executeWithoutCommitting("INSERT INTO DBZ4367_EXTRA (ID, DATA, DATA2) VALUES (300, 'second table, post-snapshot in TX', 'something')");
+            connection.executeWithoutCommitting("COMMIT");
+            // snapshot-spanning transaction ends here
+
+            // post-snapshot transaction, changes should be streamed
+            connection.execute("INSERT INTO DBZ4367 (ID, DATA) VALUES (4, 'post snapshot post TX')");
+            connection.execute("INSERT INTO DBZ4367_EXTRA (ID, DATA, DATA2) VALUES (400, 'second table, post-snapshot post TX', 'something')");
+
+            records = consumeRecordsByTopic(6);
+            ddls = records.ddlRecordsForDatabase("ORCLPDB1");
+            if (ddls != null) {
+                assertThat(ddls).isEmpty();
+            }
+            ids = records.recordsForTopic("server1.DEBEZIUM.DBZ4367").stream()
+                    .map(r -> getAfter(r).getInt32("ID"))
+                    .collect(Collectors.toList());
+            assertThat(ids).containsOnly(2, 3, 4);
+            assertThat(ids).doesNotHaveDuplicates();
+            assertThat(ids).hasSize(3);
+            ids = records.recordsForTopic("server1.DEBEZIUM.DBZ4367_EXTRA").stream()
+                    .map(r -> getAfter(r).getInt32("ID"))
+                    .collect(Collectors.toList());
+            assertThat(ids).containsOnly(200, 300, 400);
+            assertThat(ids).doesNotHaveDuplicates();
+            assertThat(ids).hasSize(3);
+        }
+        finally {
+            stopConnector();
+            TestHelper.dropTable(connection, "DBZ4367");
+            TestHelper.dropTable(connection, "DBZ4367_EXTRA");
+            secondConnection.close();
+        }
+    }
+
     private void waitForCurrentScnToHaveBeenSeenByConnector() throws SQLException {
         try (OracleConnection admin = TestHelper.adminConnection()) {
             admin.resetSessionToCdb();
@@ -2975,5 +3147,9 @@ public class OracleConnectorIT extends AbstractConnectorTest {
                         return Scn.valueOf(scnValue).compareTo(scn) > 0;
                     });
         }
+    }
+
+    private Struct getAfter(SourceRecord record) {
+        return ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
     }
 }

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1623,6 +1623,7 @@ sqlplus sys/top_secret@//localhost:1521/ORCLCDB as sysdba
   GRANT SELECT ON V_$LOGFILE TO c##dbzuser CONTAINER=ALL; <20>
   GRANT SELECT ON V_$ARCHIVED_LOG TO c##dbzuser CONTAINER=ALL; <21>
   GRANT SELECT ON V_$ARCHIVE_DEST_STATUS TO c##dbzuser CONTAINER=ALL; <22>
+  GRANT SELECT ON V_$TRANSACTION TO c##dbzuser CONTAINER=ALL; <23>
 
   exit;
 ----
@@ -1697,10 +1698,10 @@ On newer versions of Oracle this is granted via the `LOGMINING` role but on olde
 This is required to interact with Oracle LogMiner.
 On newer versions of Oracle this is granted via the `LOGMINING` role but on older versions, this must be explicitly granted.
 
-|15 to 22
+|15 to 23
 |SELECT ON V_$....
 |Enables the connector to read these tables.
-The connector must be able to read information about the Oracle redo and archive logs to prepare the Oracle LogMiner session.
+The connector must be able to read information about the Oracle redo and archive logs, and the current transaction state, to prepare the Oracle LogMiner session.
 Without these grants, the connector cannot operate.
 
 |===


### PR DESCRIPTION
https://issues.redhat.com/projects/DBZ/issues/DBZ-4367

Start mining from the start SCN of the oldest still-pending transaction
at the time the initial snapshot was taken. This ensures that no events
get lost when that transaction is committed post-snapshot.