### PR TITLE
DBZ-4933 Fix NPE on null column data in MySQL

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -26,6 +26,7 @@ Andrew Garrett
 Andrew Tongen
 Andrey Ignatenko
 Andrey Pustovetov
+Andrey Savchuk
 Andrey Yegorov
 Andy Teijelo
 Anisha Mohanty
@@ -248,11 +249,13 @@ Mohamed Pudukulathan
 Moira Tagle
 Muhammad Sufyian
 Nansen
+Narz David
 Nathan Mills
 Nathan Smit
 Navdeep Agarwal
 Naveen Kumar KR
 Nayana Hettiarachchi
+Nenad Stojanovikj
 Nick Murray
 Niels Pardon
 Nikhil Benesch

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -123,3 +123,6 @@ yingyingtang-brex,Yingying Tang
 zalmane,Oren Elias
 asibanovs,Aleksejs Sibanovs
 AleksejsSibanovs,Aleksejs Sibanovs
+nenad,Nenad Stojanovikj
+miphik,Andrey Savchuk
+narzdavid,Narz David


### PR DESCRIPTION
When doing a snapshot on a MySQL database that has char type columns (VARCHAR, TEXT, CHAR) and they are null, and a custom converter is present, the MySQL reader throws an NPE.

This fix addresses the problem by returning an object from the `null` value, as well as it checks if the converter is used for the column which is being read from.

https://issues.redhat.com/browse/DBZ-4933