### PR TITLE
DBZ-4878 Re-read incremental snapshot chunk on DDL event

### DIFF
--- a/debezium-connector-mysql/README.md
+++ b/debezium-connector-mysql/README.md
@@ -77,17 +77,17 @@ This instructs Maven to run the normal Maven lifecycle through `integration-test
 
 ### Using MySQL with GTIDs
 
-By default the build will run a MySQL server instance that is not configured to use GTIDs. However, we've provided a Maven profile that will instead run all the same integration tests against a MySQL instance that does use GTIDs. Simply use the `gtid-mysql` profile on each of your normal Maven commands. For example, to run a build:
+By default the build will run a MySQL server instance that is not configured to use GTIDs. However, we've provided a Maven profile that will instead run all the same integration tests against a MySQL instance that does use GTIDs. Simply use the `mysql-gtids` profile on each of your normal Maven commands. For example, to run a build:
 
-    $ mvn clean install -Pgtid-mysql
+    $ mvn clean install -Pmysql-gtids
 
 or to manually start the Docker container and keep it running:
 
-    $ mvn docker:start -Pgtid-mysql
+    $ mvn docker:start -Pmysql-gtids
 
 or to stop and remove the Docker container:
 
-    $ mvn docker:stop -Pgtid-mysql
+    $ mvn docker:stop -Pmysql-gtids
 
 ### Using an alternative MySQL Server
 

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -234,18 +234,6 @@ public class MySqlReadOnlyIncrementalSnapshotChangeEventSource<T extends DataCol
         sourceInfo.setQuery(query);
     }
 
-    public void rereadChunk(MySqlPartition partition) throws InterruptedException {
-        if (context == null) {
-            return;
-        }
-        if (!context.snapshotRunning() || !context.deduplicationNeeded() || window.isEmpty()) {
-            return;
-        }
-        window.clear();
-        context.revertChunk();
-        readChunk(partition);
-    }
-
     private void checkEnqueuedSnapshotSignals(MySqlPartition partition, OffsetContext offsetContext) throws InterruptedException {
         while (getContext().hasExecuteSnapshotSignals()) {
             addDataCollectionNamesToSnapshot(getContext().getExecuteSnapshotSignals(), partition, offsetContext);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
@@ -249,7 +249,7 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
                         super.lastSnapshotRecord(snapshotContext);
                     }
 
-                    dispatcher.dispatchSchemaChangeEvent(tableId, (receiver) -> receiver.schemaChangeEvent(event));
+                    dispatcher.dispatchSchemaChangeEvent(snapshotContext.partition, tableId, (receiver) -> receiver.schemaChangeEvent(event));
                 }
 
                 // Make schema available for snapshot source
@@ -555,7 +555,7 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
             if (!snapshottingTask.snapshotData() && !i.hasNext()) {
                 lastSnapshotRecord(snapshotContext);
             }
-            dispatcher.dispatchSchemaChangeEvent(tableId, (receiver) -> receiver.schemaChangeEvent(event));
+            dispatcher.dispatchSchemaChangeEvent(snapshotContext.partition, tableId, (receiver) -> receiver.schemaChangeEvent(event));
         }
 
         // Make schema available for snapshot source

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -582,7 +582,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
                 }
 
                 final TableId tableId = schemaChangeEvent.getTables().isEmpty() ? null : schemaChangeEvent.getTables().iterator().next().id();
-                eventDispatcher.dispatchSchemaChangeEvent(tableId, (receiver) -> {
+                eventDispatcher.dispatchSchemaChangeEvent(partition, tableId, (receiver) -> {
                     try {
                         receiver.schemaChangeEvent(schemaChangeEvent);
                     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
@@ -556,7 +556,8 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
         if (row.getTableName() != null) {
             counters.ddlCount++;
             final TableId tableId = row.getTableId();
-            dispatcher.dispatchSchemaChangeEvent(tableId,
+            dispatcher.dispatchSchemaChangeEvent(partition,
+                    tableId,
                     new OracleSchemaChangeEventEmitter(
                             getConfig(),
                             partition,
@@ -846,7 +847,8 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
             throws SQLException, InterruptedException {
         LOGGER.info("Table '{}' is new and will now be captured.", tableId);
         offsetContext.event(tableId, Instant.now());
-        dispatcher.dispatchSchemaChangeEvent(tableId,
+        dispatcher.dispatchSchemaChangeEvent(partition,
+                tableId,
                 new OracleSchemaChangeEventEmitter(connectorConfig,
                         partition,
                         offsetContext,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -166,6 +166,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
             }
             LOGGER.info("Table {} is new and will be captured.", tableId);
             dispatcher.dispatchSchemaChangeEvent(
+                    partition,
                     tableId,
                     new OracleSchemaChangeEventEmitter(
                             connectorConfig,
@@ -232,6 +233,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         TableId tableId = getTableId(ddlLcr);
 
         dispatcher.dispatchSchemaChangeEvent(
+                partition,
                 tableId,
                 new OracleSchemaChangeEventEmitter(
                         connectorConfig,

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -337,7 +337,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
             LOGGER.info("Migration skipped, no table schema changes detected.");
             return;
         }
-        dispatcher.dispatchSchemaChangeEvent(newTable.getSourceTableId(),
+        dispatcher.dispatchSchemaChangeEvent(partition, newTable.getSourceTableId(),
                 new SqlServerSchemaChangeEventEmitter(partition, offsetContext, newTable, tableSchema,
                         SchemaChangeEventType.ALTER));
         newTable.setSourceTable(tableSchema);
@@ -408,6 +408,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                         currentTable.getSourceTableId(),
                         Instant.now());
                 dispatcher.dispatchSchemaChangeEvent(
+                        partition,
                         currentTable.getSourceTableId(),
                         new SqlServerSchemaChangeEventEmitter(
                                 partition,

--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -301,7 +301,7 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> {
         return Optional.empty();
     }
 
-    public void dispatchSchemaChangeEvent(T dataCollectionId, SchemaChangeEventEmitter schemaChangeEventEmitter) throws InterruptedException {
+    public void dispatchSchemaChangeEvent(P partition, T dataCollectionId, SchemaChangeEventEmitter schemaChangeEventEmitter) throws InterruptedException {
         if (dataCollectionId != null && !filter.isIncluded(dataCollectionId)) {
             if (historizedSchema == null || historizedSchema.storeOnlyCapturedTables()) {
                 LOGGER.trace("Filtering schema change event for {}", dataCollectionId);
@@ -309,6 +309,9 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> {
             }
         }
         schemaChangeEventEmitter.emitSchemaChangeEvent(new SchemaChangeEventReceiver());
+        if (incrementalSnapshotChangeEventSource != null) {
+            incrementalSnapshotChangeEventSource.processSchemaChange(partition, dataCollectionId);
+        }
     }
 
     public void dispatchSchemaChangeEvent(Collection<T> dataCollectionIds, SchemaChangeEventEmitter schemaChangeEventEmitter) throws InterruptedException {

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/SchemaChanges.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/SchemaChanges.java
@@ -60,7 +60,7 @@ public class SchemaChanges<P extends Partition> implements Signal.Action<P> {
         for (TableChanges.TableChange tableChange : serializer.deserialize(changes, useCatalogBeforeSchema)) {
             if (dispatcher.getHistorizedSchema() != null) {
                 LOGGER.info("Executing schema change for table '{}' requested by signal '{}'", tableChange.getId(), signalPayload.id);
-                dispatcher.dispatchSchemaChangeEvent(tableChange.getId(), emitter -> {
+                dispatcher.dispatchSchemaChangeEvent(signalPayload.partition, tableChange.getId(), emitter -> {
                     emitter.schemaChangeEvent(new SchemaChangeEvent(signalPayload.partition.getSourcePartition(),
                             signalPayload.offsetContext.getOffset(), signalPayload.source, database, schema, null,
                             tableChange.getTable(), toSchemaChangeEventType(tableChange.getType()), false));

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -100,6 +100,25 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         readChunk(partition);
     }
 
+    @Override
+    public void processSchemaChange(P partition, DataCollectionId dataCollectionId) throws InterruptedException {
+        if (dataCollectionId.equals(context.currentDataCollectionId())) {
+            rereadChunk(partition);
+        }
+    }
+
+    public void rereadChunk(P partition) throws InterruptedException {
+        if (context == null) {
+            return;
+        }
+        if (!context.snapshotRunning() || !context.deduplicationNeeded() || window.isEmpty()) {
+            return;
+        }
+        window.clear();
+        context.revertChunk();
+        readChunk(partition);
+    }
+
     protected String getSignalTableName(String dataCollectionId) {
         if (Strings.isNullOrEmpty(dataCollectionId)) {
             return dataCollectionId;

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
@@ -40,4 +40,7 @@ public interface IncrementalSnapshotChangeEventSource<P extends Partition, T ext
 
     default void processTransactionCommittedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
     }
+
+    default void processSchemaChange(P partition, DataCollectionId dataCollectionId) throws InterruptedException {
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -272,7 +272,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
                     lastSnapshotRecord(snapshotContext);
                 }
 
-                dispatcher.dispatchSchemaChangeEvent(table.id(), (receiver) -> {
+                dispatcher.dispatchSchemaChangeEvent(snapshotContext.partition, table.id(), (receiver) -> {
                     try {
                         receiver.schemaChangeEvent(getCreateTableEvent(snapshotContext, table));
                     }


### PR DESCRIPTION
A new schema can be applied to the chunk with an old schema if DDL event is within the chunk select window.
![photo_2022-03-16_23-35-10](https://user-images.githubusercontent.com/553032/158747441-05c28205-5ca4-4970-8d95-7d37ae767424.jpg)


The chunk's JDBC schema in this case is the same as before. Schema change won't be detected. The binlog schema will get updated with the DDL event. The chunk is inserted after window close event. The events mapping uses the latest schema for the chunk.

The fix is simple: re-read chunk on DDL event. In this case chunk will have schema that is up to date with the binlog schema.