### PR TITLE
DBZ-4896 Allow `ON` as an expression value

### DIFF
--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -1717,8 +1717,8 @@ uninstallPlugin
 //    Set and show statements
 
 setStatement
-    : SET variableClause ('=' | ':=') expression
-      (',' variableClause ('=' | ':=') expression)*                             #setVariable
+    : SET variableClause ('=' | ':=') (expression | ON)
+      (',' variableClause ('=' | ':=') (expression | ON))*                      #setVariable
     | SET (CHARACTER SET | CHARSET | CHAR SET) (charsetName | DEFAULT)          #setCharset
     | SET NAMES
         (charsetName (COLLATE collationName)? | DEFAULT)                        #setNames

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_create.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_create.sql
@@ -413,6 +413,14 @@ COMMIT;
 END
 #end
 #begin
+-- delimiter //
+CREATE PROCEDURE set_unique_check()
+BEGIN
+    SET unique_checks=off;
+    SET unique_checks=on;
+END; -- //-- delimiter ;
+#end
+#begin
 -- Create Role
 create role 'RL_COMPLIANCE_NSA';
 create role if not exists 'RL_COMPLIANCE_NSA';


### PR DESCRIPTION
`ON` can be used as a value for e.g. some server system variables
like unique_checks [1].

[1] https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_unique_checks