### PR TITLE
Dbz 4655 incremental snapshots ga doc updates

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/avro.adoc
+++ b/documentation/modules/ROOT/pages/configuration/avro.adoc
@@ -23,7 +23,7 @@ For each change event record, the {prodname} connector completes the following a
 You can specify converters for each individual {prodname} connector instance.
 Kafka Connect provides a JSON converter that serializes the record keys and values into JSON documents.
 The default behavior is that the JSON converter includes the record's message schema, which makes each record very verbose.
-The xref:{link-tutorial}[{name-tutorial}] shows what the records look like when both payload and schemas are included.
+The {link-prefix}:{link-tutorial}[{name-tutorial}] shows what the records look like when both payload and schemas are included.
 If you want records to be serialized with JSON, consider setting the following connector configuration properties to `false`:
 
 * `key.converter.schemas.enable`

--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -22,7 +22,7 @@ When {prodname} detects that a new xref:debezium-signaling-example-of-a-logging-
 Signaling is available for use with the following {prodname} connectors:
 
 * Db2
-* MongoDB
+* MongoDB (Technology Preview)
 * MySQL
 * Oracle
 * PostgreSQL

--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -11,24 +11,8 @@ ifdef::community[]
 
 toc::[]
 
-[NOTE]
-====
-This feature is currently in incubating state, i.e. exact semantics, configuration options etc. may change in future revisions, based on the feedback we receive. Please let us know if you encounter any problems while using this extension.
-====
-
 == Overview
 endif::community[]
-
-ifdef::product[]
-[IMPORTANT]
-====
-Signaling is a Technology Preview feature.
-Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
-therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
-This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
-For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
-====
-endif::product[]
 
 The {prodname} signaling mechanism provides a way to modify the behavior of a connector, or to trigger a one-time action, such as initiating an xref:debezium-signaling-ad-hoc-snapshots[ad hoc snapshot] of a table.
 To trigger a connector to perform a specified action, you issue a SQL command to add a signal message to a specialized signaling table, also referred to as a signaling data collection.
@@ -38,9 +22,7 @@ When {prodname} detects that a new xref:debezium-signaling-example-of-a-logging-
 Signaling is available for use with the following {prodname} connectors:
 
 * Db2
-ifdef::community[]
 * MongoDB
-endif::community[]
 * MySQL
 * Oracle
 * PostgreSQL
@@ -71,13 +53,9 @@ The format for the fully-qualified name of the signaling collection depends on t
 The following example shows the naming formats to use for each connector:
 
 Db2:: `_<schemaName>_._<tableName>_`
-ifdef::community[]
 MongoDB:: `_<databaseName>_._<collectionName>_`
-endif::community[]
 MySQL:: `_<databaseName>_._<tableName>_`
-ifdef::community[]
 Oracle:: `_<databaseName>_._<schemaName>_._<tableName>_`
-endif::community[]
 PostgreSQL:: `_<schemaName>_._<tableName>_`
 SQL Server:: `_<databaseName>_._<schemaName>_._<tableName>_` +
  +

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2274,20 +2274,12 @@ By default, no operations are skipped.
 Use the following format to specify the collection name: +
 `_<schemaName>_._<tableName>_`
 
-ifdef::product[]
-Signaling is a Technology Preview feature.
-endif::product[]
-
 |[[db2-property-incremental-snapshot-chunk-size]]<<db2-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
 |`1024`
 |The maximum number of rows that the connector fetches and reads into memory during an incremental snapshot chunk.
 Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
 However, larger chunk sizes also require more memory to buffer the snapshot data.
 Adjust the chunk size to a value that provides the best performance in your environment.
-
-ifdef::product[]
-Incremental snapshots is a Technology Preview feature.
-endif::product[]
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2305,7 +2305,7 @@ The {prodname} Db2 connector provides three types of metrics that are in additio
 * xref:{link-db2-connector}#db2-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
 * xref:{link-db2-connector}#db2-schema-history-metrics[Schema history metrics] provide information about the status of the connector's schema history.
 
-xref:{link-debezium-monitoring}[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
+{link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
 
 // Type: reference
 // ModuleID: monitoring-debezium-during-snapshots-of-db2-databases

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -233,13 +233,11 @@ Try to avoid task reassignment and reconfiguration while the connector is perfor
 ====
 
 // Type: concept
-// ModuleID: debezium-mongodb-ad-hoc-snapshots
 [id="mongodb-ad-hoc-snapshots"]
 ==== Ad hoc snapshots
 include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
 
 // Type: concept
-// ModuleID: debezium-mongodb-incremental-snapshots
 [id="mongodb-incremental-snapshots"]
 ==== Incremental snapshots
 include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+3]
@@ -1456,7 +1454,7 @@ Defaults to 0, which indicates that the server chooses an appropriate fetch size
 The following _advanced_ configuration properties have good defaults that will work in most situations and therefore rarely need to be specified in the connector's configuration.
 
 [id="debezium-mongodb-connector-advanced-configuration-properties"]
-.Required {prodname} MongoDB connector advanced configuration properties
+.{prodname} MongoDB connector advanced configuration properties
 [cols="30%a,25%a,45%a",options="header"]
 |===
 |Property
@@ -1578,6 +1576,20 @@ A value of `0` disables this behavior.
 |`0`
 |Specifies the maximum number of milliseconds the oplog/change stream cursor will wait for the server to produce a result before causing an execution timeout exception.
 A value of `0` indicates using the server/driver default wait timeout.
+
+|[[mongodb-property-signal-data-collection]]<<mongodb-property-signal-data-collection, `+signal.data.collection+`>>
+|No default
+| Fully-qualified name of the data collection that is used to send xref:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector.
+Use the following format to specify the collection name: +
+`_<databaseName>_._<collectionName>_`
+
+|[[mongodb-property-incremental-snapshot-chunk-size]]<<mongodb-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
+|`1024`
+|The maximum number of documents that the connector fetches and reads into memory during an incremental snapshot chunk.
+Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
+However, larger chunk sizes also require more memory to buffer the snapshot data.
+Adjust the chunk size to a value that provides the best performance in your environment.
+
 |===
 
 // Type: assembly

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -232,7 +232,6 @@ If the connector is stopped before the tasks' snapshots are completed, upon rest
 Try to avoid task reassignment and reconfiguration while the connector is performing a snapshot of any replica sets. The connector does log messages with the progress of the snapshot. For utmost control, run a separate cluster of Kafka Connect for each connector.
 ====
 
-ifdef::community[]
 // Type: concept
 // ModuleID: debezium-mongodb-ad-hoc-snapshots
 [id="mongodb-ad-hoc-snapshots"]
@@ -251,8 +250,6 @@ include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot
 Incremental snapshots are currently supported for single replica set deployments only.
 This limitation will be removed in the next version.
 ====
-
-endif::community[]
 
 // Type: concept
 // ModuleID: how-the-debezium-mongodb-connector-streams-change-event-records

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1602,6 +1602,7 @@ A value of `0` disables this behavior.
 |Specifies the maximum number of milliseconds the oplog/change stream cursor will wait for the server to produce a result before causing an execution timeout exception.
 A value of `0` indicates using the server/driver default wait timeout.
 
+ifdef::community[]
 |[[mongodb-property-signal-data-collection]]<<mongodb-property-signal-data-collection, `+signal.data.collection+`>>
 |No default
 | Fully-qualified name of the data collection that is used to send xref:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector.
@@ -1614,6 +1615,7 @@ Use the following format to specify the collection name: +
 Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
 However, larger chunk sizes also require more memory to buffer the snapshot data.
 Adjust the chunk size to a value that provides the best performance in your environment.
+endif::community[]
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1602,20 +1602,24 @@ A value of `0` disables this behavior.
 |Specifies the maximum number of milliseconds the oplog/change stream cursor will wait for the server to produce a result before causing an execution timeout exception.
 A value of `0` indicates using the server/driver default wait timeout.
 
-ifdef::community[]
 |[[mongodb-property-signal-data-collection]]<<mongodb-property-signal-data-collection, `+signal.data.collection+`>>
 |No default
-| Fully-qualified name of the data collection that is used to send xref:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector.
+| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector.
 Use the following format to specify the collection name: +
-`_<databaseName>_._<collectionName>_`
+`_<databaseName>_._<collectionName>_` +
+ifdef::product[]
+Signaling is a Technology Preview feature for the {prodname} MongoDB connector.
+endif::product[]
 
 |[[mongodb-property-incremental-snapshot-chunk-size]]<<mongodb-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
 |`1024`
 |The maximum number of documents that the connector fetches and reads into memory during an incremental snapshot chunk.
 Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
 However, larger chunk sizes also require more memory to buffer the snapshot data.
-Adjust the chunk size to a value that provides the best performance in your environment.
-endif::community[]
+Adjust the chunk size to a value that provides the best performance in your environment. +
+ifdef::product[]
+Incremental snapshots is a Technology Preview feature for the {prodname} MongoDB connector.
+endif::product[]
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -229,24 +229,49 @@ If the connector is stopped before the tasks' snapshots are completed, upon rest
 
 [NOTE]
 ====
-Try to avoid task reassignment and reconfiguration while the connector is performing a snapshot of any replica sets. The connector does log messages with the progress of the snapshot. For utmost control, run a separate cluster of Kafka Connect for each connector.
+Try to avoid task reassignment and reconfiguration while the connector performs snapshots of any replica sets.
+The connector generates log messages to report on the progress of the snapshot.
+To provide for the greatest control, run a separate Kafka Connect cluster for each connector.
 ====
 
 // Type: concept
 [id="mongodb-ad-hoc-snapshots"]
 ==== Ad hoc snapshots
+
+ifdef::product[]
+[IMPORTANT]
+====
+Ad hoc snapshots are a Technology Preview feature for the {prodname} MongoDB connector.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::product[]
 include::{partialsdir}/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc[leveloffset=+3]
 
 // Type: concept
 [id="mongodb-incremental-snapshots"]
 ==== Incremental snapshots
-include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+3]
 
+ifdef::product[]
+[IMPORTANT]
+====
+Incremental snapshots are a Technology Preview feature for the {prodname} MongoDB connector.
+Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
+therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
+This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
+For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::product[]
+include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+3]
 
 [NOTE]
 ====
 Incremental snapshots are currently supported for single replica set deployments only.
+ifdef::community[]
 This limitation will be removed in the next version.
+endif::community[]
 ====
 
 // Type: concept

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -19,40 +19,6 @@ ifdef::community[]
 toc::[]
 
 
-[NOTE]
-====
-A new capturing implementation for the {prodname} MySQL connector was introduced in {prodname} 1.5,
-based on the common connector framework used by the other {prodname} Kafka Connect connectors.
-
-If you encounter any issues with the new MySQL connector implementation, please log a link:https://issues.redhat.com/browse/DBZ[Jira issue]; in this case, you can use the legacy implementation by setting the `internal.implementation=legacy` connector configuration option
-(note this option as well as the legacy connector implementation itself is scheduled for removal in a future Debezium version).
-
-The new connector implementation is intended to behave exactly the same as the existing one,
-with the exception of the *experimental* parallel snapshotting feature, which isn't available any longer.
-Users of the parallel snapshotting feature should move to the more robust and flexible notion of "incremental snapshotting" introduced in Debezium 1.6.
-====
-endif::community[]
-
-ifdef::product[]
-[IMPORTANT]
-====
-This release of the {prodname} MySQL connector includes a new default capturing implementation that is based on the common connector framework that is used by the other {prodname} connectors.
-The revised capturing implementation is a Technology Preview feature.
-Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete; therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
-This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
-For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
-
-If the connector generates errors or unexpected behavior while running with the new capturing implementation, you can revert to the earlier implementation by setting the following configuration option:
-
-[source]
-----
-internal.implementation=legacy
-----
-====
-endif::product[]
-
-
-
 MySQL has a binary log (binlog) that records all operations in the order in which they are committed to the database. This includes changes to table schemas as well as changes to the data in tables. MySQL uses the binlog for replication and recovery.
 
 The {prodname} MySQL connector reads the binlog, produces change events for row-level `INSERT`, `UPDATE`, and `DELETE` operations, and emits the change events to Kafka topics. Client applications read those Kafka topics.

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -21,7 +21,7 @@ toc::[]
 
 [NOTE]
 ====
-A new capturing implementation for the {prodname} MySQL connector has been created as of {prodname} 1.5,
+A new capturing implementation for the {prodname} MySQL connector was introduced in {prodname} 1.5,
 based on the common connector framework used by the other {prodname} Kafka Connect connectors.
 
 If you encounter any issues with the new MySQL connector implementation, please log a link:https://issues.redhat.com/browse/DBZ[Jira issue]; in this case, you can use the legacy implementation by setting the `internal.implementation=legacy` connector configuration option
@@ -2812,10 +2812,6 @@ endif::community[]
 Use the following format to specify the collection name: +
 `_<databaseName>_._<tableName>_`
 
-ifdef::product[]
-Signaling is a Technology Preview feature.
-endif::product[]
-
 |[[mysql-property-incremental-snapshot-allow-schema-changes]]<<mysql-property-incremental-snapshot-allow-schema-changes, `+incremental.snapshot.allow.schema.changes+`>>
 |`false`
 | Allow schema changes during an incremental snapshot. When enabled the connector will detect schema change during an incremental snapshot and re-select a current chunk to avoid locking DDLs. +
@@ -2828,10 +2824,6 @@ Note that changes to a primary key are not supported and can cause incorrect res
 Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
 However, larger chunk sizes also require more memory to buffer the snapshot data.
 Adjust the chunk size to a value that provides the best performance in your environment.
-
-ifdef::product[]
-Incremental snapshots is a Technology Preview feature.
-endif::product[]
 
 |[[mysql-property-read-only]]<<mysql-property-read-only, `+read.only+`>>
 |`false`

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3123,20 +3123,12 @@ By default, truncate operations are skipped.
 Use the following format to specify the collection name: +
 `_<schemaName>_._<tableName>_` +
 
-ifdef::product[]
-Signaling is a Technology Preview feature.
-endif::product[]
-
 |[[postgresql-property-incremental-snapshot-chunk-size]]<<postgresql-property-incremental-snapshot-chunk-size, `+incremental.snapshot.chunk.size+`>>
 |1024
 |The maximum number of rows that the connector fetches and reads into memory during an incremental snapshot chunk.
 Increasing the chunk size provides greater efficiency, because the snapshot runs fewer snapshot queries of a greater size.
 However, larger chunk sizes also require more memory to buffer the snapshot data.
 Adjust the chunk size to a value that provides the best performance in your environment.
-
-ifdef::product[]
-Incremental snapshots is a Technology Preview feature.
-endif::product[]
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2878,7 +2878,8 @@ However, it's best to use the minimum number that are required to specify a uniq
  +
 For information about the structure of _truncate_ events and about their ordering semantics, see xref:postgresql-truncate-events[]. +
  +
-_This option is deprecated, please use xref:postgresql-property-skipped-operations[`skipped.operations`] instead._
+This option is deprecated.
+Use xref:postgresql-property-skipped-operations[`skipped.operations`] in its place.
 
 |[[postgresql-property-money-fraction-digits]]<<postgresql-property-money-fraction-digits, `+money.fraction.digits+`>>
 |`2`

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2614,7 +2614,7 @@ The connector provides the following metrics:
 * xref:sqlserver-streaming-metrics[Streaming metrics] for monitoring the connector when reading CDC table data.
 * xref:sqlserver-schema-history-metrics[Schema history metrics] for monitoring the status of the connector's schema history.
 
-For information about how to expose the preceding metrics through JMX, see the xref:{link-debezium-monitoring}[{prodname} monitoring documentation].
+For information about how to expose the preceding metrics through JMX, see the {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation].
 
 // Type: reference
 // ModuleID: debezium-sqlserver-connector-snapshot-metrics

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2395,10 +2395,6 @@ By default, no operations are skipped.
 Use the following format to specify the collection name: +
 `_<databaseName>_._<schemaName>_._<tableName>_`
 
-ifdef::product[]
-Signaling is a Technology Preview feature.
-endif::product[]
-
 |[[sqlserver-property-incremental-snapshot-allow-schema-changes]]<<sqlserver-property-incremental-snapshot-allow-schema-changes, `+incremental.snapshot.allow.schema.changes+`>>
 |`false`
 | Allow schema changes during an incremental snapshot. When enabled the connector will detect schema change during an incremental snapshot and re-select a current chunk to avoid locking DDLs. +

--- a/documentation/modules/ROOT/pages/operations/monitoring.adoc
+++ b/documentation/modules/ROOT/pages/operations/monitoring.adoc
@@ -1,7 +1,6 @@
 
 // Category: debezium-using
 // Type: assembly
-// ModuleID: monitoring-debezium
 
 [id="monitoring-debezium"]
 = Monitoring {prodname}

--- a/documentation/modules/ROOT/pages/transformations/content-based-routing.adoc
+++ b/documentation/modules/ROOT/pages/transformations/content-based-routing.adoc
@@ -188,10 +188,16 @@ Other languages use different methods to express the same condition.
 
 [TIP]
 ====
-The {prodname} MongoDB connector emits the `after` and `patch` fields as serialized JSON documents rather than as structures.
-To use the ContentBasedRouting SMT with the MongoDB connector, you must first unwind the fields by applying the xref:{link-mongodb-event-flattening}[`ExtractNewDocumentState`] SMT.
+The {prodname} MongoDB connector emits the `after` and `patch` fields as serialized JSON documents rather than as structures. +
+To use the ContentBasedRouting SMT with the MongoDB connector, you must first unwind the array fields in the JSON into separate documents. +
+ifdef::community[]
+You can do this by applying the {link-prefix}:{link-mongodb-event-flattening}#new-record-state-extraction[MongoDB `ExtractNewDocumentState`] SMT.
 
-You could also take the approach of using a JSON parser within the expression.
+You could also take the approach of using a JSON parser within an expression to generate separate output documents for each array item. +
+endif::community[]
+ifdef::product[]
+You can use a JSON parser within an expression to generate separate output documents for each array item.
+endif::product[]
 For example, if you use Groovy as the expression language, add the `groovy-json` artifact to the classpath, and then add an expression such as `(new groovy.json.JsonSlurper()).parseText(value.after).last_name == 'Kretchmar'`.
 ====
 

--- a/documentation/modules/ROOT/pages/transformations/filtering.adoc
+++ b/documentation/modules/ROOT/pages/transformations/filtering.adoc
@@ -182,10 +182,16 @@ Other languages use different methods to express the same condition.
 
 [TIP]
 ====
-The {prodname} MongoDB connector emits the `after` and `patch` fields as serialized JSON documents rather than as structures.
-To use the filter SMT with the MongoDB connector, you must first unwind the fields by applying the xref:{link-mongodb-event-flattening}[`ExtractNewDocumentState`] SMT.
+The {prodname} MongoDB connector emits the `after` and `patch` fields as serialized JSON documents rather than as structures. +
+To use the filter SMT with the MongoDB connector, you must first unwind the array fields in the JSON into separate documents. +
+ifdef::community[]
+You can do this by applying the {link-prefix}:{link-mongodb-event-flattening}#new-record-state-extraction[MongoDB `ExtractNewDocumentState`] SMT.
 
-You could also take the approach of using a JSON parser within the expression.
+You could also take the approach of using a JSON parser within an expression to generate separate output documents for each array item. +
+endif::community[]
+ifdef::product[]
+You can use a JSON parser within an expression to generate separate output documents for each array item.
+endif::product[]
 For example, if you use Groovy as the expression language, add the `groovy-json` artifact to the classpath, and then add an expression such as `(new groovy.json.JsonSlurper()).parseText(value.after).last_name == 'Kretchmar'`.
 ====
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
@@ -1,22 +1,3 @@
-ifdef::community[]
-[NOTE]
-====
-This feature is currently in incubating state, i.e. exact semantics, configuration options etc. may change in future revisions, based on the feedback we receive.
-Please let us know if you encounter any problems while using this extension.
-====
-endif::community[]
-
-ifdef::product[]
-[IMPORTANT]
-====
-The use of ad hoc snapshots is a Technology Preview feature.
-Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
-therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
-This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
-For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
-====
-endif::product[]
-
 By default, a connector runs an initial snapshot operation only after it starts for the first time.
 Following this initial snapshot, under normal circumstances, the connector does not repeat the snapshot process.
 Any future change event data that the connector captures comes in through the streaming process only.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
@@ -17,7 +17,7 @@ This phased approach to capturing data provides the following advantages over th
 * If the progress of an incremental snapshot is interrupted, you can resume it without losing any data.
   After the process resumes, the snapshot begins at the point where it stopped, rather than recapturing the {data-collection} from the beginning.
 * You can run an incremental snapshot on demand at any time, and repeat the process as needed to adapt to database updates.
-  For example, you might re-run a snapshot after you modify the connector configuration to add a {data-collection} to its xref:{context}-property-table-include-list[`table.include.list`] property.
+  For example, you might re-run a snapshot after you modify the connector configuration to add a {data-collection} to its xref:{context}-property-table-include-list[`{data-collection}.include.list`] property.
 
 .Incremental snapshot process
 When you run an incremental snapshot, {prodname} sorts each {data-collection} by primary key and then splits the {data-collection} into chunks based on the xref:{context}-property-incremental-snapshot-chunk-size[configured chunk size].

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
@@ -17,7 +17,7 @@ This phased approach to capturing data provides the following advantages over th
 * If the progress of an incremental snapshot is interrupted, you can resume it without losing any data.
   After the process resumes, the snapshot begins at the point where it stopped, rather than recapturing the {data-collection} from the beginning.
 * You can run an incremental snapshot on demand at any time, and repeat the process as needed to adapt to database updates.
-  For example, you might re-run a snapshot after you modify the connector configuration to add a {data-collection} to its xref:{context}-property-table-include-list[`{data-collection}.include.list`] property.
+  For example, you might re-run a snapshot after you modify the connector configuration to add a {data-collection} to its xref:{context}-property-{data-collection}-include-list[`{data-collection}.include.list`] property.
 
 .Incremental snapshot process
 When you run an incremental snapshot, {prodname} sorts each {data-collection} by primary key and then splits the {data-collection} into chunks based on the xref:{context}-property-incremental-snapshot-chunk-size[configured chunk size].

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
@@ -1,22 +1,3 @@
-ifdef::community[]
-[NOTE]
-====
-This feature is currently in incubating state. The exact semantics, configuration options, and so forth is subject to change in future revisions, based on the feedback we receive.
-Please let us know if you encounter any problems while using this extension.
-====
-endif::community[]
-
-ifdef::product[]
-[IMPORTANT]
-====
-The use of incremental snapshots is a Technology Preview feature.
-Technology Preview features are not supported with Red Hat production service-level agreements (SLAs) and might not be functionally complete;
-therefore, Red Hat does not recommend implementing any Technology Preview features in production environments.
-This Technology Preview feature provides early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.
-For more information about support scope, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
-====
-endif::product[]
-
 To provide flexibility in managing snapshots, {prodname} includes a supplementary snapshot mechanism, known as _incremental snapshotting_.
 Incremental snapshots rely on the {prodname} mechanism for xref:{link-signalling}#sending-signals-to-a-debezium-connector[sending signals to a {prodname} connector].
 ifdef::community[]


### PR DESCRIPTION
[DBZ-4655](https://issues.redhat.com/browse/DBZ-4655)

This change updates connector files, shared files, and signaling files to:

-  Remove incubating/TP designations for signaling and ad hoc/incremental snapshots features. 
-  Remove filter condition that prevents MongoDB incremental snapshots topic from being exposed downstream. 

@jpechane: 
-  TBD: Should incremental snapshots be designated as TP for MongoDB? 
- Should the MongoDB connector properties table include entries for:
-- incremental.snapshot.chunk.size -- Modify the description to refer to max # documents vs. rows?
-- signal.data.collection

Tested in local Antora build.


I based the branch for this change on `main`. 
Please backport the change to 1.9.