### PR TITLE
DBZ-4705 Update Vitess connector docs on bytes support

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -805,24 +805,24 @@ a|_n/a_
 |`FLOAT64`
 a|_n/a_
 
-|`CHAR(M)]`
+|`CHAR[(M)]`
 |`STRING`
 a|_n/a_
 
-|`VARCHAR(M)]`
+|`VARCHAR[(M)]`
 |`STRING`
 a|_n/a_
 
-|`BINARY(M)]`
-|`STRING`
+|`BINARY[(M)]`
+|`BYTES`
 a|_n/a_
 
-|`VARBINARY(M)]`
-|`STRING`
+|`VARBINARY[(M)]`
+|`BYTES`
 a|_n/a_
 
 |`TINYBLOB`
-|`STRING`
+|`BYTES`
 a|_n/a_
 
 |`TINYTEXT`
@@ -830,7 +830,7 @@ a|_n/a_
 a|_n/a_
 
 |`BLOB`
-|`STRING`
+|`BYTES`
 a|_n/a_
 
 |`TEXT`
@@ -838,7 +838,7 @@ a|_n/a_
 a|_n/a_
 
 |`MEDIUMBLOB`
-|`STRING`
+|`BYTES`
 a|_n/a_
 
 |`MEDIUMTEXT`
@@ -846,7 +846,7 @@ a|_n/a_
 a|_n/a_
 
 |`LONGBLOB`
-|`STRING`
+|`BYTES`
 a|_n/a_
 
 |`LONGTEXT`


### PR DESCRIPTION
Update mappings for Vitess basic data types to accommodate https://github.com/debezium/debezium-connector-vitess/pull/74

JIRA: https://issues.redhat.com/browse/DBZ-4705

cc @gunnarmorling @jeffchao @y5w 