### PR TITLE
DBZ-5005 adjust LogMiner batch size based on comparison with currently used batch size

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -139,6 +139,7 @@ Guy Korland
 Guy Pascarella
 Grzegorz Kołakowski
 Jacob Gminder
+Jan Doms
 Jan Hendrik Dolling
 Jason Schweier
 Jiabao Sun

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -607,16 +607,16 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
         streamingMetrics.setCurrentScn(currentScn);
 
         // Add the current batch size to the starting system change number
-        Scn topScnToMine = startScn.add(Scn.valueOf(streamingMetrics.getBatchSize()));
+        final Scn currentBatchSizeScn = Scn.valueOf(streamingMetrics.getBatchSize());
+        Scn topScnToMine = startScn.add(currentBatchSizeScn);
 
         // Control adjusting batch size
         boolean topMiningScnInFarFuture = false;
-        final Scn defaultBatchScn = Scn.valueOf(connectorConfig.getLogMiningBatchSizeDefault());
-        if (topScnToMine.subtract(currentScn).compareTo(defaultBatchScn) > 0) {
+        if (topScnToMine.subtract(currentScn).compareTo(currentBatchSizeScn) > 0) {
             streamingMetrics.changeBatchSize(false, connectorConfig.isLobEnabled());
             topMiningScnInFarFuture = true;
         }
-        if (currentScn.subtract(topScnToMine).compareTo(defaultBatchScn) > 0) {
+        if (currentScn.subtract(topScnToMine).compareTo(currentBatchSizeScn) > 0) {
             streamingMetrics.changeBatchSize(true, connectorConfig.isLobEnabled());
         }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5005

seems more logical to use the current batch size in order to determine if said batch size needs to be increased or decreased.
(additionally it feels weird that the default batch size currently has an extra - hidden - meaning; this makes it harder to pick a good value for it.)
not sure if there's any formal theory to point to? (makes intuitive sense for me ...)

opening PR towards 1.9 (so I'll be able to enjoy the change faster, and because it feels like a 'fix').
is there any kind of formal statement you need from me or the company I work for regarding IP?

cc @Naros 