### PR TITLE
DBZ-5123: Interpret data-collections signal as regex for ad-hoc snapshotting

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -71,6 +71,7 @@ Chris Baumbauer
 Chris Collingwood
 Chris Cranford
 Chris Egerton
+Chris Lee
 Chris Riccomini
 Christian Posta
 Christian Stein

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/IncrementalSnapshotIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/IncrementalSnapshotIT.java
@@ -90,17 +90,34 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotWithSchema
 
     @Override
     protected String tableName() {
-        return TableId.parse(DATABASE.qualifiedTableName("a")).toQuotedString('`');
+        return tableNameId().toQuotedString('`');
     }
 
     @Override
     protected String signalTableName() {
-        return TableId.parse(DATABASE.qualifiedTableName("debezium_signal")).toQuotedString('`');
+        return tableNameId("debezium_signal").toQuotedString('`');
     }
 
     @Override
     protected String tableName(String table) {
-        return TableId.parse(DATABASE.qualifiedTableName(table)).toQuotedString('`');
+        return tableNameId(table).toQuotedString('`');
+    }
+
+    @Override
+    protected String tableDataCollectionId() {
+        return tableNameId().toString();
+    }
+
+    private String dataCollectionName(String table) {
+        return tableNameId(table).toString();
+    }
+
+    private TableId tableNameId() {
+        return tableNameId("a");
+    }
+
+    private TableId tableNameId(String table) {
+        return TableId.parse(DATABASE.qualifiedTableName(table));
     }
 
     @Override
@@ -203,7 +220,7 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotWithSchema
         waitForConnectorToStart();
         waitForAvailableRecords(5, TimeUnit.SECONDS);
 
-        sendAdHocSnapshotSignal(tableName("a_dt"));
+        sendAdHocSnapshotSignal(dataCollectionName("a_dt"));
 
         final int expectedRecordCount = ROWS;
         final Map<Integer, List<Object>> dbChanges = consumeMixedWithIncrementalSnapshot(
@@ -252,7 +269,7 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotWithSchema
         waitForConnectorToStart();
         waitForAvailableRecords(5, TimeUnit.SECONDS);
 
-        sendAdHocSnapshotSignal(tableName("a_date"));
+        sendAdHocSnapshotSignal(dataCollectionName("a_date"));
 
         final int expectedRecordCount = 1;
         final Map<Integer, List<Integer>> dbChanges = consumeMixedWithIncrementalSnapshot(

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
@@ -470,6 +470,19 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
         }
     }
 
+    @Test
+    public void snapshotWithRegexDataCollections() throws Exception {
+        populateTable();
+        startConnector();
+        sendAdHocSnapshotSignal(".*");
+
+        final int expectedRecordCount = ROW_COUNT;
+        final Map<Integer, Integer> dbChanges = consumeMixedWithIncrementalSnapshot(expectedRecordCount);
+        for (int i = 0; i < expectedRecordCount; i++) {
+            Assertions.assertThat(dbChanges).includes(MapAssert.entry(i + 1, i));
+        }
+    }
+
     @Override
     protected int getMaximumEnqueuedRecordCount() {
         return ROW_COUNT * 3;

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -521,7 +521,7 @@ See the next section for more details.
 
 |`data-collections`
 |_N/A_
-| An array of qualified names of table to be snapshotted. +
+| An array of comma-separated regular expressions that match fully-qualified names of tables to be snapshotted. +
 The format of the names is the same as for xref:#{context}-property-signal-data-collection[signal.data.collection] configuration option.
 
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
@@ -37,7 +37,7 @@ Currently, you can request only `incremental` snapshots.
 
 |`data-collections`
 |_N/A_
-| An array that contains the fully-qualified names of the {data-collection} to be snapshotted. +
+| An array that contains regular expressions matching the fully-qualified names of the {data-collection} to be snapshotted. +
 The format of the names is the same as for the `signal.data.collection` configuration option.
 
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
@@ -114,7 +114,7 @@ Rather, during the snapshot, {prodname} generates its own `id` string as a water
 
 |`data-collections`
 |A required component of the `data` field of a signal that specifies an array of {data-collection} names to include in the snapshot. +
-The array lists {data-collection}s by their fully-qualified names, using the same format as you use to specify the name of the connector's signaling {data-collection} in the xref:{context}-property-signal-data-collection[`signal.data.collection`] configuration property.
+The array lists regular expressions which match {data-collection}s by their fully-qualified names, using the same format as you use to specify the name of the connector's signaling {data-collection} in the xref:{context}-property-signal-data-collection[`signal.data.collection`] configuration property.
 
 |`incremental`
 |An optional `type` component of the `data` field of a signal that specifies the kind of snapshot operation to run. +

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -137,3 +137,4 @@ AlexMiroshnikov,Alexey Miroshnikov
 roeselert,Timo Roeseler
 troeselereos,Timo Roeseler
 Himanshu-LT,Himanshu Mishra
+Chrisss93,Chris Lee


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5123

This is a quick  attempt at redefining the data-collections-ids of a Debezium signal for ad-hoc snapshot to be a comma-separated list of regular expressions (similar to the`table.include.list` configuration parameter) instead of a comma-separated list of fully-qualified-names. Since this ad-hoc snapshotting signal and the `table.include.list` property appear to be complements, there seems to be value, at least to me, in bringing these concepts closer together by allowing them to be defined and interpreted in the same way. 

A few consequences of this:
1. the ad-hoc snapshotting no longer accepts _quoted_ fully-qualified-names (the `IncrementalSnapshotIT` class in the debezium-mysql-connector relied on this). Quoted fully-qualified-names do not work on the `table.include.list` property anyways.
2. While in most cases, users can continue to use the `data-collections` field for ad-hoc snapshotting as if it were still a fully-qualified name, this change might break existing behaviour for tables whose names are invalid regex (ie. a mysql table can be called `(` or a postgres table called `foo(`). In these cases, the offending regex characters must be escaped.

I'll add some stuff to the relevant docs in the MR once someone has given it a look over and tells me if I'm on the right track.