### PR TITLE
DBZ-5220 Fix typos in instance of link-signalling attribute, anchor ID

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -244,7 +244,7 @@ endif::community[]
 * xref:{link-postgresql-connector}#postgresql-ad-hoc-snapshots[PostgreSQL connector ad hoc snapshots]
 * xref:{link-sqlserver-connector}#sqlserver-ad-hoc-snapshots[SQL Server connector ad hoc snapshots]
 
-[id="debezium-signaling-stop-ad-hoc-snapshots]
+[id="debezium-signaling-stop-ad-hoc-snapshots"]
 === Ad hoc snapshot stop signals
 
 You can request a connector to stop an in-progress ad hoc snapshot by creating a signal table entry with the `stop-snapshot` signal type.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
@@ -189,7 +189,7 @@ For example,
 ----
 INSERT INTO myschema.debezium_signal (id, type, dat) values ('ad-hoc-1', 'stop-snapshot', '{"data-collections": ["schema1.table1", "schema2.table2"],"type":"incremental"}');
 ----
-The values of the `id`, `type`, and `data` parameters in the command correspond to the xref:{link-signaling}#debezium-signaling-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
+The values of the `id`, `type`, and `data` parameters in the command correspond to the xref:{link-signalling}#debezium-signaling-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
 +
 The following {data-collection} describes these parameters:
 +


### PR DESCRIPTION
[DBZ-5220](https://issues.redhat.com/browse/DBZ-5220)

Corrects the following typos that prevented a clean documentation build:

- The `link-signalling` attribute is spelled inconsistently (with a single `l`) in the incremental snapshots partial (`con-connector-incremental-snapshot.adoc`).
- In `signalling.adoc`, the anchor ID declaration for the topic `debezium-signaling-stop-ad-hoc-snapshots` is missing a closing `"`.

Tested in local Antora and downstream builds.

This update should be backported to 1.9.