### PR TITLE
DBZ-5007 Use single quotes in repo name

### DIFF
--- a/.github/workflows/doc-changes-workflow.yml
+++ b/.github/workflows/doc-changes-workflow.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   script:
-    if: github.repository == "debezium/debezium"
+    if: github.repository == 'debezium/debezium'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Github actions allows only signle quote in expressions [1].

[1] https://docs.github.com/en/actions/learn-github-actions/expressions#literals