### PR TITLE
DBZ-5131 Use fetch size only in tests which need it

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/IncrementalSnapshotIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/IncrementalSnapshotIT.java
@@ -67,7 +67,6 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotWithSchema
                 .with(MySqlConnectorConfig.USER, "mysqluser")
                 .with(MySqlConnectorConfig.PASSWORD, "mysqlpw")
                 .with(MySqlConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY.getValue())
-                .with(MySqlConnectorConfig.SNAPSHOT_FETCH_SIZE, 5)
                 .with(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
                 .with(MySqlConnectorConfig.SIGNAL_DATA_COLLECTION, DATABASE.qualifiedTableName("debezium_signal"))
                 .with(MySqlConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 10)
@@ -199,7 +198,11 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotWithSchema
             connection.commit();
         }
 
-        startConnector();
+        final Configuration config = config().with(MySqlConnectorConfig.SNAPSHOT_FETCH_SIZE, 5).build();
+        start(connectorClass(), config, loggingCompletion());
+        waitForConnectorToStart();
+        waitForAvailableRecords(5, TimeUnit.SECONDS);
+
         sendAdHocSnapshotSignal(tableName("a_dt"));
 
         final int expectedRecordCount = ROWS;
@@ -244,7 +247,11 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotWithSchema
             connection.commit();
         }
 
-        startConnector();
+        final Configuration config = config().with(MySqlConnectorConfig.SNAPSHOT_FETCH_SIZE, 5).build();
+        start(connectorClass(), config, loggingCompletion());
+        waitForConnectorToStart();
+        waitForAvailableRecords(5, TimeUnit.SECONDS);
+
         sendAdHocSnapshotSignal(tableName("a_date"));
 
         final int expectedRecordCount = 1;


### PR DESCRIPTION
Cuncurrent reading and modification of MySQL table can result into MySQL
JDBC driver ArrayIndexOutOfBoundsException when it tried to merge table
fields. This is result fo caching parepared statements while table
schema is modified. It seems that caching of prepared statements is
triggered by using fetch size. Use it only in test which needs this
option to work properly and which don't do any schema changes.

https://issues.redhat.com/browse/DBZ-5131