### PR TITLE
DBZ-5147 Add `event.processing.failure.handling.mode` for Oracle

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilder.java
@@ -54,7 +54,7 @@ public class LogMinerQueryBuilder {
     public static String build(OracleConnectorConfig connectorConfig, OracleDatabaseSchema schema) {
         final StringBuilder query = new StringBuilder(1024);
         query.append("SELECT SCN, SQL_REDO, OPERATION_CODE, TIMESTAMP, XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, ");
-        query.append("USERNAME, ROW_ID, ROLLBACK, RS_ID, STATUS ");
+        query.append("USERNAME, ROW_ID, ROLLBACK, RS_ID, STATUS, INFO ");
         query.append("FROM ").append(LOGMNR_CONTENTS_VIEW).append(" ");
 
         // These bind parameters will be bound when the query is executed by the caller.

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilder.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilder.java
@@ -54,7 +54,7 @@ public class LogMinerQueryBuilder {
     public static String build(OracleConnectorConfig connectorConfig, OracleDatabaseSchema schema) {
         final StringBuilder query = new StringBuilder(1024);
         query.append("SELECT SCN, SQL_REDO, OPERATION_CODE, TIMESTAMP, XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, ");
-        query.append("USERNAME, ROW_ID, ROLLBACK, RS_ID ");
+        query.append("USERNAME, ROW_ID, ROLLBACK, RS_ID, STATUS ");
         query.append("FROM ").append(LOGMNR_CONTENTS_VIEW).append(" ");
 
         // These bind parameters will be bound when the query is executed by the caller.

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEventRow.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEventRow.java
@@ -46,6 +46,7 @@ public class LogMinerEventRow {
     private static final int ROLLBACK_FLAG = 12;
     private static final int RS_ID = 13;
     private static final int STATUS = 14;
+    private static final int INFO = 15;
 
     private Scn scn;
     private TableId tableId;
@@ -61,6 +62,7 @@ public class LogMinerEventRow {
     private String rsId;
     private String redoSql;
     private int status;
+    private String info;
 
     public Scn getScn() {
         return scn;
@@ -118,6 +120,10 @@ public class LogMinerEventRow {
         return status;
     }
 
+    public String getInfo() {
+        return info;
+    }
+
     /**
      * Returns a {@link LogMinerEventRow} instance based on the current row of the JDBC {@link ResultSet}.
      *
@@ -160,6 +166,7 @@ public class LogMinerEventRow {
         this.rsId = resultSet.getString(RS_ID);
         this.redoSql = getSqlRedo(resultSet);
         this.status = resultSet.getInt(STATUS);
+        this.info = resultSet.getString(INFO);
         if (this.tableName != null) {
             this.tableId = new TableId(catalogName, tablespaceName, tableName);
         }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEventRow.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/events/LogMinerEventRow.java
@@ -45,6 +45,7 @@ public class LogMinerEventRow {
     private static final int ROW_ID = 11;
     private static final int ROLLBACK_FLAG = 12;
     private static final int RS_ID = 13;
+    private static final int STATUS = 14;
 
     private Scn scn;
     private TableId tableId;
@@ -59,6 +60,7 @@ public class LogMinerEventRow {
     private boolean rollbackFlag;
     private String rsId;
     private String redoSql;
+    private int status;
 
     public Scn getScn() {
         return scn;
@@ -112,6 +114,10 @@ public class LogMinerEventRow {
         return redoSql;
     }
 
+    public int getStatus() {
+        return status;
+    }
+
     /**
      * Returns a {@link LogMinerEventRow} instance based on the current row of the JDBC {@link ResultSet}.
      *
@@ -153,6 +159,7 @@ public class LogMinerEventRow {
         this.rollbackFlag = resultSet.getInt(ROLLBACK_FLAG) == 1;
         this.rsId = resultSet.getString(RS_ID);
         this.redoSql = getSqlRedo(resultSet);
+        this.status = resultSet.getInt(STATUS);
         if (this.tableName != null) {
             this.tableId = new TableId(catalogName, tablespaceName, tableName);
         }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
@@ -729,8 +729,8 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
                     LOGGER.warn("Oracle LogMiner event '{}' cannot be parsed. This event will be ignored and skipped.", row);
                     return;
                 default:
-                    // In this case, we explicitly log the situation in "trace" only and not as an error/warn.
-                    LOGGER.trace("Oracle LogMiner event '{}' cannot be parsed. This event will be ignored and skipped.", row);
+                    // In this case, we explicitly log the situation in "debug" only and not as an error/warn.
+                    LOGGER.debug("Oracle LogMiner event '{}' cannot be parsed. This event will be ignored and skipped.", row);
                     return;
             }
         }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -3784,8 +3784,6 @@ public class OracleConnectorIT extends AbstractConnectorTest {
             start(OracleConnector.class, config);
             assertConnectorIsRunning();
 
-            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
-
             // wait and confirm that the exception is thrown.
             Awaitility.await()
                     .atMost(60, TimeUnit.SECONDS)

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -99,6 +99,8 @@ public class OracleConnectorIT extends AbstractConnectorTest {
 
     private static final long MICROS_PER_SECOND = TimeUnit.SECONDS.toMicros(1);
     private static final String SNAPSHOT_COMPLETED_KEY = "snapshot_completed";
+    private static final String ERROR_PROCESSING_FAIL_MESSAGE = "Oracle LogMiner is unable to re-construct the SQL for '";
+    private static final String ERROR_PROCESSING_WARN_MESSAGE = "cannot be parsed. This event will be ignored and skipped.";
 
     @Rule
     public final TestRule skipAdapterRule = new SkipTestDependingOnAdapterNameRule();
@@ -3741,11 +3743,9 @@ public class OracleConnectorIT extends AbstractConnectorTest {
         }
     }
 
-    private static final String ERROR_PROCESSING_FAIL_MESSAGE = "Oracle LogMiner is unable to re-construct the SQL for '";
-    private static final String ERROR_PROCESSING_WARN_MESSAGE = "cannot be parsed. This event will be ignored and skipped.";
-
     @Test
     @FixFor("DBZ-5147")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER, reason = "Only applies to Oracle LogMiner implementation")
     public void shouldStopWhenErrorProcessingFailureHandlingModeIsDefault() throws Exception {
         TestHelper.dropTable(connection, "dbz5147");
         try {
@@ -3801,6 +3801,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
 
     @Test
     @FixFor("DBZ-5147")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER, reason = "Only applies to Oracle LogMiner implementation")
     public void shouldLogWarningAndSkipWhenErrorProcessingFailureHandlingModeIsWarn() throws Exception {
         TestHelper.dropTable(connection, "dbz5147");
         try {
@@ -3861,6 +3862,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
 
     @Test
     @FixFor("DBZ-5147")
+    @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER, reason = "Only applies to Oracle LogMiner implementation")
     public void shouldSilentlySkipWhenErrorProcessingFailureHandlingModeIsSkip() throws Exception {
         TestHelper.dropTable(connection, "dbz5147");
         try {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -69,6 +69,7 @@ import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnDatabaseOptionRule;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.logminer.LogMinerStreamingChangeEventSource;
+import io.debezium.connector.oracle.logminer.processor.AbstractLogMinerEventProcessor;
 import io.debezium.connector.oracle.util.TestHelper;
 import io.debezium.converters.CloudEventsConverterTest;
 import io.debezium.converters.spi.CloudEventsMaker;
@@ -3737,6 +3738,183 @@ public class OracleConnectorIT extends AbstractConnectorTest {
         finally {
             TestHelper.dropTable(connection, "heartbeat");
             TestHelper.dropTable(connection, "dbz5119");
+        }
+    }
+
+    private static final String ERROR_PROCESSING_FAIL_MESSAGE = "Oracle LogMiner is unable to re-construct the SQL for '";
+    private static final String ERROR_PROCESSING_WARN_MESSAGE = "cannot be parsed. This event will be ignored and skipped.";
+
+    @Test
+    @FixFor("DBZ-5147")
+    public void shouldStopWhenErrorProcessingFailureHandlingModeIsDefault() throws Exception {
+        TestHelper.dropTable(connection, "dbz5147");
+        try {
+            connection.execute("CREATE TABLE dbz5147 (id numeric(9,0) primary key, data varchar2(50))");
+            connection.execute("INSERT INTO dbz5147 VALUES (1, 'test1')");
+            TestHelper.streamTable(connection, "dbz5147");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ5147")
+                    // We explicitly use this mode here to enforce the schema evolution issues with DML
+                    // event failures because Oracle LogMiner doesn't track DDL evolution.
+                    .with(OracleConnectorConfig.LOG_MINING_STRATEGY, "online_catalog")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            SourceRecords sourceRecords = consumeRecordsByTopic(1);
+            List<SourceRecord> records = sourceRecords.recordsForTopic("server1.DEBEZIUM.DBZ5147");
+            assertThat(records).hasSize(1);
+            VerifyRecord.isValidRead(records.get(0), "ID", 1);
+
+            // We want to stop the connector and perform several DDL operations offline
+            // This will cause some DML events that happen offline to not be parsed by Oracle LogMiner.
+            stopConnector();
+
+            connection.execute("ALTER TABLE dbz5147 add data2 varchar2(50)");
+            connection.execute("INSERT INTO dbz5147 values (2, 'test2a', 'test2b')");
+            connection.execute("ALTER TABLE dbz5147 drop column data2");
+            connection.execute("INSERT INTO dbz5147 values (3, 'test3')");
+
+            final LogInterceptor interceptor = new LogInterceptor(AbstractLogMinerEventProcessor.class);
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            // wait and confirm that the exception is thrown.
+            Awaitility.await()
+                    .atMost(60, TimeUnit.SECONDS)
+                    .until(() -> interceptor.containsErrorMessage(ERROR_PROCESSING_FAIL_MESSAGE));
+
+            // there should be no records to consume since we hard-failed
+            assertNoRecordsToConsume();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz5147");
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-5147")
+    public void shouldLogWarningAndSkipWhenErrorProcessingFailureHandlingModeIsWarn() throws Exception {
+        TestHelper.dropTable(connection, "dbz5147");
+        try {
+            connection.execute("CREATE TABLE dbz5147 (id numeric(9,0) primary key, data varchar2(50))");
+            connection.execute("INSERT INTO dbz5147 VALUES (1, 'test1')");
+            TestHelper.streamTable(connection, "dbz5147");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ5147")
+                    .with(OracleConnectorConfig.EVENT_PROCESSING_FAILURE_HANDLING_MODE, "warn")
+                    // We explicitly use this mode here to enforce the schema evolution issues with DML
+                    // event failures because Oracle LogMiner doesn't track DDL evolution.
+                    .with(OracleConnectorConfig.LOG_MINING_STRATEGY, "online_catalog")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            SourceRecords sourceRecords = consumeRecordsByTopic(1);
+            List<SourceRecord> records = sourceRecords.recordsForTopic("server1.DEBEZIUM.DBZ5147");
+            assertThat(records).hasSize(1);
+            VerifyRecord.isValidRead(records.get(0), "ID", 1);
+
+            // We want to stop the connector and perform several DDL operations offline
+            // This will cause some DML events that happen offline to not be parsed by Oracle LogMiner.
+            stopConnector();
+
+            connection.execute("ALTER TABLE dbz5147 add data2 varchar2(50)");
+            connection.execute("INSERT INTO dbz5147 values (2, 'test2a', 'test2b')");
+            connection.execute("ALTER TABLE dbz5147 drop column data2");
+            connection.execute("INSERT INTO dbz5147 values (3, 'test3')");
+
+            final LogInterceptor interceptor = new LogInterceptor(AbstractLogMinerEventProcessor.class);
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            // wait and confirm that the exception is thrown.
+            Awaitility.await()
+                    .atMost(60, TimeUnit.SECONDS)
+                    .until(() -> interceptor.containsWarnMessage(ERROR_PROCESSING_WARN_MESSAGE));
+
+            // There should only be one record to consume, the valid insert for ID=3.
+            // The record for ID=2 will have yielded a WARN log entry we checked above.
+            sourceRecords = consumeRecordsByTopic(1);
+            records = sourceRecords.recordsForTopic("server1.DEBEZIUM.DBZ5147");
+            assertThat(records).hasSize(1);
+            VerifyRecord.isValidInsert(records.get(0), "ID", 3);
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz5147");
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-5147")
+    public void shouldSilentlySkipWhenErrorProcessingFailureHandlingModeIsSkip() throws Exception {
+        TestHelper.dropTable(connection, "dbz5147");
+        try {
+            connection.execute("CREATE TABLE dbz5147 (id numeric(9,0) primary key, data varchar2(50))");
+            connection.execute("INSERT INTO dbz5147 VALUES (1, 'test1')");
+            TestHelper.streamTable(connection, "dbz5147");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ5147")
+                    .with(OracleConnectorConfig.EVENT_PROCESSING_FAILURE_HANDLING_MODE, "skip")
+                    // We explicitly use this mode here to enforce the schema evolution issues with DML
+                    // event failures because Oracle LogMiner doesn't track DDL evolution.
+                    .with(OracleConnectorConfig.LOG_MINING_STRATEGY, "online_catalog")
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForSnapshotToBeCompleted(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            SourceRecords sourceRecords = consumeRecordsByTopic(1);
+            List<SourceRecord> records = sourceRecords.recordsForTopic("server1.DEBEZIUM.DBZ5147");
+            assertThat(records).hasSize(1);
+            VerifyRecord.isValidRead(records.get(0), "ID", 1);
+
+            // We want to stop the connector and perform several DDL operations offline
+            // This will cause some DML events that happen offline to not be parsed by Oracle LogMiner.
+            stopConnector();
+
+            connection.execute("ALTER TABLE dbz5147 add data2 varchar2(50)");
+            connection.execute("INSERT INTO dbz5147 values (2, 'test2a', 'test2b')");
+            connection.execute("ALTER TABLE dbz5147 drop column data2");
+            connection.execute("INSERT INTO dbz5147 values (3, 'test3')");
+
+            final LogInterceptor interceptor = new LogInterceptor(AbstractLogMinerEventProcessor.class);
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            // There should only be one record to consume, the valid insert for ID=3.
+            // The record for ID=2 will have simply been skipped due to STATUS=2.
+            sourceRecords = consumeRecordsByTopic(1);
+            records = sourceRecords.recordsForTopic("server1.DEBEZIUM.DBZ5147");
+            assertThat(records).hasSize(1);
+            VerifyRecord.isValidInsert(records.get(0), "ID", 3);
+
+            // No errors/warnings should have been logged for ID=2 record with STATUS=2.
+            assertThat(interceptor.containsErrorMessage(ERROR_PROCESSING_FAIL_MESSAGE)).isFalse();
+            assertThat(interceptor.containsWarnMessage(ERROR_PROCESSING_WARN_MESSAGE)).isFalse();
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz5147");
         }
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
@@ -60,7 +60,7 @@ public class LogMinerQueryBuilderTest {
      * {@code database.history.store.only.captured.tables.ddl} is {@code false}.
      */
     private static final String LOG_MINER_CONTENT_QUERY_TEMPLATE1 = "SELECT SCN, SQL_REDO, OPERATION_CODE, TIMESTAMP, " +
-            "XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, USERNAME, ROW_ID, ROLLBACK, RS_ID " +
+            "XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, USERNAME, ROW_ID, ROLLBACK, RS_ID, STATUS " +
             "FROM V$LOGMNR_CONTENTS WHERE SCN > ? AND SCN <= ? " +
             "${systemTablePredicate}" +
             "AND ((" +
@@ -81,7 +81,7 @@ public class LogMinerQueryBuilderTest {
      * {@code database.history.store.only.captured.tables.ddl} is {@code true}.
      */
     private static final String LOG_MINER_CONTENT_QUERY_TEMPLATE2 = "SELECT SCN, SQL_REDO, OPERATION_CODE, TIMESTAMP, " +
-            "XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, USERNAME, ROW_ID, ROLLBACK, RS_ID " +
+            "XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, USERNAME, ROW_ID, ROLLBACK, RS_ID, STATUS " +
             "FROM V$LOGMNR_CONTENTS WHERE SCN > ? AND SCN <= ? " +
             "${systemTablePredicate}" +
             "AND ((" +

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/LogMinerQueryBuilderTest.java
@@ -60,7 +60,7 @@ public class LogMinerQueryBuilderTest {
      * {@code database.history.store.only.captured.tables.ddl} is {@code false}.
      */
     private static final String LOG_MINER_CONTENT_QUERY_TEMPLATE1 = "SELECT SCN, SQL_REDO, OPERATION_CODE, TIMESTAMP, " +
-            "XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, USERNAME, ROW_ID, ROLLBACK, RS_ID, STATUS " +
+            "XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, USERNAME, ROW_ID, ROLLBACK, RS_ID, STATUS, INFO " +
             "FROM V$LOGMNR_CONTENTS WHERE SCN > ? AND SCN <= ? " +
             "${systemTablePredicate}" +
             "AND ((" +
@@ -81,7 +81,7 @@ public class LogMinerQueryBuilderTest {
      * {@code database.history.store.only.captured.tables.ddl} is {@code true}.
      */
     private static final String LOG_MINER_CONTENT_QUERY_TEMPLATE2 = "SELECT SCN, SQL_REDO, OPERATION_CODE, TIMESTAMP, " +
-            "XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, USERNAME, ROW_ID, ROLLBACK, RS_ID, STATUS " +
+            "XID, CSF, TABLE_NAME, SEG_OWNER, OPERATION, USERNAME, ROW_ID, ROLLBACK, RS_ID, STATUS, INFO " +
             "FROM V$LOGMNR_CONTENTS WHERE SCN > ? AND SCN <= ? " +
             "${systemTablePredicate}" +
             "AND ((" +


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5147

- [x] ~Implement behavior for Xstreams~
- [x] ~Documentation~

@jpechane wrt Xstream, this would be mostly to handle LcrHandler callback errors and prefer to log/skip if the processing mode is set to warn/skip or fail as we do now by default.  Do you think it's warranted or should this mostly focus on LogMiner?