### PR TITLE
DBZ-4939 Fall back to JDBC driver if we fail to read timestamp

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractMySqlFieldReader.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/AbstractMySqlFieldReader.java
@@ -42,14 +42,30 @@ public abstract class AbstractMySqlFieldReader implements MySqlFieldReader {
         }
 
         if (column.jdbcType() == Types.DATE) {
-            return readDateField(rs, columnIndex, column, table);
+            try {
+                return readDateField(rs, columnIndex, column, table);
+            }
+            catch (RuntimeException e) {
+                logger.warn("Failed to read date value: '{}'. Trying default ResultSet implementation.", e.getMessage());
+                // If our field reader failed, let's try JDBC as the last resort.
+                // Workaround for DBZ-5084.
+                return rs.getObject(columnIndex);
+            }
         }
 
         // This is for DATETIME columns (a logical date + time without time zone)
         // by reading them with a calendar based on the default time zone, we make sure that the value
         // is constructed correctly using the database's (or connection's) time zone
         if (column.jdbcType() == Types.TIMESTAMP) {
-            return readTimestampField(rs, columnIndex, column, table);
+            try {
+                return readTimestampField(rs, columnIndex, column, table);
+            }
+            catch (RuntimeException e) {
+                logger.warn("Failed to read timestamp value: '{}'. Trying default ResultSet implementation.", e.getMessage());
+                // If our field reader failed, let's try JDBC as the last resort.
+                // Workaround for DBZ-5084.
+                return rs.getObject(columnIndex);
+            }
         }
 
         // JDBC's rs.GetObject() will return a Boolean for all TINYINT(1) columns.

--- a/debezium-connector-mysql/src/test/resources/ddl/incremental_snapshot-test.sql
+++ b/debezium-connector-mysql/src/test/resources/ddl/incremental_snapshot-test.sql
@@ -29,6 +29,13 @@ CREATE TABLE a42 (
   aa integer
 );
 
+CREATE TABLE a_dt (
+  pk INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  dt DATETIME NOT NULL,
+  d DATE NOT NULL,
+  t TIME NOT NULL
+) AUTO_INCREMENT = 1;
+
 CREATE TABLE debezium_signal (
   id varchar(64),
   type varchar(32),


### PR DESCRIPTION
MySQL protocol can change during connection and as a result our custom
field reader may fail. In such case fall back to JDBC to read the value.
This is workaround until proper solution, which will require bigger
refactoring, is implemented, see DBZ-5084 for more details.

https://issues.redhat.com/browse/DBZ-4939