### PR TITLE
DBZ-4600 - Add a new ByteArrayConverter with delegate support

### DIFF
--- a/debezium-core/src/main/java/io/debezium/converters/BinaryDataConverter.java
+++ b/debezium-core/src/main/java/io/debezium/converters/BinaryDataConverter.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.converters;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.ConverterConfig;
+import org.apache.kafka.connect.storage.HeaderConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.config.Instantiator;
+
+/**
+ * A custom value converter that allows Avro messages to be delivered as raw binary data to kafka. <p/>
+ *
+ * Designed to be used in the outbox pattern where payloads are pre-serialized by KafkaAvroSerializer
+ * within the application, then get written as either a ByteBuffer or Byte[] to the database. <p/>
+ *
+ * These raw payloads become the body of the resulting Kafka message; allowing the consumer to deserialize
+ * using KafkaAvroDeserializer. <p/>
+ *
+ * To enable the converter in a connector, the following value need to be specified:
+ * "value.converter": "io.debezium.converters.BinaryDataConverter"
+ *
+ * @author Nathan Bradshaw
+ */
+public class BinaryDataConverter implements Converter, HeaderConverter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BinaryDataConverter.class);
+    private static final ConfigDef CONFIG_DEF;
+
+    protected static final String DELEGATE_CONVERTER_TYPE = "delegate.converter.type";
+
+    private Converter delegateConverter;
+
+    static {
+        CONFIG_DEF = ConverterConfig.newConfigDef();
+        CONFIG_DEF.define(DELEGATE_CONVERTER_TYPE, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW, "Specifies the delegate converter class");
+    }
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        final String converterTypeName = (String) configs.get(DELEGATE_CONVERTER_TYPE);
+        if (converterTypeName != null) {
+            delegateConverter = Instantiator.getInstance(converterTypeName, () -> getClass().getClassLoader(), null);
+            delegateConverter.configure(Configuration.from(configs).subset(DELEGATE_CONVERTER_TYPE, true).asMap(), isKey);
+        }
+    }
+
+    @Override
+    public byte[] fromConnectData(String topic, Schema schema, Object value) {
+        if (schema != null && schema.type() != Schema.Type.BYTES) {
+            assertDelegateProvided(topic, value);
+            LOGGER.debug("Value is not of Schema.Type.BYTES, delegating to " + delegateConverter.getClass().getName());
+            return delegateConverter.fromConnectData(topic, schema, value);
+        } else if ((value instanceof byte[])) {
+            return (byte[]) value;
+        } else if ((value instanceof ByteBuffer)) {
+            return ((ByteBuffer) value).array();
+        } else if (value != null) {
+            assertDelegateProvided(topic, value);
+            LOGGER.debug("Value is not of Schema.Type.BYTES, delegating to " + delegateConverter.getClass().getName());
+            return delegateConverter.fromConnectData(topic, schema, value);
+        }
+        return null;
+    }
+
+    @Override
+    public SchemaAndValue toConnectData(String topic, byte[] value) {
+        return new SchemaAndValue(Schema.OPTIONAL_BYTES_SCHEMA, value);
+    }
+
+    @Override
+    public byte[] fromConnectHeader(String topic, String headerKey, Schema schema, Object value) {
+        return this.fromConnectData(topic, schema, value);
+    }
+
+    @Override
+    public SchemaAndValue toConnectHeader(String topic, String headerKey, byte[] value) {
+        return this.toConnectData(topic, value);
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+    private void assertDelegateProvided(String name, Object type) {
+        if (delegateConverter == null) {
+            throw new DataException("A " + name + " of type '" + type + "' requires a delegate.converter.type to be configured");
+        }
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/converters/BinaryDataConverter.java
+++ b/debezium-core/src/main/java/io/debezium/converters/BinaryDataConverter.java
@@ -74,11 +74,14 @@ public class BinaryDataConverter implements Converter, HeaderConverter {
             assertDelegateProvided(topic, value);
             LOGGER.debug("Value is not of Schema.Type.BYTES, delegating to " + delegateConverter.getClass().getName());
             return delegateConverter.fromConnectData(topic, schema, value);
-        } else if ((value instanceof byte[])) {
+        }
+        else if ((value instanceof byte[])) {
             return (byte[]) value;
-        } else if ((value instanceof ByteBuffer)) {
+        }
+        else if ((value instanceof ByteBuffer)) {
             return ((ByteBuffer) value).array();
-        } else if (value != null) {
+        }
+        else if (value != null) {
             assertDelegateProvided(topic, value);
             LOGGER.debug("Value is not of Schema.Type.BYTES, delegating to " + delegateConverter.getClass().getName());
             return delegateConverter.fromConnectData(topic, schema, value);

--- a/debezium-core/src/main/java/io/debezium/converters/ByteArrayConverter.java
+++ b/debezium-core/src/main/java/io/debezium/converters/ByteArrayConverter.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.converters;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.storage.Converter;
+import org.apache.kafka.connect.storage.ConverterConfig;
+import org.apache.kafka.connect.storage.HeaderConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.config.Instantiator;
+
+/**
+ * A customized value converter to allow avro message to be delivered as it is (byte[]) to kafka, this is used
+ * for outbox pattern where payload is serialized by KafkaAvroSerializer, the consumer need to get the deseralized payload.
+ *
+ * To enabled the converter in a connector, the following value need to be specified
+ * "value.converter": "io.debezium.converters.ByteArrayConverter"
+ *
+ * @author Nathan Bradshaw
+ */
+public class ByteArrayConverter implements Converter, HeaderConverter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ByteArrayConverter.class);
+    private static final ConfigDef CONFIG_DEF;
+
+    protected static final String DELEGATE_CONVERTER_TYPE = "delegate.converter.type";
+
+    private Converter delegateConverter;
+
+    static {
+        CONFIG_DEF = ConverterConfig.newConfigDef();
+        CONFIG_DEF.define(DELEGATE_CONVERTER_TYPE, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW, "Specifies the delegate converter class");
+    }
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        final String converterTypeName = (String) configs.get(DELEGATE_CONVERTER_TYPE);
+        if (converterTypeName != null) {
+            delegateConverter = Instantiator.getInstance(converterTypeName, () -> getClass().getClassLoader(), null);
+            delegateConverter.configure(Configuration.from(configs).subset(DELEGATE_CONVERTER_TYPE, true).asMap(), isKey);
+        }
+    }
+
+    @Override
+    public byte[] fromConnectData(String topic, Schema schema, Object value) {
+        if (schema != null && schema.type() != Schema.Type.BYTES) {
+            assertDelegateProvided(topic, value);
+            LOGGER.debug("Value is not of Schema.Type.BYTES, delegating to " + delegateConverter.getClass().getName());
+            return delegateConverter.fromConnectData(topic, schema, value);
+        }
+        else if (value != null && !(value instanceof byte[])) {
+            assertDelegateProvided(topic, value);
+            LOGGER.debug("Value is not of Schema.Type.BYTES, delegating to " + delegateConverter.getClass().getName());
+            return delegateConverter.fromConnectData(topic, schema, value);
+        }
+        else {
+            return (byte[]) value;
+        }
+    }
+
+    @Override
+    public SchemaAndValue toConnectData(String topic, byte[] value) {
+        return new SchemaAndValue(Schema.OPTIONAL_BYTES_SCHEMA, value);
+    }
+
+    @Override
+    public byte[] fromConnectHeader(String topic, String headerKey, Schema schema, Object value) {
+        return this.fromConnectData(topic, schema, value);
+    }
+
+    @Override
+    public SchemaAndValue toConnectHeader(String topic, String headerKey, byte[] value) {
+        return this.toConnectData(topic, value);
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+
+    private void assertDelegateProvided(String name, Object type) {
+        if (delegateConverter == null) {
+            throw new DataException("A " + name + " of type '" + type + "' requires a delegate.converter.type to be configured");
+        }
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/converters/ByteBufferConverter.java
+++ b/debezium-core/src/main/java/io/debezium/converters/ByteBufferConverter.java
@@ -22,14 +22,19 @@ import io.debezium.config.Configuration;
 import io.debezium.config.Instantiator;
 
 /**
+ * @deprecated
+ * This class is scheduled to be renamed in Debezium 2.0 to "io.debezium.converters.BinaryDataConverter". <p/>
+ *
  * A customized value converter to allow avro message to be delivered as it is (byte[]) to kafka, this is used
  * for outbox pattern where payload is serialized by KafkaAvroSerializer, the consumer need to get the deseralized payload.
  *
- * To enabled the converter in a connector, the following value need to be specified
+ * To enable the converter in a connector, the following value need to be specified
  * "value.converter": "io.debezium.converters.ByteBufferConverter"
  *
+ * @since 1.9
  * @author Yang Yang
  */
+@Deprecated
 public class ByteBufferConverter implements Converter, HeaderConverter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ByteBufferConverter.class);

--- a/debezium-core/src/test/java/io/debezium/converters/BinaryDataConverterTest.java
+++ b/debezium-core/src/test/java/io/debezium/converters/BinaryDataConverterTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.converters;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.json.JsonDeserializer;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static junit.framework.TestCase.fail;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+public class BinaryDataConverterTest {
+    private static final String TOPIC = "topic";
+    private static final byte[] SAMPLE_BYTES = "sample string".getBytes(StandardCharsets.UTF_8);
+
+    private final BinaryDataConverter converter = new BinaryDataConverter();
+
+    @Before
+    public void setUp() {
+        converter.configure(Collections.emptyMap(), false);
+    }
+
+    @Test
+    public void shouldConvertFromBytesData() {
+        assertThat(converter.fromConnectData(TOPIC, Schema.BYTES_SCHEMA, SAMPLE_BYTES)).isEqualTo(SAMPLE_BYTES);
+    }
+
+    @Test
+    public void shouldConvertFromByteBufferData() {
+        assertThat(converter.fromConnectData(TOPIC, Schema.BYTES_SCHEMA, ByteBuffer.wrap(SAMPLE_BYTES))).isEqualTo(SAMPLE_BYTES);
+    }
+
+    @Test
+    public void shouldConvertFromBytesDataWithNullSchema() {
+        assertThat(converter.fromConnectData(TOPIC, null, SAMPLE_BYTES)).isEqualTo(SAMPLE_BYTES);
+    }
+
+    @Test
+    public void shouldConvertFromByteBufferDataWithNullSchema() {
+        assertThat(converter.fromConnectData(TOPIC, null, ByteBuffer.wrap(SAMPLE_BYTES))).isEqualTo(SAMPLE_BYTES);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenInvalidSchema() {
+        assertThrows(DataException.class,
+                () -> converter.fromConnectData(TOPIC, Schema.INT32_SCHEMA, SAMPLE_BYTES));
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenInvalidValue() {
+        assertThrows(DataException.class,
+                () -> converter.fromConnectData(TOPIC, Schema.BYTES_SCHEMA, 12));
+    }
+
+    @Test
+    public void shouldReturnNullWhenConvertingNullValue() {
+        assertThat(converter.fromConnectData(TOPIC, Schema.BYTES_SCHEMA, null)).isNull();
+    }
+
+    @Test
+    public void shouldConvertBytesFromDataIgnoringHeader() {
+        assertThat(converter.fromConnectHeader(TOPIC, "ignored", Schema.BYTES_SCHEMA, SAMPLE_BYTES))
+                .isEqualTo(SAMPLE_BYTES);
+    }
+
+    @Test
+    public void shouldConvertByteBufferFromDataIgnoringHeader() {
+        assertThat(converter.fromConnectHeader(TOPIC, "ignored", Schema.BYTES_SCHEMA, ByteBuffer.wrap(SAMPLE_BYTES)))
+                .isEqualTo(SAMPLE_BYTES);
+    }
+
+    @Test
+    public void shouldConvertBytesToConnectData() {
+        SchemaAndValue data = converter.toConnectData(TOPIC, SAMPLE_BYTES);
+        assertThat(data.schema()).isEqualTo(Schema.OPTIONAL_BYTES_SCHEMA);
+        assertThat(data.value()).isEqualTo(SAMPLE_BYTES);
+    }
+
+    @Test
+    public void shouldConvertToConnectDataForNullValue() {
+        SchemaAndValue data = converter.toConnectData(TOPIC, null);
+        assertThat(data.schema()).isEqualTo(Schema.OPTIONAL_BYTES_SCHEMA);
+        assertThat(data.value()).isNull();
+    }
+
+    @Test
+    public void shouldThrowWhenNoDelegateConverterConfigured() {
+        try {
+            converter.fromConnectData(TOPIC, Schema.OPTIONAL_STRING_SCHEMA, "Hello World");
+            fail("now expected exception thrown");
+        }
+        catch (Exception e) {
+            assertThat(e).isExactlyInstanceOf(DataException.class);
+        }
+    }
+
+    @Test
+    public void shouldThrowWhenNoSchemaOrDelegateConverterConfigured() {
+        try {
+            converter.fromConnectData(TOPIC, null, "Hello World");
+            fail("now expected exception thrown");
+        }
+        catch (Exception e) {
+            assertThat(e).isExactlyInstanceOf(DataException.class);
+        }
+    }
+
+    @Test
+    public void shouldConvertUsingDelegateConverter() {
+        // Configure delegate converter
+        converter.configure(Collections.singletonMap(ByteArrayConverter.DELEGATE_CONVERTER_TYPE, JsonConverter.class.getName()), false);
+
+        byte[] data = converter.fromConnectData(TOPIC, Schema.OPTIONAL_STRING_SCHEMA, "{\"message\": \"Hello World\"}");
+
+        JsonNode value = null;
+        try (JsonDeserializer jsonDeserializer = new JsonDeserializer()) {
+            value = jsonDeserializer.deserialize(TOPIC, data);
+        }
+
+        assertThat(value).isNotNull();
+        assertThat(value.get("schema")).isNotNull();
+        assertThat(value.get("schema").get("type").asText()).isEqualTo("string");
+        assertThat(value.get("schema").get("optional").asBoolean()).isTrue();
+        assertThat(value.get("payload")).isNotNull();
+        assertThat(value.get("payload").asText()).isEqualTo("{\"message\": \"Hello World\"}");
+    }
+
+    @Test
+    public void shouldConvertUsingDelegateConverterWithNoSchema() {
+        // Configure delegate converter
+        converter.configure(Collections.singletonMap(ByteArrayConverter.DELEGATE_CONVERTER_TYPE, JsonConverter.class.getName()), false);
+
+        byte[] data = converter.fromConnectData(TOPIC, null, "{\"message\": \"Hello World\"}");
+
+        JsonNode value = null;
+        try (JsonDeserializer jsonDeserializer = new JsonDeserializer()) {
+            value = jsonDeserializer.deserialize(TOPIC, data);
+        }
+
+        assertThat(value).isNotNull();
+        assertThat(value.get("schema")).isNotNull();
+        assertThat(value.get("schema").asText()).isEqualTo("null");
+        assertThat(value.get("payload")).isNotNull();
+        assertThat(value.get("payload").asText()).isEqualTo("{\"message\": \"Hello World\"}");
+    }
+
+    @Test
+    public void shouldConvertUsingDelegateConverterWithOptionsAndNoSchema() {
+        // Configure delegate converter
+        final Map<String, String> config = new HashMap<>();
+        config.put(ByteArrayConverter.DELEGATE_CONVERTER_TYPE, JsonConverter.class.getName());
+        config.put(ByteArrayConverter.DELEGATE_CONVERTER_TYPE + ".schemas.enable", Boolean.FALSE.toString());
+        converter.configure(config, false);
+
+        byte[] data = converter.fromConnectData(TOPIC, null, "{\"message\": \"Hello World\"}");
+
+        JsonNode value = null;
+        try (JsonDeserializer jsonDeserializer = new JsonDeserializer()) {
+            value = jsonDeserializer.deserialize(TOPIC, data);
+        }
+
+        assertThat(value.has("schema")).isFalse();
+        assertThat(value.has("payload")).isFalse();
+        assertThat(value.asText()).isEqualTo("{\"message\": \"Hello World\"}");
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/converters/BinaryDataConverterTest.java
+++ b/debezium-core/src/test/java/io/debezium/converters/BinaryDataConverterTest.java
@@ -6,7 +6,16 @@
 
 package io.debezium.converters;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import static junit.framework.TestCase.fail;
+import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.DataException;
@@ -15,15 +24,7 @@ import org.apache.kafka.connect.json.JsonDeserializer;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import static junit.framework.TestCase.fail;
-import static org.fest.assertions.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class BinaryDataConverterTest {
     private static final String TOPIC = "topic";

--- a/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
@@ -211,21 +211,24 @@ apply the following configuration to the connector:
 ----
 transforms=outbox,...
 transforms.outbox.type=io.debezium.connector.mongodb.transforms.outbox.MongoEventRouter
-value.converter=io.debezium.converters.ByteBufferConverter
+value.converter=io.debezium.converters.ByteArrayConverter
 ----
 
 By default, the `payload` field value (the Avro data) is the only message value.
-Configuration of `ByteBufferConverter` as the value converter propagates the `payload` field value as-is into the Kafka message value.
+Configuration of `ByteArrayConverter` as the value converter propagates the `payload` field value as-is into the Kafka message value.
+
+Note that this differs from the `ByteBufferConverter` suggested for other SMTs.
+This is due to the different approach MongoDB takes to storing byte arrays internally.
 
 The {prodname} connectors may be configured to emit heartbeat, transaction metadata, or schema change events (support varies by connector).
-These events cannot be serialized by the `ByteBufferConverter` so additional configuration must be provided so the converter knows how to serialize these events.
+These events cannot be serialized by the `ByteArrayConverter` so additional configuration must be provided so the converter knows how to serialize these events.
 As an example, the following configuration illustrates using the Apache Kafka `JsonConverter` with no schemas:
 
 [source]
 ----
 transforms=outbox,...
 transforms.outbox.type=io.debezium.connector.mongodb.transforms.outbox.MongoEventRouter
-value.converter=io.debezium.converters.ByteBufferConverter
+value.converter=io.debezium.converters.ByteArrayConverter
 value.converter.delegate.converter.type=org.apache.kafka.connect.json.JsonConverter
 value.converter.delegate.converter.type.schemas.enable=false
 ----


### PR DESCRIPTION
**Overview**
Debezium currently provides `ByteBufferConverter`. This converter works great when converting from PostgreSQL DBs, but doesn’t work for MongoDB (where the data shape is different - a Binary BSON object internally). See: https://issues.redhat.com/browse/DBZ-4600

Instead we ended up using `ByteArrayConverter` from core Kafka-Connect - which works fine for our basic use-case.

However - we want to take advantage of the delegate config and pattern Debezium provides. 
I.e. the user should be able to provide a value for `delegate.converter.type` in the configuration to specify a “backup” converter which can be used in the event the shape of the data doesn’t match that expected. 

We've recently added heartbeats to our Debezium config - following the docs - and immediately discovered that the Kafka-Connect `ByteArrayConverter` fails to cope with the Json sent by the heartbeat. Given this "real" use-case it seemed sensible to me to add a Debezium-packaged `ByteArrayConverter`. Also I want my application to work :)

**Note**
It's worth noting that we've tested this code locally at AT; running the build Debezium snapshot jars and testing this converter with heartbeats enabled; and things worked correctly and as expected.