### PR TITLE
DBZ-5101 Adjust schema generator for MySQL for database.server.id

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/metadata/MySqlConnectorMetadata.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/metadata/MySqlConnectorMetadata.java
@@ -14,6 +14,17 @@ import io.debezium.metadata.ConnectorMetadata;
 
 public class MySqlConnectorMetadata implements ConnectorMetadata {
 
+    /**
+     * Defines a variant of SERVER_ID where we override the default connector behavior to only
+     * expose it as required with no default value and no default value generator.
+     */
+    private static Field SERVER_ID = MySqlConnectorConfig.SERVER_ID
+            .withNoDefault()
+            .withDescription("A numeric ID of this database client, which must be unique across all "
+                    + "currently running database processes in the cluster. This connector joins the "
+                    + "MySQL database cluster as another server (with this unique ID) so it can read "
+                    + "the binlog.");
+
     @Override
     public ConnectorDescriptor getConnectorDescriptor() {
         return new ConnectorDescriptor("mysql", "Debezium MySQL Connector", MySqlConnector.class.getName(), Module.version());
@@ -22,6 +33,8 @@ public class MySqlConnectorMetadata implements ConnectorMetadata {
     @Override
     public Field.Set getConnectorFields() {
         return MySqlConnectorConfig.ALL_FIELDS
-                .filtered(f -> f != MySqlConnectorConfig.GTID_NEW_CHANNEL_POSITION);
+                .filtered(f -> f != MySqlConnectorConfig.GTID_NEW_CHANNEL_POSITION)
+                .filtered(f -> f != MySqlConnectorConfig.SERVER_ID)
+                .with(SERVER_ID);
     }
 }

--- a/debezium-core/src/main/java/io/debezium/config/Field.java
+++ b/debezium-core/src/main/java/io/debezium/config/Field.java
@@ -883,6 +883,16 @@ public final class Field {
     }
 
     /**
+     * Create and return a new Field instance that is a copy of this field but that uses no default value.
+     *
+     * @return the new field; never null
+     */
+    public Field withNoDefault() {
+        return new Field(name(), displayName(), type(), width, description(), importance(), dependents,
+                null, validator, recommender, isRequired, group, allowedValues);
+    }
+
+    /**
      * Create and return a new Field instance that is a copy of this field but with the given recommender.
      *
      * @param recommender the recommender; may be null


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5101

* Removes default value assignment from field
* Removes auto-generation blurb from description

NOTE: This specifically targets 1.9 branch because we only want this behavior there.  For Debezium 2.0, this will be defaulted by the new `Field` definition introduced in DBZ-5100, so these two are mutually exclusive changes on two differing branches.