### PR TITLE
DBZ-5374: maven version 3.8.5 is not allowed in build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>[${version.maven},3.8.5),[3.8.6,)</version>
+                                    <version>[${version.maven},3.8.5,3.8.6]</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
Debezium's pom.xml was set up to support maven versions: 3.8.4, 3.8.5,
3.8.6.  However due to a syntax error in the pom.xml, maven version
  3.8.5 was disallowed:

    [*WARNING*] Rule 0: org.apache.maven.plugins.enforcer.RequireMavenVersion failed with message:
    Detected Maven Version: 3.8.5 is not in the allowed range [3.8.4,3.8.5),[3.8.6,).

The fix is simple one-liner to fix the syntax in pom.xml allow a list of
maven versions.