### PR TITLE
DBZ-5234 Add `oracle-ide` profile, simplifies IDE integrations

### DIFF
--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -281,6 +281,33 @@
                 </plugins>
             </build>
         </profile>
+        <!-- Enables all sources for IDE build -->
+        <profile>
+            <id>oracle-ide</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.oracle.instantclient</groupId>
+                    <artifactId>xstreams</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration combine.self="override">
+                            <includes>
+                                <include>**</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>assembly</id>
             <activation>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5234

This profile can be enabled in an IDE environment so that working with the source is easier and less painful.  IDEA does not seem to automatically react to the maven-compiler-plugin include/exclude configurations and this profile allows the IDE to successfully build the sources with all dependencies for sake of running tests in the IDE.