### PR TITLE
DBZ-5033: Ignore null offsets when recovering database history

### DIFF
--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -2667,6 +2667,27 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         stopConnector();
     }
 
+    @Test
+    @FixFor("DBZ-5033")
+    public void shouldIgnoreNullOffsetsWhenRecoveringHistory() {
+        final Configuration config1 = TestHelper.defaultMultiPartitionConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_ONLY)
+                .build();
+        start(SqlServerConnector.class, config1);
+        assertConnectorIsRunning();
+        TestHelper.waitForDatabaseSnapshotToBeCompleted(TestHelper.TEST_DATABASE);
+        stopConnector();
+
+        TestHelper.createTestDatabases(TestHelper.TEST_DATABASE_2);
+        final Configuration config2 = TestHelper.defaultMultiPartitionConfig(
+                TestHelper.TEST_DATABASE, TestHelper.TEST_DATABASE_2)
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
+                .build();
+        start(SqlServerConnector.class, config2);
+        assertConnectorIsRunning();
+        stopConnector();
+    }
+
     private void assertRecord(Struct record, List<SchemaAndValueField> expected) {
         expected.forEach(schemaAndValueField -> schemaAndValueField.assertFor(record));
     }

--- a/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/DatabaseHistory.java
@@ -24,8 +24,8 @@ import io.debezium.relational.ddl.DdlParser;
 
 /**
  * A history of the database schema described by a {@link Tables}. Changes to the database schema can be
- * {@link #record(Map, Map, String, Tables, String) recorded}, and a {@link Tables database schema} can be
- * {@link #record(Map, Map, String, Tables, String) recovered} to various points in that history.
+ * {@link #record(Map, Map, String, String) recorded}, and a {@link Tables database schema} can be
+ * {@link #record(Map, Map, String, String) recovered} to various points in that history.
  *
  * @author Randall Hauch
  */
@@ -140,7 +140,7 @@ public interface DatabaseHistory {
 
     /**
      * Recover the {@link Tables database schema} to a known point in its history. Note that it is possible to recover the
-     * database schema to a point in history that is earlier than what has been {@link #record(Map, Map, String, Tables, String)
+     * database schema to a point in history that is earlier than what has been {@link #record(Map, Map, String, String)
      * recorded}. Likewise, when recovering to a point in history <em>later</em> than what was recorded, the database schema will
      * reflect the latest state known to the history.
      *
@@ -166,7 +166,7 @@ public interface DatabaseHistory {
     void recover(Map<Map<String, ?>, Map<String, ?>> offsets, Tables schema, DdlParser ddlParser);
 
     /**
-     * Stop recording history and release any resources acquired since {@link #configure(Configuration, HistoryRecordComparator, DatabaseHistoryListener)}.
+     * Stop recording history and release any resources acquired since {@link #configure(Configuration, HistoryRecordComparator, DatabaseHistoryListener, boolean)}.
      */
     void stop();
 


### PR DESCRIPTION
See [DBZ-5033](https://issues.redhat.com/browse/DBZ-5033).

The Javadoc changes complement the API changes made in https://github.com/debezium/debezium/pull/457 and https://github.com/debezium/debezium/pull/1104.