### PR TITLE
DBZ-4879 Correctly resolve archive-log-only SCN mining range

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerHelper.java
@@ -13,7 +13,6 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -48,17 +47,16 @@ public class LogMinerHelper {
      * @param archiveLogOnlyMode true to mine only archive lgos, false to mine all available logs
      * @param archiveDestinationName configured archive log destination name to use, may be {@code null}
      * @param maxRetries the number of retry attempts before giving up and throwing an exception about log state
-     * @param initialDelayMs the initial delay
-     * @param maxDelayMs the maximum delay
+     * @param initialDelay the initial delay
+     * @param maxDelay the maximum delay
      * @throws SQLException if anything unexpected happens
-     * @return current redo log sequences
+     * @return log files that were added to the current mining session
      */
     // todo: check RAC resiliency
-    public static List<BigInteger> setLogFilesForMining(OracleConnection connection, Scn lastProcessedScn, Duration archiveLogRetention,
-                                                        boolean archiveLogOnlyMode, String archiveDestinationName, int maxRetries,
-                                                        Duration initialDelay, Duration maxDelay)
+    public static List<LogFile> setLogFilesForMining(OracleConnection connection, Scn lastProcessedScn, Duration archiveLogRetention,
+                                                     boolean archiveLogOnlyMode, String archiveDestinationName, int maxRetries,
+                                                     Duration initialDelay, Duration maxDelay)
             throws SQLException {
-        List<BigInteger> ret = new LinkedList<>();
         removeLogFilesFromMining(connection);
 
         // Restrict max attempts to 0 or greater values (sanity-check)
@@ -90,12 +88,7 @@ public class LogMinerHelper {
             }
 
             LOGGER.debug("Last mined SCN: {}, Log file list to mine: {}", lastProcessedScn, logFilesNames);
-            for (LogFile logFile : logFilesForMining) {
-                if (logFile.isCurrent()) {
-                    ret.add(logFile.getSequence());
-                }
-            }
-            return ret;
+            return logFilesForMining;
         }
 
         final Scn minScn = getMinimumScn(logFilesForMining);


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4879

At a high level, the issue here is that a separate query for calculating the maximum SCN from the `V$ARCHIVED_LOG` table was being used and this could return a SCN that was higher than the logs that had previously been added to the mining session due to a redo log aging out to an archive log in between the collection of logs and calculation of the maximum archive log SCN.

The goal here was to instead return a `List<LogFile>` that way we resolve the logs once and we then use this list instead as the basis for the SCN boundary calculations when archive log mode is enabled, completely avoiding this race condition.