### PR TITLE
DBZ-5367 Fixed the problem where JSON expanding failed for Outbox eve…

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/outbox/SchemaBuilderUtil.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/outbox/SchemaBuilderUtil.java
@@ -75,7 +75,8 @@ public class SchemaBuilderUtil {
                 }
                 return Schema.OPTIONAL_FLOAT64_SCHEMA;
             case ARRAY:
-                return SchemaBuilder.array(findArrayMemberSchema((ArrayNode) node)).optional().build();
+                ArrayNode arrayNode = (ArrayNode) node;
+                return arrayNode.isEmpty() ? null : SchemaBuilder.array(findArrayMemberSchema(arrayNode)).optional().build();
             case OBJECT:
                 return jsonNodeToSchema(node);
             default:
@@ -108,10 +109,6 @@ public class SchemaBuilderUtil {
     }
 
     private static Schema findArrayMemberSchema(ArrayNode array) throws ConnectException {
-        if (array.isEmpty()) {
-            return Schema.OPTIONAL_STRING_SCHEMA;
-        }
-
         final JsonNode sample = getFirstArrayElement(array);
         if (sample.isObject()) {
             return buildDocumentUnionSchema(array);


### PR DESCRIPTION
…nt payloads that contained nested arrays where first array was empty and further array contained a Struct

With proposed changes empty arrays are skipped, as it allows us to delay defining the schema for them until an array with elements is found, as it seems that there is no way to modify a schema that was already defined for a given field

Fixes [DBZ-5367](https://issues.redhat.com/browse/DBZ-5367)