### PR TITLE
Update Quality Outreach workflow

### DIFF
--- a/.github/workflows/jdk-outreach-workflow.yml
+++ b/.github/workflows/jdk-outreach-workflow.yml
@@ -15,15 +15,10 @@ jobs:
         with:
           submodules: recursive
       - name: Setup OpenJDK
-        uses: sormuras/download-jdk@v1
-        id: jdk
+        uses: oracle-actions/setup-java@v1
         with:
-          feature: ${{ matrix.feature }}
-      - name: Setup Java
-        uses: actions/setup-java@v1.4.3
-        with:
-          java-version: ${{ steps.jdk.outputs.version }}
-          jdkFile: ${{ steps.jdk.outputs.file }}
+          website: jdk.java.net
+          release: ${{ matrix.feature }}
       - name: Maven Build
         run: mvn clean install -B -pl debezium-connector-sqlserver -am -Passembly -Dformat.formatter.goal=validate -Dformat.imports.goal=check -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
   mysql:


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4924

Use Quality Outreach's new [oracle-actions/setup-java](https://github.com/oracle-actions/setup-java) action to download and setup "latest-and-greatest" OpenJDK.

See also https://inside.java/2022/03/11/setup-java