### PR TITLE
DBZ-4581 Remove Oracle benchmark dependency on XStreams

### DIFF
--- a/debezium-microbenchmark-oracle/pom.xml
+++ b/debezium-microbenchmark-oracle/pom.xml
@@ -47,10 +47,6 @@
             <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.oracle.instantclient</groupId>
-            <artifactId>xstreams</artifactId>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4581

With this merged, the GH actions workflow improvements can be adjusted to no longer need to exclude the benchmark from the builds since the xstream dependency will be excluded automatically via the profile `-xstream-dependency` like we do for the Oracle connector submodule.