### PR TITLE
DBZ-5070 Don't reset lsn when lastCommitLsn is null

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/SourceInfo.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/SourceInfo.java
@@ -150,7 +150,9 @@ public final class SourceInfo extends BaseSourceInfo {
      */
     protected SourceInfo updateLastCommit(Lsn lsn) {
         this.lastCommitLsn = lsn;
-        this.lsn = lsn;
+        if (lsn != null) {
+            this.lsn = lsn;
+        }
         return this;
     }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresOffsetContextTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresOffsetContextTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.connector.postgresql.connection.Lsn;
+import io.debezium.doc.FixFor;
+import io.debezium.pipeline.spi.OffsetContext;
+
+/**
+ * @author vjuranek
+ */
+public class PostgresOffsetContextTest {
+
+    private PostgresConnectorConfig connectorConfig;
+    private OffsetContext.Loader offsetLoader;
+
+    @Before
+    public void beforeEach() throws Exception {
+        this.connectorConfig = new PostgresConnectorConfig(TestHelper.defaultConfig().build());
+        this.offsetLoader = new PostgresOffsetContext.Loader(this.connectorConfig);
+    }
+
+    @Test
+    @FixFor("DBZ-5070")
+    public void shouldNotResetLsnWhenLastCommitLsnIsNull() throws Exception {
+        final Map<String, Object> offsetValues = new HashMap<>();
+        offsetValues.put(SourceInfo.LSN_KEY, 12345L);
+        offsetValues.put(SourceInfo.TIMESTAMP_USEC_KEY, 67890L);
+        offsetValues.put(PostgresOffsetContext.LAST_COMMIT_LSN_KEY, null);
+
+        final PostgresOffsetContext offsetContext = (PostgresOffsetContext) offsetLoader.load(offsetValues);
+        assertThat(offsetContext.lsn()).isEqualTo(Lsn.valueOf(12345L));
+    }
+}


### PR DESCRIPTION
Currently we update first `lsn` and then update `lastCommitLsn`.
However, when `lastCommitLsn` is for whatever reason `null`, previously
updated `lsn` is reset to `null` as `updateLastCommit()` updates also
`lsn`. This can have unwanted consequences like streaming again records
which were already streamed. To prevent this, update `lastCommitLsn`
only when it's not `null`.

Unfortunately, I wasn't able to figure out any reasonable test for it. Still looking on it, but I'm already little bit skeptical I'll come up with something reasonable:-(. So far tested only manually with Debezium server.

https://issues.redhat.com/browse/DBZ-5070