### PR TITLE
DBZ-4956 Create trigger job to run all downstream preparation jobs

### DIFF
--- a/jenkins-jobs/job-dsl/ocp_downstream_trigger_all_prepare.groovy
+++ b/jenkins-jobs/job-dsl/ocp_downstream_trigger_all_prepare.groovy
@@ -1,4 +1,4 @@
-pipelineJob('trigger-downstream-preparations') {
+pipelineJob('ocp-downstream-trigger-all-prepare') {
     displayName('Trigger Downstream Prepararions')
     description('Triggers downstream preparation jobs')
 

--- a/jenkins-jobs/job-dsl/ocp_downstream_trigger_all_prepare.groovy
+++ b/jenkins-jobs/job-dsl/ocp_downstream_trigger_all_prepare.groovy
@@ -1,5 +1,5 @@
 pipelineJob('ocp-downstream-trigger-all-prepare') {
-    displayName('Trigger Downstream Prepararions')
+    displayName('Trigger Downstream Preparations')
     description('Triggers downstream preparation jobs')
 
     parameters {

--- a/jenkins-jobs/job-dsl/ocp_downstream_trigger_all_prepare.groovy
+++ b/jenkins-jobs/job-dsl/ocp_downstream_trigger_all_prepare.groovy
@@ -25,9 +25,9 @@ pipelineJob('ocp-downstream-trigger-all-prepare') {
         stringParam('STRZ_RESOURCES_DEPLOYMENT_DESCRIPTOR', '060-Deployment-strimzi-cluster-operator.yaml', 'OCP Downstream strimzi - Descriptor for cluster-operator deployment')
         textParam('STRZ_IMAGES', '', 'OCP Downstream strimzi - List of productised strimzi images')
 //      DEBEZIUM CONNECT IMAGE CONFIG
-        booleanParam('DBZ_CONNECT_BUILD', true, 'OCP Downstream strimzi - Also build debezium images')
-        textParam('DBZ_CONNECTOR_ARCHIVE_URLS', '', 'OCP Downstream strimzi - List of URLs to productised Debezium connectors')
-        textParam('DBZ_EXTRA_LIBS', '', 'Downstream Strimzi, RHEL - List of extra libraries added to connectors')
+        booleanParam('STRZ_DBZ_CONNECT_BUILD', true, 'OCP Downstream strimzi - Also build debezium images')
+        textParam('STRZ_DBZ_CONNECTOR_ARCHIVE_URLS', '', 'OCP Downstream strimzi - List of URLs to productised Debezium connectors')
+        textParam('STRZ_DBZ_EXTRA_LIBS', '', 'Downstream Strimzi, RHEL - List of extra libraries added to connectors')
 
 //      APICURIO
         stringParam('APIC_RESOURCES_ARCHIVE_URL', '', 'URL to productised apicurio sources')

--- a/jenkins-jobs/job-dsl/trigger_preparations.groovy
+++ b/jenkins-jobs/job-dsl/trigger_preparations.groovy
@@ -1,0 +1,60 @@
+pipelineJob('trigger-downstream-preparations') {
+    displayName('Trigger Downstream Prepararions')
+    description('Triggers downstream preparation jobs')
+
+    parameters {
+        stringParam('LABEL', '', 'Optional label for the preparation jobs')
+        booleanParam('EXECUTE_AS', false, 'Execute downstream Artifact Server prepare')
+        booleanParam('EXECUTE_STRIMZI', false, 'Execute AMQ Stream Deployment Preparation')
+        booleanParam('EXECUTE_APICURIO', false, 'Execute Apicurio deployment preparation')
+        booleanParam('EXECUTE_RHEL', false, 'Execute AMQ Streams on RHEL Preparation')
+
+
+        stringParam('MAIL_TO', 'debezium-qe@redhat.com')
+//      QUAY CONFIG
+        stringParam('QUAY_CREDENTIALS', 'debezium-quay-creds', 'Quay.io credentials id')
+        stringParam('QUAY_ORGANISATION', 'debezium', 'Organisation where images are copied')
+//      DEBEZIUM CONFIG
+        stringParam('DBZ_GIT_REPOSITORY', 'https://github.com/debezium/debezium.git', 'Repository from which Debezium sources are cloned')
+        stringParam('DBZ_GIT_BRANCH', 'main', 'A branch/tag of Debezium sources')
+        stringParam('DBZ_GIT_REPOSITORY_DB2', 'https://github.com/debezium/debezium-connector-db2.git', 'Repository from which Debezium DB2 sources are cloned')
+        stringParam('DBZ_GIT_BRANCH_DB2', 'main', 'A branch/tag of Debezium DB2 sources')
+
+//      OCP STRIMZI
+        stringParam('STRZ_RESOURCES_ARCHIVE_URL', '', 'OCP Downstream strimzi - URL to productised strimzi sources')
+        stringParam('STRZ_RESOURCES_DEPLOYMENT_DESCRIPTOR', '060-Deployment-strimzi-cluster-operator.yaml', 'OCP Downstream strimzi - Descriptor for cluster-operator deployment')
+        textParam('STRZ_IMAGES', '', 'OCP Downstream strimzi - List of productised strimzi images')
+//      DEBEZIUM CONNECT IMAGE CONFIG
+        booleanParam('DBZ_CONNECT_BUILD', true, 'OCP Downstream strimzi - Also build debezium images')
+        textParam('DBZ_CONNECTOR_ARCHIVE_URLS', '', 'OCP Downstream strimzi - List of URLs to productised Debezium connectors')
+        textParam('DBZ_EXTRA_LIBS', '', 'Downstream Strimzi, RHEL - List of extra libraries added to connectors')
+
+//      APICURIO
+        stringParam('APIC_RESOURCES_ARCHIVE_URL', '', 'URL to productised apicurio sources')
+        stringParam('APIC_RESOURCES_DEPLOYMENT_DESCRIPTOR', 'install.yaml', 'Descriptor for deployment')
+        booleanParam('PUSH_IMAGES', true, 'Apicurio - Push images to quay.io')
+        textParam('APIC_IMAGES', '', 'List of productised apicurio images')
+
+
+//      RHEL
+        booleanParam('AUTO_TAG', true, 'RHEL - Use automatically generated tag')
+        textParam('EXTRA_IMAGE_TAGS', 'latest', 'RHEL - List of extra texts tags for multiple images')
+        stringParam('RHEL_IMAGE', 'registry.access.redhat.com/ubi8:latest', 'Base RHEL image')
+        stringParam('KAFKA_URL', '', 'RHEL - AMQ streams kafka')
+
+
+//      ARTIFACT SERVER
+        textParam('AS_DBZ_EXTRA_LIBS', '', 'Artifact Server - List of extra libraries added to connectors')
+        textParam('AS_EXTRA_IMAGE_TAGS', 'latest', 'Artifact Server - List of extra texts tags for multiple images')
+        booleanParam('AS_AUTO_TAG', true, 'Artifact Server - Use automatically generated tag')
+        textParam('AS_DBZ_CONNECTOR_ARCHIVE_URLS', '', 'Artifact Server - List of URLs to productised Debezium connectors')
+
+
+    }
+    definition {
+        cps {
+            script(readFileFromWorkspace('jenkins-jobs/pipelines/downstream_preparations_trigger_pipeline.groovy'))
+            sandbox()
+        }
+    }
+}

--- a/jenkins-jobs/pipelines/connector_tests_trigger_pipeline.groovy
+++ b/jenkins-jobs/pipelines/connector_tests_trigger_pipeline.groovy
@@ -102,7 +102,13 @@ pipeline {
                     if (!params["${db.toUpperCase()}_TEST"]) {
                         continue
                     }
-                    def build = jenkins.model.Jenkins.instance.getItem("connector-debezium-${db}-matrix-test").lastBuild
+                    def jobName = "connector-debezium-${db}-matrix-test"
+                    def build = jenkins.model.Jenkins.instance.getItem(jobName).lastBuild
+
+                    if (!build) {
+                        println "No build of ${jobName} found!"
+                        return
+                    }
 
                     label = "#${build.number} parent: #${currentBuild.number}"
 

--- a/jenkins-jobs/pipelines/connector_tests_trigger_pipeline.groovy
+++ b/jenkins-jobs/pipelines/connector_tests_trigger_pipeline.groovy
@@ -103,7 +103,7 @@ pipeline {
                         continue
                     }
                     def jobName = "connector-debezium-${db}-matrix-test"
-                    def build = jenkins.model.Jenkins.instance.getItem(jobName).lastBuild
+                    def build = jenkins.model.Jenkins.instance.getItem(jobName).getLastCompletedBuild()
 
                     if (!build) {
                         println "No build of ${jobName} found!"

--- a/jenkins-jobs/pipelines/downstream_apicurio_prepare_pipeline.groovy
+++ b/jenkins-jobs/pipelines/downstream_apicurio_prepare_pipeline.groovy
@@ -53,6 +53,14 @@ pipeline {
                         `if [ $PUSH_IMAGES = false ]; then echo " -s"; fi`            
                     '''
                     zip(archive: true, zipFile: 'apicurio-registry-install-examples.zip', dir: 'apicurio')
+
+                    sh '''
+                    set -x
+                    mkdir "${WORKSPACE}/apicurio-all"
+                    cp -R "${WORKSPACE}/apicurio" "${WORKSPACE}/apicurio-all/apicurio"
+                    cp "${WORKSPACE}/published_images.txt" "${WORKSPACE}/apicurio-all/apicurio-published-images.txt"
+                    '''
+                    zip(archive: true, zipFile: 'apicurio-all.zip', dir: 'apicurio-all')
                 }
             }
         }

--- a/jenkins-jobs/pipelines/downstream_artifact_server_prepare_pipeline.groovy
+++ b/jenkins-jobs/pipelines/downstream_artifact_server_prepare_pipeline.groovy
@@ -41,6 +41,7 @@ pipeline {
                         --dest-pass="${QUAY_PASSWORD}"                              \\
                         --img-output="${WORKSPACE}/published_image_dbz.txt"
                     '''
+                    zip(archive: true, zipFile: 'artifact-server-all.zip', glob: 'published_image_dbz.txt')
                 }
             }
         }

--- a/jenkins-jobs/pipelines/downstream_preparations_trigger_pipeline.groovy
+++ b/jenkins-jobs/pipelines/downstream_preparations_trigger_pipeline.groovy
@@ -107,7 +107,7 @@ pipeline {
                         return
                     }
 
-                    def build = jenkins.model.Jenkins.instance.getItem("${entry.key}").lastBuild
+                    def build = jenkins.model.Jenkins.instance.getItem("${entry.key}").getLastCompletedBuild()
 
                     if (!build) {
                         println "No build of ${entry.key} found!"

--- a/jenkins-jobs/pipelines/downstream_preparations_trigger_pipeline.groovy
+++ b/jenkins-jobs/pipelines/downstream_preparations_trigger_pipeline.groovy
@@ -1,0 +1,137 @@
+pipeline {
+    agent {
+        label 'Slave'
+    }
+    stages {
+        stage('Start') {
+            parallel {
+                stage('Invoke_downstream_as') {
+                    when {
+                        expression { params.EXECUTE_AS }
+                    }
+                    steps {
+                        build job: 'ocp-downstream-artifact-server-prepare-job', parameters: [
+                            string(name: MAIL_TO, value: params.MAIL_TO),
+                            string(name: 'QUAY_CREDENTIALS', value: params.QUAY_CREDENTIALS),
+                            string(name: 'QUAY_ORGANISATION', value: params.QUAY_ORGANISATION),
+                            string(name: 'DBZ_GIT_REPOSITORY', value: params.DBZ_GIT_REPOSITORY),
+                            string(name: 'DBZ_GIT_BRANCH', value: params.DBZ_GIT_BRANCH),
+                            string(name: 'DBZ_EXTRA_LIBS', value: params.AS_DBZ_EXTRA_LIBS ),
+                            string(name: 'EXTRA_IMAGE_TAGS', value: params.AS_EXTRA_IMAGE_TAGS),
+                            booleanParam(name: 'AUTO_TAG', value: params.AS_AUTO_TAG),
+                            string(name: 'DBZ_CONNECTOR_ARCHIVE_URLS', value: params.AS_DBZ_CONNECTOR_ARCHIVE_URLS),
+                        ]
+                        copyArtifacts(projectName: 'ocp-downstream-artifact-server-prepare-job', selector: lastCompleted())
+                    }
+                }
+
+                 stage('Invoke_downstream_strimzi') {
+                     when {
+                         expression { params.EXECUTE_STRIMZI }
+                     }
+                     steps {
+                         build job: 'ocp-downstream-strimzi-prepare-job', parameters: [
+                             string(name: MAIL_TO, value: params.MAIL_TO),
+                             string(name: 'QUAY_CREDENTIALS', value: params.QUAY_CREDENTIALS),
+                             string(name: 'QUAY_ORGANISATION', value: params.QUAY_ORGANISATION),
+                             string(name: 'STRZ_RESOURCES_ARCHIVE_URL', value: params.STRZ_RESOURCES_ARCHIVE_URL),
+                             string(name: 'STRZ_RESOURCES_DEPLOYMENT_DESCRIPTOR', value: params.STRZ_RESOURCES_DEPLOYMENT_DESCRIPTOR),
+                             string(name: 'STRZ_IMAGES', value: params.STRZ_IMAGES),
+                             string(name: 'DBZ_GIT_REPOSITORY', value: params.DBZ_GIT_REPOSITORY),
+                             string(name: 'DBZ_GIT_BRANCH', value: params.DBZ_GIT_BRANCH),
+                             booleanParam(name: 'DBZ_CONNECT_BUILD', value: params.DBZ_CONNECT_BUILD),
+                             string(name: 'DBZ_CONNECTOR_ARCHIVE_URLS', value: params.DBZ_CONNECTOR_ARCHIVE_URLS),
+                             string(name: 'DBZ_EXTRA_LIBS', value: params.DBZ_EXTRA_LIBS),
+                         ]
+                         copyArtifacts(projectName: 'ocp-downstream-strimzi-prepare-job', selector: lastCompleted())
+
+                    }
+                }
+
+                    stage('Invoke_apicurio') {
+                        when {
+                            expression { params.EXECUTE_APICURIO }
+                        }
+                        steps {
+                            build job: 'ocp-downstream-apicurio-prepare-job', parameters: [
+                                string(name: MAIL_TO, value: params.MAIL_TO),
+                                string(name: 'QUAY_CREDENTIALS', value: params.QUAY_CREDENTIALS),
+                                string(name: 'QUAY_ORGANISATION', value: params.QUAY_ORGANISATION),
+                                string(name: 'APIC_RESOURCES_ARCHIVE_URL', value: params.APIC_RESOURCES_ARCHIVE_URL),
+                                string(name: 'APIC_RESOURCES_DEPLOYMENT_DESCRIPTOR', value: params.APIC_RESOURCES_DEPLOYMENT_DESCRIPTOR),
+                                string(name: 'APIC_IMAGES', value: params.APIC_IMAGES),
+                                string(name: 'DBZ_GIT_REPOSITORY', value: params.DBZ_GIT_REPOSITORY),
+                                string(name: 'DBZ_GIT_BRANCH', value: params.DBZ_GIT_BRANCH),
+                                booleanParam(name: 'PUSH_IMAGES', value: params.PUSH_IMAGES),
+                            ]
+                        copyArtifacts(projectName: 'ocp-downstream-apicurio-prepare-job', selector: lastCompleted())
+                        }
+                    }
+
+                stage('Invoke_rhel') {
+                    when {
+                        expression { params.EXECUTE_RHEL }
+                    }
+                    steps {
+                        build job: 'rhel-downstream-prepare-job', parameters: [
+                            string(name: MAIL_TO, value: params.MAIL_TO),
+                            string(name: 'QUAY_CREDENTIALS', value: params.QUAY_CREDENTIALS),
+                            string(name: 'QUAY_ORGANISATION', value: params.QUAY_ORGANISATION),
+                            string(name: 'RHEL_IMAGE', value: params.RHEL_IMAGE),
+                            string(name: 'KAFKA_URL', value: params.KAFKA_URL),
+                            string(name: 'DBZ_GIT_REPOSITORY', value: params.DBZ_GIT_REPOSITORY),
+                            string(name: 'DBZ_GIT_BRANCH', value: params.DBZ_GIT_BRANCH),
+                            booleanParam(name: 'AUTO_TAG', value: params.AUTO_TAG),
+                            string(name: 'EXTRA_IMAGE_TAGS', value: params.EXTRA_IMAGE_TAGS),
+                            string(name: 'DBZ_CONNECTOR_ARCHIVE_URLS', value: params.DBZ_CONNECTOR_ARCHIVE_URLS),
+                            string(name: 'DBZ_EXTRA_LIBS', value: params.DBZ_EXTRA_LIBS),
+                        ]
+                        copyArtifacts(projectName: 'rhel-downstream-prepare-job', selector: lastCompleted())
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            script {
+                def jobMap = [:] as TreeMap
+                jobMap.put("ocp-downstream-artifact-server-prepare-job", params.EXECUTE_AS)
+                jobMap.put("ocp-downstream-strimzi-prepare-job", params.EXECUTE_STRIMZI)
+                jobMap.put("rhel-downstream-prepare-job", params.EXECUTE_RHEL)
+                jobMap.put("ocp-downstream-apicurio-prepare-job", EXECUTE_APICURIO)
+
+                def label = params.LABEL
+                def currentBuildLabel = label
+                def jobArtifactOutputs = ''
+                jobMap.each { entry ->
+                    if (!entry.value) {
+                        return
+                    }
+
+                    def build = jenkins.model.Jenkins.instance.getItem("${entry.key}").lastBuild
+
+                    if (!build) {
+                        println "No build of ${entry.key} found!"
+                        return
+                    }
+
+                    // if no label is set and not a product build, add branch name
+                    if (!label) {
+                        println "using branch name and build number for label"
+                        label = "#${build.number} ${params.DBZ_GIT_BRANCH}"
+                        currentBuildLabel = "#${currentBuild.number} ${params.DBZ_GIT_BRANCH}"
+                    }
+
+                    // set label
+                    build.displayName = label
+                }
+                if (label) {
+                    currentBuild.displayName = currentBuildLabel
+                }
+               archiveArtifacts "**/*.zip"
+            }
+        }
+    }
+}

--- a/jenkins-jobs/pipelines/downstream_preparations_trigger_pipeline.groovy
+++ b/jenkins-jobs/pipelines/downstream_preparations_trigger_pipeline.groovy
@@ -115,14 +115,13 @@ pipeline {
                     }
 
                     // if no label is set, add branch name
-                    def label = params.LABEL
-                    if (!label) {
-                        println "using branch name and build number for label"
-                        label = "#${build.number} parent: #${currentBuild.number}"
+                    def label = "#${build.number} parent: #${currentBuild.number}"
+                    if (params.LABEL) {
+                        label += " ${params.LABEL}"
                     }
 
                     // set label
-                    build.displayName = "#${build.number} parent: #${currentBuild.number} ${label}"
+                    build.displayName = "${label}"
                 }
 
                 // set parent job label

--- a/jenkins-jobs/pipelines/downstream_prepare_pipeline.groovy
+++ b/jenkins-jobs/pipelines/downstream_prepare_pipeline.groovy
@@ -77,6 +77,20 @@ pipeline {
                 }
             }
         }
+
+        stage('Create main artefact') {
+            steps {
+                sh '''
+                set -x
+                mkdir "${WORKSPACE}/amq-streams-all"
+                cp -R "${WORKSPACE}/strimzi" "${WORKSPACE}/amq-streams-all/strimzi"
+                cp "${WORKSPACE}/published_images.txt" "${WORKSPACE}/amq-streams-all/amq-streams-published-images.txt"
+                cp "${WORKSPACE}/published_images_dbz.txt" \\
+                "${WORKSPACE}/amq-streams-all/amq-streams-published-images-dbz.txt" || :
+                '''
+                zip(archive: true, zipFile: 'amq-streams-all.zip', dir: 'amq-streams-all')
+            }
+        }
     }
 
     post {

--- a/jenkins-jobs/pipelines/rhel_downstream_prepare_pipeline.groovy
+++ b/jenkins-jobs/pipelines/rhel_downstream_prepare_pipeline.groovy
@@ -42,6 +42,7 @@ pipeline {
                         --dest-pass="${QUAY_PASSWORD}"                              \\
                         --img-output="${WORKSPACE}/published_image_dbz.txt"
                     '''
+                    zip(archive: true, zipFile: 'rhel-kafka-all.zip', glob: 'published_image_dbz.txt')
                 }
             }
         }


### PR DESCRIPTION
added a job, that triggers all downstream preparation jobs, collects artifacts from them and modified downstream preparation jobs to archive zips with its names on them, so the trigger job doesn't have duplicities in collected artifact
https://issues.redhat.com/browse/DBZ-4956?filter=-1