### PR TITLE
DBZ-5128 Assign unique anchor ID to recently added topic routing option

### DIFF
--- a/documentation/modules/ROOT/pages/transformations/topic-routing.adoc
+++ b/documentation/modules/ROOT/pages/transformations/topic-routing.adoc
@@ -194,7 +194,7 @@ Specify `false` if you do not want the transformation to add a key field.  For e
 |
 |Specifies a regular expression for determining the value of the inserted key field in terms of the groups captured by the expression specified for `key.field.regex`. For the SMT to apply this expression, `key.enforce.uniqueness` must be `true`, which is the default.
 
-|[[by-logical-table-router-logical-table-cache-size]]xref:by-logical-table-router-logical-table-cache-size[`schema.name.adjustment.mode`]
+|[[by-logical-table-router-schema-name-adjustment-mode]]xref:by-logical-table-router-schema-name-adjustment-mode[`schema.name.adjustment.mode`]
 |`avro`
 |Specify how the message key schema names derived from the resulting topic name should be adjusted for compatibility with the message converter used by the connector, including: `avro` replaces the characters that cannot be used in the Avro type name with underscore (default), `none` does not apply any adjustment.
 


### PR DESCRIPTION
[DBZ-5128](https://issues.redhat.com/browse/DBZ-5128)

Assigns unique anchor ID to topic routing option that was introduced in DBZ-5072 (`schema.name.adjustment.mode`). The option was originally assigned the same ID as `logical.table.cache.size`. The resulting collision resulted in an error when attempting to build the Antora documentation.

If DBZ-5072 is backported to 1.9, then this fix should be treated likewise. 