### PR TITLE
DBZ-5089: Add partition to outbox event router

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -82,6 +82,7 @@ Claus Guttesen
 Clément Loiselet
 Cliff Wheadon
 Collin Van Dyck
+Connor Szczepaniak
 Cory Harper
 Cyprien Etienne
 Cyril Scetbon

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterConfigDefinition.java
@@ -65,7 +65,8 @@ public class EventRouterConfigDefinition {
 
     public enum AdditionalFieldPlacement implements EnumeratedValue {
         HEADER("header"),
-        ENVELOPE("envelope");
+        ENVELOPE("envelope"),
+        PARTITION("partition");
 
         private final String value;
 
@@ -188,7 +189,7 @@ public class EventRouterConfigDefinition {
             .withImportance(ConfigDef.Importance.HIGH)
             .withDescription("Extra fields can be added as part of the event envelope or a message header, format" +
                     " is a list of colon-delimited pairs or trios when you desire to have aliases," +
-                    " e.g. <code>id:header,field_name:envelope:alias</code> ");
+                    " e.g. <code>id:header,field_name:envelope:alias,field_name:partition</code> ");
 
     public static final Field FIELD_SCHEMA_VERSION = Field.create("table.field.event.schema.version")
             .withDisplayName("Event Schema Version Field")

--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/EventRouterDelegate.java
@@ -175,6 +175,10 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
 
         final Struct structValue = onlyHeadersInOutputMessage ? null : new Struct(structValueSchema).put(ENVELOPE_PAYLOAD, payload);
 
+        var partition = new Object() {
+            Integer value = null;
+        };
+
         additionalFields.forEach((additionalField -> {
             switch (additionalField.getPlacement()) {
                 case ENVELOPE:
@@ -188,6 +192,8 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
                             eventStruct.get(additionalField.getField()),
                             eventValueSchema.field(additionalField.getField()).schema());
                     break;
+                case PARTITION:
+                    partition.value = eventStruct.getInt32(additionalField.getField());
             }
         }));
 
@@ -213,7 +219,7 @@ public class EventRouterDelegate<R extends ConnectRecord<R>> {
 
         R newRecord = r.newRecord(
                 eventStruct.getString(routeByField),
-                null,
+                partition.value,
                 defineRecordKeySchema(fieldEventKey, eventValueSchema, fallbackPayloadIdField),
                 recordKey,
                 updatedSchema,

--- a/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
@@ -240,26 +240,44 @@ If any extra configuration options are needed by the converter, they can also be
 // Title: Emitting additional fields in {prodname} MongoDB outbox messages
 // ModuleID: emitting-additional-fields-in-debezium-mongodb-outbox-messages
 [[mongodb-outbox-emitting-messages-with-additional-fields]]
-== Emitting messages with additional fields
 
-Your outbox collection might contain fields whose values you want to add to the emitted outbox messages. For example, consider an outbox collection that has a value of `purchase-order` in the `aggregatetype` field and another field, `eventType`, whose possible values are `order-created` and `order-shipped`.
+Your outbox collection might contain fields whose values you want to add to the emitted outbox messages. For example, consider an outbox collection that has a value of `purchase-order` in the `aggregatetype` field and another field, `eventType`, whose possible values are `order-created` and `order-shipped`. Additional fields can be added with the syntax `field:placement:alias`.
+
+The allowed values for `placement` are:
+- `header`
+- `envelope`
+- `partition`
+
 To emit the `eventType` field value in the outbox message header, configure the SMT like this:
 
 [source]
 ----
 transforms=outbox,...
-transforms.outbox.type=io.debezium.connector.mongodb.transforms.outbox.MongoEventRouter
-transforms.outbox.collection.fields.additional.placement=type:header:eventType
+transforms.outbox.type=io.debezium.transforms.outbox.EventRouter
+transforms.outbox.table.fields.additional.placement=eventType:header:type
 ----
+
+The result will be a header on the Kafka message with `type` as its key, and the value of the `eventType` field as its value.
 
 To emit the `eventType` field value in the outbox message envelope, configure the SMT like this:
 
 [source]
 ----
 transforms=outbox,...
-transforms.outbox.type=io.debezium.connector.mongodb.transforms.outbox.MongoEventRouter
-transforms.outbox.collection.fields.additional.placement=type:envelope:eventType
+transforms.outbox.type=io.debezium.transforms.outbox.EventRouter
+transforms.outbox.table.fields.additional.placement=eventType:envelope:type
 ----
+
+To control which partition the outbox message is produced on, configure the SMT like this:
+
+[source]
+----
+transforms=outbox,...
+transforms.outbox.type=io.debezium.transforms.outbox.EventRouter
+transforms.outbox.table.fields.additional.placement=partitionField:partition
+----
+
+Note that for the `partition` placement, adding an alias will have no effect.
 
 // Type: concept
 // Title: Expanding escaped JSON String as JSON

--- a/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
@@ -247,15 +247,23 @@ If any extra configuration options are needed by the converter, they can also be
 [[emitting-messages-with-additional-fields]]
 == Emitting messages with additional fields
 
-Your outbox table might contain columns whose values you want to add to the emitted outbox messages. For example, consider an outbox table that has a value of `purchase-order` in the `aggregatetype` column and another column, `eventType`, whose possible values are `order-created` and `order-shipped`.
+Your outbox table might contain columns whose values you want to add to the emitted outbox messages. For example, consider an outbox table that has a value of `purchase-order` in the `aggregatetype` column and another column, `eventType`, whose possible values are `order-created` and `order-shipped`. Additional fields can be added with the syntax `column:placement:alias`.
+
+The allowed values for `placement` are:
+- `header`
+- `envelope`
+- `partition`
+
 To emit the `eventType` column value in the outbox message header, configure the SMT like this:
 
 [source]
 ----
 transforms=outbox,...
 transforms.outbox.type=io.debezium.transforms.outbox.EventRouter
-transforms.outbox.table.fields.additional.placement=type:header:eventType
+transforms.outbox.table.fields.additional.placement=eventType:header:type
 ----
+
+The result will be a header on the Kafka message with `type` as its key, and the value of the `eventType` column as its value.
 
 To emit the `eventType` column value in the outbox message envelope, configure the SMT like this:
 
@@ -263,8 +271,19 @@ To emit the `eventType` column value in the outbox message envelope, configure t
 ----
 transforms=outbox,...
 transforms.outbox.type=io.debezium.transforms.outbox.EventRouter
-transforms.outbox.table.fields.additional.placement=type:envelope:eventType
+transforms.outbox.table.fields.additional.placement=eventType:envelope:type
 ----
+
+To control which partition the outbox message is produced on, configure the SMT like this:
+
+[source]
+----
+transforms=outbox,...
+transforms.outbox.type=io.debezium.transforms.outbox.EventRouter
+transforms.outbox.table.fields.additional.placement=partitionColumn:partition
+----
+
+Note that for the `partition` placement, adding an alias will have no effect.
 
 // Type: concept
 // Title: Expanding escaped JSON String as JSON

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -138,3 +138,4 @@ roeselert,Timo Roeseler
 troeselereos,Timo Roeseler
 Himanshu-LT,Himanshu Mishra
 Chrisss93,Chris Lee
+connorszczepaniak-wk,Connor Szczepaniak


### PR DESCRIPTION
[DBZ-5089](https://issues.redhat.com/browse/DBZ-5089)

In some use cases, it would be useful to be able to specify on which partition an outbox event should be produced. This is currently not possible as `null` is hardcoded into the record constructor - let's add it to the config and plumb it down.