### PR TITLE
DBZ-5233-refactor-MBean-name-formats-for-1.9-branch

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2360,6 +2360,7 @@ The {prodname} Db2 connector provides three types of metrics that are in additio
 [[db2-snapshot-metrics]]
 === Snapshot metrics
 
+include::{partialsdir}/modules/all-connectors/frag-common-snapshot-mbean-name.adoc[leveloffset=+1]
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc[leveloffset=+1]
@@ -2370,6 +2371,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-increment
 [[db2-streaming-metrics]]
 === Streaming metrics
 
+include::{partialsdir}/modules/all-connectors/frag-common-streaming-mbean-name.adoc[leveloffset=+1]
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 
 // Type: reference

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1664,6 +1664,7 @@ The xref:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring do
 [[mongodb-snapshot-metrics]]
 === Snapshot Metrics
 
+include::{partialsdir}/modules/all-connectors/frag-mongodb-snapshot-mbean-name.adoc[leveloffset=+1]
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
 The {prodname} MongoDB connector also provides the following custom snapshot metrics:
@@ -1684,6 +1685,7 @@ The {prodname} MongoDB connector also provides the following custom snapshot met
 [[mongodb-streaming-metrics]]
 === Streaming Metrics
 
+include::{partialsdir}/modules/all-connectors/frag-mongodb-streaming-mbean-name.adoc[leveloffset=+1]
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 
 The {prodname} MongoDB connector also provides the following custom streaming metrics:

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2918,6 +2918,7 @@ The {prodname} MySQL connector provides three types of metrics that are in addit
 [[mysql-snapshot-metrics]]
 === Snapshot metrics
 
+include::{partialsdir}/modules/all-connectors/frag-common-snapshot-mbean-name.adoc[leveloffset=+1]
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc[leveloffset=+1]
@@ -2932,6 +2933,7 @@ The {prodname} MySQL connector also provides the `HoldingGlobalLock` custom snap
 
 Transaction-related attributes are available only if binlog event buffering is enabled. See xref:{link-mysql-connector}#mysql-property-binlog-buffer-size[`binlog.buffer.size`] in the advanced connector configuration properties for more details.
 
+include::{partialsdir}/modules/all-connectors/frag-common-streaming-mbean-name.adoc[leveloffset=+1]
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 
 The {prodname} MySQL connector also provides the following additional streaming metrics:

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3075,7 +3075,7 @@ Please refer to the xref:{link-debezium-monitoring}#monitoring-debezium[monitori
 === Snapshot Metrics
 
 [[oracle-monitoring-snapshots]]
-
+include::{partialsdir}/modules/all-connectors/frag-common-snapshot-mbean-name.adoc[leveloffset=+1]
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc[leveloffset=+1]
@@ -3087,7 +3087,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-increment
 === Streaming Metrics
 
 [[oracle-monitoring-streaming]]
-
+include::{partialsdir}/modules/all-connectors/frag-common-streaming-mbean-name.adoc[leveloffset=+1]
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 
 The {prodname} Oracle connector also provides the following additional streaming metrics:

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3205,6 +3205,7 @@ xref:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring docume
 [[postgresql-snapshot-metrics]]
 === Snapshot metrics
 
+include::{partialsdir}/modules/all-connectors/frag-common-snapshot-mbean-name.adoc[leveloffset=+1]
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc[leveloffset=+1]
@@ -3215,6 +3216,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-increment
 [[postgresql-streaming-metrics]]
 === Streaming metrics
 
+include::{partialsdir}/modules/all-connectors/frag-common-streaming-mbean-name.adoc[leveloffset=+1]
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2682,6 +2682,7 @@ For information about how to expose the preceding metrics through JMX, see the {
 [[sqlserver-snapshot-metrics]]
 === Snapshot metrics
 
+include::{partialsdir}/modules/all-connectors/frag-sqlserver-snapshot-mbean-name.adoc[leveloffset=+1]
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc[leveloffset=+1]
 
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc[leveloffset=+1]
@@ -2692,6 +2693,7 @@ include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-increment
 [[sqlserver-streaming-metrics]]
 === Streaming metrics
 
+include::{partialsdir}/modules/all-connectors/frag-sqlserver-streaming-mbean-name.adoc[leveloffset=+1]
 include::{partialsdir}/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc[leveloffset=+1]
 
 // Type: reference

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -3,7 +3,7 @@
 [id="debezium-connector-for-vitess"]
 = {prodname} connector for Vitess
 :context: vitess
-
+:mbean-name: {context}
 :toc:
 :toc-placement: macro
 :linkattrs:
@@ -1029,7 +1029,7 @@ xref:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring docume
 [[vitess-streaming-metrics]]
 ==== Streaming metrics
 
-The *MBean* is `debezium.vitess:type=connector-metrics,context=streaming,server=_<database.server.name>_`.
+include::{partialsdir}/modules/all-connectors/frag-common-streaming-mbean-name.adoc[leveloffset=+1]
 
 [cols="45%a,25%a,30%a",options="header"]
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/frag-common-snapshot-mbean-name.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/frag-common-snapshot-mbean-name.adoc
@@ -1,0 +1,1 @@
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=snapshot,server=_<{context}.server.name>_`.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/frag-common-streaming-mbean-name.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/frag-common-streaming-mbean-name.adoc
@@ -1,0 +1,1 @@
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=streaming,server=_<{context}.server.name>_`.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/frag-mongodb-snapshot-mbean-name.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/frag-mongodb-snapshot-mbean-name.adoc
@@ -1,0 +1,1 @@
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=snapshot,server=_<{context}.server.name>_,task=_<task.id>_`.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/frag-mongodb-streaming-mbean-name.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/frag-mongodb-streaming-mbean-name.adoc
@@ -1,0 +1,1 @@
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=streaming,server=_<{context}.server.name>_,task=_<task.id>_`.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/frag-sqlserver-snapshot-mbean-name.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/frag-sqlserver-snapshot-mbean-name.adoc
@@ -1,0 +1,1 @@
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,server=_<{context}.server.name>_,task=_<task.id>_,context=snapshot`.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/frag-sqlserver-streaming-mbean-name.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/frag-sqlserver-streaming-mbean-name.adoc
@@ -1,0 +1,1 @@
+The *MBean* is `debezium.{mbean-name}:type=connector-metrics,server=_<{context}.server.name>_,task=_<task.id>_,context=streaming`.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-snapshot-metrics.adoc
@@ -1,21 +1,3 @@
-ifeval::['{context}' == 'mongodb']
-The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=snapshot,server=_<{context}.server.name>_`.
-
-[NOTE]
-====
-When the connector is configured with `tasks.max` greater than `1`, the MBean name will also include the task identifier.
-As an example, when using a value of `2`, the MBean names will also be suffixed by `,task=0` and `,task=1` respectively.
-====
-endif::[]
-ifeval::['{context}' == 'sqlserver']
-The *MBean* is `debezium.{mbean-name}:type=connector-metrics,server=_<{context}.server.name>_,task=_<task.id>_,context=snapshot`.
-endif::[]
-ifeval::['{context}' != 'mongodb']
-ifeval::['{context}' != 'sqlserver']
-The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=snapshot,server=_<{context}.server.name>_`.
-endif::[]
-endif::[]
-
 Snapshot metrics are not exposed unless a snapshot operation is active, or if a snapshot has occurred since the last connector start.
 
 The following table lists the shapshot metrics that are available.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-streaming-metrics.adoc
@@ -1,21 +1,3 @@
-ifeval::['{context}' == 'mongodb']
-The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=streaming,server=_<{context}.server.name>_`.
-
-[NOTE]
-====
-When the connector is configured with `tasks.max` greater than `1`, the MBean name will also include the task identifier.
-As an example, when using a value of `2`, the MBean names will also be suffixed by `,task=0` and `,task=1` respectively.
-====
-endif::[]
-ifeval::['{context}' == 'sqlserver']
-The *MBean* is `debezium.{mbean-name}:type=connector-metrics,server=_<{context}.server.name>_,task=_<task.id>_,context=streaming`.
-endif::[]
-ifeval::['{context}' != 'mongodb']
-ifeval::['{context}' != 'sqlserver']
-The *MBean* is `debezium.{mbean-name}:type=connector-metrics,context=streaming,server=_<{context}.server.name>_`.
-endif::[]
-endif::[]
-
 The following table lists the streaming metrics that are available.
 
 [cols="45%a,25%a,30%a",options="header"]


### PR DESCRIPTION
[DBZ-5233](https://issues.redhat.com/browse/DBZ-5233)

This pull request cherry picks the changes in #3599 and addresses conflicts that prevented the original PR from being merged to the 1.9 branch.

Tested in a local Antora build and in a local build of the downstream 1.9 docs. 