### PR TITLE
DBZ-5007 Run doc changes workflow only on main repo

### DIFF
--- a/.github/workflows/doc-changes-workflow.yml
+++ b/.github/workflows/doc-changes-workflow.yml
@@ -4,13 +4,14 @@
 name: Documentation Changes
 
 on:
-  # Schedule job to run at midnight UTC every Saturday
+  # Schedule job to run at midnight UTC every day
   schedule:
     - cron: "0 0 * * *"
 
 jobs:
 
   script:
+    if: github.repository == "debezium/debezium"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
* Don't run doc changes workflow on fork where it fails anyway.
* Fix cron comment to reflect the reality.

https://issues.redhat.com/browse/DBZ-5007