### PR TITLE
DBZ-4014 Warns users not to modify database.server.name

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2013,7 +2013,15 @@ The following configuration properties are _required_ unless a default value is 
 
 |[[db2-property-database-server-name]]<<db2-property-database-server-name, `+database.server.name+`>>
 |No default
-|Logical name that identifies and provides a namespace for the particular Db2 database server that hosts the database for which {prodname} is capturing changes. Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name. The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
+|Logical name that identifies and provides a namespace for the particular Db2 database server that hosts the database for which {prodname} is capturing changes.
+Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name.
+The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector. +
+ +
+[WARNING]
+====
+Changing the value of this property disrupts connector operations.
+All stored offsets are flushed and the connector must re-consume all of the source data.
+====
 
 |[[db2-property-table-include-list]]<<db2-property-table-include-list, `+table.include.list+`>>
 |No default

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2016,11 +2016,12 @@ The following configuration properties are _required_ unless a default value is 
 |Logical name that identifies and provides a namespace for the particular Db2 database server that hosts the database for which {prodname} is capturing changes.
 Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name.
 The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
- +
++
 [WARNING]
 ====
-Changing the value of this property disrupts connector operations.
-All stored offsets are flushed and the connector must re-consume all of the source data.
+Do not change the value of this property.
+If you change the name value, after a restart, instead of continuing to emit events to the original topics, the connector emits subsequent events to topics whose names are based on the new value.
+The connector is also unable to recover its database history topic.
 ====
 
 |[[db2-property-table-include-list]]<<db2-property-table-include-list, `+table.include.list+`>>

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2015,7 +2015,7 @@ The following configuration properties are _required_ unless a default value is 
 |No default
 |Logical name that identifies and provides a namespace for the particular Db2 database server that hosts the database for which {prodname} is capturing changes.
 Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name.
-The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector. +
+The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
  +
 [WARNING]
 ====

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1381,8 +1381,16 @@ The following configuration properties are _required_ unless a default value is 
 
 |[[mongodb-property-mongodb-name]]<<mongodb-property-mongodb-name, `+mongodb.name+`>>
 |
-|A unique name that identifies the connector and/or MongoDB replica set or sharded cluster that this connector monitors. Each server should be monitored by at most one {prodname} connector, since this server name prefixes all persisted Kafka topics emanating from the MongoDB replica set or cluster.
-Only alphanumeric characters, hyphens, dots and underscores must be used.
+|A unique name that identifies the connector and/or MongoDB replica set or sharded cluster that this connector monitors.
+Each server should be monitored by at most one {prodname} connector, since this server name prefixes all persisted Kafka topics emanating from the MongoDB replica set or cluster.
+Use only alphanumeric characters, hyphens, dots and underscores to form the name.
+The logical name should be unique across all other connectors, because the name is used as the prefix in naming the Kafka topics that receive records from this connector.
++
+[WARNING]
+====
+Do not change the value of this property.
+If you change the name value, after a restart, instead of continuing to emit events to the original topics, the connector emits subsequent events to topics whose names are based on the new value.
+====
 
 |[[mongodb-property-mongodb-user]]<<mongodb-property-mongodb-user, `+mongodb.user+`>>
 |

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2339,11 +2339,12 @@ The following configuration properties are _required_ unless a default value is 
 |No default
 |Logical name that identifies and provides a namespace for the particular MySQL database server/cluster in which {prodname} is capturing changes. The logical name should be unique across all other connectors, since it is used as a prefix for all Kafka topic names that receive events emitted by this connector.
 Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name. +
- +
++
 [WARNING]
 ====
-Changing the value of this property disrupts connector operations.
-All stored offsets are flushed and the connector must re-consume all of the source data.
+Do not change the value of this property.
+If you change the name value, after a restart, instead of continuing to emit events to the original topics, the connector emits subsequent events to topics whose names are based on the new value.
+The connector is also unable to recover its database history topic.
 ====
 
 |[[mysql-property-database-server-id]]<<mysql-property-database-server-id, `+database.server.id+`>>

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2338,7 +2338,13 @@ The following configuration properties are _required_ unless a default value is 
 |[[mysql-property-database-server-name]]<<mysql-property-database-server-name, `+database.server.name+`>>
 |No default
 |Logical name that identifies and provides a namespace for the particular MySQL database server/cluster in which {prodname} is capturing changes. The logical name should be unique across all other connectors, since it is used as a prefix for all Kafka topic names that receive events emitted by this connector.
-Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name.
+Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name. +
+ +
+[WARNING]
+====
+Changing the value of this property disrupts connector operations.
+All stored offsets are flushed and the connector must re-consume all of the source data.
+====
 
 |[[mysql-property-database-server-id]]<<mysql-property-database-server-id, `+database.server.id+`>>
 |_random_

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2376,14 +2376,13 @@ endif::product[]
 |Logical name that identifies and provides a namespace for the Oracle database server from which the connector captures changes.
 The value that you set is used as a prefix for all Kafka topic names that the connector emits.
 Specify a logical name that is unique among all connectors in your {prodname} environment.
-The following characters are valid: alphanumeric characters, hyphens, dots, and underscores. +
+The following characters are valid: alphanumeric characters, hyphens, dots, and underscores.
  +
 [WARNING]
 ====
 Changing the value of this property disrupts connector operations.
 All stored offsets are flushed and the connector must re-consume all of the source data.
 ====
-
 
 |[[oracle-property-database-connection-adapter]]<<oracle-property-database-connection-adapter, `+database.connection.adapter+`>>
 |`logminer`

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2376,7 +2376,14 @@ endif::product[]
 |Logical name that identifies and provides a namespace for the Oracle database server from which the connector captures changes.
 The value that you set is used as a prefix for all Kafka topic names that the connector emits.
 Specify a logical name that is unique among all connectors in your {prodname} environment.
-The following characters are valid: alphanumeric characters, hyphens, dots, and underscores.
+The following characters are valid: alphanumeric characters, hyphens, dots, and underscores. +
+ +
+[WARNING]
+====
+Changing the value of this property disrupts connector operations.
+All stored offsets are flushed and the connector must re-consume all of the source data.
+====
+
 
 |[[oracle-property-database-connection-adapter]]<<oracle-property-database-connection-adapter, `+database.connection.adapter+`>>
 |`logminer`

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2377,11 +2377,12 @@ endif::product[]
 The value that you set is used as a prefix for all Kafka topic names that the connector emits.
 Specify a logical name that is unique among all connectors in your {prodname} environment.
 The following characters are valid: alphanumeric characters, hyphens, dots, and underscores.
- +
++
 [WARNING]
 ====
-Changing the value of this property disrupts connector operations.
-All stored offsets are flushed and the connector must re-consume all of the source data.
+Do not change the value of this property.
+If you change the name value, after a restart, instead of continuing to emit events to the original topics, the connector emits subsequent events to topics whose names are based on the new value.
+The connector is also unable to recover its database history topic.
 ====
 
 |[[oracle-property-database-connection-adapter]]<<oracle-property-database-connection-adapter, `+database.connection.adapter+`>>

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2662,7 +2662,7 @@ If the publication already exists, either for all tables or configured with a su
 |No default
 |Logical name that identifies and provides a namespace for the particular PostgreSQL database server or cluster in which {prodname} is capturing changes.
 The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
-Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name. +
+Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name.
  +
 [WARNING]
 ====

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2663,11 +2663,11 @@ If the publication already exists, either for all tables or configured with a su
 |Logical name that identifies and provides a namespace for the particular PostgreSQL database server or cluster in which {prodname} is capturing changes.
 The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
 Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name.
- +
++
 [WARNING]
 ====
-Changing the value of this property disrupts connector operations.
-All stored offsets are flushed and the connector must re-consume all of the source data.
+Do not change the value of this property.
+If you change the name value, after a restart, instead of continuing to emit events to the original topics, the connector emits subsequent events to topics whose names are based on the new value.
 ====
 
 |[[postgresql-property-schema-include-list]]<<postgresql-property-schema-include-list, `+schema.include.list+`>>

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2660,7 +2660,15 @@ If the publication already exists, either for all tables or configured with a su
 
 |[[postgresql-property-database-server-name]]<<postgresql-property-database-server-name, `+database.server.name+`>>
 |No default
-|Logical name that identifies and provides a namespace for the particular PostgreSQL database server or cluster in which {prodname} is capturing changes. Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name. The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
+|Logical name that identifies and provides a namespace for the particular PostgreSQL database server or cluster in which {prodname} is capturing changes.
+The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
+Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name. +
+ +
+[WARNING]
+====
+Changing the value of this property disrupts connector operations.
+All stored offsets are flushed and the connector must re-consume all of the source data.
+====
 
 |[[postgresql-property-schema-include-list]]<<postgresql-property-schema-include-list, `+schema.include.list+`>>
 |No default

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2077,8 +2077,16 @@ incompatible with the default configuration with no upgrade or downgrade path:
 
 |[[sqlserver-property-database-server-name]]<<sqlserver-property-database-server-name, `+database.server.name+`>>
 |No default
-|Logical name that identifies and provides a namespace for the SQL Server database server that you want {prodname} to capture. The logical name should be unique across all other connectors, since it is used as a prefix for all Kafka topic names emanating from this connector.
-Only alphanumeric characters, hyphens, dots and underscores must be used.
+|Logical name that identifies and provides a namespace for the SQL Server database server that you want {prodname} to capture.
+The logical name should be unique across all other connectors, since it is used as the prefix for all Kafka topic names that receive records from this connector.
+Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name.
+ +
+[WARNING]
+====
+Changing the value of this property disrupts connector operations.
+All stored offsets are flushed and the connector must re-consume all of the source data.
+====
+
 
 |[[sqlserver-property-table-include-list]]<<sqlserver-property-table-include-list, `+table.include.list+`>>
 |No default

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2080,11 +2080,12 @@ incompatible with the default configuration with no upgrade or downgrade path:
 |Logical name that identifies and provides a namespace for the SQL Server database server that you want {prodname} to capture.
 The logical name should be unique across all other connectors, since it is used as the prefix for all Kafka topic names that receive records from this connector.
 Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name.
- +
++
 [WARNING]
 ====
-Changing the value of this property disrupts connector operations.
-All stored offsets are flushed and the connector must re-consume all of the source data.
+Do not change the value of this property.
+If you change the name value, after a restart, instead of continuing to emit events to the original topics, the connector emits subsequent events to topics whose names are based on the new value.
+The connector is also unable to recover its database history topic.
 ====
 
 

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -908,7 +908,7 @@ a|_n/a_
 [[setting-up-vitess]]
 == Seting up Vitess
 
-{prodname} does not require any specific configuration for use with Vitess. Install Vitess according to the standard instructions in the link:https://vitess.io/docs/get-started/local-docker/[Local Install via Docker] guide, or the link:https://vitess.io/docs/get-started/operator/[Vitess Operator for Kubernetes] guide. 
+{prodname} does not require any specific configuration for use with Vitess. Install Vitess according to the standard instructions in the link:https://vitess.io/docs/get-started/local-docker/[Local Install via Docker] guide, or the link:https://vitess.io/docs/get-started/operator/[Vitess Operator for Kubernetes] guide.
 
 .Checklist
 
@@ -1161,7 +1161,15 @@ If set to `true`, you should also consider setting `vitess.gtid` in the configur
 
 |[[vitess-property-database-server-name]]<<vitess-property-database-server-name, `+database.server.name+`>>
 |
-|Logical name that identifies and provides a namespace for the particular Vitess database server or cluster in which {prodname} is capturing changes. Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name. The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
+|Logical name that identifies and provides a namespace for the particular Vitess database server or cluster in which {prodname} is capturing changes.
+Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name.
+The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector. +
+ +
+[WARNING]
+====
+Changing the value of this property disrupts connector operations.
+All stored offsets are flushed and the connector must re-consume all of the source data.
+====
 
 |[[vitess-property-table-include-list]]<<vitess-property-table-include-list, `+table.include.list+`>>
 |

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -1164,11 +1164,11 @@ If set to `true`, you should also consider setting `vitess.gtid` in the configur
 |Logical name that identifies and provides a namespace for the particular Vitess database server or cluster in which {prodname} is capturing changes.
 Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name.
 The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
- +
++
 [WARNING]
 ====
-Changing the value of this property disrupts connector operations.
-All stored offsets are flushed and the connector must re-consume all of the source data.
+Do not change the value of this property.
+If you change the name value, after a restart, instead of continuing to emit events to the original topics, the connector emits subsequent events to topics whose names are based on the new value.
 ====
 
 |[[vitess-property-table-include-list]]<<vitess-property-table-include-list, `+table.include.list+`>>

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -1163,7 +1163,7 @@ If set to `true`, you should also consider setting `vitess.gtid` in the configur
 |
 |Logical name that identifies and provides a namespace for the particular Vitess database server or cluster in which {prodname} is capturing changes.
 Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name.
-The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector. +
+The logical name should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
  +
 [WARNING]
 ====


### PR DESCRIPTION
[DBZ-4014](https://issues.redhat.com/browse/DBZ-4014)

Adds admonition to description of `database.server.name` property for all connectors, warning users that changing the value disrupts connector operations.

Tested in local Antora build. 

Need clarification of whether property is intentionally omitted for MongoDB connector. 

