### PR TITLE
DBZ-4891 Oracle Logminer : escaped single quote handling in DML

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -8,6 +8,7 @@ Adham
 Adrian Kreuziger
 Ahmed Eljami
 Akshath Patkar
+Aleksejs Sibanovs
 Alex Mansell
 Alex Soto
 Alexander Iskuskov

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
@@ -278,7 +278,6 @@ public class LogMinerDmlParser implements DmlParser {
         int columnIndex = 0;
         StringBuilder collectedValue = null;
         for (; index < sql.length(); ++index) {
-            char lookAhead = (index + 1 < sql.length()) ? sql.charAt(index + 1) : 0;
             char c = sql.charAt(index);
 
             if (inQuote) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/SelectLobParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/SelectLobParser.java
@@ -150,7 +150,7 @@ public class SelectLobParser {
             else if (c == '\'') {
                 // skip over double single quote
                 if (inSingleQuotes && lookAhead == '\'') {
-                    index += 1;
+                    i += 2;
                     continue;
                 }
                 if (inSingleQuotes) {

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -121,4 +121,4 @@ pmalon,Paweł Malon
 limer2,Li Mo
 yingyingtang-brex,Yingying Tang
 zalmane,Oren Elias
-AleksejsSibanovs,Aleksejs Sibanovs
+asibanovs,Aleksejs Sibanovs

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -121,3 +121,4 @@ pmalon,Paweł Malon
 limer2,Li Mo
 yingyingtang-brex,Yingying Tang
 zalmane,Oren Elias
+AleksejsSibanovs,Aleksejs Sibanovs


### PR DESCRIPTION
Fix Oracle Logminer's escaped single quotes parsing in DMLs, related unit test and fix for the old DBZ-3413 test