### PR TITLE
DBZ-4582 Clarify that an existing KC can be used to deploy a connector

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
@@ -25,7 +25,7 @@ ImageStreams are not available by default.
 .Procedure
 
 . Log in to the OpenShift cluster.
-. Create a new {prodname} `KafkaConnect` custom resource (CR) for the connector.
+. Create a {prodname} `KafkaConnect` custom resource (CR) for the connector, or modify an existing one.
 For example, create a `KafkaConnect` CR that specifies the `metadata.annotations` and `spec.build` properties, as shown in the following example.
 Save the file with a name such as `dbz-connect.yaml`.
 +


### PR DESCRIPTION
[DBZ-4582](https://issues.redhat.com/browse/DBZ-4582)

Per review comment from @jcechace, the instructions in the deployment file that is shared by the downstream connectors seem to imply that it's necessary to create a Kafka Connect instance for each connector that is deployed. 

This change modifies the sentence to indicate that you can use an existing KC to deploy. 

This change applies to content that is conditionalized for downstream use only and it does not affect the community version of the doc.

Please backport to 1.7 and 1.8.
