### PR TITLE
DBZ-4606 Dropping superfluous link-prefix attribute

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -40,7 +40,6 @@ asciidoc:
     link-mongodb-event-flattening: 'transformations/mongodb-event-flattening.adoc'
     link-mysql-connector: 'connectors/mysql.adoc'
     link-oracle-connector: 'connectors/oracle.adoc'
-    link-prefix: 'xref'
     link-postgresql-connector: 'connectors/postgresql.adoc'
     link-postgresql-plugins: 'postgres-plugins.adoc'
     link-serdes: 'integrations/serdes.adoc'

--- a/documentation/modules/ROOT/pages/configuration/avro.adoc
+++ b/documentation/modules/ROOT/pages/configuration/avro.adoc
@@ -23,7 +23,7 @@ For each change event record, the {prodname} connector completes the following a
 You can specify converters for each individual {prodname} connector instance.
 Kafka Connect provides a JSON converter that serializes the record keys and values into JSON documents.
 The default behavior is that the JSON converter includes the record's message schema, which makes each record very verbose.
-The {link-prefix}:{link-tutorial}[{name-tutorial}] shows what the records look like when both payload and schemas are included.
+The xref:{link-tutorial}[{name-tutorial}] shows what the records look like when both payload and schemas are included.
 If you want records to be serialized with JSON, consider setting the following connector configuration properties to `false`:
 
 * `key.converter.schemas.enable`

--- a/documentation/modules/ROOT/pages/configuration/topic-auto-create-config.adoc
+++ b/documentation/modules/ROOT/pages/configuration/topic-auto-create-config.adoc
@@ -83,8 +83,8 @@ You specify topic configuration properties in the {prodname} connector configura
 The connector configuration defines a default topic creation group, and, optionally, one or more custom topic creation groups.
 Custom topic creation groups use lists of topic name patterns to specify the topics to which the group's settings apply.
 
-For details about how Kafka Connect matches topics to topic creation groups, see {link-prefix}:{link-topic-auto-creation}#topic-creation-groups[Topic creation groups].
-For more information about how configuration properties are assigned to groups, see {link-prefix}:{link-topic-auto-creation}#topic-creation-group-configuration-properties[Topic creation group configuration properties].
+For details about how Kafka Connect matches topics to topic creation groups, see xref:{link-topic-auto-creation}#topic-creation-groups[Topic creation groups].
+For more information about how configuration properties are assigned to groups, see xref:{link-topic-auto-creation}#topic-creation-group-configuration-properties[Topic creation group configuration properties].
 
 By default, topics that Kafka Connect creates are named based on the pattern `server.schema.table`, for example, `dbserver.myschema.inventory`.
 
@@ -169,12 +169,12 @@ If no custom groups are registered, or if the `include` patterns for any registe
 then Kafka Connect uses the configuration of the `default` group to create topics.
 
 ifdef::community[]
-See {link-prefix}:{link-install-debezium}#_configuring_debezium_topics[Configuring {prodname} topics] in the
+See xref:{link-install-debezium}#_configuring_debezium_topics[Configuring {prodname} topics] in the
 {prodname} installation guide on generic topic configuration considerations.
 endif::community[]
 
 ifdef::product[]
-For general information about configuring topics, see {link-prefix}:{LinkDebeziumInstallOpenShift}#kafka-topic-creation-recommendations[Kafka topic creation recommendations] in {NameDebeziumInstallOpenShift}.
+For general information about configuring topics, see xref:{LinkDebeziumInstallOpenShift}#kafka-topic-creation-recommendations[Kafka topic creation recommendations] in {NameDebeziumInstallOpenShift}.
 endif::product[]
 
 // Type: procedure

--- a/documentation/modules/ROOT/pages/connectors/cassandra.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cassandra.adoc
@@ -29,7 +29,7 @@ Since Cassandra 3.0, a http://cassandra.apache.org/doc/3.11.3/operating/cdc.html
 
 The Cassandra connector resides on each Cassandra node and monitors the `cdc_raw` directory for change. It processes all local commit log segments as they are detected, produces a change event for every row-level insert, update, and delete operations in the commit log, publishes all change events for each table in a separate Kafka topic, and finally deletes the commit log from the `cdc_raw` directory. This last step is important because once CDC is enabled, Cassandra itself cannot purge the commit logs. If the `cdc_free_space_in_mb` fills up, writes to CDC-enabled tables will be rejected.
 
-The connector is tolerant of failures. As the connector reads commit logs and produces events, it records each commit log segment's filename and position along with each event. If the connector stops for any reason (including communication failures, network problems, or crashes), upon restart it simply continues reading the commit log where it last left off. This includes snapshots: if the snapshot was not completed when the connector is stopped, upon restart it will begin a new snapshot. We'll talk later about how the connector behaves {link-prefix}:{link-cassandra-connector}#cassandra-when-things-go-wrong[when things go wrong].
+The connector is tolerant of failures. As the connector reads commit logs and produces events, it records each commit log segment's filename and position along with each event. If the connector stops for any reason (including communication failures, network problems, or crashes), upon restart it simply continues reading the commit log where it last left off. This includes snapshots: if the snapshot was not completed when the connector is stopped, upon restart it will begin a new snapshot. We'll talk later about how the connector behaves xref:{link-cassandra-connector}#cassandra-when-things-go-wrong[when things go wrong].
 
 [NOTE]
 ====
@@ -181,7 +181,7 @@ Please note that with the current schema evolution approach, the Cassandra conne
 [[cassandra-events]]
 === Events
 
-All data change events produced by the Cassandra connector have a key and a value, although the structure of the key and value depends on the table from which the change events originated (see {link-prefix}:{link-cassandra-connector}#cassandra-topic-names[Topic Names]).
+All data change events produced by the Cassandra connector have a key and a value, although the structure of the key and value depends on the table from which the change events originated (see xref:{link-cassandra-connector}#cassandra-topic-names[Topic Names]).
 
 [[cassandra-change-events-key]]
 ==== Change Event's Key
@@ -785,7 +785,7 @@ If a Cassandra table temporarily disables CDC and then re-enables it again after
 [[cassandra-deploying-a-connector]]
 == Deploying A Connector
 
-The Cassandra connector should be deployed each Cassandra node in a Cassandra cluster. The Cassandra connector Jar file takes in a cdc configuration (.properties) file. See {link-prefix}:{link-cassandra-connector}#cassandra-example-configuration[see example configurations] for reference.
+The Cassandra connector should be deployed each Cassandra node in a Cassandra cluster. The Cassandra connector Jar file takes in a cdc configuration (.properties) file. See xref:{link-cassandra-connector}#cassandra-example-configuration[see example configurations] for reference.
 
 [[cassandra-example-configuration]]
 === Example configuration
@@ -1018,7 +1018,7 @@ refreshing the cached Cassandra table schemas.
 |[[cassandra-property-sanitize-field-names]]<<cassandra-property-sanitize-field-names, `sanitize.field.names`>>
 |`true` when connector configuration explicitly specifies the `key.converter` or `value.converter` parameters to use Avro, otherwise defaults to `false`.
 |Whether field names will be sanitized to adhere to Avro naming requirements.
-See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
+See xref:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 
 |[[cassandra-property-skipped-operations]]<<cassandra-property-skipped-operations, `+skipped.operations+`>>
 |

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -79,7 +79,7 @@ that enable SQL Replication in Db2. A capture agent:
 
 The {prodname} connector uses a SQL interface to query change-data tables for  change events.
 
-The database administrator must put the tables for which you want to capture changes into capture mode. For convenience and for automating testing, there are {link-prefix}:{link-db2-connector}#managing-debezium-db2-connectors[{prodname} user-defined functions (UDFs)] in C that you can compile and then use to do the following management tasks:
+The database administrator must put the tables for which you want to capture changes into capture mode. For convenience and for automating testing, there are xref:{link-db2-connector}#managing-debezium-db2-connectors[{prodname} user-defined functions (UDFs)] in C that you can compile and then use to do the following management tasks:
 
 * Start, stop, and reinitialize the ASN agent
 * Put tables into capture mode
@@ -200,7 +200,7 @@ The connector applies similar naming conventions to label its internal database 
 
 If the default topic name do not meet your requirements, you can configure custom topic names.
 To configure custom topic names, you specify regular expressions in the logical topic routing SMT.
-For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].
+For more information about using the logical topic routing SMT to customize topic naming, see xref:{link-topic-routing}#topic-routing[Topic routing].
 
 // Type: concept
 // Title: About the {prodname} Db2 connector schema change topic
@@ -213,7 +213,7 @@ You can configure a {prodname} Db2 connector to produce schema change events tha
 
 * A new table goes into capture mode.
 * A table is removed from capture mode.
-* During a {link-prefix}:{link-db2-connector}#db2-schema-evolution[database schema update], there is a change in the schema for a table that is in capture mode.
+* During a xref:{link-db2-connector}#db2-schema-evolution[database schema update], there is a change in the schema for a table that is in capture mode.
 
 The connector writes schema change events to a Kafka schema change topic that has the name `_<serverName>_` where `_<serverName>_` is the logical server name that is specified in the xref:db2-property-database-server-name[`database.server.name`] connector configuration property.
 Messages that the connector sends to the schema change topic contain a payload that includes the following elements:
@@ -546,7 +546,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 |`schema`
 |The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed. +
  +
-It is possible to override the table's primary key by setting the {link-prefix}:{link-db2-connector}#db2-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the the key identified by that property.
+It is possible to override the table's primary key by setting the xref:{link-db2-connector}#db2-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the the key identified by that property.
 
 |2
 |`payload`
@@ -562,7 +562,7 @@ It is possible to override the table's primary key by setting the {link-prefix}:
 
 |===
 
-By default, the connector streams change event records to topics with names that are the same as the event's originating table. See {link-prefix}:{link-db2-connector}#db2-topic-names[topic names].
+By default, the connector streams change event records to topics with names that are the same as the event's originating table. See xref:{link-db2-connector}#db2-topic-names[topic names].
 
 [WARNING]
 ====
@@ -1010,7 +1010,7 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 
 [NOTE]
 ====
-Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a {link-prefix}:{link-db2-connector}#db2-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row.
+Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a xref:{link-db2-connector}#db2-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row.
 ====
 
 [[db2-delete-events]]
@@ -1221,7 +1221,7 @@ String representation of an XML document
 
 If present, a column's default value is propagated to the corresponding field's Kafka Connect schema. Change events contain the field's default value unless an explicit column value had been given. Consequently, there is rarely a need to obtain the default value from the schema.
 ifdef::community[]
-Passing the default value helps satisfy compatibility rules when {link-prefix}:{link-avro-serialization}[using Avro] as the serialization format together with the Confluent schema registry.
+Passing the default value helps satisfy compatibility rules when xref:{link-avro-serialization}[using Avro] as the serialization format together with the Confluent schema registry.
 endif::community[]
 
 [[db2-temporal-types]]
@@ -1544,7 +1544,7 @@ VALUES ASNCDC.ASNCDCSERVICES('reinit','asncdc');
 
 .Additional resource
 
-{link-prefix}:{link-db2-connector}#managing-debezium-db2-connectors[Reference table for {prodname} Db2 management UDFs]
+xref:{link-db2-connector}#managing-debezium-db2-connectors[Reference table for {prodname} Db2 management UDFs]
 
 // Type: concept
 // ModuleID: effect-of-db2-capture-agent-configuration-on-server-load-and-latency
@@ -1605,7 +1605,7 @@ To deploy a {prodname} Db2 connector, you install the {prodname} Db2 connector a
 .Prerequisites
 
 * link:https://zookeeper.apache.org/[Apache ZooKeeper], link:http://kafka.apache.org/[Apache Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
-* Db2 is installed and {link-prefix}:{link-db2-connector}#setting-up-db2[capture mode is enabled for tables] to prepare the database to be used with the {prodname} connector.
+* Db2 is installed and xref:{link-db2-connector}#setting-up-db2[capture mode is enabled for tables] to prepare the database to be used with the {prodname} connector.
 
 .Procedure
 
@@ -1614,7 +1614,7 @@ To deploy a {prodname} Db2 connector, you install the {prodname} Db2 connector a
 . Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
 . Obtain the link:https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads[JDBC driver for Db2].
 . Add the JDBC driver JAR file to the directory with the {prodname} Db2 connector JARs.
-. {link-prefix}:{link-db2-connector}#db2-adding-connector-configuration[Configure the connector and add the configuration to your Kafka Connect cluster.]
+. xref:{link-db2-connector}#db2-adding-connector-configuration[Configure the connector and add the configuration to your Kafka Connect cluster.]
 . Restart your Kafka Connect process to pick up the new JAR files.
 
 If you are working with immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s container images] for Apache ZooKeeper, Apache Kafka and Kafka Connect with the Db2 connector already installed and ready to run.
@@ -1905,14 +1905,14 @@ Optionally, you can ignore, mask, or truncate columns that contain sensitive dat
 <5> The name of the Db2 user.
 <6> The password for the Db2 user.
 <7> The name of the database to capture changes from.
-<8> The logical name of the Db2 instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the {link-prefix}:{link-avro-serialization}[Avro Connector] is used.
+<8> The logical name of the Db2 instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the xref:{link-avro-serialization}[Avro Connector] is used.
 <9> A list of all tables whose changes {prodname} should capture.
 <10> The list of Kafka brokers that this connector uses to write and recover DDL statements to the database history topic.
 <11> The name of the database history topic where the connector writes and recovers DDL statements. This topic is for internal use only and should not be used by consumers.
 
 endif::community[]
 
-For the complete list of the configuration properties that you can set for the {prodname} Db2 connector, see {link-prefix}:{link-db2-connector}#db2-connector-properties[Db2 connector properties].
+For the complete list of the configuration properties that you can set for the {prodname} Db2 connector, see xref:{link-db2-connector}#db2-connector-properties[Db2 connector properties].
 
 ifdef::community[]
 
@@ -1930,7 +1930,7 @@ To start running a Db2 connector, create a connector configuration and add the c
 
 .Prerequisites
 
-* {link-prefix}:{link-db2-connector}#setting-up-db2[Db2 replication is enabled] to expose change data for tables that are in capture mode.
+* xref:{link-db2-connector}#setting-up-db2[Db2 replication is enabled] to expose change data for tables that are in capture mode.
 * The Db2 connector is installed.
 
 .Procedure
@@ -1942,7 +1942,7 @@ endif::community[]
 
 .Results
 
-After the connector starts, it {link-prefix}:{link-db2-connector}#db2-snapshots[performs a consistent snapshot] of the Db2 database tables that the connector is configured to capture changes for.
+After the connector starts, it xref:{link-db2-connector}#db2-snapshots[performs a consistent snapshot] of the Db2 database tables that the connector is configured to capture changes for.
 The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
 
 ifdef::product[]
@@ -2056,7 +2056,7 @@ Depending on the _hashAlgorithm_ used, the _salt_ selected, and the actual data 
  +
 `adaptive` captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type. +
  +
-`connect` always represents time and timestamp values by using Kafka Connect's built-in representations for `Time`, `Date`, and `Timestamp`, which uses millisecond precision regardless of the database columns' precision. See {link-prefix}:{link-db2-connector}#db2-temporal-values[temporal values].
+`connect` always represents time and timestamp values by using Kafka Connect's built-in representations for `Time`, `Date`, and `Timestamp`, which uses millisecond precision regardless of the database columns' precision. See xref:{link-db2-connector}#db2-temporal-values[temporal values].
 
 |[[db2-property-tombstones-on-delete]]<<db2-property-tombstones-on-delete, `+tombstones.on.delete+`>>
 |`true`
@@ -2106,7 +2106,7 @@ For these data types, the connector adds parameters to the corresponding field s
  +
 These parameters propagate a column's original type name and length, for variable-width types, respectively. This property is useful for properly sizing corresponding columns in sink databases. +
  +
-See {link-prefix}:{link-db2-connector}#db2-data-types[Db2 data types] for the list of Db2-specific data type names.
+See xref:{link-db2-connector}#db2-data-types[Db2 data types] for the list of Db2-specific data type names.
 
 |[[db2-property-message-key-columns]]<<db2-property-message-key-columns, `+message.key.columns+`>>
 |_empty string_
@@ -2213,7 +2213,7 @@ Heartbeat messages are useful when there are many updates in a database that is 
 
 |[[db2-property-snapshot-lock-timeout-ms]]<<db2-property-snapshot-lock-timeout-ms, `+snapshot.lock.timeout.ms+`>>
 |`10000`
-|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this interval, the snapshot fails. {link-prefix}:{link-db2-connector}#db2-snapshots[How the connector performs snapshots] provides details. Other possible settings are: +
+|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this interval, the snapshot fails. xref:{link-db2-connector}#db2-snapshots[How the connector performs snapshots] provides details. Other possible settings are: +
  +
 `0` -  The connector immediately fails when it cannot obtain a lock. +
  +
@@ -2252,11 +2252,11 @@ In the resulting snapshot, the connector includes only the records for which `de
 |`true` if connector configuration sets the `key.converter` or `value.converter` property to the Avro converter.
 
 `false` if not.
-|Indicates whether field names are sanitized to adhere to {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming requirements].
+|Indicates whether field names are sanitized to adhere to xref:{link-avro-serialization}#avro-naming[Avro naming requirements].
 
 |[[db2-property-provide-transaction-metadata]]<<db2-property-provide-transaction-metadata, `+provide.transaction.metadata+`>>
 |`false`
-|Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See {link-prefix}:{link-db2-connector}#db2-transaction-metadata[Transaction metadata] for details.
+|Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See xref:{link-db2-connector}#db2-transaction-metadata[Transaction metadata] for details.
 
 |[[db2-property-transaction-topic]]<<db2-property-transaction-topic, `transaction.topic`>>
 |`${database.server.name}.transaction`
@@ -2270,7 +2270,7 @@ By default, no operations are skipped.
 
 |[[db2-property-signal-data-collection]]<<db2-property-signal-data-collection, `+signal.data.collection+`>>
 |No default
-| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector.
+| Fully-qualified name of the data collection that is used to send xref:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector.
 Use the following format to specify the collection name: +
 `_<schemaName>_._<tableName>_`
 
@@ -2309,11 +2309,11 @@ include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-databas
 
 The {prodname} Db2 connector provides three types of metrics that are in addition to the built-in support for JMX metrics that Apache ZooKeeper, Apache Kafka, and Kafka Connect provide.
 
-* {link-prefix}:{link-db2-connector}#db2-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
-* {link-prefix}:{link-db2-connector}#db2-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
-* {link-prefix}:{link-db2-connector}#db2-schema-history-metrics[Schema history metrics] provide information about the status of the connector's schema history.
+* xref:{link-db2-connector}#db2-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
+* xref:{link-db2-connector}#db2-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
+* xref:{link-db2-connector}#db2-schema-history-metrics[Schema history metrics] provide information about the status of the connector's schema history.
 
-{link-prefix}:{link-debezium-monitoring}[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
+xref:{link-debezium-monitoring}[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
 
 // Type: reference
 // ModuleID: monitoring-debezium-during-snapshots-of-db2-databases
@@ -2395,8 +2395,8 @@ It is vital to execute a schema update procedure completely before there is a ne
 
 There are generally two procedures for updating table schemas:
 
-* {link-prefix}:{link-db2-connector}#db2-offline-schema-update[Offline - executed while {prodname} is stopped]
-* {link-prefix}:{link-db2-connector}#db2-online-schema-update[Online - executed while {prodname} is running]
+* xref:{link-db2-connector}#db2-offline-schema-update[Offline - executed while {prodname} is stopped]
+* xref:{link-db2-connector}#db2-online-schema-update[Online - executed while {prodname} is running]
 
 Each approach has advantages and disadvantages.
 
@@ -2419,11 +2419,11 @@ You stop the {prodname} Db2 connector before you perform an offline schema updat
 . Stop the {prodname} connector.
 . Apply all changes to the source table schema.
 . In the ASN register table, mark the tables with updated schemas as `INACTIVE`.
-. {link-prefix}:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service].
-. Remove the source table with the old schema from capture mode by {link-prefix}:{link-db2-connector}#debezium-db2-remove-capture-mode[running the {prodname} UDF for removing tables from capture mode].
-. Add the source table with the new schema to capture mode by {link-prefix}:{link-db2-connector}#debezium-db2-put-capture-mode[running the {prodname} UDF for adding tables to capture mode].
+. xref:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service].
+. Remove the source table with the old schema from capture mode by xref:{link-db2-connector}#debezium-db2-remove-capture-mode[running the {prodname} UDF for removing tables from capture mode].
+. Add the source table with the new schema to capture mode by xref:{link-db2-connector}#debezium-db2-put-capture-mode[running the {prodname} UDF for adding tables to capture mode].
 . In the ASN register table, mark the updated source tables as `ACTIVE`.
-. {link-prefix}:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
+. xref:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
 . Resume the application that updates the database.
 . Restart the {prodname} connector.
 
@@ -2445,18 +2445,18 @@ However, when a table is in capture mode, after a change to a column name, the D
 
 . Lock the source tables whose schema you want to change.
 . In the ASN register table, mark the locked tables as `INACTIVE`.
-. {link-prefix}:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
+. xref:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
 . Apply all changes to the schemas for the source tables.
 . Apply all changes to the schemas for the corresponding change-data tables.
 . In the ASN register table, mark the source tables as `ACTIVE`.
-. {link-prefix}:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
+. xref:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
 . Optional. Restart the connector to see updated column names in change events.
 
 .Procedure when adding a column to the middle of a table
 
 . Lock the source table(s) to be changed.
 . In the ASN register table, mark the locked tables as `INACTIVE`.
-. {link-prefix}:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
+. xref:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
 . For each source table to be changed:
 .. Export the data in the source table.
 .. Truncate the source table.
@@ -2467,5 +2467,5 @@ However, when a table is in capture mode, after a change to a column name, the D
 .. Alter the change-data table and add the column.
 .. Load the exported data into the altered change-data table.
 . In the ASN register table, mark the tables as `INACTIVE`. This marks the old change-data tables as inactive, which allows the data in them to remain but they are no longer updated.
-. {link-prefix}:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
+. xref:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
 . Optional. Restart the connector to see updated column names in change events.

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -216,7 +216,7 @@ We recommend logical names begin with an alphabetic or underscore character, and
 === Performing a snapshot
 
 When a task starts up using a replica set, it uses the connector's logical name and the replica set name to find an _offset_ that describes the position where the connector previously stopped reading changes.
-If an offset can be found and it still exists in the oplog, then the task immediately proceeds with {link-prefix}:{link-mongodb-connector}#mongodb-streaming-changes[streaming changes], starting at the recorded offset position.
+If an offset can be found and it still exists in the oplog, then the task immediately proceeds with xref:{link-mongodb-connector}#mongodb-streaming-changes[streaming changes], starting at the recorded offset position.
 
 However, if no offset is found or if the oplog no longer contains that position, the task must first obtain the current state of the replica set contents by performing a _snapshot_.
 This process starts by recording the current position of the oplog and recording that as the offset (along with a flag that denotes a snapshot has been started).
@@ -263,7 +263,7 @@ endif::community[]
 
 After the connector task for a replica set records an offset, it uses the offset to determine the position in the oplog where it should start streaming changes.
 The task then (depending on the configuration) either connects to the replica set's primary node or connects to a replica-set-wide change stream and starts streaming changes from that position.
-It processes all of create, insert, and delete operations, and converts them into {prodname} {link-prefix}:{link-mongodb-connector}#mongodb-events[change events].
+It processes all of create, insert, and delete operations, and converts them into {prodname} xref:{link-mongodb-connector}#mongodb-events[change events].
 Each change event includes the position in the oplog where the operation was found, and the connector periodically records this as its most recent offset.
 The interval at which the offset is recorded is governed by link:https://kafka.apache.org/documentation/#offset.flush.interval.ms[`offset.flush.interval.ms`], which is a Kafka Connect worker configuration property.
 
@@ -286,7 +286,7 @@ To summarize, the MongoDB connector continues running in most situations. Commun
 === Topic names
 
 The MongoDB connector writes events for all insert, update, and delete operations to documents in each collection to a single Kafka topic.
-The name of the Kafka topics always takes the form _logicalName_._databaseName_._collectionName_, where _logicalName_ is the {link-prefix}:{link-mongodb-connector}#mongodb-logical-connector-name[logical name] of the connector as specified with the `mongodb.name` configuration property, _databaseName_ is the name of the database where the operation occurred, and _collectionName_ is the name of the MongoDB collection in which the affected document existed.
+The name of the Kafka topics always takes the form _logicalName_._databaseName_._collectionName_, where _logicalName_ is the xref:{link-mongodb-connector}#mongodb-logical-connector-name[logical name] of the connector as specified with the `mongodb.name` configuration property, _databaseName_ is the name of the database where the operation occurred, and _collectionName_ is the name of the MongoDB collection in which the affected document existed.
 
 For example, consider a MongoDB replica set with an `inventory` database that contains four collections: `products`, `products_on_hand`, `customers`, and `orders`.
 If the connector monitoring this database were given a logical name of `fulfillment`, then the connector would produce events on these four Kafka topics:
@@ -367,7 +367,7 @@ The following example shows a typical message:
 }
 ----
 
-Unless overridden via the {link-prefix}:{link-mongodb-connector}#mongodb-property-transaction-topic[`transaction.topic`] option,
+Unless overridden via the xref:{link-mongodb-connector}#mongodb-property-transaction-topic[`transaction.topic`] option,
 transaction events are written to the topic named `_database.server.name_.transaction`.
 
 .Change data event enrichment
@@ -451,7 +451,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 
 |===
 
-By default, the connector streams change event records to topics with names that are the same as the event's originating collection. See {link-prefix}:{link-mongodb-connector}#mongodb-topic-names[topic names].
+By default, the connector streams change event records to topics with names that are the same as the event's originating collection. See xref:{link-mongodb-connector}#mongodb-topic-names[topic names].
 
 [WARNING]
 ====
@@ -1052,7 +1052,7 @@ To deploy a {prodname} MongoDB connector, you install the {prodname} MongoDB con
 
 .Prerequisites
 * link:https://zookeeper.apache.org/[Apache Zookeeper], link:http://kafka.apache.org/[Apache Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
-* MongoDB is installed and is {link-prefix}:{link-mongodb-connector}#setting-up-mongodb[set up to work with the {prodname} connector].
+* MongoDB is installed and is xref:{link-mongodb-connector}#setting-up-mongodb[set up to work with the {prodname} connector].
 
 .Procedure
 . Download the
@@ -1282,7 +1282,7 @@ Optionally, you can filter out collections that are not needed.
 endif::community[]
 
 For the complete list of the configuration properties that you can set for the {prodname} MongoDB connector,
-see {link-prefix}:{link-mongodb-connector}#mongodb-connector-properties[MongoDB connector configuration properties].
+see xref:{link-mongodb-connector}#mongodb-connector-properties[MongoDB connector configuration properties].
 
 ifdef::community[]
 You can send this configuration with a `POST` command to a running Kafka Connect service.
@@ -1301,7 +1301,7 @@ To start running a {prodname} MongoDB connector, create a connector configuratio
 
 .Prerequisites
 
-* {link-prefix}:{link-mongodb-connector}#setting-up-mongodb[MongoDB is set up to work with a {prodname} connector].
+* xref:{link-mongodb-connector}#setting-up-mongodb[MongoDB is set up to work with a {prodname} connector].
 * The {prodname} MongoDB connector is installed.
 
 .Procedure
@@ -1314,7 +1314,7 @@ endif::community[]
 .Results
 After the connector starts, it completes the following actions:
 
-* {link-prefix}:{link-mongodb-connector}#mongodb-performing-a-snapshot[Performs a consistent snapshot] of the collections in your MongoDB replica sets.
+* xref:{link-mongodb-connector}#mongodb-performing-a-snapshot[Performs a consistent snapshot] of the collections in your MongoDB replica sets.
 * Reads the oplogs/change streams for the replica sets.
 * Produces change events for every inserted, updated, and deleted document.
 * Streams change event records to Kafka topics.
@@ -1495,7 +1495,7 @@ The following _advanced_ configuration properties have good defaults that will w
 
 |[[mongodb-property-mongodb-members-auto-discover]]<<mongodb-property-mongodb-members-auto-discover, `+mongodb.members.auto.discover+`>>
 |`true`
-|Boolean value that specifies whether the addresses in 'mongodb.hosts' are seeds that should be used to discover all members of the cluster or replica set (`true`), or whether the address(es) in `mongodb.hosts` should be used as is (`false`). The default is `true` and should be used in all cases except where MongoDB is {link-prefix}:{link-mongodb-connector}#mongodb-replicaset[fronted by a proxy].
+|Boolean value that specifies whether the addresses in 'mongodb.hosts' are seeds that should be used to discover all members of the cluster or replica set (`true`), or whether the address(es) in `mongodb.hosts` should be used as is (`false`). The default is `true` and should be used in all cases except where MongoDB is xref:{link-mongodb-connector}#mongodb-replicaset[fronted by a proxy].
 
 ifdef::community[]
 |[[mongodb-property-source-struct-version]]<<mongodb-property-source-struct-version, `+source.struct.version+`>>
@@ -1529,7 +1529,7 @@ The topic is named according to the pattern `<heartbeat.topics.prefix>.<server.n
 |`true` when connector configuration explicitly specifies the `key.converter` or `value.converter` parameters to use Avro, otherwise defaults to `false`.
 |Whether field names are sanitized to adhere to Avro naming requirements.
 ifdef::community[]
-See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
+See xref:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 endif::community[]
 
 |[[mongodb-property-skipped-operations]]<<mongodb-property-skipped-operations, `+skipped.operations+`>>
@@ -1549,7 +1549,7 @@ For each collection that you specify, also specify another configuration propert
 |`false`
 |When set to `true` {prodname} generates events with transaction boundaries and enriches data events envelope with transaction metadata.
 
-See {link-prefix}:{link-mongodb-connector}#mongodb-transaction-metadata[Transaction Metadata] for additional details.
+See xref:{link-mongodb-connector}#mongodb-transaction-metadata[Transaction Metadata] for additional details.
 
 |[[mongodb-property-transaction-topic]]<<mongodb-property-transaction-topic, `transaction.topic`>>
 |`${database.server.name}.transaction`
@@ -1590,10 +1590,10 @@ A value of `0` indicates using the server/driver default wait timeout.
 
 The {prodname} MongoDB connector has two metric types in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect have.
 
-* {link-prefix}:{link-mongodb-connector}#mongodb-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
-* {link-prefix}:{link-mongodb-connector}#mongodb-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
+* xref:{link-mongodb-connector}#mongodb-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
+* xref:{link-mongodb-connector}#mongodb-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
 
-The {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details about how to expose these metrics by using JMX.
+The xref:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details about how to expose these metrics by using JMX.
 
 // Type: reference
 // ModuleID: monitoring-debezium-during-mongodb-snapshots

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -161,7 +161,7 @@ When the MySQL connector captures changes in a table to which a schema change to
 The connector needs to be configured to capture change to these helper tables.
 If consumers do not need the records generated for helper tables, then a single message transform can be applied to filter them out.
 
-See {link-prefix}:{link-mysql-connector}#mysql-topic-names[default names for topics] that receive {prodname} event records.
+See xref:{link-mysql-connector}#mysql-topic-names[default names for topics] that receive {prodname} event records.
 
 // Type: concept
 // ModuleID: how-debezium-mysql-connectors-expose-database-schema-changes
@@ -401,7 +401,7 @@ In the case of a table rename, this identifier is a concatenation of `_<old>_,_<
 
 |===
 
-See also: {link-prefix}:{link-mysql-connector}#mysql-schema-history-topic[schema history topic].
+See also: xref:{link-mysql-connector}#mysql-schema-history-topic[schema history topic].
 
 // Type: concept
 // Title: How {prodname} MySQL connectors perform database snapshots
@@ -409,7 +409,7 @@ See also: {link-prefix}:{link-mysql-connector}#mysql-schema-history-topic[schema
 [[mysql-snapshots]]
 === Snapshots
 
-When a {prodname} MySQL connector is first started, it performs an initial _consistent snapshot_ of your database. The following flow describes how the connector creates this snapshot. This flow is for the default snapshot mode, which is `initial`. For information about other snapshot modes, see the {link-prefix}:{link-mysql-connector}#mysql-property-snapshot-mode[MySQL connector `snapshot.mode` configuration property].
+When a {prodname} MySQL connector is first started, it performs an initial _consistent snapshot_ of your database. The following flow describes how the connector creates this snapshot. This flow is for the default snapshot mode, which is `initial`. For information about other snapshot modes, see the xref:{link-mysql-connector}#mysql-property-snapshot-mode[MySQL connector `snapshot.mode` configuration property].
 
 .Workflow for performing an initial snapshot with a global read lock
 [cols="1,9",options="header",subs="+attributes"]
@@ -450,7 +450,7 @@ a|Records the completed snapshot in the connector offsets.
 Connector restarts::
 If the connector fails, stops, or is rebalanced while performing the _initial snapshot_, then after the connector restarts, it performs a new snapshot. After that _intial snapshot_ is completed, the {prodname} MySQL connector restarts from the same position in the binlog so it does not miss any updates.
 +
-If the connector stops for long enough, MySQL could purge old binlog files and the connector's position would be lost. If the position is lost, the connector reverts to the _initial snapshot_ for its starting position. For more tips on troubleshooting the {prodname} MySQL connector, see {link-prefix}:{link-mysql-connector}#mysql-when-things-go-wrong[behavior when things go wrong].
+If the connector stops for long enough, MySQL could purge old binlog files and the connector's position would be lost. If the position is lost, the connector reverts to the _initial snapshot_ for its starting position. For more tips on troubleshooting the {prodname} MySQL connector, see xref:{link-mysql-connector}#mysql-when-things-go-wrong[behavior when things go wrong].
 
 Global read locks not allowed::
 Some environments do not allow global read locks. If the {prodname} MySQL connector detects that global read locks are not permitted, the connector uses table-level locks instead and performs a snapshot with this method. This requires the database user for the {prodname} connector to have `LOCK TABLES` privileges.
@@ -514,7 +514,7 @@ The MySQL connector allows for running incremental snapshots with a read-only co
 To run an incremental snapshot with read-only access, the connector uses the executed global transaction IDs (GTID) set as high and low watermarks.
 The state of a chunk's window is updated by comparing the GTIDs of binary log (binlog) events or the server's heartbeats against low and high watermarks.
 
-To switch to a read-only implementation, set the value of the {link-prefix}:{link-mysql-connector}#mysql-property-read-only[`read.only`] property to `true`.
+To switch to a read-only implementation, set the value of the xref:{link-mysql-connector}#mysql-property-read-only[`read.only`] property to `true`.
 
 .Prerequisites
 
@@ -527,8 +527,8 @@ you must set one of the following options:
 
 ==== Ad hoc read-only incremental snapshots
 
-When the MySQL connection is read-only, the {link-prefix}:{link-signalling}[signaling table] mechanism can also run a snapshot by sending a message to the Kafka topic that is specified in
-the {link-prefix}:{link-mysql-connector}#mysql-property-signal-kafka-topic[signal.kafka.topic] property.
+When the MySQL connection is read-only, the xref:{link-signalling}[signaling table] mechanism can also run a snapshot by sending a message to the Kafka topic that is specified in
+the xref:{link-mysql-connector}#mysql-property-signal-kafka-topic[signal.kafka.topic] property.
 
 The key of the Kafka message must match the value of the `database.server.name` connector configuration option.
 
@@ -549,7 +549,7 @@ See the next section for more details.
 |`data-collections`
 |_N/A_
 | An array of qualified names of table to be snapshotted. +
-The format of the names is the same as for {link-prefix}:#{context}-property-signal-data-collection[signal.data.collection] configuration option.
+The format of the names is the same as for xref:#{context}-property-signal-data-collection[signal.data.collection] configuration option.
 
 |===
 
@@ -610,7 +610,7 @@ The connector applies similar naming conventions to label its internal database 
 
 If the default topic name do not meet your requirements, you can configure custom topic names.
 To configure custom topic names, you specify regular expressions in the logical topic routing SMT.
-For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].
+For more information about using the logical topic routing SMT to customize topic naming, see xref:{link-topic-routing}#topic-routing[Topic routing].
 
 [[mysql-transaction-metadata]]
 === Transaction metadata
@@ -737,7 +737,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 |`schema`
 |The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed. +
  +
-It is possible to override the table's primary key by setting the {link-prefix}:{link-mysql-connector}#mysql-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
+It is possible to override the table's primary key by setting the xref:{link-mysql-connector}#mysql-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
 
 |2
 |`payload`
@@ -753,7 +753,7 @@ It is possible to override the table's primary key by setting the {link-prefix}:
 
 |===
 
-By default, the connector streams change event records to topics with names that are the same as the event's originating table. See {link-prefix}:{link-mysql-connector}#mysql-topic-names[topic names].
+By default, the connector streams change event records to topics with names that are the same as the event's originating table. See xref:{link-mysql-connector}#mysql-topic-names[topic names].
 
 [WARNING]
 ====
@@ -1133,7 +1133,7 @@ a| Mandatory field that describes the source metadata for the event. This field 
 * MySQL server ID (if available)
 * Timestamp for when the change was made in the database
 
-If the {link-prefix}:{link-mysql-connector}#enable-query-log-events[`binlog_rows_query_log_events`] MySQL configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
+If the xref:{link-mysql-connector}#enable-query-log-events[`binlog_rows_query_log_events`] MySQL configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
 
 |===
 
@@ -1211,7 +1211,7 @@ a|Mandatory field that describes the source metadata for the event. The `source`
 * MySQL server ID (if available)
 * Timestamp for when the change was made in the database
 
-If the {link-prefix}:{link-mysql-connector}#enable-query-log-events[`binlog_rows_query_log_events`] MySQL configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
+If the xref:{link-mysql-connector}#enable-query-log-events[`binlog_rows_query_log_events`] MySQL configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
 
 |4
 |`op`
@@ -1227,7 +1227,7 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 
 [NOTE]
 ====
-Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a {link-prefix}:{link-mysql-connector}#mysql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row. Details are in the next section.
+Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a xref:{link-mysql-connector}#mysql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row. Details are in the next section.
 ====
 
 // Type: continue
@@ -1309,7 +1309,7 @@ a|Mandatory field that describes the source metadata for the event. In a _delete
 * MySQL server ID (if available)
 * Timestamp for when the change was made in the database
 
-If the {link-prefix}:{link-mysql-connector}#enable-query-log-events[`binlog_rows_query_log_events`] MySQL configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
+If the xref:{link-mysql-connector}#enable-query-log-events[`binlog_rows_query_log_events`] MySQL configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
 
 |4
 |`op`
@@ -1425,17 +1425,17 @@ a|_n/a_
 |`BINARY(M)]`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the {link-prefix}:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
+Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`VARBINARY(M)]`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the {link-prefix}:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
+Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`TINYBLOB`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the {link-prefix}:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
+Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`TINYTEXT`
 |`STRING`
@@ -1444,7 +1444,7 @@ a|_n/a_
 |`BLOB`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the {link-prefix}:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting. +
+Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting. +
 Only values with a size of up to 2GB are supported. It is recommended to externalize large column values, using the claim check pattern.
 
 |`TEXT`
@@ -1455,7 +1455,7 @@ Only values with a size of up to 2GB are supported. It is recommended to externa
 |`MEDIUMBLOB`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the {link-prefix}:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
+Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`MEDIUMTEXT`
 |`STRING`
@@ -1464,7 +1464,7 @@ a|_n/a_
 |`LONGBLOB`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the {link-prefix}:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting. +
+Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting. +
 Only values with a size of up to 2GB are supported. It is recommended to externalize large column values, using the claim check pattern.
 
 |`LONGTEXT`
@@ -1515,7 +1515,7 @@ Such columns are converted into an equivalent `io.debezium.time.ZonedTimestamp` 
 
 The time zone of the JVM running Kafka Connect and Debezium does not affect these conversions.
 
-More details about properties related to temporal values are in the documentation for {link-prefix}:{link-mysql-connector}#mysql-connector-properties[MySQL connector configuration properties].
+More details about properties related to temporal values are in the documentation for xref:{link-mysql-connector}#mysql-connector-properties[MySQL connector configuration properties].
 
 time.precision.mode=adaptive_time_microseconds(default)::
 The MySQL connector determines the literal type and semantic type based on the column's data type definition so that events represent exactly the values in the database. All time fields are in microseconds. Only positive `TIME` field values in the range of `00:00:00.000000` to `23:59:59.999999` can be captured correctly.
@@ -1575,7 +1575,7 @@ Represents the number of milliseconds since the epoch, and does not include time
 [id="mysql-decimal-types"]
 === Decimal types
 
-{prodname} connectors handle decimals according to the setting of the {link-prefix}:{link-mysql-connector}#mysql-property-decimal-handling-mode[`decimal.handling.mode` connector configuration property].
+{prodname} connectors handle decimals according to the setting of the xref:{link-mysql-connector}#mysql-property-decimal-handling-mode[`decimal.handling.mode` connector configuration property].
 
 decimal.handling.mode=precise::
 +
@@ -1639,7 +1639,7 @@ When the table is created during streaming then it uses proper `BOOLEAN` mapping
 During snapshots, {prodname} executes `SHOW CREATE TABLE` to obtain table definitions that return `TINYINT(1)` for both `BOOLEAN` and `TINYINT(1)` columns. {prodname} then has no way to obtain the original type mapping and so maps to `TINYINT(1)`.
 
 ifdef::community[]
-The operator can configure the out-of-the-box {link-prefix}:{link-custom-converters}[`TinyIntOneToBooleanConverter` custom converter] that would either map all `TINYINT(1)` columns to `BOOLEAN` or if the `selector` parameter is set then a subset of columns could be enumerated using comma-separated regular expressions.
+The operator can configure the out-of-the-box xref:{link-custom-converters}[`TinyIntOneToBooleanConverter` custom converter] that would either map all `TINYINT(1)` columns to `BOOLEAN` or if the `selector` parameter is set then a subset of columns could be enumerated using comma-separated regular expressions.
 endif::community[]
 
 Following is an example configuration:
@@ -1726,7 +1726,7 @@ mysql> GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIE
 +
 The table below describes the permissions.
 +
-IMPORTANT: If using a hosted option such as Amazon RDS or Amazon Aurora that does not allow a global read lock, table-level locks are used to create the _consistent snapshot_. In this case, you need to also grant `LOCK TABLES` permissions to the user that you create. See {link-prefix}:{link-mysql-connector}#mysql-snapshots[snapshots] for more details.
+IMPORTANT: If using a hosted option such as Amazon RDS or Amazon Aurora that does not allow a global read lock, table-level locks are used to create the _consistent snapshot_. In this case, you need to also grant `LOCK TABLES` permissions to the user that you create. See xref:{link-mysql-connector}#mysql-snapshots[snapshots] for more details.
 
 . Finalize the user's permissions:
 +
@@ -1834,7 +1834,7 @@ FROM information_schema.global_variables WHERE variable_name='log_bin';
 |The `binlog_row_image` must be set to `FULL` or `full`.
 
 |`expire_logs_days`
-|This is the number of days for automatic binlog file removal. The default is `0`, which means no automatic removal. Set the value to match the needs of your environment. See {link-prefix}:{link-mysql-connector}#mysql-purges-binlog-files-used-by-debezium[MySQL purges binlog files].
+|This is the number of days for automatic binlog file removal. The default is `0`, which means no automatic removal. Set the value to match the needs of your environment. See xref:{link-mysql-connector}#mysql-purges-binlog-files-used-by-debezium[MySQL purges binlog files].
 
 |===
 
@@ -1992,7 +1992,7 @@ To deploy a {prodname} MySQL connector, you install the {prodname} MySQL connect
 
 .Prerequisites
 * link:https://zookeeper.apache.org/[Apache Zookeeper], link:http://kafka.apache.org/[Apache Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
-* MySQL Server is installed and is {link-prefix}:{link-mysql-connector}#setting-up-mysql[set up to work with the {prodname} connector].
+* MySQL Server is installed and is xref:{link-mysql-connector}#setting-up-mysql[set up to work with the {prodname} connector].
 
 .Procedure
 
@@ -2004,7 +2004,7 @@ ifeval::['{page-version}' != 'master']
 endif::[]
 . Extract the files into your Kafka Connect environment.
 . Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
-. {link-prefix}:{link-mysql-connector}#mysql-example-configuration[Configure the connector] and {link-prefix}:{link-mysql-connector}#mysql-adding-configuration[add the configuration to your Kafka Connect cluster.]
+. xref:{link-mysql-connector}#mysql-example-configuration[Configure the connector] and xref:{link-mysql-connector}#mysql-adding-configuration[add the configuration to your Kafka Connect cluster.]
 . Restart your Kafka Connect process to pick up the new JAR files.
 
 If you are working with immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s Container images] for Apache Zookeeper, Apache Kafka, MySQL, and Kafka Connect with the MySQL connector already installed and ready to run.
@@ -2278,7 +2278,7 @@ Optionally, you can ignore, mask, or truncate columns that contain sensitive dat
 endif::community[]
 
 For the complete list of the configuration properties that you can set for the {prodname} MySQL connector,
-see {link-prefix}:{link-mysql-connector}#mysql-connector-properties[MySQL connector configuration properties].
+see xref:{link-mysql-connector}#mysql-connector-properties[MySQL connector configuration properties].
 
 ifdef::community[]
 You can send this configuration with a `POST` command to a running Kafka Connect service.
@@ -2295,7 +2295,7 @@ To start running a MySQL connector, configure a connector configuration, and add
 
 .Prerequisites
 
-* {link-prefix}:{link-mysql-connector}#setting-up-mysql[MySQL is set up to work with a {prodname} connector].
+* xref:{link-mysql-connector}#setting-up-mysql[MySQL is set up to work with a {prodname} connector].
 * The {prodname} MySQL connector is installed.
 
 .Procedure
@@ -2306,7 +2306,7 @@ To start running a MySQL connector, configure a connector configuration, and add
 endif::community[]
 
 .Results
-After the connector starts, it {link-prefix}:{link-mysql-connector}#mysql-snapshots[performs a consistent snapshot] of the MySQL databases that the connector is configured for.
+After the connector starts, it xref:{link-mysql-connector}#mysql-snapshots[performs a consistent snapshot] of the MySQL databases that the connector is configured for.
 The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
 
 ifdef::product[]
@@ -2470,7 +2470,7 @@ _databaseName_._tableName_._typeName_
 
 _databaseName_._schemaName_._tableName_._typeName_
 
-See {link-prefix}:{link-mysql-connector}#mysql-data-types[how MySQL connectors map data types] for the list of MySQL-specific data type names.
+See xref:{link-mysql-connector}#mysql-data-types[how MySQL connectors map data types] for the list of MySQL-specific data type names.
 
 |[[mysql-property-time-precision-mode]]<<mysql-property-time-precision-mode, `+time.precision.mode+`>>
 |`adaptive_time_microseconds`
@@ -2629,7 +2629,7 @@ However, it's best to use the minimum number that are required to specify a uniq
 [id="mysql-advanced-connector-configuration-properties"]
 ==== Advanced MySQL connector configuration properties
 
-The following table describes {link-prefix}:{link-mysql-connector}#mysql-advanced-connector-configuration-properties[advanced MySQL connector properties]. The default values for these properties rarely need to be changed. Therefore, you do not need to specify them in the connector configuration.
+The following table describes xref:{link-mysql-connector}#mysql-advanced-connector-configuration-properties[advanced MySQL connector properties]. The default values for these properties rarely need to be changed. Therefore, you do not need to specify them in the connector configuration.
 
 .Descriptions of MySQL connector advanced configuration properties
 [cols="30%a,20%a,50%a",options="header",subs="+attributes"]
@@ -2781,7 +2781,7 @@ The connector might establish JDBC connections at its own discretion, so this pr
 
 |[[mysql-property-snapshot-lock-timeout-ms]]<<mysql-property-snapshot-lock-timeout-ms, `+snapshot.lock.timeout.ms+`>>
 |`10000`
-|Positive integer that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. See {link-prefix}:{link-mysql-connector}#mysql-snapshots[how MySQL connectors perform database snapshots].
+|Positive integer that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. See xref:{link-mysql-connector}#mysql-snapshots[how MySQL connectors perform database snapshots].
 
 |[[mysql-property-enable-time-adjuster]]<<mysql-property-enable-time-adjuster, `+enable.time.adjuster+`>>
 |`true`
@@ -2800,7 +2800,7 @@ endif::community[]
 |[[mysql-property-sanitize-field-names]]<<mysql-property-sanitize-field-names, `+sanitize.field.names+`>>
 |`true` if connector configuration sets the `key.converter` or `value.converter` property to the Avro converter. +
 `false` if not.
-|Indicates whether field names are sanitized to adhere to {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming requirements].
+|Indicates whether field names are sanitized to adhere to xref:{link-avro-serialization}#avro-naming[Avro naming requirements].
 
 |[[mysql-property-skipped-operations]]<<mysql-property-skipped-operations, `+skipped.operations+`>>
 |No default
@@ -2808,7 +2808,7 @@ endif::community[]
 
 |[[mysql-property-signal-data-collection]]<<mysql-property-signal-data-collection,`+signal.data.collection+`>>
 |No default value
-|Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector. +
+|Fully-qualified name of the data collection that is used to send xref:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector. +
 Use the following format to specify the collection name: +
 `_<databaseName>_._<tableName>_`
 
@@ -2839,7 +2839,7 @@ endif::product[]
 
 |[[mysql-property-provide-transaction-metadata]]<<mysql-property-provide-transaction-metadata, `provide.transaction.metadata`>>
 |`false`
-|Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See {link-prefix}:{link-mysql-connector}#mysql-transaction-metadata[Transaction metadata] for details.
+|Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See xref:{link-mysql-connector}#mysql-transaction-metadata[Transaction metadata] for details.
 
 |[[mysql-property-transaction-topic]]<<mysql-property-transaction-topic, `transaction.topic`>>
 |`${database.server.name}.transaction`
@@ -2900,11 +2900,11 @@ include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-databas
 
 The {prodname} MySQL connector provides three types of metrics that are in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect provide.
 
-* {link-prefix}:{link-mysql-connector}#mysql-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
-* {link-prefix}:{link-mysql-connector}#mysql-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is reading the binlog.
-* {link-prefix}:{link-mysql-connector}#mysql-schema-history-metrics[Schema history metrics] provide information about the status of the connector's schema history.
+* xref:{link-mysql-connector}#mysql-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
+* xref:{link-mysql-connector}#mysql-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is reading the binlog.
+* xref:{link-mysql-connector}#mysql-schema-history-metrics[Schema history metrics] provide information about the status of the connector's schema history.
 
-{link-prefix}:{link-debezium-monitoring}[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
+xref:{link-debezium-monitoring}[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
 
 // Type: reference
 // ModuleID: monitoring-debezium-during-snapshots-of-mysql-databases
@@ -2924,7 +2924,7 @@ The {prodname} MySQL connector also provides the `HoldingGlobalLock` custom snap
 [[mysql-streaming-metrics]]
 === Streaming metrics
 
-Transaction-related attributes are available only if binlog event buffering is enabled. See {link-prefix}:{link-mysql-connector}#mysql-property-binlog-buffer-size[`binlog.buffer.size`] in the advanced connector configuration properties for more details.
+Transaction-related attributes are available only if binlog event buffering is enabled. See xref:{link-mysql-connector}#mysql-property-binlog-buffer-size[`binlog.buffer.size`] in the advanced connector configuration properties for more details.
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 
@@ -3054,4 +3054,4 @@ The Kafka Connect framework records {prodname} change events in Kafka by using t
 
 If the {prodname} MySQL connector stops for too long, the MySQL server purges older binlog files and the connector's last position may be lost. When the connector is restarted, the MySQL server no longer has the starting point and the connector performs another initial snapshot. If the snapshot is disabled, the connector fails with an error.
 
-See {link-prefix}:{link-mysql-connector}#mysql-snapshots[snapshots] for details about how MySQL connectors perform initial snapshots.
+See xref:{link-mysql-connector}#mysql-snapshots[snapshots] for details about how MySQL connectors perform initial snapshots.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -177,7 +177,7 @@ The connector applies similar naming conventions to label its internal database 
 
 If the default topic name do not meet your requirements, you can configure custom topic names.
 To configure custom topic names, you specify regular expressions in the logical topic routing SMT.
-For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].
+For more information about using the logical topic routing SMT to customize topic naming, see xref:{link-topic-routing}#topic-routing[Topic routing].
 
 // Type: concept
 // ModuleID: how-debezium-oracle-connectors-expose-database-schema-changes
@@ -230,7 +230,7 @@ ifdef::community[]
 
 [NOTE]
 ====
-Following a change in table structure, you must follow (the {link-prefix}:{link-oracle-connector}#oracle-schema-evolution[schema evolution procedure].
+Following a change in table structure, you must follow (the xref:{link-oracle-connector}#oracle-schema-evolution[schema evolution procedure].
 ====
 endif::community[]
 
@@ -621,7 +621,7 @@ SCN gap detection is available only if the large SCN increment occurs while the 
 
 Every data change event that the Oracle connector emits has a key and a value.
 The structures of the key and value depend on the table from which the change events originate.
-For information about how {prodname} constructs topic names, see {link-prefix}:{link-oracle-connector}#oracle-topic-names[Topic names]).
+For information about how {prodname} constructs topic names, see xref:{link-oracle-connector}#oracle-topic-names[Topic names]).
 
 [WARNING]
 ====
@@ -970,7 +970,7 @@ When the columns for a row's primary/unique key are updated, the value of the ro
 As a result, {prodname} emits _three_ events after such an update:
 
 * A `DELETE` event.
-* A {link-prefix}:{link-oracle-connector}#oracle-tombstone-events[tombstone event] with the old key for the row.
+* A xref:{link-oracle-connector}#oracle-tombstone-events[tombstone event] with the old key for the row.
 * An `INSERT` event that provides the new key for the row.
 ====
 
@@ -1744,14 +1744,14 @@ To deploy a {prodname} Oracle connector, you install the {prodname} Oracle conne
 
 .Prerequisites
 * link:https://zookeeper.apache.org/[Apache ZooKeeper], link:http://kafka.apache.org/[Apache Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
-* Oracle Database is installed, and is {link-prefix}:{link-oracle-connector}#setting-up-oracle[configured to work with the {prodname} connector].
+* Oracle Database is installed, and is xref:{link-oracle-connector}#setting-up-oracle[configured to work with the {prodname} connector].
 * You have a copies of the Oracle JDBC driver and the XStream API JAR.
 +
 [IMPORTANT]
 ====
 Due to licensing requirements, the {prodname} Oracle connector does not ship with the Oracle JDBC driver or XStream API files.
 You must download these files directly from Oracle and add them to your environment.
-For more information, see {link-prefix}:{link-oracle-connector}#obtaining-oracle-jdbc-driver-and-xstreams-api-files[Obtaining the Oracle JDBC driver and XStream API files].
+For more information, see xref:{link-oracle-connector}#obtaining-oracle-jdbc-driver-and-xstreams-api-files[Obtaining the Oracle JDBC driver and XStream API files].
 ====
 
 .Procedure
@@ -1762,7 +1762,7 @@ For more information, see {link-prefix}:{link-oracle-connector}#obtaining-oracle
 
 . Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
 
-  . {link-prefix}:{link-oracle-connector}#oracle-example-configuration[Configure the connector] and {link-prefix}:{link-oracle-connector}#oracle-adding-connector-configuration[add the configuration to your Kafka Connect cluster.]
+  . xref:{link-oracle-connector}#oracle-example-configuration[Configure the connector] and xref:{link-oracle-connector}#oracle-adding-connector-configuration[add the configuration to your Kafka Connect cluster.]
 . Restart your Kafka Connect process to pick up the new JAR files.
 endif::community[]
 
@@ -1822,7 +1822,7 @@ You then need to create the following custom resources (CRs):
 * You have a copy of the Oracle JDBC driver.
 Due to licensing requirements, the {prodname} Oracle connector does not include the required driver file.
 +
-For more information, see {link-prefix}:{link-oracle-connector}#obtaining-the-oracle-jdbc-driver[Obtaining the Oracle JDBC driver].
+For more information, see xref:{link-oracle-connector}#obtaining-the-oracle-jdbc-driver[Obtaining the Oracle JDBC driver].
 
 .Procedure
 
@@ -1962,10 +1962,10 @@ spec:
 |The port number of the Oracle instance.
 
 |5
-|The name of the Oracle user, as specified in {link-prefix}:{link-oracle-connector}#creating-users-for-the-connector[Creating users for the connector].
+|The name of the Oracle user, as specified in xref:{link-oracle-connector}#creating-users-for-the-connector[Creating users for the connector].
 
 |6
-|The password for the Oracle user, as specified in {link-prefix}:{link-oracle-connector}#creating-users-for-the-connector[Creating users for the connector].
+|The password for the Oracle user, as specified in xref:{link-oracle-connector}#creating-users-for-the-connector[Creating users for the connector].
 
 |7
 |The name of the database to capture changes from.
@@ -2111,8 +2111,8 @@ Optionally, you can ignore, mask, or truncate columns that contain sensitive dat
 <2> The name of this Oracle connector class.
 <3> The address of the Oracle instance.
 <4> The port number of the Oracle instance.
-<5> The name of the Oracle user, as specified in {link-prefix}:{link-oracle-connector}#creating-users-for-the-connector[Creating users for the connector].
-<6> The password for the Oracle user, as specified in {link-prefix}:{link-oracle-connector}#creating-users-for-the-connector[Creating users for the connector].
+<5> The name of the Oracle user, as specified in xref:{link-oracle-connector}#creating-users-for-the-connector[Creating users for the connector].
+<6> The password for the Oracle user, as specified in xref:{link-oracle-connector}#creating-users-for-the-connector[Creating users for the connector].
 <7> The name of the database to capture changes from.
 <8> Logical name that identifies and provides a namespace for the Oracle database server from which the connector captures changes.
 <9> The maximum number of tasks to create for this connector.
@@ -2212,7 +2212,7 @@ For non-CDB installation, do *not* specify the `database.pdb.name` property.
 
 endif::community[]
 
-For the complete list of the configuration properties that you can set for the {prodname} Oracle connector, see {link-prefix}:{link-oracle-connector}#oracle-connector-properties[Oracle connector properties].
+For the complete list of the configuration properties that you can set for the {prodname} Oracle connector, see xref:{link-oracle-connector}#oracle-connector-properties[Oracle connector properties].
 
 ifdef::community[]
 You can send this configuration with a `POST` command to a running Kafka Connect service.
@@ -2229,19 +2229,19 @@ To start running a {prodname} Oracle connector, create a connector configuration
 
 .Prerequisites
 
-* {link-prefix}:{link-oracle-connector}#setting-up-oracle[Oracle is configured for use with {prodname}].
+* xref:{link-oracle-connector}#setting-up-oracle[Oracle is configured for use with {prodname}].
 * The {prodname} Oracle connector is installed.
 
 .Procedure
 
-. Create a {link-prefix}:{link-oracle-connector}#oracle-example-configuration[configuration] for the Oracle connector.
+. Create a xref:{link-oracle-connector}#oracle-example-configuration[configuration] for the Oracle connector.
 
 . Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster.
 endif::community[]
 
 .Results
 
-After the connector starts, it {link-prefix}:{link-oracle-connector}#oracle-snapshots[performs a consistent snapshot] of the Oracle databases that the connector is configured for.
+After the connector starts, it xref:{link-oracle-connector}#oracle-snapshots[performs a consistent snapshot] of the Oracle databases that the connector is configured for.
 The connector then starts generating data change events for row-level operations and streaming the change event records to Kafka topics.
 
 ifdef::product[]
@@ -2611,7 +2611,7 @@ The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pa
 Useful to properly size corresponding columns in sink databases. +
  +
 Fully-qualified data type names are of the form `_<tableName>_._<typeName>_`, or `_<schemaName>_._<tableName>_._<typeName>_`. +
-See the {link-prefix}:{link-oracle-connector}#oracle-data-type-mappings[list of Oracle-specific data type names].
+See the xref:{link-oracle-connector}#oracle-data-type-mappings[list of Oracle-specific data type names].
 
 |[[oracle-property-heartbeat-interval-ms]]<<oracle-property-heartbeat-interval-ms, `+heartbeat.interval.ms+`>>
 |`0`
@@ -2641,13 +2641,13 @@ The connector reads table contents in multiple batches of the specified size.
 |[[oracle-property-sanitize-field-names]]<<oracle-property-sanitize-field-names, `+sanitize.field.names+`>>
 |`true` when the connector configuration explicitly specifies the `key.converter` or `value.converter` parameters to use Avro, otherwise defaults to `false`.
 |Specifies whether field names are normalized to comply with Avro naming requirements.
-For more information, see {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming].
+For more information, see xref:{link-avro-serialization}#avro-naming[Avro naming].
 
 |[[oracle-property-provide-transaction-metadata]]<<oracle-property-provide-transaction-metadata, `+provide.transaction.metadata+`>>
 |`false`
 |Set the property to `true` if you want {prodname} to generate events with transaction boundaries and enriches data events envelope with transaction metadata.
 
-See {link-prefix}:{link-oracle-connector}#oracle-transaction-metadata[Transaction Metadata] for additional details.
+See xref:{link-oracle-connector}#oracle-transaction-metadata[Transaction Metadata] for additional details.
 
 |[[oracle-property-transaction-topic]]<<oracle-property-transaction-topic, `transaction.topic`>>
 |`${database.server.name}.transaction`
@@ -2775,7 +2775,7 @@ long-running transactions should be avoided in order to not overflow that buffer
 Any transaction that exceeds this configured value is discarded entirely, and the connector does not emit any messages for the operations that were part of the transaction.
 ifdef::community[]
 While this option allows the behavior to be configured on a case-by-case basis,
-we have plans to enhance this behavior in a future release by means of adding a scalable transaction buffer, (see {link-prefix}:{jira-url}/browse/DBZ-3123[DBZ-3123]).
+we have plans to enhance this behavior in a future release by means of adding a scalable transaction buffer, (see xref:{jira-url}/browse/DBZ-3123[DBZ-3123]).
 endif::community[]
 |[[oracle-property-log-mining-archive-destination-name]]<<oracle-property-log-mining-archive-destination-name, `+log.mining.archive.destination.name+`>>
 |No default
@@ -2852,7 +2852,7 @@ By default, no operations are skipped.
 
 |[[oracle-property-signal-data-collection]]<<oracle-property-signal-data-collection,`+signal.data.collection+`>>
 |No default value
-a|Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector. +
+a|Fully-qualified name of the data collection that is used to send xref:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector. +
 Use the following format to specify the collection name: +
 `_<databaseName>_._<schemaName>_._<tableName>_`
 
@@ -2882,11 +2882,11 @@ include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-databas
 
 The {prodname} Oracle connector provides three metric types in addition to the built-in support for JMX metrics that Apache Zookeeper, Apache Kafka, and Kafka Connect have.
 
-* {link-prefix}:{link-oracle-connector}#oracle-snapshot-metrics[snapshot metrics]; for monitoring the connector when performing snapshots
-* {link-prefix}:{link-oracle-connector}#oracle-streaming-metrics[streaming metrics]; for monitoring the connector when processing change events
-* {link-prefix}:{link-oracle-connector}#oracle-schema-history-metrics[schema history metrics]; for monitoring the status of the connector's schema history
+* xref:{link-oracle-connector}#oracle-snapshot-metrics[snapshot metrics]; for monitoring the connector when performing snapshots
+* xref:{link-oracle-connector}#oracle-streaming-metrics[streaming metrics]; for monitoring the connector when processing change events
+* xref:{link-oracle-connector}#oracle-schema-history-metrics[schema history metrics]; for monitoring the status of the connector's schema history
 
-Please refer to the {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[monitoring documentation] for details of how to expose these metrics via JMX.
+Please refer to the xref:{link-debezium-monitoring}#monitoring-debezium[monitoring documentation] for details of how to expose these metrics via JMX.
 
 // Type: reference
 // ModuleID: debezium-oracle-connector-snapshot-metrics

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -84,7 +84,7 @@ The connector relies on and reflects the PostgreSQL logical decoding feature, wh
 * Logical decoding does not support DDL changes. This means that the connector is unable to report DDL change events back to consumers.
 * Logical decoding replication slots are supported on only `primary` servers. When there is a cluster of PostgreSQL servers, the connector can run on only the active `primary` server. It cannot run on `hot` or `warm` standby replicas. If the `primary` server fails or is demoted, the connector stops. After the `primary` server has recovered, you can restart the connector. If a different PostgreSQL server has been promoted to `primary`, adjust the connector configuration before restarting the connector.
 
-{link-prefix}:{link-postgresql-connector}#postgresql-when-things-go-wrong[ Behavior when things go wrong] describes what the connector does when there is a problem.
+xref:{link-postgresql-connector}#postgresql-when-things-go-wrong[ Behavior when things go wrong] describes what the connector does when there is a problem.
 ====
 
 [IMPORTANT]
@@ -122,7 +122,7 @@ To use the {prodname} connector to stream changes from a PostgreSQL database, th
 Although one way to grant the necessary privileges is to provide the user with `superuser` privileges, doing so potentially exposes your PostgreSQL data to unauthorized access.
 Rather than granting excessive privileges to the {prodname} user, it is best to create a dedicated {prodname} replication user to which you grant specific privileges.
 
-For more information about configuring privileges for the {prodname} PostgreSQL user, see {link-prefix}:{link-postgresql-connector}#postgresql-permissions[Setting up permissions].
+For more information about configuring privileges for the {prodname} PostgreSQL user, see xref:{link-postgresql-connector}#postgresql-permissions[Setting up permissions].
 For more information about PostgreSQL logical replication security, see the link:https://www.postgresql.org/docs/current/logical-replication-security.html[PostgreSQL documentation].
 
 // Type: concept
@@ -131,7 +131,7 @@ For more information about PostgreSQL logical replication security, see the link
 [[postgresql-snapshots]]
 === Snapshots
 
-Most PostgreSQL servers are configured to not retain the complete history of the database in the WAL segments. This means that the PostgreSQL connector would be unable to see the entire history of the database by reading only the WAL. Consequently, the first time that the connector starts, it performs an initial _consistent snapshot_ of the database. The default behavior for performing a snapshot consists of the following steps. You can change this behavior by setting the {link-prefix}:{link-postgresql-connector}#postgresql-property-snapshot-mode[`snapshot.mode` connector configuration property] to a value other than `initial`.
+Most PostgreSQL servers are configured to not retain the complete history of the database in the WAL segments. This means that the PostgreSQL connector would be unable to see the entire history of the database by reading only the WAL. Consequently, the first time that the connector starts, it performs an initial _consistent snapshot_ of the database. The default behavior for performing a snapshot consists of the following steps. You can change this behavior by setting the xref:{link-postgresql-connector}#postgresql-property-snapshot-mode[`snapshot.mode` connector configuration property] to a value other than `initial`.
 
 . Start a transaction with a link:https://www.postgresql.org/docs/current/static/sql-set-transaction.html[SERIALIZABLE, READ ONLY, DEFERRABLE] isolation level to ensure that subsequent reads in this transaction are against a single consistent version of the data. Any changes to the data due to subsequent `INSERT`, `UPDATE`, and `DELETE` operations by other clients are not visible to this transaction.
 . Read the current position in the server's transaction log.
@@ -165,7 +165,7 @@ If the connector fails, is rebalanced, or stops after Step 1 begins but before S
 
 ifdef::community[]
 |`custom`
-|The `custom` snapshot mode lets you inject your own implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. Set the `snapshot.custom.class` configuration property to the class on the classpath of your Kafka Connect cluster or included in the JAR if using the `EmbeddedEngine`. For more details, see {link-prefix}:{link-postgresql-connector}#postgresql-custom-snapshot[custom snapshotter SPI].
+|The `custom` snapshot mode lets you inject your own implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. Set the `snapshot.custom.class` configuration property to the class on the classpath of your Kafka Connect cluster or included in the JAR if using the `EmbeddedEngine`. For more details, see xref:{link-postgresql-connector}#postgresql-custom-snapshot[custom snapshotter SPI].
 endif::community[]
 
 |===
@@ -296,7 +296,7 @@ endif::community[]
 
 The PostgreSQL connector typically spends the vast majority of its time streaming changes from the PostgreSQL server to which it is connected. This mechanism relies on link:https://www.postgresql.org/docs/current/static/protocol-replication.html[_PostgreSQL's replication protocol_]. This protocol enables clients to receive changes from the server as they are committed in the server's transaction log at certain positions, which are referred to as Log Sequence Numbers (LSNs).
 
-Whenever the server commits a transaction, a separate server process invokes a callback function from the {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in]. This function processes the changes from the transaction, converts them to a specific format (Protobuf or JSON in the case of {prodname} plug-in) and writes them on an output stream, which can then be consumed by clients.
+Whenever the server commits a transaction, a separate server process invokes a callback function from the xref:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in]. This function processes the changes from the transaction, converts them to a specific format (Protobuf or JSON in the case of {prodname} plug-in) and writes them on an output stream, which can then be consumed by clients.
 
 The {prodname} PostgreSQL connector acts as a PostgreSQL client. When the connector receives changes it transforms the events into {prodname} _create_, _update_, or _delete_ events that include the LSN of the event. The PostgreSQL connector forwards these change events in records to the Kafka Connect framework, which is running in the same process. The Kafka Connect process asynchronously writes the change event records in the same order in which they were generated to the appropriate Kafka topic.
 
@@ -323,7 +323,7 @@ As of PostgreSQL 10+, there is a logical replication stream mode, called `pgoutp
 without the need for additional plug-ins.
 This is particularly valuable for environments where installation of plug-ins is not supported or not allowed.
 
-See {link-prefix}:{link-postgresql-connector}#setting-up-postgresql[Setting up PostgreSQL] for more details.
+See xref:{link-postgresql-connector}#setting-up-postgresql[Setting up PostgreSQL] for more details.
 
 // Type: concept
 // ModuleID: default-names-of-kafka-topics-that-receive-debezium-postgresql-change-event-records
@@ -360,7 +360,7 @@ The connector applies similar naming conventions to label its xref:postgresql-tr
 
 If the default topic name do not meet your requirements, you can configure custom topic names.
 To configure custom topic names, you specify regular expressions in the logical topic routing SMT.
-For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].
+For more information about using the logical topic routing SMT to customize topic naming, see xref:{link-topic-routing}#topic-routing[Topic routing].
 
 // Type: concept
 // ModuleID: metadata-in-debezium-postgresql-change-event-records
@@ -368,7 +368,7 @@ For more information about using the logical topic routing SMT to customize topi
 [[postgresql-meta-information]]
 === Meta information
 
-In addition to a {link-prefix}:{link-postgresql-connector}#postgresql-events[_database change event_], each record produced by a PostgreSQL connector contains some metadata. Metadata includes where the event occurred on the server, the name of the source partition and the name of the Kafka topic and partition where the event should go, for example:
+In addition to a xref:{link-postgresql-connector}#postgresql-events[_database change event_], each record produced by a PostgreSQL connector contains some metadata. Metadata includes where the event occurred on the server, the name of the source partition and the name of the Kafka topic and partition where the event should go, for example:
 
 [source,json,indent=0]
 ----
@@ -442,7 +442,7 @@ For every transaction `BEGIN` and `END`, {prodname} generates an event that cont
 }
 ----
 
-Unless overridden via the {link-prefix}:{link-postgresql-connector}#postgresql-property-transaction-topic[`transaction.topic`] option,
+Unless overridden via the xref:{link-postgresql-connector}#postgresql-property-transaction-topic[`transaction.topic`] option,
 transaction events are written to the topic named `_database.server.name_.transaction`.
 
 .Change data event enrichment
@@ -516,7 +516,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 |`schema`
 |The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed. +
  +
-It is possible to override the table's primary key by setting the {link-prefix}:{link-postgresql-connector}#postgresql-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
+It is possible to override the table's primary key by setting the xref:{link-postgresql-connector}#postgresql-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
 
 |2
 |`payload`
@@ -533,7 +533,7 @@ It is possible to override the table's primary key by setting the {link-prefix}:
 |===
 
 
-By default behavior is that the connector streams change event records to {link-prefix}:{link-postgresql-connector}#postgresql-topic-names[topics with names that are the same as the event's originating table].
+By default behavior is that the connector streams change event records to xref:{link-postgresql-connector}#postgresql-topic-names[topics with names that are the same as the event's originating table].
 
 [NOTE]
 ====
@@ -908,7 +908,7 @@ a|An optional field that specifies the state of the row before the event occurre
  +
 [NOTE]
 ====
-Whether or not this field is available is dependent on the {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting for each table.
+Whether or not this field is available is dependent on the xref:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting for each table.
 ====
 
 |7
@@ -994,7 +994,7 @@ The value of a change event for an update in the sample `customers` table has th
 
 |1
 |`before`
-|An optional field that contains values that were in the row before the database commit. In this example, only the primary key column, `id`, is present because the table's {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting is, by default, `DEFAULT`.
+|An optional field that contains values that were in the row before the database commit. In this example, only the primary key column, `id`, is present because the table's xref:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting is, by default, `DEFAULT`.
 +
 For an _update_ event to contain the previous values of all columns in the row, you would have to change the `customers` table by running `ALTER TABLE customers REPLICA IDENTITY FULL`.
 
@@ -1029,7 +1029,7 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 
 [NOTE]
 ====
-Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a {link-prefix}:{link-postgresql-connector}#postgresql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row. Details are in the next section.
+Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a xref:{link-postgresql-connector}#postgresql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row. Details are in the next section.
 ====
 
 // Type: continue
@@ -1086,7 +1086,7 @@ The value in a _delete_ change event has the same `schema` portion as _create_ a
 |`before`
 |Optional field that specifies the state of the row before the event occurred. In a _delete_ event value, the `before` field contains the values that were in the row before it was deleted with the database commit. +
  +
-In this example, the `before` field contains only the primary key column because the table's {link-prefix}:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting is `DEFAULT`.
+In this example, the `before` field contains only the primary key column because the table's xref:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting is `DEFAULT`.
 
 |2
 |`after`
@@ -1308,7 +1308,7 @@ For non-transactional _message_ events, the `source` object's `ts_ms` indicates 
 a|Field that contains the message metadata
 
 * Prefix (text)
-* Content (byte array that is encoded based on the {link-prefix}:{link-postgresql-connector}#postgresql-property-binary-handling-mode[binary handling mode] setting)
+* Content (byte array that is encoded based on the xref:{link-postgresql-connector}#postgresql-property-binary-handling-mode[binary handling mode] setting)
 
 |===
 
@@ -2032,7 +2032,7 @@ It is possible to use {prodname} with link:https://crunchybridge.com/[CrunchyBri
 
 [IMPORTANT]
 ====
-While using the `pgoutput` plug-in, it is recommended that you configure `filtered` as the {link-prefix}:{link-postgresql-connector}#postgresql-publication-autocreate-mode[`publication.autocreate.mode`]. If you use `all_tables`, which is the default value for `publication.autocreate.mode`, and the publication is not found, the connector tries to create one by using `CREATE PUBLICATION <publication_name> FOR ALL TABLES;`, but this fails due to lack of permissions.
+While using the `pgoutput` plug-in, it is recommended that you configure `filtered` as the xref:{link-postgresql-connector}#postgresql-publication-autocreate-mode[`publication.autocreate.mode`]. If you use `all_tables`, which is the default value for `publication.autocreate.mode`, and the publication is not found, the connector tries to create one by using `CREATE PUBLICATION <publication_name> FOR ALL TABLES;`, but this fails due to lack of permissions.
 ====
 
 [[installing-postgresql-output-plugin]]
@@ -2040,7 +2040,7 @@ While using the `pgoutput` plug-in, it is recommended that you configure `filter
 
 [TIP]
 ====
-See {link-prefix}:{link-postgresql-plugins}[Logical Decoding Output Plug-in Installation for PostgreSQL] for more detailed instructions for setting up and testing logical decoding plug-ins.
+See xref:{link-postgresql-plugins}[Logical Decoding Output Plug-in Installation for PostgreSQL] for more detailed instructions for setting up and testing logical decoding plug-ins.
 ====
 
 As of PostgreSQL 9.4, the only way to read changes to the write-ahead-log is to install a logical decoding output plug-in. Plug-ins are written in C, compiled, and installed on the machine that runs the PostgreSQL server. Plug-ins use  a number of PostgreSQL specific APIs, as described by the link:https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[PostgreSQL documentation].
@@ -2069,7 +2069,7 @@ All up-to-date differences are tracked in a test suite link:https://github.com/d
 [[postgresql-server-configuration]]
 === Configuring the PostgreSQL server
 
-If you are using a {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] other than pgoutput, after installing it, configure the PostgreSQL server as follows:
+If you are using a xref:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] other than pgoutput, after installing it, configure the PostgreSQL server as follows:
 
 . To load the plug-in at startup, add the following to the `postgresql.conf` file::
 +
@@ -2116,7 +2116,7 @@ endif::community[]
 Setting up a PostgreSQL server to run a {prodname} connector requires a database user that can perform replications.
 Replication can be performed only by a database user that has appropriate permissions and only for a configured number of hosts.
 
-Although, by default, superusers have the necessary `REPLICATION` and `LOGIN` roles, as mentioned in {link-prefix}:{link-postgresql-connector}#postgresql-security[Security], it is best not to provide the {prodname} replication user with elevated privileges.
+Although, by default, superusers have the necessary `REPLICATION` and `LOGIN` roles, as mentioned in xref:{link-postgresql-connector}#postgresql-security[Security], it is best not to provide the {prodname} replication user with elevated privileges.
 Instead, create a {prodname} user that has the the minimum required privileges.
 
 .Prerequisites
@@ -2154,7 +2154,7 @@ In general, it is best to manually create publications for the tables that you w
 However, you can configure your environment in a way that permits {prodname} to create publications automatically, and to specify the data that is added to them.
 
 {prodname} uses include list and exclude list properties to specify how data is inserted in the publication.
-For more information about the options for enabling {prodname} to create publications, see {link-prefix}:{link-postgresql-connector}#postgresql-publication-autocreate-mode[`publication.autocreate.mode`].
+For more information about the options for enabling {prodname} to create publications, see xref:{link-postgresql-connector}#postgresql-publication-autocreate-mode[`publication.autocreate.mode`].
 
 For {prodname} to create a PostgreSQL publication, it must run as a user that has the following privileges:
 
@@ -2193,7 +2193,7 @@ GRANT REPLICATION_GROUP TO __<replication_user>__;
 ALTER TABLE __<table_name>__ OWNER TO REPLICATION_GROUP;
 ----
 
-For {prodname} to specify the capture configuration, the value of {link-prefix}:{link-postgresql-connector}#postgresql-publication-autocreate-mode[`publication.autocreate.mode`] must be set to `filtered`.
+For {prodname} to specify the capture configuration, the value of xref:{link-postgresql-connector}#postgresql-publication-autocreate-mode[`publication.autocreate.mode`] must be set to `filtered`.
 
 // Type: procedure
 // ModuleID: configuring-postgresql-to-allow-replication-with-the-connector-host
@@ -2231,7 +2231,7 @@ ifdef::community[]
 
 The PostgreSQL connector can be used with a standalone PostgreSQL server or with a cluster of PostgreSQL servers.
 
-As mentioned {link-prefix}:{link-postgresql-connector}#postgresql-limitations[in the beginning], PostgreSQL (for all versions <= 12) supports logical replication slots on only `primary` servers. This means that a replica in a PostgreSQL cluster cannot be configured for logical replication, and consequently that the {prodname} PostgreSQL connector can connect and communicate with only the primary server. Should this server fail, the connector stops. When the cluster is repaired, if the original primary server is once again promoted to `primary`, you can restart the connector. However, if a different PostgreSQL server _with the plug-in and proper configuration_ is promoted to `primary`, you must change the connector configuration to point to the new `primary` server and then you can restart the connector.
+As mentioned xref:{link-postgresql-connector}#postgresql-limitations[in the beginning], PostgreSQL (for all versions <= 12) supports logical replication slots on only `primary` servers. This means that a replica in a PostgreSQL cluster cannot be configured for logical replication, and consequently that the {prodname} PostgreSQL connector can connect and communicate with only the primary server. Should this server fail, the connector stops. When the cluster is repaired, if the original primary server is once again promoted to `primary`, you can restart the connector. However, if a different PostgreSQL server _with the plug-in and proper configuration_ is promoted to `primary`, you must change the connector configuration to point to the new `primary` server and then you can restart the connector.
 endif::community[]
 
 // Type: concept
@@ -2248,7 +2248,7 @@ Also in the `pg_replication_slots` view, the `restart_lsn` column contains the L
 +
 The database typically reclaims disk space in batch blocks. This is expected behavior and no action by a user is necessary.
 
-* There are many updates in a database that is being tracked but only a tiny number of updates are related to the table(s) and schema(s) for which the connector is capturing changes. This situation can be easily solved with periodic heartbeat events. Set the {link-prefix}:{link-postgresql-connector}#postgresql-property-heartbeat-interval-ms[`heartbeat.interval.ms`] connector configuration property.
+* There are many updates in a database that is being tracked but only a tiny number of updates are related to the table(s) and schema(s) for which the connector is capturing changes. This situation can be easily solved with periodic heartbeat events. Set the xref:{link-postgresql-connector}#postgresql-property-heartbeat-interval-ms[`heartbeat.interval.ms`] connector configuration property.
 
 * The PostgreSQL instance contains multiple databases and one of them is a high-traffic database. {prodname} captures changes in another database that is low-traffic in comparison to the other database. {prodname} then cannot confirm the LSN as replication slots work per-database and {prodname} is not invoked. As WAL is shared by all databases, the amount used tends to grow until an event is emitted by the database for which {prodname} is capturing changes. To overcome this, it is necessary to:
 
@@ -2258,7 +2258,7 @@ The database typically reclaims disk space in batch blocks. This is expected beh
 +
 A separate process would then periodically update the table by either inserting a new row or repeatedly updating the same row.
 PostgreSQL then invokes {prodname}, which confirms the latest LSN and allows the database to reclaim the WAL space.
-This task can be automated by means of the {link-prefix}:{link-postgresql-connector}#postgresql-property-heartbeat-action-query[`heartbeat.action.query`] connector configuration property.
+This task can be automated by means of the xref:{link-postgresql-connector}#postgresql-property-heartbeat-action-query[`heartbeat.action.query`] connector configuration property.
 
 ifdef::community[]
 [TIP]
@@ -2280,7 +2280,7 @@ To deploy a {prodname} PostgreSQL connector, you install the {prodname} PostgreS
 .Prerequisites
 
 * link:https://zookeeper.apache.org/[Zookeeper], link:http://kafka.apache.org/[Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
-* PostgreSQL is installed and is {link-prefix}:{link-postgresql-connector}#setting-up-postgresql[set up to run the {prodname} connector].
+* PostgreSQL is installed and is xref:{link-postgresql-connector}#setting-up-postgresql[set up to run the {prodname} connector].
 
 .Procedure
 
@@ -2431,7 +2431,7 @@ This updates your Kafka Connect environment in OpenShift to add a Kafka Connecto
 +
 You configure a {prodname} PostgreSQL connector in a `.yaml` file that specifies the configuration properties for the connector.
 The connector configuration might instruct {prodname} to produce events for a subset of the schemas and tables, or it might set properties so that {prodname} ignores, masks, or truncates values in specified columns that are sensitive, too large, or not needed.
-For the complete list of the configuration properties that you can set for the {prodname} PostgreSQL connector, see {link-prefix}:{link-postgresql-connector}#descriptions-of-debezium-sql-server-connector-configuration-properties[PostgreSQL connector properties].
+For the complete list of the configuration properties that you can set for the {prodname} PostgreSQL connector, see xref:{link-postgresql-connector}#descriptions-of-debezium-sql-server-connector-configuration-properties[PostgreSQL connector properties].
 +
 The following example configures a {prodname} connector that connects to a PostgreSQL server host, `192.168.99.100`, on port `5432`. This host has a database named `sampledb`, a schema named `public`, and `fulfillment` is the server's logical name.
 +
@@ -2470,8 +2470,8 @@ those tasks will be redistributed to running services.
 <5> A unique server name.
 The server name is the logical identifier for the PostgreSQL server or cluster of servers.
 This name is used as the prefix for all Kafka topics that receive change event records.
-<6> The connector captures changes in only the `public` schema. It is possible to configure the connector to capture changes in only the tables that you choose. See {link-prefix}:{link-postgresql-connector}#postgresql-property-table-include-list[`table.include.list` connector configuration property].
-<7> The name of the PostgreSQL {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed on the PostgreSQL server. While the only supported value for PostgreSQL 10 and later is `pgoutput`, you must explicitly set `plugin.name` to `pgoutput`.
+<6> The connector captures changes in only the `public` schema. It is possible to configure the connector to capture changes in only the tables that you choose. See xref:{link-postgresql-connector}#postgresql-property-table-include-list[`table.include.list` connector configuration property].
+<7> The name of the PostgreSQL xref:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed on the PostgreSQL server. While the only supported value for PostgreSQL 10 and later is `pgoutput`, you must explicitly set `plugin.name` to `pgoutput`.
 
 . Create your connector instance with Kafka Connect. For example, if you saved your `KafkaConnector` resource in the `fulfillment-connector.yaml` file, you would run the following command:
 +
@@ -2519,13 +2519,13 @@ Optionally, you can ignore, mask, or truncate columns that contain sensitive dat
 <2> The name of this PostgreSQL connector class.
 <3> The address of the PostgreSQL server.
 <4> The port number of the PostgreSQL server.
-<5> The name of the PostgreSQL user that has the {link-prefix}:{link-postgresql-connector}#postgresql-permissions[required privileges].
-<6> The password for the PostgreSQL user that has the {link-prefix}:{link-postgresql-connector}#postgresql-permissions[required privileges].
+<5> The name of the PostgreSQL user that has the xref:{link-postgresql-connector}#postgresql-permissions[required privileges].
+<6> The password for the PostgreSQL user that has the xref:{link-postgresql-connector}#postgresql-permissions[required privileges].
 <7> The name of the PostgreSQL database to connect to
 <8> The logical name of the PostgreSQL server/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
 <9> A list of all tables hosted by this server that this connector will monitor. This is optional, and there are other properties for listing the schemas and tables to include or exclude from monitoring.
 
-See the {link-prefix}:{link-postgresql-connector}#postgresql-connector-properties[complete list of PostgreSQL connector properties] that can be specified in these configurations.
+See the xref:{link-postgresql-connector}#postgresql-connector-properties[complete list of PostgreSQL connector properties] that can be specified in these configurations.
 
 You can send this configuration with a `POST` command to a running Kafka Connect service.
 The service records the configuration and starts one connector task that performs the following actions:
@@ -2541,9 +2541,9 @@ To run a {prodname} PostgreSQL connector, create a connector configuration and a
 
 .Prerequisites
 
-* {link-prefix}:{link-postgresql-connector}#postgresql-server-configuration[PostgreSQL is configured to support logical replication].
+* xref:{link-postgresql-connector}#postgresql-server-configuration[PostgreSQL is configured to support logical replication].
 
-* The {link-prefix}:{link-postgresql-connector}#installing-postgresql-output-plugin[logical decoding plug-in] is installed.
+* The xref:{link-postgresql-connector}#installing-postgresql-output-plugin[logical decoding plug-in] is installed.
 
 * The PostgreSQL connector is installed.
 
@@ -2557,7 +2557,7 @@ endif::community[]
 
 .Results
 
-After the connector starts, it {link-prefix}:{link-postgresql-connector}#postgresql-snapshots[performs a consistent snapshot] of the PostgreSQL server databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
+After the connector starts, it xref:{link-postgresql-connector}#postgresql-snapshots[performs a consistent snapshot] of the PostgreSQL server databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
 
 ifdef::product[]
 // Type: procedure
@@ -2603,7 +2603,7 @@ The following configuration properties are _required_ unless a default value is 
 
 |[[postgresql-property-plugin-name]]<<postgresql-property-plugin-name, `+plugin.name+`>>
 |`decoderbufs`
-|The name of the PostgreSQL {link-prefix}:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed on the PostgreSQL server.
+|The name of the PostgreSQL xref:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed on the PostgreSQL server.
 
 ifdef::community[]
 Supported values are `decoderbufs`, and `pgoutput`.
@@ -2694,7 +2694,7 @@ If the publication already exists, either for all tables or configured with a su
  +
 `adaptive_time_microseconds` captures the date, datetime and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type. An exception is `TIME` type fields, which are always captured as microseconds. +
  +
-`connect` always represents time and timestamp values by using Kafka Connect's built-in representations for `Time`, `Date`, and `Timestamp`, which use millisecond precision regardless of the database columns' precision. See {link-prefix}:{link-postgresql-connector}#postgresql-temporal-values[temporal values].
+`connect` always represents time and timestamp values by using Kafka Connect's built-in representations for `Time`, `Date`, and `Timestamp`, which use millisecond precision regardless of the database columns' precision. See xref:{link-postgresql-connector}#postgresql-temporal-values[temporal values].
 
 |[[postgresql-property-decimal-handling-mode]]<<postgresql-property-decimal-handling-mode, `+decimal.handling.mode+`>>
 |`precise`
@@ -2704,7 +2704,7 @@ If the publication already exists, either for all tables or configured with a su
  +
 `double` represents values by using `double` values, which might result in a loss of precision but which is easier to use. +
  +
-`string` encodes values as formatted strings, which are easy to consume but semantic information about the real type is lost. See {link-prefix}:{link-postgresql-connector}#postgresql-decimal-types[Decimal types].
+`string` encodes values as formatted strings, which are easy to consume but semantic information about the real type is lost. See xref:{link-postgresql-connector}#postgresql-decimal-types[Decimal types].
 
 |[[postgresql-property-hstore-handling-mode]]<<postgresql-property-hstore-handling-mode, `+hstore.handling.mode+`>>
 |`map`
@@ -2712,7 +2712,7 @@ If the publication already exists, either for all tables or configured with a su
  +
 `map` represents values by using `MAP`. +
  +
-`json` represents values by using `json string`. This setting encodes values as formatted strings such as `{"key" : "val"}`. See {link-prefix}:{link-postgresql-connector}#postgresql-hstore-type[PostgreSQL `HSTORE` type].
+`json` represents values by using `json string`. This setting encodes values as formatted strings such as `{"key" : "val"}`. See xref:{link-postgresql-connector}#postgresql-hstore-type[PostgreSQL `HSTORE` type].
 
 |[[postgresql-property-interval-handling-mode]]<<postgresql-property-interval-handling-mode, `+interval.handling.mode+`>>
 |`numeric`
@@ -2720,7 +2720,7 @@ If the publication already exists, either for all tables or configured with a su
  +
 `numeric` represents intervals using approximate number of microseconds. +
  +
-`string` represents intervals exactly by using the string pattern representation `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`. For example: `P1Y2M3DT4H5M6.78S`. See {link-prefix}:{link-postgresql-connector}#postgresql-basic-types[PostgreSQL basic types].
+`string` represents intervals exactly by using the string pattern representation `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`. For example: `P1Y2M3DT4H5M6.78S`. See xref:{link-postgresql-connector}#postgresql-basic-types[PostgreSQL basic types].
 
 |[[postgresql-property-database-sslmode]]<<postgresql-property-database-sslmode, `+database.sslmode+`>>
 |`disable`
@@ -2816,7 +2816,7 @@ For these data types, the connector adds parameters to the corresponding field s
  +
 These parameters propagate a column's original type name and length, for variable-width types, respectively. This property is useful for properly sizing corresponding columns in sink databases. +
  +
-See the {link-prefix}:{link-postgresql-connector}#postgresql-data-types[list of PostgreSQL-specific data type names].
+See the xref:{link-postgresql-connector}#postgresql-data-types[list of PostgreSQL-specific data type names].
 
 |[[postgresql-property-message-key-columns]]<<postgresql-property-message-key-columns, `+message.key.columns+`>>
 |_empty string_
@@ -2932,7 +2932,7 @@ For more information, see the xref:#postgresql-connector-snapshot-mode-options[t
 ifdef::community[]
 |[[postgresql-property-snapshot-custom-class]]<<postgresql-property-snapshot-custom-class, `+snapshot.custom.class+`>>
 |No default
-| A full Java class name that is an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. Required when the `snapshot.mode` property is set to `custom`. See {link-prefix}:{link-postgresql-connector}#postgresql-custom-snapshot[custom snapshotter SPI].
+| A full Java class name that is an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. Required when the `snapshot.mode` property is set to `custom`. See xref:{link-postgresql-connector}#postgresql-custom-snapshot[custom snapshotter SPI].
 endif::community[]
 
 |[[postgresql-property-snapshot-include-collection-list]]<<postgresql-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>
@@ -2945,7 +2945,7 @@ This property does not affect the behavior of incremental snapshots.
 
 |[[postgresql-property-snapshot-lock-timeout-ms]]<<postgresql-property-snapshot-lock-timeout-ms, `+snapshot.lock.timeout.ms+`>>
 |`10000`
-|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. {link-prefix}:{link-postgresql-connector}#postgresql-snapshots[How the connector performs snapshots] provides details.
+|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. xref:{link-postgresql-connector}#postgresql-snapshots[How the connector performs snapshots] provides details.
 
 |[[postgresql-property-snapshot-select-statement-overrides]]<<postgresql-property-snapshot-select-statement-overrides, `+snapshot.select.statement.overrides+`>>
 |No default
@@ -3006,7 +3006,7 @@ In the resulting snapshot, the connector includes only the records for which `de
 |`false`
 |Specifies connector behavior when the connector encounters a field whose data type is unknown. The default behavior is that the connector omits the field from the change event and logs a warning. +
  +
-Set this property to `true` if you want the change event to contain an opaque binary representation of the field. This lets consumers decode the field. You can control the exact representation by setting the {link-prefix}:{link-postgresql-connector}#postgresql-property-binary-handling-mode[`binary handling mode`] property.
+Set this property to `true` if you want the change event to contain an opaque binary representation of the field. This lets consumers decode the field. You can control the exact representation by setting the xref:{link-postgresql-connector}#postgresql-property-binary-handling-mode[`binary handling mode`] property.
 
 NOTE: Consumers risk backward compatibility issues when `include.unknown.datatypes` is set to `true`. Not only may the database-specific binary representation change between releases, but if the data type is eventually supported by {prodname}, the data type will be sent downstream in a logical type, which would require adjustments by consumers. In general, when encountering unsupported data types, create a feature request so that support can be added.
 
@@ -3044,7 +3044,7 @@ For example, if the database server name is `fulfillment`, the default topic nam
 |No default
 |Specifies a query that the connector executes on the source database when the connector sends a heartbeat message. +
  +
-This is useful for resolving the situation described in {link-prefix}:{link-postgresql-connector}#postgresql-wal-disk-space[WAL disk space consumption], where capturing changes from a low-traffic database on the same host as a high-traffic database prevents {prodname} from processing WAL records and thus acknowledging WAL positions with the database. To address this situation, create a heartbeat table in the low-traffic database, and set this property to a statement that inserts records into that table, for example:  +
+This is useful for resolving the situation described in xref:{link-postgresql-connector}#postgresql-wal-disk-space[WAL disk space consumption], where capturing changes from a low-traffic database on the same host as a high-traffic database prevents {prodname} from processing WAL records and thus acknowledging WAL positions with the database. To address this situation, create a heartbeat table in the low-traffic database, and set this property to a statement that inserts records into that table, for example:  +
  +
 `INSERT INTO test_heartbeat_table (text) VALUES ('test_heartbeat')` +
  +
@@ -3077,7 +3077,7 @@ become outdated if TOASTable columns are dropped from the table.
 |`true` if connector configuration sets the `key.converter` or `value.converter` property to the Avro converter.
 
 `false` if not.
-|Indicates whether field names are sanitized to adhere to {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming requirements].
+|Indicates whether field names are sanitized to adhere to xref:{link-avro-serialization}#avro-naming[Avro naming requirements].
 
 |[[postgresql-property-slot-max-retries]]<<postgresql-property-slot-max-retries, `+slot.max.retries+`>>
 |`6`
@@ -3101,7 +3101,7 @@ If the setting of `unavailable.value.placeholder` starts with the `hex:` prefix 
 
 |[[postgresql-property-provide-transaction-metadata]]<<postgresql-property-provide-transaction-metadata, `+provide.transaction.metadata+`>>
 |`false`
-|Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See {link-prefix}:{link-postgresql-connector}#postgresql-transaction-metadata[Transaction metadata] for details.
+|Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See xref:{link-postgresql-connector}#postgresql-transaction-metadata[Transaction metadata] for details.
 
 |[[postgresql-property-transaction-topic]]<<postgresql-property-transaction-topic, `transaction.topic`>>
 |`${database.server.name}.transaction`
@@ -3155,10 +3155,10 @@ Be sure to consult the {link-kafka-docs}.html[Kafka documentation] for all of th
 
 The {prodname} PostgreSQL connector provides two types of metrics that are in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect provide.
 
-* {link-prefix}:{link-postgresql-connector}#postgresql-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
-* {link-prefix}:{link-postgresql-connector}#postgresql-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
+* xref:{link-postgresql-connector}#postgresql-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
+* xref:{link-postgresql-connector}#postgresql-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
 
-{link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
+xref:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
 
 // Type: reference
 // ModuleID: monitoring-debezium-during-snapshots-of-postgresql-databases
@@ -3232,7 +3232,7 @@ Also, replication slots themselves are not propagated to replicas.
 If the primary server goes down, a new primary must be promoted.
 
 ifdef::community[]
-The new primary must have the {link-prefix}:{link-postgresql-connector}#installing-postgresql-output-plugin[logical decoding plug-in] installed and a replication slot that is configured for use by the plug-in and the database for which you want to capture changes. Only then can you point the connector to the new server and restart the connector.
+The new primary must have the xref:{link-postgresql-connector}#installing-postgresql-output-plugin[logical decoding plug-in] installed and a replication slot that is configured for use by the plug-in and the database for which you want to capture changes. Only then can you point the connector to the new server and restart the connector.
 endif::community[]
 
 ifdef::product[]

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -213,7 +213,7 @@ The connector applies similar naming conventions to label its internal database 
 
 If the default topic name do not meet your requirements, you can configure custom topic names.
 To configure custom topic names, you specify regular expressions in the logical topic routing SMT.
-For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].
+For more information about using the logical topic routing SMT to customize topic naming, see xref:{link-topic-routing}#topic-routing[Topic routing].
 
 
 // Type: concept
@@ -250,7 +250,7 @@ The format of the messages that a connector emits to its schema change topic is 
 
 * You enable CDC for a table.
 * You disable CDC for a table.
-* You alter the structure of a table for which CDC is enabled by following the {link-prefix}:{link-sqlserver-connector}#sqlserver-schema-evolution[schema evolution procedure].
+* You alter the structure of a table for which CDC is enabled by following the xref:{link-sqlserver-connector}#sqlserver-schema-evolution[schema evolution procedure].
 
 .Example: Message emitted to the SQL Server connector schema change topic
 The following example shows a message in the schema change topic.
@@ -461,7 +461,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 |`schema`
 |The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed. +
  +
-It is possible to override the table's primary key by setting the {link-prefix}:{link-sqlserver-connector}#sqlserver-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
+It is possible to override the table's primary key by setting the xref:{link-sqlserver-connector}#sqlserver-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
 
 |2
 |`payload`
@@ -477,7 +477,7 @@ It is possible to override the table's primary key by setting the {link-prefix}:
 
 |===
 
-By default, the connector streams change event records to topics with names that are the same as the event's originating table. See {link-prefix}:{link-sqlserver-connector}#sqlserver-topic-names[topic names].
+By default, the connector streams change event records to topics with names that are the same as the event's originating table. See xref:{link-sqlserver-connector}#sqlserver-topic-names[topic names].
 
 [WARNING]
 ====
@@ -949,7 +949,7 @@ By comparing the value for `payload.source.ts_ms` with the value for `payload.ts
 
 [NOTE]
 ====
-Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a _delete_ event and a {link-prefix}:{link-sqlserver-connector}#sqlserver-tombstone-events[tombstone event] with the old key for the row, followed by a _create_ event with the new key for the row.
+Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a _delete_ event and a xref:{link-sqlserver-connector}#sqlserver-tombstone-events[tombstone event] with the old key for the row, followed by a _create_ event with the new key for the row.
 ====
 
 [[sqlserver-delete-events]]
@@ -1094,7 +1094,7 @@ The following example shows a typical transaction boundary message:
 }
 ----
 
-Unless overridden via the {link-prefix}:{link-sqlserver-connector}#sqlserver-property-transaction-topic[`transaction.topic`] option,
+Unless overridden via the xref:{link-sqlserver-connector}#sqlserver-property-transaction-topic[`transaction.topic`] option,
 transaction events are written to the topic named `_database.server.name_.transaction`.
 
 //Type: concept
@@ -1242,7 +1242,7 @@ If present, a column's default value is propagated to the corresponding field's 
 Change messages will contain the field's default value
 (unless an explicit column value had been given), so there should rarely be the need to obtain the default value from the schema.
 ifdef::community[]
-Passing the default value helps though with satisfying the compatibility rules when {link-prefix}:{link-avro-serialization}[using Avro] as serialization format together with the Confluent schema registry.
+Passing the default value helps though with satisfying the compatibility rules when xref:{link-avro-serialization}[using Avro] as serialization format together with the Confluent schema registry.
 endif::community[]
 
 [[sql-server-temporal-values]]
@@ -1364,7 +1364,7 @@ Note that the timezone of the JVM running Kafka Connect and {prodname} does not 
 [id="sql-server-decimal-values"]
 ==== Decimal values
 
-{prodname} connectors handle decimals according to the setting of the {link-prefix}:{link-sqlserver-connector}#sqlserver-property-decimal-handling-mode[`decimal.handling.mode` connector configuration property].
+{prodname} connectors handle decimals according to the setting of the xref:{link-sqlserver-connector}#sqlserver-property-decimal-handling-mode[`decimal.handling.mode` connector configuration property].
 
 decimal.handling.mode=precise::
 +
@@ -1683,13 +1683,13 @@ To deploy a {prodname} SQL Server connector, you install the {prodname} SQL Serv
 
 .Prerequisites
 * link:https://zookeeper.apache.org/[Apache ZooKeeper], link:http://kafka.apache.org/[Apache Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
-* SQL Server is installed, is {link-prefix}:{link-sqlserver-connector}#setting-up-sqlserver[configured for CDC], and is ready to be used with the {prodname} connector.
+* SQL Server is installed, is xref:{link-sqlserver-connector}#setting-up-sqlserver[configured for CDC], and is ready to be used with the {prodname} connector.
 
 .Procedure
 . Download the {prodname} https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/{debezium-version}/debezium-connector-sqlserver-{debezium-version}-plugin.tar.gz[SQL Server connector plug-in archive]
 . Extract the files into your Kafka Connect environment.
 . Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
-. {link-prefix}:{link-sqlserver-connector}#sqlserver-example-configuration[Configure the connector] and {link-prefix}:{link-sqlserver-connector}#sqlserver-adding-connector-configuration[add the configuration to your Kafka Connect cluster.]
+. xref:{link-sqlserver-connector}#sqlserver-example-configuration[Configure the connector] and xref:{link-sqlserver-connector}#sqlserver-adding-connector-configuration[add the configuration to your Kafka Connect cluster.]
 . Restart your Kafka Connect process to pick up the new JAR files.
 
 If you are working with immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s container images] for Åpache ZooKeeper, Apache Kafka, and Kafka Connect.
@@ -1968,7 +1968,7 @@ Optionally, you can ignore, mask, or truncate columns that contain sensitive dat
 
 endif::community[]
 
-For the complete list of the configuration properties that you can set for the {prodname} SQL Server connector, see {link-prefix}:{link-sqlserver-connector}#sqlserver-connector-properties[SQL Server connector properties].
+For the complete list of the configuration properties that you can set for the {prodname} SQL Server connector, see xref:{link-sqlserver-connector}#sqlserver-connector-properties[SQL Server connector properties].
 
 ifdef::community[]
 You can send this configuration with a `POST` command to a running Kafka Connect service.
@@ -1985,7 +1985,7 @@ To start running a {prodname} SQL Server connector, create a connector configura
 
 .Prerequisites
 
-* {link-prefix}:{link-sqlserver-connector}#setting-up-sqlserver[CDC is enabled on SQL Server].
+* xref:{link-sqlserver-connector}#setting-up-sqlserver[CDC is enabled on SQL Server].
 * The {prodname} SQL Server connector is installed.
 
 .Procedure
@@ -1997,7 +1997,7 @@ endif::community[]
 
 .Results
 
-When the connector starts, it {link-prefix}:{link-sqlserver-connector}#sqlserver-snapshots[performs a consistent snapshot] of the SQL Server databases that the connector is configured for.
+When the connector starts, it xref:{link-sqlserver-connector}#sqlserver-snapshots[performs a consistent snapshot] of the SQL Server databases that the connector is configured for.
 The connector then starts generating data change events for row-level operations and streaming the change event records to Kafka topics.
 
 // Type: reference
@@ -2132,7 +2132,7 @@ Hashing strategy version 2 should be used to ensure fidelity if the value is bei
 
 |[[sqlserver-property-time-precision-mode]]<<sqlserver-property-time-precision-mode, `+time.precision.mode+`>>
 |`adaptive`
-| Time, date, and timestamps can be represented with different kinds of precision, including: `adaptive` (the default) captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type; or `connect` always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which uses millisecond precision regardless of the database columns' precision. See {link-prefix}:{link-sqlserver-connector}#sqlserver-temporal-values[temporal values].
+| Time, date, and timestamps can be represented with different kinds of precision, including: `adaptive` (the default) captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type; or `connect` always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which uses millisecond precision regardless of the database columns' precision. See xref:{link-sqlserver-connector}#sqlserver-temporal-values[temporal values].
 
 |[[sqlserver-property-decimal-handling-mode]]<<sqlserver-property-decimal-handling-mode,`+decimal.handling.mode+`>>
 |`precise`
@@ -2179,7 +2179,7 @@ Fully-qualified names for columns are of the form _schemaName_._tableName_._colu
 The schema parameters `pass:[_]pass:[_]debezium.source.column.type`, `pass:[_]pass:[_]debezium.source.column.length` and `pass:[_]pass:[_]debezium.source.column.scale` will be used to propagate the original type name and length (for variable-width types), respectively.
 Useful to properly size corresponding columns in sink databases.
 Fully-qualified data type names are of the form _schemaName_._tableName_._typeName_.
-See {link-prefix}:{link-sqlserver-connector}#sqlserver-data-types[SQL Server data types] for the list of SQL Server-specific data type names.
+See xref:{link-sqlserver-connector}#sqlserver-data-types[SQL Server data types] for the list of SQL Server-specific data type names.
 
 |[[sqlserver-property-message-key-columns]]<<sqlserver-property-message-key-columns, `+message.key.columns+`>>
 |_n/a_
@@ -2322,7 +2322,7 @@ Defaults to the JDBC driver's default fetch size.
 
 |[[sqlserver-property-snapshot-lock-timeout-ms]]<<sqlserver-property-snapshot-lock-timeout-ms, `+snapshot.lock.timeout.ms+`>>
 |`10000`
-|An integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If table locks cannot be acquired in this time interval, the snapshot will fail (also see {link-prefix}:{link-sqlserver-connector}#sqlserver-snapshots[snapshots]). +
+|An integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If table locks cannot be acquired in this time interval, the snapshot will fail (also see xref:{link-sqlserver-connector}#sqlserver-snapshots[snapshots]). +
 When set to `0` the connector will fail immediately when it cannot obtain the lock. Value `-1` indicates infinite waiting.
 
 |[[sqlserver-property-snapshot-select-statement-overrides]]<<sqlserver-property-snapshot-select-statement-overrides, `+snapshot.select.statement.overrides+`>>
@@ -2391,7 +2391,7 @@ By default, no operations are skipped.
 
 |[[sqlserver-property-signal-data-collection]]<<sqlserver-property-signal-data-collection,`+signal.data.collection+`>>
 |No default value
-| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector. +
+| Fully-qualified name of the data collection that is used to send xref:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector. +
 Use the following format to specify the collection name: +
 `_<databaseName>_._<schemaName>_._<tableName>_`
 
@@ -2451,8 +2451,8 @@ As a {prodname} user, you must coordinate tasks with the SQL Server database ope
 
 You can use one of the following methods to update capture tables after a schema change:
 
-* {link-prefix}:{link-sqlserver-connector}#offline-schema-updates[Offline schema updates] require you to stop the {prodname} connector before you can update capture tables.
-* {link-prefix}:{link-sqlserver-connector}#online-schema-updates[Online schema updates] can update capture tables while the {prodname} connector is running.
+* xref:{link-sqlserver-connector}#offline-schema-updates[Offline schema updates] require you to stop the {prodname} connector before you can update capture tables.
+* xref:{link-sqlserver-connector}#online-schema-updates[Online schema updates] can update capture tables while the {prodname} connector is running.
 
 There are advantages and disadvantages to using each type of procedure.
 
@@ -2618,7 +2618,7 @@ The connector provides the following metrics:
 * xref:sqlserver-streaming-metrics[Streaming metrics] for monitoring the connector when reading CDC table data.
 * xref:sqlserver-schema-history-metrics[Schema history metrics] for monitoring the status of the connector's schema history.
 
-For information about how to expose the preceding metrics through JMX, see the {link-prefix}:{link-debezium-monitoring}[{prodname} monitoring documentation].
+For information about how to expose the preceding metrics through JMX, see the xref:{link-debezium-monitoring}[{prodname} monitoring documentation].
 
 // Type: reference
 // ModuleID: debezium-sqlserver-connector-snapshot-metrics

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -525,7 +525,7 @@ a|In the `schema` section, each `name` field specifies the schema for a field in
  +
 `Vitess_server.commerce.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table. +
  +
-Names of schemas for `before` and `after` fields are of the form `_logicalName_._keyspaceName_._tableName_.Value`, which ensures that the schema name is unique in the database. This means that when using the {link-prefix}:{link-avro-serialization}[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
+Names of schemas for `before` and `after` fields are of the form `_logicalName_._keyspaceName_._tableName_.Value`, which ensures that the schema name is unique in the database. This means that when using the xref:{link-avro-serialization}[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
 
 |3
 |`name`
@@ -540,7 +540,7 @@ a|`Vitess_server.commerce.customers.Envelope` is the schema for the overall stru
 |The value's actual data. This is the information that the change event is providing. +
  +
 It may appear that the JSON representations of the events are much larger than the rows they describe. This is because the JSON representation must include the schema and the payload portions of the message.
-However, by using the {link-prefix}:{link-avro-serialization}[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
+However, by using the xref:{link-avro-serialization}[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
 
 |6
 |`before`
@@ -1019,7 +1019,7 @@ The {prodname} Vitess connector provides only one type of metrics that are in ad
 
 * xref:vitess-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
 
-{link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
+xref:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
 
 // Type: reference
 // ModuleID: monitoring-debezium-vitess-connector-record-streaming
@@ -1243,7 +1243,7 @@ The following _advanced_ configuration properties have defaults that work in mos
 |[[vitess-property-sanitize-field-names]]<<vitess-property-sanitize-field-names, `+sanitize.field.names+`>>
 |`true` if connector configuration sets the `key.converter` or `value.converter` property to the Avro converter. +
 `false` if not.
-|Indicates whether field names are sanitized to adhere to {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming requirements].
+|Indicates whether field names are sanitized to adhere to xref:{link-avro-serialization}#avro-naming[Avro naming requirements].
 
 |[[vitess-property-skipped-operations]]<<vitess-property-skipped-operations, `+skipped.operations+`>>
 |

--- a/documentation/modules/ROOT/pages/development/engine.adoc
+++ b/documentation/modules/ROOT/pages/development/engine.adoc
@@ -76,11 +76,11 @@ You create the `DebeziumEngine` instance using its builder API,
 providing the following things:
 
 * The format in which you want to receive the message, e.g. JSON, Avro or as Kafka Connect `SourceRecord`
-(see {link-prefix}:{link-engine}#engine-output-message-formats[output message formats])
+(see xref:{link-engine}#engine-output-message-formats[output message formats])
 * Configuration properties (perhaps loaded from a properties file) that define the environment for both the engine and the connector
 * A method that will be called for every data change event produced by the connector
 
-Here's an example of code that configures and runs an embedded {link-prefix}:{link-mysql-connector}[MySQL connector]:
+Here's an example of code that configures and runs an embedded xref:{link-mysql-connector}[MySQL connector]:
 
 [source,java,indent=0]
 ----
@@ -259,8 +259,8 @@ Allowed values are:
 
 * `Connect.class` - the output value is change event wrapping Kafka Connect's `SourceRecord`
 * `Json.class` - the output value is a pair of key and value encoded as `JSON` strings
-* `Avro.class` - the output value is a pair of key and value encoded as Avro serialized records (see {link-prefix}:{link-avro-serialization}[Avro Serialization] for more details)
-* `CloudEvents.class` - the output value is a pair of key and value encoded as {link-prefix}:{link-cloud-events}[Cloud Events] messages
+* `Avro.class` - the output value is a pair of key and value encoded as Avro serialized records (see xref:{link-avro-serialization}[Avro Serialization] for more details)
+* `CloudEvents.class` - the output value is a pair of key and value encoded as xref:{link-cloud-events}[Cloud Events] messages
 
 Internally, the engine uses the apropriate Kafka Connect converter implementation to which the conversion is delegated.
 The converter can be parametrized using engine properties to modify its behaviour.

--- a/documentation/modules/ROOT/pages/features.adoc
+++ b/documentation/modules/ROOT/pages/features.adoc
@@ -38,7 +38,7 @@ The documentation for each connector provides details about the connectors featu
 endif::product[]
 
 ifdef::community[]
-See the {link-prefix}:{link-connectors}[connector documentation] for a list of all supported databases and detailed information about the features and configuration options of each connector.
+See the xref:{link-connectors}[connector documentation] for a list of all supported databases and detailed information about the features and configuration options of each connector.
 
 {prodname} can also be used as xref:development/engine.adoc[library embedded] into your JVM-based applications;
 via xref:operations/debezium-server.adoc[Debezium Server], you can emit change events to messaging infrastructure like Amazon Kinesis, Google Cloud Pub/Sub, Apache Pulsar, etc.

--- a/documentation/modules/ROOT/pages/install.adoc
+++ b/documentation/modules/ROOT/pages/install.adoc
@@ -111,7 +111,7 @@ e.g. when updating them
 *** You can relax the single partition rule but your application must handle out-of-order events for different rows in database (events for a single row are still totally ordered). If multiple partitions are used, Kafka will determine the partition by hashing the key by default. Other partition strategies require using SMTs to set the partition number for each record.
 // the condition can be removed once downstream  is updated to Kafka 2.6+
 ifdef::community[]
-** For customizable topic auto-creation (available since Kafka Connect 2.6.0) see {link-prefix}:{link-topic-auto-creation}[Custom Topic Auto-Creation]
+** For customizable topic auto-creation (available since Kafka Connect 2.6.0) see xref:{link-topic-auto-creation}[Custom Topic Auto-Creation]
 endif::community[]
 
 == Using the {prodname} Libraries

--- a/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
+++ b/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
@@ -51,7 +51,7 @@ endif::product[]
 
 For information about using Avro, see:
 
-* {link-prefix}:{link-avro-serialization}#avro-serialization[Avro serialization]
+* xref:{link-avro-serialization}#avro-serialization[Avro serialization]
 
 * link:https://github.com/Apicurio/apicurio-registry[Apicurio Registry]
 

--- a/documentation/modules/ROOT/pages/integrations/serdes.adoc
+++ b/documentation/modules/ROOT/pages/integrations/serdes.adoc
@@ -89,7 +89,7 @@ The deserializer behaviour is driven by the `from.field` configuration option an
 * if the value is deserialized and contains the {prodname} event envelope then:
 ** if `from.field` is not set, then deserialize the complete envelope into the target type
 ** otherwise deserialize and map only content of the field configured into the target type, thus effectively flatting the message
-* if the value is deserialized and contains already a flattened message (i.e. when using the SMT for {link-prefix}:{link-event-flattening}[Event Flattening]) then map the flattened record into the target logical type
+* if the value is deserialized and contains already a flattened message (i.e. when using the SMT for xref:{link-event-flattening}[Event Flattening]) then map the flattened record into the target logical type
 
 [[serdes-configuration_options]]
 === Configuration options
@@ -101,12 +101,12 @@ The deserializer behaviour is driven by the `from.field` configuration option an
 |Description
 
 [id="serdes-from-field"]
-|{link-prefix}:{link-serdes}#serdes-from-field[`from.field`]
+|xref:{link-serdes}#serdes-from-field[`from.field`]
 |`N/A`
 |Empty if a message with full envelope should be deserialized, `before`/`after` if only data values before or after the change are required.
 
 [id="serdes-unknown-properties-ignored"]
-|{link-prefix}:{link-serdes}#serdes-unknown-properties-ignored[`unknown.properties.ignored`]
+|xref:{link-serdes}#serdes-unknown-properties-ignored[`unknown.properties.ignored`]
 |`false`
 |Determines when an unknown property is encountered whether it should be silently ignored or if a runtime exception should be thrown.
 |===

--- a/documentation/modules/ROOT/pages/operations/monitoring.adoc
+++ b/documentation/modules/ROOT/pages/operations/monitoring.adoc
@@ -36,14 +36,14 @@ be sure to use distinct JMX ports for each service.
 In addition to the built-in support for JMX metrics in Kafka, Zookeeper, and Kafka Connect,
 each connector provides additional metrics that you can use to monitor their activities.
 
-* {link-prefix}:{link-mysql-connector}#mysql-monitoring[MySQL connector metrics]
-* {link-prefix}:{link-mongodb-connector}#mongodb-monitoring[MongoDB connector metrics]
-* {link-prefix}:{link-postgresql-connector}#postgresql-monitoring[PostgreSQL connector metrics]
-* {link-prefix}:{link-sqlserver-connector}#sqlserver-monitoring[SQL Server connector metrics]
-* {link-prefix}:{link-db2-connector}#db2-monitoring[Db2 connector metrics]
+* xref:{link-mysql-connector}#mysql-monitoring[MySQL connector metrics]
+* xref:{link-mongodb-connector}#mongodb-monitoring[MongoDB connector metrics]
+* xref:{link-postgresql-connector}#postgresql-monitoring[PostgreSQL connector metrics]
+* xref:{link-sqlserver-connector}#sqlserver-monitoring[SQL Server connector metrics]
+* xref:{link-db2-connector}#db2-monitoring[Db2 connector metrics]
 ifdef::community[]
-* {link-prefix}:{link-oracle-connector}#oracle-monitoring[Oracle connector metrics]
-* {link-prefix}:{link-cassandra-connector}#cassandra-monitoring[Cassandra connector metrics]
+* xref:{link-oracle-connector}#oracle-monitoring[Oracle connector metrics]
+* xref:{link-cassandra-connector}#cassandra-monitoring[Cassandra connector metrics]
 endif::community[]
 
 

--- a/documentation/modules/ROOT/pages/postgres-plugins.adoc
+++ b/documentation/modules/ROOT/pages/postgres-plugins.adoc
@@ -256,7 +256,7 @@ Test that the `wal2json` is working properly by obtaining the `test_table` chang
 https://www.postgresql.org/docs/9.6/static/app-pgrecvlogical.html[pg_recvlogical] PostgreSQL client application
 that controls PostgreSQL logical decoding streams.
 
-Before starting make sure that you have logged in as a user with database replication permissions, as configured at a {link-prefix}:{link-postgresql-plugins}#setting_replication_permissions[previous step].
+Before starting make sure that you have logged in as a user with database replication permissions, as configured at a xref:{link-postgresql-plugins}#setting_replication_permissions[previous step].
 Otherwise, the slot creation and streaming fails with the following error message:
 [source,bash]
 ----
@@ -361,7 +361,7 @@ Upon the `INSERT`, `UPDATE` and `DELETE` events, the `wal2json` plug-in outputs 
 
 [TIP]
 ====
-Note that the {link-prefix}:{link-postgresql-plugins}#replica-identity[REPLICA IDENTITY] of the table `test_table` is set to `DEFAULT`.
+Note that the xref:{link-postgresql-plugins}#replica-identity[REPLICA IDENTITY] of the table `test_table` is set to `DEFAULT`.
 ====
 
 When the test is finished, the slot `test_slot` for the database `test` can be removed by the following command:
@@ -401,7 +401,7 @@ Replica Identity: FULL
 ----
 
 Here is the output of `wal2json` plug-in on `UPDATE` event and `REPLICA IDENTITY` set to `FULL`.
-Compare with the {link-prefix}:{link-postgresql-plugins}#update-table-change-event[respective output] when `REPLICA IDENTITY` is set to `DEFAULT`.
+Compare with the xref:{link-postgresql-plugins}#update-table-change-event[respective output] when `REPLICA IDENTITY` is set to `DEFAULT`.
 
 ._Output for `UPDATE`_
 [source,json]

--- a/documentation/modules/ROOT/pages/transformations/content-based-routing.adoc
+++ b/documentation/modules/ROOT/pages/transformations/content-based-routing.adoc
@@ -167,7 +167,7 @@ In addition to the change event messages that a {prodname} connector emits when 
 Because the structure of these other messages differs from the structure of the change event messages that the SMT is designed to process, it's best to configure the connector to selectively apply the SMT, so that it processes only the intended data change messages.
 You can use one of the following methods to configure the connector to apply the SMT selectively:
 
-* {link-prefix}:{link-smt-predicates}#applying-transformation-selectively[Configure an SMT predicate for the transformation].
+* xref:{link-smt-predicates}#applying-transformation-selectively[Configure an SMT predicate for the transformation].
 * Use the xref:content-based-router-topic-regex[topic.regex] configuration option for the SMT.
 
 // Type: reference
@@ -176,7 +176,7 @@ You can use one of the following methods to configure the connector to apply the
 == Language specifics
 
 The way that you express content-based routing conditions depends on the scripting language that you use.
-For example, as shown in the {link-prefix}:{link-content-based-routing}#example-basic-content-based-routing-configuration[basic configuration example], when you use `Groovy` as the expression language,
+For example, as shown in the xref:{link-content-based-routing}#example-basic-content-based-routing-configuration[basic configuration example], when you use `Groovy` as the expression language,
 the following expression reroutes all update (`u`) records to the `updates` topic, while routing other records to the default topic:
 
 [source,groovy]
@@ -189,7 +189,7 @@ Other languages use different methods to express the same condition.
 [TIP]
 ====
 The {prodname} MongoDB connector emits the `after` and `patch` fields as serialized JSON documents rather than as structures.
-To use the ContentBasedRouting SMT with the MongoDB connector, you must first unwind the fields by applying the {link-prefix}:{link-mongodb-event-flattening}[`ExtractNewDocumentState`] SMT.
+To use the ContentBasedRouting SMT with the MongoDB connector, you must first unwind the fields by applying the xref:{link-mongodb-event-flattening}[`ExtractNewDocumentState`] SMT.
 
 You could also take the approach of using a JSON parser within the expression.
 For example, if you use Groovy as the expression language, add the `groovy-json` artifact to the classpath, and then add an expression such as `(new groovy.json.JsonSlurper()).parseText(value.after).last_name == 'Kretchmar'`.

--- a/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
@@ -17,7 +17,7 @@ toc::[]
 ifdef::community[]
 [NOTE]
 ====
-This single message transformation (SMT) is supported for only the SQL database connectors. For the MongoDB connector, see the {link-prefix}:{link-mongodb-event-flattening}[documentation for the MongoDB equivalent to this SMT].
+This single message transformation (SMT) is supported for only the SQL database connectors. For the MongoDB connector, see the xref:{link-mongodb-event-flattening}[documentation for the MongoDB equivalent to this SMT].
 ====
 endif::community[]
 
@@ -224,7 +224,7 @@ To add metadata to a simplified Kafka record that is for a `DELETE` operation, y
 In addition to the change event messages that a {prodname} connector emits when a database change occurs, the connector also emits other types of messages, including heartbeat messages, and metadata messages about schema changes and transactions.
 Because the structure of these other messages differs from the structure of the change event messages that the SMT is designed to process, it's best to configure the connector to selectively apply the SMT, so that it processes only the intended data change messages.
 
-For more information about how to apply the SMT selectively, see {link-prefix}:{link-smt-predicates}#applying-transformation-selectively[Configure an SMT predicate for the transformation].
+For more information about how to apply the SMT selectively, see xref:{link-smt-predicates}#applying-transformation-selectively[Configure an SMT predicate for the transformation].
 
 ifdef::community[]
 [id="configuration-options"]
@@ -244,12 +244,12 @@ The following table describes the options that you can specify to configure the 
 |Default
 |Description
 
-|[[extract-new-record-state-drop-tombstones]]{link-prefix}:{link-event-flattening}#extract-new-record-state-drop-tombstones[`drop.tombstones`]
+|[[extract-new-record-state-drop-tombstones]]xref:{link-event-flattening}#extract-new-record-state-drop-tombstones[`drop.tombstones`]
 |`true`
 |{prodname} generates a tombstone record for each `DELETE` operation. The default behavior is that event flattening SMT removes tombstone records from the stream. To keep tombstone records in the stream, specify `drop.tombstones=false`.
 
 [id="extract-new-record-state-delete-handling-mode"]
-|{link-prefix}:{link-event-flattening}#extract-new-record-state-delete-handling-mode[`delete.handling{zwsp}.mode`]
+|xref:{link-event-flattening}#extract-new-record-state-delete-handling-mode[`delete.handling{zwsp}.mode`]
 |`drop`
 |{prodname} generates a change event record for each `DELETE` operation. The default behavior is that event flattening SMT removes these records from the stream. To keep Kafka records for `DELETE` operations in the stream, set `delete.handling.mode` to `none` or `rewrite`. +
  +
@@ -260,7 +260,7 @@ Specify `rewrite` to keep the change event record in the stream and edit the rec
 When you  specify `rewrite`, the updated simplified records for `DELETE` operations might be all you need to track deleted records. You can consider accepting the default behavior of dropping the tombstone records that the {prodname} connector creates.
 
 [id="extract-new-record-state-route-by-field"]
-|{link-prefix}:{link-event-flattening}#extract-new-record-state-route-by-field[`route.by.field`]
+|xref:{link-event-flattening}#extract-new-record-state-route-by-field[`route.by.field`]
 |
 |To use row data to determine the topic to route the record to, set this option to an `after` field attribute. The SMT routes the record to the topic whose name matches the value of the specified `after` field attribute. For a `DELETE` operation, set this option to a `before` field attribute. +
  +
@@ -269,12 +269,12 @@ For example, configuration of `route.by.field=destination` routes records to the
 If you are configuring the event flattening SMT on a sink connector, setting this option might be useful when the destination topic name dictates the name of the database table that will be updated with the simplified change event record. If the topic name is not correct for your use case, you can configure `route.by.field` to re-route the event.
 
 [id="extract-new-record-state-add-fields-prefix"]
-|{link-prefix}:{link-event-flattening}#extract-new-record-state-add-fields-prefix[`add.fields.prefix`]
+|xref:{link-event-flattening}#extract-new-record-state-add-fields-prefix[`add.fields.prefix`]
 | __ (double-underscore)
 |Set this optional string to prefix a field.
 
 [id="extract-new-record-state-add-fields"]
-|{link-prefix}:{link-event-flattening}#extract-new-record-state-add-fields[`add.fields`]
+|xref:{link-event-flattening}#extract-new-record-state-add-fields[`add.fields`]
 |
 |Set this option to a comma-separated list, with no spaces, of metadata fields to add to the simplified Kafka record's value. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
  +
@@ -285,12 +285,12 @@ When the SMT adds metadata fields to the simplified record's value, it prefixes 
 If you specify a field that is not in the change event record, the SMT still adds the field to the record's value.
 
 [id="extract-new-record-state-add-headers-prefix"]
-|{link-prefix}:{link-event-flattening}#extract-new-record-state-add-headers-prefix[`add.headers.prefix`]
+|xref:{link-event-flattening}#extract-new-record-state-add-headers-prefix[`add.headers.prefix`]
 | __ (double-underscore)
 |Set this optional string to prefix a header.
 
 [id="extract-new-record-state-add-headers"]
-|{link-prefix}:{link-event-flattening}#extract-new-record-state-add-headers[`add.headers`]
+|xref:{link-event-flattening}#extract-new-record-state-add-headers[`add.headers`]
 |
 |Set this option to a comma-separated list, with no spaces, of metadata fields to add to the header of the simplified Kafka record. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
  +

--- a/documentation/modules/ROOT/pages/transformations/filtering.adoc
+++ b/documentation/modules/ROOT/pages/transformations/filtering.adoc
@@ -161,7 +161,7 @@ In addition to the change event messages that a {prodname} connector emits when 
 Because the structure of these other messages differs from the structure of the change event messages that the SMT is designed to process, it's best to configure the connector to selectively apply the SMT, so that it processes only the intended data change messages.
 You can use one of the following methods to configure the connector to apply the SMT selectively:
 
-* {link-prefix}:{link-smt-predicates}#applying-transformation-selectively[Configure an SMT predicate for the transformation].
+* xref:{link-smt-predicates}#applying-transformation-selectively[Configure an SMT predicate for the transformation].
 * Use the xref:filter-topic-regex[topic.regex] configuration option for the SMT.
 
 // Type: reference
@@ -171,7 +171,7 @@ You can use one of the following methods to configure the connector to apply the
 
 The way that you express filtering conditions depends on the scripting language that you use.
 
-For example, as shown in the {link-prefix}:{link-filtering}#example-basic-filter-configuration-example[basic configuration example], when you use `Groovy` as the expression language,
+For example, as shown in the xref:{link-filtering}#example-basic-filter-configuration-example[basic configuration example], when you use `Groovy` as the expression language,
 the following expression removes all messages, except for update records that have `id` values set to `2`:
 
 [source,groovy]
@@ -183,7 +183,7 @@ Other languages use different methods to express the same condition.
 [TIP]
 ====
 The {prodname} MongoDB connector emits the `after` and `patch` fields as serialized JSON documents rather than as structures.
-To use the filter SMT with the MongoDB connector, you must first unwind the fields by applying the {link-prefix}:{link-mongodb-event-flattening}[`ExtractNewDocumentState`] SMT.
+To use the filter SMT with the MongoDB connector, you must first unwind the fields by applying the xref:{link-mongodb-event-flattening}[`ExtractNewDocumentState`] SMT.
 
 You could also take the approach of using a JSON parser within the expression.
 For example, if you use Groovy as the expression language, add the `groovy-json` artifact to the classpath, and then add an expression such as `(new groovy.json.JsonSlurper()).parseText(value.after).last_name == 'Kretchmar'`.

--- a/documentation/modules/ROOT/pages/transformations/index.adoc
+++ b/documentation/modules/ROOT/pages/transformations/index.adoc
@@ -1,6 +1,6 @@
 = Transformations
 
-Connectors can be configured with transformations to make lightweight per message modifications. {prodname} provides several link:{link-kafka-docs}/#connect_transforms[single message transformations] (SMTs) that you can use to either modify records before they are sent to Apache Kafka (by applying them to the {prodname} connectors), or when they are read from Kafka by a sink connector. Also {link-prefix}:{link-debezium-server}[{prodname} Server] supports the usage of SMTs.
+Connectors can be configured with transformations to make lightweight per message modifications. {prodname} provides several link:{link-kafka-docs}/#connect_transforms[single message transformations] (SMTs) that you can use to either modify records before they are sent to Apache Kafka (by applying them to the {prodname} connectors), or when they are read from Kafka by a sink connector. Also xref:{link-debezium-server}[{prodname} Server] supports the usage of SMTs.
 
 The following SMTs are provided by {prodname}:
 

--- a/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
@@ -19,7 +19,7 @@ Please see below for a descriptions of known limitations of this transformation.
 [NOTE]
 ====
 This SMT is supported only for the MongoDB connector.
-See {link-prefix}:{link-event-flattening}[Extracting source record `after` state from {prodname} change events] for the relational database equivalent to this SMT.
+See xref:{link-event-flattening}[Extracting source record `after` state from {prodname} change events] for the relational database equivalent to this SMT.
 ====
 
 The {prodname} MongoDB connector generates the data in a form of a complex message structure.
@@ -40,7 +40,7 @@ E.g. the general message structure for a insert event looks like this:
 }
 ----
 
-More details about the message structure are provided in {link-prefix}:{link-mongodb-connector}[the documentation] of the MongoDB connector.
+More details about the message structure are provided in xref:{link-mongodb-connector}[the documentation] of the MongoDB connector.
 
 While this structure is a good fit to represent changes to MongoDB's schemaless collections,
 it is not understood by existing sink connectors such as the Confluent JDBC sink connector.
@@ -207,7 +207,7 @@ Note that other MongoDB operations might cause an `$unset` internally, `$rename`
 
 === Determine original operation
 
-When a message is flattened the final result does not show whether it was an insert, update or first read. (Deletions can be detected via tombstones or rewrites, see {link-prefix}:{link-mongodb-event-flattening}#mongodb-extract-new-record-state-configuration-options[Configuration options].)
+When a message is flattened the final result does not show whether it was an insert, update or first read. (Deletions can be detected via tombstones or rewrites, see xref:{link-mongodb-event-flattening}#mongodb-extract-new-record-state-configuration-options[Configuration options].)
 
 To solve this problem, you can propagate the original operation either as a field added to message value or as a header property,
 e.g. like so to use a header property:
@@ -219,13 +219,13 @@ transforms.unwrap.type=io.debezium.connector.mongodb.transforms.ExtractNewDocume
 transforms.unwrap.add.headers=op
 ----
 
-The possible values are the ones from the `op` field of {link-prefix}:{link-mongodb-connector}#mongodb-change-events-value[MongoDB connector change events].
+The possible values are the ones from the `op` field of xref:{link-mongodb-connector}#mongodb-change-events-value[MongoDB connector change events].
 
 === Adding source metadata fields
 
 The SMT can optionally add metadata fields from the original change event's `source` structure to the final flattened record (prefixed with "__").
 This ability to add metadata to the event record makes it possible to include content such as the name of the collection associated with the change event, or such connector-specific fields as the replica set name.
-For more information about the MongoDB source structure, see {link-prefix}:{link-mongodb-connector}[the documentation] for the MongoDB connector.
+For more information about the MongoDB source structure, see xref:{link-mongodb-connector}[the documentation] for the MongoDB connector.
 
 For example, you might specify the following configuration to add a replica set name (`rs`) and the collection name for a change event to the final flattened event record:
 
@@ -252,7 +252,7 @@ For `DELETE` events, the option to add metadata fields is supported only if the 
 In addition to the change event messages that a {prodname} connector emits when a database change occurs, the connector also emits other types of messages, including heartbeat messages, and metadata messages about schema changes and transactions.
 Because the structure of these other messages differs from the structure of the change event messages that the SMT is designed to process, it's best to configure the connector to selectively apply the SMT, so that it processes only the intended data change messages.
 
-For more information about how to apply the SMT selectively, see {link-prefix}:{link-smt-predicates}#applying-transformation-selectively[Configure an SMT predicate for the transformation].
+For more information about how to apply the SMT selectively, see xref:{link-smt-predicates}#applying-transformation-selectively[Configure an SMT predicate for the transformation].
 
 [[mongodb-extract-new-record-state-configuration-options]]
 == Configuration options
@@ -305,7 +305,7 @@ Please use a comma separated list without spaces.
 |[[mongodb-extract-new-record-state-sanitize-field-names]]<<mongodb-extract-new-record-state-sanitize-field-names, `sanitize.field.names`>>
 |`false`
 |Whether field names will be sanitized to adhere to Avro naming requirements.
-See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
+See xref:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 |===
 
 == Known limitations

--- a/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
@@ -193,7 +193,7 @@ In addition to the change event messages that a {prodname} connector emits when 
 Because the structure of these other messages differs from the structure of the change event messages that the SMT is designed to process, it's best to configure the connector to selectively apply the SMT, so that it processes only the intended data change messages.
 You can use one of the following methods to configure the connector to apply the SMT selectively:
 
-* {link-prefix}:{link-smt-predicates}#applying-transformation-selectively[Configure an SMT predicate for the transformation].
+* xref:{link-smt-predicates}#applying-transformation-selectively[Configure an SMT predicate for the transformation].
 * Use the xref:mongodb-outbox-event-router-property-route-topic-regex[`route.topic.regex`] configuration option for the SMT.
 
 ifdef::community[]

--- a/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
@@ -208,7 +208,7 @@ In addition to the change event messages that a {prodname} connector emits when 
 Because the structure of these other messages differs from the structure of the change event messages that the SMT is designed to process, it's best to configure the connector to selectively apply the SMT, so that it processes only the intended data change messages.
 You can use one of the following methods to configure the connector to apply the SMT selectively:
 
-* {link-prefix}:{link-smt-predicates}#applying-transformation-selectively[Configure an SMT predicate for the transformation].
+* xref:{link-smt-predicates}#applying-transformation-selectively[Configure an SMT predicate for the transformation].
 * Use the xref:outbox-event-router-property-route-topic-regex[route.topic.regex] configuration option for the SMT.
 
 // Type: concept

--- a/documentation/modules/ROOT/pages/transformations/topic-routing.adoc
+++ b/documentation/modules/ROOT/pages/transformations/topic-routing.adoc
@@ -49,7 +49,7 @@ You can re-route change event records for tables in any of the shards to the sam
 
 .Partitioned PostgreSQL tables
 
-When the {prodname} PostgreSQL connector captures changes in a partitioned table, the default behavior is that change event records are routed to a different topic for each partition. To emit records from all partitions to one topic, configure the topic routing SMT. Because each key in a partitioned table is guaranteed to be unique, configure {link-prefix}:{link-topic-routing}#by-logical-table-router-key-enforce-uniqueness[`key.enforce.uniqueness=false`] so that the SMT does not add a key field to ensure unique keys. The addition of a key field is default behavior.
+When the {prodname} PostgreSQL connector captures changes in a partitioned table, the default behavior is that change event records are routed to a different topic for each partition. To emit records from all partitions to one topic, configure the topic routing SMT. Because each key in a partitioned table is guaranteed to be unique, configure xref:{link-topic-routing}#by-logical-table-router-key-enforce-uniqueness[`key.enforce.uniqueness=false`] so that the SMT does not add a key field to ensure unique keys. The addition of a key field is default behavior.
 
 // Type: concept
 // ModuleID: example-of-routing-debezium-records-for-multiple-tables-to-one-topic
@@ -145,7 +145,7 @@ Because the structure of these other messages differs from the structure of the 
 
 You can use one of the following methods to configure the connector to apply the SMT selectively:
 
-* {link-prefix}:{link-smt-predicates}#applying-transformation-selectively[Configure an SMT predicate for the transformation].
+* xref:{link-smt-predicates}#applying-transformation-selectively[Configure an SMT predicate for the transformation].
 * Use the xref:by-logical-table-router-topic-regex[topic.regex] configuration option for the SMT.
 
 ifdef::community[]

--- a/documentation/modules/ROOT/partials/assemblies/tutorial/assembly-viewing-change-events.adoc
+++ b/documentation/modules/ROOT/partials/assemblies/tutorial/assembly-viewing-change-events.adoc
@@ -13,7 +13,7 @@ When you watched the connector start up,
 you saw that events were written to the following topics with the `dbserver1` prefix (the name of the connector):
 
 `dbserver1`::
-The {link-prefix}:{link-mysql-connector}#mysql-schema-change-topic[schema change topic] to which all of the DDL statements are written.
+The xref:{link-mysql-connector}#mysql-schema-change-topic[schema change topic] to which all of the DDL statements are written.
 
 `dbserver1.inventory.products`::
 Captures change events for the `products` table in the `inventory` database.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
@@ -30,7 +30,7 @@ The following changes in a database might be cause for performing an ad hoc snap
 * Data corruption occurs due to a configuration error or some other problem.
 
 You can re-run a snapshot for a {data-collection} for which you previously captured a snapshot by initiating a so-called _ad-hoc snapshot_.
-Ad hoc snapshots require the use of {link-prefix}:{link-signalling}#sending-signals-to-a-debezium-connector[signaling {data-collection}s].
+Ad hoc snapshots require the use of xref:{link-signalling}#sending-signals-to-a-debezium-connector[signaling {data-collection}s].
 You initiate an ad hoc snapshot by sending a signal request to the {prodname} signaling {data-collection}.
 
 When you initiate an ad hoc snapshot of an existing {data-collection}, the connector appends content to the topic that already exists for the {data-collection}.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/obs_ref-connector-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/obs_ref-connector-incremental-snapshot.adoc
@@ -17,7 +17,7 @@ Examples for such use cases include:
 * some of the topics were deleted and their content needs to be rebuilt
 * the data were corrupted due to a configuration error
 
-Debezium can be requested via the {link-prefix}:{link-signalling}[signalling {data-collection}] mechanism to execute a new snapshot of a defined list of {data-collection}s.
+Debezium can be requested via the xref:{link-signalling}[signalling {data-collection}] mechanism to execute a new snapshot of a defined list of {data-collection}s.
 The signal is named `execute-snapshot` and accepts messages in the following format:
 
 .Example of a signal record
@@ -33,7 +33,7 @@ See the next section for more details.
 |`data-collections`
 |_N/A_
 | An array of qualified names of {data-collection}s to be snapshotted. +
-The format of the names is the same as for {link-prefix}:#{context}-property-signal-data-collection[signal.data.collection] configuration option.
+The format of the names is the same as for xref:#{context}-property-signal-data-collection[signal.data.collection] configuration option.
 
 |===
 
@@ -76,12 +76,12 @@ To mitigate these issues, a new mechanism called _incremental snapshotting_ has 
 
 [NOTE]
 ====
-Incremental snapshots can be started current only as {link-prefix}:#{context}-adhoc-snapshot[an ad-hoc snapshot].
+Incremental snapshots can be started current only as xref:#{context}-adhoc-snapshot[an ad-hoc snapshot].
 ====
 
 [NOTE]
 ====
-Configuration option {link-prefix}:#{context}-property-signal-data-collection[signal.data.collection] must be set.
+Configuration option xref:#{context}-property-signal-data-collection[signal.data.collection] must be set.
 ====
 
 Incremental snapshot is based on link:https://github.com/debezium/debezium-design-documents/blob/main/DDD-3.md[DDD-3] design document.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc
@@ -176,7 +176,7 @@ spec:
 |The logical name of the database instance or cluster. +
 The specified name must be formed only from alphanumeric characters or underscores. +
 Because the logical name is used as the prefix for any Kafka topics that receive change events from this connector, the name must be unique among the connectors in the cluster. +
-The namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro connector].
+The namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the xref:{link-avro-serialization}#avro-serialization[Avro connector].
 
 |11
 |The list of tables from which the connector captures change events.

--- a/documentation/modules/ROOT/partials/modules/tutorial/con-introduction-debezium.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/con-introduction-debezium.adoc
@@ -16,4 +16,4 @@ it will not miss anything:
 when the application restarts, it will resume consuming the events where it left off.
 
 {prodname} includes multiple connectors.
-In this tutorial, you will use the {link-prefix}:{link-mysql-connector}[MySQL connector].
+In this tutorial, you will use the xref:{link-mysql-connector}[MySQL connector].

--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-registering-connector-monitor-inventory-database.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-registering-connector-monitor-inventory-database.adoc
@@ -16,7 +16,7 @@ When a row in the database changes,
 ====
 In a production environment, you would typically either use the Kafka tools to manually create the necessary topics,
 including specifying the number of replicas,
-or you'd use the Kafka Connect mechanism for customizing the settings of {link-prefix}:{link-topic-auto-creation}[auto-created] topics.
+or you'd use the Kafka Connect mechanism for customizing the settings of xref:{link-topic-auto-creation}[auto-created] topics.
 However, for this tutorial, Kafka is configured to automatically create the topics with just one replica.
 ====
 
@@ -67,7 +67,7 @@ This name will be used as the prefix for all Kafka topics.
 <7> The connector will store the history of the database schemas in Kafka using this broker (the same broker to which you are sending events) and topic name.
 Upon restart, the connector will recover the schemas of the database that existed at the point in time in the `binlog` when the connector should begin reading.
 
-For more information, see {link-prefix}:{link-mysql-connector}#mysql-connector-properties[MySQL connector configuration properties].
+For more information, see xref:{link-mysql-connector}#mysql-connector-properties[MySQL connector configuration properties].
 --
 
 ifdef::community[]

--- a/documentation/modules/ROOT/partials/modules/tutorial/ref-watching-connector-start-up.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/ref-watching-connector-start-up.adoc
@@ -132,7 +132,7 @@ even when the tables have a large number of rows.
 And although an exclusive write lock is used at the beginning of the snapshot process,
 it should not last very long even for large databases.
 This is because the lock is released before any data is copied.
-For more information, see the {link-prefix}:{link-mysql-connector}#debezium-connector-for-mysql[MySQL connector documentation].
+For more information, see the xref:{link-mysql-connector}#debezium-connector-for-mysql[MySQL connector documentation].
 ====
 
 Next, Kafka Connect reports some "errors".


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4606

Hey @roldanbob, can you check out this one? I've moved forward and dropped the "link-prefix" attribute altogether. Please also see my latest comment in the Jira issue, I'm wondering whether we actually need to have _any_ page names in xref links at all; as per our documentation contribution guide, this should be resolved automatically (i.e. anchor ids are enough), but you'd have to tell me whether that is the case for downstream too.