### PR TITLE
DBZ-4635 Prevent NPE from offsets during Oracle connector upgrade

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleOffsetContext.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleOffsetContext.java
@@ -71,7 +71,10 @@ public class OracleOffsetContext implements OffsetContext {
         sourceInfo.setLcrPosition(lcrPosition);
         sourceInfoSchema = sourceInfo.schema();
 
-        this.snapshotScn = snapshotScn;
+        // Snapshot SCN is a new field and may be null in cases where the offsets are being read from
+        // and older version of Debezium. In this case, we need to explicitly enforce Scn#NULL usage
+        // when the value is null.
+        this.snapshotScn = snapshotScn == null ? Scn.NULL : snapshotScn;
         this.snapshotPendingTransactions = snapshotPendingTransactions;
 
         this.transactionContext = transactionContext;


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4635

Fixes a regression during the upgrade from older connectors to 1.8.1+ or 1.9.0.Alpha2+.