### PR TITLE
DBZ-5219 Restore deleted topic heading

### DIFF
--- a/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
@@ -239,6 +239,7 @@ If any extra configuration options are needed by the converter, they can also be
 // Type: concept
 // Title: Emitting additional fields in {prodname} MongoDB outbox messages
 // ModuleID: emitting-additional-fields-in-debezium-mongodb-outbox-messages
+== Emitting messages with additional fields
 [[mongodb-outbox-emitting-messages-with-additional-fields]]
 
 Your outbox collection might contain fields whose values you want to add to the emitted outbox messages. For example, consider an outbox collection that has a value of `purchase-order` in the `aggregatetype` field and another field, `eventType`, whose possible values are `order-created` and `order-shipped`. Additional fields can be added with the syntax `field:placement:alias`.


### PR DESCRIPTION
[DBZ-5219](https://issues.redhat.com/browse/DBZ-5219)

Reinstates the heading _Emitting messages with additional fields_ in` mongodb-outbox-event-router.adoc`. 
The heading was [present in 1.8](https://debezium.io/documentation/reference/1.8/transformations/mongodb-outbox-event-router.html#emitting-messages-with-additional-fields), but was inadvertently removed in [DBZ-5089](https://github.com/debezium/debezium/commit/802feaea7145e3c510a46e55d235531ebba42339#diff-cce4a09e0aba9be7ba0293df7c28dd8057895065250cb3c95936bc5bd6be5ee4L243).

Tested in local Antora build and local downstream build.

This fix should be backported to 1.9.