### PR TITLE
DBZ-5031 Stop skipping message if last received Lsn is higher or equal to start streaming Lsn

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -152,6 +152,7 @@ Jan Hendrik Dolling
 Jason Schweier
 Jiabao Sun
 Juan Fiallo
+Jun Zhao
 Hady Willi
 Hans-Peter Grahsl
 Harvey Yue

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
@@ -130,8 +130,13 @@ public class WalPositionLocator {
         if (passMessages) {
             return false;
         }
-        if (startStreamingLsn == null || startStreamingLsn.compareTo(lsn) <= 0) {
+        if (startStreamingLsn == null || startStreamingLsn.equals(lsn)) {
             LOGGER.info("Message with LSN '{}' arrived, switching off the filtering", lsn);
+            passMessages = true;
+            return false;
+        }
+        if (startStreamingLsn.compareTo(lsn) < 0) {
+            LOGGER.warn("Message with LSN '{}' larger than expected LSN '{}' arrived, switching off the filtering", lsn, startStreamingLsn);
             passMessages = true;
             return false;
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
@@ -130,7 +130,7 @@ public class WalPositionLocator {
         if (passMessages) {
             return false;
         }
-        if (startStreamingLsn == null || startStreamingLsn.equals(lsn)) {
+        if (startStreamingLsn == null || startStreamingLsn.compareTo(lsn) <= 0) {
             LOGGER.info("Message with LSN '{}' arrived, switching off the filtering", lsn);
             passMessages = true;
             return false;


### PR DESCRIPTION
We had an incident where the Debezium connector restarted and kept skipping messages for 22 hours while committing offset, which causes lots of data lost. More details can be found in https://issues.redhat.com/browse/DBZ-5031.

We propose to enhance the skip message condition to prevent this kind of issue. In the current `WalPositionLocator`, if the last received Lsn passes the `startStreamingLsn` for any reason after restart, the connector would never stop skipping the messages (seems nobody will switch off the filtering).

In our case, when the connector resumed and started processing messages, its last received Lsn jumped to `LSN{DAE0/CCEEC338}` for some reason, which is higher than the startStreamingLsn `LSN{DAE0/CBE21C68}` in `WalPositionLocator`. Then it just kept skipping following messages even the Lsn is not processed. Here are related logs after connector restart:
```
"2022-06-13T21:50:16.098Z","Found previous partition offset io.debezium.connector.postgresql.PostgresPartition@2eaf9f: PostgresOffsetContext [sourceInfoSchema=Schema{io.debezium.connector.postgresql.Source:STRUCT}, sourceInfo=source_info[server='core'db='veyond', lsn=LSN{DAE0/CBE21938}, txId=789922852, lastCommitLsn=LSN{DAE0/CBE21938}, timestamp=2022-06-13T21:49:16.023151Z, snapshot=FALSE, schema=, table=], lastSnapshotRecord=false, lastCompletelyProcessedLsn=LSN{DAE0/CBE21938}, lastCommitLsn=LSN{DAE0/CBE21938}, streamingStoppingLsn=null, transactionContext=TransactionContext [currentTransactionId=null, perTableEventCount={}, totalEventCount=0], incrementalSnapshotContext=IncrementalSnapshotContext [windowOpened=false, chunkEndPosition=null, dataCollectionsToSnapshot=[], lastEventKeySent=null, maximumKey=null]]"
...
"2022-06-13T21:50:16.173Z","Starting streaming"
"2022-06-13T21:50:16.173Z","Retrieved latest position from stored offset 'LSN{DAE0/CBE21938}'"
"2022-06-13T21:50:16.173Z","Looking for WAL restart position for last commit LSN 'LSN{DAE0/CBE21938}' and last change LSN 'LSN{DAE0/CBE21938}'"
"2022-06-13T21:50:16.173Z","Initializing PgOutput logical decoder publication"
"2022-06-13T21:50:16.277Z","Obtained valid replication slot ReplicationSlot [active=false, latestFlushedLsn=LSN{DAE0/CBE109C8}, catalogXmin=789921888]"
"2022-06-13T21:50:16.279Z","Connection gracefully closed"
"2022-06-13T21:50:16.291Z","Requested thread factory for connector PostgresConnector, id = core named = keep-alive"
"2022-06-13T21:50:16.291Z","Creating thread debezium-postgresconnector-core-keep-alive"
...
"2022-06-13T21:50:16.304Z","Searching for WAL resume position"
"2022-06-13T21:50:16.671Z","WorkerSourceTask{id=tep-core-database-connector-0} flushing 0 outstanding messages for offset commit"
"2022-06-13T21:50:16.810Z","First LSN 'LSN{DAE0/CBE15030}' received"
"2022-06-13T21:50:16.818Z","LSN after last stored change LSN 'LSN{DAE0/CBE21C68}' received"
"2022-06-13T21:50:16.819Z","WAL resume position 'LSN{DAE0/CBE21C68}' discovered"
"2022-06-13T21:50:16.820Z","Connection gracefully closed"
"2022-06-13T21:50:16.824Z","Connection gracefully closed"
"2022-06-13T21:50:16.876Z","Initializing PgOutput logical decoder publication"
"2022-06-13T21:50:16.888Z","Requested thread factory for connector PostgresConnector, id = core named = keep-alive"
"2022-06-13T21:50:16.888Z","Creating thread debezium-postgresconnector-core-keep-alive"
"2022-06-13T21:50:16.888Z","Processing messages"
"2022-06-13T21:50:17.395Z","Streaming requested from LSN LSN{DAE0/CBE21938}, received LSN LSN{DAE0/CCEEC338} identified as already processed"
"2022-06-13T21:50:17.395Z","Streaming requested from LSN LSN{DAE0/CBE21938}, received LSN LSN{0/0} identified as already processed"
"2022-06-13T21:50:17.454Z","Streaming requested from LSN LSN{DAE0/CBE21938}, received LSN LSN{DAE0/CCEFAAD0} identified as already processed"
"2022-06-13T21:50:17.454Z","Streaming requested from LSN LSN{DAE0/CBE21938}, received LSN LSN{DAE0/CCEFB068} identified as already processed"
"2022-06-13T21:50:17.454Z","Streaming requested from LSN LSN{DAE0/CBE21938}, received LSN LSN{DAE0/CCEFB0F8} identified as already processed"
"2022-06-13T21:50:17.455Z","Streaming requested from LSN LSN{DAE0/CBE21938}, received LSN LSN{DAE0/CCEFB130} identified as already processed"
"2022-06-13T21:50:17.455Z","Streaming requested from LSN LSN{DAE0/CBE21938}, received LSN LSN{DAE0/CCEFB1F0} identified as already processed"
"2022-06-13T21:50:17.455Z","Streaming requested from LSN LSN{DAE0/CBE21938}, received LSN LSN{DAE0/CCEFB1F0} identified as already processed"
"2022-06-13T21:50:17.455Z","Streaming requested from LSN LSN{DAE0/CBE21938}, received LSN LSN{DAE0/CCEFB458} identified as already processed"
...
```