### PR TITLE
DBZ-4726: Remove SQL Server single-partition mode

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
@@ -6,7 +6,6 @@
 package io.debezium.connector.sqlserver;
 
 import static io.debezium.config.CommonConnectorConfig.TASK_ID;
-import static io.debezium.connector.sqlserver.SqlServerConnectorConfig.DATABASE_NAME;
 import static io.debezium.connector.sqlserver.SqlServerConnectorConfig.DATABASE_NAMES;
 
 import java.sql.SQLException;
@@ -71,7 +70,6 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
 
     private List<Map<String, String>> buildTaskConfigs(SqlServerConnection connection, SqlServerConnectorConfig config,
                                                        int maxTasks) {
-        final boolean multiPartitionMode = config.isMultiPartitionModeEnabled();
         List<String> databaseNames = config.getDatabaseNames();
 
         // Initialize the database list for each task
@@ -92,13 +90,8 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
         for (int taskIndex = 0; taskIndex < maxTasks; taskIndex++) {
             String taskDatabases = String.join(",", databasesByTask.get(taskIndex));
             Map<String, String> taskProperties = new HashMap<>(properties);
-            if (multiPartitionMode) {
-                taskProperties.put(SqlServerConnectorConfig.DATABASE_NAMES.name(), taskDatabases);
-                taskProperties.put(TASK_ID, String.valueOf(taskIndex));
-            }
-            else {
-                taskProperties.put(SqlServerConnectorConfig.DATABASE_NAME.name(), taskDatabases);
-            }
+            taskProperties.put(SqlServerConnectorConfig.DATABASE_NAMES.name(), taskDatabases);
+            taskProperties.put(TASK_ID, String.valueOf(taskIndex));
             taskConfigs.add(Collections.unmodifiableMap(taskProperties));
         }
 
@@ -116,8 +109,7 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
 
     @Override
     protected void validateConnection(Map<String, ConfigValue> configValues, Configuration config) {
-        if (!configValues.get(DATABASE_NAME.name()).errorMessages().isEmpty()
-                || !configValues.get(DATABASE_NAMES.name()).errorMessages().isEmpty()) {
+        if (!configValues.get(DATABASE_NAMES.name()).errorMessages().isEmpty()) {
             return;
         }
 
@@ -130,12 +122,20 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
             LOGGER.debug("Successfully tested connection for {} with user '{}'", connection.connectionString(),
                     connection.username());
             LOGGER.info("Checking if user has access to CDC table");
-            boolean userHasAccessToCDCTable = connection.checkIfConnectedUserHasAccessToCDCTable();
-            if (!userHasAccessToCDCTable
-                    && sqlServerConfig.getSnapshotMode() != SqlServerConnectorConfig.SnapshotMode.INITIAL_ONLY) {
-                String errorMessage = "User " + userValue.value() + " does not have access to CDC table and can only be used in initial_only snapshot mode";
-                LOGGER.error(errorMessage);
-                userValue.addErrorMessage(errorMessage);
+            if (sqlServerConfig.getSnapshotMode() != SqlServerConnectorConfig.SnapshotMode.INITIAL_ONLY) {
+                final List<String> noAccessDatabaseNames = new ArrayList<>();
+                for (String databaseName : sqlServerConfig.getDatabaseNames()) {
+                    if (!connection.checkIfConnectedUserHasAccessToCDCTable(databaseName)) {
+                        noAccessDatabaseNames.add(databaseName);
+                    }
+                }
+                if (!noAccessDatabaseNames.isEmpty()) {
+                    String errorMessage = String.format(
+                            "User %s does not have access to CDC schema in the following databases: %s. This user can only be used in initial_only snapshot mode",
+                            userValue.value(), String.join(", ", noAccessDatabaseNames));
+                    LOGGER.error(errorMessage);
+                    userValue.addErrorMessage(errorMessage);
+                }
             }
         }
         catch (Exception e) {
@@ -155,7 +155,6 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
         return new SqlServerConnection(sqlServerConfig.getJdbcConfig(),
                 sqlServerConfig.getSourceTimestampMode(), null,
                 () -> getClass().getClassLoader(),
-                Collections.emptySet(),
-                sqlServerConfig.isMultiPartitionModeEnabled());
+                Collections.emptySet());
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -23,8 +23,6 @@ import io.debezium.pipeline.ChangeEventSourceCoordinator;
 import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
-import io.debezium.pipeline.metrics.DefaultChangeEventSourceMetricsFactory;
-import io.debezium.pipeline.metrics.spi.ChangeEventSourceMetricsFactory;
 import io.debezium.pipeline.spi.Offsets;
 import io.debezium.relational.TableId;
 import io.debezium.spi.topic.TopicNamingStrategy;
@@ -66,18 +64,18 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
                 .build();
 
         final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(config);
-        final boolean multiPartitionMode = connectorConfig.isMultiPartitionModeEnabled();
-        final TopicNamingStrategy topicNamingStrategy = connectorConfig.getTopicNamingStrategy(CommonConnectorConfig.TOPIC_NAMING_STRATEGY, multiPartitionMode);
+        final TopicNamingStrategy topicNamingStrategy = connectorConfig.getTopicNamingStrategy(
+                CommonConnectorConfig.TOPIC_NAMING_STRATEGY, true);
         final SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjustmentMode().createAdjuster();
         final SqlServerValueConverters valueConverters = new SqlServerValueConverters(connectorConfig.getDecimalMode(),
                 connectorConfig.getTemporalPrecisionMode(), connectorConfig.binaryHandlingMode());
 
         dataConnection = new SqlServerConnection(connectorConfig.getJdbcConfig(), connectorConfig.getSourceTimestampMode(), valueConverters,
                 () -> getClass().getClassLoader(),
-                connectorConfig.getSkippedOperations(), multiPartitionMode, connectorConfig.getOptionRecompile());
+                connectorConfig.getSkippedOperations(), connectorConfig.getOptionRecompile());
         metadataConnection = new SqlServerConnection(connectorConfig.getJdbcConfig(), connectorConfig.getSourceTimestampMode(), valueConverters,
                 () -> getClass().getClassLoader(),
-                connectorConfig.getSkippedOperations(), multiPartitionMode);
+                connectorConfig.getSkippedOperations());
 
         this.schema = new SqlServerDatabaseSchema(connectorConfig, metadataConnection.getDefaultValueConverter(), valueConverters, topicNamingStrategy,
                 schemaNameAdjuster);
@@ -120,7 +118,7 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
                 SqlServerConnector.class,
                 connectorConfig,
                 new SqlServerChangeEventSourceFactory(connectorConfig, dataConnection, metadataConnection, errorHandler, dispatcher, clock, schema),
-                createChangeEventSourceMetricsFactory(multiPartitionMode, offsets),
+                new SqlServerMetricsFactory(offsets.getPartitions()),
                 dispatcher,
                 schema,
                 clock);
@@ -169,15 +167,5 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
     @Override
     protected Iterable<Field> getAllConfigurationFields() {
         return SqlServerConnectorConfig.ALL_FIELDS;
-    }
-
-    private ChangeEventSourceMetricsFactory<SqlServerPartition> createChangeEventSourceMetricsFactory(boolean multiPartitionMode,
-                                                                                                      Offsets<SqlServerPartition, SqlServerOffsetContext> offsets) {
-        if (multiPartitionMode) {
-            return new SqlServerMetricsFactory(offsets.getPartitions());
-        }
-        else {
-            return new DefaultChangeEventSourceMetricsFactory<>();
-        }
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerDatabaseSchema.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerDatabaseSchema.java
@@ -40,7 +40,7 @@ public class SqlServerDatabaseSchema extends HistorizedRelationalDatabaseSchema 
                         connectorConfig.customConverterRegistry(),
                         connectorConfig.getSourceInfoStructMaker().schema(),
                         connectorConfig.getSanitizeFieldNames(),
-                        connectorConfig.isMultiPartitionModeEnabled()),
+                        true),
                 false, connectorConfig.getKeyMapper());
     }
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerPartition.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerPartition.java
@@ -5,12 +5,9 @@
  */
 package io.debezium.connector.sqlserver;
 
-import static io.debezium.connector.sqlserver.SqlServerConnectorConfig.DATABASE_NAME;
 import static io.debezium.connector.sqlserver.SqlServerConnectorConfig.DATABASE_NAMES;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -29,14 +26,11 @@ public class SqlServerPartition extends AbstractPartition implements Partition {
     private final Map<String, String> sourcePartition;
     private final int hashCode;
 
-    public SqlServerPartition(String serverName, String databaseName, boolean multiPartitionMode) {
+    public SqlServerPartition(String serverName, String databaseName) {
         super(databaseName);
         this.serverName = serverName;
 
-        this.sourcePartition = Collect.hashMapOf(SERVER_PARTITION_KEY, serverName);
-        if (multiPartitionMode) {
-            this.sourcePartition.put(DATABASE_PARTITION_KEY, databaseName);
-        }
+        this.sourcePartition = Collect.hashMapOf(SERVER_PARTITION_KEY, serverName, DATABASE_PARTITION_KEY, databaseName);
 
         this.hashCode = Objects.hash(serverName, databaseName);
     }
@@ -87,19 +81,9 @@ public class SqlServerPartition extends AbstractPartition implements Partition {
         @Override
         public Set<SqlServerPartition> getPartitions() {
             String serverName = connectorConfig.getLogicalName();
-            boolean multiPartitionMode = connectorConfig.isMultiPartitionModeEnabled();
 
-            List<String> databaseNames;
-
-            if (multiPartitionMode) {
-                databaseNames = Arrays.asList(taskConfig.getString(DATABASE_NAMES.name()).split(","));
-            }
-            else {
-                databaseNames = Collections.singletonList(taskConfig.getString(DATABASE_NAME.name()));
-            }
-
-            return databaseNames.stream()
-                    .map(databaseName -> new SqlServerPartition(serverName, databaseName, multiPartitionMode))
+            return Arrays.stream(taskConfig.getString(DATABASE_NAMES.name()).split(","))
+                    .map(databaseName -> new SqlServerPartition(serverName, databaseName))
                     .collect(Collectors.toSet());
         }
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerTopicSelector.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerTopicSelector.java
@@ -7,7 +7,6 @@ package io.debezium.connector.sqlserver;
 
 import io.debezium.relational.TableId;
 import io.debezium.schema.TopicSelector;
-import io.debezium.schema.TopicSelector.DataCollectionTopicNamer;
 
 /**
  * The topic naming strategy based on connector configuration and table name
@@ -18,14 +17,9 @@ import io.debezium.schema.TopicSelector.DataCollectionTopicNamer;
 public class SqlServerTopicSelector {
 
     public static TopicSelector<TableId> defaultSelector(SqlServerConnectorConfig connectorConfig) {
-        DataCollectionTopicNamer<TableId> topicNamer;
-        if (connectorConfig.isMultiPartitionModeEnabled()) {
-            topicNamer = (tableId, prefix, delimiter) -> String.join(delimiter, prefix, tableId.catalog(), tableId.schema(), tableId.table());
-        }
-        else {
-            topicNamer = (tableId, prefix, delimiter) -> String.join(delimiter, prefix, tableId.schema(), tableId.table());
-        }
 
-        return TopicSelector.defaultSelector(connectorConfig, topicNamer);
+        return TopicSelector.defaultSelector(
+                connectorConfig,
+                (tableId, prefix, delimiter) -> String.join(delimiter, prefix, tableId.catalog(), tableId.schema(), tableId.table()));
     }
 }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/AbstractSqlServerDatatypesTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/AbstractSqlServerDatatypesTest.java
@@ -213,7 +213,7 @@ public abstract class AbstractSqlServerDatatypesTest extends AbstractConnectorTe
 
         final SourceRecords records = consumeRecordsByTopic(EXPECTED_RECORD_COUNT);
 
-        List<SourceRecord> testTableRecords = records.recordsForTopic("server1.dbo.type_int");
+        List<SourceRecord> testTableRecords = records.recordsForTopic("server1.testDB1.dbo.type_int");
         assertThat(testTableRecords).hasSize(1);
 
         // insert
@@ -228,7 +228,7 @@ public abstract class AbstractSqlServerDatatypesTest extends AbstractConnectorTe
 
         final SourceRecords records = consumeRecordsByTopic(EXPECTED_RECORD_COUNT);
 
-        List<SourceRecord> testTableRecords = records.recordsForTopic("server1.dbo.type_fp");
+        List<SourceRecord> testTableRecords = records.recordsForTopic("server1.testDB1.dbo.type_fp");
         assertThat(testTableRecords).hasSize(1);
 
         // insert
@@ -243,7 +243,7 @@ public abstract class AbstractSqlServerDatatypesTest extends AbstractConnectorTe
 
         final SourceRecords records = consumeRecordsByTopic(EXPECTED_RECORD_COUNT);
 
-        List<SourceRecord> testTableRecords = records.recordsForTopic("server1.dbo.type_string");
+        List<SourceRecord> testTableRecords = records.recordsForTopic("server1.testDB1.dbo.type_string");
         assertThat(testTableRecords).hasSize(1);
 
         // insert
@@ -258,7 +258,7 @@ public abstract class AbstractSqlServerDatatypesTest extends AbstractConnectorTe
 
         final SourceRecords records = consumeRecordsByTopic(EXPECTED_RECORD_COUNT);
 
-        List<SourceRecord> testTableRecords = records.recordsForTopic("server1.dbo.type_time");
+        List<SourceRecord> testTableRecords = records.recordsForTopic("server1.testDB1.dbo.type_time");
         assertThat(testTableRecords).hasSize(1);
 
         // insert
@@ -276,7 +276,7 @@ public abstract class AbstractSqlServerDatatypesTest extends AbstractConnectorTe
 
         final SourceRecords records = consumeRecordsByTopic(EXPECTED_RECORD_COUNT);
 
-        List<SourceRecord> testTableRecords = records.recordsForTopic("server1.dbo.type_time");
+        List<SourceRecord> testTableRecords = records.recordsForTopic("server1.testDB1.dbo.type_time");
         assertThat(testTableRecords).hasSize(1);
 
         // insert
@@ -291,7 +291,7 @@ public abstract class AbstractSqlServerDatatypesTest extends AbstractConnectorTe
 
         final SourceRecords records = consumeRecordsByTopic(EXPECTED_RECORD_COUNT);
 
-        List<SourceRecord> testTableRecords = records.recordsForTopic("server1.dbo.type_xml");
+        List<SourceRecord> testTableRecords = records.recordsForTopic("server1.testDB1.dbo.type_xml");
         assertThat(testTableRecords).hasSize(1);
 
         // insert

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/CaseSensitivenessIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/CaseSensitivenessIT.java
@@ -62,7 +62,7 @@ public class CaseSensitivenessIT extends AbstractConnectorTest {
     @FixFor("DBZ-1051")
     public void caseSensitiveDatabase() throws Exception {
         connection.execute(
-                "ALTER DATABASE testDB COLLATE Latin1_General_BIN",
+                "ALTER DATABASE testDB1 COLLATE Latin1_General_BIN",
                 "CREATE TABLE MyTableOne (Id int primary key, ColA varchar(30))",
                 "INSERT INTO MyTableOne VALUES(1, 'a')");
         TestHelper.enableTableCdc(connection, "MyTableOne");
@@ -78,40 +78,40 @@ public class CaseSensitivenessIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
 
         SourceRecords records = consumeRecordsByTopic(1);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.MyTableOne")).hasSize(1);
-        SourceRecord record = records.recordsForTopic("server1.dbo.MyTableOne").get(0);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.MyTableOne")).hasSize(1);
+        SourceRecord record = records.recordsForTopic("server1.testDB1.dbo.MyTableOne").get(0);
         assertSchemaMatchesStruct(
                 (Struct) ((Struct) record.value()).get("after"),
                 SchemaBuilder.struct()
                         .optional()
-                        .name("server1.dbo.MyTableOne.Value")
+                        .name("server1.testDB1.dbo.MyTableOne.Value")
                         .field("Id", Schema.INT32_SCHEMA)
                         .field("ColA", Schema.OPTIONAL_STRING_SCHEMA)
                         .build());
         assertSchemaMatchesStruct(
                 (Struct) record.key(),
                 SchemaBuilder.struct()
-                        .name("server1.dbo.MyTableOne.Key")
+                        .name("server1.testDB1.dbo.MyTableOne.Key")
                         .field("Id", Schema.INT32_SCHEMA)
                         .build());
         Assertions.assertThat(((Struct) ((Struct) record.value()).get("after")).getInt32("Id")).isEqualTo(1);
 
         connection.execute("INSERT INTO MyTableOne VALUES(2, 'b')");
         records = consumeRecordsByTopic(1);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.MyTableOne")).hasSize(1);
-        record = records.recordsForTopic("server1.dbo.MyTableOne").get(0);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.MyTableOne")).hasSize(1);
+        record = records.recordsForTopic("server1.testDB1.dbo.MyTableOne").get(0);
         assertSchemaMatchesStruct(
                 (Struct) ((Struct) record.value()).get("after"),
                 SchemaBuilder.struct()
                         .optional()
-                        .name("server1.dbo.MyTableOne.Value")
+                        .name("server1.testDB1.dbo.MyTableOne.Value")
                         .field("Id", Schema.INT32_SCHEMA)
                         .field("ColA", Schema.OPTIONAL_STRING_SCHEMA)
                         .build());
         assertSchemaMatchesStruct(
                 (Struct) record.key(),
                 SchemaBuilder.struct()
-                        .name("server1.dbo.MyTableOne.Key")
+                        .name("server1.testDB1.dbo.MyTableOne.Key")
                         .field("Id", Schema.INT32_SCHEMA)
                         .build());
         Assertions.assertThat(((Struct) ((Struct) record.value()).get("after")).getInt32("Id")).isEqualTo(2);
@@ -121,20 +121,20 @@ public class CaseSensitivenessIT extends AbstractConnectorTest {
         TestHelper.enableTableCdc(connection, "MyTableTwo");
         connection.execute("INSERT INTO MyTableTwo VALUES(3, 'b')");
         records = consumeRecordsByTopic(1);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.MyTableTwo")).hasSize(1);
-        record = records.recordsForTopic("server1.dbo.MyTableTwo").get(0);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.MyTableTwo")).hasSize(1);
+        record = records.recordsForTopic("server1.testDB1.dbo.MyTableTwo").get(0);
         assertSchemaMatchesStruct(
                 (Struct) ((Struct) record.value()).get("after"),
                 SchemaBuilder.struct()
                         .optional()
-                        .name("server1.dbo.MyTableTwo.Value")
+                        .name("server1.testDB1.dbo.MyTableTwo.Value")
                         .field("Id", Schema.INT32_SCHEMA)
                         .field("ColB", Schema.OPTIONAL_STRING_SCHEMA)
                         .build());
         assertSchemaMatchesStruct(
                 (Struct) record.key(),
                 SchemaBuilder.struct()
-                        .name("server1.dbo.MyTableTwo.Key")
+                        .name("server1.testDB1.dbo.MyTableTwo.Key")
                         .field("Id", Schema.INT32_SCHEMA)
                         .build());
         Assertions.assertThat(((Struct) ((Struct) record.value()).get("after")).getInt32("Id")).isEqualTo(3);

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/EventProcessingFailureHandlingIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/EventProcessingFailureHandlingIT.java
@@ -84,8 +84,8 @@ public class EventProcessingFailureHandlingIT extends AbstractConnectorTest {
         }
 
         SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).isNull();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).isNull();
 
         Awaitility.await()
                 .alias("Found warning message in logs")
@@ -120,8 +120,8 @@ public class EventProcessingFailureHandlingIT extends AbstractConnectorTest {
         }
 
         SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).isNull();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).isNull();
     }
 
     @Test

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/IncrementalSnapshotIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/IncrementalSnapshotIT.java
@@ -75,27 +75,27 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotWithSchema
 
     @Override
     protected String topicName() {
-        return "server1.dbo.a";
+        return "server1.testDB1.dbo.a";
     }
 
     @Override
     protected List<String> topicNames() {
-        return List.of("server1.dbo.a", "server1.dbo.b");
+        return List.of("server1.testDB1.dbo.a", "server1.testDB1.dbo.b");
     }
 
     @Override
     protected String tableName() {
-        return "testDB.dbo.a";
+        return "testDB1.dbo.a";
     }
 
     @Override
     protected List<String> tableNames() {
-        return List.of("testDB.dbo.a", "testDB.dbo.b");
+        return List.of("testDB1.dbo.a", "testDB1.dbo.b");
     }
 
     @Override
     protected String tableName(String table) {
-        return "testDB.dbo." + table;
+        return "testDB1.dbo." + table;
     }
 
     @Override
@@ -149,7 +149,7 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotWithSchema
     protected Builder config() {
         return TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
-                .with(SqlServerConnectorConfig.SIGNAL_DATA_COLLECTION, "testDB.dbo.debezium_signal")
+                .with(SqlServerConnectorConfig.SIGNAL_DATA_COLLECTION, "testDB1.dbo.debezium_signal")
                 .with(SqlServerConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 250)
                 .with(SqlServerConnectorConfig.INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES, true);
     }
@@ -165,7 +165,7 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotWithSchema
         }
         return TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
-                .with(SqlServerConnectorConfig.SIGNAL_DATA_COLLECTION, "testDB.dbo.debezium_signal")
+                .with(SqlServerConnectorConfig.SIGNAL_DATA_COLLECTION, "testDB1.dbo.debezium_signal")
                 .with(SqlServerConnectorConfig.TABLE_INCLUDE_LIST, tableIncludeList)
                 .with(SqlServerConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 250)
                 .with(SqlServerConnectorConfig.INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES, true)

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/IncrementalSnapshotWithRecompileIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/IncrementalSnapshotWithRecompileIT.java
@@ -74,22 +74,22 @@ public class IncrementalSnapshotWithRecompileIT extends AbstractIncrementalSnaps
 
     @Override
     protected String topicName() {
-        return "server1.dbo.a";
+        return "server1.testDB1.dbo.a";
     }
 
     @Override
     public List<String> topicNames() {
-        return List.of("server1.dbo.a", "server1.dbo.b");
+        return List.of("server1.testDB1.dbo.a", "server1.testDB1.dbo.b");
     }
 
     @Override
     protected String tableName() {
-        return "testDB.dbo.a";
+        return "testDB1.dbo.a";
     }
 
     @Override
     protected List<String> tableNames() {
-        return List.of("testDB.dbo.a", "testDB.dbo.b");
+        return List.of("testDB1.dbo.a", "testDB1.dbo.b");
     }
 
     @Override
@@ -101,7 +101,7 @@ public class IncrementalSnapshotWithRecompileIT extends AbstractIncrementalSnaps
     protected Builder config() {
         return TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
-                .with(SqlServerConnectorConfig.SIGNAL_DATA_COLLECTION, "testDB.dbo.debezium_signal")
+                .with(SqlServerConnectorConfig.SIGNAL_DATA_COLLECTION, "testDB1.dbo.debezium_signal")
                 .with(SqlServerConnectorConfig.INCREMENTAL_SNAPSHOT_OPTION_RECOMPILE, true);
     }
 
@@ -116,7 +116,7 @@ public class IncrementalSnapshotWithRecompileIT extends AbstractIncrementalSnaps
         }
         return TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
-                .with(SqlServerConnectorConfig.SIGNAL_DATA_COLLECTION, "testDB.dbo.debezium_signal")
+                .with(SqlServerConnectorConfig.SIGNAL_DATA_COLLECTION, "testDB1.dbo.debezium_signal")
                 .with(SqlServerConnectorConfig.INCREMENTAL_SNAPSHOT_OPTION_RECOMPILE, true)
                 .with(SqlServerConnectorConfig.TABLE_INCLUDE_LIST, tableIncludeList)
                 .with(DatabaseHistory.STORE_ONLY_CAPTURED_TABLES_DDL, storeOnlyCapturedDdl);

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SQLServerNumericColumnIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SQLServerNumericColumnIT.java
@@ -88,7 +88,7 @@ public class SQLServerNumericColumnIT extends AbstractConnectorTest {
 
         connection.execute("INSERT INTO tablenuma VALUES (111.1111, 1111111, 1111111.1, 1111111 );");
         final SourceRecords records = consumeRecordsByTopic(1);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.tablenuma");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablenuma");
         Assertions.assertThat(tableA).hasSize(1);
         final Struct valueA = (Struct) tableA.get(0).value();
         assertSchema(valueA, Schema.OPTIONAL_STRING_SCHEMA);
@@ -120,7 +120,7 @@ public class SQLServerNumericColumnIT extends AbstractConnectorTest {
 
         connection.execute("INSERT INTO tablenumb VALUES (222.2222, 22222, 22222.2, 2222222 );");
         final SourceRecords records = consumeRecordsByTopic(1);
-        final List<SourceRecord> results = records.recordsForTopic("server1.dbo.tablenumb");
+        final List<SourceRecord> results = records.recordsForTopic("server1.testDB1.dbo.tablenumb");
         Assertions.assertThat(results).hasSize(1);
         final Struct valueA = (Struct) results.get(0).value();
         assertSchema(valueA, Schema.OPTIONAL_FLOAT64_SCHEMA);
@@ -151,7 +151,7 @@ public class SQLServerNumericColumnIT extends AbstractConnectorTest {
 
         connection.execute("INSERT INTO tablenumc VALUES (333.3333, 3333, 3333.3, 33333333 );");
         final SourceRecords records = consumeRecordsByTopic(1);
-        final List<SourceRecord> results = records.recordsForTopic("server1.dbo.tablenumc");
+        final List<SourceRecord> results = records.recordsForTopic("server1.testDB1.dbo.tablenumc");
         Assertions.assertThat(results).hasSize(1);
         final Struct valueA = (Struct) results.get(0).value();
         Assertions.assertThat(valueA.schema().field("after").schema().field("cola").schema())

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SchemaHistoryTopicIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SchemaHistoryTopicIT.java
@@ -8,9 +8,7 @@ package io.debezium.connector.sqlserver;
 import static org.fest.assertions.Assertions.assertThat;
 
 import java.sql.SQLException;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.connect.data.Schema;
@@ -98,7 +96,7 @@ public class SchemaHistoryTopicIT extends AbstractConnectorTest {
         Assertions.assertThat(schemaRecords).hasSize(3);
         schemaRecords.forEach(record -> {
             Assertions.assertThat(record.topic()).isEqualTo("server1");
-            Assertions.assertThat(((Struct) record.key()).getString("databaseName")).isEqualTo("testDB");
+            Assertions.assertThat(((Struct) record.key()).getString("databaseName")).isEqualTo("testDB1");
             Assertions.assertThat(record.sourceOffset().get("snapshot")).isEqualTo(true);
         });
         Assertions.assertThat(((Struct) schemaRecords.get(0).value()).getStruct("source").getString("snapshot")).isEqualTo("true");
@@ -112,8 +110,8 @@ public class SchemaHistoryTopicIT extends AbstractConnectorTest {
         waitForAvailableRecords(TestHelper.waitTimeForRecords(), TimeUnit.SECONDS);
 
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES, 24);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        final List<SourceRecord> tablebRecords = records.recordsForTopic("server1.dbo.tableb");
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        final List<SourceRecord> tablebRecords = records.recordsForTopic("server1.testDB1.dbo.tableb");
         // Additional schema change record was emitted
         if (tablebRecords.size() == RECORDS_PER_TABLE - 1) {
             tablebRecords.add(consumeRecord());
@@ -124,7 +122,7 @@ public class SchemaHistoryTopicIT extends AbstractConnectorTest {
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("colb", Schema.OPTIONAL_STRING_SCHEMA)
                             .build());
@@ -152,7 +150,7 @@ public class SchemaHistoryTopicIT extends AbstractConnectorTest {
         Assertions.assertThat(records.allRecordsInOrder()).hasSize(1);
         final SourceRecord schemaRecord = records.allRecordsInOrder().get(0);
         Assertions.assertThat(schemaRecord.topic()).isEqualTo("server1");
-        Assertions.assertThat(((Struct) schemaRecord.key()).getString("databaseName")).isEqualTo("testDB");
+        Assertions.assertThat(((Struct) schemaRecord.key()).getString("databaseName")).isEqualTo("testDB1");
         Assertions.assertThat(schemaRecord.sourceOffset().get("snapshot")).isNull();
 
         Assertions.assertThat(((Struct) schemaRecord.value()).getStruct("source").getString("snapshot")).isNull();
@@ -163,15 +161,15 @@ public class SchemaHistoryTopicIT extends AbstractConnectorTest {
         Assertions.assertThat(lastUpdate.sourceOffset()).isEqualTo(schemaRecord.sourceOffset());
 
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
 
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("newcolb", Schema.OPTIONAL_STRING_SCHEMA)
                             .build());
@@ -185,14 +183,14 @@ public class SchemaHistoryTopicIT extends AbstractConnectorTest {
                     "INSERT INTO tableb VALUES(" + id + ", 'b3')");
         }
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("newcolb", Schema.OPTIONAL_STRING_SCHEMA)
                             .build());
@@ -230,7 +228,7 @@ public class SchemaHistoryTopicIT extends AbstractConnectorTest {
         Assertions.assertThat(schemaRecords).hasSize(3);
         schemaRecords.forEach(record -> {
             Assertions.assertThat(record.topic()).isEqualTo("server1");
-            Assertions.assertThat(((Struct) record.key()).getString("databaseName")).isEqualTo("testDB");
+            Assertions.assertThat(((Struct) record.key()).getString("databaseName")).isEqualTo("testDB1");
             Assertions.assertThat(record.sourceOffset().get("snapshot")).isEqualTo(true);
         });
         Assertions.assertThat(((Struct) schemaRecords.get(0).value()).getStruct("source").getString("snapshot")).isEqualTo("true");
@@ -242,14 +240,14 @@ public class SchemaHistoryTopicIT extends AbstractConnectorTest {
         Assertions.assertThat(tableChanges.get(0).get("type")).isEqualTo("CREATE");
 
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("colb", Schema.OPTIONAL_STRING_SCHEMA)
                             .build());
@@ -282,7 +280,7 @@ public class SchemaHistoryTopicIT extends AbstractConnectorTest {
         // 1 schema event + 1 data event
         Testing.Print.enable();
         SourceRecords records = consumeRecordsByTopic(1 + 1);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablec")).hasSize(1);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablec")).hasSize(1);
 
         stopConnector();
         assertConnectorNotRunning();
@@ -307,7 +305,7 @@ public class SchemaHistoryTopicIT extends AbstractConnectorTest {
 
         // 1-2 schema events + 1 data event
         records = consumeRecordsByTopic(2 + 1);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tabled")).hasSize(1);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tabled")).hasSize(1);
 
         final List<SourceRecord> schemaEvents = records.recordsForTopic("server1");
 
@@ -323,29 +321,12 @@ public class SchemaHistoryTopicIT extends AbstractConnectorTest {
     }
 
     @Test
-    @FixFor("DBZ-3347")
-    public void shouldContainPartitionInSchemaChangeEventInSinglePartitionMode() throws Exception {
-        shouldContainPartitionInSchemaChangeEvent(TestHelper.defaultConfig(),
-                TestHelper::waitForStreamingStarted,
-                Collections.singletonMap("server", "server1"));
-    }
-
-    @Test
     @FixFor({ "DBZ-3347", "DBZ-2975" })
-    public void shouldContainPartitionInSchemaChangeEventInMultiPartitionMode() throws Exception {
-        shouldContainPartitionInSchemaChangeEvent(TestHelper.defaultMultiPartitionConfig(),
-                TestHelper::waitForTaskStreamingStarted,
-                Collect.hashMapOf("server", "server1", "database", "testDB"));
-    }
-
-    private void shouldContainPartitionInSchemaChangeEvent(Configuration.Builder configBuilder,
-                                                           Runnable waitForStreamingStarted,
-                                                           Map<String, String> expectedPartition)
-            throws Exception {
+    public void shouldContainPartitionInSchemaChangeEvent() throws Exception {
         connection.execute("create table dbz3347 (id int primary key, data varchar(50))");
         TestHelper.enableTableCdc(connection, "dbz3347");
 
-        Configuration config = configBuilder
+        Configuration config = TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.TABLE_INCLUDE_LIST, "dbo\\.dbz3347")
                 .with(SqlServerConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
                 .build();
@@ -353,10 +334,10 @@ public class SchemaHistoryTopicIT extends AbstractConnectorTest {
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
 
-        waitForStreamingStarted.run();
+        TestHelper.waitForStreamingStarted();
 
         SourceRecords schemaChanges = consumeRecordsByTopic(1);
         SourceRecord change = schemaChanges.recordsForTopic("server1").get(0);
-        assertThat(change.sourcePartition()).isEqualTo(expectedPartition);
+        assertThat(change.sourcePartition()).isEqualTo(Collect.hashMapOf("server", "server1", "database", "testDB1"));
     }
 }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotIT.java
@@ -119,7 +119,7 @@ public class SnapshotIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
 
         final SourceRecords records = consumeRecordsByTopic(INITIAL_RECORDS_PER_TABLE);
-        final List<SourceRecord> table1 = records.recordsForTopic("server1.dbo.table1");
+        final List<SourceRecord> table1 = records.recordsForTopic("server1.testDB1.dbo.table1");
 
         assertThat(table1).hasSize(INITIAL_RECORDS_PER_TABLE);
 
@@ -153,7 +153,7 @@ public class SnapshotIT extends AbstractConnectorTest {
 
         // Ignore initial records
         final SourceRecords records = consumeRecordsByTopic(INITIAL_RECORDS_PER_TABLE);
-        final List<SourceRecord> table1 = records.recordsForTopic("server1.dbo.table1");
+        final List<SourceRecord> table1 = records.recordsForTopic("server1.testDB1.dbo.table1");
         assertThat(((Struct) table1.get(0).value()).getStruct("source").getString("snapshot")).isEqualTo("first");
         table1.subList(1, INITIAL_RECORDS_PER_TABLE - 1).forEach(record -> {
             assertThat(((Struct) record.value()).getStruct("source").getString("snapshot")).isEqualTo("true");
@@ -193,7 +193,7 @@ public class SnapshotIT extends AbstractConnectorTest {
         TestHelper.waitForCdcRecord(connection, "table1", rs -> rs.getInt("id") == lastId);
 
         final SourceRecords records = consumeRecordsByTopic(STREAMING_RECORDS_PER_TABLE);
-        final List<SourceRecord> table1 = records.recordsForTopic("server1.dbo.table1");
+        final List<SourceRecord> table1 = records.recordsForTopic("server1.testDB1.dbo.table1");
 
         assertThat(table1).hasSize(INITIAL_RECORDS_PER_TABLE);
 
@@ -256,7 +256,7 @@ public class SnapshotIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
 
         final SourceRecords records = consumeRecordsByTopic(INITIAL_RECORDS_PER_TABLE);
-        final List<SourceRecord> user = records.recordsForTopic("server1.dbo.User");
+        final List<SourceRecord> user = records.recordsForTopic("server1.testDB1.dbo.User");
 
         assertThat(user).hasSize(INITIAL_RECORDS_PER_TABLE);
 
@@ -317,8 +317,8 @@ public class SnapshotIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
 
         SourceRecords records = consumeRecordsByTopic(1);
-        List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.table_a");
-        List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.table_b");
+        List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.table_a");
+        List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.table_b");
 
         Assertions.assertThat(tableA).hasSize(1);
         Assertions.assertThat(tableB).isNull();
@@ -327,8 +327,8 @@ public class SnapshotIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO table_b VALUES(24, 'some_name', 558)");
 
         records = consumeRecordsByTopic(2);
-        tableA = records.recordsForTopic("server1.dbo.table_a");
-        tableB = records.recordsForTopic("server1.dbo.table_b");
+        tableA = records.recordsForTopic("server1.testDB1.dbo.table_a");
+        tableB = records.recordsForTopic("server1.testDB1.dbo.table_b");
 
         Assertions.assertThat(tableA).hasSize(1);
         Assertions.assertThat(tableB).hasSize(1);
@@ -357,12 +357,12 @@ public class SnapshotIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
 
         final SourceRecords records = consumeRecordsByTopic(2);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.blacklist_column_table_a");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.blacklist_column_table_b");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.blacklist_column_table_a");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.blacklist_column_table_b");
 
         Schema expectedSchemaA = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.blacklist_column_table_a.Value")
+                .name("server1.testDB1.dbo.blacklist_column_table_a.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
@@ -372,7 +372,7 @@ public class SnapshotIT extends AbstractConnectorTest {
 
         Schema expectedSchemaB = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.blacklist_column_table_b.Value")
+                .name("server1.testDB1.dbo.blacklist_column_table_b.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("amount", Schema.OPTIONAL_INT32_SCHEMA)
@@ -414,14 +414,14 @@ public class SnapshotIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
 
         SourceRecords records = consumeRecordsByTopic(1);
-        List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.table_a");
-        List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.table_b");
+        List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.table_a");
+        List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.table_b");
 
         Assertions.assertThat(tableB).hasSize(1);
         Assertions.assertThat(tableA).isNull();
 
         records = consumeRecordsByTopic(1);
-        tableA = records.recordsForTopic("server1.dbo.table_a");
+        tableA = records.recordsForTopic("server1.testDB1.dbo.table_a");
         Assertions.assertThat(tableA).hasSize(1);
 
         stopConnector();
@@ -449,21 +449,21 @@ public class SnapshotIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
 
         SourceRecords records = consumeRecordsByTopic(1);
-        List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.table_a");
-        List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.table_ab");
-        List<SourceRecord> tableC = records.recordsForTopic("server1.dbo.table_ac");
+        List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.table_a");
+        List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.table_ab");
+        List<SourceRecord> tableC = records.recordsForTopic("server1.testDB1.dbo.table_ac");
 
         Assertions.assertThat(tableB).hasSize(1);
         Assertions.assertThat(tableA).isNull();
         Assertions.assertThat(tableC).isNull();
 
         records = consumeRecordsByTopic(1);
-        tableA = records.recordsForTopic("server1.dbo.table_a");
+        tableA = records.recordsForTopic("server1.testDB1.dbo.table_a");
         Assertions.assertThat(tableA).hasSize(1);
         Assertions.assertThat(tableC).isNull();
 
         records = consumeRecordsByTopic(1);
-        tableC = records.recordsForTopic("server1.dbo.table_ac");
+        tableC = records.recordsForTopic("server1.testDB1.dbo.table_ac");
         Assertions.assertThat(tableC).hasSize(1);
 
         stopConnector();
@@ -492,21 +492,21 @@ public class SnapshotIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
 
         SourceRecords records = consumeRecordsByTopic(1);
-        List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.table_a");
-        List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.table_ab");
-        List<SourceRecord> tableC = records.recordsForTopic("server1.dbo.table_ac");
+        List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.table_a");
+        List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.table_ab");
+        List<SourceRecord> tableC = records.recordsForTopic("server1.testDB1.dbo.table_ac");
 
         Assertions.assertThat(tableA).hasSize(1);
         Assertions.assertThat(tableB).isNull();
         Assertions.assertThat(tableC).isNull();
 
         records = consumeRecordsByTopic(1);
-        tableB = records.recordsForTopic("server1.dbo.table_ab");
+        tableB = records.recordsForTopic("server1.testDB1.dbo.table_ab");
         Assertions.assertThat(tableB).hasSize(1);
         Assertions.assertThat(tableC).isNull();
 
         records = consumeRecordsByTopic(1);
-        tableC = records.recordsForTopic("server1.dbo.table_ac");
+        tableC = records.recordsForTopic("server1.testDB1.dbo.table_ac");
         Assertions.assertThat(tableC).hasSize(1);
 
         stopConnector();
@@ -521,7 +521,7 @@ public class SnapshotIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
 
         final SourceRecords snapshotRecords = consumeRecordsByTopic(INITIAL_RECORDS_PER_TABLE);
-        final List<SourceRecord> snapshotTable1 = snapshotRecords.recordsForTopic("server1.dbo.table1");
+        final List<SourceRecord> snapshotTable1 = snapshotRecords.recordsForTopic("server1.testDB1.dbo.table1");
 
         assertThat(snapshotTable1).hasSize(INITIAL_RECORDS_PER_TABLE);
 
@@ -539,7 +539,7 @@ public class SnapshotIT extends AbstractConnectorTest {
         }
 
         final SourceRecords streamingRecords = consumeRecordsByTopic(STREAMING_RECORDS_PER_TABLE);
-        final List<SourceRecord> streamingTable1 = streamingRecords.recordsForTopic("server1.dbo.table1");
+        final List<SourceRecord> streamingTable1 = streamingRecords.recordsForTopic("server1.testDB1.dbo.table1");
 
         assertThat(streamingTable1).hasSize(INITIAL_RECORDS_PER_TABLE);
 
@@ -572,7 +572,7 @@ public class SnapshotIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
 
         SourceRecords records = consumeRecordsByTopic(1);
-        List<SourceRecord> recordsForTopic = records.recordsForTopic("server1.dbo.user_detail");
+        List<SourceRecord> recordsForTopic = records.recordsForTopic("server1.testDB1.dbo.user_detail");
         assertThat(recordsForTopic.get(0).key()).isNotNull();
         Struct value = (Struct) ((Struct) recordsForTopic.get(0).value()).get("after");
         System.out.println("DATA: " + value);

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotWithSelectOverridesIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotWithSelectOverridesIT.java
@@ -91,37 +91,20 @@ public class SnapshotWithSelectOverridesIT extends AbstractConnectorTest {
     }
 
     @Test
-    @FixFor("DBZ-1224")
-    public void takeSnapshotWithOverridesInSinglePartitionMode() throws Exception {
+    @FixFor({ "DBZ-1224", "DBZ-2975" })
+    public void takeSnapshotWithOverridesInMultiPartitionMode() throws Exception {
         final Configuration config = TestHelper.defaultConfig()
                 .with(
                         RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
                         "dbo.table1,dbo.table3")
                 .with(
                         RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + ".dbo.table1",
-                        "SELECT * FROM [dbo].[table1] where soft_deleted = 0 order by id desc")
+                        "SELECT * FROM [" + TestHelper.TEST_DATABASE_1 + "].[dbo].[table1] where soft_deleted = 0 order by id desc")
                 .with(
                         RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + ".dbo.table3",
-                        "SELECT * FROM [dbo].[table3] where soft_deleted = 0")
+                        "SELECT * FROM [" + TestHelper.TEST_DATABASE_1 + "].[dbo].[table3] where soft_deleted = 0")
                 .build();
-        takeSnapshotWithOverrides(config, "server1.dbo.");
-    }
-
-    @Test
-    @FixFor({ "DBZ-1224", "DBZ-2975" })
-    public void takeSnapshotWithOverridesInMultiPartitionMode() throws Exception {
-        final Configuration config = TestHelper.defaultMultiPartitionConfig()
-                .with(
-                        RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
-                        "dbo.table1,dbo.table3")
-                .with(
-                        RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + ".dbo.table1",
-                        "SELECT * FROM [" + TestHelper.TEST_DATABASE + "].[dbo].[table1] where soft_deleted = 0 order by id desc")
-                .with(
-                        RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + ".dbo.table3",
-                        "SELECT * FROM [" + TestHelper.TEST_DATABASE + "].[dbo].[table3] where soft_deleted = 0")
-                .build();
-        takeSnapshotWithOverrides(config, "server1.testDB.dbo.");
+        takeSnapshotWithOverrides(config, "server1.testDB1.dbo.");
     }
 
     private void takeSnapshotWithOverrides(Configuration config, String topicPrefix) throws Exception {
@@ -157,37 +140,20 @@ public class SnapshotWithSelectOverridesIT extends AbstractConnectorTest {
     }
 
     @Test
-    @FixFor("DBZ-3429")
-    public void takeSnapshotWithOverridesWithAdditionalWhitespaceInSinglePartitionMode() throws Exception {
+    @FixFor({ "DBZ-3429", "DBZ-2975" })
+    public void takeSnapshotWithOverridesWithAdditionalWhitespaceInMultiPartitionMode() throws Exception {
         final Configuration config = TestHelper.defaultConfig()
                 .with(
                         RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
                         "  dbo.table1 , dbo.table3  ")
                 .with(
                         RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + ".dbo.table1",
-                        "SELECT * FROM [dbo].[table1] where soft_deleted = 0 order by id desc")
+                        "SELECT * FROM [" + TestHelper.TEST_DATABASE_1 + "].[dbo].[table1] where soft_deleted = 0 order by id desc")
                 .with(
                         RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + ".dbo.table3",
-                        "SELECT * FROM [dbo].[table3] where soft_deleted = 0")
+                        "SELECT * FROM [" + TestHelper.TEST_DATABASE_1 + "].[dbo].[table3] where soft_deleted = 0")
                 .build();
-        takeSnapshotWithOverridesWithAdditionalWhitespace(config, "server1.dbo.");
-    }
-
-    @Test
-    @FixFor({ "DBZ-3429", "DBZ-2975" })
-    public void takeSnapshotWithOverridesWithAdditionalWhitespaceInMultiPartitionMode() throws Exception {
-        final Configuration config = TestHelper.defaultMultiPartitionConfig()
-                .with(
-                        RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE,
-                        "  dbo.table1 , dbo.table3  ")
-                .with(
-                        RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + ".dbo.table1",
-                        "SELECT * FROM [" + TestHelper.TEST_DATABASE + "].[dbo].[table1] where soft_deleted = 0 order by id desc")
-                .with(
-                        RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE + ".dbo.table3",
-                        "SELECT * FROM [" + TestHelper.TEST_DATABASE + "].[dbo].[table3] where soft_deleted = 0")
-                .build();
-        takeSnapshotWithOverridesWithAdditionalWhitespace(config, "server1.testDB.dbo.");
+        takeSnapshotWithOverridesWithAdditionalWhitespace(config, "server1.testDB1.dbo.");
     }
 
     private void takeSnapshotWithOverridesWithAdditionalWhitespace(Configuration config, String topicPrefix) throws Exception {

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SpecialCharsInNamesIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SpecialCharsInNamesIT.java
@@ -66,10 +66,10 @@ public class SpecialCharsInNamesIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
 
         SourceRecords actualRecords = consumeRecordsByTopic(2, false);
-        assertThat(actualRecords.recordsForTopic("server1.dbo.UAT_WAG_CZ_Fixed_Asset")).hasSize(1);
-        assertThat(actualRecords.recordsForTopic("server1.dbo.UAT_WAG_CZ_Fixed_Prop")).hasSize(1);
+        assertThat(actualRecords.recordsForTopic("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset")).hasSize(1);
+        assertThat(actualRecords.recordsForTopic("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Prop")).hasSize(1);
 
-        List<SourceRecord> carRecords = actualRecords.recordsForTopic("server1.dbo.UAT_WAG_CZ_Fixed_Asset");
+        List<SourceRecord> carRecords = actualRecords.recordsForTopic("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset");
         assertThat(carRecords.size()).isEqualTo(1);
         SourceRecord carRecord = carRecords.get(0);
 
@@ -77,19 +77,19 @@ public class SpecialCharsInNamesIT extends AbstractConnectorTest {
                 (Struct) ((Struct) carRecord.value()).get("after"),
                 SchemaBuilder.struct()
                         .optional()
-                        .name("server1.dbo.UAT_WAG_CZ_Fixed_Asset.Value")
+                        .name("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset.Value")
                         .field("id", Schema.INT32_SCHEMA)
                         .field("my col$a", Schema.OPTIONAL_STRING_SCHEMA)
                         .build());
         assertSchemaMatchesStruct(
                 (Struct) carRecord.key(),
                 SchemaBuilder.struct()
-                        .name("server1.dbo.UAT_WAG_CZ_Fixed_Asset.Key")
+                        .name("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset.Key")
                         .field("id", Schema.INT32_SCHEMA)
                         .build());
         assertThat(((Struct) carRecord.value()).getStruct("after").getString("my col$a")).isEqualTo("asset");
 
-        List<SourceRecord> personRecords = actualRecords.recordsForTopic("server1.dbo.UAT_WAG_CZ_Fixed_Prop");
+        List<SourceRecord> personRecords = actualRecords.recordsForTopic("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Prop");
         assertThat(personRecords.size()).isEqualTo(1);
         SourceRecord personRecord = personRecords.get(0);
 
@@ -97,14 +97,14 @@ public class SpecialCharsInNamesIT extends AbstractConnectorTest {
                 (Struct) ((Struct) personRecord.value()).get("after"),
                 SchemaBuilder.struct()
                         .optional()
-                        .name("server1.dbo.UAT_WAG_CZ_Fixed_Prop.Value")
+                        .name("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Prop.Value")
                         .field("id", Schema.INT32_SCHEMA)
                         .field("my col$a", Schema.OPTIONAL_STRING_SCHEMA)
                         .build());
         assertSchemaMatchesStruct(
                 (Struct) personRecord.key(),
                 SchemaBuilder.struct()
-                        .name("server1.dbo.UAT_WAG_CZ_Fixed_Prop.Key")
+                        .name("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Prop.Key")
                         .field("id", Schema.INT32_SCHEMA)
                         .build());
         assertThat(((Struct) personRecord.value()).getStruct("after").getString("my col$a")).isEqualTo("prop");
@@ -133,41 +133,41 @@ public class SpecialCharsInNamesIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
 
         SourceRecords records = consumeRecordsByTopic(1);
-        assertThat(records.recordsForTopic("server1.dbo.UAT_WAG_CZ_Fixed_Asset")).hasSize(1);
+        assertThat(records.recordsForTopic("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset")).hasSize(1);
 
-        SourceRecord record = records.recordsForTopic("server1.dbo.UAT_WAG_CZ_Fixed_Asset").get(0);
+        SourceRecord record = records.recordsForTopic("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset").get(0);
         assertSchemaMatchesStruct(
                 (Struct) ((Struct) record.value()).get("after"),
                 SchemaBuilder.struct()
                         .optional()
-                        .name("server1.dbo.UAT_WAG_CZ_Fixed_Asset.Value")
+                        .name("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset.Value")
                         .field("id", Schema.INT32_SCHEMA)
                         .field("my_col_a", Schema.OPTIONAL_STRING_SCHEMA)
                         .build());
         assertSchemaMatchesStruct(
                 (Struct) record.key(),
                 SchemaBuilder.struct()
-                        .name("server1.dbo.UAT_WAG_CZ_Fixed_Asset.Key")
+                        .name("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset.Key")
                         .field("id", Schema.INT32_SCHEMA)
                         .build());
         assertThat(((Struct) record.value()).getStruct("after").getInt32("id")).isEqualTo(1);
 
         connection.execute("INSERT INTO [UAT WAG CZ$Fixed Asset] VALUES(2, 'b')");
         records = consumeRecordsByTopic(1);
-        assertThat(records.recordsForTopic("server1.dbo.UAT_WAG_CZ_Fixed_Asset")).hasSize(1);
-        record = records.recordsForTopic("server1.dbo.UAT_WAG_CZ_Fixed_Asset").get(0);
+        assertThat(records.recordsForTopic("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset")).hasSize(1);
+        record = records.recordsForTopic("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset").get(0);
         assertSchemaMatchesStruct(
                 (Struct) ((Struct) record.value()).get("after"),
                 SchemaBuilder.struct()
                         .optional()
-                        .name("server1.dbo.UAT_WAG_CZ_Fixed_Asset.Value")
+                        .name("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset.Value")
                         .field("id", Schema.INT32_SCHEMA)
                         .field("my_col_a", Schema.OPTIONAL_STRING_SCHEMA)
                         .build());
         assertSchemaMatchesStruct(
                 (Struct) record.key(),
                 SchemaBuilder.struct()
-                        .name("server1.dbo.UAT_WAG_CZ_Fixed_Asset.Key")
+                        .name("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset.Key")
                         .field("id", Schema.INT32_SCHEMA)
                         .build());
         assertThat(((Struct) record.value()).getStruct("after").getInt32("id")).isEqualTo(2);
@@ -177,13 +177,13 @@ public class SpecialCharsInNamesIT extends AbstractConnectorTest {
         TestHelper.enableTableCdc(connection, "UAT WAG CZ$Fixed Asset Two");
         connection.execute("INSERT INTO [UAT WAG CZ$Fixed Asset Two] VALUES(3, 'b', 'empty')");
         records = consumeRecordsByTopic(1);
-        assertThat(records.recordsForTopic("server1.dbo.UAT_WAG_CZ_Fixed_Asset_Two")).hasSize(1);
-        record = records.recordsForTopic("server1.dbo.UAT_WAG_CZ_Fixed_Asset_Two").get(0);
+        assertThat(records.recordsForTopic("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset_Two")).hasSize(1);
+        record = records.recordsForTopic("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset_Two").get(0);
         assertSchemaMatchesStruct(
                 (Struct) ((Struct) record.value()).get("after"),
                 SchemaBuilder.struct()
                         .optional()
-                        .name("server1.dbo.UAT_WAG_CZ_Fixed_Asset_Two.Value")
+                        .name("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset_Two.Value")
                         .field("id", Schema.INT32_SCHEMA)
                         .field("my_col_", Schema.OPTIONAL_STRING_SCHEMA)
                         .field("Description", Schema.STRING_SCHEMA)
@@ -191,20 +191,20 @@ public class SpecialCharsInNamesIT extends AbstractConnectorTest {
         assertSchemaMatchesStruct(
                 (Struct) record.key(),
                 SchemaBuilder.struct()
-                        .name("server1.dbo.UAT_WAG_CZ_Fixed_Asset_Two.Key")
+                        .name("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset_Two.Key")
                         .field("id", Schema.INT32_SCHEMA)
                         .build());
         assertThat(((Struct) record.value()).getStruct("after").getInt32("id")).isEqualTo(3);
 
         connection.execute("UPDATE [UAT WAG CZ$Fixed Asset Two] SET Description='c1' WHERE id=3");
         records = consumeRecordsByTopic(1);
-        assertThat(records.recordsForTopic("server1.dbo.UAT_WAG_CZ_Fixed_Asset_Two")).hasSize(1);
-        record = records.recordsForTopic("server1.dbo.UAT_WAG_CZ_Fixed_Asset_Two").get(0);
+        assertThat(records.recordsForTopic("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset_Two")).hasSize(1);
+        record = records.recordsForTopic("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset_Two").get(0);
         assertSchemaMatchesStruct(
                 (Struct) ((Struct) record.value()).get("after"),
                 SchemaBuilder.struct()
                         .optional()
-                        .name("server1.dbo.UAT_WAG_CZ_Fixed_Asset_Two.Value")
+                        .name("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset_Two.Value")
                         .field("id", Schema.INT32_SCHEMA)
                         .field("my_col_", Schema.OPTIONAL_STRING_SCHEMA)
                         .field("Description", Schema.STRING_SCHEMA)
@@ -213,7 +213,7 @@ public class SpecialCharsInNamesIT extends AbstractConnectorTest {
                 (Struct) ((Struct) record.value()).get("before"),
                 SchemaBuilder.struct()
                         .optional()
-                        .name("server1.dbo.UAT_WAG_CZ_Fixed_Asset_Two.Value")
+                        .name("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset_Two.Value")
                         .field("id", Schema.INT32_SCHEMA)
                         .field("my_col_", Schema.OPTIONAL_STRING_SCHEMA)
                         .field("Description", Schema.STRING_SCHEMA)
@@ -228,20 +228,20 @@ public class SpecialCharsInNamesIT extends AbstractConnectorTest {
 
         connection.execute("INSERT INTO [UAT WAG CZ$Fixed Asset] VALUES(4, 'b')");
         records = consumeRecordsByTopic(1);
-        assertThat(records.recordsForTopic("server1.dbo.UAT_WAG_CZ_Fixed_Asset")).hasSize(1);
-        record = records.recordsForTopic("server1.dbo.UAT_WAG_CZ_Fixed_Asset").get(0);
+        assertThat(records.recordsForTopic("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset")).hasSize(1);
+        record = records.recordsForTopic("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset").get(0);
         assertSchemaMatchesStruct(
                 (Struct) ((Struct) record.value()).get("after"),
                 SchemaBuilder.struct()
                         .optional()
-                        .name("server1.dbo.UAT_WAG_CZ_Fixed_Asset.Value")
+                        .name("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset.Value")
                         .field("id", Schema.INT32_SCHEMA)
                         .field("my_col_a", Schema.OPTIONAL_STRING_SCHEMA)
                         .build());
         assertSchemaMatchesStruct(
                 (Struct) record.key(),
                 SchemaBuilder.struct()
-                        .name("server1.dbo.UAT_WAG_CZ_Fixed_Asset.Key")
+                        .name("server1.testDB1.dbo.UAT_WAG_CZ_Fixed_Asset.Key")
                         .field("id", Schema.INT32_SCHEMA)
                         .build());
         assertThat(((Struct) record.value()).getStruct("after").getInt32("id")).isEqualTo(4);
@@ -257,9 +257,8 @@ public class SpecialCharsInNamesIT extends AbstractConnectorTest {
         initializeConnectorTestFramework();
         Testing.Files.delete(TestHelper.DB_HISTORY_PATH);
 
-        final Configuration config = TestHelper.defaultConfig()
+        final Configuration config = TestHelper.defaultConfig(databaseName)
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
-                .with(SqlServerConnectorConfig.DATABASE_NAME, databaseName)
                 .with(SqlServerConnectorConfig.SANITIZE_FIELD_NAMES, false)
                 .build();
         connection.execute(
@@ -271,7 +270,7 @@ public class SpecialCharsInNamesIT extends AbstractConnectorTest {
 
         // Wait for snapshot completion
         SourceRecords recordsByTopic = consumeRecordsByTopic(1);
-        List<SourceRecord> records = recordsByTopic.recordsForTopic("server1.dbo.tablea");
+        List<SourceRecord> records = recordsByTopic.recordsForTopic("server1.test-db.dbo.tablea");
         assertThat(records).hasSize(1);
         Struct source = (Struct) ((Struct) records.get(0).value()).get("source");
         assertThat(source.get("db")).isEqualTo("test-db");

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerBinaryModeIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerBinaryModeIT.java
@@ -90,7 +90,7 @@ public class SqlServerBinaryModeIT extends AbstractConnectorTest {
         TestHelper.waitForSnapshotToBeCompleted();
 
         SourceRecords records = consumeRecordsByTopic(1);
-        final List<SourceRecord> results = records.recordsForTopic("server1.dbo.binary_mode_test");
+        final List<SourceRecord> results = records.recordsForTopic("server1.testDB1.dbo.binary_mode_test");
         Assertions.assertThat(results).hasSize(1);
 
         return (Struct) ((Struct) results.get(0).value()).get("after");

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerChangeTableSetIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerChangeTableSetIT.java
@@ -87,8 +87,8 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
         }
 
         SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
 
         // Enable CDC for already existing table
         TestHelper.enableTableCdc(connection, "tablec");
@@ -106,24 +106,24 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
                     "INSERT INTO tabled VALUES(" + id + ", 'd')");
         }
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablec")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tabled")).hasSize(RECORDS_PER_TABLE);
-        records.recordsForTopic("server1.dbo.tablec").forEach(record -> {
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablec")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tabled")).hasSize(RECORDS_PER_TABLE);
+        records.recordsForTopic("server1.testDB1.dbo.tablec").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tablec.Value")
+                            .name("server1.testDB1.dbo.tablec.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("colc", Schema.OPTIONAL_STRING_SCHEMA)
                             .build());
         });
-        records.recordsForTopic("server1.dbo.tabled").forEach(record -> {
+        records.recordsForTopic("server1.testDB1.dbo.tabled").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tabled.Value")
+                            .name("server1.testDB1.dbo.tabled.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("cold", Schema.OPTIONAL_STRING_SCHEMA)
                             .build());
@@ -153,8 +153,8 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
         }
 
         SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
 
         // Disable CDC for a table
         TestHelper.disableTableCdc(connection, "tableb");
@@ -167,8 +167,8 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
                     "INSERT INTO tableb VALUES(" + id + ", 'b2')");
         }
         records = consumeRecordsByTopic(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).isNullOrEmpty();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).isNullOrEmpty();
     }
 
     @Test
@@ -228,14 +228,14 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
         }
 
         SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("colb", Schema.OPTIONAL_STRING_SCHEMA)
                             .build());
@@ -252,15 +252,15 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
                     "INSERT INTO tableb VALUES(" + id + ", 'b2', 2)");
         }
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
 
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("colb", Schema.OPTIONAL_STRING_SCHEMA)
                             .build());
@@ -279,15 +279,15 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
                     "INSERT INTO tableb VALUES(" + id + ", 'b3', 3)");
         }
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
 
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("colb", Schema.OPTIONAL_STRING_SCHEMA)
                             .field("newcol", SchemaBuilder.int32().defaultValue(0).build())
@@ -302,14 +302,14 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
                     "INSERT INTO tableb VALUES(" + id + ", 'b4', 4)");
         }
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("colb", Schema.OPTIONAL_STRING_SCHEMA)
                             .field("newcol", SchemaBuilder.int32().defaultValue(0).build())
@@ -341,14 +341,14 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
         }
 
         SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("colb", Schema.OPTIONAL_STRING_SCHEMA)
                             .build());
@@ -366,15 +366,15 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
                     "INSERT INTO tableb VALUES(" + id + ")");
         }
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
 
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .build());
         });
@@ -387,14 +387,14 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
                     "INSERT INTO tableb VALUES(" + id + ")");
         }
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .build());
         });
@@ -427,13 +427,13 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
         }
 
         SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb2")).hasSize(RECORDS_PER_TABLE);
-        records.recordsForTopic("server1.dbo.tableb2").forEach(record -> {
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb2")).hasSize(RECORDS_PER_TABLE);
+        records.recordsForTopic("server1.testDB1.dbo.tableb2").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb2.Value")
+                            .name("server1.testDB1.dbo.tableb2.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .build());
         });
@@ -463,14 +463,14 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
         }
 
         SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("colb", Schema.OPTIONAL_STRING_SCHEMA)
                             .build());
@@ -498,12 +498,12 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
         TestHelper.enableTableCdc(connection, "tableb", "after_change");
 
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
 
         final AtomicInteger beforeChangeCount = new AtomicInteger();
         final AtomicInteger afterChangeCount = new AtomicInteger();
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             if (((Struct) record.value()).getStruct("after").schema().field("colb2") != null) {
                 afterChangeCount.incrementAndGet();
             }
@@ -523,14 +523,14 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
                     "INSERT INTO tableb VALUES(" + id + ", 'b1', 'b2')");
         }
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("colb", Schema.OPTIONAL_STRING_SCHEMA)
                             .field("colb2", Schema.OPTIONAL_STRING_SCHEMA)
@@ -562,8 +562,8 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
         }
 
         SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
 
         // Enable a second capture instance
         connection.execute("ALTER TABLE dbo.tableb DROP COLUMN colb");
@@ -577,8 +577,8 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
                     "INSERT INTO tableb VALUES(" + id + ")");
         }
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
 
         stopConnector();
         start(SqlServerConnector.class, config);
@@ -592,14 +592,14 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
                     "INSERT INTO tableb VALUES(" + id + ")");
         }
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .build());
         });
@@ -628,7 +628,7 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
         final String type = changeArray.get(0).asDocument().getString("type");
         final String tableIid = changeArray.get(0).asDocument().getString("id");
         Assertions.assertThat(type).isEqualTo("ALTER");
-        Assertions.assertThat(tableIid).isEqualTo("\"testDB\".\"dbo\".\"tableb\"");
+        Assertions.assertThat(tableIid).isEqualTo("\"testDB1\".\"dbo\".\"tableb\"");
     }
 
     @Test
@@ -655,14 +655,14 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
         }
 
         SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("colb", Schema.OPTIONAL_STRING_SCHEMA)
                             .build());
@@ -682,15 +682,15 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
                     "INSERT INTO tableb(id,newcolb) VALUES(" + id + ", 'b2')");
         }
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
 
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("newcolb", Schema.OPTIONAL_STRING_SCHEMA)
                             .build());
@@ -704,14 +704,14 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
                     "INSERT INTO tableb VALUES(" + id + ", 'b3')");
         }
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("newcolb", Schema.OPTIONAL_STRING_SCHEMA)
                             .build());
@@ -742,14 +742,14 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
         }
 
         SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("colb", Schema.OPTIONAL_STRING_SCHEMA)
                             .build());
@@ -771,15 +771,15 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
                     "INSERT INTO tableb VALUES(" + id + ", '" + id + " ')");
         }
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
 
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("colb", Schema.OPTIONAL_INT32_SCHEMA)
                             .build());
@@ -797,14 +797,14 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
                     "INSERT INTO tableb VALUES(" + id + ", '" + id + " ')");
         }
         records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
-        records.recordsForTopic("server1.dbo.tableb").forEach(record -> {
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tablea")).hasSize(RECORDS_PER_TABLE);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.tableb")).hasSize(RECORDS_PER_TABLE);
+        records.recordsForTopic("server1.testDB1.dbo.tableb").forEach(record -> {
             assertSchemaMatchesStruct(
                     (Struct) ((Struct) record.value()).get("after"),
                     SchemaBuilder.struct()
                             .optional()
-                            .name("server1.dbo.tableb.Value")
+                            .name("server1.testDB1.dbo.tableb.Value")
                             .field("id", Schema.INT32_SCHEMA)
                             .field("colb", Schema.OPTIONAL_INT32_SCHEMA)
                             .build());
@@ -835,7 +835,7 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO tableb VALUES('1', 'some_value')");
         TestHelper.waitForCdcRecord(connection, "tableb", "after_change", rs -> rs.getInt("id") == 1);
 
-        List<SourceRecord> records = consumeRecordsByTopic(1).recordsForTopic("server1.dbo.tableb");
+        List<SourceRecord> records = consumeRecordsByTopic(1).recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(records).hasSize(1);
         Testing.debug("Records: " + records);
         Testing.debug("Value Schema: " + records.get(0).valueSchema());
@@ -874,7 +874,7 @@ public class SqlServerChangeTableSetIT extends AbstractConnectorTest {
         TestHelper.enableTableCdc(connection, "table_dv", "after_change");
 
         connection.execute("INSERT INTO table_dv VALUES('2', 'some_value2')");
-        List<SourceRecord> records = consumeRecordsByTopic(1).recordsForTopic("server1.dbo.table_dv");
+        List<SourceRecord> records = consumeRecordsByTopic(1).recordsForTopic("server1.testDB1.dbo.table_dv");
         Assertions.assertThat(records).hasSize(1);
 
         Schema colbSchema = records.get(0).valueSchema().field("after").schema().field("colb").schema();

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorConfigTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorConfigTest.java
@@ -20,38 +20,19 @@ public class SqlServerConnectorConfigTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(SqlServerConnectorConfigTest.class);
 
     @Test
-    public void noDatabaseName() {
+    public void emptyDatabaseNames() {
         final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(
                 defaultConfig().build());
         assertFalse(connectorConfig.validateAndRecord(SqlServerConnectorConfig.ALL_FIELDS, LOGGER::error));
     }
 
     @Test
-    public void onlyDatabaseName() {
+    public void nonEmptyDatabaseNames() {
         final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(
                 defaultConfig()
-                        .with(SqlServerConnectorConfig.DATABASE_NAME, "testDB")
+                        .with(SqlServerConnectorConfig.DATABASE_NAMES, "testDB1")
                         .build());
         assertTrue(connectorConfig.validateAndRecord(SqlServerConnectorConfig.ALL_FIELDS, LOGGER::error));
-    }
-
-    @Test
-    public void onlyDatabaseNames() {
-        final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(
-                defaultConfig()
-                        .with(SqlServerConnectorConfig.DATABASE_NAMES, "testDB")
-                        .build());
-        assertTrue(connectorConfig.validateAndRecord(SqlServerConnectorConfig.ALL_FIELDS, LOGGER::error));
-    }
-
-    @Test
-    public void databaseNameAndDatabaseNames() {
-        final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(
-                defaultConfig()
-                        .with(SqlServerConnectorConfig.DATABASE_NAME, "testDB")
-                        .with(SqlServerConnectorConfig.DATABASE_NAMES, "testDB")
-                        .build());
-        assertFalse(connectorConfig.validateAndRecord(SqlServerConnectorConfig.ALL_FIELDS, LOGGER::error));
     }
 
     private Configuration.Builder defaultConfig() {

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -126,8 +126,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         }
 
         final SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.tablea");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablea");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(tableA).hasSize(RECORDS_PER_TABLE);
         Assertions.assertThat(tableB).hasSize(RECORDS_PER_TABLE);
         for (int i = 0; i < RECORDS_PER_TABLE; i++) {
@@ -153,8 +153,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         connection.execute("DELETE FROM tableB");
         final SourceRecords deleteRecords = consumeRecordsByTopic(2 * RECORDS_PER_TABLE);
-        final List<SourceRecord> deleteTableA = deleteRecords.recordsForTopic("server1.dbo.tablea");
-        final List<SourceRecord> deleteTableB = deleteRecords.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> deleteTableA = deleteRecords.recordsForTopic("server1.testDB1.dbo.tablea");
+        final List<SourceRecord> deleteTableB = deleteRecords.recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(deleteTableA).isNullOrEmpty();
         Assertions.assertThat(deleteTableB).hasSize(2 * RECORDS_PER_TABLE);
 
@@ -210,8 +210,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         }
 
         final SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES, 24);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.tablea");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablea");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(tableA).hasSize(RECORDS_PER_TABLE);
         Assertions.assertThat(tableB).hasSize(RECORDS_PER_TABLE);
         for (int i = 0; i < RECORDS_PER_TABLE; i++) {
@@ -290,8 +290,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
             }
 
             final SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-            final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.tablea");
-            final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.tableb");
+            final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablea");
+            final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.tableb");
             Assertions.assertThat(tableA).hasSize(RECORDS_PER_TABLE);
             Assertions.assertThat(tableB).hasSize(RECORDS_PER_TABLE);
             for (int i = 0; i < RECORDS_PER_TABLE; i++) {
@@ -335,8 +335,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         connection.execute("DELETE FROM tableB");
         final SourceRecords deleteRecords = consumeRecordsByTopic(RECORDS_PER_TABLE);
-        final List<SourceRecord> deleteTableA = deleteRecords.recordsForTopic("server1.dbo.tablea");
-        final List<SourceRecord> deleteTableB = deleteRecords.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> deleteTableA = deleteRecords.recordsForTopic("server1.testDB1.dbo.tablea");
+        final List<SourceRecord> deleteTableB = deleteRecords.recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(deleteTableA).isNullOrEmpty();
         Assertions.assertThat(deleteTableB).hasSize(RECORDS_PER_TABLE);
 
@@ -382,7 +382,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         connection.execute("UPDATE tableb SET colb='z'");
 
         final SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * 2);
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(tableB).hasSize(RECORDS_PER_TABLE * 2);
         for (int i = 0; i < RECORDS_PER_TABLE; i++) {
             final SourceRecord recordB = tableB.get(i);
@@ -438,8 +438,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
                 "UPDATE tableb SET id=100 WHERE id=1");
 
         final SourceRecords records = consumeRecordsByTopic(6);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.tablea");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablea");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(tableA).hasSize(3);
         Assertions.assertThat(tableB).hasSize(3);
 
@@ -546,9 +546,9 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
         final SourceRecords records2 = consumeRecordsByTopic(4);
 
-        final List<SourceRecord> tableA = records1.recordsForTopic("server1.dbo.tablea");
-        tableA.addAll(records2.recordsForTopic("server1.dbo.tablea"));
-        final List<SourceRecord> tableB = records2.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> tableA = records1.recordsForTopic("server1.testDB1.dbo.tablea");
+        tableA.addAll(records2.recordsForTopic("server1.testDB1.dbo.tablea"));
+        final List<SourceRecord> tableB = records2.recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(tableA).hasSize(3);
         Assertions.assertThat(tableB).hasSize(3);
 
@@ -661,8 +661,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
         final SourceRecords records2 = consumeRecordsByTopic(6);
 
-        final List<SourceRecord> tableB = records1.recordsForTopic("server1.dbo.tableb");
-        tableB.addAll(records2.recordsForTopic("server1.dbo.tableb"));
+        final List<SourceRecord> tableB = records1.recordsForTopic("server1.testDB1.dbo.tableb");
+        tableB.addAll(records2.recordsForTopic("server1.testDB1.dbo.tableb"));
 
         Assertions.assertThat(tableB).hasSize(20);
 
@@ -707,8 +707,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
 
         final SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.tablea");
-        List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablea");
+        List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.tableb");
 
         Assertions.assertThat(tableA).hasSize(RECORDS_PER_TABLE);
         Assertions.assertThat(tableB).hasSize(RECORDS_PER_TABLE);
@@ -762,21 +762,21 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> {
             // Wait for max lsn to be available
-            if (!connection.getMaxLsn(TestHelper.TEST_DATABASE).isAvailable()) {
+            if (!connection.getMaxLsn(TestHelper.TEST_DATABASE_1).isAvailable()) {
                 return false;
             }
 
             // verify pre-snapshot inserts have succeeded
             Map<String, Boolean> resultMap = new HashMap<>();
-            connection.getChangeTables(TestHelper.TEST_DATABASE).forEach(ct -> {
+            connection.getChangeTables(TestHelper.TEST_DATABASE_1).forEach(ct -> {
                 final String tableName = ct.getChangeTableId().table();
                 if (tableName.endsWith("dbo_" + tableaCT) || tableName.endsWith("dbo_" + tablebCT)) {
                     try {
-                        final Lsn minLsn = connection.getMinLsn(TestHelper.TEST_DATABASE, tableName);
-                        final Lsn maxLsn = connection.getMaxLsn(TestHelper.TEST_DATABASE);
+                        final Lsn minLsn = connection.getMinLsn(TestHelper.TEST_DATABASE_1, tableName);
+                        final Lsn maxLsn = connection.getMaxLsn(TestHelper.TEST_DATABASE_1);
                         SqlServerChangeTable[] tables = Collections.singletonList(ct).toArray(new SqlServerChangeTable[]{});
                         final List<Integer> ids = new ArrayList<>();
-                        connection.getChangesForTables(TestHelper.TEST_DATABASE, tables, minLsn, maxLsn, resultsets -> {
+                        connection.getChangesForTables(TestHelper.TEST_DATABASE_1, tables, minLsn, maxLsn, resultsets -> {
                             final ResultSet rs = resultsets[0];
                             while (rs.next()) {
                                 ids.add(rs.getInt("id"));
@@ -826,8 +826,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         assertConnectorIsRunning();
 
         final SourceRecords sourceRecords = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        final List<SourceRecord> tableA = sourceRecords.recordsForTopic("server1.dbo.tablea");
-        final List<SourceRecord> tableB = sourceRecords.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> tableA = sourceRecords.recordsForTopic("server1.testDB1.dbo.tablea");
+        final List<SourceRecord> tableB = sourceRecords.recordsForTopic("server1.testDB1.dbo.tableb");
 
         Assertions.assertThat(tableA).hasSize(RECORDS_PER_TABLE);
         Assertions.assertThat(tableB).hasSize(RECORDS_PER_TABLE);
@@ -888,8 +888,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         }
 
         final SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.tablea");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablea");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(tableA == null || tableA.isEmpty()).isTrue();
         Assertions.assertThat(tableB).hasSize(RECORDS_PER_TABLE);
 
@@ -961,7 +961,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         // Wait for snapshot completion
         final SourceRecords snapshotRecords = consumeRecordsByTopic(1);
-        Assertions.assertThat(snapshotRecords.recordsForTopic("server1.dbo.tableb")).isNotEmpty();
+        Assertions.assertThat(snapshotRecords.recordsForTopic("server1.testDB1.dbo.tableb")).isNotEmpty();
 
         for (int i = 0; i < RECORDS_PER_TABLE; i++) {
             final int id = ID_START + i;
@@ -972,8 +972,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         }
 
         final SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.tablea");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablea");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(tableA == null || tableA.isEmpty()).isTrue();
         Assertions.assertThat(tableB).hasSize(RECORDS_PER_TABLE);
 
@@ -1007,8 +1007,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         }
 
         final SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.tablea");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablea");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(tableA == null || tableA.isEmpty()).isTrue();
         Assertions.assertThat(tableB).hasSize(RECORDS_PER_TABLE);
 
@@ -1037,11 +1037,11 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO table_a VALUES(10, 'some_name', 120, 'some_string')");
 
         final SourceRecords records = consumeRecordsByTopic(1);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.table_a");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.table_a");
 
         Schema expectedSchemaA = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.table_a.Value")
+                .name("server1.testDB1.dbo.table_a.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("amount", Schema.OPTIONAL_INT32_SCHEMA)
@@ -1083,12 +1083,12 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO blacklist_column_table_b VALUES(11, 'some_name', 447)");
 
         final SourceRecords records = consumeRecordsByTopic(2);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.blacklist_column_table_a");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.blacklist_column_table_b");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.blacklist_column_table_a");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.blacklist_column_table_b");
 
         Schema expectedSchemaA = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.blacklist_column_table_a.Value")
+                .name("server1.testDB1.dbo.blacklist_column_table_a.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
@@ -1098,7 +1098,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         Schema expectedSchemaB = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.blacklist_column_table_b.Value")
+                .name("server1.testDB1.dbo.blacklist_column_table_b.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("amount", Schema.OPTIONAL_INT32_SCHEMA)
@@ -1137,7 +1137,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
-        waitForSnapshotToBeCompleted("sql_server", "server1");
+        TestHelper.waitForSnapshotToBeCompleted();
 
         // Wait for snapshot completion
         consumeRecordsByTopic(1);
@@ -1146,12 +1146,12 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO include_list_column_table_b VALUES(11, 'some_name', 447)");
 
         final SourceRecords records = consumeRecordsByTopic(2);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.include_list_column_table_a");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.include_list_column_table_b");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.include_list_column_table_a");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.include_list_column_table_b");
 
         Schema expectedSchemaA = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.include_list_column_table_a.Value")
+                .name("server1.testDB1.dbo.include_list_column_table_a.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
@@ -1161,7 +1161,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         Schema expectedSchemaB = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.include_list_column_table_b.Value")
+                .name("server1.testDB1.dbo.include_list_column_table_b.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("amount", Schema.OPTIONAL_INT32_SCHEMA)
@@ -1201,7 +1201,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         // should be no more records
         assertNoRecordsToConsume();
 
-        final String message = "All columns in table testDB.dbo.tablea were excluded due to include/exclude lists, defaulting to selecting all columns";
+        final String message = "All columns in table testDB1.dbo.tablea were excluded due to include/exclude lists, defaulting to selecting all columns";
         stopConnector(value -> assertThat(logInterceptor.containsMessage(message)).isTrue());
     }
 
@@ -1216,7 +1216,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         final Configuration config = TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
-                .with("column.mask.hash.SHA-256.with.salt.CzQMA0cB5K", "testDB.dbo.masked_hashed_column_table_a.name, testDB.dbo.masked_hashed_column_table_b.name")
+                .with("column.mask.hash.SHA-256.with.salt.CzQMA0cB5K", "testDB1.dbo.masked_hashed_column_table_a.name, testDB1.dbo.masked_hashed_column_table_b.name")
                 .build();
 
         start(SqlServerConnector.class, config);
@@ -1229,8 +1229,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO masked_hashed_column_table_b VALUES(11, 'some_name')");
 
         final SourceRecords records = consumeRecordsByTopic(2);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.masked_hashed_column_table_a");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.masked_hashed_column_table_b");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.masked_hashed_column_table_a");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.masked_hashed_column_table_b");
 
         assertThat(tableA).hasSize(1);
         SourceRecord record = tableA.get(0);
@@ -1264,8 +1264,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         final Configuration config = TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
-                .with("column.mask.with.12.chars", "testDB.dbo.masked_hashed_column_table.name")
-                .with("column.truncate.to.4.chars", "testDB.dbo.truncated_column_table.name")
+                .with("column.mask.with.12.chars", "testDB1.dbo.masked_hashed_column_table.name")
+                .with("column.truncate.to.4.chars", "testDB1.dbo.truncated_column_table.name")
                 .build();
 
         start(SqlServerConnector.class, config);
@@ -1278,8 +1278,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO truncated_column_table VALUES(11, 'some_name')");
 
         final SourceRecords records = consumeRecordsByTopic(2);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.masked_hashed_column_table");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.truncated_column_table");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.masked_hashed_column_table");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.truncated_column_table");
 
         assertThat(tableA).hasSize(1);
         SourceRecord record = tableA.get(0);
@@ -1317,16 +1317,16 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
-        waitForSnapshotToBeCompleted("sql_server", "server1");
+        TestHelper.waitForSnapshotToBeCompleted();
 
         connection.execute("INSERT INTO excluded_column_table_a VALUES(11, 'some_name', 120)");
 
         final SourceRecords records = consumeRecordsByTopic(3);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.excluded_column_table_a");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.excluded_column_table_a");
 
         Schema expectedSchemaA = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.excluded_column_table_a.Value")
+                .name("server1.testDB1.dbo.excluded_column_table_a.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
@@ -1367,16 +1367,16 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
-        waitForSnapshotToBeCompleted("sql_server", "server1");
+        TestHelper.waitForSnapshotToBeCompleted();
 
         connection.execute("INSERT INTO excluded_column_table_a VALUES(11, 'some_name', 120, 'a note')");
 
         final SourceRecords records = consumeRecordsByTopic(3);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.excluded_column_table_a");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.excluded_column_table_a");
 
         Schema expectedSchema = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.excluded_column_table_a.Value")
+                .name("server1.testDB1.dbo.excluded_column_table_a.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .field("note", Schema.OPTIONAL_STRING_SCHEMA)
@@ -1419,7 +1419,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
-        waitForStreamingRunning("sql_server", "server1");
+        TestHelper.waitForStreamingStarted();
 
         TestHelper.disableTableCdc(connection, "excluded_column_table_a");
         connection.execute("EXEC sp_RENAME 'excluded_column_table_a.name', 'first_name', 'COLUMN'");
@@ -1430,11 +1430,11 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         TestHelper.waitForCdcRecord(connection, "excluded_column_table_a", "dbo_excluded_column_table_a", rs -> rs.getInt("id") == 11);
 
         final SourceRecords records = consumeRecordsByTopic(2);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.excluded_column_table_a");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.excluded_column_table_a");
 
         Schema expectedSchema1 = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.excluded_column_table_a.Value")
+                .name("server1.testDB1.dbo.excluded_column_table_a.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
@@ -1443,7 +1443,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
                 .put("name", "a name");
         Schema expectedSchema2 = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.excluded_column_table_a.Value")
+                .name("server1.testDB1.dbo.excluded_column_table_a.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("first_name", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
@@ -1477,15 +1477,15 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
 
-        waitForStreamingRunning("sql_server", "server1");
+        TestHelper.waitForStreamingStarted();
         connection.execute("INSERT INTO excluded_column_table_a VALUES(10, 'some_name', 120)");
 
         final SourceRecords records = consumeRecordsByTopic(1);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.excluded_column_table_a");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.excluded_column_table_a");
 
         Schema expectedSchemaA = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.excluded_column_table_a.Value")
+                .name("server1.testDB1.dbo.excluded_column_table_a.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
@@ -1517,17 +1517,17 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
-        waitForSnapshotToBeCompleted("sql_server", "server1");
+        TestHelper.waitForSnapshotToBeCompleted();
 
         connection.execute("INSERT INTO exclude_list_column_table_a VALUES(11, 120, 'some_name')");
         TestHelper.waitForCdcRecord(connection, "exclude_list_column_table_a", rs -> rs.getInt("id") == 11);
 
         final SourceRecords records = consumeRecordsByTopic(2);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.exclude_list_column_table_a");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.exclude_list_column_table_a");
 
         Schema expectedSchemaA = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.exclude_list_column_table_a.Value")
+                .name("server1.testDB1.dbo.exclude_list_column_table_a.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
@@ -1564,17 +1564,17 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
-        waitForSnapshotToBeCompleted("sql_server", "server1");
+        TestHelper.waitForSnapshotToBeCompleted();
 
         connection.execute("INSERT INTO include_list_column_table_a VALUES(10, 120, 'some_name')");
         TestHelper.waitForCdcRecord(connection, "include_list_column_table_a", rs -> rs.getInt("id") == 10);
 
         final SourceRecords records = consumeRecordsByTopic(1);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.include_list_column_table_a");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.include_list_column_table_a");
 
         Schema expectedSchemaA = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.include_list_column_table_a.Value")
+                .name("server1.testDB1.dbo.include_list_column_table_a.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
@@ -1606,17 +1606,17 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
-        waitForSnapshotToBeCompleted("sql_server", "server1");
+        TestHelper.waitForSnapshotToBeCompleted();
 
         connection.execute("INSERT INTO exclude_list_column_table_a VALUES(10, 120, 'a note', 'some_name')");
         TestHelper.waitForCdcRecord(connection, "exclude_list_column_table_a", rs -> rs.getInt("id") == 10);
 
         final SourceRecords records = consumeRecordsByTopic(1);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.exclude_list_column_table_a");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.exclude_list_column_table_a");
 
         Schema expectedSchemaA = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.exclude_list_column_table_a.Value")
+                .name("server1.testDB1.dbo.exclude_list_column_table_a.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
@@ -1648,17 +1648,17 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
-        waitForSnapshotToBeCompleted("sql_server", "server1");
+        TestHelper.waitForSnapshotToBeCompleted();
 
         connection.execute("INSERT INTO include_list_column_table_a VALUES(10, 120, 'a note', 'some_name')");
         TestHelper.waitForCdcRecord(connection, "include_list_column_table_a", rs -> rs.getInt("id") == 10);
 
         final SourceRecords records = consumeRecordsByTopic(1);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.include_list_column_table_a");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.include_list_column_table_a");
 
         Schema expectedSchemaA = SchemaBuilder.struct()
                 .optional()
-                .name("server1.dbo.include_list_column_table_a.Value")
+                .name("server1.testDB1.dbo.include_list_column_table_a.Value")
                 .field("id", Schema.INT32_SCHEMA)
                 .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                 .build();
@@ -1720,7 +1720,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         }
 
         start(SqlServerConnector.class, config, record -> {
-            if (!"server1.dbo.tablea.Envelope".equals(record.valueSchema().name())) {
+            if (!"server1.testDB1.dbo.tablea.Envelope".equals(record.valueSchema().name())) {
                 return false;
             }
             final Struct envelope = (Struct) record.value();
@@ -1774,8 +1774,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         records = sourceRecords.allRecordsInOrder();
         assertThat(records).hasSize(RECORDS_PER_TABLE);
 
-        List<SourceRecord> tableA = sourceRecords.recordsForTopic("server1.dbo.tablea");
-        List<SourceRecord> tableB = sourceRecords.recordsForTopic("server1.dbo.tableb");
+        List<SourceRecord> tableA = sourceRecords.recordsForTopic("server1.testDB1.dbo.tablea");
+        List<SourceRecord> tableB = sourceRecords.recordsForTopic("server1.testDB1.dbo.tableb");
         for (int i = 0; i < RECORDS_PER_TABLE / 2; i++) {
             final int id = HALF_ID + i;
             final SourceRecord recordA = tableA.get(i);
@@ -1809,8 +1809,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         TestHelper.waitForCdcRecord(connection, "tableb", rs -> rs.getInt("id") == (ID_RESTART + RECORDS_PER_TABLE - 1));
 
         sourceRecords = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        tableA = sourceRecords.recordsForTopic("server1.dbo.tablea");
-        tableB = sourceRecords.recordsForTopic("server1.dbo.tableb");
+        tableA = sourceRecords.recordsForTopic("server1.testDB1.dbo.tablea");
+        tableB = sourceRecords.recordsForTopic("server1.testDB1.dbo.tableb");
 
         Assertions.assertThat(tableA).hasSize(RECORDS_PER_TABLE);
         Assertions.assertThat(tableB).hasSize(RECORDS_PER_TABLE);
@@ -1917,19 +1917,19 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         // Wait for snapshot completion
         SourceRecords records = consumeRecordsByTopic(1);
-        assertThat(records.recordsForTopic("server1.dbo.keyless").get(0).key()).isNull();
-        assertThat(records.recordsForTopic("server1.dbo.keyless").get(0).keySchema()).isNull();
+        assertThat(records.recordsForTopic("server1.testDB1.dbo.keyless").get(0).key()).isNull();
+        assertThat(records.recordsForTopic("server1.testDB1.dbo.keyless").get(0).keySchema()).isNull();
 
         connection.execute(
                 "INSERT INTO keyless VALUES(2, 'k')");
         records = consumeRecordsByTopic(1);
-        assertThat(records.recordsForTopic("server1.dbo.keyless").get(0).key()).isNull();
-        assertThat(records.recordsForTopic("server1.dbo.keyless").get(0).key()).isNull();
+        assertThat(records.recordsForTopic("server1.testDB1.dbo.keyless").get(0).key()).isNull();
+        assertThat(records.recordsForTopic("server1.testDB1.dbo.keyless").get(0).key()).isNull();
 
         connection.execute(
                 "UPDATE keyless SET id=3 WHERE ID=2");
         records = consumeRecordsByTopic(3);
-        final SourceRecord update1 = records.recordsForTopic("server1.dbo.keyless").get(0);
+        final SourceRecord update1 = records.recordsForTopic("server1.testDB1.dbo.keyless").get(0);
 
         assertThat(update1.key()).isNull();
         assertThat(update1.keySchema()).isNull();
@@ -1939,9 +1939,9 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         connection.execute(
                 "DELETE FROM keyless WHERE id=3");
         records = consumeRecordsByTopic(2, false);
-        assertThat(records.recordsForTopic("server1.dbo.keyless").get(0).key()).isNull();
-        assertThat(records.recordsForTopic("server1.dbo.keyless").get(0).keySchema()).isNull();
-        assertNull(records.recordsForTopic("server1.dbo.keyless").get(1).value());
+        assertThat(records.recordsForTopic("server1.testDB1.dbo.keyless").get(0).key()).isNull();
+        assertThat(records.recordsForTopic("server1.testDB1.dbo.keyless").get(0).keySchema()).isNull();
+        assertNull(records.recordsForTopic("server1.testDB1.dbo.keyless").get(1).value());
 
         stopConnector();
     }
@@ -1965,7 +1965,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         start(SqlServerConnector.class, config);
 
         SourceRecords records = consumeRecordsByTopic(1);
-        List<SourceRecord> recordsForTopic = records.recordsForTopic("server1.dbo.keyless");
+        List<SourceRecord> recordsForTopic = records.recordsForTopic("server1.testDB1.dbo.keyless");
         assertThat(recordsForTopic.get(0).key()).isNotNull();
         Struct key = (Struct) recordsForTopic.get(0).key();
         Assertions.assertThat(key.get("id")).isNotNull();
@@ -1997,17 +1997,17 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         connection.execute(
                 "INSERT INTO table_schema_test (key_cola, key_colb, cola, colb, colc, cold) VALUES(1, 'a', 100, '2019-01-01 10:20:39.1234567 +02:00', 'some_value', 100.20)");
 
-        List<SourceRecord> records = consumeRecordsByTopic(1).recordsForTopic("server1.dbo.table_schema_test");
+        List<SourceRecord> records = consumeRecordsByTopic(1).recordsForTopic("server1.testDB1.dbo.table_schema_test");
         assertThat(records).hasSize(1);
         SourceRecordAssert.assertThat(records.get(0))
                 .keySchemaIsEqualTo(SchemaBuilder.struct()
-                        .name("server1.dbo.table_schema_test.Key")
+                        .name("server1.testDB1.dbo.table_schema_test.Key")
                         .field("key_cola", Schema.INT32_SCHEMA)
                         .field("key_colb", Schema.STRING_SCHEMA)
                         .build())
                 .valueAfterFieldSchemaIsEqualTo(SchemaBuilder.struct()
                         .optional()
-                        .name("server1.dbo.table_schema_test.Value")
+                        .name("server1.testDB1.dbo.table_schema_test.Value")
                         .field("key_cola", Schema.INT32_SCHEMA)
                         .field("key_colb", Schema.STRING_SCHEMA)
                         .field("cola", Schema.INT32_SCHEMA)
@@ -2041,7 +2041,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         Awaitility.await().atMost(30, TimeUnit.SECONDS).pollInterval(100, TimeUnit.MILLISECONDS).until(() -> {
             Testing.debug("Waiting for initial changes to be propagated to CDC structures");
-            return connection.getMaxLsn(TestHelper.TEST_DATABASE).isAvailable();
+            return connection.getMaxLsn(TestHelper.TEST_DATABASE_1).isAvailable();
         });
 
         start(SqlServerConnector.class, config);
@@ -2103,8 +2103,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         }
 
         final SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.tablea");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablea");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(tableA).hasSize(RECORDS_PER_TABLE);
         Assertions.assertThat(tableB).hasSize(RECORDS_PER_TABLE);
         for (int i = 0; i < RECORDS_PER_TABLE; i++) {
@@ -2133,7 +2133,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         final int ID_START = 10;
         final Configuration config = TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
-                .with("column.mask.with.4.chars", "testDB.dbo.tablea.cola")
+                .with("column.mask.with.4.chars", "testDB1.dbo.tablea.cola")
                 .build();
 
         start(SqlServerConnector.class, config);
@@ -2151,8 +2151,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         }
 
         final SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.tablea");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablea");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(tableA).hasSize(RECORDS_PER_TABLE);
         Assertions.assertThat(tableB).hasSize(RECORDS_PER_TABLE);
         for (int i = 0; i < RECORDS_PER_TABLE; i++) {
@@ -2181,7 +2181,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         final int ID_START = 10;
         final Configuration config = TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
-                .with(SqlServerConnectorConfig.MSG_KEY_COLUMNS, "testDB.dbo.tablea:cola")
+                .with(SqlServerConnectorConfig.MSG_KEY_COLUMNS, "testDB1.dbo.tablea:cola")
                 .build();
 
         start(SqlServerConnector.class, config);
@@ -2199,8 +2199,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         }
 
         final SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.tablea");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablea");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(tableA).hasSize(RECORDS_PER_TABLE);
         Assertions.assertThat(tableB).hasSize(RECORDS_PER_TABLE);
         for (int i = 0; i < RECORDS_PER_TABLE; i++) {
@@ -2247,8 +2247,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         }
 
         final SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.tablea");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablea");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(tableA).hasSize(RECORDS_PER_TABLE);
         Assertions.assertThat(tableB).hasSize(RECORDS_PER_TABLE);
         for (int i = 0; i < RECORDS_PER_TABLE; i++) {
@@ -2283,11 +2283,11 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
-        waitForSnapshotToBeCompleted("sql_server", "server1");
+        TestHelper.waitForSnapshotToBeCompleted();
         connection.execute("INSERT INTO dt_table (id,c1,c2,c3a,c3b,f1,f2) values (1, 123, 456, 789.01, 'test', 1.228, 234.56)");
 
         SourceRecords records = consumeRecordsByTopic(1);
-        List<SourceRecord> recordsForTopic = records.recordsForTopic("server1.dbo.dt_table");
+        List<SourceRecord> recordsForTopic = records.recordsForTopic("server1.testDB1.dbo.dt_table");
 
         final SourceRecord record = recordsForTopic.get(0);
         final Field before = record.valueSchema().field("before");
@@ -2364,8 +2364,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         }
 
         final SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.tablea");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablea");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(tableA).hasSize(RECORDS_PER_TABLE);
         Assertions.assertThat(tableB).hasSize(RECORDS_PER_TABLE);
 
@@ -2399,8 +2399,8 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         }
 
         final SourceRecords records = consumeRecordsByTopic(RECORDS_PER_TABLE * TABLES);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.tablea");
-        final List<SourceRecord> tableB = records.recordsForTopic("server1.dbo.tableb");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablea");
+        final List<SourceRecord> tableB = records.recordsForTopic("server1.testDB1.dbo.tableb");
         Assertions.assertThat(tableA).hasSize(RECORDS_PER_TABLE);
         Assertions.assertThat(tableB).hasSize(RECORDS_PER_TABLE);
 
@@ -2428,7 +2428,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO tablea VALUES(203, 'insert203')");
 
         final SourceRecords records = consumeRecordsByTopic(3);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.dbo.tablea");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablea");
         Assertions.assertThat(tableA).hasSize(3);
         tableA.forEach((SourceRecord record) -> {
             Struct value = (Struct) record.value();
@@ -2476,22 +2476,22 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
     @Test
     @FixFor("DBZ-2975")
     public void shouldIncludeDatabaseNameIntoTopicAndSchemaNamesInMultiPartitionMode() throws Exception {
-        final Configuration config = TestHelper.defaultMultiPartitionConfig()
+        final Configuration config = TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
                 .build();
 
         start(SqlServerConnector.class, config);
         assertConnectorIsRunning();
 
-        TestHelper.waitForDatabaseSnapshotToBeCompleted(TestHelper.TEST_DATABASE);
+        TestHelper.waitForDatabaseSnapshotToBeCompleted(TestHelper.TEST_DATABASE_1);
 
         final SourceRecords records = consumeRecordsByTopic(1);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB.dbo.tablea");
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.tablea");
         Assertions.assertThat(tableA).hasSize(1);
 
         final SourceRecord record = tableA.get(0);
-        assertThat(record.keySchema().name()).isEqualTo("server1.testDB.dbo.tablea.Key");
-        assertThat(record.valueSchema().name()).isEqualTo("server1.testDB.dbo.tablea.Envelope");
+        assertThat(record.keySchema().name()).isEqualTo("server1.testDB1.dbo.tablea.Key");
+        assertThat(record.valueSchema().name()).isEqualTo("server1.testDB1.dbo.tablea.Envelope");
     }
 
     @Test
@@ -2539,12 +2539,12 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO tableb VALUES(1001, 'b')");
 
         SourceRecords records = consumeRecordsByTopic(4);
-        List<SourceRecord> tableS1A = records.recordsForTopic("server1.s1.tablea");
-        List<SourceRecord> tableS1B = records.recordsForTopic("server1.s1.tableb");
-        List<SourceRecord> tableS2A = records.recordsForTopic("server1.s2.tablea");
-        List<SourceRecord> tableS2B = records.recordsForTopic("server1.s2.tableb");
-        List<SourceRecord> tableDboA = records.recordsForTopic("server1.dbo.tablea");
-        List<SourceRecord> tableDboB = records.recordsForTopic("server1.dbo.tableb");
+        List<SourceRecord> tableS1A = records.recordsForTopic("server1.testDB1.s1.tablea");
+        List<SourceRecord> tableS1B = records.recordsForTopic("server1.testDB1.s1.tableb");
+        List<SourceRecord> tableS2A = records.recordsForTopic("server1.testDB1.s2.tablea");
+        List<SourceRecord> tableS2B = records.recordsForTopic("server1.testDB1.s2.tableb");
+        List<SourceRecord> tableDboA = records.recordsForTopic("server1.testDB1.dbo.tablea");
+        List<SourceRecord> tableDboB = records.recordsForTopic("server1.testDB1.dbo.tableb");
 
         assertNull(tableS1A);
         assertNull(tableS1B);
@@ -2572,12 +2572,12 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO s1.tableb VALUES(2, 2)");
 
         records = consumeRecordsByTopic(2);
-        tableS2A = records.recordsForTopic("server1.s2.tablea");
-        tableS2B = records.recordsForTopic("server1.s2.tableb");
-        tableDboA = records.recordsForTopic("server1.dbo.tablea");
-        tableDboB = records.recordsForTopic("server1.dbo.tableb");
-        tableS1A = records.recordsForTopic("server1.s1.tablea");
-        tableS1B = records.recordsForTopic("server1.s1.tableb");
+        tableS2A = records.recordsForTopic("server1.testDB1.s2.tablea");
+        tableS2B = records.recordsForTopic("server1.testDB1.s2.tableb");
+        tableDboA = records.recordsForTopic("server1.testDB1.dbo.tablea");
+        tableDboB = records.recordsForTopic("server1.testDB1.dbo.tableb");
+        tableS1A = records.recordsForTopic("server1.testDB1.s1.tablea");
+        tableS1B = records.recordsForTopic("server1.testDB1.s1.tableb");
 
         Assertions.assertThat(tableS1A).hasSize(1);
         Assertions.assertThat(tableS1B).hasSize(1);
@@ -2592,17 +2592,17 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
     @Test
     @FixFor("DBZ-5033")
     public void shouldIgnoreNullOffsetsWhenRecoveringHistory() {
-        final Configuration config1 = TestHelper.defaultMultiPartitionConfig()
+        final Configuration config1 = TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_ONLY)
                 .build();
         start(SqlServerConnector.class, config1);
         assertConnectorIsRunning();
-        TestHelper.waitForDatabaseSnapshotToBeCompleted(TestHelper.TEST_DATABASE);
+        TestHelper.waitForDatabaseSnapshotToBeCompleted(TestHelper.TEST_DATABASE_1);
         stopConnector();
 
         TestHelper.createTestDatabases(TestHelper.TEST_DATABASE_2);
-        final Configuration config2 = TestHelper.defaultMultiPartitionConfig(
-                TestHelper.TEST_DATABASE, TestHelper.TEST_DATABASE_2)
+        final Configuration config2 = TestHelper.defaultConfig(
+                TestHelper.TEST_DATABASE_1, TestHelper.TEST_DATABASE_2)
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
                 .build();
         start(SqlServerConnector.class, config2);

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorMultiPartitionModeIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorMultiPartitionModeIT.java
@@ -60,7 +60,7 @@ public class SqlServerConnectorMultiPartitionModeIT extends AbstractConnectorTes
 
     @Test
     public void snapshotAndStreaming() throws Exception {
-        final Configuration config = TestHelper.defaultMultiPartitionConfig(
+        final Configuration config = TestHelper.defaultConfig(
                 TestHelper.TEST_DATABASE_1,
                 TestHelper.TEST_DATABASE_2)
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SqlServerConnectorConfig.SnapshotMode.INITIAL)
@@ -94,7 +94,7 @@ public class SqlServerConnectorMultiPartitionModeIT extends AbstractConnectorTes
                 "USE " + TestHelper.TEST_DATABASE_2,
                 "INSERT INTO tableA VALUES(6, 'a2s')");
 
-        TestHelper.waitForTaskStreamingStarted();
+        TestHelper.waitForStreamingStarted();
         records = consumeRecordsByTopic(2);
 
         tableA1 = records.recordsForTopic(TestHelper.topicName(TestHelper.TEST_DATABASE_1, "tableA"));

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorTest.java
@@ -35,7 +35,7 @@ public class SqlServerConnectorTest {
         config.put(SqlServerConnectorConfig.SERVER_NAME.name(), "dbserver1");
         config.put(SqlServerConnectorConfig.HOSTNAME.name(), "narnia");
         config.put(SqlServerConnectorConfig.PORT.name(), "4321");
-        config.put(SqlServerConnectorConfig.DATABASE_NAME.name(), "sqlserver");
+        config.put(SqlServerConnectorConfig.DATABASE_NAMES.name(), "sqlserver");
         config.put(SqlServerConnectorConfig.USER.name(), "pikachu");
         config.put(SqlServerConnectorConfig.PASSWORD.name(), "raichu");
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerPartitionTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerPartitionTest.java
@@ -11,11 +11,11 @@ public class SqlServerPartitionTest extends AbstractPartitionTest<SqlServerParti
 
     @Override
     protected SqlServerPartition createPartition1() {
-        return new SqlServerPartition("server1", "database1", false);
+        return new SqlServerPartition("server1", "database1");
     }
 
     @Override
     protected SqlServerPartition createPartition2() {
-        return new SqlServerPartition("server2", "database2", false);
+        return new SqlServerPartition("server2", "database2");
     }
 }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerSchemaNameAdjustmentModeIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerSchemaNameAdjustmentModeIT.java
@@ -76,7 +76,7 @@ public class SqlServerSchemaNameAdjustmentModeIT extends AbstractConnectorTest {
         TestHelper.waitForSnapshotToBeCompleted();
 
         SourceRecords records = consumeRecordsByTopic(1);
-        final List<SourceRecord> results = records.recordsForTopic("server1.dbo.name-adjustment");
+        final List<SourceRecord> results = records.recordsForTopic("server1.testDB1.dbo.name-adjustment");
         Assertions.assertThat(results).hasSize(1);
 
         return (Struct) results.get(0).value();

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TablesWithUniqueIndexOnlyIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TablesWithUniqueIndexOnlyIT.java
@@ -70,8 +70,8 @@ public class TablesWithUniqueIndexOnlyIT extends AbstractConnectorTest {
         final int expectedRecordsCount = 1;
 
         final SourceRecords records = consumeRecordsByTopic(expectedRecordsCount);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t1").get(0).keySchema().field("key1")).isNotNull();
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t1").get(0).keySchema().field("key2")).isNotNull();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t1").get(0).keySchema().field("key1")).isNotNull();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t1").get(0).keySchema().field("key2")).isNotNull();
     }
 
     @Test
@@ -90,14 +90,14 @@ public class TablesWithUniqueIndexOnlyIT extends AbstractConnectorTest {
         final int expectedRecordsCount = 1;
 
         SourceRecords records = consumeRecordsByTopic(expectedRecordsCount);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t1").get(0).keySchema().field("key1")).isNotNull();
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t1").get(0).keySchema().field("key2")).isNotNull();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t1").get(0).keySchema().field("key1")).isNotNull();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t1").get(0).keySchema().field("key2")).isNotNull();
 
         connection.execute("INSERT INTO t1 VALUES (2, 20, 'data2', 200);");
 
         records = consumeRecordsByTopic(expectedRecordsCount);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t1").get(0).keySchema().field("key1")).isNotNull();
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t1").get(0).keySchema().field("key2")).isNotNull();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t1").get(0).keySchema().field("key1")).isNotNull();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t1").get(0).keySchema().field("key2")).isNotNull();
 
         connection.execute(DDL_STATEMENTS_STREAM);
         TestHelper.enableTableCdc(connection, "t2", "t2_CT", Collect.arrayListOf("key1", "key2"));
@@ -105,7 +105,7 @@ public class TablesWithUniqueIndexOnlyIT extends AbstractConnectorTest {
         connection.execute("INSERT INTO t2 VALUES (2, 20, 'data2', 200);");
 
         records = consumeRecordsByTopic(expectedRecordsCount);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t2").get(0).keySchema().field("key1")).isNotNull();
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t2").get(0).keySchema().field("key2")).isNotNull();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t2").get(0).keySchema().field("key1")).isNotNull();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t2").get(0).keySchema().field("key2")).isNotNull();
     }
 }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TablesWithoutPrimaryKeyIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/TablesWithoutPrimaryKeyIT.java
@@ -68,11 +68,11 @@ public class TablesWithoutPrimaryKeyIT extends AbstractConnectorTest {
         final int expectedRecordsCount = 1 + 1 + 1;
 
         final SourceRecords records = consumeRecordsByTopic(expectedRecordsCount);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t1").get(0).keySchema().field("pk")).isNotNull();
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t1").get(0).keySchema().fields()).hasSize(1);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t2").get(0).keySchema().field("pk")).isNotNull();
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t2").get(0).keySchema().fields()).hasSize(1);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t3").get(0).keySchema()).isNull();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t1").get(0).keySchema().field("pk")).isNotNull();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t1").get(0).keySchema().fields()).hasSize(1);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t2").get(0).keySchema().field("pk")).isNotNull();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t2").get(0).keySchema().fields()).hasSize(1);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t3").get(0).keySchema()).isNull();
     }
 
     @Test
@@ -120,10 +120,10 @@ public class TablesWithoutPrimaryKeyIT extends AbstractConnectorTest {
         final int expectedRecordsCount = 1 + 1 + 1;
 
         final SourceRecords records = consumeRecordsByTopic(expectedRecordsCount, 24);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t1").get(0).keySchema().field("pk")).isNotNull();
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t1").get(0).keySchema().fields()).hasSize(1);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t2").get(0).keySchema().field("pk")).isNotNull();
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t2").get(0).keySchema().fields()).hasSize(1);
-        Assertions.assertThat(records.recordsForTopic("server1.dbo.t3").get(0).keySchema()).isNull();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t1").get(0).keySchema().field("pk")).isNotNull();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t1").get(0).keySchema().fields()).hasSize(1);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t2").get(0).keySchema().field("pk")).isNotNull();
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t2").get(0).keySchema().fields()).hasSize(1);
+        Assertions.assertThat(records.recordsForTopic("server1.testDB1.dbo.t3").get(0).keySchema()).isNull();
     }
 }

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -204,10 +204,10 @@ _tableName_:: The name of the database table in which the change event occurred.
 For example, if `fulfillment` is the server name, and `dbo` is the schema name, and the database contains tables with the names `products`, `products_on_hand`, `customers`, and `orders`,
 the connector would stream change event records to the following Kafka topics:
 
-* `fulfillment.dbo.products`
-* `fulfillment.dbo.products_on_hand`
-* `fulfillment.dbo.customers`
-* `fulfillment.dbo.orders`
+* `fulfillment.testDB.dbo.products`
+* `fulfillment.testDB.dbo.products_on_hand`
+* `fulfillment.testDB.dbo.customers`
+* `fulfillment.testDB.dbo.orders`
 
 The connector applies similar naming conventions to label its internal database history topics, xref:about-the-debezium-sqlserver-connector-schema-change-topic[schema change topics], and xref:sqlserver-transaction-metadata[transaction metadata topics].
 
@@ -539,7 +539,7 @@ Every change event that captures a change to the `customers` table has the same 
             }
         ],
         "optional": false, // <3>
-        "name": "server1.dbo.customers.Key" // <4>
+        "name": "server1.testDB.dbo.customers.Key" // <4>
     },
     "payload": { // <5>
         "id": 1004
@@ -565,7 +565,7 @@ Every change event that captures a change to the `customers` table has the same 
 |Indicates whether the event key must contain a value in its `payload` field. In this example, a value in the key's payload is required. A value in the key's payload field is optional when a table does not have a primary key.
 
 |4
-|`server1.dbo.customers.Key`
+|`server1.dbo.testDB.customers.Key`
 a|Name of the schema that defines the structure of the key's payload. This schema describes the structure of the primary key for the table that was changed. Key schema names have the format _connector-name_._database-schema-name_._table-name_.`Key`. In this example: +
 
 * `server1` is the name of the connector that generated this event. +
@@ -657,7 +657,7 @@ The following example shows the value portion of a change event that the connect
           }
         ],
         "optional": true,
-        "name": "server1.dbo.customers.Value", // <2>
+        "name": "server1.dbo.testDB.customers.Value", // <2>
         "field": "before"
       },
       {
@@ -685,7 +685,7 @@ The following example shows the value portion of a change event that the connect
           }
         ],
         "optional": true,
-        "name": "server1.dbo.customers.Value",
+        "name": "server1.dbo.testDB.customers.Value",
         "field": "after"
       },
       {
@@ -764,7 +764,7 @@ The following example shows the value portion of a change event that the connect
       }
     ],
     "optional": false,
-    "name": "server1.dbo.customers.Envelope" // <4>
+    "name": "server1.dbo.testDB.customers.Envelope" // <4>
   },
   "payload": { // <5>
     "before": null, // <6>
@@ -807,7 +807,7 @@ The following example shows the value portion of a change event that the connect
 |`name`
 a|In the `schema` section, each `name` field specifies the schema for a field in the value's payload. +
  +
-`server1.dbo.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table. +
+`server1.dbo.testDB.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table. +
  +
  Names of schemas for `before` and `after` fields are of the form `_logicalName_._database-schemaName_._tableName_.Value`, which ensures that the schema name is unique in the database.
  This means that when using the xref:{link-avro-serialization}#avro-serialization[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
@@ -818,7 +818,7 @@ a|`io.debezium.connector.sqlserver.Source` is the schema for the payload's `sour
 
 |4
 |`name`
-a|`server1.dbo.customers.Envelope` is the schema for the overall structure of the payload, where `server1` is the connector name, `dbo` is the database schema name, and `customers` is the table.
+a|`server1.dbo.testDB.customers.Envelope` is the schema for the overall structure of the payload, where `server1` is the connector name, `dbo` is the database schema name, and `customers` is the table.
 
 |5
 |`payload`
@@ -1094,11 +1094,11 @@ The following example shows a typical transaction boundary message:
   "event_count": 2,
   "data_collections": [
     {
-      "data_collection": "testDB.dbo.tablea",
+      "data_collection": "testDB.dbo.testDB.tablea",
       "event_count": 1
     },
     {
-      "data_collection": "testDB.dbo.tableb",
+      "data_collection": "testDB.dbo.testDB.tableb",
       "event_count": 1
     }
   ]
@@ -2060,12 +2060,6 @@ Can be omitted when using Kerberos authentication, which can be configured using
 |No default
 |Password to use when connecting to the SQL Server database server.
 
-|[[sqlserver-property-database-dbname]]<<sqlserver-property-database-dbname, `+database.dbname+`>>
-|No default
-|The name of the SQL Server database from which to stream the changes.
-ifdef::community[]
-Must not be used with `database.names`.
-endif::community[]
 |[[sqlserver-property-database-instance]] <<sqlserver-property-database-instance, `+database.instance+`>>
 |No default
 |Specifies the instance name of the link:https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/database-engine-instances-sql-server?view=sql-server-latest#instances[SQL Server named instance].
@@ -2074,15 +2068,6 @@ ifdef::community[]
 |[[sqlserver-property-database-names]]<<sqlserver-property-database-names, `+database.names+`>>
 |No default
 |The comma-separated list of the SQL Server database names from which to stream the changes.
-Currently, only one database name is supported. Must not be used with `database.dbname`.
-
-This option is *experimental* and must not be used in production. Using it will make the behavior of the connector
-incompatible with the default configuration with no upgrade or downgrade path:
-
-* The connector will use different keys for its committed offset messages.
-* The SQL statements used in `snapshot.select.statement.overrides` will have to use the database name
-  as part of the fully-qualified table name.
-* The structure of the exposed connector metrics will be different.
 endif::community[]
 |[[sqlserver-property-database-server-name]]<<sqlserver-property-database-server-name, `+database.server.name+`>>
 |No default


### PR DESCRIPTION
**Breaking changes**:

1. The `database.dbname` configuration parameter for the SQL Server connector is no longer supported.
2. The message keys in the Kafka Connect offsets topic are now expected to contain the source database name.
3. The database history is now expected to contain the database name in the source metadata of its messages.
4. The topic and the schema names now include the database name: `server1.dbo.MyTable` → `server1.testDB.dbo.MyTable`.
5. Snapshot SELECT override statements should now include the database name. Not sure how this is going to work with multiple databases. See: https://github.com/debezium/debezium/blob/f465f5ad8672ac4689cfc033e1c105d2e0901fe7/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SnapshotWithSelectOverridesIT.java#L112-L125 The closest open issue in Jira is [DBZ-4799](https://issues.redhat.com/browse/DBZ-4799) but there's no issue namely about overriding SELECT statements.
6. The connector metrics will be exposed in a different format. See https://github.com/debezium/debezium/pull/2946 for details and examples.

**TODO**:
- [x] Update documentation.

Documenting the upgrade path is tracked in [DBZ-4827](https://issues.redhat.com/browse/DBZ-4827).