### PR TITLE
DBZ-5374: docker-maven-plugin needs to be upgraded for Mac Apple M1

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -157,6 +157,7 @@ Jun Zhao
 Hady Willi
 Hans-Peter Grahsl
 Harvey Yue
+Henry Cai
 Henryk Konsek
 Himanshu Mishra
 Hoa Le

--- a/debezium-parent/pom.xml
+++ b/debezium-parent/pom.xml
@@ -17,7 +17,7 @@
 
         <!-- Maven Plugins -->
         <version.google.formatter.plugin>0.4</version.google.formatter.plugin>
-        <version.docker.maven.plugin>0.31.0</version.docker.maven.plugin>
+        <version.docker.maven.plugin>0.39.1</version.docker.maven.plugin>
         <version.protoc.maven.plugin>3.8.0</version.protoc.maven.plugin>
         <version.code.formatter>2.16.0</version.code.formatter>
         <version.impsort>1.6.2</version.impsort>


### PR DESCRIPTION
Running 'mvn clean verify' for vitess connector (which includes launch docker for integration tests) would fail when run on an Mac M1 laptop:

    [*ERROR*] Failed to execute goal io.fabric8:docker-maven-plugin:0.31.0:build (start) on project debezium-connector-vitess: Execution start of goal io.fabric8:docker-maven-plugin:0.31.0:build failed: An API incompatibility was encountered while executing io.fabric8:docker-maven-plugin:0.31.0:build: java.lang.UnsatisfiedLinkError: could not load FFI provider jnr.ffi.provider.jffi.Provider

The problem is specific to Apple M1 laptop, and is discussed further in: https://github.com/fabric8io/docker-maven-plugin/issues/1257

This is already fixed in docker-maven-plugin 0.39.1