### PR TITLE
DBZ-5064 Use maven 3.8.4

### DIFF
--- a/jenkins-jobs/docker/debezium-testing-system/Dockerfile
+++ b/jenkins-jobs/docker/debezium-testing-system/Dockerfile
@@ -3,7 +3,7 @@ USER root
 RUN microdnf install git   
 RUN microdnf install unzip
 
-ARG MAVEN=3.6.3
+ARG MAVEN=3.8.4
 ARG OCP_CLIENT=3.7.23
 
 RUN curl --retry 7 -Lo /tmp/client-tools.tar.gz "https://mirror.openshift.com/pub/openshift-v3/clients/${OCP_CLIENT}/linux/oc.tar.gz"


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5064

(more changes in other repos for preparing OS images are needed)