### PR TITLE
DBZ-5204 Avoid incorrect connection close in PgOutputMessageDecoder

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputMessageDecoder.java
@@ -761,8 +761,6 @@ public class PgOutputMessageDecoder extends AbstractMessageDecoder {
 
     @Override
     public void close() {
-        if (connection != null) {
-            connection.close();
-        }
+        // Connection is owned by instantiator so we should not close it.
     }
 }


### PR DESCRIPTION
Adding a test for this seems like it would be straightforward for someone who is more familiar with the PostgreSQL integration test setup than I. @jpechane would you be able to help with that, maybe?

----

Since #3454, the same PostgreSQL connection is used for repeated
PgOutputMessageDecoder instantiations. Therefore the
PgOutputMessageDecoder#close method should not close this connection,
because it belongs to the instantiator. (Previously each instantiation
of PgOutputMessageDecoder created its own PostgreSQL connection, and so
the close method did have the responsbility of closing this connection.)

The observable symptom of this bug was a Debezium crash in the following
scenario:

  1. Create Debezium connector.

  2. Add a new type:
     CREATE TYPE enum1 AS ENUM ('val1', 'val2');

  3. Add a new table:
     CREATE TABLE enum_type (f1 enum1);

  4. Wait for Debezium to crash because the metadata connection it would
     use to fetch the metadata about `enum1` is closed.

Note that it is critical that the connector be created _before_ the type. If the type is created first, then the type metadata is cached up front, and Debezium doesn't attempt to use the closed metadata connection.