### PR TITLE
DBZ-4653 Cron-based doc changes workflow

### DIFF
--- a/.github/workflows/doc-changes-workflow.yml
+++ b/.github/workflows/doc-changes-workflow.yml
@@ -1,0 +1,46 @@
+# This workflow is designed to notify a given email address with pertinent information
+# about changes to the Documentation files, using a cron-based trigger.
+
+name: Documentation Changes
+
+on:
+  # Schedule job to run at midnight UTC every Saturday
+  schedule:
+    - cron: "0 0 * * 6"
+
+jobs:
+
+  script:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout action
+        uses: actions/checkout@v2
+        with:
+          # This is necessary as this script needs to examine all history and prepare an output
+          # report that defines all changes made to the Documentation within the last number of
+          # days.
+          fetch-depth: 0
+          # Always run this against main
+          ref: 'main'
+
+      - name: Run script
+        id: changes
+        run: |
+          ./github-support/notify-documentation-changes.sh "main"
+          CHANGES=$(cat documentation_changes.txt)          
+          echo "CHANGES<<EOF" >> $GITHUB_ENV
+          echo "$CHANGES" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Send email notification
+        uses: zulip/github-actions-zulip/send-message@v1
+        with:
+          api-key: ${{ secrets.ZULIP_TOKEN }}
+          email: ${{ secrets.ZULIP_TOKEN_EMAIL_ADDRESS }}
+          organization-url: "https://debezium.zulipchat.com"
+          to: "documentation"
+          type: "stream"
+          topic: "activity"
+          content: ${{ env.CHANGES }}
+

--- a/.github/workflows/doc-changes-workflow.yml
+++ b/.github/workflows/doc-changes-workflow.yml
@@ -6,7 +6,7 @@ name: Documentation Changes
 on:
   # Schedule job to run at midnight UTC every Saturday
   schedule:
-    - cron: "0 0 * * 6"
+    - cron: "0 0 * * *"
 
 jobs:
 

--- a/github-support/notify-documentation-changes.sh
+++ b/github-support/notify-documentation-changes.sh
@@ -2,24 +2,29 @@
 
 set -ouo > /dev/null 2>&1
 
-GIT_SINCE="1.weeks"
+GIT_SINCE="24 hours ago"
 GITHUB_COMMIT_URL="https://github.com/debezium/debezium/commit/"
 OUTPUT="documentation_changes.txt"
 GIT_OUTPUT_FILE="git_history.txt"
 GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
 
 # Get the history from Git
-git log --pretty=oneline --follow --since=$GIT_SINCE -- documentation > $GIT_OUTPUT_FILE
+git log --pretty=oneline --follow --since="$GIT_SINCE" -- documentation > $GIT_OUTPUT_FILE
 
 rm -f $OUTPUT
-echo "The following Debezium documentation changes have been made in the last 7 days on branch \"$GIT_BRANCH\":" >> $OUTPUT
+echo "The following Debezium documentation changes have been made in the last 24 hours on branch \"$GIT_BRANCH\":" >> $OUTPUT
 echo "" >> $OUTPUT
 
-while IFS=" " read -r COMMIT_SHA COMMIT_MSG
-do
-  echo "* [$COMMIT_SHA]($GITHUB_COMMIT_URL$COMMIT_SHA)" >> $OUTPUT
-  echo "$COMMIT_MSG" >> $OUTPUT
-done < $GIT_OUTPUT_FILE
+if [ -s "$GIT_OUTPUT_FILE" ]; then
+  while IFS=" " read -r COMMIT_SHA COMMIT_MSG
+  do
+    echo "* [$COMMIT_SHA]($GITHUB_COMMIT_URL$COMMIT_SHA)" >> $OUTPUT
+    echo "$COMMIT_MSG" >> $OUTPUT
+  done < $GIT_OUTPUT_FILE
+else
+  echo "* No changes found" >> $OUTPUT
+fi
+
 rm -f $GIT_OUTPUT_FILE
 
 cat $OUTPUT

--- a/github-support/notify-documentation-changes.sh
+++ b/github-support/notify-documentation-changes.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -ouo > /dev/null 2>&1
+
+GIT_SINCE="1.weeks"
+GITHUB_COMMIT_URL="https://github.com/debezium/debezium/commit/"
+OUTPUT="documentation_changes.txt"
+GIT_OUTPUT_FILE="git_history.txt"
+GIT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+
+# Get the history from Git
+git log --pretty=oneline --follow --since=$GIT_SINCE -- documentation > $GIT_OUTPUT_FILE
+
+rm -f $OUTPUT
+echo "The following Debezium documentation changes have been made in the last 7 days on branch \"$GIT_BRANCH\":" >> $OUTPUT
+echo "" >> $OUTPUT
+
+while IFS=" " read -r COMMIT_SHA COMMIT_MSG
+do
+  echo "* [$COMMIT_SHA]($GITHUB_COMMIT_URL$COMMIT_SHA)" >> $OUTPUT
+  echo "$COMMIT_MSG" >> $OUTPUT
+done < $GIT_OUTPUT_FILE
+rm -f $GIT_OUTPUT_FILE
+
+cat $OUTPUT


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4653

### Setup Requirements
* Secrets :exclamation: 
** ZULIP_TOKEN
** ZULIP_TOKEN_EMAIL_ADDRESS
* Zulip Stream :heavy_check_mark: 

As communicated to @roldanbob, I investigated a number of avenues for this which included:
1. Sending email directly to Bob
2. Checking whether we could send a custom notification to Bob's GH notifications inbox
3. Zulip integration

With (1), this would have required we set up all the necessary authentication to send email via a public provider and you would still have the risk that an email could be lost in transit, consumed by a junk/spam filter, etc.  With (2), I didn't find any action that provided this so unfortunately, I had to skip this.  With (3), we already have some integration with GH with our notification webhooks so I utilized an action that builds on top of that. 

If this looks acceptable, we can coordinate the secret setup just before merging.  

The output on Zulip appears as follows:
![image](https://user-images.githubusercontent.com/3255568/152656504-d8ffe4fc-31b8-4071-accc-295bfe7a88a7.png)
