### PR TITLE
DBZ-4821 Added run.bat to debezium-server-dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,6 +19,9 @@
 *.groovy text
 *.css text
 
+# Specify CRLF for batch files 
+*.bat text eol=crlf
+
 # Specify we want Java-friendly readable chunk headers for diff:
 
 *.java	diff=java

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -72,6 +72,7 @@ Claus Guttesen
 Cliff Wheadon
 Collin Van Dyck
 Cory Harper
+Cyprien Etienne
 Cyril Scetbon
 Daan Roosen
 Daniel Petisme

--- a/debezium-server/debezium-server-dist/src/main/resources/distro/run.bat
+++ b/debezium-server/debezium-server-dist/src/main/resources/distro/run.bat
@@ -1,0 +1,7 @@
+
+SET PATH_SEP=;
+SET JAVA_BINARY=%JAVA_HOME%\bin\java
+
+for %%i in (debezium-server-*runner.jar) do set RUNNER=%%~i
+echo %RUNNER%
+call "%JAVA_BINARY%" %DEBEZIUM_OPTS% %JAVA_OPTS% -cp %RUNNER%%PATH_SEP%conf%PATH_SEP%lib\* io.debezium.server.Main


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4821

The current run.sh is not working if the path to Java has spaces in it. Also the file separator is not the right one in lib/*.