### PR TITLE
DBZ-4961 Update Pulsar client version used by Debezium Server to 2.9.2

### DIFF
--- a/debezium-server/debezium-server-bom/pom.xml
+++ b/debezium-server/debezium-server-bom/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <version.kinesis>2.13.13</version.kinesis>
         <version.pubsub>25.0.0</version.pubsub>
-        <version.pulsar>2.5.2</version.pulsar>
+        <version.pulsar>2.9.2</version.pulsar>
         <version.eventhubs>5.1.1</version.eventhubs>
         <version.jedis>4.1.1</version.jedis>
         <version.pravega>0.9.1</version.pravega>


### PR DESCRIPTION
Bump the Pulsar client version used by Debezium Server from 2.5.2 to 2.9.2