### PR TITLE
DBZ-4573 Conditionalize note about using the MongoDB outbox event router

### DIFF
--- a/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
@@ -43,8 +43,11 @@ endif::community[]
 
 [NOTE]
 ====
-This SMT does *not* support the MongoDB connector;
-please use the xref:transformations/mongodb-outbox-event-router.adoc[MongoDB outbox event router] SMT with that connector.
+The outbox event router SMT is not compatible with the MongoDB connector.
+
+ifdef::community[]
+As an alternative, MongoDB users can run the xref:transformations/mongodb-outbox-event-router.adoc[MongoDB outbox event router SMT].
+endif::community[]
 ====
 
 ifdef::product[]


### PR DESCRIPTION
[DBZ-4573](https://issues.redhat.com/browse/DBZ-4573)

Reword admonition and add filter to designate information about using the MongoDB outbox router as `community` content.

Tested in local Antora build and in a local downstream build.

Please backport to the 1.7 and 1.8 branches.  

This change is already implemented downstream. so merging this PR is not a dependency  for building the downstream 1.7 doc.