### PR TITLE
DBZ-5336 Add note about escaping dot (.) characters

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
@@ -70,6 +70,13 @@ To specify the {data-collection}s to include in the snapshot, provide a `data-co
 The `data-collections` array for an incremental snapshot signal has no default value.
 If the `data-collections` array is empty, {prodname} detects that no action is required and does not perform a snapshot.
 
+[NOTE]
+====
+If the name of a {data-collection} that you want to include in a snapshot contains a dot (`.`) in the name of the database, schema, or table, to add the {data-collection} to the `data-collections` array, you must escape each part of the name in double quotes. +
+ +
+For example, to include a table that exists in the `*public*` schema and that has the name `*My.Table*`, use the following format: `*"public"."My.Table"*`.
+====
+
 .Prerequisites
 
 * xref:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled]. +


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5336

Updated incremental snapshot documentation to note that tables that have a dot (.) in their name should be escaped with double-quotes.