### PR TITLE
Dbz 4835 note that oracle and db2 connectors exclude jdbc driver

### DIFF
--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -20,6 +20,7 @@ asciidoc:
     strimzi-version: '0.18.0'
     apicurio-version: '2.1.5.Final'
     db2-version: '11.5.0.0'
+    ojdbc8-version: '21.1.0.0'
     community: true
     registry: 'Apicurio Registry'
     registry-name-full: Apicurio API and Schema Registry

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1613,6 +1613,9 @@ To deploy a {prodname} Db2 connector, you install the {prodname} Db2 connector a
 . Extract the JAR files into your Kafka Connect environment.
 . Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
 . Obtain the link:https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads[JDBC driver for Db2].
++
+The {prodname} Db2 connector archive does not include the Db2 JDBC driver that {prodname} requires to connect to a Db2 database.
+
 . Add the JDBC driver JAR file to the directory with the {prodname} Db2 connector JARs.
 . xref:{link-db2-connector}#db2-adding-connector-configuration[Configure the connector and add the configuration to your Kafka Connect cluster.]
 . Restart your Kafka Connect process to pick up the new JAR files.
@@ -1630,7 +1633,7 @@ You can use either of the following methods to deploy a {prodname} Db2 connector
 This is the preferred method.
 * xref:deploying-debezium-db2-connectors[Build a custom Kafka Connect container image from a Dockerfile].
 
-The {prodname} Db2 connector requires the Db2 JDBC driver to connect to Db2 databases.
+The {prodname} Db2 connector does not include the Db2 JDBC driver that is required to connect to Db2 databases.
 For information about how to obtain the driver, see xref:obtaining-the-db2-jdbc-driver[Obtaining the Db2 JDBC driver].
 
 .Additional resources

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1612,10 +1612,11 @@ To deploy a {prodname} Db2 connector, you install the {prodname} Db2 connector a
 . Download the link:https://repo1.maven.org/maven2/io/debezium/debezium-connector-db2/{debezium-version}/debezium-connector-db2-{debezium-version}-plugin.tar.gz[connector's plug-in archive].
 . Extract the JAR files into your Kafka Connect environment.
 . Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
-. Obtain the link:https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads[JDBC driver for Db2].
-+
+. Obtain the link:https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads[JDBC driver for Db2]. +
+[IMPORTANT]
+====
 The {prodname} Db2 connector archive does not include the Db2 JDBC driver that {prodname} requires to connect to a Db2 database.
-
+====
 . Add the JDBC driver JAR file to the directory with the {prodname} Db2 connector JARs.
 . xref:{link-db2-connector}#db2-adding-connector-configuration[Configure the connector and add the configuration to your Kafka Connect cluster.]
 . Restart your Kafka Connect process to pick up the new JAR files.

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1611,22 +1611,23 @@ To deploy a {prodname} Db2 connector, you install the {prodname} Db2 connector a
 
 . Download the link:https://repo1.maven.org/maven2/io/debezium/debezium-connector-db2/{debezium-version}/debezium-connector-db2-{debezium-version}-plugin.tar.gz[connector's plug-in archive].
 . Extract the JAR files into your Kafka Connect environment.
-. Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
-. Obtain the link:https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads[JDBC driver for Db2].
+. Download the link:https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads[JDBC driver for Db2], and extract the downloaded driver file to the directory that contains the {prodname} Db2 connector JAR file (that is, `debezium-connector-db2-{debezium-version}.jar`).
 +
 [IMPORTANT]
 ====
 Due to licensing requirements, the {prodname} Db2 connector archive does not include the Db2 JDBC driver that {prodname} requires to connect to a Db2 database.
 To enable the connector to access the database, you must add the driver to your connector environment.
 ====
-
-. Add the JDBC driver JAR file to the directory with the {prodname} Db2 connector JARs.
-. xref:{link-db2-connector}#db2-adding-connector-configuration[Configure the connector and add the configuration to your Kafka Connect cluster.]
+. Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
 . Restart your Kafka Connect process to pick up the new JAR files.
 
 If you are working with immutable containers, see link:https://hub.docker.com/r/debezium/[{prodname}'s container images] for Apache ZooKeeper, Apache Kafka and Kafka Connect with the Db2 connector already installed and ready to run.
 
 You can also xref:operations/openshift.adoc[run {prodname} on Kubernetes and OpenShift].
+
+.Next steps
+
+* xref:db2-example-configuration[Configure the connector] and xref:db2-adding-connector-configuration[add the configuration to your Kafka Connect cluster.]
 endif::community[]
 
 ifdef::product[]
@@ -1637,8 +1638,12 @@ You can use either of the following methods to deploy a {prodname} Db2 connector
 This is the preferred method.
 * xref:deploying-debezium-db2-connectors[Build a custom Kafka Connect container image from a Dockerfile].
 
-The {prodname} Db2 connector does not include the Db2 JDBC driver that is required to connect to Db2 databases.
+[IMPORTANT]
+====
+Due to licensing requirements, the {prodname} Db2 connector archive does not include the Db2 JDBC driver that {prodname} requires to connect to a Db2 database.
+To enable the connector to access the database, you must add the driver to your connector environment.
 For information about how to obtain the driver, see xref:obtaining-the-db2-jdbc-driver[Obtaining the Db2 JDBC driver].
+====
 
 .Additional resources
 
@@ -1657,7 +1662,7 @@ The following steps describe how to obtain the driver and use it your your envir
 
 . From a browser, navigate to the link:https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads[IBM Support site] and download the JDBC driver that matches your version of Db2.
 
-* If you xref:deploying-debezium-db2-connectors[use a Dockerfile to build the connector], copy the downloaded file to the directory that contains the {prodname} Db2 connector files, for example, `_<kafka_home>_/libs` directory.
+* If you xref:deploying-debezium-db2-connectors[use a Dockerfile to build the connector], copy the downloaded driver file to the directory that contains the {prodname} Db2 connector JAR file (that is, `debezium-connector-db2-{debezium-version}.jar`).
 
 * If you xref:openshift-streams-db2-connector-deployment[use {StreamsName} to add the connector to your Kafka Connect image]:
 .. Deploy the driver to a Maven repository or to another HTTP server that is available to your OpenShift cluster.

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1612,11 +1612,14 @@ To deploy a {prodname} Db2 connector, you install the {prodname} Db2 connector a
 . Download the link:https://repo1.maven.org/maven2/io/debezium/debezium-connector-db2/{debezium-version}/debezium-connector-db2-{debezium-version}-plugin.tar.gz[connector's plug-in archive].
 . Extract the JAR files into your Kafka Connect environment.
 . Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
-. Obtain the link:https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads[JDBC driver for Db2]. +
+. Obtain the link:https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads[JDBC driver for Db2].
++
 [IMPORTANT]
 ====
-The {prodname} Db2 connector archive does not include the Db2 JDBC driver that {prodname} requires to connect to a Db2 database.
+Due to licensing requirements, the {prodname} Db2 connector archive does not include the Db2 JDBC driver that {prodname} requires to connect to a Db2 database.
+To enable the connector to access the database, you must add the driver to your connector environment.
 ====
+
 . Add the JDBC driver JAR file to the directory with the {prodname} Db2 connector JARs.
 . xref:{link-db2-connector}#db2-adding-connector-configuration[Configure the connector and add the configuration to your Kafka Connect cluster.]
 . Restart your Kafka Connect process to pick up the new JAR files.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1871,12 +1871,12 @@ To deploy a {prodname} Oracle connector, you install the {prodname} Oracle conne
 * link:https://zookeeper.apache.org/[Apache ZooKeeper], link:http://kafka.apache.org/[Apache Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
 * Oracle Database is installed, and is xref:{link-oracle-connector}#setting-up-oracle[configured to work with the {prodname} connector].
 * You have a copy of the Oracle JDBC driver.
-  For more information, see xref:obtaining-the-oracle-jdbc-driver[Obtaining the Oracle JDBC driver].
 +
 [IMPORTANT]
 ====
-Due to licensing requirements, the {prodname} Oracle connector archive does not include the Oracle JDBC driver.
+Due to licensing requirements, the {prodname} Oracle connector archive does not include the Oracle JDBC driver that the connector requires to connect to an Oracle database.
 To enable the connector to access the database, you must add the driver to your connector environment.
+For more information, see xref:obtaining-the-oracle-jdbc-driver[Obtaining the Oracle JDBC driver].
 ====
 
 .Procedure
@@ -1899,8 +1899,12 @@ You can use either of the following methods to deploy a {prodname} Oracle connec
 This is the preferred method.
 * xref:deploying-debezium-oracle-connectors[Build a custom Kafka Connect container image from a Dockerfile].
 
-The {prodname} Oracle connector requires the Oracle JDBC driver (ojdbc8.jar) to connect to Oracle databases.
-For information about how to obtain the driver, see xref:obtaining-the-oracle-jdbc-driver[Obtaining the Oracle JDBC driver].
+[IMPORTANT]
+====
+Due to licensing requirements, the {prodname} Oracle connector archive does not include the Oracle JDBC driver that the connector requires to connect to an Oracle database.
+To enable the connector to access the database, you must add the driver to your connector environment.
+For more information, see xref:obtaining-the-oracle-jdbc-driver[Obtaining the Oracle JDBC driver].
+====
 
 .Additional resources
 
@@ -1945,7 +1949,7 @@ You then need to create the following custom resources (CRs):
 * You have an account and permissions to create and manage containers in the container registry (such as `quay.io` or `docker.io`) to which you plan to add the container that will run your {prodname} connector.
 
 * You have a copy of the Oracle JDBC driver.
-Due to licensing requirements, the {prodname} Oracle connector does not include the required driver file.
+You must obtain a copy of the Oracle JDBC driver that to enable {prodname} to connect to an Oracle database.
 +
 For more information, see xref:{link-oracle-connector}#obtaining-the-oracle-jdbc-driver[Obtaining the Oracle JDBC driver].
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1881,7 +1881,7 @@ To deploy a {prodname} Oracle connector, you install the {prodname} Oracle conne
 
 .Next steps
 
-xref:{link-oracle-connector}#oracle-example-configuration[Configure the connector] and xref:{link-oracle-connector}#oracle-adding-connector-configuration[add the configuration to your Kafka Connect cluster.]
+* xref:{link-oracle-connector}#oracle-example-configuration[Configure the connector] and xref:{link-oracle-connector}#oracle-adding-connector-configuration[add the configuration to your Kafka Connect cluster.]
 
 endif::community[]
 
@@ -2146,7 +2146,7 @@ For more information about the YAML file for the `KafkaConnector` CR, see xref:o
 
 ** If you use a Dockerfile to deploy the connector:
 .. From a browser, link:https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/{ojdbc8-version}/ojdbc8-{ojdbc8-version}.jar[download the 'ojdbc8.jar' from Maven Central].
-.. Copy the downloaded driver file to the directory that contains the {prodname} Oracle connector JAR file (`debezium-connector-oracle-{debezium-version}.jar`).
+.. Copy the downloaded driver file to the directory that contains the {prodname} Oracle connector JAR file (that is, `debezium-connector-oracle-{debezium-version}.jar`).
 
 endif::product[]
 ifdef::community[]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1870,25 +1870,19 @@ To deploy a {prodname} Oracle connector, you install the {prodname} Oracle conne
 .Prerequisites
 * link:https://zookeeper.apache.org/[Apache ZooKeeper], link:http://kafka.apache.org/[Apache Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
 * Oracle Database is installed, and is xref:{link-oracle-connector}#setting-up-oracle[configured to work with the {prodname} connector].
-* You have a copy of the Oracle JDBC driver.
-+
-[IMPORTANT]
-====
-Due to licensing requirements, the {prodname} Oracle connector archive does not include the Oracle JDBC driver that the connector requires to connect to an Oracle database.
-To enable the connector to access the database, you must add the driver to your connector environment.
-For more information, see xref:obtaining-the-oracle-jdbc-driver[Obtaining the Oracle JDBC driver].
-====
 
 .Procedure
 
 . Download the {prodname} https://repo1.maven.org/maven2/io/debezium/debezium-connector-oracle/{debezium-version}/debezium-connector-oracle-{debezium-version}-plugin.tar.gz[Oracle connector plug-in archive].
-
 . Extract the files into your Kafka Connect environment.
-
+. xref:obtaining-the-oracle-jdbc-driver[Download the Oracle JDBC driver from Maven Central and extract it to the directory with the connector JAR files.]
 . Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
-
-  . xref:{link-oracle-connector}#oracle-example-configuration[Configure the connector] and xref:{link-oracle-connector}#oracle-adding-connector-configuration[add the configuration to your Kafka Connect cluster.]
 . Restart your Kafka Connect process to pick up the new JAR files.
+
+.Next steps
+
+xref:{link-oracle-connector}#oracle-example-configuration[Configure the connector] and xref:{link-oracle-connector}#oracle-adding-connector-configuration[add the configuration to your Kafka Connect cluster.]
+
 endif::community[]
 
 ifdef::product[]
@@ -2141,28 +2135,29 @@ There are two methods for obtaining the driver, depending on the deployment meth
 
 . Complete one of the following procedures, depending on your deployment type:
 ** If you use {StreamsName} to deploy the connector:
-.. Navigate to link:https://repo1.maven.org/maven2/com/oracle/database/jdbc/[Maven Central].
-.. In the YAML for the `KafkaConnector` custom resource (CR), add the URL path for the driver to the `artifacts.url` field for the `debezium-connector-oracle` artifact.
+.. In the YAML for the `KafkaConnector` custom resource (CR), add the following URL path for the driver to the `artifacts.url` field for the `debezium-connector-oracle` artifact:
++
+[source,shell,subs="attributes+"]
+----
+https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/{ojdbc8-version}/ojdbc8-{ojdbc8-version}.jar
+----
 +
 For more information about the YAML file for the `KafkaConnector` CR, see xref:openshift-streams-oracle-connector-deployment[Using {StreamsName} to deploy a {prodname} Oracle connector].
 
 ** If you use a Dockerfile to deploy the connector:
-.. From a browser, navigate to link:https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/[Maven Central].
-.. Click the directory for your version of Oracle Database, and then download the `ojdbc8.jar` driver file.
-.. Copy the downloaded file to the directory that stores the {prodname} Oracle connector files, for example, `_<kafka_home>_/libs`.
-+
-When the connector starts, it is automatically configured to use the specified driver.
+.. From a browser, link:https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/{ojdbc8-version}/ojdbc8-{ojdbc8-version}.jar[download the 'ojdbc8.jar' from Maven Central].
+.. Copy the downloaded driver file to the directory that contains the {prodname} Oracle connector JAR file (`debezium-connector-oracle-{debezium-version}.jar`).
+
 endif::product[]
 ifdef::community[]
 
-NOTE: If you use the {prodname} Oracle connector with Oracle XStream, download the JDBC driver as part of the Oracle Instant Client package.
+NOTE: If you use the {prodname} Oracle connector with Oracle XStream, obtain the JDBC driver as part of the Oracle Instant Client package.
 For more information, see xref:obtaining-oracle-jdbc-driver-and-xstreams-api-files[].
 
 .Procedure
 
-. From a browser, navigate to link:https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/[Maven Central].
-. Click the directory for your version of Oracle Database, and then download the `ojdbc8.jar` driver file.
-. Copy the downloaded file to the `_<kafka_home>_/libs` directory that stores the {prodname} Oracle connector files, for example, `kafka/libs` .
+. From a browser, link:https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/{ojdbc8-version}/ojdbc8-{ojdbc8-version}.jar[download the 'ojdbc8.jar' from Maven Central].
+. Copy the downloaded driver file to the directory that contains the {prodname} Oracle connector JAR file (`debezium-connector-oracle-{debezium-version}.jar`).
 endif::community[]
 
 ifdef::community[]


### PR DESCRIPTION
[DBZ-4835](https://issues.redhat.com/browse/DBZ-4835)

Modifies the deployment instructions for the Db2 and Oracle connectors to highlight that the connectors do not include the JDBC drivers that are required to enable access to source databases. 
This change also incorporates the update requested in [DBZ-4883](https://issues.redhat.com/browse/DBZ-4883), to specify that driver files be added to the same directory as the connector plugin file.
Tested in local Antora build. 

