### PR TITLE
DBZ-4404 Added signal table support for Oracle 11G

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -237,6 +237,7 @@ Moira Tagle
 Muhammad Sufyian
 Nansen
 Nathan Mills
+Nathan Smit
 Navdeep Agarwal
 Naveen Kumar KR
 Nayana Hettiarachchi

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -454,12 +454,23 @@ public class OracleConnection extends JdbcConnection {
                     .append(" WHERE ")
                     .append(condition.get());
         }
-        sql
-                .append(" ORDER BY ")
-                .append(orderBy)
-                .append(" FETCH NEXT ")
-                .append(limit)
-                .append(" ROWS ONLY");
+        if (getOracleVersion().getMajor() < 12) {
+            sql
+                    .insert(0, " SELECT * FROM (")
+                    .append(" ORDER BY ")
+                    .append(orderBy)
+                    .append(")")
+                    .append(" WHERE ROWNUM <=")
+                    .append(limit);
+        }
+        else {
+            sql
+                    .append(" ORDER BY ")
+                    .append(orderBy)
+                    .append(" FETCH NEXT ")
+                    .append(limit)
+                    .append(" ROWS ONLY");
+        }
         return sql.toString();
     }
 

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -111,3 +111,4 @@ AChangFeng,胡琴
 sarumont,Richard Kolkovich
 poonam-meghnani,Poonam Meghnani
 Oscar,Oscar Romero
+nathan-smit-1,Nathan Smit


### PR DESCRIPTION
Currently, it's not possible to perform ad hoc snapshots using Oracle 11g because the algorithm makes use of syntax that was only introduced in Oracle 12c and later.  As suggested on DBZ-4404, I've added logic to support Oracle 11g by having conditional logic for versions earlier than major version 12.

The structure of the select for versions earlier than 12c will be:

SELECT * FROM (SELECT columnname FROM tablename ORDER BY orderbycolumn) WHERE ROWNUM <=1

This is slightly more complicated than initially proposed as I did a bunch of reading and I couldn't find any confirmation that Oracle guarantees the "order by" without the nested select and so I'd rather be safe when constructing the alternate sql query.
