### PR TITLE
DBZ-4949 Use Java 17 for Cassandra connector tests

### DIFF
--- a/.github/workflows/debezium-workflow.yml
+++ b/.github/workflows/debezium-workflow.yml
@@ -646,14 +646,6 @@ jobs:
           -Dmaven.wagon.http.pool=false 
           -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
-      # Cassandra currently requires JDK8, so we build this connector with that JDK version after we have
-      # built core using JDK11.
-      - name: Set up Java 8
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: 8
-
       - name: Build Debezium Connector Cassandra
         run: >
           mvn clean install -f cassandra/pom.xml -Passembly


### PR DESCRIPTION
After merging Cassandra connector [PR #52](https://github.com/debezium/debezium-connector-cassandra/pull/52), connector stopped requesting Java 1.8 and uses default Java 11. However, GH workflow still uses 1.8 and therefore tests fail.

https://issues.redhat.com/browse/DBZ-4949