### PR TITLE
DBZ-4718 Process transaction retention on each mining iteration

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -174,8 +174,6 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
                             endMiningSession(jdbcConnection, offsetContext);
                             initializeRedoLogsForMining(jdbcConnection, true, startScn);
 
-                            processor.abandonTransactions(connectorConfig.getLogMiningTransactionRetention());
-
                             // This needs to be re-calculated because building the data dictionary will force the
                             // current redo log sequence to be advanced due to a complete log switch of all logs.
                             currentRedoLogSequences = getCurrentRedoLogSequences();
@@ -184,10 +182,10 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
                         if (context.isRunning()) {
                             startMiningSession(jdbcConnection, startScn, endScn);
                             startScn = processor.process(partition, startScn, endScn);
+                            streamingMetrics.setCurrentBatchProcessingTime(Duration.between(start, Instant.now()));
 
                             captureSessionMemoryStatistics(jdbcConnection);
 
-                            streamingMetrics.setCurrentBatchProcessingTime(Duration.between(start, Instant.now()));
                             pauseBetweenMiningSessions();
                         }
                     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/LogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/LogMinerEventProcessor.java
@@ -31,5 +31,5 @@ public interface LogMinerEventProcessor extends AutoCloseable {
      *
      * @param retention the maximum duration in which long running transactions are allowed.
      */
-    void abandonTransactions(Duration retention);
+    void abandonTransactions(Duration retention) throws InterruptedException;
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/AbstractInfinispanLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/infinispan/AbstractInfinispanLogMinerEventProcessor.java
@@ -115,7 +115,7 @@ public abstract class AbstractInfinispanLogMinerEventProcessor extends AbstractL
     }
 
     @Override
-    public void abandonTransactions(Duration retention) {
+    public void abandonTransactions(Duration retention) throws InterruptedException {
         // no-op, transactions are never abandoned
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4718

There PR fixes a problem where transaction retention was being managed on each log switch rather than after each mining session which could lead to a situation on a restart where the SCN in the connector offsets has aged out of the available logs.  We will now tick transaction retention on each mining loop so that when heartbeats are enabled or events are received from the database, the offset's SCN is kept up-to-date in really low volume environments.