### PR TITLE
[ci] Use single quotes for repository name

### DIFF
--- a/.github/workflows/doc-changes-workflow.yml
+++ b/.github/workflows/doc-changes-workflow.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   script:
-    if: github.repository == "debezium/debezium"
+    if: github.repository == 'debezium/debezium'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The docs workflow was having a [startup failure](https://github.com/debezium/debezium/actions/runs/2223624630). Here is a quick fix. 