### PR TITLE
DBZ-5166 Fixed ExtractNewRecordState SMT to pass all columns' data as is

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -313,6 +313,7 @@ Renato Mefi
 René Kerner
 Robert Hana
 Roman Kuchar
+Rotem Adhoh
 Sagar Rao
 Sahan Dilshan
 René Kerner

--- a/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java
@@ -234,7 +234,9 @@ public class ExtractNewRecordState<R extends ConnectRecord<R>> implements Transf
         // Update the value with the new fields
         Struct updatedValue = new Struct(updatedSchema);
         for (org.apache.kafka.connect.data.Field field : value.schema().fields()) {
-            updatedValue.put(field.name(), value.get(field));
+            // We use getWithoutDefault method (instead of get) to get the raw value of the field
+            // Using get method may perform unwanted manipulation for the value (e.g: replacing null value with default value)
+            updatedValue.put(field.name(), value.getWithoutDefault(field.name()));
 
         }
 
@@ -365,10 +367,10 @@ public class ExtractNewRecordState<R extends ConnectRecord<R>> implements Transf
         }
 
         Object getValue(Struct originalRecordValue) {
-            Struct parentStruct = struct != null ? (Struct) originalRecordValue.get(struct) : originalRecordValue;
+            Struct parentStruct = struct != null ? (Struct) originalRecordValue.getWithoutDefault(struct) : originalRecordValue;
 
             // transaction is optional; e.g. not present during snapshotting atm.
-            return parentStruct != null ? parentStruct.get(field) : null;
+            return parentStruct != null ? parentStruct.getWithoutDefault(field) : null;
         }
 
         Schema getSchema(Schema originalRecordSchema) {

--- a/debezium-core/src/test/java/io/debezium/transforms/ExtractNewRecordStateTest.java
+++ b/debezium-core/src/test/java/io/debezium/transforms/ExtractNewRecordStateTest.java
@@ -126,6 +126,29 @@ public class ExtractNewRecordStateTest {
         return new SourceRecord(new HashMap<>(), new HashMap<>(), "dummy", envelope.schema(), payload);
     }
 
+    private SourceRecord createCreateRecordWithOptionalNull() {
+        final Schema recordSchema = SchemaBuilder.struct()
+                .field("id", Schema.INT8_SCHEMA)
+                .field("name", SchemaBuilder.string().optional().defaultValue("default_str").build())
+                .build();
+
+        final Envelope envelope = Envelope.defineSchema()
+                .withName("dummy.Envelope")
+                .withRecord(recordSchema)
+                .withSource(sourceSchema)
+                .build();
+
+        final Struct after = new Struct(recordSchema);
+        final Struct source = new Struct(sourceSchema);
+
+        after.put("id", (byte) 1);
+        after.put("name", null);
+        source.put("lsn", 1234);
+        source.put("ts_ms", 12836);
+        final Struct payload = envelope.create(after, source, Instant.now());
+        return new SourceRecord(new HashMap<>(), new HashMap<>(), "dummy", envelope.schema(), payload);
+    }
+
     private SourceRecord createUpdateRecord() {
         final Struct before = new Struct(recordSchema);
         final Struct after = new Struct(recordSchema);
@@ -270,6 +293,21 @@ public class ExtractNewRecordStateTest {
             final SourceRecord createRecord = createCreateRecord();
             final SourceRecord unwrapped = transform.apply(createRecord);
             assertThat(((Struct) unwrapped.value()).getInt8("id")).isEqualTo((byte) 1);
+            assertThat(((Struct) unwrapped.value()).getString("name")).isEqualTo("myRecord");
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-5166")
+    public void testUnwrapCreateRecordWithOptionalDefaultValue() {
+        try (final ExtractNewRecordState<SourceRecord> transform = new ExtractNewRecordState<>()) {
+            final Map<String, String> props = new HashMap<>();
+            transform.configure(props);
+
+            final SourceRecord createRecord = createCreateRecordWithOptionalNull();
+            final SourceRecord unwrapped = transform.apply(createRecord);
+            assertThat(((Struct) unwrapped.value()).getInt8("id")).isEqualTo((byte) 1);
+            assertThat(((Struct) unwrapped.value()).getString("name")).isEqualTo(null);
         }
     }
 


### PR DESCRIPTION
DBZ-5166 Fixed ExtractNewRecordState SMT to pass all columns' data "as is", i.e: without potential unwanted values manipulation.

Prior to this fix, when inserting an explicit NULL value to a nullable column which has a default value, resulted in a record which contains the corresponding field with the default value (instead of NULL) after applying ExtractNewRecordState transformation.
A new unit test was added as well.