### PR TITLE
DBZ-5076 Fix typo: `archive_log_target` to `archive_lag_target`

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3715,7 +3715,7 @@ The following configuration forces Oracle to switch log files every 20 minutes i
 
 [source,sql]
 ----
-ALTER SYSTEM SET archive_log_target=1200 scope=both;
+ALTER SYSTEM SET archive_lag_target=1200 scope=both;
 ----
 
 This change will likely require SYSDBA permissions, so coordinate with your database administrator.


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5076