### PR TITLE
DBZ-5268 Removing clientSetName command in Redis to be able to use GCP Managed Redis

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -421,3 +421,4 @@ Zoran Regvart
 Snigdhajyoti Ghosh
 Andrei Isac
 Mark Allanson
+Rahul Khanna

--- a/debezium-server/debezium-server-redis/src/main/java/io/debezium/server/redis/RedisConnection.java
+++ b/debezium-server/debezium-server-redis/src/main/java/io/debezium/server/redis/RedisConnection.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisDataException;
 
 /**
  * Establishes a new connection to Redis
@@ -55,7 +56,13 @@ public class RedisConnection {
             client.ping();
         }
 
-        client.clientSetname(clientName);
+        try {
+            client.clientSetname(clientName);
+        }
+        catch (JedisDataException e) {
+            LOGGER.warn("Failed to set client name", e);
+        }
+
         LOGGER.info("Using Jedis '{}'", client);
 
         return client;

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -142,4 +142,4 @@ connorszczepaniak-wk,Connor Szczepaniak
 ajunwalker,Andrew Walker
 alwaysbemark,Mark Bereznitsky
 Eliran,Eliran Agranovich
-rahulkhanna2,Rahul Khanna
+rahulkhanna,Rahul Khanna

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -142,3 +142,4 @@ connorszczepaniak-wk,Connor Szczepaniak
 ajunwalker,Andrew Walker
 alwaysbemark,Mark Bereznitsky
 Eliran,Eliran Agranovich
+rahulkhanna2,Rahul Khanna


### PR DESCRIPTION
**GCP Managed Redis does not support client commands.** 

**Solution:** 
Removing clientSetName to be able to use GCP Managed Redis
