### PR TITLE
DBZ-4547 Create History Topic with optional RF

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/relational/history/KafkaDatabaseHistoryTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/relational/history/KafkaDatabaseHistoryTest.java
@@ -8,7 +8,6 @@ package io.debezium.relational.history;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -21,7 +20,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.connect.errors.ConnectException;
 import org.fest.assertions.Assertions;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -399,7 +397,13 @@ public class KafkaDatabaseHistoryTest {
         history.configure(config, null, DatabaseHistoryMetrics.NOOP, true);
         history.start();
 
-        ConnectException connectException = assertThrows(ConnectException.class, () -> history.initializeStorage());
-        assertEquals(TimeoutException.class, connectException.getCause().getClass());
+        try {
+            history.initializeStorage();
+        }
+        catch (Exception ex) {
+            assertEquals(TimeoutException.class, ex.getCause().getClass());
+        }
+
+        assertTrue(history.storageExists());
     }
 }


### PR DESCRIPTION
Currently, History topic creation will fail if the KafkaHistory Admin client has no DESCRIBE_CLUSTER ACL at the broker level.
In a SaaS environment, you won't likely have this higher privilege.

Since Kafka 2.4, NewTopic can be used without specifying the replication factor, using Kafka Broker default automatically.

This will try first using this new constructor and will revert to old behaviour if it's not supported yet.

https://issues.redhat.com/browse/DBZ-4547
https://kafka.apache.org/24/javadoc/org/apache/kafka/clients/admin/NewTopic.html#NewTopic-java.lang.String-java.util.Map-