### PR TITLE
DBZ-3535: Introduce schema.name.adjustment.mode

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/LegacyV1MongoDbSourceInfoStructMaker.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/LegacyV1MongoDbSourceInfoStructMaker.java
@@ -21,7 +21,7 @@ public class LegacyV1MongoDbSourceInfoStructMaker extends LegacyV1AbstractSource
     public LegacyV1MongoDbSourceInfoStructMaker(String connector, String version, CommonConnectorConfig connectorConfig) {
         super(connector, version, connectorConfig);
         schema = commonSchemaBuilder()
-                .name(SchemaNameAdjuster.defaultAdjuster().adjust("io.debezium.connector.mongo.Source"))
+                .name(SchemaNameAdjuster.avroAdjuster().adjust("io.debezium.connector.mongo.Source"))
                 .version(SourceInfo.SCHEMA_VERSION)
                 .field(SourceInfo.SERVER_NAME_KEY, Schema.STRING_SCHEMA)
                 .field(SourceInfo.REPLICA_SET_NAME, Schema.STRING_SCHEMA)

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -614,7 +614,8 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
             .connector(
                     MAX_COPY_THREADS,
                     SNAPSHOT_MODE,
-                    CAPTURE_MODE)
+                    CAPTURE_MODE,
+                    SCHEMA_NAME_ADJUSTMENT_MODE)
             .create();
 
     /**

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
@@ -71,13 +71,13 @@ public final class MongoDbConnectorTask extends BaseSourceTask<MongoDbPartition,
     @Override
     public ChangeEventSourceCoordinator<MongoDbPartition, MongoDbOffsetContext> start(Configuration config) {
         final MongoDbConnectorConfig connectorConfig = new MongoDbConnectorConfig(config);
-        final SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create();
+        final SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjustmentMode().createAdjuster();
 
         this.taskName = "task" + config.getInteger(MongoDbConnectorConfig.TASK_ID);
         this.taskContext = new MongoDbTaskContext(config);
 
         final Schema structSchema = connectorConfig.getSourceInfoStructMaker().schema();
-        this.schema = new MongoDbSchema(taskContext.filters(), taskContext.topicSelector(), structSchema);
+        this.schema = new MongoDbSchema(taskContext.filters(), taskContext.topicSelector(), structSchema, schemaNameAdjuster);
 
         final ReplicaSets replicaSets = getReplicaSets(config);
         final MongoDbOffsetContext previousOffset = getPreviousOffset(connectorConfig, replicaSets);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSchema.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSchema.java
@@ -55,14 +55,16 @@ public class MongoDbSchema implements DatabaseSchema<CollectionId> {
     private final Filters filters;
     private final TopicSelector<CollectionId> topicSelector;
     private final Schema sourceSchema;
-    private final SchemaNameAdjuster adjuster = SchemaNameAdjuster.create();
+    private final SchemaNameAdjuster adjuster;
     private final ConcurrentMap<CollectionId, MongoDbCollectionSchema> collections = new ConcurrentHashMap<>();
     private final JsonSerialization serialization = new JsonSerialization();
 
-    public MongoDbSchema(Filters filters, TopicSelector<CollectionId> topicSelector, Schema sourceSchema) {
+    public MongoDbSchema(Filters filters, TopicSelector<CollectionId> topicSelector, Schema sourceSchema,
+                         SchemaNameAdjuster schemaNameAdjuster) {
         this.filters = filters;
         this.topicSelector = topicSelector;
         this.sourceSchema = sourceSchema;
+        this.adjuster = schemaNameAdjuster;
     }
 
     @Override

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSourceInfoStructMaker.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSourceInfoStructMaker.java
@@ -10,7 +10,6 @@ import org.apache.kafka.connect.data.Struct;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.connector.AbstractSourceInfoStructMaker;
-import io.debezium.util.SchemaNameAdjuster;
 
 public class MongoDbSourceInfoStructMaker extends AbstractSourceInfoStructMaker<SourceInfo> {
 
@@ -19,7 +18,7 @@ public class MongoDbSourceInfoStructMaker extends AbstractSourceInfoStructMaker<
     public MongoDbSourceInfoStructMaker(String connector, String version, CommonConnectorConfig connectorConfig) {
         super(connector, version, connectorConfig);
         schema = commonSchemaBuilder()
-                .name(SchemaNameAdjuster.defaultAdjuster().adjust("io.debezium.connector.mongo.Source"))
+                .name(connectorConfig.schemaNameAdjustmentMode().createAdjuster().adjust("io.debezium.connector.mongo.Source"))
                 .field(SourceInfo.REPLICA_SET_NAME, Schema.STRING_SCHEMA)
                 .field(SourceInfo.COLLECTION, Schema.STRING_SCHEMA)
                 .field(SourceInfo.ORDER, Schema.INT32_SCHEMA)

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbSchemaIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbSchemaIT.java
@@ -44,6 +44,8 @@ public class MongoDbSchemaIT {
 
     private static MongoDbSchema getSchema(Configuration config, MongoDbTaskContext taskContext) {
         final MongoDbConnectorConfig connectorConfig = new MongoDbConnectorConfig(config);
-        return new MongoDbSchema(taskContext.filters(), taskContext.topicSelector(), connectorConfig.getSourceInfoStructMaker().schema());
+        return new MongoDbSchema(taskContext.filters(), taskContext.topicSelector(),
+                connectorConfig.getSourceInfoStructMaker().schema(),
+                connectorConfig.schemaNameAdjustmentMode().createAdjuster());
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -987,6 +987,7 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
                     TIME_PRECISION_MODE,
                     ENABLE_TIME_ADJUSTER,
                     BINARY_HANDLING_MODE,
+                    SCHEMA_NAME_ADJUSTMENT_MODE,
                     ROW_COUNT_FOR_STREAMING_RESULT_SETS,
                     INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
                     INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES)

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -68,7 +68,7 @@ public class MySqlConnectorTask extends BaseSourceTask<MySqlPartition, MySqlOffs
                         .with(AbstractDatabaseHistory.INTERNAL_PREFER_DDL, true)
                         .build());
         final TopicSelector<TableId> topicSelector = MySqlTopicSelector.defaultSelector(connectorConfig);
-        final SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create();
+        final SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjustmentMode().createAdjuster();
         final MySqlValueConverters valueConverters = getValueConverters(connectorConfig);
 
         // DBZ-3238: automatically set "useCursorFetch" to true when a snapshot fetch size other than the default of -1 is given
@@ -159,7 +159,7 @@ public class MySqlConnectorTask extends BaseSourceTask<MySqlPartition, MySqlOffs
                             default:
                                 break;
                         }
-                    });
+                    }, schemaNameAdjuster);
         }
 
         final EventDispatcher<MySqlPartition, TableId> dispatcher = new EventDispatcher<>(
@@ -172,8 +172,7 @@ public class MySqlConnectorTask extends BaseSourceTask<MySqlPartition, MySqlOffs
                 null,
                 metadataProvider,
                 heartbeat,
-                schemaNameAdjuster
-        );
+                schemaNameAdjuster);
 
         final MySqlStreamingChangeEventSourceMetrics streamingMetrics = new MySqlStreamingChangeEventSourceMetrics(taskContext, queue, metadataProvider);
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -172,8 +172,8 @@ public class MySqlConnectorTask extends BaseSourceTask<MySqlPartition, MySqlOffs
                 null,
                 metadataProvider,
                 heartbeat,
-                schemaNameAdjuster,
-                connection);
+                schemaNameAdjuster
+        );
 
         final MySqlStreamingChangeEventSourceMetrics streamingMetrics = new MySqlStreamingChangeEventSourceMetrics(taskContext, queue, metadataProvider);
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/BinlogReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/BinlogReader.java
@@ -86,6 +86,7 @@ import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
 import io.debezium.util.ElapsedTimeStrategy;
 import io.debezium.util.Metronome;
+import io.debezium.util.SchemaNameAdjuster;
 import io.debezium.util.Strings;
 import io.debezium.util.Threads;
 
@@ -317,7 +318,8 @@ public class BinlogReader extends AbstractReader {
         // Set up for JMX ...
         metrics = new BinlogReaderMetrics(client, context, name, changeEventQueueMetrics);
         heartbeat = Heartbeat.create(context.getConnectorConfig().getHeartbeatInterval(),
-                context.topicSelector().getHeartbeatTopic(), context.getConnectorConfig().getLogicalName());
+                context.topicSelector().getHeartbeatTopic(), context.getConnectorConfig().getLogicalName(),
+                SchemaNameAdjuster.create());
     }
 
     @Override

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SnapshotReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/legacy/SnapshotReader.java
@@ -51,6 +51,7 @@ import io.debezium.relational.Column;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
+import io.debezium.util.SchemaNameAdjuster;
 import io.debezium.util.Strings;
 import io.debezium.util.Threads;
 
@@ -741,7 +742,8 @@ public class SnapshotReader extends AbstractReader {
                             .create(
                                     context.getConnectorConfig().getHeartbeatInterval(),
                                     context.topicSelector().getHeartbeatTopic(),
-                                    context.getConnectorConfig().getLogicalName())
+                                    context.getConnectorConfig().getLogicalName(),
+                                    SchemaNameAdjuster.create())
                             .forcedBeat(source.partition(), source.offset(), this::enqueueRecord);
                 }
                 finally {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -79,7 +79,7 @@ public class MySqlAntlrDdlParserTest {
         tableSchemaBuilder = new TableSchemaBuilder(
                 converters,
                 new MySqlDefaultValueConverter(converters),
-                SchemaNameAdjuster.create(), new CustomConverterRegistry(null), SchemaBuilder.struct().build(), false, false);
+                SchemaNameAdjuster.NO_OP, new CustomConverterRegistry(null), SchemaBuilder.struct().build(), false, false);
     }
 
     @Test

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDefaultValueTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDefaultValueTest.java
@@ -57,7 +57,7 @@ public class MySqlDefaultValueTest {
         tableSchemaBuilder = new TableSchemaBuilder(
                 converters,
                 new MySqlDefaultValueConverter(converters),
-                SchemaNameAdjuster.create(), new CustomConverterRegistry(null), SchemaBuilder.struct().build(), false, false);
+                SchemaNameAdjuster.NO_OP, new CustomConverterRegistry(null), SchemaBuilder.struct().build(), false, false);
 
     }
 
@@ -195,7 +195,7 @@ public class MySqlDefaultValueTest {
         final TableSchemaBuilder tableSchemaBuilder = new TableSchemaBuilder(
                 converters,
                 new MySqlDefaultValueConverter(converters),
-                SchemaNameAdjuster.create(), new CustomConverterRegistry(null), SchemaBuilder.struct().build(), false, false);
+                SchemaNameAdjuster.NO_OP, new CustomConverterRegistry(null), SchemaBuilder.struct().build(), false, false);
 
         String sql = "CREATE TABLE UNSIGNED_BIGINT_TABLE (\n" +
                 "  A BIGINT UNSIGNED NULL DEFAULT 0,\n" +
@@ -352,7 +352,7 @@ public class MySqlDefaultValueTest {
         final TableSchemaBuilder tableSchemaBuilder = new TableSchemaBuilder(
                 converters,
                 new MySqlDefaultValueConverter(converters),
-                SchemaNameAdjuster.create(), new CustomConverterRegistry(null), SchemaBuilder.struct().build(), false, false);
+                SchemaNameAdjuster.NO_OP, new CustomConverterRegistry(null), SchemaBuilder.struct().build(), false, false);
         String sql = "CREATE TABLE NUMERIC_DECIMAL_TABLE (\n" +
                 "  A NUMERIC NOT NULL DEFAULT 1.23,\n" +
                 "  B DECIMAL(5,3) NOT NULL DEFAULT 2.321,\n" +

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSchemaNameAdjustmentModeIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSchemaNameAdjustmentModeIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assume.assumeFalse;
+
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.fest.assertions.Assertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.CommonConnectorConfig.SchemaNameAdjustmentMode;
+import io.debezium.config.Configuration;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.util.Testing;
+
+public class MySqlSchemaNameAdjustmentModeIT extends AbstractConnectorTest {
+
+    private static final Path DB_HISTORY_PATH = Testing.Files.createTestingPath("file-db-history-json.txt")
+            .toAbsolutePath();
+    private final UniqueDatabase DATABASE = new UniqueDatabase("adjustment1", "schema_name_adjustment")
+            .withDbHistoryPath(DB_HISTORY_PATH);
+
+    @Before
+    public void beforeEach() throws SQLException {
+        stopConnector();
+        DATABASE.createAndInitialize();
+
+        initializeConnectorTestFramework();
+        Testing.Files.delete(DB_HISTORY_PATH);
+    }
+
+    @After
+    public void afterEach() {
+        try {
+            stopConnector();
+        }
+        finally {
+            Testing.Files.delete(DB_HISTORY_PATH);
+        }
+    }
+
+    @Test
+    public void shouldAdjustNamesForAvro() throws InterruptedException {
+        Struct data = consume(SchemaNameAdjustmentMode.AVRO);
+
+        assertThat(data.schema().name()).contains("name_adjustment");
+    }
+
+    @Test
+    public void shouldNotAdjustNames() throws InterruptedException {
+        assumeFalse(MySqlConnector.LEGACY_IMPLEMENTATION.equals(System.getProperty(MySqlConnector.IMPLEMENTATION_PROP)));
+
+        skipAvroValidation();
+        Struct data = consume(SchemaNameAdjustmentMode.NONE);
+
+        assertThat(data.schema().name()).contains("name-adjustment");
+    }
+
+    private Struct consume(SchemaNameAdjustmentMode adjustmentMode) throws InterruptedException {
+        final Configuration config = DATABASE.defaultConfig()
+                .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.INITIAL)
+                .with(MySqlConnectorConfig.TABLE_INCLUDE_LIST, DATABASE.qualifiedTableName("name-adjustment"))
+                .with(MySqlConnectorConfig.SCHEMA_NAME_ADJUSTMENT_MODE, adjustmentMode)
+                .build();
+
+        start(MySqlConnector.class, config);
+
+        SourceRecords records = consumeRecordsByTopic(6 + 1); // 6 DDL changes, 1 INSERT
+        final List<SourceRecord> results = records.recordsForTopic(DATABASE.topicForTable("name-adjustment"));
+        Assertions.assertThat(results).hasSize(1);
+
+        return (Struct) results.get(0).value();
+    }
+}

--- a/debezium-connector-mysql/src/test/resources/ddl/schema_name_adjustment.sql
+++ b/debezium-connector-mysql/src/test/resources/ddl/schema_name_adjustment.sql
@@ -1,0 +1,2 @@
+CREATE TABLE `name-adjustment` (id INT);
+INSERT INTO `name-adjustment` (id) VALUES (1);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -509,6 +509,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     LOG_MINING_SCN_GAP_DETECTION_TIME_INTERVAL_MAX_MS,
                     UNAVAILABLE_VALUE_PLACEHOLDER,
                     BINARY_HANDLING_MODE,
+                    SCHEMA_NAME_ADJUSTMENT_MODE,
                     LOG_MINING_LOG_QUERY_MAX_RETRIES,
                     LOG_MINING_LOG_BACKOFF_INITIAL_DELAY_MS,
                     LOG_MINING_LOG_BACKOFF_MAX_DELAY_MS)

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
@@ -50,7 +50,7 @@ public class OracleConnectorTask extends BaseSourceTask<OraclePartition, OracleO
     public ChangeEventSourceCoordinator<OraclePartition, OracleOffsetContext> start(Configuration config) {
         OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
         TopicSelector<TableId> topicSelector = OracleTopicSelector.defaultSelector(connectorConfig);
-        SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create();
+        SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjustmentMode().createAdjuster();
 
         JdbcConfiguration jdbcConfig = connectorConfig.getJdbcConfig();
         jdbcConnection = new OracleConnection(jdbcConfig, () -> getClass().getClassLoader());

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
@@ -290,7 +290,7 @@ public class LogMinerQueryBuilderTest {
         TableNameCaseSensitivity tableNameSensitivity = connectorConfig.getAdapter().getTableNameCaseSensitivity(connection);
 
         TopicSelector<TableId> topicSelector = OracleTopicSelector.defaultSelector(connectorConfig);
-        SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create();
+        SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjustmentMode().createAdjuster();
 
         return new OracleDatabaseSchema(connectorConfig, converters, defaultValueConverter, schemaNameAdjuster, topicSelector, tableNameSensitivity);
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/processor/AbstractProcessorUnitTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/processor/AbstractProcessorUnitTest.java
@@ -271,7 +271,7 @@ public abstract class AbstractProcessorUnitTest<T extends AbstractLogMinerEventP
     private OracleDatabaseSchema createOracleDatabaseSchema() throws Exception {
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(getConfig().build());
         final TopicSelector<TableId> topicSelector = OracleTopicSelector.defaultSelector(connectorConfig);
-        final SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create();
+        final SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjustmentMode().createAdjuster();
         final OracleValueConverters converters = new OracleValueConverters(connectorConfig, connection);
         final OracleDefaultValueConverter defaultValueConverter = new OracleDefaultValueConverter(converters, connection);
         final TableNameCaseSensitivity sensitivity = connectorConfig.getAdapter().getTableNameCaseSensitivity(connection);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/LogicalDecodingMessageMonitor.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/LogicalDecodingMessageMonitor.java
@@ -65,7 +65,7 @@ public class LogicalDecodingMessageMonitor {
     private final Schema valueSchema;
 
     public LogicalDecodingMessageMonitor(PostgresConnectorConfig connectorConfig, BlockingConsumer<SourceRecord> sender) {
-        this.schemaNameAdjuster = SchemaNameAdjuster.create();
+        this.schemaNameAdjuster = connectorConfig.schemaNameAdjustmentMode().createAdjuster();
         this.sender = sender;
         this.topicName = connectorConfig.getLogicalName() + LOGICAL_DECODING_MESSAGE_TOPIC_SUFFIX;
         this.binaryMode = connectorConfig.binaryHandlingMode();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -1274,6 +1274,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                     SNAPSHOT_MODE_CLASS,
                     HSTORE_HANDLING_MODE,
                     BINARY_HANDLING_MODE,
+                    SCHEMA_NAME_ADJUSTMENT_MODE,
                     INTERVAL_HANDLING_MODE,
                     SCHEMA_REFRESH_MODE,
                     TRUNCATE_HANDLING_MODE,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -65,7 +65,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
         final PostgresConnectorConfig connectorConfig = new PostgresConnectorConfig(config);
         final TopicSelector<TableId> topicSelector = PostgresTopicSelector.create(connectorConfig);
         final Snapshotter snapshotter = connectorConfig.getSnapshotter();
-        final SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create();
+        final SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjustmentMode().createAdjuster();
 
         if (snapshotter == null) {
             throw new ConnectException("Unable to load snapshotter, if using custom snapshot mode, double check your settings");
@@ -183,7 +183,7 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                             default:
                                 break;
                         }
-                    });
+                    }, schemaNameAdjuster);
 
             final PostgresEventDispatcher<TableId> dispatcher = new PostgresEventDispatcher<>(
                     connectorConfig,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresEventDispatcher.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresEventDispatcher.java
@@ -58,7 +58,7 @@ public class PostgresEventDispatcher<T extends DataCollectionId> extends EventDi
                                    EventMetadataProvider metadataProvider, Heartbeat customHeartbeat, SchemaNameAdjuster schemaNameAdjuster,
                                    JdbcConnection jdbcConnection) {
         super(connectorConfig, topicSelector, schema, queue, filter, changeEventCreator, inconsistentSchemaHandler, metadataProvider,
-                customHeartbeat, schemaNameAdjuster, jdbcConnection);
+                customHeartbeat, schemaNameAdjuster);
         this.queue = queue;
         this.logicalDecodingMessageMonitor = new LogicalDecodingMessageMonitor(connectorConfig, this::enqueueLogicalDecodingMessage);
         this.messageFilter = connectorConfig.getMessageFilter();

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSchema.java
@@ -29,7 +29,6 @@ import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchemaBuilder;
 import io.debezium.relational.Tables;
 import io.debezium.schema.TopicSelector;
-import io.debezium.util.SchemaNameAdjuster;
 
 /**
  * Component that records the schema information for the {@link PostgresConnector}. The schema information contains
@@ -70,7 +69,7 @@ public class PostgresSchema extends RelationalDatabaseSchema {
 
     private static TableSchemaBuilder getTableSchemaBuilder(PostgresConnectorConfig config, PostgresValueConverter valueConverter,
                                                             PostgresDefaultValueConverter defaultValueConverter) {
-        return new TableSchemaBuilder(valueConverter, defaultValueConverter, SchemaNameAdjuster.create(),
+        return new TableSchemaBuilder(valueConverter, defaultValueConverter, config.schemaNameAdjustmentMode().createAdjuster(),
                 config.customConverterRegistry(), config.getSourceInfoStructMaker().schema(),
                 config.getSanitizeFieldNames(), false);
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -356,6 +356,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
                     SOURCE_TIMESTAMP_MODE,
                     MAX_TRANSACTIONS_PER_ITERATION,
                     BINARY_HANDLING_MODE,
+                    SCHEMA_NAME_ADJUSTMENT_MODE,
                     INCREMENTAL_SNAPSHOT_OPTION_RECOMPILE,
                     INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
                     INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES)

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -66,7 +66,7 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
 
         final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(config);
         final TopicSelector<TableId> topicSelector = SqlServerTopicSelector.defaultSelector(connectorConfig);
-        final SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create();
+        final SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjustmentMode().createAdjuster();
         final SqlServerValueConverters valueConverters = new SqlServerValueConverters(connectorConfig.getDecimalMode(),
                 connectorConfig.getTemporalPrecisionMode(), connectorConfig.binaryHandlingMode());
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
@@ -209,7 +209,7 @@ public class SqlServerConnectionIT {
             TableSchemaBuilder tableSchemaBuilder = new TableSchemaBuilder(
                     new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE, null),
                     connection.getDefaultValueConverter(),
-                    SchemaNameAdjuster.create(), new CustomConverterRegistry(null), SchemaBuilder.struct().build(), false, false);
+                    SchemaNameAdjuster.NO_OP, new CustomConverterRegistry(null), SchemaBuilder.struct().build(), false, false);
 
             assertColumnHasNotDefaultValue(table, "int_no_default_not_null");
             assertColumnHasDefaultValue(table, "int_no_default", null, tableSchemaBuilder);
@@ -379,7 +379,7 @@ public class SqlServerConnectionIT {
             TableSchemaBuilder tableSchemaBuilder = new TableSchemaBuilder(
                     new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE, null),
                     connection.getDefaultValueConverter(),
-                    SchemaNameAdjuster.create(), new CustomConverterRegistry(null), SchemaBuilder.struct().build(), false, false);
+                    SchemaNameAdjuster.NO_OP, new CustomConverterRegistry(null), SchemaBuilder.struct().build(), false, false);
 
             assertColumnHasNotDefaultValue(table, "int_no_default_not_null");
             assertColumnHasDefaultValue(table, "int_no_default", null, tableSchemaBuilder);

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerSchemaNameAdjustmentModeIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerSchemaNameAdjustmentModeIT.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.fest.assertions.Assertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.CommonConnectorConfig.SchemaNameAdjustmentMode;
+import io.debezium.config.Configuration;
+import io.debezium.connector.sqlserver.util.TestHelper;
+import io.debezium.embedded.AbstractConnectorTest;
+
+public class SqlServerSchemaNameAdjustmentModeIT extends AbstractConnectorTest {
+
+    private SqlServerConnection connection;
+
+    @Before
+    public void before() throws SQLException {
+        TestHelper.createTestDatabase();
+        connection = TestHelper.testConnection();
+
+        connection.execute(
+                "CREATE TABLE [name-adjustment] (id INT)",
+                "INSERT INTO [name-adjustment] (id) VALUES (1);");
+        TestHelper.enableTableCdc(connection, "name-adjustment");
+
+        initializeConnectorTestFramework();
+        Files.delete(TestHelper.DB_HISTORY_PATH);
+    }
+
+    @After
+    public void after() throws SQLException {
+        stopConnector();
+
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void shouldAdjustNamesForAvro() throws InterruptedException {
+        Struct data = consume(SchemaNameAdjustmentMode.AVRO);
+
+        assertThat(data.schema().name()).contains("name_adjustment");
+    }
+
+    @Test
+    public void shouldNotAdjustNames() throws InterruptedException {
+        skipAvroValidation();
+        Struct data = consume(SchemaNameAdjustmentMode.NONE);
+
+        assertThat(data.schema().name()).contains("name-adjustment");
+    }
+
+    private Struct consume(SchemaNameAdjustmentMode adjustmentMode) throws InterruptedException {
+        final Configuration config = TestHelper.defaultConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SqlServerConnectorConfig.SnapshotMode.INITIAL)
+                .with(SqlServerConnectorConfig.TABLE_INCLUDE_LIST, "dbo\\.name-adjustment")
+                .with(SqlServerConnectorConfig.SCHEMA_NAME_ADJUSTMENT_MODE, adjustmentMode)
+                .build();
+
+        start(SqlServerConnector.class, config);
+        assertConnectorIsRunning();
+        TestHelper.waitForSnapshotToBeCompleted();
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        final List<SourceRecord> results = records.recordsForTopic("server1.dbo.name-adjustment");
+        Assertions.assertThat(results).hasSize(1);
+
+        return (Struct) results.get(0).value();
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/converters/CloudEventsConverter.java
+++ b/debezium-core/src/main/java/io/debezium/converters/CloudEventsConverter.java
@@ -130,6 +130,7 @@ public class CloudEventsConverter implements Converter {
 
     private Converter avroConverter;
     private List<String> schemaRegistryUrls;
+    private SchemaNameAdjuster schemaNameAdjuster;
 
     public CloudEventsConverter() {
         this(null);
@@ -149,6 +150,7 @@ public class CloudEventsConverter implements Converter {
         CloudEventsConverterConfig ceConfig = new CloudEventsConverterConfig(conf);
         ceSerializerType = ceConfig.cloudeventsSerializerType();
         dataSerializerType = ceConfig.cloudeventsDataSerializerTypeConfig();
+        schemaNameAdjuster = ceConfig.schemaNameAdjustmentMode().createAdjuster();
 
         boolean usingAvro = false;
 
@@ -412,7 +414,6 @@ public class CloudEventsConverter implements Converter {
     }
 
     private SchemaAndValue convertToCloudEventsFormat(RecordParser parser, CloudEventsMaker maker, Schema dataSchemaType, String dataSchema, Object serializedData) {
-        SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create();
         Struct source = parser.source();
         Schema sourceSchema = parser.source().schema();
         final Struct transaction = parser.transaction();

--- a/debezium-core/src/main/java/io/debezium/converters/CloudEventsConverterConfig.java
+++ b/debezium-core/src/main/java/io/debezium/converters/CloudEventsConverterConfig.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.storage.ConverterConfig;
 
+import io.debezium.config.CommonConnectorConfig.SchemaNameAdjustmentMode;
 import io.debezium.converters.spi.SerializerType;
 
 /**
@@ -25,6 +26,12 @@ public class CloudEventsConverterConfig extends ConverterConfig {
     public static final String CLOUDEVENTS_DATA_SERIALIZER_TYPE_DEFAULT = "json";
     private static final String CLOUDEVENTS_DATA_SERIALIZER_TYPE_DOC = "Specify a serializer to serialize the data field of CloudEvents values";
 
+    public static final String CLOUDEVENTS_SCHEMA_NAME_ADJUSTMENT_MODE_CONFIG = "schema.name.adjustment.mode";
+    public static final String CLOUDEVENTS_SCHEMA_NAME_ADJUSTMENT_MODE_DEFAULT = "avro";
+    private static final String CLOUDEVENTS_SCHEMA_NAME_ADJUSTMENT_MODE_DOC = "Specify how schema names should be adjusted for compatibility with the message converter used by the connector, including:"
+            + "'avro' replaces the characters that cannot be used in the Avro type name with underscore (default)"
+            + "'none' does not apply any adjustment";
+
     private static final ConfigDef CONFIG;
 
     static {
@@ -34,6 +41,8 @@ public class CloudEventsConverterConfig extends ConverterConfig {
                 CLOUDEVENTS_SERIALIZER_TYPE_DOC);
         CONFIG.define(CLOUDEVENTS_DATA_SERIALIZER_TYPE_CONFIG, ConfigDef.Type.STRING, CLOUDEVENTS_DATA_SERIALIZER_TYPE_DEFAULT, ConfigDef.Importance.HIGH,
                 CLOUDEVENTS_DATA_SERIALIZER_TYPE_DOC);
+        CONFIG.define(CLOUDEVENTS_SCHEMA_NAME_ADJUSTMENT_MODE_CONFIG, ConfigDef.Type.STRING, CLOUDEVENTS_SCHEMA_NAME_ADJUSTMENT_MODE_DEFAULT, ConfigDef.Importance.LOW,
+                CLOUDEVENTS_SCHEMA_NAME_ADJUSTMENT_MODE_DOC);
     }
 
     public static ConfigDef configDef() {
@@ -60,5 +69,14 @@ public class CloudEventsConverterConfig extends ConverterConfig {
      */
     public SerializerType cloudeventsDataSerializerTypeConfig() {
         return SerializerType.withName(getString(CLOUDEVENTS_DATA_SERIALIZER_TYPE_CONFIG));
+    }
+
+    /**
+     * Return which adjustment mode is used to build message schema names.
+     *
+     * @return schema name adjustment mode
+     */
+    public SchemaNameAdjustmentMode schemaNameAdjustmentMode() {
+        return SchemaNameAdjustmentMode.parse(getString(CLOUDEVENTS_SCHEMA_NAME_ADJUSTMENT_MODE_CONFIG));
     }
 }

--- a/debezium-core/src/main/java/io/debezium/heartbeat/DatabaseHeartbeatImpl.java
+++ b/debezium-core/src/main/java/io/debezium/heartbeat/DatabaseHeartbeatImpl.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import io.debezium.config.Field;
 import io.debezium.function.BlockingConsumer;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.util.SchemaNameAdjuster;
 
 /**
  *  Implementation of the heartbeat feature that allows for a DB query to be executed with every heartbeat.
@@ -39,8 +40,8 @@ public class DatabaseHeartbeatImpl extends HeartbeatImpl {
     private final HeartbeatErrorHandler errorHandler;
 
     DatabaseHeartbeatImpl(Duration heartbeatInterval, String topicName, String key, JdbcConnection jdbcConnection, String heartBeatActionQuery,
-                          HeartbeatErrorHandler errorHandler) {
-        super(heartbeatInterval, topicName, key);
+                          HeartbeatErrorHandler errorHandler, SchemaNameAdjuster schemaNameAdjuster) {
+        super(heartbeatInterval, topicName, key, schemaNameAdjuster);
 
         this.heartBeatActionQuery = heartBeatActionQuery;
         this.jdbcConnection = jdbcConnection;

--- a/debezium-core/src/main/java/io/debezium/heartbeat/Heartbeat.java
+++ b/debezium-core/src/main/java/io/debezium/heartbeat/Heartbeat.java
@@ -16,6 +16,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import io.debezium.config.Field;
 import io.debezium.function.BlockingConsumer;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.util.SchemaNameAdjuster;
 
 /**
  * A class that is able to generate periodic heartbeat messages based on a pre-configured interval. The clients are
@@ -128,20 +129,20 @@ public interface Heartbeat {
      * @param topicName topic to which the heartbeat messages will be sent
      * @param key kafka partition key to use for the heartbeat message
      */
-    static Heartbeat create(Duration heartbeatInterval, String topicName, String key) {
-        return heartbeatInterval.isZero() ? DEFAULT_NOOP_HEARTBEAT : new HeartbeatImpl(heartbeatInterval, topicName, key);
+    static Heartbeat create(Duration heartbeatInterval, String topicName, String key, SchemaNameAdjuster schemaNameAdjuster) {
+        return heartbeatInterval.isZero() ? DEFAULT_NOOP_HEARTBEAT : new HeartbeatImpl(heartbeatInterval, topicName, key, schemaNameAdjuster);
     }
 
     static Heartbeat create(Duration heartbeatInterval, String heartbeatQuery, String topicName, String key, JdbcConnection jdbcConnection,
-                            HeartbeatErrorHandler errorHandler) {
+                            HeartbeatErrorHandler errorHandler, SchemaNameAdjuster schemaNameAdjuster) {
         if (heartbeatInterval.isZero()) {
             return DEFAULT_NOOP_HEARTBEAT;
         }
 
         if (heartbeatQuery != null) {
-            return new DatabaseHeartbeatImpl(heartbeatInterval, topicName, key, jdbcConnection, heartbeatQuery, errorHandler);
+            return new DatabaseHeartbeatImpl(heartbeatInterval, topicName, key, jdbcConnection, heartbeatQuery, errorHandler, schemaNameAdjuster);
         }
 
-        return new HeartbeatImpl(heartbeatInterval, topicName, key);
+        return new HeartbeatImpl(heartbeatInterval, topicName, key, schemaNameAdjuster);
     }
 }

--- a/debezium-core/src/main/java/io/debezium/heartbeat/HeartbeatImpl.java
+++ b/debezium-core/src/main/java/io/debezium/heartbeat/HeartbeatImpl.java
@@ -30,7 +30,6 @@ import io.debezium.util.Threads.Timer;
 class HeartbeatImpl implements Heartbeat {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HeartbeatImpl.class);
-    private static final SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create();
 
     /**
      * Default length of interval in which connector generates periodically
@@ -45,25 +44,30 @@ class HeartbeatImpl implements Heartbeat {
 
     private static final String SERVER_NAME_KEY = "serverName";
 
-    private static final Schema KEY_SCHEMA = SchemaBuilder.struct()
-            .name(schemaNameAdjuster.adjust("io.debezium.connector.common.ServerNameKey"))
-            .field(SERVER_NAME_KEY, Schema.STRING_SCHEMA)
-            .build();
-    private static final Schema VALUE_SCHEMA = SchemaBuilder.struct()
-            .name(schemaNameAdjuster.adjust("io.debezium.connector.common.Heartbeat"))
-            .field(AbstractSourceInfo.TIMESTAMP_KEY, Schema.INT64_SCHEMA)
-            .build();
-
     private final String topicName;
     private final Duration heartbeatInterval;
     private final String key;
 
+    private final Schema keySchema;
+    private final Schema valueSchema;
+
     private volatile Timer heartbeatTimeout;
 
-    HeartbeatImpl(Duration heartbeatInterval, String topicName, String key) {
+    HeartbeatImpl(Duration heartbeatInterval, String topicName, String key, SchemaNameAdjuster schemaNameAdjuster) {
         this.topicName = topicName;
         this.key = key;
         this.heartbeatInterval = heartbeatInterval;
+
+        keySchema = SchemaBuilder.struct()
+                .name(schemaNameAdjuster.adjust("io.debezium.connector.common.ServerNameKey"))
+                .field(SERVER_NAME_KEY, Schema.STRING_SCHEMA)
+                .build();
+
+        valueSchema = SchemaBuilder.struct()
+                .name(schemaNameAdjuster.adjust("io.debezium.connector.common.Heartbeat"))
+                .field(AbstractSourceInfo.TIMESTAMP_KEY, Schema.INT64_SCHEMA)
+                .build();
+
         heartbeatTimeout = resetHeartbeat();
     }
 
@@ -104,7 +108,7 @@ class HeartbeatImpl implements Heartbeat {
      *
      */
     private Struct serverNameKey(String serverName) {
-        Struct result = new Struct(KEY_SCHEMA);
+        Struct result = new Struct(keySchema);
         result.put(SERVER_NAME_KEY, serverName);
         return result;
     }
@@ -114,7 +118,7 @@ class HeartbeatImpl implements Heartbeat {
      *
      */
     private Struct messageValue() {
-        Struct result = new Struct(VALUE_SCHEMA);
+        Struct result = new Struct(valueSchema);
         result.put(AbstractSourceInfo.TIMESTAMP_KEY, Instant.now().toEpochMilli());
         return result;
     }
@@ -127,7 +131,7 @@ class HeartbeatImpl implements Heartbeat {
         final Integer partition = 0;
 
         return new SourceRecord(sourcePartition, sourceOffset,
-                topicName, partition, KEY_SCHEMA, serverNameKey(key), VALUE_SCHEMA, messageValue());
+                topicName, partition, keySchema, serverNameKey(key), valueSchema, messageValue());
     }
 
     private Timer resetHeartbeat() {

--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -120,7 +120,8 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> {
         this.skippedOperations = connectorConfig.getSkippedOperations();
         this.neverSkip = connectorConfig.supportsOperationFiltering() || this.skippedOperations.isEmpty();
 
-        this.transactionMonitor = new TransactionMonitor(connectorConfig, metadataProvider, this::enqueueTransactionMessage);
+        this.transactionMonitor = new TransactionMonitor(connectorConfig, metadataProvider, schemaNameAdjuster,
+                this::enqueueTransactionMessage);
         this.signal = new Signal<>(connectorConfig, this);
         if (customHeartbeat != null) {
             heartbeat = customHeartbeat;

--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -27,7 +27,6 @@ import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.data.Envelope;
 import io.debezium.data.Envelope.Operation;
 import io.debezium.heartbeat.Heartbeat;
-import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.signal.Signal;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
@@ -94,7 +93,7 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> {
                            DatabaseSchema<T> schema, ChangeEventQueue<DataChangeEvent> queue, DataCollectionFilter<T> filter,
                            ChangeEventCreator changeEventCreator, EventMetadataProvider metadataProvider, SchemaNameAdjuster schemaNameAdjuster) {
         this(connectorConfig, topicSelector, schema, queue, filter, changeEventCreator, null, metadataProvider,
-                null, schemaNameAdjuster, null);
+                null, schemaNameAdjuster);
     }
 
     public EventDispatcher(CommonConnectorConfig connectorConfig, TopicSelector<T> topicSelector,
@@ -102,14 +101,13 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> {
                            ChangeEventCreator changeEventCreator, EventMetadataProvider metadataProvider,
                            Heartbeat heartbeat, SchemaNameAdjuster schemaNameAdjuster) {
         this(connectorConfig, topicSelector, schema, queue, filter, changeEventCreator, null, metadataProvider,
-                heartbeat, schemaNameAdjuster, null);
+                heartbeat, schemaNameAdjuster);
     }
 
     public EventDispatcher(CommonConnectorConfig connectorConfig, TopicSelector<T> topicSelector,
                            DatabaseSchema<T> schema, ChangeEventQueue<DataChangeEvent> queue, DataCollectionFilter<T> filter,
                            ChangeEventCreator changeEventCreator, InconsistentSchemaHandler<P, T> inconsistentSchemaHandler,
-                           EventMetadataProvider metadataProvider, Heartbeat customHeartbeat, SchemaNameAdjuster schemaNameAdjuster,
-                           JdbcConnection jdbcConnection) {
+                           EventMetadataProvider metadataProvider, Heartbeat customHeartbeat, SchemaNameAdjuster schemaNameAdjuster) {
         this.connectorConfig = connectorConfig;
         this.topicSelector = topicSelector;
         this.schema = schema;

--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -130,7 +130,8 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> {
             heartbeat = Heartbeat.create(
                     connectorConfig.getHeartbeatInterval(),
                     topicSelector.getHeartbeatTopic(),
-                    connectorConfig.getLogicalName());
+                    connectorConfig.getLogicalName(),
+                    schemaNameAdjuster);
         }
 
         schemaChangeKeySchema = SchemaBuilder.struct()

--- a/debezium-core/src/main/java/io/debezium/util/SchemaNameAdjuster.java
+++ b/debezium-core/src/main/java/io/debezium/util/SchemaNameAdjuster.java
@@ -123,7 +123,9 @@ public interface SchemaNameAdjuster {
         }
     }
 
-    public static final SchemaNameAdjuster DEFAULT = create();
+    SchemaNameAdjuster NO_OP = proposedName -> proposedName;
+
+    SchemaNameAdjuster AVRO = create();
 
     /**
      * Create a stateful Avro fullname adjuster that logs a warning the first time an invalid fullname is seen and replaced
@@ -132,16 +134,14 @@ public interface SchemaNameAdjuster {
      *
      * @return the validator; never null
      */
-    public static SchemaNameAdjuster defaultAdjuster() {
-        return DEFAULT;
+    public static SchemaNameAdjuster avroAdjuster() {
+        return AVRO;
     }
 
     /**
      * Create a stateful Avro fullname adjuster that logs a warning the first time an invalid fullname is seen and replaced
      * with a valid fullname, and throws an error if the replacement conflicts with that of a different original. This method
      * replaces all invalid characters with the underscore character ('_').
-     *
-     * @param logger the logger to use; may not be null     * @return the validator; never null
      */
     public static SchemaNameAdjuster create() {
         return create((original, replacement, conflict) -> {

--- a/debezium-core/src/test/java/io/debezium/data/VerifyRecord.java
+++ b/debezium-core/src/test/java/io/debezium/data/VerifyRecord.java
@@ -790,14 +790,16 @@ public class VerifyRecord {
             msg = "comparing value to its schema";
             schemaMatchesStruct(valueWithSchema);
 
+            // Introduced due to https://github.com/confluentinc/schema-registry/issues/1693
+            // and https://issues.redhat.com/browse/DBZ-3535
+            if (ignoreAvro) {
+                return;
+            }
+
             // Make sure the schema names are valid Avro schema names ...
             validateSchemaNames(record.keySchema());
             validateSchemaNames(record.valueSchema());
 
-            // Introduced due to https://github.com/confluentinc/schema-registry/issues/1693
-            if (ignoreAvro) {
-                return;
-            }
             // Serialize and deserialize the key using the Avro converter, and check that we got the same result ...
             msg = "serializing key using Avro converter";
             byte[] avroKeyBytes = avroValueConverter.fromConnectData(record.topic(), record.keySchema(), record.key());

--- a/debezium-core/src/test/java/io/debezium/relational/history/HistoryRecordTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/history/HistoryRecordTest.java
@@ -22,6 +22,7 @@ import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.history.TableChanges.TableChangesSerializer;
 import io.debezium.util.Collect;
+import io.debezium.util.SchemaNameAdjuster;
 
 /**
  * @author Randall Hauch
@@ -105,7 +106,7 @@ public class HistoryRecordTest {
         final TableChangesSerializer<Array> tableChangesSerializer = new JsonTableChangeSerializer();
         assertThat((Object) tableChangesSerializer.deserialize(deserialized.tableChanges(), true)).isEqualTo(tableChanges);
 
-        final TableChangesSerializer<List<Struct>> connectTableChangeSerializer = new ConnectTableChangeSerializer();
+        final TableChangesSerializer<List<Struct>> connectTableChangeSerializer = new ConnectTableChangeSerializer(SchemaNameAdjuster.NO_OP);
         Struct struct = connectTableChangeSerializer.serialize(tableChanges).get(0);
         Struct tableStruct = (Struct) struct.get(ConnectTableChangeSerializer.TABLE_KEY);
         assertThat(tableStruct.get(ConnectTableChangeSerializer.COMMENT_KEY)).isEqualTo("table comment");

--- a/debezium-core/src/test/java/io/debezium/transforms/ByLogicalTableRouterTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ByLogicalTableRouterTest.java
@@ -50,7 +50,19 @@ public class ByLogicalTableRouterTest {
     }
 
     @Test
-    public void testKeyReplacementWorkingConfiguration() {
+    public void testKeyReplacementWorkingConfigurationWithAvroSchemaNameAdjustment() {
+        testKeyReplacementWorkingConfiguration("avro",
+                "mysql_server_1.inventory.customers_all_shards.Key");
+    }
+
+    @Test
+    @FixFor("DBZ-3535")
+    public void testKeyReplacementWorkingConfigurationWithNoSchemaNameAdjustment() {
+        testKeyReplacementWorkingConfiguration("none",
+                "mysql-server-1.inventory.customers_all_shards.Key");
+    }
+
+    private void testKeyReplacementWorkingConfiguration(String schemaNameAdjustmentMode, String expectedKeySchemaName) {
         final ByLogicalTableRouter<SourceRecord> router = new ByLogicalTableRouter<>();
         final Map<String, String> props = new HashMap<>();
 
@@ -59,6 +71,7 @@ public class ByLogicalTableRouterTest {
         props.put("key.field.name", "shard_id");
         props.put("key.field.regex", "(.*)customers_shard_(.*)");
         props.put("key.field.replacement", "$2");
+        props.put("schema.name.adjustment.mode", schemaNameAdjustmentMode);
         router.configure(props);
 
         Schema keySchema = SchemaBuilder.struct()
@@ -75,7 +88,7 @@ public class ByLogicalTableRouterTest {
         assertThat(transformed1).isNotNull();
         assertThat(transformed1.topic()).isEqualTo("mysql-server-1.inventory.customers_all_shards");
 
-        assertThat(transformed1.keySchema().name()).isEqualTo("mysql_server_1.inventory.customers_all_shards.Key");
+        assertThat(transformed1.keySchema().name()).isEqualTo(expectedKeySchemaName);
         assertThat(transformed1.keySchema().fields()).hasSize(2);
         assertThat(transformed1.keySchema().fields().get(0).name()).isEqualTo("id");
         assertThat(transformed1.keySchema().fields().get(1).name()).isEqualTo("shard_id");
@@ -92,7 +105,7 @@ public class ByLogicalTableRouterTest {
         assertThat(transformed2).isNotNull();
         assertThat(transformed2.topic()).isEqualTo("mysql-server-1.inventory.customers_all_shards");
 
-        assertThat(transformed2.keySchema().name()).isEqualTo("mysql_server_1.inventory.customers_all_shards.Key");
+        assertThat(transformed2.keySchema().name()).isEqualTo(expectedKeySchemaName);
         assertThat(transformed2.keySchema().fields()).hasSize(2);
         assertThat(transformed2.keySchema().fields().get(0).name()).isEqualTo("id");
         assertThat(transformed2.keySchema().fields().get(1).name()).isEqualTo("shard_id");
@@ -109,7 +122,7 @@ public class ByLogicalTableRouterTest {
         assertThat(transformed3).isNotNull();
         assertThat(transformed3.topic()).isEqualTo("mysql-server-1.inventory.customers_all_shards");
 
-        assertThat(transformed3.keySchema().name()).isEqualTo("mysql_server_1.inventory.customers_all_shards.Key");
+        assertThat(transformed3.keySchema().name()).isEqualTo(expectedKeySchemaName);
         assertThat(transformed3.keySchema().fields()).hasSize(2);
         assertThat(transformed3.keySchema().fields().get(0).name()).isEqualTo("id");
         assertThat(transformed3.keySchema().fields().get(1).name()).isEqualTo("shard_id");

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2155,6 +2155,13 @@ The following example sets the message key for the tables `inventory.customers` 
  +
 In the preceding example, the columns `pk1` and `pk2` are specified as the message key for the table `inventory.customer`.
 For `purchaseorders` tables in any schema, the columns `pk3` and `pk4` serve as the message key.
+
+|[[db2-property-schema-name-adjustment-mode]]<<db2-property-schema-name-adjustment-mode,`+schema.name.adjustment.mode+`>>
+|avro
+|Specifies how schema names should be adjusted for compatibility with the message converter used by the connector. Possible settings:  +
+
+* `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
+* `none` does not apply any adjustment. +
 |===
 
 [id="db2-advanced-configuration-properties"]

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1488,6 +1488,13 @@ Can be used to avoid snapshot interruptions when starting multiple connectors in
 The connector will read the collection contents in multiple batches of this size. +
 Defaults to 0, which indicates that the server chooses an appropriate fetch size.
 
+|[[mongodb-property-schema-name-adjustment-mode]]<<mongodb-property-schema-name-adjustment-mode,`+schema.name.adjustment.mode+`>>
+|avro
+|Specifies how schema names should be adjusted for compatibility with the message converter used by the connector. Possible settings:  +
+
+* `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
+* `none` does not apply any adjustment. +
+
 |===
 
 The following _advanced_ configuration properties have good defaults that will work in most situations and therefore rarely need to be specified in the connector's configuration.

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2615,6 +2615,13 @@ However, it's best to use the minimum number that are required to specify a uniq
  +
 `hex` represents binary data as a hex-encoded (base16) String.
 
+|[[mysql-property-schema-name-adjustment-mode]]<<mysql-property-schema-name-adjustment-mode,`+schema.name.adjustment.mode+`>>
+|avro
+|Specifies how schema names should be adjusted for compatibility with the message converter used by the connector. Possible settings:  +
+
+* `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
+* `none` does not apply any adjustment. +
+
 |===
 
 [id="mysql-advanced-connector-configuration-properties"]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2589,6 +2589,13 @@ Hashing strategy version 2 should be used to ensure fidelity if the value is bei
 |bytes
 |Specifies how binary (`blob`) columns should be represented in change events, including: `bytes` represents binary data as byte array (default), `base64` represents binary data as base64-encoded String, `hex` represents binary data as hex-encoded (base16) String
 
+|[[oracle-property-schema-name-adjustment-mode]]<<oracle-property-schema-name-adjustment-mode,`+schema.name.adjustment.mode+`>>
+|avro
+|Specifies how schema names should be adjusted for compatibility with the message converter used by the connector. Possible settings:  +
+
+* `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
+* `none` does not apply any adjustment. +
+
 |[[oracle-property-decimal-handling-mode]]<<oracle-property-decimal-handling-mode, `+decimal.handling.mode+`>>
 |`precise`
 | Specifies how the connector should handle floating point values for `NUMBER`, `DECIMAL` and `NUMERIC` columns.

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2876,6 +2876,13 @@ However, it's best to use the minimum number that are required to specify a uniq
  +
 `hex` represents binary data as hex-encoded (base16) strings.
 
+|[[postgresql-property-schema-name-adjustment-mode]]<<postgresql-property-schema-name-adjustment-mode,`+schema.name.adjustment.mode+`>>
+|avro
+|Specifies how schema names should be adjusted for compatibility with the message converter used by the connector. Possible settings:  +
+
+* `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
+* `none` does not apply any adjustment. +
+
 |[[postgresql-property-truncate-handling-mode]]<<postgresql-property-truncate-handling-mode, `+truncate.handling.mode+`>>
 |skip
 |Specifies how whether `TRUNCATE` events should be propagated or not (only available when using the `pgoutput` plug-in with Postgres 11 or later): +

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2230,6 +2230,14 @@ However, it's best to use the minimum number that are required to specify a uniq
 |[[sqlserver-property-binary-handling-mode]]<<sqlserver-property-binary-handling-mode, `+binary.handling.mode+`>>
 |bytes
 |Specifies how binary (`binary`, `varbinary`) columns should be represented in change events, including: `bytes` represents binary data as byte array (default), `base64` represents binary data as base64-encoded String, `hex` represents binary data as hex-encoded (base16) String
+
+|[[sqlserver-property-schema-name-adjustment-mode]]<<sqlserver-property-schema-name-adjustment-mode,`+schema.name.adjustment.mode+`>>
+|avro
+|Specifies how schema names should be adjusted for compatibility with the message converter used by the connector. Possible settings:  +
+
+* `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
+* `none` does not apply any adjustment. +
+
 |===
 
 [id="sqlserver-advanced-connector-configuration-properties"]

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -1210,6 +1210,13 @@ For example, +
 `keyspaceA.table_a:regex_1;keyspaceA.table_b:regex_2;keyspaceA.table_c:regex_3` +
  +
 If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column that starts with `i`), the connector maps the value in ``table_a``'s `id` column to a key field in change events that the connector sends to Kafka.
+
+|[[vitess-property-schema-name-adjustment-mode]]<<vitess-property-schema-name-adjustment-mode,`+schema.name.adjustment.mode+`>>
+|avro
+|Specifies how schema names should be adjusted for compatibility with the message converter used by the connector. Possible settings:  +
+
+* `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
+* `none` does not apply any adjustment. +
 |===
 
 [id="vitess-advanced-configuration-properties"]

--- a/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
+++ b/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
@@ -200,4 +200,8 @@ The value can be `json` or `avro`.
 |[[cloud-events-converter-avro]]xref:cloud-events-converter-avro[`avro. \...`]
 |N/A
 |Any configuration options to be passed through to the underlying converter when using Avro. The `avro.` prefix is removed. For example, for Avro `data`, you would specify the `avro.schema.registry.url` option.
+
+|[[cloud-events-converter-schema-name-adjustment-mode]]xref:cloud-events-converter-schema-name-adjustment-mode[`schema.name.adjustment.mode`]
+|`avro`
+|Specifies how schema names should be adjusted for compatibility with the message converter used by the connector. The value can be `avro` or `none`.
 |===

--- a/documentation/modules/ROOT/pages/transformations/topic-routing.adoc
+++ b/documentation/modules/ROOT/pages/transformations/topic-routing.adoc
@@ -81,6 +81,8 @@ In the example, the regular expression, `pass:[(.*)customers_shard(.*)]` matches
 
 `topic.replacement`:: Specifies a regular expression that represents the destination topic name. The transformation routes each matching record to the topic identified by this expression. In this example, records for the three sharded tables listed above would be routed to the `myserver.mydb.customers_all_shards` topic.
 
+`schema.name.adjustment.mode`:: Specifies how the message key schema names derived from the resulting topic name should be adjusted for compatibility with the message converter used by the connector. The value can be `avro` (default) or `none`.
+
 // Type: procedure
 // ModuleID: ensuring-unique-keys-across-debezium-records-routed-to-the-same-topic
 // Title: Ensuring unique keys across {prodname} records routed to the same topic


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3535

**TODO**:
- [x] Update `debezium/debezium-connector-db2` (https://github.com/debezium/debezium-connector-db2/pull/47)
- [x] Update `debezium/debezium-connector-vitess` (https://github.com/debezium/debezium-connector-vitess/pull/77)
- [x] Update `debezium/debezium-connector-cassandra` (https://github.com/debezium/debezium-connector-cassandra/pull/49)
- [x] Add tests for `schema.name.adjustment.mode=none`
- [x] Update documentation
- [x] Decide what to do with `ByLogicalTableRouter` and `CloudEventsConverter` which are instantiated by Kafka Connect and are configured separately.
- [x] Rework `ConnectTableChangeSerializer` and `TransactionMonitor` which currently use a static instance of the default `SchemaNameAdjuster`.
- [x] Should the default value depend on `isUsingAvroConverter()`? Not at this time.