### PR TITLE
DBZ-4885 Bump guava version

### DIFF
--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -17,7 +17,7 @@
 
         <!-- Connectors -->
         <version.dropwizard>4.0.1</version.dropwizard>
-        <version.guava>30.0-jre</version.guava>
+        <version.guava>30.1.1-jre</version.guava>
         <version.jaxb>2.3.1</version.jaxb>
         <version.jetty>9.4.12.v20180830</version.jetty>
 


### PR DESCRIPTION
Bump the version to match version required by
kafka-connect-avro-converter for avoid CNFE exception.

https://issues.redhat.com/browse/DBZ-4885