### PR TITLE
Both of filter event and error event don't need to increment when dat…

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/meters/CommonEventMeter.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/meters/CommonEventMeter.java
@@ -72,22 +72,18 @@ public class CommonEventMeter implements CommonEventMetricsMXBean {
 
     public void onFilteredEvent() {
         numberOfEventsFiltered.incrementAndGet();
-        updateCommonEventMetrics();
     }
 
     public void onFilteredEvent(Operation operation) {
         numberOfEventsFiltered.incrementAndGet();
-        updateCommonEventMetrics(operation);
     }
 
     public void onErroneousEvent() {
         numberOfErroneousEvents.incrementAndGet();
-        updateCommonEventMetrics();
     }
 
     public void onErroneousEvent(Operation operation) {
         numberOfErroneousEvents.incrementAndGet();
-        updateCommonEventMetrics(operation);
     }
 
     @Override


### PR DESCRIPTION
Maybe updateCommonEventMetrics should be triggered when updating 'table.include.list' in configuration. Users don't care about excluding table metrics.