### PR TITLE
DBZ-4783: Support for multiple databases and tasks in the SQL Server connector

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceCoordinator.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceCoordinator.java
@@ -81,8 +81,11 @@ public class SqlServerChangeEventSourceCoordinator extends ChangeEventSourceCoor
     private void streamEvents(ChangeEventSourceContext context, Offsets<SqlServerPartition, SqlServerOffsetContext> streamingOffsets)
             throws InterruptedException {
 
-        // TODO: Determine how to do incremental snapshots with multiple partitions but for now just use the first offset
-        initStreamEvents(streamingOffsets.getTheOnlyPartition(), streamingOffsets.getTheOnlyOffset());
+        // TODO: Determine how to do incremental snapshots with multiple partitions
+        for (Map.Entry<SqlServerPartition, SqlServerOffsetContext> entry : streamingOffsets) {
+            initStreamEvents(entry.getKey(), entry.getValue());
+        }
+
         final Metronome metronome = Metronome.sleeper(pollInterval, clock);
 
         LOGGER.info("Starting streaming");

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.connector.sqlserver;
 
+import static io.debezium.config.CommonConnectorConfig.TASK_ID;
+
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -64,6 +66,7 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
             final String realDatabaseName = connection.retrieveRealDatabaseName(databaseName);
             if (!sqlServerConfig.isMultiPartitionModeEnabled()) {
                 taskConfig.put(SqlServerConnectorConfig.DATABASE_NAME.name(), realDatabaseName);
+                taskConfig.put(TASK_ID, "0");
             }
             else {
                 taskConfig.put(SqlServerConnectorConfig.DATABASE_NAMES.name(), realDatabaseName);

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -7,6 +7,9 @@ package io.debezium.connector.sqlserver;
 
 import java.time.DateTimeException;
 import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -372,7 +375,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
         return CONFIG_DEFINITION.configDef();
     }
 
-    private final String databaseName;
+    private final List<String> databaseNames;
     private final String instanceName;
     private final SnapshotMode snapshotMode;
     private final SnapshotIsolationMode snapshotIsolationMode;
@@ -391,16 +394,16 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
 
         if (databaseName != null) {
             multiPartitionMode = false;
-            this.databaseName = databaseName;
+            this.databaseNames = Collections.singletonList(databaseName);
         }
         else if (databaseNames != null) {
             multiPartitionMode = true;
-            this.databaseName = databaseNames;
+            this.databaseNames = Arrays.asList(databaseNames.split(","));
             LOGGER.info("Multi-partition mode is enabled");
         }
         else {
             multiPartitionMode = false;
-            this.databaseName = null;
+            this.databaseNames = Collections.emptyList();
         }
 
         this.instanceName = config.getString(INSTANCE);
@@ -429,8 +432,8 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
         return getConfig().subset(DATABASE_CONFIG_PREFIX, true);
     }
 
-    public String getDatabaseName() {
-        return databaseName;
+    public List<String> getDatabaseNames() {
+        return databaseNames;
     }
 
     public String getInstanceName() {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -533,8 +533,8 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
                 problems.accept(field, null, "Cannot be specified alongside " + DATABASE_NAME);
                 ++count;
             }
-            if (databaseNames.contains(",")) {
-                problems.accept(field, databaseNames, "Only a single database name is currently supported");
+            if (databaseNames.split(",").length == 0) {
+                problems.accept(field, databaseNames, "Cannot be empty");
                 ++count;
             }
         }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -83,14 +83,10 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
         this.schema.initializeStorage();
 
         Offsets<SqlServerPartition, SqlServerOffsetContext> offsets = getPreviousOffsets(
-                new SqlServerPartition.Provider(connectorConfig),
+                new SqlServerPartition.Provider(connectorConfig, config),
                 new SqlServerOffsetContext.Loader(connectorConfig));
-        SqlServerPartition partition = offsets.getTheOnlyPartition();
-        SqlServerOffsetContext previousOffset = offsets.getTheOnlyOffset();
 
-        if (previousOffset != null) {
-            schema.recover(partition, previousOffset);
-        }
+        schema.recover(offsets);
 
         taskContext = new SqlServerTaskContext(connectorConfig, schema);
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerTaskContext.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerTaskContext.java
@@ -16,6 +16,6 @@ import io.debezium.connector.common.CdcSourceTaskContext;
 public class SqlServerTaskContext extends CdcSourceTaskContext {
 
     public SqlServerTaskContext(SqlServerConnectorConfig config, SqlServerDatabaseSchema schema) {
-        super(config.getContextName(), config.getLogicalName(), schema::tableIds);
+        super(config.getContextName(), config.getLogicalName(), config.getTaskId(), schema::tableIds);
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/AbstractSqlServerTaskMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/AbstractSqlServerTaskMetrics.java
@@ -40,7 +40,7 @@ abstract class AbstractSqlServerTaskMetrics<B extends AbstractSqlServerPartition
                                  Function<SqlServerPartition, B> beanFactory) {
         super(taskContext, Collect.linkMapOf(
                 "server", taskContext.getConnectorName(),
-                "task", "0",
+                "task", taskContext.getTaskId(),
                 "context", contextName));
         this.changeEventQueueMetrics = changeEventQueueMetrics;
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotTaskMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerSnapshotTaskMetrics.java
@@ -27,7 +27,7 @@ class SqlServerSnapshotTaskMetrics extends AbstractSqlServerTaskMetrics<SqlServe
                 (SqlServerPartition partition) -> new SqlServerSnapshotPartitionMetrics(taskContext,
                         Collect.linkMapOf(
                                 "server", taskContext.getConnectorName(),
-                                "task", "0",
+                                "task", taskContext.getTaskId(),
                                 "context", "snapshot",
                                 "database", partition.getDatabaseName()),
                         metadataProvider));

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetrics.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/metrics/SqlServerStreamingTaskMetrics.java
@@ -28,7 +28,7 @@ class SqlServerStreamingTaskMetrics extends AbstractSqlServerTaskMetrics<SqlServ
                 (SqlServerPartition partition) -> new SqlServerStreamingPartitionMetrics(taskContext,
                         Collect.linkMapOf(
                                 "server", taskContext.getConnectorName(),
-                                "task", "0",
+                                "task", taskContext.getTaskId(),
                                 "context", "streaming",
                                 "database", partition.getDatabaseName()),
                         metadataProvider));

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SchemaHistoryTopicIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SchemaHistoryTopicIT.java
@@ -334,7 +334,7 @@ public class SchemaHistoryTopicIT extends AbstractConnectorTest {
     @FixFor({ "DBZ-3347", "DBZ-2975" })
     public void shouldContainPartitionInSchemaChangeEventInMultiPartitionMode() throws Exception {
         shouldContainPartitionInSchemaChangeEvent(TestHelper.defaultMultiPartitionConfig(),
-                () -> TestHelper.waitForTaskStreamingStarted("0"),
+                TestHelper::waitForTaskStreamingStarted,
                 Collect.hashMapOf("server", "server1", "database", "testDB"));
     }
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorConfigTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorConfigTest.java
@@ -54,15 +54,6 @@ public class SqlServerConnectorConfigTest {
         assertFalse(connectorConfig.validateAndRecord(SqlServerConnectorConfig.ALL_FIELDS, LOGGER::error));
     }
 
-    @Test
-    public void multipleDatabaseNames() {
-        final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(
-                defaultConfig()
-                        .with(SqlServerConnectorConfig.DATABASE_NAMES, "testDB1,testDB2")
-                        .build());
-        assertFalse(connectorConfig.validateAndRecord(SqlServerConnectorConfig.ALL_FIELDS, LOGGER::error));
-    }
-
     private Configuration.Builder defaultConfig() {
         return Configuration.create()
                 .with(SqlServerConnectorConfig.SERVER_NAME, "server")

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -2519,6 +2519,36 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
     }
 
     @Test
+    public void shouldReturnSingleTaskConfig() {
+        final Map<String, String> props = TestHelper.defaultConnectorConfig()
+                .with(SqlServerConnectorConfig.DATABASE_NAMES, "mAsTeR,mOdEl")
+                .build()
+                .asMap();
+
+        SqlServerConnector connector = new SqlServerConnector();
+        connector.start(props);
+        List<Map<String, String>> taskConfigs = connector.taskConfigs(1);
+        assertThat(taskConfigs).hasSize(1);
+        assertThat(taskConfigs.get(0).get(SqlServerConnectorConfig.DATABASE_NAMES.name()))
+                .isEqualTo("master,model");
+    }
+
+    @Test
+    public void shouldReturnTwoTaskConfigs() {
+        final Map<String, String> props = TestHelper.defaultConnectorConfig()
+                .with(SqlServerConnectorConfig.DATABASE_NAMES, "MaStEr,MoDeL")
+                .build()
+                .asMap();
+
+        SqlServerConnector connector = new SqlServerConnector();
+        connector.start(props);
+        List<Map<String, String>> taskConfigs = connector.taskConfigs(2);
+        assertThat(taskConfigs).hasSize(2);
+        assertThat(taskConfigs.get(0).get(SqlServerConnectorConfig.DATABASE_NAMES.name())).isEqualTo("master");
+        assertThat(taskConfigs.get(1).get(SqlServerConnectorConfig.DATABASE_NAMES.name())).isEqualTo("model");
+    }
+
+    @Test
     @FixFor("DBZ-2975")
     public void shouldIncludeDatabaseNameIntoTopicAndSchemaNamesInMultiPartitionMode() throws Exception {
         final Configuration config = TestHelper.defaultMultiPartitionConfig()

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorMultiPartitionModeIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorMultiPartitionModeIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.fest.assertions.Assertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.sqlserver.util.TestHelper;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.util.Testing;
+
+public class SqlServerConnectorMultiPartitionModeIT extends AbstractConnectorTest {
+
+    private SqlServerConnection connection;
+
+    @Before
+    public void before() throws SQLException {
+        TestHelper.createTestDatabases(TestHelper.TEST_DATABASE_1, TestHelper.TEST_DATABASE_2);
+        connection = TestHelper.multiPartitionTestConnection();
+        connection.execute(
+                "USE " + TestHelper.TEST_DATABASE_1,
+                "CREATE TABLE tableA (id int primary key, colA varchar(32))",
+                "CREATE TABLE tableB (id int primary key, colB varchar(32))",
+                "INSERT INTO tableA VALUES(1, 'a1')",
+                "INSERT INTO tableB VALUES(2, 'b')");
+        TestHelper.enableTableCdc(connection, "tableA");
+        TestHelper.enableTableCdc(connection, "tableB");
+        connection.execute(
+                "USE " + TestHelper.TEST_DATABASE_2,
+                "CREATE TABLE tableA (id int primary key, colA varchar(32))",
+                "CREATE TABLE tableC (id int primary key, colC varchar(32))",
+                "INSERT INTO tableA VALUES(3, 'a2')",
+                "INSERT INTO tableC VALUES(4, 'c')");
+        TestHelper.enableTableCdc(connection, "tableA");
+        TestHelper.enableTableCdc(connection, "tableC");
+
+        initializeConnectorTestFramework();
+        Testing.Files.delete(TestHelper.DB_HISTORY_PATH);
+    }
+
+    @After
+    public void after() throws SQLException {
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void snapshotAndStreaming() throws Exception {
+        final Configuration config = TestHelper.defaultMultiPartitionConfig(
+                TestHelper.TEST_DATABASE_1,
+                TestHelper.TEST_DATABASE_2)
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SqlServerConnectorConfig.SnapshotMode.INITIAL)
+                .build();
+        start(SqlServerConnector.class, config);
+        assertConnectorIsRunning();
+
+        TestHelper.waitForDatabaseSnapshotsToBeCompleted(TestHelper.TEST_DATABASE_1, TestHelper.TEST_DATABASE_2);
+        SourceRecords records = consumeRecordsByTopic(4);
+
+        List<SourceRecord> tableA1 = records.recordsForTopic(TestHelper.topicName(TestHelper.TEST_DATABASE_1, "tableA"));
+        Assertions.assertThat(tableA1).hasSize(1);
+        assertValue(tableA1.get(0), "colA", "a1");
+
+        List<SourceRecord> tableB = records.recordsForTopic(TestHelper.topicName(TestHelper.TEST_DATABASE_1, "tableB"));
+        Assertions.assertThat(tableB).hasSize(1);
+        assertValue(tableB.get(0), "colB", "b");
+
+        List<SourceRecord> tableA2 = records.recordsForTopic(TestHelper.topicName(TestHelper.TEST_DATABASE_2, "tableA"));
+        Assertions.assertThat(tableA2).hasSize(1);
+        assertValue(tableA2.get(0), "colA", "a2");
+
+        List<SourceRecord> tableC = records.recordsForTopic(TestHelper.topicName(TestHelper.TEST_DATABASE_2, "tableC"));
+        Assertions.assertThat(tableC).hasSize(1);
+        assertValue(tableC.get(0), "colC", "c");
+
+        connection.execute(
+                "USE " + TestHelper.TEST_DATABASE_1,
+                "INSERT INTO tableA VALUES(5, 'a1s')");
+        connection.execute(
+                "USE " + TestHelper.TEST_DATABASE_2,
+                "INSERT INTO tableA VALUES(6, 'a2s')");
+
+        TestHelper.waitForTaskStreamingStarted();
+        records = consumeRecordsByTopic(2);
+
+        tableA1 = records.recordsForTopic(TestHelper.topicName(TestHelper.TEST_DATABASE_1, "tableA"));
+        Assertions.assertThat(tableA1).hasSize(1);
+        assertValue(tableA1.get(0), "colA", "a1s");
+
+        tableA2 = records.recordsForTopic(TestHelper.topicName(TestHelper.TEST_DATABASE_2, "tableA"));
+        Assertions.assertThat(tableA1).hasSize(1);
+        assertValue(tableA2.get(0), "colA", "a2s");
+    }
+
+    private void assertValue(SourceRecord record, String fieldName, Object expected) {
+        final Struct value = (Struct) record.value();
+        final Struct after = (Struct) value.get("after");
+        assertThat(after.get(fieldName)).isEqualTo(expected);
+    }
+}

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -58,6 +58,7 @@ public class TestHelper {
     public static final String TEST_DATABASE = "testDB";
     private static final String TEST_PROPERTY_PREFIX = "debezium.test.";
 
+    private static final String TEST_TASK_ID = "0";
     private static final String STATEMENTS_PLACEHOLDER = "#";
 
     private static final String ENABLE_DB_CDC = "IF EXISTS(select 1 from sys.databases where name='#' AND is_cdc_enabled=0)\n"
@@ -467,7 +468,7 @@ public class TestHelper {
     private static ObjectName getObjectName(String context, String serverName, String databaseName) {
         return getObjectName(Collect.linkMapOf(
                 "server", serverName,
-                "task", "0",
+                "task", TEST_TASK_ID,
                 "context", context,
                 "database", databaseName));
     }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -56,6 +56,9 @@ public class TestHelper {
 
     public static final Path DB_HISTORY_PATH = Testing.Files.createTestingPath("file-db-history-connect.txt").toAbsolutePath();
     public static final String TEST_DATABASE = "testDB";
+    public static final String TEST_DATABASE_1 = "testDB1";
+    public static final String TEST_DATABASE_2 = "testDB2";
+    public static final String TEST_SERVER_NAME = "server1";
     private static final String TEST_PROPERTY_PREFIX = "debezium.test.";
 
     private static final String TEST_TASK_ID = "0";
@@ -98,15 +101,6 @@ public class TestHelper {
         }
     }
 
-    public static JdbcConfiguration adminJdbcConfig() {
-        return JdbcConfiguration.copy(Configuration.fromSystemProperties(SqlServerConnectorConfig.DATABASE_CONFIG_PREFIX))
-                .withDefault(JdbcConfiguration.HOSTNAME, "localhost")
-                .withDefault(JdbcConfiguration.PORT, 1433)
-                .withDefault(JdbcConfiguration.USER, "sa")
-                .withDefault(JdbcConfiguration.PASSWORD, "Password!")
-                .build();
-    }
-
     public static JdbcConfiguration defaultJdbcConfig() {
         return JdbcConfiguration.copy(Configuration.fromSystemProperties(SqlServerConnectorConfig.DATABASE_CONFIG_PREFIX))
                 .withDefault(JdbcConfiguration.HOSTNAME, "localhost")
@@ -141,13 +135,23 @@ public class TestHelper {
     /**
      * Returns a default configuration for connectors in multi-partition mode.
      */
-    public static Configuration.Builder defaultMultiPartitionConfig() {
+    public static Configuration.Builder defaultMultiPartitionConfig(String... databaseNames) {
         return defaultConnectorConfig()
-                .with(SqlServerConnectorConfig.DATABASE_NAMES.name(), TEST_DATABASE);
+                .with(SqlServerConnectorConfig.DATABASE_NAMES.name(), String.join(",", databaseNames));
+    }
+
+    public static Configuration.Builder defaultMultiPartitionConfig() {
+        return defaultMultiPartitionConfig(TEST_DATABASE);
     }
 
     public static void createTestDatabase() {
         createTestDatabase(TEST_DATABASE);
+    }
+
+    public static void createTestDatabases(String... databaseNames) {
+        for (String databaseName : databaseNames) {
+            createTestDatabase(databaseName);
+        }
     }
 
     public static void createTestDatabase(String databaseName) {
@@ -229,7 +233,7 @@ public class TestHelper {
     }
 
     public static SqlServerConnection adminConnection() {
-        return new SqlServerConnection(TestHelper.adminJdbcConfig(), SourceTimestampMode.getDefaultMode(),
+        return new SqlServerConnection(TestHelper.defaultJdbcConfig(), SourceTimestampMode.getDefaultMode(),
                 new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE, null), () -> TestHelper.class.getClassLoader(),
                 Collections.emptySet(), true);
     }
@@ -238,12 +242,23 @@ public class TestHelper {
         return testConnection(TEST_DATABASE);
     }
 
+    /**
+     * Returns a database connection that isn't explicitly connected to any database.
+     */
+    public static SqlServerConnection multiPartitionTestConnection() {
+        return testConnection(defaultJdbcConfig());
+    }
+
     public static SqlServerConnection testConnection(String databaseName) {
         Configuration config = defaultJdbcConfig()
                 .edit()
                 .with(JdbcConfiguration.ON_CONNECT_STATEMENTS, "USE [" + databaseName + "]")
                 .build();
 
+        return testConnection(config);
+    }
+
+    private static SqlServerConnection testConnection(Configuration config) {
         return new SqlServerConnection(config, SourceTimestampMode.getDefaultMode(),
                 new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE, null), () -> TestHelper.class.getClassLoader(),
                 Collections.emptySet(), true);
@@ -393,6 +408,12 @@ public class TestHelper {
         waitForSnapshotToBeCompleted(getObjectName("snapshot", "server1", databaseName));
     }
 
+    public static void waitForDatabaseSnapshotsToBeCompleted(String... databaseNames) {
+        for (String databaseName : databaseNames) {
+            waitForDatabaseSnapshotToBeCompleted(databaseName);
+        }
+    }
+
     private static void waitForSnapshotToBeCompleted(ObjectName objectName) {
         final MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
         try {
@@ -416,6 +437,10 @@ public class TestHelper {
                 "server", "server1",
                 "task", taskId,
                 "context", "streaming")));
+    }
+
+    public static void waitForTaskStreamingStarted() {
+        waitForTaskStreamingStarted(TEST_TASK_ID);
     }
 
     public static void waitForStreamingStarted() {
@@ -592,6 +617,10 @@ public class TestHelper {
         catch (ConditionTimeoutException e) {
             throw new IllegalStateException("Expected record never appeared in the CDC table", e);
         }
+    }
+
+    public static String topicName(String databaseName, String tableName) {
+        return String.join(".", TEST_SERVER_NAME, databaseName, "dbo", tableName);
     }
 
     @FunctionalInterface

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -47,6 +47,7 @@ import io.debezium.util.Strings;
  * @author Gunnar Morling
  */
 public abstract class CommonConnectorConfig {
+    public static final String TASK_ID = "task.id";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CommonConnectorConfig.class);
 
@@ -538,6 +539,7 @@ public abstract class CommonConnectorConfig {
     private final String signalingDataCollection;
     private final EnumSet<Operation> skippedOperations;
     private final String transactionTopic;
+    private final String taskId;
 
     protected CommonConnectorConfig(Configuration config, String logicalName, int defaultSnapshotFetchSize) {
         this.config = config;
@@ -565,6 +567,7 @@ public abstract class CommonConnectorConfig {
         this.signalingDataCollection = config.getString(SIGNAL_DATA_COLLECTION);
         this.skippedOperations = determineSkippedOperations(config);
         this.transactionTopic = config.getString(TRANSACTION_TOPIC).replace("${database.server.name}", logicalName);
+        this.taskId = config.getString(TASK_ID);
     }
 
     private static EnumSet<Envelope.Operation> determineSkippedOperations(Configuration config) {
@@ -874,5 +877,9 @@ public abstract class CommonConnectorConfig {
 
     public Optional<String> customRetriableException() {
         return Optional.ofNullable(config.getString(CUSTOM_RETRIABLE_EXCEPTION));
+    }
+
+    public String getTaskId() {
+        return taskId;
     }
 }

--- a/debezium-core/src/main/java/io/debezium/connector/common/CdcSourceTaskContext.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/CdcSourceTaskContext.java
@@ -25,6 +25,7 @@ public class CdcSourceTaskContext {
 
     private final String connectorType;
     private final String connectorName;
+    private final String taskId;
     private final Clock clock;
 
     /**
@@ -32,12 +33,17 @@ public class CdcSourceTaskContext {
      */
     private final Supplier<Collection<? extends DataCollectionId>> collectionsSupplier;
 
-    public CdcSourceTaskContext(String connectorType, String connectorName, Supplier<Collection<? extends DataCollectionId>> collectionsSupplier) {
+    public CdcSourceTaskContext(String connectorType, String connectorName, String taskId, Supplier<Collection<? extends DataCollectionId>> collectionsSupplier) {
         this.connectorType = connectorType;
         this.connectorName = connectorName;
+        this.taskId = taskId;
         this.collectionsSupplier = collectionsSupplier != null ? collectionsSupplier : Collections::emptyList;
 
         this.clock = Clock.system();
+    }
+
+    public CdcSourceTaskContext(String connectorType, String connectorName, Supplier<Collection<? extends DataCollectionId>> collectionsSupplier) {
+        this(connectorType, connectorName, "0", collectionsSupplier);
     }
 
     /**
@@ -84,5 +90,9 @@ public class CdcSourceTaskContext {
 
     public String getConnectorName() {
         return connectorName;
+    }
+
+    public String getTaskId() {
+        return taskId;
     }
 }

--- a/debezium-core/src/main/java/io/debezium/metrics/Metrics.java
+++ b/debezium-core/src/main/java/io/debezium/metrics/Metrics.java
@@ -51,7 +51,7 @@ public abstract class Metrics {
         if (multiPartitionMode) {
             this.name = metricName(connectorType, Collect.linkMapOf(
                     "server", connectorName,
-                    "task", "0",
+                    "task", connectorConfig.getTaskId(),
                     "context", contextName));
         }
         else {

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -441,7 +441,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
             return Optional.of(enhanceOverriddenSelect(snapshotContext, overriddenSelect, tableId));
         }
 
-        List<String> columns = getPreparedColumnNames(schema.tableFor(tableId));
+        List<String> columns = getPreparedColumnNames(snapshotContext.partition, schema.tableFor(tableId));
 
         return getSnapshotSelect(snapshotContext, tableId, columns);
     }
@@ -453,10 +453,10 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
      *
      * @return list of snapshot select columns
      */
-    protected List<String> getPreparedColumnNames(Table table) {
+    protected List<String> getPreparedColumnNames(P partition, Table table) {
         List<String> columnNames = table.retrieveColumnNames()
                 .stream()
-                .filter(columnName -> additionalColumnFilter(table.id(), columnName))
+                .filter(columnName -> additionalColumnFilter(partition, table.id(), columnName))
                 .filter(columnName -> connectorConfig.getColumnFilter().matches(table.id().catalog(), table.id().schema(), table.id().table(), columnName))
                 .map(columnName -> jdbcConnection.quotedColumnIdString(columnName))
                 .collect(Collectors.toList());
@@ -476,7 +476,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
     /**
      * Additional filter handling for preparing column names for snapshot select
      */
-    protected boolean additionalColumnFilter(TableId tableId, String columnName) {
+    protected boolean additionalColumnFilter(P partition, TableId tableId, String columnName) {
         return true;
     }
 


### PR DESCRIPTION
Change summary:
1. Manage change tables for each partition individually.
2. Expose the actual task id to the metrics in order to be able to run multiple tasks.
3. Run the connector with multiple databases and multiple tasks.

Note, running multiple tasks is _not_ necessary for capturing multiple databases. Furthermore, running multiple tasks cannot be tested in the current test suite. The only reason why it's contributed here is that extracting the support for multiple tasks in a separate patch would require extra work (it was originally implemented like this). I can remove it from the patch, if necessary.

**TODO**:
- [x] Provide an integration test for the multi-partition scenario.

### Manual testing of the multi-database and multi-task configuration

1. Modify `docker-compose-sqlserver.yaml` from the [tutorial](https://github.com/debezium/debezium-examples/tree/main/tutorial#using-sql-server) to use the Docker image built from this PR.
2. Start the services:
   ```shell
   export DEBEZIUM_VERSION=1.9
   docker-compose -f docker-compose-sqlserver.yaml up
   ```
3. Initialize test databases:
   ```shell
   docker-compose -f docker-compose-sqlserver.yaml exec -T sqlserver bash -c '/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD' << 'EOF'
   CREATE DATABASE testDB1;
   GO
   USE testDB1;
   EXEC sys.sp_cdc_enable_db;
   
   CREATE TABLE products (
     id INTEGER IDENTITY(101,1) NOT NULL PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     description VARCHAR(512),
     weight FLOAT
   );
   INSERT INTO products(name,description,weight)
     VALUES ('scooter','Small 2-wheel scooter',3.14);
   
   EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'products', @role_name = NULL, @supports_net_changes = 0;
   GO
   
   CREATE DATABASE testDB2;
   GO
   USE testDB2;
   EXEC sys.sp_cdc_enable_db;
   
   CREATE TABLE customers (
     id INTEGER IDENTITY(1001,1) NOT NULL PRIMARY KEY,
     first_name VARCHAR(255) NOT NULL,
     last_name VARCHAR(255) NOT NULL,
     email VARCHAR(255) NOT NULL UNIQUE
   );
   INSERT INTO customers(first_name,last_name,email)
     VALUES ('Sally','Thomas','sally.thomas@acme.com');
   
   EXEC sys.sp_cdc_enable_table @source_schema = 'dbo', @source_name = 'customers', @role_name = NULL, @supports_net_changes = 0;
   GO
   EOF
   ```

4. Start the connector:

   ```shell
   curl -i -X POST -H "Accept:application/json" -H "Content-Type:application/json" http://localhost:8083/connectors/ -d@- << 'EOF'
   {
       "name": "inventory-connector",
       "config": {
           "connector.class" : "io.debezium.connector.sqlserver.SqlServerConnector",
           "tasks.max" : "2",
           "database.server.name" : "server1",
           "database.hostname" : "sqlserver",
           "database.port" : "1433",
           "database.user" : "sa",
           "database.password" : "Password!",
           "database.names" : "testDB1,testDB2",
           "database.history.kafka.bootstrap.servers" : "kafka:9092",
           "database.history.kafka.topic": "schema-changes.inventory"
       }
   }
   EOF
   ```

5. Check that the connector and both tasks are running:

   ```shell
   curl -s http://localhost:8083/connectors/inventory-connector/status
   ```

6. Check that each task exposes metrics for its subset of databases:
   ![Multi-partition and multi-task metrics](https://user-images.githubusercontent.com/59683/155426735-5e0b7ce3-df4b-46a9-880d-0086bd00ca3c.png)

7. Run a consumer and confirm that both databases were snapshotted:

   ```shell
   docker-compose -f docker-compose-sqlserver.yaml exec kafka /kafka/bin/kafka-console-consumer.sh \
     --bootstrap-server kafka:9092 \
     --from-beginning \
     --property print.key=true \
     --whitelist 'server1\.(testDB\d+)\..*'
   ```

8. Make changes in both databases and confirm that the changes from both databases are captured:

   ```shell
   docker-compose -f docker-compose-sqlserver.yaml exec -T sqlserver bash -c '/opt/mssql-tools/bin/sqlcmd -U sa -P $SA_PASSWORD' << 'EOF'
   UPDATE testDB1.dbo.products SET weight = 3.15 WHERE id = 101;
   UPDATE testDB2.dbo.customers SET first_name = 'Molly' WHERE id = 1001;
   EOF
   ```