### PR TITLE
DBZ-4852 DBZ-4853 DBZ-4880 Graceful handling of Oracle unsupported data types in DDL parsing

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/ColumnDefinitionParserListener.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/ColumnDefinitionParserListener.java
@@ -293,7 +293,9 @@ public class ColumnDefinitionParserListener extends BaseParserListener {
                         .type("ROWID");
             }
             else {
-                throw new IllegalArgumentException("Unsupported column type: " + ctx.native_datatype_element().getText());
+                columnEditor
+                        .jdbcType(OracleTypes.OTHER)
+                        .type(ctx.native_datatype_element().getText());
             }
         }
         else if (ctx.INTERVAL() != null
@@ -330,7 +332,7 @@ public class ColumnDefinitionParserListener extends BaseParserListener {
             }
         }
         else {
-            throw new IllegalArgumentException("Unsupported column type: " + ctx.getText());
+            columnEditor.jdbcType(OracleTypes.OTHER).type(ctx.getText());
         }
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/ColumnDefinitionParserListener.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/antlr/listener/ColumnDefinitionParserListener.java
@@ -272,6 +272,11 @@ public class ColumnDefinitionParserListener extends BaseParserListener {
                         .jdbcType(Types.CLOB)
                         .type("CLOB");
             }
+            else if (ctx.native_datatype_element().NCLOB() != null) {
+                columnEditor
+                        .jdbcType(Types.NCLOB)
+                        .type("NCLOB");
+            }
             else if (ctx.native_datatype_element().RAW() != null) {
                 columnEditor
                         .jdbcType(OracleTypes.RAW)


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4852 - Gracefully handle BFILE column data type while streaming
https://issues.redhat.com/browse/DBZ-4853 - Gracefully handle LONG column data type while streaming
https://issues.redhat.com/browse/DBZ-4880 - Oracle DDL correctly interpret NCLOB column types while streaming