### PR TITLE
DBZ-4906 Fixes typo in link text

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2211,7 +2211,7 @@ When {prodname} reads events streamed from the database, it places the events in
 The blocking queue can provide backpressure for reading change events from the database
 in cases where the connector ingests messages faster than it can write them to Kafka, or when Kafka becomes unavailable.
 Events that are held in the queue are disregarded when the connector periodically records offsets.
-Always set the value of `max.queue.size` to be larger than the value of xref:{context}-property-max-batch-size[`max.batch.size]`.
+Always set the value of `max.queue.size` to be larger than the value of xref:{context}-property-max-batch-size[`max.batch.size`].
 
 |[[db2-property-max-queue-size-in-bytes]]<<db2-property-max-queue-size-in-bytes, `+max.queue.size.in.bytes+`>>
 |`0`

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1511,7 +1511,7 @@ When {prodname} reads events streamed from the database, it places the events in
 The blocking queue can provide backpressure for reading change events from the database
 in cases where the connector ingests messages faster than it can write them to Kafka, or when Kafka becomes unavailable.
 Events that are held in the queue are disregarded when the connector periodically records offsets.
-Always set the value of `max.queue.size` to be larger than the value of xref:{context}-property-max-batch-size[`max.batch.size]`.
+Always set the value of `max.queue.size` to be larger than the value of xref:{context}-property-max-batch-size[`max.batch.size`].
 
 |[[mongodb-property-max-queue-size-in-bytes]]<<mongodb-property-max-queue-size-in-bytes, `+max.queue.size.in.bytes+`>>
 |`0`

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2531,7 +2531,7 @@ When {prodname} reads events streamed from the database, it places the events in
 The blocking queue can provide backpressure for reading change events from the database
 in cases where the connector ingests messages faster than it can write them to Kafka, or when Kafka becomes unavailable.
 Events that are held in the queue are disregarded when the connector periodically records offsets.
-Always set the value of `max.queue.size` to be larger than the value of xref:{context}-property-max-batch-size[`max.batch.size]`.
+Always set the value of `max.queue.size` to be larger than the value of xref:{context}-property-max-batch-size[`max.batch.size`].
 
 |[[mysql-property-max-queue-size-in-bytes]]<<mysql-property-max-queue-size-in-bytes, `+max.queue.size.in.bytes+`>>
 |`0`

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2629,7 +2629,7 @@ When {prodname} reads events streamed from the database, it places the events in
 The blocking queue can provide backpressure for reading change events from the database
 in cases where the connector ingests messages faster than it can write them to Kafka, or when Kafka becomes unavailable.
 Events that are held in the queue are disregarded when the connector periodically records offsets.
-Always set the value of `max.queue.size` to be larger than the value of xref:{context}-property-max-batch-size[`max.batch.size]`.
+Always set the value of `max.queue.size` to be larger than the value of xref:{context}-property-max-batch-size[`max.batch.size`].
 
 |[[oracle-property-max-queue-size-in-bytes]]<<oracle-property-max-queue-size-in-bytes, `+max.queue.size.in.bytes+`>>
 |`0` (disabled)

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3006,7 +3006,7 @@ When {prodname} reads events streamed from the database, it places the events in
 The blocking queue can provide backpressure for reading change events from the database
 in cases where the connector ingests messages faster than it can write them to Kafka, or when Kafka becomes unavailable.
 Events that are held in the queue are disregarded when the connector periodically records offsets.
-Always set the value of `max.queue.size` to be larger than the value of xref:{context}-property-max-batch-size[`max.batch.size]`.
+Always set the value of `max.queue.size` to be larger than the value of xref:{context}-property-max-batch-size[`max.batch.size`].
 
 |[[postgresql-property-max-queue-size-in-bytes]]<<postgresql-property-max-queue-size-in-bytes, `+max.queue.size.in.bytes+`>>
 |`0`

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2302,7 +2302,7 @@ When {prodname} reads events streamed from the database, it places the events in
 The blocking queue can provide backpressure for reading change events from the database
 in cases where the connector ingests messages faster than it can write them to Kafka, or when Kafka becomes unavailable.
 Events that are held in the queue are disregarded when the connector periodically records offsets.
-Always set the value of `max.queue.size` to be larger than the value of xref:{context}-property-max-batch-size[`max.batch.size]`.
+Always set the value of `max.queue.size` to be larger than the value of xref:{context}-property-max-batch-size[`max.batch.size`].
 
 |[[sqlserver-property-max-queue-size-in-bytes]]<<sqlserver-property-max-queue-size-in-bytes, `+max.queue.size.in.bytes+`>>
 |`0`

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -1239,7 +1239,7 @@ When {prodname} reads events streamed from the database, it places the events in
 The blocking queue can provide backpressure for reading change events from the database
 in cases where the connector ingests messages faster than it can write them to Kafka, or when Kafka becomes unavailable.
 Events that are held in the queue are disregarded when the connector periodically records offsets.
-Always set the value of `max.queue.size` to be larger than the value of xref:{context}-property-max-batch-size[`max.batch.size]`.
+Always set the value of `max.queue.size` to be larger than the value of xref:{context}-property-max-batch-size[`max.batch.size`].
 
 |[[vitess-property-max-batch-size]]<<vitess-property-max-batch-size, `+max.batch.size+`>>
 |`10240`


### PR DESCRIPTION
[DBZ-4906](https://issues.redhat.com/browse/DBZ-4906)

Fixes link error introduced in DBZ-4052 [79fd0a6](https://github.com/debezium/debezium/pull/3290/commits/79fd0a6f9dadac6d5aa847e4c0ba8c7038bbb793)

Upstream, this fix does not result in any apparent change, as  the links worked correctly despite the typo.
But the fix is significant downstream, because previously, the error did not pass the validator, and prevented the build from completing. 

This change is required in the 1.9 branch.