### PR TITLE
DBZ-4733: support mongodb connection string 

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
@@ -126,7 +126,7 @@ public class ConnectionContext implements AutoCloseable {
         return false;
     }
 
-    public MongoClient clientForReplicaSet(ReplicaSet replicaSet) {
+    public MongoClient clientFor(ReplicaSet replicaSet) {
         return clientFor(replicaSet.addresses());
     }
 
@@ -427,7 +427,7 @@ public class ConnectionContext implements AutoCloseable {
      * @return the client, or {@code null} if no primary could be found for the replica set
      */
     protected MongoClient clientForPrimary(ReplicaSet replicaSet) {
-        MongoClient replicaSetClient = clientForReplicaSet(replicaSet);
+        MongoClient replicaSetClient = clientFor(replicaSet);
         final ClusterDescription clusterDescription = replicaSetClient.getClusterDescription();
         if (clusterDescription == null) {
             if (!this.useHostsAsSeeds) {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoClients.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoClients.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.mongodb;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -159,22 +158,6 @@ public class MongoClients {
         return clientForMembers(MongoUtil.parseAddresses(addressList));
     }
 
-    /**
-     * Obtain a client connection to the replica set or cluster. The supplied addresses are used as seeds, and once a connection
-     * is established it will discover all of the members.
-     *
-     * @param seeds the seed addresses
-     * @return the MongoClient instance; never null
-     */
-    public MongoClient clientForMembers(ServerAddress... seeds) {
-        List<ServerAddress> addresses = new ArrayList<>();
-        for (ServerAddress seedAddress : seeds) {
-            if (seedAddress != null) {
-                addresses.add(seedAddress);
-            }
-        }
-        return clientForMembers(addresses);
-    }
 
     /**
      * Obtain a client connection to the replica set or cluster. The supplied addresses are used as seeds, and once a connection

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnector.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnector.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -113,7 +114,7 @@ public class MongoDbConnector extends SourceConnector {
 
         PreviousContext previousLogContext = taskContext.configureLoggingContext("conn");
         try {
-            logger.info("Starting MongoDB connector and discovering replica set(s) at {}", connectionContext.hosts());
+            logger.info("Starting MongoDB connector and discovering replica set(s) at {}", connectionContext.connectionSeed());
 
             // Set up and start the thread that monitors the members of all of the replica sets ...
             replicaSetMonitorExecutor = Threads.newSingleThreadExecutor(MongoDbConnector.class, taskContext.serverName(), "replica-set-monitor");
@@ -121,7 +122,7 @@ public class MongoDbConnector extends SourceConnector {
             monitorThread = new ReplicaSetMonitorThread(monitor::getReplicaSets, connectionContext.pollInterval(),
                     Clock.SYSTEM, () -> taskContext.configureLoggingContext("disc"), this::replicaSetsChanged);
             replicaSetMonitorExecutor.execute(monitorThread);
-            logger.info("Successfully started MongoDB connector, and continuing to discover changes in replica set(s) at {}", connectionContext.hosts());
+            logger.info("Successfully started MongoDB connector, and continuing to discover changes in replica set(s) at {}", connectionContext.connectionSeed());
         }
         finally {
             previousLogContext.restore();
@@ -130,7 +131,7 @@ public class MongoDbConnector extends SourceConnector {
 
     protected void replicaSetsChanged(ReplicaSets replicaSets) {
         if (logger.isInfoEnabled()) {
-            logger.info("Requesting task reconfiguration due to new/removed replica set(s) for MongoDB with seeds {}", connectionContext.hosts());
+            logger.info("Requesting task reconfiguration due to new/removed replica set(s) for MongoDB with seeds {}", connectionContext.connectionSeed());
             logger.info("New replica sets include:");
             replicaSets.onEachReplicaSet(replicaSet -> logger.info("  {}", replicaSet));
         }
@@ -156,6 +157,8 @@ public class MongoDbConnector extends SourceConnector {
                     // Create the configuration for each task ...
                     int taskId = taskConfigs.size();
                     logger.info("Configuring MongoDB connector task {} to capture events for replica set(s) at {}", taskId, replicaSetsForTask.hosts());
+                    Properties configProps = config.asProperties();
+                    configProps.remove(MongoDbConnectorConfig.CONNECTION_STRING.name());
                     taskConfigs.add(config.edit()
                             .with(MongoDbConnectorConfig.HOSTS, replicaSetsForTask.hosts())
                             .with(MongoDbConnectorConfig.TASK_ID, taskId)
@@ -211,6 +214,7 @@ public class MongoDbConnector extends SourceConnector {
         Map<String, ConfigValue> results = config.validate(MongoDbConnectorConfig.EXPOSED_FIELDS);
 
         // Get the config values for each of the connection-related fields ...
+        ConfigValue connectionStringValue = results.get(MongoDbConnectorConfig.CONNECTION_STRING.name());
         ConfigValue hostsValue = results.get(MongoDbConnectorConfig.HOSTS.name());
         ConfigValue userValue = results.get(MongoDbConnectorConfig.USER.name());
         ConfigValue passwordValue = results.get(MongoDbConnectorConfig.PASSWORD.name());
@@ -218,10 +222,12 @@ public class MongoDbConnector extends SourceConnector {
         // If there are no errors on any of these ...
         if (hostsValue.errorMessages().isEmpty()
                 && userValue.errorMessages().isEmpty()
-                && passwordValue.errorMessages().isEmpty()) {
+                && passwordValue.errorMessages().isEmpty()
+                && connectionStringValue.errorMessages().isEmpty()) {
             // Try to connect to the database ...
             try (ConnectionContext connContext = new ConnectionContext(config)) {
-                try (MongoClient client = connContext.clientFor(connContext.hosts())) {
+
+                try (MongoClient client = connContext.clientForSeedConnection()) {
                     client.listDatabaseNames();
                 }
             }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -7,7 +7,9 @@ package io.debezium.connector.mongodb;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -20,6 +22,8 @@ import org.apache.kafka.connect.data.Struct;
 import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.mongodb.ConnectionString;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.ConfigDefinition;
@@ -235,6 +239,14 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
             .withImportance(Importance.HIGH)
             .withDescription("Password to be used when connecting to MongoDB, if necessary.");
 
+    public static final Field CONNECTION_STRING = Field.create("mongodb.connection.string")
+            .withDisplayName("Connection String")
+            .withType(Type.STRING)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION, 0))
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.HIGH)
+            .withValidation(MongoDbConnectorConfig::validateConnectionString)
+            .withDescription("Database connection string.");
     public static final Field AUTH_SOURCE = Field.create("mongodb.authsource")
             .withDisplayName("Credentials Database")
             .withType(Type.STRING)
@@ -551,7 +563,56 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
         this.cursorMaxAwaitTimeMs = config.getInteger(MongoDbConnectorConfig.CURSOR_MAX_AWAIT_TIME_MS, 0);
     }
 
+    public static Configuration translateConfigProperties(Configuration base) {
+        if (!base.hasKey(CONNECTION_STRING)) {
+            return base;
+        }
+
+        String rawConnectionString = base.getString(CONNECTION_STRING);
+        LOGGER.info("Using configuration from connection string '" + rawConnectionString + "'");
+
+        final ConnectionString cs = new ConnectionString(rawConnectionString);
+
+        final String hosts = hostsFromConnectionString(cs);
+        final boolean sslEnabled = Objects.requireNonNullElse(cs.getSslEnabled(), base.getBoolean(SSL_ENABLED));
+        final boolean sslAllowInvalidHostnames = Objects.requireNonNullElse(cs.getSslInvalidHostnameAllowed(), base.getBoolean(SSL_ALLOW_INVALID_HOSTNAMES));
+        final int connectTimeoutMs = Objects.requireNonNullElse(cs.getConnectTimeout(), base.getInteger(CONNECT_TIMEOUT_MS));
+        final int socketTimeoutMs = Objects.requireNonNullElse(cs.getSocketTimeout(), base.getInteger(SOCKET_TIMEOUT_MS));
+        final int serverSelectionTimeoutMs = Objects.requireNonNullElse(cs.getServerSelectionTimeout(), base.getInteger(SERVER_SELECTION_TIMEOUT_MS));
+
+        Configuration.Builder translatedConfig = base.edit()
+                .with(HOSTS, hosts)
+                .with(SSL_ENABLED, sslEnabled)
+                .with(SSL_ALLOW_INVALID_HOSTNAMES, sslAllowInvalidHostnames)
+                .with(CONNECT_TIMEOUT_MS, connectTimeoutMs)
+                .with(SOCKET_TIMEOUT_MS, socketTimeoutMs)
+                .with(SERVER_SELECTION_TIMEOUT_MS, serverSelectionTimeoutMs);
+
+        if (cs.getUsername() != null) {
+            translatedConfig.withDefault(USER, cs.getUsername());
+        }
+        if (cs.getPassword() != null) {
+            translatedConfig.withDefault(PASSWORD, String.valueOf(cs.getPassword()));
+        }
+
+        return translatedConfig.build();
+    }
+
+    private static String hostsFromConnectionString(ConnectionString cs) {
+        String rsName = cs.getRequiredReplicaSetName();
+        String hosts = String.join(",", cs.getHosts());
+
+        if (rsName != null && !rsName.isEmpty()) {
+            return rsName + "/" + hosts;
+        }
+        return hosts;
+    }
+
     private static int validateHosts(Configuration config, Field field, ValidationOutput problems) {
+        if (config.hasKey(CONNECTION_STRING)) {
+            return 0;
+        }
+
         String hosts = config.getString(field);
         if (hosts == null) {
             problems.accept(field, hosts, "Host specification is required");
@@ -563,6 +624,35 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
             ++count;
         }
         return count;
+    }
+
+    private static int validateConnectionString(Configuration config, Field field, ValidationOutput problems) {
+        final List<Field> exclusive = List.of(
+                SSL_ENABLED, SSL_ALLOW_INVALID_HOSTNAMES, SOCKET_TIMEOUT_MS, CONNECT_TIMEOUT_MS,
+                SERVER_SELECTION_TIMEOUT_MS, USER, PASSWORD, AUTH_SOURCE);
+
+        String value = config.getString(field);
+        Optional<Field> conflict = exclusive.stream().filter(k -> config.keys().contains(k)).findAny();
+
+        if (conflict.isPresent()) {
+            problems.accept(field, value, "Connection string used together with conflicting property");
+            return 1;
+        }
+
+        try {
+            ConnectionString cs = new ConnectionString(value);
+            String hosts = hostsFromConnectionString(cs);
+            int count = 0;
+            if (ReplicaSets.parse(hosts).all().isEmpty()) {
+                problems.accept(field, hosts, "Invalid host specification extracted from connection string");
+                ++count;
+            }
+            return count;
+        }
+        catch (Exception e) {
+            problems.accept(field, value, "Connection string is invalid");
+            return 1;
+        }
     }
 
     private static int validateFieldExcludeList(Configuration config, Field field, ValidationOutput problems) {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbTaskContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbTaskContext.java
@@ -29,6 +29,7 @@ public class MongoDbTaskContext extends CdcSourceTaskContext {
      */
     public MongoDbTaskContext(Configuration config) {
         super(Module.contextName(), config.getString(MongoDbConnectorConfig.LOGICAL_NAME), Collections::emptySet);
+        config = MongoDbConnectorConfig.translateConfigProperties(config);
 
         this.filters = new Filters(config);
         this.connectorConfig = new MongoDbConnectorConfig(config);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbTaskContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbTaskContext.java
@@ -29,7 +29,6 @@ public class MongoDbTaskContext extends CdcSourceTaskContext {
      */
     public MongoDbTaskContext(Configuration config) {
         super(Module.contextName(), config.getString(MongoDbConnectorConfig.LOGICAL_NAME), Collections::emptySet);
-        config = MongoDbConnectorConfig.translateConfigProperties(config);
 
         this.filters = new Filters(config);
         this.connectorConfig = new MongoDbConnectorConfig(config);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoUtil.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoUtil.java
@@ -14,6 +14,7 @@ import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.mongodb.connection.ClusterType;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
 import org.bson.Document;
@@ -381,6 +382,24 @@ public class MongoUtil {
         ServerAddress primaryAddress = primaryDescription.get().getAddress();
 
         return new ServerAddress(primaryAddress.getHost(), primaryAddress.getPort());
+    }
+
+    /**
+     * Retrieves cluster description, forcing a connection if not yet available
+     *
+     * @param client cluster connection client
+     * @return cluster description
+     */
+    public static ClusterDescription clusterDescription(MongoClient client) {
+        ClusterDescription description = client.getClusterDescription();
+
+        if (description.getType() == ClusterType.UNKNOWN) {
+            // force the connection and try again
+            client.listDatabaseNames().first(); // force the connection
+            description = client.getClusterDescription();
+        }
+
+        return description;
     }
 
     private MongoUtil() {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoUtil.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoUtil.java
@@ -14,7 +14,6 @@ import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.mongodb.connection.ClusterType;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
 import org.bson.Document;

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSet.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSet.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.mongodb;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -53,12 +54,16 @@ public final class ReplicaSet implements Comparable<ReplicaSet> {
     private final String shardName;
     private final int hc;
 
-    public ReplicaSet(String addresses, String replicaSetName, String shardName) {
-        this.addresses = MongoUtil.parseAddresses(addresses);
+    public ReplicaSet(List<ServerAddress> addresses, String replicaSetName, String shardName) {
+        this.addresses = new ArrayList<>(addresses);
         this.addresses.sort(ReplicaSet::compareServerAddresses);
         this.replicaSetName = replicaSetName != null ? replicaSetName.trim() : null;
         this.shardName = shardName != null ? shardName.trim() : null;
         this.hc = addresses.hashCode();
+    }
+
+    public ReplicaSet(String addresses, String replicaSetName, String shardName) {
+        this(MongoUtil.parseAddresses(addresses), replicaSetName, shardName);
     }
 
     /**

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSetDiscovery.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSetDiscovery.java
@@ -18,8 +18,8 @@ import com.mongodb.MongoInterruptedException;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoClient;
 import com.mongodb.connection.ClusterDescription;
-import com.mongodb.connection.ServerConnectionState;
 import com.mongodb.connection.ClusterType;
+import com.mongodb.connection.ServerConnectionState;
 import com.mongodb.connection.ServerDescription;
 
 import io.debezium.annotation.ThreadSafe;

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSetDiscovery.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSetDiscovery.java
@@ -15,9 +15,11 @@ import org.slf4j.LoggerFactory;
 
 import com.mongodb.MongoException;
 import com.mongodb.MongoInterruptedException;
+import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoClient;
 import com.mongodb.connection.ClusterDescription;
 import com.mongodb.connection.ServerConnectionState;
+import com.mongodb.connection.ClusterType;
 import com.mongodb.connection.ServerDescription;
 
 import io.debezium.annotation.ThreadSafe;
@@ -65,59 +67,47 @@ public class ReplicaSetDiscovery {
         MongoClient client = context.getConnectionContext().clientFor(seedAddresses);
         Set<ReplicaSet> replicaSetSpecs = new HashSet<>();
 
-        // First see if the addresses are for a config server replica set ...
-        String shardsCollection = "shards";
-        try {
-            MongoUtil.onCollectionDocuments(client, CONFIG_DATABASE_NAME, shardsCollection, doc -> {
-                LOGGER.info("Checking shard details from configuration replica set {}", seedAddresses);
-                String shardName = doc.getString("_id");
-                String hostStr = doc.getString("host");
-                String replicaSetName = MongoUtil.replicaSetUsedIn(hostStr);
-                replicaSetSpecs.add(new ReplicaSet(hostStr, replicaSetName, shardName));
-            });
+        final ClusterDescription clusterDescription = MongoUtil.clusterDescription(client);
+
+        if (clusterDescription.getType() == ClusterType.SHARDED) {
+            // First see if the addresses are for a config server replica set ...
+            String shardsCollection = "shards";
+            try {
+                MongoUtil.onCollectionDocuments(client, CONFIG_DATABASE_NAME, shardsCollection, doc -> {
+                    LOGGER.info("Checking shard details from configuration replica set {}", seedAddresses);
+                    String shardName = doc.getString("_id");
+                    String hostStr = doc.getString("host");
+                    String replicaSetName = MongoUtil.replicaSetUsedIn(hostStr);
+                    replicaSetSpecs.add(new ReplicaSet(hostStr, replicaSetName, shardName));
+                });
+            }
+            catch (MongoInterruptedException e) {
+                LOGGER.error("Interrupted while reading the '{}' collection in the '{}' database: {}",
+                        shardsCollection, CONFIG_DATABASE_NAME, e.getMessage(), e);
+                Thread.currentThread().interrupt();
+            }
+            catch (MongoException e) {
+                LOGGER.error("Error while reading the '{}' collection in the '{}' database: {}",
+                        shardsCollection, CONFIG_DATABASE_NAME, e.getMessage(), e);
+            }
         }
-        catch (MongoInterruptedException e) {
-            LOGGER.error("Interrupted while reading the '{}' collection in the '{}' database: {}",
-                    shardsCollection, CONFIG_DATABASE_NAME, e.getMessage(), e);
-            Thread.currentThread().interrupt();
-        }
-        catch (MongoException e) {
-            LOGGER.error("Error while reading the '{}' collection in the '{}' database: {}",
-                    shardsCollection, CONFIG_DATABASE_NAME, e.getMessage(), e);
-        }
-        if (replicaSetSpecs.isEmpty()) {
-            // The addresses may be a replica set ...
-            final ClusterDescription clusterDescription = client.getClusterDescription();
+
+        if (clusterDescription.getType() == ClusterType.REPLICA_SET) {
             LOGGER.info("Checking current members of replica set at {}", seedAddresses);
-            if (clusterDescription != null) {
-                // This is a replica set ...
-                final List<ServerDescription> serverDescriptions = clusterDescription.getServerDescriptions().stream()
-                        .filter(x -> x.getState() == ServerConnectionState.CONNECTED).collect(Collectors.toList());
-                if (serverDescriptions.size() == 0) {
-                    LOGGER.warn("Server descriptions not available, got '{}'", serverDescriptions);
-                }
-                else {
-                    String addressStr = serverDescriptions.stream().map(x -> x.getAddress().toString()).collect(Collectors.joining(","));
-                    String replicaSetName = serverDescriptions.get(0).getSetName();
-                    replicaSetSpecs.add(new ReplicaSet(addressStr, replicaSetName, null));
-                }
+            final List<ServerDescription> serverDescriptions = clusterDescription.getServerDescriptions().stream()
+                    .filter(x -> x.getState() == ServerConnectionState.CONNECTED).collect(Collectors.toList());
+            if (serverDescriptions.size() == 0) {
+                LOGGER.warn("Server descriptions not available, got '{}'", serverDescriptions);
             }
             else {
-                LOGGER.debug("Found standalone MongoDB replica set at {}", seedAddresses);
-                // We aren't connecting to it as a replica set (likely not using auto-discovery of members),
-                // but we can't monitor standalone servers unless they really are replica sets. We already know
-                // that we're not connected to a config server replica set, so any replica set name from the seed addresses
-                // is almost certainly our replica set name ...
-                String replicaSetName = MongoUtil.replicaSetUsedIn(seedAddresses);
-                if (replicaSetName != null) {
-                    for (String address : MongoUtil.ADDRESS_DELIMITER_PATTERN.split(seedAddresses)) {
-                        replicaSetSpecs.add(new ReplicaSet(address, replicaSetName, null));
-                    }
-                }
+                List<ServerAddress> addresses = serverDescriptions.stream().map(ServerDescription::getAddress).collect(Collectors.toList());
+                String replicaSetName = serverDescriptions.get(0).getSetName();
+                replicaSetSpecs.add(new ReplicaSet(addresses, replicaSetName, null));
             }
         }
+
         if (replicaSetSpecs.isEmpty()) {
-            // Without a replica set name, we can't do anything ...
+            // Without a replica sets, we can't do anything ...
             LOGGER.error(
                     "Found no replica sets at {}, so there is nothing to monitor and no connector tasks will be started. Check seed addresses in connector configuration.",
                     seedAddresses);

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSets.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSets.java
@@ -9,13 +9,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.kafka.connect.util.ConnectorUtils;
 
@@ -43,18 +44,22 @@ public class ReplicaSets {
      * @see ReplicaSets#hosts()
      */
     public static ReplicaSets parse(String hosts) {
-        Set<ReplicaSet> replicaSets = new HashSet<>();
-        if (hosts != null) {
-            for (String replicaSetStr : REPLICA_DELIMITER_PATTERN.split(hosts.trim())) {
-                if (!replicaSetStr.isEmpty()) {
-                    ReplicaSet replicaSet = ReplicaSet.parse(replicaSetStr);
-                    if (replicaSetStr != null) {
-                        replicaSets.add(replicaSet);
-                    }
-                }
-            }
-        }
+        Set<ReplicaSet> replicaSets = splitHosts(hosts).stream()
+                .map(ReplicaSet::parse)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
         return new ReplicaSets(replicaSets);
+    }
+
+    public static List<String> splitHosts(String hosts) {
+        if (hosts == null) {
+            return List.of();
+        }
+        return Stream.of(REPLICA_DELIMITER_PATTERN
+                .split(hosts.trim()))
+                .filter(h -> !h.isBlank())
+                .collect(Collectors.toList());
     }
 
     /**

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoClientsIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoClientsIT.java
@@ -78,9 +78,8 @@ public class MongoClientsIT {
         MongoClient client2 = clients.clientForMembers(addresses);
         assertThat(client1).isSameAs(client2);
 
-        ServerAddress[] array = addresses.toArray(new ServerAddress[addresses.size()]);
-        MongoClient client3 = clients.clientForMembers(array);
-        MongoClient client4 = clients.clientForMembers(array);
+        MongoClient client3 = clients.clientForMembers(addresses);
+        MongoClient client4 = clients.clientForMembers(addresses);
         assertThat(client3).isSameAs(client4);
         assertThat(client3).isSameAs(client1);
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorWithConnectionStringIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorWithConnectionStringIT.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.Assume;
+import org.junit.Test;
+
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.InsertOneOptions;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.mongodb.ConnectionContext.MongoPrimary;
+import io.debezium.data.Envelope;
+import io.debezium.data.Envelope.Operation;
+import io.debezium.util.IoUtil;
+import io.debezium.util.Testing;
+
+/**
+ * @author Randall Hauch
+ *
+ */
+public class MongoDbConnectorWithConnectionStringIT extends AbstractMongoConnectorIT {
+
+    @Test
+    public void shouldConsumeAllEventsFromSingleReplicaWithMongoProtocol() throws InterruptedException {
+        shouldConsumeAllEventsFromDatabase("mongodb://localhost:27017/", false);
+    }
+
+    @Test
+    public void shouldConsumeAllEventsFromSingleReplicaWithMongoSrvProtocol() throws InterruptedException {
+        var connectionString = System.getProperty("mongodb.connection.string");
+        Assume.assumeThat(connectionString, notNullValue());
+        shouldConsumeAllEventsFromDatabase(connectionString, true);
+    }
+
+    public void shouldConsumeAllEventsFromDatabase(String connectionString, boolean ssl) throws InterruptedException {
+        // Use the DB configuration to define the connector's configuration ...
+        var properties = TestHelper.getConfiguration().asProperties();
+        properties.remove(MongoDbConnectorConfig.HOSTS.name());
+
+        config = Configuration.from(properties).edit()
+                .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
+                .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
+                .with(MongoDbConnectorConfig.LOGICAL_NAME, "mongo")
+                .with(MongoDbConnectorConfig.CONNECTION_STRING, connectionString)
+                .with(MongoDbConnectorConfig.SSL_ENABLED, ssl)
+                .with(MongoDbConnectorConfig.AUTO_DISCOVER_MEMBERS, true)
+                .build();
+
+        // Set up the replication context for connections ...
+        context = new MongoDbTaskContext(config);
+
+        // Cleanup database
+        TestHelper.cleanDatabase(primary(), "dbit");
+
+        // Before starting the connector, add data to the databases ...
+        storeDocuments("dbit", "simpletons", "simple_objects.json");
+        storeDocuments("dbit", "restaurants", "restaurants1.json");
+
+        // Start the connector ...
+        start(MongoDbConnector.class, config);
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Consume all of the events due to startup and initialization of the database
+        // ---------------------------------------------------------------------------------------------------------------
+        SourceRecords records = consumeRecordsByTopic(12);
+        records.topics().forEach(System.out::println);
+        assertThat(records.recordsForTopic("mongo.dbit.simpletons").size()).isEqualTo(6);
+        assertThat(records.recordsForTopic("mongo.dbit.restaurants").size()).isEqualTo(6);
+        assertThat(records.topics().size()).isEqualTo(2);
+        AtomicBoolean foundLast = new AtomicBoolean(false);
+        records.forEach(record -> {
+            // Check that all records are valid, and can be serialized and deserialized ...
+            validate(record);
+            verifyFromInitialSync(record, foundLast);
+            verifyReadOperation(record);
+        });
+        assertThat(foundLast.get()).isTrue();
+
+        // At this point, the connector has performed the initial sync and awaits changes ...
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Store more documents while the connector is still running
+        // ---------------------------------------------------------------------------------------------------------------
+        storeDocuments("dbit", "restaurants", "restaurants2.json");
+
+        // Wait until we can consume the 4 documents we just added ...
+        SourceRecords records2 = consumeRecordsByTopic(4);
+        assertThat(records2.recordsForTopic("mongo.dbit.restaurants").size()).isEqualTo(4);
+        assertThat(records2.topics().size()).isEqualTo(1);
+        records2.forEach(record -> {
+            // Check that all records are valid, and can be serialized and deserialized ...
+            validate(record);
+            verifyNotFromInitialSync(record);
+            verifyCreateOperation(record);
+        });
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Stop the connector
+        // ---------------------------------------------------------------------------------------------------------------
+        stopConnector();
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Store more documents while the connector is NOT running
+        // ---------------------------------------------------------------------------------------------------------------
+        storeDocuments("dbit", "restaurants", "restaurants3.json");
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Start the connector and we should only see the documents added since it was stopped
+        // ---------------------------------------------------------------------------------------------------------------
+        start(MongoDbConnector.class, config);
+
+        // Wait until we can consume the 4 documents we just added ...
+        SourceRecords records3 = consumeRecordsByTopic(5);
+        assertThat(records3.recordsForTopic("mongo.dbit.restaurants").size()).isEqualTo(5);
+        assertThat(records3.topics().size()).isEqualTo(1);
+        records3.forEach(record -> {
+            // Check that all records are valid, and can be serialized and deserialized ...
+            validate(record);
+            verifyNotFromInitialSync(record);
+            verifyCreateOperation(record);
+        });
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Store more documents while the connector is still running
+        // ---------------------------------------------------------------------------------------------------------------
+        storeDocuments("dbit", "restaurants", "restaurants4.json");
+
+        // Wait until we can consume the 4 documents we just added ...
+        SourceRecords records4 = consumeRecordsByTopic(8);
+        assertThat(records4.recordsForTopic("mongo.dbit.restaurants").size()).isEqualTo(8);
+        assertThat(records4.topics().size()).isEqualTo(1);
+        records4.forEach(record -> {
+            // Check that all records are valid, and can be serialized and deserialized ...
+            validate(record);
+            verifyNotFromInitialSync(record);
+            verifyCreateOperation(record);
+        });
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Create and then update a document
+        // ---------------------------------------------------------------------------------------------------------------
+        // Testing.Debug.enable();
+        AtomicReference<String> id = new AtomicReference<>();
+        primary().execute("create", mongo -> {
+            MongoDatabase db1 = mongo.getDatabase("dbit");
+            MongoCollection<Document> coll = db1.getCollection("arbitrary");
+            coll.drop();
+
+            // Insert the document with a generated ID ...
+            Document doc = Document.parse("{\"a\": 1, \"b\": 2}");
+            InsertOneOptions insertOptions = new InsertOneOptions().bypassDocumentValidation(true);
+            coll.insertOne(doc, insertOptions);
+
+            // Find the document to get the generated ID ...
+            doc = coll.find().first();
+            Testing.debug("Document: " + doc);
+            id.set(doc.getObjectId("_id").toString());
+            Testing.debug("Document ID: " + id.get());
+        });
+
+        primary().execute("update", mongo -> {
+            MongoDatabase db1 = mongo.getDatabase("dbit");
+            MongoCollection<Document> coll = db1.getCollection("arbitrary");
+
+            // Find the document ...
+            Document doc = coll.find().first();
+            Testing.debug("Document: " + doc);
+            Document filter = Document.parse("{\"a\": 1}");
+            Document operation = Document.parse("{ \"$set\": { \"b\": 10 } }");
+            coll.updateOne(filter, operation);
+
+            doc = coll.find().first();
+            Testing.debug("Document: " + doc);
+        });
+
+        // Wait until we can consume the 1 insert and 1 update ...
+        SourceRecords insertAndUpdate = consumeRecordsByTopic(2);
+        assertThat(insertAndUpdate.recordsForTopic("mongo.dbit.arbitrary").size()).isEqualTo(2);
+        assertThat(insertAndUpdate.topics().size()).isEqualTo(1);
+        records4.forEach(record -> {
+            // Check that all records are valid, and can be serialized and deserialized ...
+            validate(record);
+            verifyNotFromInitialSync(record);
+            verifyCreateOperation(record);
+        });
+        SourceRecord insertRecord = insertAndUpdate.allRecordsInOrder().get(0);
+        SourceRecord updateRecord = insertAndUpdate.allRecordsInOrder().get(1);
+        Testing.debug("Insert event: " + insertRecord);
+        Testing.debug("Update event: " + updateRecord);
+        Struct insertKey = (Struct) insertRecord.key();
+        Struct updateKey = (Struct) updateRecord.key();
+        String insertId = toObjectId(insertKey.getString("id")).toString();
+        String updateId = toObjectId(updateKey.getString("id")).toString();
+        assertThat(insertId).isEqualTo(id.get());
+        assertThat(updateId).isEqualTo(id.get());
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Delete a document
+        // ---------------------------------------------------------------------------------------------------------------
+        primary().execute("delete", mongo -> {
+            MongoDatabase db1 = mongo.getDatabase("dbit");
+            MongoCollection<Document> coll = db1.getCollection("arbitrary");
+            Document filter = Document.parse("{\"a\": 1}");
+            coll.deleteOne(filter);
+        });
+
+        // Wait until we can consume the 1 delete ...
+        SourceRecords delete = consumeRecordsByTopic(2);
+        assertThat(delete.recordsForTopic("mongo.dbit.arbitrary").size()).isEqualTo(2);
+        assertThat(delete.topics().size()).isEqualTo(1);
+
+        SourceRecord deleteRecord = delete.allRecordsInOrder().get(0);
+        validate(deleteRecord);
+        verifyNotFromInitialSync(deleteRecord);
+        verifyDeleteOperation(deleteRecord);
+
+        SourceRecord tombStoneRecord = delete.allRecordsInOrder().get(1);
+        validate(tombStoneRecord);
+
+        Testing.debug("Delete event: " + deleteRecord);
+        Testing.debug("Tombstone event: " + tombStoneRecord);
+        Struct deleteKey = (Struct) deleteRecord.key();
+        String deleteId = toObjectId(deleteKey.getString("id")).toString();
+        assertThat(deleteId).isEqualTo(id.get());
+    }
+
+    protected void verifyFromInitialSync(SourceRecord record, AtomicBoolean foundLast) {
+        if (record.sourceOffset().containsKey(SourceInfo.INITIAL_SYNC)) {
+            assertThat(record.sourceOffset().containsKey(SourceInfo.INITIAL_SYNC)).isTrue();
+            Struct value = (Struct) record.value();
+            assertThat(value.getStruct(Envelope.FieldName.SOURCE).getString(SourceInfo.SNAPSHOT_KEY)).isEqualTo("true");
+        }
+        else {
+            // Only the last record in the initial sync should be marked as not being part of the initial sync ...
+            assertThat(foundLast.getAndSet(true)).isFalse();
+            Struct value = (Struct) record.value();
+            assertThat(value.getStruct(Envelope.FieldName.SOURCE).getString(SourceInfo.SNAPSHOT_KEY)).isEqualTo("last");
+        }
+    }
+
+    protected void verifyNotFromInitialSync(SourceRecord record) {
+        assertThat(record.sourceOffset().containsKey(SourceInfo.INITIAL_SYNC)).isFalse();
+        Struct value = (Struct) record.value();
+        assertThat(value.getStruct(Envelope.FieldName.SOURCE).getString(SourceInfo.SNAPSHOT_KEY)).isNull();
+    }
+
+    protected void verifyCreateOperation(SourceRecord record) {
+        verifyOperation(record, Operation.CREATE);
+    }
+
+    protected void verifyReadOperation(SourceRecord record) {
+        verifyOperation(record, Operation.READ);
+    }
+
+    protected void verifyDeleteOperation(SourceRecord record) {
+        verifyOperation(record, Operation.DELETE);
+    }
+
+    protected void verifyOperation(SourceRecord record, Operation expected) {
+        Struct value = (Struct) record.value();
+        assertThat(value.getString(Envelope.FieldName.OPERATION)).isEqualTo(expected.code());
+    }
+
+    @Override
+    protected MongoPrimary primary() {
+        var discovery = new ReplicaSetDiscovery(context);
+        var sets = discovery.getReplicaSets();
+        var replicaSet = sets.all().get(0);
+        return context.getConnectionContext().primaryFor(replicaSet, context.filters(), connectionErrorHandler(3));
+    }
+
+    protected void storeDocuments(String dbName, String collectionName, String pathOnClasspath) {
+        primary().execute("storing documents", mongo -> {
+            Testing.debug("Storing in '" + dbName + "." + collectionName + "' documents loaded from from '" + pathOnClasspath + "'");
+            MongoDatabase db1 = mongo.getDatabase(dbName);
+            MongoCollection<Document> coll = db1.getCollection(collectionName);
+            coll.drop();
+            storeDocuments(coll, pathOnClasspath);
+        });
+    }
+
+    protected void storeDocuments(MongoCollection<Document> collection, String pathOnClasspath) {
+        InsertOneOptions insertOptions = new InsertOneOptions().bypassDocumentValidation(true);
+        loadTestDocuments(pathOnClasspath).forEach(doc -> {
+            assertThat(doc).isNotNull();
+            assertThat(doc.size()).isGreaterThan(0);
+            collection.insertOne(doc, insertOptions);
+        });
+    }
+
+    protected void storeDocumentsInTx(String dbName, String collectionName, String pathOnClasspath) {
+        primary().execute("storing documents", mongo -> {
+            Testing.debug("Storing in '" + dbName + "." + collectionName + "' documents loaded from from '" + pathOnClasspath + "'");
+            MongoDatabase db1 = mongo.getDatabase(dbName);
+            MongoCollection<Document> coll = db1.getCollection(collectionName);
+            coll.drop();
+            db1.createCollection(collectionName);
+            final ClientSession session = mongo.startSession();
+
+            MongoDatabase admin = mongo.getDatabase("admin");
+            if (admin != null) {
+                int timeout = Integer.parseInt(System.getProperty("mongo.transaction.lock.request.timeout.ms", "1000"));
+                Testing.debug("Setting MongoDB transaction lock request timeout as '" + timeout + "ms'");
+                admin.runCommand(session, new Document().append("setParameter", 1).append("maxTransactionLockRequestTimeoutMillis", timeout));
+            }
+
+            session.startTransaction();
+            storeDocuments(session, coll, pathOnClasspath);
+            session.commitTransaction();
+        });
+    }
+
+    protected void storeDocuments(ClientSession session, MongoCollection<Document> collection, String pathOnClasspath) {
+        InsertOneOptions insertOptions = new InsertOneOptions().bypassDocumentValidation(true);
+        loadTestDocuments(pathOnClasspath).forEach(doc -> {
+            assertThat(doc).isNotNull();
+            assertThat(doc.size()).isGreaterThan(0);
+            if (session == null) {
+                collection.insertOne(doc, insertOptions);
+            }
+            else {
+                collection.insertOne(session, doc, insertOptions);
+            }
+        });
+    }
+
+    protected List<Document> loadTestDocuments(String pathOnClasspath) {
+        List<Document> results = new ArrayList<>();
+        try (InputStream stream = Files.readResourceAsStream(pathOnClasspath)) {
+            assertThat(stream).isNotNull();
+            IoUtil.readLines(stream, line -> {
+                Document doc = Document.parse(line);
+                assertThat(doc.size()).isGreaterThan(0);
+                results.add(doc);
+            });
+        }
+        catch (IOException e) {
+            fail("Unable to find or read file '" + pathOnClasspath + "': " + e.getMessage());
+        }
+        return results;
+    }
+
+    protected BiConsumer<String, Throwable> connectionErrorHandler(int numErrorsBeforeFailing) {
+        AtomicInteger attempts = new AtomicInteger();
+        return (desc, error) -> {
+            if (attempts.incrementAndGet() > numErrorsBeforeFailing) {
+                fail("Unable to connect to primary after " + numErrorsBeforeFailing + " errors trying to " + desc + ": " + error);
+            }
+            logger.error("Error while attempting to {}: {}", desc, error.getMessage(), error);
+        };
+    }
+
+    private String formatObjectId(ObjectId objId) {
+        return "{\"$oid\": \"" + objId + "\"}";
+    }
+
+    private ObjectId toObjectId(String oid) {
+        return new ObjectId(oid.substring(10, oid.length() - 2));
+    }
+}

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ReplicaSetDiscoveryTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ReplicaSetDiscoveryTest.java
@@ -30,7 +30,6 @@ public class ReplicaSetDiscoveryTest {
     private MongoDbTaskContext context;
     private ConnectionContext connectionContext;
     private MongoClient mongoClient;
-    private String seedHosts = "host1:27017,host2:27017";
 
     @Before
     public void setup() {
@@ -38,8 +37,7 @@ public class ReplicaSetDiscoveryTest {
         connectionContext = mock(ConnectionContext.class);
         mongoClient = mock(MongoClient.class);
         when(context.getConnectionContext()).thenReturn(connectionContext);
-        when(connectionContext.hosts()).thenReturn(seedHosts);
-        when(connectionContext.clientFor(seedHosts)).thenReturn(mongoClient);
+        when(connectionContext.clientForSeedConnection()).thenReturn(mongoClient);
         replicaSetDiscovery = new ReplicaSetDiscovery(context);
     }
 

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -100,7 +100,7 @@ public abstract class AbstractConnectorTest implements Testing {
     private ExecutorService executor;
     protected EmbeddedEngine engine;
     protected BlockingQueue<SourceRecord> consumedLines;
-    protected long pollTimeoutInMs = TimeUnit.SECONDS.toMillis(5);
+    protected long pollTimeoutInMs = TimeUnit.SECONDS.toMillis(10);
     protected final Logger logger = LoggerFactory.getLogger(getClass());
     private CountDownLatch latch;
     private JsonConverter keyJsonConverter = new JsonConverter();

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1377,6 +1377,16 @@ It is mandatory to provide the current primary address.
 This limitation will be removed in the next {prodname} release.
 ====
 
+|[[mongodb-property-mongodb-connection-string]]<<mongodb-property-mongodb-connection-string, `+mongodb.connection.string+`>>
+|
+|Mongodb connection string used for initial replica set discovery. This option requires `mongodb.members.auto.discover` to be set to `true` and it mustn't be used together with `mognodb.hosts` +
+ +
+[NOTE]
+====
+At the moment the connection string is used only for the initial replica set discovery. Other
+configuration properties are still used when connecting directly to primary rs members -- with the exception of credential which (when present) is extracted from given connection string.
+====
+
 |[[mongodb-property-mongodb-name]]<<mongodb-property-mongodb-name, `+mongodb.name+`>>
 |
 |A unique name that identifies the connector and/or MongoDB replica set or sharded cluster that this connector monitors.


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4733

Initial support for connection string. The CS is currently used only to retrieve the initial Replica Sets,  once that is done the connector works the same as before. 

Configuration of other connection properties (e.g. ssl, timeouts, etc..) is still kept in separate properties, with he exception of credential (which when provided in connection string is extracted and applied to our client's cluster settings). This needs to be done this way because the configuration can differ for the initial connection and for direct connection to replica sets (for example when SRV protocol is in use with Atlas). 

The PR also 
- consolidates some  connection methods names in ConnectionContext
- Fixes thread safety of MongoClients
- Fixes some incorrect usage of v4 mongo APIs 