### PR TITLE
DBZ-4787 Skip some tests with SSL auth enabled

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlParserIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlParserIT.java
@@ -11,7 +11,9 @@ import java.sql.SQLException;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.BindMode;
@@ -21,6 +23,8 @@ import org.testcontainers.utility.DockerImageName;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.junit.SkipTestDependingOnSslModeRule;
+import io.debezium.connector.mysql.junit.SkipWhenSslModeIsNot;
 import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
@@ -30,39 +34,35 @@ import io.debezium.util.Testing;
 /**
  * Integration test for {@link MySqlConnector} using Testcontainers infrastructure for testing column constraints supported in MySQL 8.0.x.
  */
-
+@SkipWhenSslModeIsNot(value = MySqlConnectorConfig.SecureConnectionMode.DISABLED, reason = "Only running with ssl disabled mode")
 public class MySqlParserIT extends AbstractConnectorTest {
 
+    @Rule
+    public TestRule skipTestRule = new SkipTestDependingOnSslModeRule();
+
     private static final Logger LOGGER = LoggerFactory.getLogger(MySqlParserIT.class);
-
-    private static final String MYSQL_IMAGE = ContainerImageVersions.getStableImage("debezium/example-mysql");
-
-    private static final DockerImageName MYSQL_DOCKER_IMAGE_NAME = DockerImageName.parse(MYSQL_IMAGE)
-            .asCompatibleSubstituteFor("mysql");
-
     private static final String DB_NAME = "inventory";
 
-    private static final MySQLContainer<?> mySQLContainer = new MySQLContainer<>(MYSQL_DOCKER_IMAGE_NAME)
-            .withDatabaseName("mysql")
-            .withUsername("mysqluser")
-            .withPassword("mysql")
-            .withClasspathResourceMapping("/docker/conf/mysql.cnf", "/etc/mysql/conf.d/", BindMode.READ_ONLY)
-            .withLogConsumer(new Slf4jLogConsumer(LOGGER))
-            .withExposedPorts(3306)
-            .withNetworkAliases("mysql");
-
+    private MySQLContainer<?> mySQLContainer;
     private Configuration config;
     private String oldContainerPort;
-    private String oldSslMode;
 
     @Before
     public void beforeEach() {
+        String mysqlImage = ContainerImageVersions.getStableImage("debezium/example-mysql");
+        DockerImageName mysqlDockerImageName = DockerImageName.parse(mysqlImage).asCompatibleSubstituteFor("mysql");
+        mySQLContainer = new MySQLContainer<>(mysqlDockerImageName)
+                .withDatabaseName("mysql")
+                .withUsername("mysqluser")
+                .withPassword("mysql")
+                .withClasspathResourceMapping("/docker/conf/mysql.cnf", "/etc/mysql/conf.d/", BindMode.READ_ONLY)
+                .withLogConsumer(new Slf4jLogConsumer(LOGGER))
+                .withExposedPorts(3306)
+                .withNetworkAliases("mysql");
         mySQLContainer.start();
         oldContainerPort = System.getProperty("database.port", "3306");
-        oldSslMode = System.getProperty("database.ssl.mode", "disabled");
 
         System.setProperty("database.port", String.valueOf(mySQLContainer.getMappedPort(3306)));
-        System.setProperty("database.ssl.mode", "disabled");
         initializeConnectorTestFramework();
     }
 
@@ -71,7 +71,6 @@ public class MySqlParserIT extends AbstractConnectorTest {
         stopConnector();
         mySQLContainer.stop();
         System.setProperty("database.port", oldContainerPort);
-        System.setProperty("database.ssl.mode", oldSslMode);
     }
 
     public Configuration.Builder defaultConfig() {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/junit/SkipTestDependingOnSslModeRule.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/junit/SkipTestDependingOnSslModeRule.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.junit;
+
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import io.debezium.junit.AnnotationBasedTestRule;
+
+/**
+ * JUnit rule that skips a test based on the {@link SkipWhenSslModeIsNot} annotation on either a test method or a test class.
+ */
+public class SkipTestDependingOnSslModeRule extends AnnotationBasedTestRule {
+    private static final String CURRENT_SSL_MODE = System.getProperty("database.ssl.mode", "disabled");
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        SkipWhenSslModeIsNot skipSslMode = hasAnnotation(description, SkipWhenSslModeIsNot.class);
+        if (skipSslMode != null && !skipSslMode.value().name().equalsIgnoreCase(CURRENT_SSL_MODE)) {
+            String reasonForSkipping = "Current SSL_MODE is " + CURRENT_SSL_MODE + System.lineSeparator() + skipSslMode.reason();
+            return emptyStatement(reasonForSkipping, description);
+        }
+        return base;
+    }
+}

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/junit/SkipWhenSslModeIsNot.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/junit/SkipWhenSslModeIsNot.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+
+/**
+ * Marker annotation used together with the {@link SkipTestDependingOnSslModeRule} JUnit rule, that allows
+ * tests to be skipped based on the SSL mode set by system env used for testing
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+public @interface SkipWhenSslModeIsNot {
+
+    MySqlConnectorConfig.SecureConnectionMode value();
+
+    /**
+     * Returns the reason why the test should be skipped.
+     */
+    String reason() default "";
+}


### PR DESCRIPTION
I implement the SkipWhenSslModeIsNot annotation and SkipTestDependingOnSslModeRule rule to skip MySqlParserIT test when ssl is not enabled mode.