### PR TITLE
DBZ-5297 Upgrade azure-messaging-eventhubs to 5.12.1 version

### DIFF
--- a/debezium-server/debezium-server-bom/pom.xml
+++ b/debezium-server/debezium-server-bom/pom.xml
@@ -15,7 +15,7 @@
         <version.kinesis>2.13.13</version.kinesis>
         <version.pubsub>25.0.0</version.pubsub>
         <version.pulsar>2.9.2</version.pulsar>
-        <version.eventhubs>5.1.1</version.eventhubs>
+        <version.eventhubs>5.12.1</version.eventhubs>
         <version.jedis>4.1.1</version.jedis>
         <version.pravega>0.9.1</version.pravega>
         <version.nats>2.8.0</version.nats>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5279