### PR TITLE
DBZ-4646 Changing exists method for FileDataBaseHistory

### DIFF
--- a/debezium-core/src/main/java/io/debezium/relational/history/FileDatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/FileDatabaseHistory.java
@@ -162,7 +162,19 @@ public final class FileDatabaseHistory extends AbstractDatabaseHistory {
 
     @Override
     public boolean exists() {
-        return storageExists();
+        boolean exists = false;
+        if (storageExists()) {
+            try {
+                // Checking if the history file is empty
+                if (Files.size(path) > 0) {
+                    exists = true;
+                }
+            }
+            catch (IOException e) {
+                logger.error("Unable to determine if history file empty " + path + ": " + e.getMessage(), e);
+            }
+        }
+        return exists;
     }
 
     @Override


### PR DESCRIPTION
Hi there,

I thought I'd take a stab at this...I believe an issue currently is that the exists method implementation in io.debezium.relational.history.FileDatabaseHistory is simply a call to storageExists.  This leads to it not being possible for exists to be false as by the time the exists method is called the FileDatabaseHistory file has already been created.

I compared this to the Kafka implementation, and in KafkaDatabaseHistory the storageExists method checks for the existence of the topic and exists checks if the topic has any data (hopefully I'm reading that correctly).

My update then is to change the exists method to check if the file on disk is empty.  So if the file is deleted, the file will be created but will be empty, which means that the schema_only_recovery will run (if set as the snapshot.mode).

Let me know if this makes sense?
