### PR TITLE
DBZ-5179 Use BoundedLinkedHashSet to avoid high memory usage

### DIFF
--- a/debezium-core/src/main/java/io/debezium/util/LRUCacheMap.java
+++ b/debezium-core/src/main/java/io/debezium/util/LRUCacheMap.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.util;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.common.cache.Cache;
+
+import io.debezium.annotation.NotThreadSafe;
+
+/**
+ * A custom implementation of {@link org.apache.kafka.common.cache.LRUCache} that allows exposure
+ * to the underlying delegate's key or values collections.
+ *
+ * @author Chris Cranford
+ */
+@NotThreadSafe
+public class LRUCacheMap<K, V> implements Cache<K, V> {
+
+    private final LinkedHashMap<K, V> delegate;
+
+    public LRUCacheMap(int maxSize) {
+        this.delegate = new LinkedHashMap<K, V>(16, 0.75F, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+                return this.size() > maxSize;
+            }
+        };
+    }
+
+    @Override
+    public V get(K key) {
+        return delegate.get(key);
+    }
+
+    @Override
+    public void put(K key, V value) {
+        delegate.put(key, value);
+    }
+
+    @Override
+    public boolean remove(K key) {
+        return delegate.remove(key) != null;
+    }
+
+    @Override
+    public long size() {
+        return delegate.size();
+    }
+
+    public Set<K> keySet() {
+        return delegate.keySet();
+    }
+
+    public Collection<V> values() {
+        return delegate.values();
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+}

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3268,12 +3268,12 @@ See <<oracle-property-log-mining-transaction-retention-hours, `log.mining.transa
 
 |[[oracle-streaming-metrics-abandoned-transaction-ids]]<<oracle-streaming-metrics-abandoned-transaction-ids, `+AbandonedTransactionIds+`>>
 |`string[]`
-|An array of abandoned transaction identifiers removed from the transaction buffer due to their age.
+|An array of the most recent abandoned transaction identifiers removed from the transaction buffer due to their age.
 See <<oracle-property-log-mining-transaction-retention-hours, `log.mining.transaction.retention.hours`>> for details.
 
 |[[oracle-streaming-metrics-rolled-back-transaction-ids]]<<oracle-streaming-metrics-rolled-back-transaction-ids, `+RolledBackTransactionIds+`>>
 |`string[]`
-|An array of transaction identifiers that have been mined and rolled back in the transaction buffer.
+|An array of the most recent transaction identifiers that have been mined and rolled back in the transaction buffer.
 
 |[[oracle-streaming-metrics-last-commit-duration-in-milliseconds]]<<oracle-streaming-metrics-last-commit-duration-in-milliseconds, `+LastCommitDurationInMilliseconds+`>>
 |`long`


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5179

So we previously used an unbounded `Set` implementation in the Oracle metrics to track the rollback and abandoned transaction identifiers.  In some environments with high numbers of rollback or abandoned transactions, this could cause this object's memory footprint to grow unbounded.  This PR is meant to cap the number of elements in these collections to a maximum number of elements defined by `OracleStreamingChangeEventSourceMetrics#TRANSACTION_ID_SET_SIZE`.  