### PR TITLE
DBZ-3848 Mysql connector throws java.lang.ArrayIndexOutOfBoundsException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <!-- Database drivers, should align with databases -->
         <version.postgresql.driver>42.3.3</version.postgresql.driver>
         <version.mysql.driver>8.0.28</version.mysql.driver>
-        <version.mysql.binlog>0.25.5</version.mysql.binlog>
+        <version.mysql.binlog>0.25.6</version.mysql.binlog>
         <version.mongo.driver>4.3.3</version.mongo.driver>
         <version.sqlserver.driver>9.4.1.jre8</version.sqlserver.driver>
         <version.oracle.driver>21.1.0.0</version.oracle.driver>


### PR DESCRIPTION
https://github.com/osheroff/mysql-binlog-connector-java/commit/324858397ec1cb8328d6035f67d411bb16d17740
Hi guys, 
The version 0.25.6 from mysql-binlog-connector-java had fixed the array index out of bounds exception, so we need to upgrade it.