### PR TITLE
DBZ-4742 change connect config to use WorkerConfig

### DIFF
--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -724,7 +724,7 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord> {
 
                 try {
                     // Start the connector with the given properties and get the task configurations ...
-                    connector.start(config.asMap());
+                    connector.start(workerConfig.originalsStrings());
                     connectorCallback.ifPresent(DebeziumEngine.ConnectorCallback::connectorStarted);
                     List<Map<String, String>> taskConfigs = connector.taskConfigs(1);
                     Class<? extends Task> taskClass = connector.taskClass();

--- a/debezium-server/debezium-server-core/src/test/java/io/debezium/server/DebeziumServerConfigProvidersIT.java
+++ b/debezium-server/debezium-server-core/src/test/java/io/debezium/server/DebeziumServerConfigProvidersIT.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server;
+
+import java.time.Duration;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.awaitility.Awaitility;
+import org.fest.assertions.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.debezium.server.events.ConnectorCompletedEvent;
+import io.debezium.server.events.ConnectorStartedEvent;
+import io.debezium.testing.testcontainers.PostgresTestResourceLifecycleManager;
+import io.debezium.util.Testing;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * Integration test that verifies basic reading from PostgreSQL database.
+ *
+ * @author Jiri Pechanec
+ */
+@QuarkusTest
+@TestProfile(DebeziumServerFileConfigProviderProfile.class)
+@QuarkusTestResource(PostgresTestResourceLifecycleManager.class)
+public class DebeziumServerConfigProvidersIT {
+
+    private static final int MESSAGE_COUNT = 4;
+    @Inject
+    DebeziumServer server;
+
+    {
+        Testing.Files.delete(TestConfigSource.OFFSET_STORE_PATH);
+    }
+
+    void setupDependencies(@Observes ConnectorStartedEvent event) {
+        if (!TestConfigSource.isItTest()) {
+            return;
+        }
+
+    }
+
+    void connectorCompleted(@Observes ConnectorCompletedEvent event) throws Exception {
+        if (!event.isSuccess()) {
+            throw (Exception) event.getError().get();
+        }
+    }
+
+    @Test
+    public void testPostgresWithJson() throws Exception {
+        Testing.Print.enable();
+        final TestConsumer testConsumer = (TestConsumer) server.getConsumer();
+        Awaitility.await().atMost(Duration.ofSeconds(TestConfigSource.waitForSeconds()))
+                .until(() -> (testConsumer.getValues().size() >= MESSAGE_COUNT));
+        Assertions.assertThat(testConsumer.getValues().size()).isEqualTo(MESSAGE_COUNT);
+        Assertions.assertThat(((String) testConsumer.getValues().get(MESSAGE_COUNT - 1))).contains(
+                "\"after\":{\"id\":1004,\"first_name\":\"Anne\",\"last_name\":\"Kretchmar\",\"email\":\"annek@noanswer.org\"}");
+    }
+}

--- a/debezium-server/debezium-server-core/src/test/java/io/debezium/server/DebeziumServerConfigProvidersIT.java
+++ b/debezium-server/debezium-server-core/src/test/java/io/debezium/server/DebeziumServerConfigProvidersIT.java
@@ -13,6 +13,8 @@ import javax.inject.Inject;
 import org.awaitility.Awaitility;
 import org.fest.assertions.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.debezium.server.events.ConnectorCompletedEvent;
 import io.debezium.server.events.ConnectorStartedEvent;
@@ -25,11 +27,14 @@ import io.quarkus.test.junit.TestProfile;
 /**
  * Integration test that verifies basic reading from PostgreSQL database.
  *
- * @author Jiri Pechanec
+ * @author Oren Elias
  */
 @QuarkusTest
 @TestProfile(DebeziumServerFileConfigProviderProfile.class)
 @QuarkusTestResource(PostgresTestResourceLifecycleManager.class)
+@EnabledIfSystemProperty(named = "test.apicurio", matches = "false", disabledReason = "DebeziumServerConfigProvidersIT doesn't run with apicurio profile.")
+@DisabledIfSystemProperty(named = "debezium.format.key", matches = "protobuf")
+@DisabledIfSystemProperty(named = "debezium.format.value", matches = "protobuf")
 public class DebeziumServerConfigProvidersIT {
 
     private static final int MESSAGE_COUNT = 4;

--- a/debezium-server/debezium-server-core/src/test/java/io/debezium/server/DebeziumServerFileConfigProviderProfile.java
+++ b/debezium-server/debezium-server-core/src/test/java/io/debezium/server/DebeziumServerFileConfigProviderProfile.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.server;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class DebeziumServerFileConfigProviderProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        Map<String, String> config = new HashMap<String, String>();
+        URL secretFile = DebeziumServerFileConfigProviderProfile.class.getClassLoader().getResource("secrets_test.txt");
+
+        config.put("debezium.source.database.user", "\\${file:" + secretFile.getPath() + ":user}");
+
+        config.put("debezium.source.config.providers", "file");
+        config.put("debezium.source.config.providers.file.class", "org.apache.kafka.common.config.provider.FileConfigProvider");
+
+        return config;
+    }
+
+}

--- a/debezium-server/debezium-server-core/src/test/resources/secrets_test.txt
+++ b/debezium-server/debezium-server-core/src/test/resources/secrets_test.txt
@@ -1,0 +1,1 @@
+user=postgres


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4742

This changes the config values passed to the connector to use those that were processed by the WorkerConfig, similar to those sent to the OffsetStore. It then enables any ConfigProviders such as FileConfig to support secrets.
I ran the tests and could not see any side effects. Please review.