### PR TITLE
DBZ-4949 Use Java 11 as a baseline

### DIFF
--- a/.github/workflows/debezium-workflow.yml
+++ b/.github/workflows/debezium-workflow.yml
@@ -510,11 +510,11 @@ jobs:
       - name: Checkout Action
         uses: actions/checkout@v2
 
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
 
       - name: Cache Maven Repository
         uses: actions/cache@v2
@@ -542,11 +542,11 @@ jobs:
       - name: Checkout Action
         uses: actions/checkout@v2
 
-      - name: Set up Java 11
+      - name: Set up Java 17
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
 
       - name: Cache Maven Repository
         uses: actions/cache@v2

--- a/debezium-connect-rest-extension/pom.xml
+++ b/debezium-connect-rest-extension/pom.xml
@@ -15,7 +15,6 @@
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
     <timestamp>${maven.build.timestamp}</timestamp>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/debezium-core/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedSnapshotChangeEventSourceTest.java
+++ b/debezium-core/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedSnapshotChangeEventSourceTest.java
@@ -87,8 +87,16 @@ public class SignalBasedSnapshotChangeEventSourceTest {
         Assertions.assertThat(source.buildChunkQuery(table)).isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1, 5 });
         context.maximumKey(new Object[]{ 10, 50 });
-        Assertions.assertThat(source.buildChunkQuery(table)).isEqualTo(
-                "SELECT * FROM \"s1\".\"table1\" WHERE ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?) OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?)) ORDER BY \"pk1\", \"pk2\", \"pk3\" LIMIT 1024");
+        Assertions.assertThat(source.buildChunkQuery(table)).isEqualTo("""
+                        SELECT * FROM \"s1\".\"table1\"
+                        WHERE ((\"pk1\" > ?)
+                        OR (\"pk1\" = ? AND \"pk2\" > ?)
+                        OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?))
+                        AND NOT ((\"pk1\" > ?) OR (\"pk1\" = ? AND \"pk2\" > ?)
+                        OR (\"pk1\" = ? AND \"pk2\" = ? AND \"pk3\" > ?))
+                        ORDER BY \"pk1\", \"pk2\", \"pk3\"
+                        LIMIT 1024
+                """.replace(System.getProperty("line.separator"), "").replace("        ", " ").trim());
     }
 
     @Test

--- a/debezium-parent/pom.xml
+++ b/debezium-parent/pom.xml
@@ -32,11 +32,9 @@
         <version.javadoc.plugin>3.3.2</version.javadoc.plugin>
         <version.code.formatter>2.16.0</version.code.formatter>
         <version.surefire.plugin>3.0.0-M4</version.surefire.plugin>
-        <version.checkstyle.plugin>3.1.1</version.checkstyle.plugin>
         <version.release.plugin>2.5.3</version.release.plugin>
         <version.impsort>1.6.2</version.impsort>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
-        <version.checkstyle>8.32</version.checkstyle>
         <version.revapi.plugin>0.11.5</version.revapi.plugin>
         <version.jandex>1.0.8</version.jandex>
         <version.revapi-java.plugin>0.21.0</version.revapi-java.plugin>
@@ -57,6 +55,7 @@
         <!-- Set formatting default goals -->
         <format.formatter.goal>format</format.formatter.goal>
         <format.imports.goal>sort</format.imports.goal>
+        <format.imports.source.compliance>15</format.imports.source.compliance>
 
         <!-- No debug options by default -->
         <debug.argline />
@@ -290,6 +289,7 @@
                         <artifactId>impsort-maven-plugin</artifactId>
                         <configuration>
                             <removeUnused>true</removeUnused>
+                            <compliance>${format.imports.source.compliance}</compliance>
                         </configuration>
                         <executions>
                             <execution>

--- a/debezium-schema-generator/pom.xml
+++ b/debezium-schema-generator/pom.xml
@@ -13,10 +13,6 @@
   <name>Debezium Schema Generator</name>
   <packaging>maven-plugin</packaging>
 
-  <properties>
-    <maven.compiler.release>11</maven.compiler.release>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.debezium</groupId>

--- a/debezium-server/debezium-server-http/pom.xml
+++ b/debezium-server/debezium-server-http/pom.xml
@@ -131,18 +131,10 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <release>11</release>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <show>private</show>
                     <nohelp>true</nohelp>
-                    <release>11</release>
                 </configuration>
             </plugin>
         </plugins>

--- a/jenkins-jobs/docker/debezium-testing-system/Dockerfile
+++ b/jenkins-jobs/docker/debezium-testing-system/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/openjdk-11
+FROM registry.access.redhat.com/ubi8/openjdk-17
 USER root
 RUN microdnf install git   
 RUN microdnf install unzip

--- a/jenkins-jobs/docker/rhel_kafka/Dockerfile
+++ b/jenkins-jobs/docker/rhel_kafka/Dockerfile
@@ -16,9 +16,9 @@ ENV KAFKA_HOME=/opt/kafka \
     KAFKA_CONNECT_PLUGINS=$KAFKA_HOME/new-connector-plugins
 
 #
-# Install openjdk-11, iproute and unzip
+# Install openjdk-17, iproute and unzip
 #
-RUN dnf -y install java-11-openjdk 
+RUN dnf -y install java-17-openjdk 
 RUN dnf -y install unzip
 RUN dnf -y install iproute && dnf clean all
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <!-- Can't use the (generally preferable) release option yet, as the
-             Cassandra connector still needs to be built with Java 1.8 which
-             isn't aware of this option -->
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.testRelease>17</maven.compiler.testRelease>
 
         <!-- Enforce JDK 11 for building (handled via JBoss parent POM)-->
         <jdk.min.version>11</jdk.min.version>
@@ -435,16 +432,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>jdk11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <properties>
-                <modules.argline>--illegal-access=permit</modules.argline>
-                <maven.compiler.release>8</maven.compiler.release>
-            </properties>
         </profile>
         <profile>
             <id>oracle</id>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <version.release.plugin>2.5.3</version.release.plugin>
         <version.impsort>1.6.2</version.impsort>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
-        <version.checkstyle>8.32</version.checkstyle>
+        <version.checkstyle>10.1</version.checkstyle>
         <version.revapi.plugin>0.11.5</version.revapi.plugin>
         <version.jandex>1.0.8</version.jandex>
         <version.revapi-java.plugin>0.21.0</version.revapi-java.plugin>


### PR DESCRIPTION
Debezium now uses Java 11 as baseline and Java 17 for tests, e.g.
```
$ javap -verbose debezium-core/target/classes/io/debezium/annotation/GuardedBy.class |grep "major version"
  major version: 55
$ javap -verbose debezium-core/target/test-classes/io/debezium/config/ConfigDefinitionMetadataTest.class |grep "major version"                                                                                        
  major version: 61
```
TBD:
* test changes in Jenkins job
* update Cassandra connector to be able to run tests with Java 17, see [DBZ-4910](https://issues.redhat.com/browse/DBZ-4910)

https://issues.redhat.com/browse/DBZ-4949