### PR TITLE
DBZ-4588 restructure custom converters doc

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/cassandra.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cassandra.adoc
@@ -984,7 +984,6 @@ For example, +
 
  isbn.schema.name: io.debezium.cassandra.type.Isbn
 
-
 |[[cassandra-property-offset-backing-store-dir]]<<cassandra-property-offset-backing-store-dir, `offset.backing.store.dir`>>
 |
 |The directory to store offset tracking files.

--- a/documentation/modules/ROOT/pages/connectors/cassandra.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cassandra.adoc
@@ -964,12 +964,15 @@ Cassandra connector has built-in support for JMX metrics. The Cassandra driver a
 
 |[[cassandra-property-converters]]<<cassandra-property-converters, `converters`>>
 |No default
-|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use. +
-For example, `isbn`. +
-This property is required to enable the connector to use a custom converter.
+|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use.
+For example, +
 
-For each converter that you configure for a connector, you must also add a property to specify the fully-qualifed name of the class that implements the converter interface.
-This second property uses the following format: +
+`isbn`
+
+You must set the `converters` property to enable the connector to use a custom converter.
+
+For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualifed name of the class that implements the converter interface.
+The `.type` property uses the following format: +
 
 `_<converterSymbolicName>_.type` +
 
@@ -977,9 +980,8 @@ For example, +
 
  isbn.type: io.debezium.test.IsbnConverter
 
-If a configured converter requires further information to customize the way that it converts specific data types, you can add configuration properties to pass these instructions.
-To associate such configuration properties with the converter, prefix their names with the converter's symbolic name. +
- +
+If you want to further control the behavior of a configured converter, you can add one or more configuration parameters to pass values to the converter.
+To associate any additional configuration parameter with a converter, prefix the parameter names with the symbolic name of the converter.
 For example, +
 
  isbn.schema.name: io.debezium.cassandra.type.Isbn

--- a/documentation/modules/ROOT/pages/connectors/cassandra.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cassandra.adoc
@@ -751,6 +751,8 @@ The following table describes how the connector maps each of the Cassandra data 
 
 **TODO**: add logical types
 
+If the default data type conversions do not meet your needs, you can {link-prefix}:{link-custom-converters}#custom-converters[create a custom converter] for the connector.
+
 [[cassandra-when-things-go-wrong]]
 === When Things Go Wrong
 

--- a/documentation/modules/ROOT/pages/connectors/cassandra.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cassandra.adoc
@@ -962,6 +962,29 @@ Cassandra connector has built-in support for JMX metrics. The Cassandra driver a
 |false
 |Determines whether or not the CommitLogProcessor should re-process error commit logs.
 
+|[[cassandra-property-converters]]<<cassandra-property-converters, `converters`>>
+|No default
+|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use. +
+For example, `isbn`. +
+This property is required to enable the connector to use a custom converter.
+
+For each converter that you configure for a connector, you must also add a property to specify the fully-qualifed name of the class that implements the converter interface.
+This second property uses the following format: +
+
+`_<converterSymbolicName>_.type` +
+
+For example, +
+
+ isbn.type: io.debezium.test.IsbnConverter
+
+If a configured converter requires further information to customize the way that it converts specific data types, you can add configuration properties to pass these instructions.
+To associate such configuration properties with the converter, prefix their names with the converter's symbolic name. +
+ +
+For example, +
+
+ isbn.schema.name: io.debezium.cassandra.type.Isbn
+
+
 |[[cassandra-property-offset-backing-store-dir]]<<cassandra-property-offset-backing-store-dir, `offset.backing.store.dir`>>
 |
 |The directory to store offset tracking files.

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2161,12 +2161,15 @@ The following _advanced_ configuration properties have defaults that work in mos
 
 |[[db2-property-converters]]<<db2-property-converters, `converters`>>
 |No default
-|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use. +
-For example, `isbn`. +
-This property is required to enable the connector to use a custom converter.
+|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use.
+For example, +
 
-For each converter that you configure for a connector, you must also add a property to specify the fully-qualifed name of the class that implements the converter interface.
-This second property uses the following format: +
+`isbn`
+
+You must set the `converters` property to enable the connector to use a custom converter.
+
+For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualifed name of the class that implements the converter interface.
+The `.type` property uses the following format: +
 
 `_<converterSymbolicName>_.type` +
 
@@ -2174,9 +2177,8 @@ For example, +
 
  isbn.type: io.debezium.test.IsbnConverter
 
-If a configured converter requires further information to customize the way that it converts specific data types, you can add configuration properties to pass these instructions.
-To associate such configuration properties with the converter, prefix their names with the converter's symbolic name. +
- +
+If you want to further control the behavior of a configured converter, you can add one or more configuration parameters to pass values to the converter.
+To associate any additional configuration parameter with a converter, prefix the parameter names with the symbolic name of the converter. +
 For example, +
 
  isbn.schema.name: io.debezium.db2.type.Isbn

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2159,6 +2159,28 @@ The following _advanced_ configuration properties have defaults that work in mos
 |===
 |Property |Default |Description
 
+|[[db2-property-converters]]<<db2-property-converters, `converters`>>
+|No default
+|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use. +
+For example, `isbn`. +
+This property is required to enable the connector to use a custom converter.
+
+For each converter that you configure for a connector, you must also add a property to specify the fully-qualifed name of the class that implements the converter interface.
+This second property uses the following format: +
+
+`_<converterSymbolicName>_.type` +
+
+For example, +
+
+ isbn.type: io.debezium.test.IsbnConverter
+
+If a configured converter requires further information to customize the way that it converts specific data types, you can add configuration properties to pass these instructions.
+To associate such configuration properties with the converter, prefix their names with the converter's symbolic name. +
+ +
+For example, +
+
+ isbn.schema.name: io.debezium.db2.type.Isbn
+
 |[[db2-property-snapshot-mode]]<<db2-property-snapshot-mode, `+snapshot.mode+`>>
 |`initial`
 |Specifies the criteria for performing a snapshot when the connector starts: +

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1102,6 +1102,7 @@ When a row is deleted, the _delete_ event value still works with log compaction,
 Db2's data types are described in https://www.ibm.com/support/knowledgecenter/en/SSEPGG_11.5.0/com.ibm.db2.luw.sql.ref.doc/doc/r0008483.html[Db2 SQL Data Types].
 
 The Db2 connector represents changes to rows with events that are structured like the table in which the row exists. The event contains a field for each column value. How that value is represented in the event depends on the Db2 data type of the column. This section describes these mappings.
+If the default data type conversions do not meet your needs, you can {link-prefix}:{link-custom-converters}#custom-converters[create a custom converter] for the connector.
 
 ifdef::product[]
 Details are in the following sections:

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -1310,8 +1310,10 @@ Columns that store strings are defined in MySQL with a character set and collati
 
 The connector can map MySQL data types to both _literal_ and _semantic_ types.
 
-* *Literal type*: how the value is represented using Kafka Connect schema types
-* *Semantic type*: how the Kafka Connect schema captures the meaning of the field (schema name)
+* *Literal type*: how the value is represented using Kafka Connect schema types.
+* *Semantic type*: how the Kafka Connect schema captures the meaning of the field (schema name).
+
+If the default data type conversions do not meet your needs, you can {link-prefix}:{link-custom-converters}#custom-converters[create a custom converter] for the connector.
 
 ifdef::product[]
 Details are in the following sections:

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -1606,12 +1606,13 @@ The `BOOLEAN` column is internally mapped to the `TINYINT(1)` data type.
 When the table is created during streaming then it uses proper `BOOLEAN` mapping as {prodname} receives the original DDL.
 During snapshots, {prodname} executes `SHOW CREATE TABLE` to obtain table definitions that return `TINYINT(1)` for both `BOOLEAN` and `TINYINT(1)` columns. {prodname} then has no way to obtain the original type mapping and so maps to `TINYINT(1)`.
 
-ifdef::community[]
-The operator can configure the out-of-the-box xref:{link-custom-converters}[`TinyIntOneToBooleanConverter` custom converter] that would either map all `TINYINT(1)` columns to `BOOLEAN` or if the `selector` parameter is set then a subset of columns could be enumerated using comma-separated regular expressions.
-endif::community[]
+To enable you to convert source columns to Boolean data types, {prodname} provides a `TinyIntOneToBooleanConverter` {link-prefix}:{link-custom-converters}#custom-converters[custom converter] that you can use in one of the following ways:
 
-Following is an example configuration:
-
+* Map all `TINYINT(1)` columns to `BOOLEAN` types.
+* Enumerate a subset of columns by using a comma-separated list of regular expressions. +
+  To use this type of conversion you must set the `selector` parameter as shown in the following configuration example:
++
+[source]
 ----
 converters=boolean
 boolean.type=io.debezium.connector.mysql.converters.TinyIntOneToBooleanConverter

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -1610,7 +1610,7 @@ To enable you to convert source columns to Boolean data types, {prodname} provid
 
 * Map all `TINYINT(1)` columns to `BOOLEAN` types.
 * Enumerate a subset of columns by using a comma-separated list of regular expressions. +
-  To use this type of conversion you must set the `selector` parameter as shown in the following configuration example:
+To use this type of conversion, you must set the xref:mysql-property-converters[`converters`] configuration property with the `selector` parameter, as shown in the following example:
 +
 [source]
 ----
@@ -2635,24 +2635,24 @@ The following table describes xref:{link-mysql-connector}#mysql-advanced-connect
 |[[mysql-property-converters]]<<mysql-property-converters, `converters`>>
 |No default
 |Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use. +
-For example, `isbn`. +
+For example, `boolean`. +
 This property is required to enable the connector to use a custom converter.
 
-For each converter that you configure for a connector, you must also add a property to specify the fully-qualifed name of the class that implements the converter interface.
-This second property uses the following format: +
+For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualifed name of the class that implements the converter interface.
+The `.type` property uses the following format: +
 
 `_<converterSymbolicName>_.type` +
 
 For example, +
 
- isbn.type: io.debezium.test.IsbnConverter
+ boolean.type: io.debezium.connector.mysql.converters.TinyIntOneToBooleanConverter
 
-If a configured converter requires further information to customize the way that it converts specific data types, you can add configuration properties to pass these instructions.
-To associate such configuration properties with the converter, prefix their names with the converter's symbolic name. +
+If you want to further control the behavior of a configured converter, you can add one or more configuration parameters to pass values to the converter.
+To associate these additional configuration parameter with a converter, prefix the paraemeter name with the symbolic name of the converter. +
  +
-For example, +
+For example, to define a `selector` parameter that specifies the subset of columns that the `boolean` converter processes, add the following property: +
 
- isbn.schema.name: io.debezium.mysql.type.Isbn
+ boolean.selector=db1.table1.*, db1.table2.column1
 
 |[[mysql-property-table-ignore-builtin]]<<mysql-property-table-ignore-builtin, `+table.ignore.builtin+`>>
 |`true`

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2631,6 +2631,28 @@ The following table describes xref:{link-mysql-connector}#mysql-advanced-connect
 |`true`
 |A Boolean value that specifies whether a separate thread should be used to ensure that the connection to the MySQL server/cluster is kept alive.
 
+|[[mysql-property-converters]]<<mysql-property-converters, `converters`>>
+|No default
+|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use. +
+For example, `isbn`. +
+This property is required to enable the connector to use a custom converter.
+
+For each converter that you configure for a connector, you must also add a property to specify the fully-qualifed name of the class that implements the converter interface.
+This second property uses the following format: +
+
+`_<converterSymbolicName>_.type` +
+
+For example, +
+
+ isbn.type: io.debezium.test.IsbnConverter
+
+If a configured converter requires further information to customize the way that it converts specific data types, you can add configuration properties to pass these instructions.
+To associate such configuration properties with the converter, prefix their names with the converter's symbolic name. +
+ +
+For example, +
+
+ isbn.schema.name: io.debezium.mysql.type.Isbn
+
 |[[mysql-property-table-ignore-builtin]]<<mysql-property-table-ignore-builtin, `+table.ignore.builtin+`>>
 |`true`
 |A Boolean value that specifies whether built-in system tables should be ignored. This applies regardless of the table include and exclude lists. By default, system tables are excluded from having their changes captured, and no events are generated when changes are made to any system tables.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1355,11 +1355,12 @@ When the `decimal.handling.mode` property is set to `string`, the connector repr
 Oracle does not natively have support for a `BOOLEAN` data type; however,
 it is common practice to use other data types with certain semantics to simulate the concept of a logical `BOOLEAN` data type.
 
-The operator can configure the out-of-the-box `NumberOneToBooleanConverter` custom converter that would either map all `NUMBER(1)` columns to a `BOOLEAN` or if the `selector` parameter is set,
-then a subset of columns could be enumerated using a comma-separated list of regular expressions.
+To enable you to convert source columns to Boolean data types, {prodname} provides a `NumberOneToBooleanConverter` {link-prefix}:{link-custom-converters}#custom-converters[custom converter] that you can use in one of the following ways:
 
-Following is an example configuration:
-
+* Map all `NUMBER(1)` columns to a `BOOLEAN` type.
+* Enumerate a subset of columns by using a comma-separated list of regular expressions. +
+To use this type of conversion you must set the `selector` parameter as shown in the following configuration example:
++
 [source]
 ----
 converters=boolean

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1110,6 +1110,8 @@ Literal types:: Describe how the value is literally represented, using one of th
 
 Semantic types:: Describe how the Kafka Connect schema captures the _meaning_ of the field, by using the name of the Kafka Connect schema for the field.
 
+If the default data type conversions do not meet your needs, you can {link-prefix}:{link-custom-converters}#custom-converters[create a custom converter] for the connector.
+
 For some Oracle large object (CLOB, NCLOB, and BLOB) and numeric data types, you can manipulate the way that the connector performs the type mapping by changing default configuration property settings.
 For more information about how {prodname} properties control mappings for these data types, see xref:oracle-binary-character-lob-types[Binary and Character LOB types] and xref:oracle-numeric-types[Numeric types].
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1359,7 +1359,7 @@ To enable you to convert source columns to Boolean data types, {prodname} provid
 
 * Map all `NUMBER(1)` columns to a `BOOLEAN` type.
 * Enumerate a subset of columns by using a comma-separated list of regular expressions. +
-To use this type of conversion you must set the `selector` parameter as shown in the following configuration example:
+To use this type of conversion, you must set the xref:oracle-property-converters[`converters`] configuration property with the `selector` parameter, as shown in the following example:
 +
 [source]
 ----
@@ -2320,24 +2320,24 @@ The following configuration properties are _required_ unless a default value is 
 |[[oracle-property-converters]]<<oracle-property-converters, `converters`>>
 |No default
 |Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use. +
-For example, `isbn`. +
+For example, `boolean`. +
 This property is required to enable the connector to use a custom converter.
 
-For each converter that you configure for a connector, you must also add a property to specify the fully-qualifed name of the class that implements the converter interface.
-This second property uses the following format: +
+For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualifed name of the class that implements the converter interface.
+The `.type` property uses the following format: +
 
 `_<converterSymbolicName>_.type` +
 
 For example, +
 
- isbn.type: io.debezium.test.IsbnConverter
+ boolean.type: io.debezium.connector.oracle.converters.NumberOneToBooleanConverter
 
-If a configured converter requires further information to customize the way that it converts specific data types, you can add configuration properties to pass these instructions.
-To associate such configuration properties with the converter, prefix their names with the converter's symbolic name. +
+If you want to further control the behavior of a configured converter, you can add one or more configuration parameters to pass values to the converter.
+To associate any additional configuration parameters with a converter, prefix the parameter names with the symbolic name of the converter. +
  +
-For example, +
+For example, to define a `selector` parameter that specifies the subset of columns that the `boolean` converter processes, add the following property: +
 
- isbn.schema.name: io.debezium.oracle.type.Isbn
+ boolean.selector: .*MYTABLE.FLAG,.*.IS_ARCHIVED
 
 |[[oracle-property-tasks-max]]<<oracle-property-tasks-max, `+tasks.max+`>>
 |`1`

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2316,6 +2316,28 @@ The following configuration properties are _required_ unless a default value is 
 |No default
 |The name of the Java class for the connector. Always use a value of `io.debezium.connector.oracle.OracleConnector` for the Oracle connector.
 
+|[[oracle-property-converters]]<<oracle-property-converters, `converters`>>
+|No default
+|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use. +
+For example, `isbn`. +
+This property is required to enable the connector to use a custom converter.
+
+For each converter that you configure for a connector, you must also add a property to specify the fully-qualifed name of the class that implements the converter interface.
+This second property uses the following format: +
+
+`_<converterSymbolicName>_.type` +
+
+For example, +
+
+ isbn.type: io.debezium.test.IsbnConverter
+
+If a configured converter requires further information to customize the way that it converts specific data types, you can add configuration properties to pass these instructions.
+To associate such configuration properties with the converter, prefix their names with the converter's symbolic name. +
+ +
+For example, +
+
+ isbn.schema.name: io.debezium.oracle.type.Isbn
+
 |[[oracle-property-tasks-max]]<<oracle-property-tasks-max, `+tasks.max+`>>
 |`1`
 |The maximum number of tasks that should be created for this connector. The Oracle connector always uses a single task and therefore does not use this value, so the default is always acceptable.

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1323,6 +1323,8 @@ The PostgreSQL connector represents changes to rows with events that are structu
 
 * _semantic type_ describes how the Kafka Connect schema captures the _meaning_ of the field using the name of the Kafka Connect schema for the field.
 
+If the default data type conversions do not meet your needs, you can {link-prefix}:{link-custom-converters}#custom-converters[create a custom converter] for the connector.
+
 ifdef::product[]
 Details are in the following sections:
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2913,6 +2913,28 @@ The following _advanced_ configuration properties have defaults that work in mos
 |Default
 |Description
 
+|[[postgresql-property-converters]]<<postgresql-property-converters, `converters`>>
+|No default
+|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use. +
+For example, `isbn`. +
+This property is required to enable the connector to use a custom converter.
+
+For each converter that you configure for a connector, you must also add a property to specify the fully-qualifed name of the class that implements the converter interface.
+This second property uses the following format: +
+
+`_<converterSymbolicName>_.type` +
+
+For example, +
+
+ isbn.type: io.debezium.test.IsbnConverter
+
+If a configured converter requires further information to customize the way that it converts specific data types, you can add configuration properties to pass these instructions.
+To associate such configuration properties with the converter, prefix their names with the converter's symbolic name. +
+ +
+For example, +
+
+ isbn.schema.name: io.debezium.postgresql.type.Isbn
+
 |[[postgresql-property-snapshot-mode]]<<postgresql-property-snapshot-mode, `+snapshot.mode+`>>
 |`initial`
 |Specifies the criteria for performing a snapshot when the connector starts: +

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2915,12 +2915,15 @@ The following _advanced_ configuration properties have defaults that work in mos
 
 |[[postgresql-property-converters]]<<postgresql-property-converters, `converters`>>
 |No default
-|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use. +
-For example, `isbn`. +
-This property is required to enable the connector to use a custom converter.
+|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use.
+For example, +
 
-For each converter that you configure for a connector, you must also add a property to specify the fully-qualifed name of the class that implements the converter interface.
-This second property uses the following format: +
+`isbn`
+
+You must set the `converters` property to enable the connector to use a custom converter.
+
+For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualifed name of the class that implements the converter interface.
+The `.type` property uses the following format: +
 
 `_<converterSymbolicName>_.type` +
 
@@ -2928,9 +2931,8 @@ For example, +
 
  isbn.type: io.debezium.test.IsbnConverter
 
-If a configured converter requires further information to customize the way that it converts specific data types, you can add configuration properties to pass these instructions.
-To associate such configuration properties with the converter, prefix their names with the converter's symbolic name. +
- +
+If you want to further control the behavior of a configured converter, you can add one or more configuration parameters to pass values to the converter.
+To associate any additional configuration parameter with a converter, prefix the parameter names with the symbolic name of the converter. +
 For example, +
 
  isbn.schema.name: io.debezium.postgresql.type.Isbn

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2251,6 +2251,28 @@ The following _advanced_ configuration properties have good defaults that will w
 |Default
 |Description
 
+|[[sqlserver-property-converters]]<<sqlserver-property-converters, `converters`>>
+|No default
+|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use. +
+For example, `isbn`. +
+This property is required to enable the connector to use a custom converter.
+
+For each converter that you configure for a connector, you must also add a property to specify the fully-qualifed name of the class that implements the converter interface.
+This second property uses the following format: +
+
+`_<converterSymbolicName>_.type` +
+
+For example, +
+
+ isbn.type: io.debezium.test.IsbnConverter
+
+If a configured converter requires further information to customize the way that it converts specific data types, you can add configuration properties to pass these instructions.
+To associate such configuration properties with the converter, prefix their names with the converter's symbolic name. +
+ +
+For example, +
+
+ isbn.schema.name: io.debezium.sqlserver.type.Isbn
+
 |[[sqlserver-property-snapshot-mode]]<<sqlserver-property-snapshot-mode, `+snapshot.mode+`>>
 |_initial_
 |A mode for taking an initial snapshot of the structure and optionally data of captured tables.

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -1147,6 +1147,8 @@ The connector can map SQL Server data types to both _literal_ and _semantic_ typ
 Literal type:: Describes how the value is literally represented by using Kafka Connect schema types, namely `INT8`, `INT16`, `INT32`, `INT64`, `FLOAT32`, `FLOAT64`, `BOOLEAN`, `STRING`, `BYTES`, `ARRAY`, `MAP`, and `STRUCT`.
 Semantic type:: Describes how the Kafka Connect schema captures the _meaning_ of the field using the name of the Kafka Connect schema for the field.
 
+If the default data type conversions do not meet your needs, you can {link-prefix}:{link-custom-converters}#custom-converters[create a custom converter] for the connector.
+
 ifdef::product[]
 
 For more information about data type mappings, see the following sections:

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2253,12 +2253,15 @@ The following _advanced_ configuration properties have good defaults that will w
 
 |[[sqlserver-property-converters]]<<sqlserver-property-converters, `converters`>>
 |No default
-|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use. +
-For example, `isbn`. +
-This property is required to enable the connector to use a custom converter.
+|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use.
+For example, +
 
-For each converter that you configure for a connector, you must also add a property to specify the fully-qualifed name of the class that implements the converter interface.
-This second property uses the following format: +
+`isbn`
+
+You must set the `converters` property to enable the connector to use a custom converter.
+
+For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualifed name of the class that implements the converter interface.
+The `.type` property uses the following format: +
 
 `_<converterSymbolicName>_.type` +
 
@@ -2266,9 +2269,8 @@ For example, +
 
  isbn.type: io.debezium.test.IsbnConverter
 
-If a configured converter requires further information to customize the way that it converts specific data types, you can add configuration properties to pass these instructions.
-To associate such configuration properties with the converter, prefix their names with the converter's symbolic name. +
- +
+If you want to further control the behavior of a configured converter, you can add one or more configuration parameters to pass values to the converter.
+To associate any additional configuration parameter with a converter, prefix the parameter names with the symbolic name of the converter.
 For example, +
 
  isbn.schema.name: io.debezium.sqlserver.type.Isbn

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -745,6 +745,8 @@ When a row is deleted, the _delete_ event value still works with log compaction,
 
 The Vitess connector represents changes to rows with events that are structured like the table in which the row exists. The event contains a field for each column value. How that value is represented in the event depends on the Vitess data type of the column. This section describes these mappings.
 
+If the default data type conversions do not meet your needs, you can {link-prefix}:{link-custom-converters}#custom-converters[create a custom converter] for the connector.
+
 [id="vitess-basic-types"]
 === Basic types
 

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -1231,6 +1231,28 @@ The following _advanced_ configuration properties have defaults that work in mos
 |Default
 |Description
 
+|[[vitess-property-converters]]<<vitess-property-converters, `converters`>>
+|No default
+|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use. +
+For example, `isbn`. +
+This property is required to enable the connector to use a custom converter.
+
+For each converter that you configure for a connector, you must also add a property to specify the fully-qualifed name of the class that implements the converter interface.
+This second property uses the following format: +
+
+`_<converterSymbolicName>_.type` +
+
+For example, +
+
+ isbn.type: io.debezium.test.IsbnConverter
+
+If a configured converter requires further information to customize the way that it converts specific data types, you can add configuration properties to pass these instructions.
+To associate such configuration properties with the converter, prefix their names with the converter's symbolic name. +
+ +
+For example, +
+
+ isbn.schema.name: io.debezium.vitess.type.Isbn
+
 |[[vitess-property-event-processing-failure-handling-mode]]<<vitess-property-event-processing-failure-handling-mode, `+event.processing.failure.handling.mode+`>>
 |`fail`
 | Specifies how the connector should react to exceptions during processing of events: +

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -1233,12 +1233,15 @@ The following _advanced_ configuration properties have defaults that work in mos
 
 |[[vitess-property-converters]]<<vitess-property-converters, `converters`>>
 |No default
-|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use. +
-For example, `isbn`. +
-This property is required to enable the connector to use a custom converter.
+|Enumerates a comma-separated list of the symbolic names of the {link-prefix}:{link-custom-converters}#custom-converters[custom converter] instances that the connector can use.
+For example, +
 
-For each converter that you configure for a connector, you must also add a property to specify the fully-qualifed name of the class that implements the converter interface.
-This second property uses the following format: +
+`isbn`
+
+You must set the `converters` property to enable the connector to use a custom converter.
+
+For each converter that you configure for a connector, you must also add a `.type` property, which specifies the fully-qualifed name of the class that implements the converter interface.
+The `.type` property uses the following format: +
 
 `_<converterSymbolicName>_.type` +
 
@@ -1246,9 +1249,8 @@ For example, +
 
  isbn.type: io.debezium.test.IsbnConverter
 
-If a configured converter requires further information to customize the way that it converts specific data types, you can add configuration properties to pass these instructions.
-To associate such configuration properties with the converter, prefix their names with the converter's symbolic name. +
- +
+If you want to further control the behavior of a configured converter, you can add one or more configuration parameters to pass values to the converter.
+To associate any additional configuration parameter with a converter, prefix the parameter names with the symbolic name of the converter.
 For example, +
 
  isbn.schema.name: io.debezium.vitess.type.Isbn

--- a/documentation/modules/ROOT/pages/development/converters.adoc
+++ b/documentation/modules/ROOT/pages/development/converters.adoc
@@ -33,27 +33,27 @@ For more information about the support scope of Red Hat Technology Preview featu
 endif::product[]
 
 Each field in a {prodname} change event record represents a field or column in the source table or data collection.
-The connector converts data types in the source to a corresponding Kafka Connect schema types.
+When a connector emits a change event record to Kafka, it converts the data type of each field in the source to a Kafka Connect schema type.
 Column values are likewise converted to match the schema type of the destination field.
 For each connector, a default mapping specifies how the connector converts each data type.
-The documentation for each connector provides details about the default mappings that the connector uses to convert data types.
+These default mappings are described in the data types documentation for each connector.
 
-The default mappings are sufficient to satisfy most needs, but for some applications it might be necessary to apply an alternate mapping.
-For example, the default mapping for a column might export values using the format of milliseconds since the UNIX epoch, but you have a downstream application that requires the values to be formatted strings.
-To customize data type mappings you can develop and deploy custom converters.
-You can configure a custom converter to apply to all columns of a certain type, or to a specific table column only.
-The converter function intercepts conversion requests for columns that match a specified criteria, and performs the specified format conversion.
+While the default mappings are generally sufficient, for some applications you might want to apply an alternate mapping.
+For example, you might need a custom mapping if the default mapping exports a column using the format of milliseconds since the UNIX epoch, but your downstream application can only consume the column values as formatted strings.
+You customize data type mappings by developing and deploying a custom converter.
+You configure custom converters to act on all columns of a certain type, or you can narrow their scope so that they apply to a specific table column only.
+The converter function intercepts data type conversion requests for any columns that match a specified criteria, and then performs the specified conversion.
 The converter ignores columns that do not match the specified criteria.
 
 Custom converters are Java classes that implement the Debezium service provider interface (SPI).
 You enable and configure a custom converter by setting the `converters` property in the connector configuration.
-The `converters` property defines the criteria for identifying the columns that you want the converter to process and provides other details that determine conversion behavior.
+The `converters` property specifies the converters avaialble to a connector, and can include sub-properties that further modify conversion behavior.
 
-After you start a connector, any converters that are enabled in the connector configuration are instantiated and are added to a registry.
+After you start a connector, the converters that are enabled in the connector configuration are instantiated and are added to a registry.
 The registry associates each converter with the columns or fields for it to process.
 Whenever {prodname} processes a new change event, it invokes the configured converter to convert the columns or fields for which it is registered.
 
-// Type: procedure
+// Type: assembly
 // Title: Creating a {prodname} custom data type converter
 // ModuleID: creating-a-debezium-custom-data-type-converter
 [id="implementing-a-custom-converter"]
@@ -85,8 +85,10 @@ public interface CustomConverter<S, F extends ConvertedField> {
 Should not be invoked more than once for the same field.
 <4> Registers the customized value and schema converter for use with a specific field.
 
-.Custom converter methods
-The `configure()` and `converterFor()` methods are mandatory for each {prodname} custom converter:
+[id="debezium-custom-converter-methods"]
+=== Custom converter methods
+
+Implementations of the `CustomConverter` interface must include the following methods:
 
 `configure()`::
 Passes the properties specified in the connector configuration to the converter instance.
@@ -116,6 +118,10 @@ ifdef::community[]
 In the future, an independent schema definition API will be added.
 endif::community[]
 
+// Type: concept
+[id="debezium-custom-converter-example"]
+=== {prodname} custom converter example
+
 The following example implements a simple converter that performs the following operations:
 
 * Runs the `configure` method, which configures the converter based on the value of the `schema.name` property that is specified in the connector configuration.
@@ -124,7 +130,6 @@ The converter configuration is specific to each instance.
 ** Identifies the target `STRING` schema based on the value that is specified for the `schema.name` property.
 ** Converts ISBN data in the source column to `String` values.
 
-=== {prodname} custom converter example
 [id="example-debezium-simple-custom-converter"]
 .A simple custom converter
 ====
@@ -151,12 +156,12 @@ The converter configuration is specific to each instance.
 ----
 ====
 
-// Type: procedure
+// Type: concept
 [id="debezium-and-kafka-connect-api-module-dependencies"]
 === {prodname} and Kafka Connect API module dependencies
 
-The converter code depends on the {prodname} and Kafka Connect API library modules.
-To enable your converter code to compile, add these dependencies to your converter Java project as shown in the following example:
+A custom converter Java project has compile dependencies on the {prodname} API and Kafka Connect API library modules.
+These compile dependencies must be included in your project's `pom.xml`, as shown in the following example:
 
 [source,xml]
 ----
@@ -180,31 +185,30 @@ To enable your converter code to compile, add these dependencies to your convert
 [id="configuring-and-using-converters"]
 == Configuring and Using Converters
 
-To use the converter with a connector, you deploy the converter JAR file alongside the connector file, and then configure the connector to use the converter.
+Custom converters act on specific columns or column types in a source table to specify how to convert the data types in the source to Kafka Connect schema types.
+To use a custom converter with a connector, you deploy the converter JAR file alongside the connector file, and then configure the connector to use the converter.
 
 // Type: procedure
 [id="deploying-a-debezium-custom-converter"]
 === Deploying a custom converter
 
-.Procedure
-* To use a custom converter with a {prodname} connector, export the Java project to a JAR file, and add the file to the directory that contains the JAR file for each {prodname} connector that you want to use it with. +
- +
-For example, in a typical deployment, you might store {prodname} connector files in subdirectories of a Kafka Connect directory, such as `/kafka/connect`,
-and then store the JAR for each connector in its own subdirectory (`debezium-connector-db2`, `debezium-connector-mysql`, and so forth).
-To use a converter with a connector, add the converter JAR file to the connector subdirectory.
+.Prerequisites
+* You have a custom converter Java program.
 
-NOTE: To use a converter with multiple connectors, add the connector JAR file to the directory for each of the connectors.
+.Procedure
+* To use a custom converter with a {prodname} connector, export the Java project to a JAR file, and copy the file to the directory that contains the JAR file for each {prodname} connector that you want to use it with. +
+ +
+For example, in a typical deployment, the {prodname} connector files are stored in subdirectories of a Kafka Connect directory (`/kafka/connect`), with each connector JAR in its own subdirectory (`/kafka/connect/debezium-connector-db2`, `/kafka/connect/debezium-connector-mysql`, and so forth).
+To use a converter with a connector, add the converter JAR file to the connector's subdirectory.
+
+NOTE: To use a converter with multiple connectors, you must place a copy of the converter JAR file in each connector subdirectory.
 
 // Type: procedure
 [id="configuring-a-connectors-to-use-a-custom-converter"]
 === Configuring a connector to use a custom converter
 
-Custom converters act on specific columns or column types in a source table to specify how to convert their data types.
 To enable a connector to use the custom converter, you add properties to the connector configuration that specify the converter name and class.
 If the converter requires further information to customize the formats of specific data types, you can also define other coniguration options to provide that information.
-
-.Prerequisites
-* You have a custom converter Java program.
 
 .Procedure
 
@@ -225,8 +229,8 @@ converters: isbn
 isbn.type: io.debezium.test.IsbnConverter
 ----
 
-* If provide further configuration properties for a converter, prefix the property names with the symbolic name of the converter, followed by a dot (`.`).
-  The symbolic name is label that you specify as a value for the `converters` property.
+* To associate other properties with a custom converter, prefix the property names with the symbolic name of the converter, followed by a dot (`.`).
+  The symbolic name is a label that you specify as a value for the `converters` property.
   For example, to add a property for the preceding `isbn` converter to specify the `schema.name` to pass to the `configure` method in the converter code, add the following property:
 +
 ----

--- a/documentation/modules/ROOT/pages/development/converters.adoc
+++ b/documentation/modules/ROOT/pages/development/converters.adoc
@@ -1,12 +1,16 @@
+// Category: debezium-using
+// Type: assembly
+// ModuleID: developing-debezium-custom-data-type-converters
+// Title: Developing {prodname} custom data type converters
 [id="custom-converters"]
 = Custom Converters
 
+ifdef::community[]
 :source-highlighter: highlight.js
 :toc:
 :toc-placement: macro
 :linkattrs:
 :icons: font
-
 toc::[]
 
 [NOTE]
@@ -15,58 +19,115 @@ This feature is currently in incubating state, i.e. exact semantics, configurati
 ====
 
 == Datatype Conversion
+endif::community[]
 
-The {prodname} connectors map database column types to corresponding Kafka Connect schema types and convert the column values accordingly.
-The specific column type mappings are documented for each of the connectors and represent a reasonable default behavior for most of the time.
-It is still possible that an application requires a specific handling of a certain column type or specific column due to downstream system requirements.
-For instance you might want to export temporal column values as a formatted string instead of milli-seconds since epoch.
+ifdef::product[]
+[IMPORTANT]
+====
+The use of custom-developed converters is a Technology Preview feature only.
+Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete.
+Red Hat does not recommend using them in production.
+These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[https://access.redhat.com/support/offerings/techpreview].
+====
+endif::product[]
 
-For this purpose {prodname} provides an extension point that allows users to inject their own converters based on their business requirements.
-The converters are written in Java and are enabled and configured via connector properties.
+Each field in a {prodname} change event record represents a field or column in the source table or data collection.
+The connector converts data types in the source to a corresponding Kafka Connect schema types.
+Column values are likewise converted to match the schema type of the destination field.
+For each connector, a default mapping specifies how the connector converts each data type.
+The documentation for each connector provides details about the default mappings that the connector uses to convert data types.
 
-During connector startup, all configured converters are instantiated and placed in an registry.
-While the connector-internal schema representation is built, every converter is invoked for every column/field of every table/collection and it can register itself to become responsible for the conversion of the given column or field.
+The default mappings are sufficient to satisfy most needs, but for some applications it might be necessary to apply an alternate mapping.
+For example, the default mapping for a column might export values using the format of milliseconds since the UNIX epoch, but you have a downstream application that requires the values to be formatted strings.
+To customize data type mappings you can develop and deploy custom converters.
+You can configure a custom converter to apply to all columns of a certain type, or to a specific table column only.
+The converter function intercepts conversion requests for columns that match a specified criteria, and performs the specified format conversion.
+The converter ignores columns that do not match the specified criteria.
 
-Whenever a new change is processed by {prodname}, the converter is invoked to execute the actual conversion for the registered columns or fields.
+Custom converters are Java classes that implement the Debezium service provider interface (SPI).
+You enable and configure a custom converter by setting the `converters` property in the connector configuration.
+The `converters` property defines the criteria for identifying the columns that you want the converter to process and provides other details that determine conversion behavior.
 
-== Implementing Converters
+After you start a connector, any converters that are enabled in the connector configuration are instantiated and are added to a registry.
+The registry associates each converter with the columns or fields for it to process.
+Whenever {prodname} processes a new change event, it invokes the configured converter to convert the columns or fields for which it is registered.
 
-The converter implementation is a Java class that implements the interface `io.debezium.spi.converter.CustomConverter`:
+// Type: procedure
+// Title: Creating a {prodname} custom data type converter
+// ModuleID: creating-a-debezium-custom-data-type-converter
+[id="implementing-a-custom-converter"]
+== Implementing custom converters
+
+The following example shows a converter implementation of a Java class that implements the interface `io.debezium.spi.converter.CustomConverter`:
 
 [source,java,indent=0]
 ----
 public interface CustomConverter<S, F extends ConvertedField> {
 
     @FunctionalInterface
-    interface Converter {
+    interface Converter {  // <1>
         Object convert(Object input);
     }
 
-    public interface ConverterRegistration<S> {
-        void register(S fieldSchema, Converter converter);
+    public interface ConverterRegistration<S> { // <2>
+        void register(S fieldSchema, Converter converter); // <3>
     }
 
     void configure(Properties props);
 
-    void converterFor(F field, ConverterRegistration<S> registration);
+    void converterFor(F field, ConverterRegistration<S> registration); // <4>
 }
 ----
+<1> A function for converting data from one type to another.
+<2> Callback for registering a converter.
+<3> Registers the given schema and converter for the current field.
+Should not be invoked more than once for the same field.
+<4> Registers the customized value and schema converter for use with a specific field.
 
-The method `configure()` is used to pass converter configuration options into the converter after its instantiation, so it can modify its runtime behaviour for each specific instance.
-The method `converterFor()` is invoked by {prodname} and the converter is required to call `registration` in case of taking responsibility for the conversion.
-The registration provides the target schema definition and the actual conversion code.
-Schemas are currently represented using Kafka Connect's `SchemaBuilder` API.
+.Custom converter methods
+The `configure()` and `converterFor()` methods are mandatory for each {prodname} custom converter:
+
+`configure()`::
+Passes the properties specified in the connector configuration to the converter instance.
+The `configure` method runs when the connector is initialized.
+You can use a converter with multiple connectors and modify its behavior based on the connector's property settings. +
+The `configure` method accepts the following argument:
+
+`props`::: Contains the properties to pass to the converter instance.
+Each property specifies the format for converting the values of a particular type of column.
+
+`converterFor()`::
+Registers the converter to process specific columns or fields in the data source.
+{prodname} invokes the `converterFor()` method to prompt the converter to call `registration` for the conversion.
+The `converterFor` method runs once for each column. +
+The method accepts the following arguments:
+
+`field`:::
+An object that passes metadata about the field or column that is processed.
+The column metadata can include the name of the column or field, the name of the table or collection, the data type, size, and so forth.
+
+`registration`:::
+An object of type `io.debezium.spi.converter.CustomConverter.ConverterRegistration` that provides the target schema definition and the code for converting the column data.
+The converter calls the `registration` parameter when the source column matches the type that the converter should process.
+  calls the `register` method to define the converter for each column in the schema.
+Schemas are represented using the Kafka Connect link:https://kafka.apache.org/31/javadoc/org/apache/kafka/connect/data/SchemaBuilder.html[`SchemaBuilder`] API.
+ifdef::community[]
 In the future, an independent schema definition API will be added.
-The metadata about the column or field are passed via the `field` parameter.
-They contain information like table or collection name, column or field name, type name, and others.
+endif::community[]
 
-The following example implements a simple converter that will:
+The following example implements a simple converter that performs the following operations:
 
- * accept one parameter named `schema.name`
- * register itself for every column of type `isbn` with
- ** the target `STRING` schema named according to the `schema.name` parameter
- ** the conversion code that converts the ISBN data to `String`
- 
+* Runs the `configure` method, which configures the converter based on the value of the `schema.name` property that is specified in the connector configuration.
+The converter configuration is specific to each instance.
+* Runs the `converterFor` method, which registers the converter to process values in source columns for which the data type is set to `isbn`.
+** Identifies the target `STRING` schema based on the value that is specified for the `schema.name` property.
+** Converts ISBN data in the source column to `String` values.
+
+=== {prodname} custom converter example
+[id="example-debezium-simple-custom-converter"]
+.A simple custom converter
+====
 [source,java,indent=0]
 ----
     public static class IsbnConverter implements CustomConverter<SchemaBuilder, RelationalColumn> {
@@ -88,38 +149,86 @@ The following example implements a simple converter that will:
         }
     }
 ----
+====
 
-To compile the code it is necessary to provide dependencies to the `debezium-api` and `connect-api` modules like:
+// Type: procedure
+[id="debezium-and-kafka-connect-api-module-dependencies"]
+=== {prodname} and Kafka Connect API module dependencies
+
+The converter code depends on the {prodname} and Kafka Connect API library modules.
+To enable your converter code to compile, add these dependencies to your converter Java project as shown in the following example:
+
 [source,xml]
 ----
 <dependency>
     <groupId>io.debezium</groupId>
     <artifactId>debezium-api</artifactId>
-    <version>${version.debezium}</version>
+    <version>${version.debezium}</version> // <1>
 </dependency>
 <dependency>
     <groupId>org.apache.kafka</groupId>
     <artifactId>connect-api</artifactId>
-    <version>${version.kafka}</version>
+    <version>${version.kafka}</version> <2>
 </dependency>
 ----
+<1> `${version.debezium}` represents the version of the {prodname} connector.
+<2> `${version.kafka}` represents the version of Apache Kafka in your environment.
 
-where `${version.debezium}` and `${version.kafka}` are the versions of {prodname} and Apache Kafka, respectively.
-
+// Type: assembly
+// Title: Using custom converters with {prodname} connectors
+// ModuleID: deploying-and-configuring-debezium-custom-data-type-converters
+[id="configuring-and-using-converters"]
 == Configuring and Using Converters
 
-After the converter is developed it has to be deployed in a JAR file side-by-side with the {prodname} connector JARs.
-To enable the converter for a given connector instance it is necessary to provide the connector options like this:
+To use the converter with a connector, you deploy the converter JAR file alongside the connector file, and then configure the connector to use the converter.
 
+// Type: procedure
+[id="deploying-a-debezium-custom-converter"]
+=== Deploying a custom converter
+
+.Procedure
+* To use a custom converter with a {prodname} connector, export the Java project to a JAR file, and add the file to the directory that contains the JAR file for each {prodname} connector that you want to use it with. +
+ +
+For example, in a typical deployment, you might store {prodname} connector files in subdirectories of a Kafka Connect directory, such as `/kafka/connect`,
+and then store the JAR for each connector in its own subdirectory (`debezium-connector-db2`, `debezium-connector-mysql`, and so forth).
+To use a converter with a connector, add the converter JAR file to the connector subdirectory.
+
+NOTE: To use a converter with multiple connectors, add the connector JAR file to the directory for each of the connectors.
+
+// Type: procedure
+[id="configuring-a-connectors-to-use-a-custom-converter"]
+=== Configuring a connector to use a custom converter
+
+Custom converters act on specific columns or column types in a source table to specify how to convert their data types.
+To enable a connector to use the custom converter, you add properties to the connector configuration that specify the converter name and class.
+If the converter requires further information to customize the formats of specific data types, you can also define other coniguration options to provide that information.
+
+.Prerequisites
+* You have a custom converter Java program.
+
+.Procedure
+
+* Enable a converter for a connector instance by adding the following mandatory properties to the connector configuration:
++
+[subs="+quotes"]
 ----
-converters=isbn
-isbn.type=io.debezium.test.IsbnConverter
-isbn.schema.name=io.debezium.postgresql.type.Isbn
+converters: _<converterSymbolicName>_ // <1>
+_<converterSymbolicName>_.type: _<fullyQualifiedConverterClassName>_ // <2>
+----
+<1> The `converters` property is mandatory and enumerates a comma-separated list of symbolic names of the converter instances to use with the connector.
+The values listed for this property serve as prefixes in the names of other properties that you specify for the converter.
+<2> The `_<converterSymbolicName>_.type` property is mandatory, and specifies the name of the class that implements the converter.
+For example, for the earlier xref:example-debezium-simple-custom-converter[custom converter example], you would add the following properties to the connector configuration:
++
+----
+converters: isbn
+isbn.type: io.debezium.test.IsbnConverter
 ----
 
-The option `converters` is mandatory and enumerates comma-separated symbolic names of converter instances to be used.
-The symbolic names are used as a prefix for further configuration options.
-
-`isbn.type` (generally `<prefix>.type`) is mandatory and is the name of the class that implements the converter.
-
-`isbn.schema.name` is a converter parameter that is passed to the converter's `configure` method as `schema.name`.
+* If provide further configuration properties for a converter, prefix the property names with the symbolic name of the converter, followed by a dot (`.`).
+  The symbolic name is label that you specify as a value for the `converters` property.
+  For example, to add a property for the preceding `isbn` converter to specify the `schema.name` to pass to the `configure` method in the converter code, add the following property:
++
+----
+isbn.schema.name: io.debezium.postgresql.type.Isbn
+----


### PR DESCRIPTION
[DBZ-4588](https://issues.redhat.com/browse/DBZ-4588)

- Prepares custom converters doc for downstream use (edits and add modularization comments).
- Adds links to the converters doc from the data types topics in the connectors docs.
- Add `converters` entry to connector configuration properties tables. 

Tested in local Antora build and local downstream build.

Todos:
* Add links from MySQL and Oracle Boolean custom converter examples to Custom converters topic.
* Update properties table entry for consistency with the Boolean custom converter example. 