### PR TITLE
DBZ-5015 Get the json value of a Document when parsing signaling message

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -60,6 +60,7 @@ Brandon Maguire
 Brennan Vincent
 Camile Sing
 Cao Manh Dat
+Chad Marmon
 Cheng Pan
 Ching Tsai
 Chris Baumbauer

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -835,7 +835,8 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
         for (Object fieldValue : fields.values()) {
             if (fieldValue instanceof Document) {
                 result[idx++] = ((Document) fieldValue).toJson();
-            } else {
+            }
+            else {
                 result[idx++] = fieldValue.toString();
             }
         }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -833,7 +833,11 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
         final String[] result = new String[3];
         int idx = 0;
         for (Object fieldValue : fields.values()) {
-            result[idx++] = fieldValue.toString();
+            if (fieldValue instanceof Document) {
+                result[idx++] = ((Document) fieldValue).toJson();
+            } else {
+                result[idx++] = fieldValue.toString();
+            }
         }
         return Optional.of(result);
     }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorConfigTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorConfigTest.java
@@ -1,0 +1,30 @@
+package io.debezium.connector.mongodb;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.Optional;
+
+public class MongoDbConnectorConfigTest {
+
+    @Test
+    public void parseSignallingMessage() {
+        Schema schema = new SchemaBuilder(Schema.Type.STRUCT).field("after", Schema.STRING_SCHEMA).build();
+        Struct struct = new Struct(schema);
+        struct.put("after", "{\"_id\":\"test-1\"," +
+                            "\"type\":\"execute-snapshot\"," +
+                            "\"data\":{\"data-collections\":[\"database.collection\"],\"type\":\"incremental\"}}");
+        MongoDbConnectorConfig mongoDbConnectorConfig = new MongoDbConnectorConfig(TestHelper.getConfiguration());
+
+        Optional<String[]> resultOpt = mongoDbConnectorConfig.parseSignallingMessage(struct);
+
+        Assert.assertTrue(resultOpt.isPresent());
+        String[] result = resultOpt.get();
+        Assert.assertEquals(3, result.length);
+        Assert.assertEquals("test-1", result[0]);
+        Assert.assertEquals("execute-snapshot", result[1]);
+        Assert.assertEquals("{\"data-collections\": [\"database.collection\"], \"type\": \"incremental\"}", result[2]);
+    }
+}

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorConfigTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorConfigTest.java
@@ -1,11 +1,17 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.debezium.connector.mongodb;
+
+import java.util.Optional;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.Assert;
 import org.junit.Test;
-import java.util.Optional;
 
 public class MongoDbConnectorConfigTest {
 
@@ -14,8 +20,8 @@ public class MongoDbConnectorConfigTest {
         Schema schema = new SchemaBuilder(Schema.Type.STRUCT).field("after", Schema.STRING_SCHEMA).build();
         Struct struct = new Struct(schema);
         struct.put("after", "{\"_id\":\"test-1\"," +
-                            "\"type\":\"execute-snapshot\"," +
-                            "\"data\":{\"data-collections\":[\"database.collection\"],\"type\":\"incremental\"}}");
+                "\"type\":\"execute-snapshot\"," +
+                "\"data\":{\"data-collections\":[\"database.collection\"],\"type\":\"incremental\"}}");
         MongoDbConnectorConfig mongoDbConnectorConfig = new MongoDbConnectorConfig(TestHelper.getConfiguration());
 
         Optional<String[]> resultOpt = mongoDbConnectorConfig.parseSignallingMessage(struct);

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -127,3 +127,4 @@ nenad,Nenad Stojanovikj
 miphik,Andrey Savchuk
 narzdavid,Narz David
 LarsWerkman, Lars Werkman
+chadthman, Chad Marmon


### PR DESCRIPTION
Incremental snapshots on a MongoDB connector are broken. In the signaling table you are expected to provide json in the `data` (ex: `"data": { "data-collections": ["database.collection"] }`) that specifies which tables to make the snapshot. However when parsing that `data` using `Document.parse` and looping over the values of the fields, if it finds nested json will be treated as another `Document`. Just calling the `.toString()` on that will not give the value in json. We need the resulting string for that field to be in json still as there is another json parser later in the method `Signal.process`