### PR TITLE
fix replication role check on RDS Postgres

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
@@ -118,12 +118,17 @@ public class PostgresConnector extends RelationalBaseSourceConnector {
                                 " FROM pg_catalog.pg_auth_members m" +
                                 " JOIN pg_catalog.pg_roles b ON (m.roleid = b.oid)" +
                                 " WHERE m.member = r.oid), 'rdsrepladmin') AS BOOL) IS TRUE AS aws_repladmin" +
+                                ", CAST(array_position(ARRAY(SELECT b.rolname" +
+                                " FROM pg_catalog.pg_auth_members m" +
+                                " JOIN pg_catalog.pg_roles b ON (m.roleid = b.oid)" +
+                                " WHERE m.member = r.oid), 'rds_replication') AS BOOL) IS TRUE AS aws_replication" +
                                 " FROM pg_roles r WHERE r.rolname = current_user",
                         connection.singleResultMapper(rs -> rs.getBoolean("rolcanlogin")
                                 && (rs.getBoolean("rolreplication")
                                         || rs.getBoolean("aws_superuser")
                                         || rs.getBoolean("aws_admin")
-                                        || rs.getBoolean("aws_repladmin")),
+                                        || rs.getBoolean("aws_repladmin")
+                                        || rs.getBoolean("aws_replication")),
                                 "Could not fetch roles"))) {
                     final String errorMessage = "Postgres roles LOGIN and REPLICATION are not assigned to user: " + connection.username();
                     LOGGER.error(errorMessage);


### PR DESCRIPTION
According to Debezium documentation[1], on AWS RDS, the `rds_replication` role
is enough to read the wal_log. However, on the connection validation step,
this case is ommited and the connector cannot start. The issue is pressent
starting at least v1.4.x.Final.

[1] https://debezium.io/documentation/reference/1.8/connectors/postgresql.html#postgresql-on-amazon-rds