### PR TITLE
DBZ-4574 Update description of `snapshot.mode` property in PG doc

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -86,7 +86,7 @@ Typically, the redo logs on an Oracle server are configured to not retain the co
 As a result, the {prodname} Oracle connector cannot retrieve the entire history of the database from the logs.
 To enable the connector to establish a baseline for the current state of the database, the first time that the connector starts, it performs an initial _consistent snapshot_ of the database.
 
-You can customize the way that the connector creates snapshots by setting the value of the xref:oracle-connector-snapshot-mode-configuration-property[`snapshot.mode`] connector configuration property.
+You can customize the way that the connector creates snapshots by setting the value of the xref:oracle-property-snapshot-mode[`snapshot.mode`] connector configuration property.
 By default, the connector's snapshot mode is set to `initial`.
 
 [[default-workflow-for-performing-an-initial-snapshot]]
@@ -105,7 +105,7 @@ After the snapshot process begins, if the process is interrupted due to connecto
 After the connector completes the initial snapshot, it continues streaming from the position that it read in Step 3 so that it does not miss any updates.
 If the connector stops again for any reason, after it restarts, it resumes streaming changes from where it previously left off.
 
-[id="oracle-connector-snapshot-mode-configuration-property"]
+[id="oracle-connector-snapshot-mode-options"]
 .Settings for `snapshot.mode` connector configuration property
 [cols="30%a,70%a",options="header"]
 |===
@@ -2324,6 +2324,8 @@ Database history topics require infinite retention.
 Note this mode is only safe to be used when it is guaranteed that no schema changes happened since the point in time the connector was shut down before and the point in time the snapshot is taken.
 
 After the snapshot is complete, the connector continues to read change events from the database's redo logs except when `snapshot.mode` is configured as `initial_only`.
+
+For more information, see the xref:#oracle-connector-snapshot-mode-options[table of `snapshot.mode` options].
 
 |[[oracle-property-snapshot-locking-mode]]<<oracle-property-snapshot-locking-mode, `+snapshot.locking.mode+`>>
 |_shared_

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -141,11 +141,11 @@ Most PostgreSQL servers are configured to not retain the complete history of the
 
 If the connector fails, is rebalanced, or stops after Step 1 begins but before Step 6 completes, upon restart the connector begins a new snapshot. After the connector completes its initial snapshot, the PostgreSQL connector continues streaming from the position that it read in step 3. This ensures that the connector does not miss any updates. If the connector stops again for any reason, upon restart, the connector continues streaming changes from where it previously left off.
 
-[id="snapshot-mode-settings"]
-.Settings for `snapshot.mode` connector configuration property
+[id="postgresql-connector-snapshot-mode-options"]
+.Options for the `snapshot.mode` connector configuration property
 [cols="20%a,80%a",options="header"]
 |===
-|Setting
+|Option
 |Description
 
 |`always`
@@ -2968,7 +2968,7 @@ ifdef::community[]
 `custom` - The connector performs a snapshot according to the setting for the `snapshot.custom.class` property, which is a custom implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. +
 endif::community[]
  +
-The{link-prefix}:{link-postgresql-connector}#snapshot-mode-settings[reference table for snapshot mode settings] has more details.
+For more information, see the xref:#postgresql-connector-snapshot-mode-options[table of `snapshot.mode` options].
 
 ifdef::community[]
 |[[postgresql-property-snapshot-custom-class]]<<postgresql-property-snapshot-custom-class, `+snapshot.custom.class+`>>


### PR DESCRIPTION
[DBZ-4574](https://issues.redhat.com/browse/DBZ-4574)

The PG connector doc had a missing space between two words in a property description. This change rewrites the description and updates the link and target anchor. 
For consistency, I added a similar note to the same property in the Oracle connector doc, and similarly updated the links and target anchor.

Tested in local Antora and downstream builds.

Please backport this change to 1.7 and 1.8. The updates are _not_ required to build the doc downstream for 1.7.