### PR TITLE
DBZ-5234 Rename `oracle-ide` to `oracle-all`

### DIFF
--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -281,9 +281,9 @@
                 </plugins>
             </build>
         </profile>
-        <!-- Enables all sources for IDE build -->
+        <!-- Enables all sources, useful for IDE build or releases -->
         <profile>
-            <id>oracle-ide</id>
+            <id>oracle-all</id>
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>

--- a/jenkins-jobs/pipelines/deploy-snapshots.groovy
+++ b/jenkins-jobs/pipelines/deploy-snapshots.groovy
@@ -55,7 +55,7 @@ node('Slave') {
 
         stage('Build and deploy Debezium') {
             dir(DEBEZIUM_DIR) {
-                sh "mvn clean deploy -U -s $HOME/.m2/settings-snapshots.xml -DdeployAtEnd=true -DskipITs -DskipTests -Passembly,oracle,docs  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.rto=20000 -Dmaven.wagon.http.retryHandler.count=1 -Dmaven.wagon.http.serviceUnavailableRetryStrategy.retryInterval=5000"
+                sh "mvn clean deploy -U -s $HOME/.m2/settings-snapshots.xml -DdeployAtEnd=true -DskipITs -DskipTests -Passembly,oracle-all,docs  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.rto=20000 -Dmaven.wagon.http.retryHandler.count=1 -Dmaven.wagon.http.serviceUnavailableRetryStrategy.retryInterval=5000"
             }
         }
 

--- a/jenkins-jobs/pipelines/release-pipeline.groovy
+++ b/jenkins-jobs/pipelines/release-pipeline.groovy
@@ -427,13 +427,13 @@ node('Slave') {
         stage('Prepare release') {
             dir(DEBEZIUM_DIR) {
                 sh "git checkout -b $CANDIDATE_BRANCH"
-                sh "mvn clean install -DskipTests -DskipITs -Poracle-xstream"
+                sh "mvn clean install -DskipTests -DskipITs -Poracle-all"
                 modifyFile('debezium-testing/debezium-testing-system/pom.xml') {
                     it.replaceFirst('<version.debezium.connector>.+</version.debezium.connector>', "<version.debezium.connector>$RELEASE_VERSION</version.debezium.connector>")
                 }
                 sh "git commit -a -m '[release] Stable $RELEASE_VERSION for testing module deps'"
             }
-            STAGING_REPO_ID = mvnRelease(DEBEZIUM_DIR, DEBEZIUM_REPOSITORY, CANDIDATE_BRANCH, '-Poracle-xstream')
+            STAGING_REPO_ID = mvnRelease(DEBEZIUM_DIR, DEBEZIUM_REPOSITORY, CANDIDATE_BRANCH, '-Poracle-all')
             dir(DEBEZIUM_DIR) {
                 modifyFile('debezium-testing/debezium-testing-system/pom.xml') {
                     it.replaceFirst('<version.debezium.connector>.+</version.debezium.connector>', '<version.debezium.connector>\\${project.version}</version.debezium.connector>')

--- a/jenkins-jobs/pipelines/system_pipeline.groovy
+++ b/jenkins-jobs/pipelines/system_pipeline.groovy
@@ -207,7 +207,7 @@ pipeline {
                 sh '''
                 set -x
                 cd ${WORKSPACE}/debezium
-                mvn install -Passembly,oracle -DskipTests -DskipITs 
+                mvn install -Passembly,oracle-all -DskipTests -DskipITs 
                 '''
             }
         }

--- a/jenkins-jobs/pipelines/upstream_artifact_server_prepare_pipeline.groovy
+++ b/jenkins-jobs/pipelines/upstream_artifact_server_prepare_pipeline.groovy
@@ -80,7 +80,7 @@ pipeline {
                 sh '''
                 set -x
                 cd ${WORKSPACE}/debezium
-                mvn install -Passembly,oracle -DskipTests -DskipITs -Dmaven.repo.local=local-maven-repo
+                mvn install -Passembly,oracle-all -DskipTests -DskipITs -Dmaven.repo.local=local-maven-repo
                 '''
 //              Build DB2 Connector
                 sh '''

--- a/jenkins-jobs/pipelines/upstream_kafka_connect_prepare_pipeline.groovy
+++ b/jenkins-jobs/pipelines/upstream_kafka_connect_prepare_pipeline.groovy
@@ -80,7 +80,7 @@ pipeline {
                 sh '''
                 set -x
                 cd ${WORKSPACE}/debezium
-                mvn install -Passembly,oracle -DskipTests -DskipITs -Dmaven.repo.local=local-maven-repo
+                mvn install -Passembly,oracle-all -DskipTests -DskipITs -Dmaven.repo.local=local-maven-repo
                 '''
 //              Build DB2 Connector
                 sh '''

--- a/jenkins-jobs/scripts/release-pipeline.groovy
+++ b/jenkins-jobs/scripts/release-pipeline.groovy
@@ -334,7 +334,7 @@ node('Slave') {
 
     stage ('Prepare release') {
         dir(DEBEZIUM_DIR) {
-            sh "mvn clean install -DskipTests -DskipITs -Poracle-xstream"
+            sh "mvn clean install -DskipTests -DskipITs -Poracle-all"
         }
         STAGING_REPO_ID = mvnRelease(DEBEZIUM_DIR, DEBEZIUM_REPOSITORY, DEBEZIUM_BRANCH)
         ADDITIONAL_REPOSITORIES.each { id, repo ->


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5234

I did one last scrub across the Jenkins jobs and found a few references I missed.  In addition, I decided to change the `oracle-ide` profile to `oracle-all` as it made more sense from the perspective of its usage in the various job scripts imo.