### PR TITLE
DBZ-5097: Add two new retryable postgresql error messages

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -408,3 +408,4 @@ Zoran Regvart
 胡琴
 Snigdhajyoti Ghosh
 Andrei Isac
+Mark Allanson

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresErrorHandler.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresErrorHandler.java
@@ -28,7 +28,9 @@ public class PostgresErrorHandler extends ErrorHandler {
             "Database connection failed when reading from copy",
             "An I/O error occurred while sending to the backend",
             "ERROR: could not open relation with OID",
-            "This connection has been closed");
+            "This connection has been closed",
+            "terminating connection due to unexpected postmaster exit",
+            "terminating connection due to administrator command");
 
     public PostgresErrorHandler(PostgresConnectorConfig connectorConfig, ChangeEventQueue<?> queue) {
         super(PostgresConnector.class, connectorConfig, queue);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresErrorHandlerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresErrorHandlerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import org.fest.assertions.Assertions;
+import org.junit.Test;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.Configuration;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.pipeline.DataChangeEvent;
+
+public class PostgresErrorHandlerTest {
+    private static final String A_CLASSIFIED_EXCEPTION = "Database connection failed when writing to copy";
+
+    private final PostgresErrorHandler errorHandler = new PostgresErrorHandler(
+            new PostgresConnectorConfig(Configuration.create()
+                    .with(PostgresConnectorConfig.SERVER_NAME, "postgres")
+                    .build()),
+            new ChangeEventQueue.Builder<DataChangeEvent>().build());
+
+    @Test
+    public void classifiedPSQLExceptionIsRetryable() {
+        PSQLException testException = new PSQLException(A_CLASSIFIED_EXCEPTION, PSQLState.CONNECTION_FAILURE);
+        Assertions.assertThat(errorHandler.isRetriable(testException)).isTrue();
+    }
+
+    @Test
+    public void psqlExceptionWithNullErrorMesdsageNotRetryable() {
+        PSQLException testException = new PSQLException(null, PSQLState.CONNECTION_FAILURE);
+        Assertions.assertThat(errorHandler.isRetriable(testException)).isFalse();
+    }
+
+    @Test
+    public void nullThrowableIsNotRetryable() {
+        Assertions.assertThat(errorHandler.isRetriable(null)).isFalse();
+    }
+
+    @Test
+    public void unclassifiedPSQLExceptionIsNotRetryable() {
+        PSQLException testException = new PSQLException(
+                "definitely not a postgres error", PSQLState.CONNECTION_FAILURE);
+        Assertions.assertThat(errorHandler.isRetriable(testException)).isFalse();
+    }
+
+    @Test
+    public void classifiedPSQLExceptionWrappedInDebeziumExceptionIsRetryable() {
+        PSQLException psqlException = new PSQLException(A_CLASSIFIED_EXCEPTION, PSQLState.CONNECTION_FAILURE);
+        DebeziumException testException = new DebeziumException(psqlException);
+        Assertions.assertThat(errorHandler.isRetriable(testException)).isTrue();
+    }
+
+    @Test
+    public void randomUnhandledExceptionIsNotRetryable() {
+        RuntimeException testException = new RuntimeException();
+        Assertions.assertThat(errorHandler.isRetriable(testException)).isFalse();
+    }
+}

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -130,3 +130,4 @@ LarsWerkman,Lars Werkman
 chadthamn,Chad Marmon
 xqshe,Xinquan She
 wangminchao,Wang Min Chao
+markallanson,Mark Allanson


### PR DESCRIPTION
These two error messages can occur when running inside docker and the
postgres container is either killed (sigtermed) or brought down
using `docker stop`.

In both cases these are retryable as the postgres server can be
restarted shortly thereafter.