### PR TITLE
DBZ-5295 Reselect LOB columns on Primary Key changes

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/BaseChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/BaseChangeRecordEmitter.java
@@ -5,31 +5,194 @@
  */
 package io.debezium.connector.oracle;
 
-import org.apache.kafka.connect.data.Struct;
+import java.nio.ByteBuffer;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
+import org.apache.kafka.connect.data.Struct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.DebeziumException;
 import io.debezium.data.Envelope.Operation;
+import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.Column;
 import io.debezium.relational.RelationalChangeRecordEmitter;
 import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchema;
 import io.debezium.util.Clock;
+import io.debezium.util.Strings;
+import oracle.jdbc.OracleTypes;
 
 /**
  * Base class to emit change data based on a single entry event.
  */
 public abstract class BaseChangeRecordEmitter<T> extends RelationalChangeRecordEmitter {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(BaseChangeRecordEmitter.class);
+
+    private final OracleConnectorConfig connectorConfig;
+    private final byte[] unavailableValuePlaceholderBinary;
+    private final String unavailableValuePlaceholderString;
+    private final Object[] oldColumnValues;
+    private final Object[] newColumnValues;
     protected final Table table;
 
-    protected BaseChangeRecordEmitter(Partition partition, OffsetContext offset, Table table, Clock clock) {
+    protected BaseChangeRecordEmitter(OracleConnectorConfig connectorConfig, Partition partition, OffsetContext offset,
+                                      Table table, Clock clock, Object[] oldColumnValues, Object[] newColumnValues) {
         super(partition, offset, clock);
+        this.connectorConfig = connectorConfig;
+        this.unavailableValuePlaceholderBinary = connectorConfig.getUnavailableValuePlaceholder();
+        this.unavailableValuePlaceholderString = new String(connectorConfig.getUnavailableValuePlaceholder());
+        this.oldColumnValues = oldColumnValues;
+        this.newColumnValues = newColumnValues;
         this.table = table;
     }
 
+    @Override
+    protected Object[] getOldColumnValues() {
+        return oldColumnValues;
+    }
+
+    @Override
+    protected Object[] getNewColumnValues() {
+        return newColumnValues;
+    }
+
+    @Override
     protected void emitTruncateRecord(Receiver receiver, TableSchema tableSchema) throws InterruptedException {
         Struct envelope = tableSchema.getEnvelopeSchema().truncate(getOffset().getSourceInfo(), getClock().currentTimeAsInstant());
         receiver.changeRecord(getPartition(), tableSchema, Operation.TRUNCATE, null, envelope, getOffset(), null);
     }
 
+    @Override
+    protected void emitUpdateAsPrimaryKeyChangeRecord(Receiver receiver, TableSchema tableSchema, Struct oldKey,
+            Struct newKey, Struct oldValue, Struct newValue) throws InterruptedException {
+        if (connectorConfig.isLobEnabled()) {
+            final List<Column> reselectColumns = getReselectColumns(newValue);
+            if (!reselectColumns.isEmpty()) {
+                LOGGER.info("Table '{}' primary key changed from '{}' to '{}' via an UPDATE, re-selecting LOB columns {} out of bands.",
+                            table.id(), oldKey, newKey, reselectColumns.stream().map(Column::name).collect(Collectors.toList()));
+
+                final String query = getReselectQuery(reselectColumns, table);
+                final JdbcConfiguration jdbcConfig = connectorConfig.getJdbcConfig();
+                try (OracleConnection connection = new OracleConnection(jdbcConfig, () -> getClass().getClassLoader(), false)) {
+                    if (!Strings.isNullOrBlank(connectorConfig.getPdbName())) {
+                        connection.setSessionToPdb(connectorConfig.getPdbName());
+                    }
+                    connection.prepareQuery(query,
+                                            ps -> prepareReselectQueryStatement(ps, table, newKey),
+                                            rs -> updateNewValuesFromReselectQueryResults(rs, reselectColumns));
+
+                    // newColumnValues have been updated via re-select, re-create the event's value
+                    //
+                    // NOTE: The conversion of the column data must occur within the current connection's context.
+                    // This is because the converters for LOB may make specific callbacks to the underlying database
+                    // and if the converter is called outside the scope of the current LOB object, the call will
+                    // fail due to database connection being unavailable.
+                    newValue = tableSchema.valueFromColumnData(newColumnValues);
+                }
+                catch (SQLException e) {
+                    throw new DebeziumException("Failed to re-select table with LOB columns due to primary key update", e);
+                }
+            }
+        }
+        super.emitUpdateAsPrimaryKeyChangeRecord(receiver, tableSchema, oldKey, newKey, oldValue, newValue);
+    }
+
+
+    /**
+     * Returns a list of columns that should be reselected.
+     *
+     * Currently, this method is only concerned about LOB-based columns and so if a table does not have any
+     * LOB columns or if the LOB column's value is not the unavailable value placeholder configured in the
+     * connector configuration, this method may return no columns indicating that a reselection is not
+     * required for the change event.
+     *
+     * @param newValue the currently constructed new value payload for the change event, should not be null
+     * @return list of columns that should be reselected, which can be empty
+     */
+    private List<Column> getReselectColumns(Struct newValue) {
+        // todo: eventually move this to the relational model to avoid needing to perform this iteration per change event
+        final List<Column> reselectColumns = new ArrayList<>();
+        for (Column column : table.columns()) {
+            switch (column.jdbcType()) {
+                case OracleTypes.CLOB:
+                case OracleTypes.NCLOB:
+                    if (newValue.get(column.name()).equals(unavailableValuePlaceholderString)) {
+                        reselectColumns.add(column);
+                    }
+                    break;
+                case OracleTypes.BLOB:
+                    if (newValue.get(column.name()).equals(ByteBuffer.wrap(unavailableValuePlaceholderBinary))) {
+                        reselectColumns.add(column);
+                    }
+                    break;
+            }
+        }
+        return reselectColumns;
+    }
+
+    /**
+     * Creates the reselect query, a query that explicitly only selects the LOB-based columns from the
+     * underlying relational table based on the event's current primary key value set.
+     *
+     * @param reselectColumns the columns that should be reselected, should never be null or empty
+     * @param table the relational table model
+     * @return the query string for the reselect query
+     */
+    private String getReselectQuery(List<Column> reselectColumns, Table table) {
+        final TableId id = new TableId(null, table.id().schema(), table.id().table());
+        final StringBuilder query = new StringBuilder("SELECT ")
+                .append(reselectColumns.stream().map(c -> '"' + c.name() + '"').collect(Collectors.joining(", ")))
+                .append(" FROM " )
+                .append(id.toDoubleQuotedString())
+                .append(" WHERE ");
+
+        for (int i = 0; i < table.primaryKeyColumnNames().size(); ++i) {
+            if (i > 0) {
+                query.append(" AND ");
+            }
+            query.append('"').append(table.primaryKeyColumnNames().get(i)).append("\"=?");
+        }
+
+        return query.toString();
+    }
+
+    /**
+     * Prepares the reselect query, binding the primary key column values
+     *
+     * @param ps the prepared statement
+     * @param table the relational model table
+     * @param newKey the row's new key
+     * @throws SQLException if a database error occurred
+     */
+    private void prepareReselectQueryStatement(PreparedStatement ps, Table table, Struct newKey) throws SQLException {
+        for (int i = 0; i < table.primaryKeyColumnNames().size(); ++i) {
+            ps.setObject(i + 1, newKey.get(table.primaryKeyColumnNames().get(i)));
+        }
+    }
+
+    /**
+     * Applies the reselect query results to the new column values object array.
+     *
+     * @param rs the reselect query result set
+     * @param reselectColumns the columns that were re-selected
+     * @throws SQLException if a database error occurred
+     */
+    private void updateNewValuesFromReselectQueryResults(ResultSet rs, List<Column> reselectColumns) throws SQLException {
+        if (rs.next()) {
+            for (int i = 0; i < reselectColumns.size(); ++i) {
+                final Column column = reselectColumns.get(i);
+                newColumnValues[column.position() - 1] = rs.getObject(i + 1);
+            }
+        }
+    }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/BaseChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/BaseChangeRecordEmitter.java
@@ -76,12 +76,13 @@ public abstract class BaseChangeRecordEmitter<T> extends RelationalChangeRecordE
 
     @Override
     protected void emitUpdateAsPrimaryKeyChangeRecord(Receiver receiver, TableSchema tableSchema, Struct oldKey,
-            Struct newKey, Struct oldValue, Struct newValue) throws InterruptedException {
+                                                      Struct newKey, Struct oldValue, Struct newValue)
+            throws InterruptedException {
         if (connectorConfig.isLobEnabled()) {
             final List<Column> reselectColumns = getReselectColumns(newValue);
             if (!reselectColumns.isEmpty()) {
                 LOGGER.info("Table '{}' primary key changed from '{}' to '{}' via an UPDATE, re-selecting LOB columns {} out of bands.",
-                            table.id(), oldKey, newKey, reselectColumns.stream().map(Column::name).collect(Collectors.toList()));
+                        table.id(), oldKey, newKey, reselectColumns.stream().map(Column::name).collect(Collectors.toList()));
 
                 final String query = getReselectQuery(reselectColumns, table);
                 final JdbcConfiguration jdbcConfig = connectorConfig.getJdbcConfig();
@@ -90,8 +91,8 @@ public abstract class BaseChangeRecordEmitter<T> extends RelationalChangeRecordE
                         connection.setSessionToPdb(connectorConfig.getPdbName());
                     }
                     connection.prepareQuery(query,
-                                            ps -> prepareReselectQueryStatement(ps, table, newKey),
-                                            rs -> updateNewValuesFromReselectQueryResults(rs, reselectColumns));
+                            ps -> prepareReselectQueryStatement(ps, table, newKey),
+                            rs -> updateNewValuesFromReselectQueryResults(rs, reselectColumns));
 
                     // newColumnValues have been updated via re-select, re-create the event's value
                     //
@@ -108,7 +109,6 @@ public abstract class BaseChangeRecordEmitter<T> extends RelationalChangeRecordE
         }
         super.emitUpdateAsPrimaryKeyChangeRecord(receiver, tableSchema, oldKey, newKey, oldValue, newValue);
     }
-
 
     /**
      * Returns a list of columns that should be reselected.
@@ -147,7 +147,7 @@ public abstract class BaseChangeRecordEmitter<T> extends RelationalChangeRecordE
         final TableId id = new TableId(null, table.id().schema(), table.id().table());
         final StringBuilder query = new StringBuilder("SELECT ")
                 .append(reselectColumns.stream().map(c -> '"' + c.name() + '"').collect(Collectors.joining(", ")))
-                .append(" FROM " )
+                .append(" FROM ")
                 .append(id.toDoubleQuotedString())
                 .append(" WHERE ");
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseSchema.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleDatabaseSchema.java
@@ -26,6 +26,7 @@ import io.debezium.relational.Tables;
 import io.debezium.schema.SchemaChangeEvent;
 import io.debezium.schema.TopicSelector;
 import io.debezium.util.SchemaNameAdjuster;
+
 import oracle.jdbc.OracleTypes;
 
 /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleValueConverters.java
@@ -123,6 +123,14 @@ public class OracleValueConverters extends JdbcValueConverters {
         this.unavailableValuePlaceholderString = new String(config.getUnavailableValuePlaceholder());
     }
 
+    public byte[] getUnavailableValuePlaceholderBinary() {
+        return unavailableValuePlaceholderBinary;
+    }
+
+    public String getUnavailableValuePlaceholderString() {
+        return unavailableValuePlaceholderString;
+    }
+
     @Override
     public SchemaBuilder schemaBuilder(Column column) {
         logger.debug("Building schema for column {} of type {} named {} with constraints ({},{})",

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerChangeRecordEmitter.java
@@ -7,7 +7,6 @@ package io.debezium.connector.oracle.logminer;
 
 import io.debezium.DebeziumException;
 import io.debezium.connector.oracle.BaseChangeRecordEmitter;
-
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.logminer.events.EventType;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerChangeRecordEmitter.java
@@ -7,6 +7,8 @@ package io.debezium.connector.oracle.logminer;
 
 import io.debezium.DebeziumException;
 import io.debezium.connector.oracle.BaseChangeRecordEmitter;
+
+import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.logminer.events.EventType;
 import io.debezium.data.Envelope.Operation;
 import io.debezium.pipeline.spi.OffsetContext;
@@ -20,20 +22,16 @@ import io.debezium.util.Clock;
 public class LogMinerChangeRecordEmitter extends BaseChangeRecordEmitter<Object> {
 
     private final Operation operation;
-    private final Object[] oldValues;
-    private final Object[] newValues;
 
-    public LogMinerChangeRecordEmitter(Partition partition, OffsetContext offset, Operation operation, Object[] oldValues,
-                                       Object[] newValues, Table table, Clock clock) {
-        super(partition, offset, table, clock);
-        this.oldValues = oldValues;
-        this.newValues = newValues;
+    public LogMinerChangeRecordEmitter(OracleConnectorConfig connectorConfig, Partition partition, OffsetContext offset,
+                                       Operation operation, Object[] oldValues, Object[] newValues, Table table, Clock clock) {
+        super(connectorConfig, partition, offset, table, clock, oldValues, newValues);
         this.operation = operation;
     }
 
-    public LogMinerChangeRecordEmitter(Partition partition, OffsetContext offset, EventType eventType, Object[] oldValues,
-                                       Object[] newValues, Table table, Clock clock) {
-        this(partition, offset, getOperation(eventType), oldValues, newValues, table, clock);
+    public LogMinerChangeRecordEmitter(OracleConnectorConfig connectorConfig, Partition partition, OffsetContext offset,
+                                       EventType eventType, Object[] oldValues, Object[] newValues, Table table, Clock clock) {
+        this(connectorConfig, partition, offset, getOperation(eventType), oldValues, newValues, table, clock);
     }
 
     private static Operation getOperation(EventType eventType) {
@@ -53,15 +51,5 @@ public class LogMinerChangeRecordEmitter extends BaseChangeRecordEmitter<Object>
     @Override
     public Operation getOperation() {
         return operation;
-    }
-
-    @Override
-    protected Object[] getOldColumnValues() {
-        return oldValues;
-    }
-
-    @Override
-    protected Object[] getNewColumnValues() {
-        return newValues;
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerChangeRecordEmitter.java
@@ -9,6 +9,7 @@ import io.debezium.DebeziumException;
 import io.debezium.connector.oracle.BaseChangeRecordEmitter;
 
 import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.logminer.events.EventType;
 import io.debezium.data.Envelope.Operation;
 import io.debezium.pipeline.spi.OffsetContext;
@@ -24,14 +25,16 @@ public class LogMinerChangeRecordEmitter extends BaseChangeRecordEmitter<Object>
     private final Operation operation;
 
     public LogMinerChangeRecordEmitter(OracleConnectorConfig connectorConfig, Partition partition, OffsetContext offset,
-                                       Operation operation, Object[] oldValues, Object[] newValues, Table table, Clock clock) {
-        super(connectorConfig, partition, offset, table, clock, oldValues, newValues);
+                                       Operation operation, Object[] oldValues, Object[] newValues, Table table,
+                                       OracleDatabaseSchema schema, Clock clock) {
+        super(connectorConfig, partition, offset, schema, table, clock, oldValues, newValues);
         this.operation = operation;
     }
 
     public LogMinerChangeRecordEmitter(OracleConnectorConfig connectorConfig, Partition partition, OffsetContext offset,
-                                       EventType eventType, Object[] oldValues, Object[] newValues, Table table, Clock clock) {
-        this(connectorConfig, partition, offset, getOperation(eventType), oldValues, newValues, table, clock);
+                                       EventType eventType, Object[] oldValues, Object[] newValues, Table table,
+                                       OracleDatabaseSchema schema, Clock clock) {
+        this(connectorConfig, partition, offset, getOperation(eventType), oldValues, newValues, table, schema, clock);
     }
 
     private static Operation getOperation(EventType eventType) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
@@ -6,12 +6,11 @@
 package io.debezium.connector.oracle.logminer.parser;
 
 import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.OracleValueConverters;
 import io.debezium.connector.oracle.logminer.LogMinerHelper;
 import io.debezium.relational.Column;
 import io.debezium.relational.Table;
-
-import oracle.jdbc.OracleTypes;
 
 /**
  * A simple DML parser implementation specifically for Oracle LogMiner.
@@ -672,13 +671,10 @@ public class LogMinerDmlParser implements DmlParser {
             return value;
         }
 
-        switch (column.jdbcType()) {
-            case OracleTypes.CLOB:
-            case OracleTypes.NCLOB:
-            case OracleTypes.BLOB:
-                return OracleValueConverters.UNAVAILABLE_VALUE;
-            default:
-                return null;
+        if (OracleDatabaseSchema.isClobColumn(column) || OracleDatabaseSchema.isBlobColumn(column)) {
+            return OracleValueConverters.UNAVAILABLE_VALUE;
         }
+
+        return null;
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/parser/LogMinerDmlParser.java
@@ -667,14 +667,9 @@ public class LogMinerDmlParser implements DmlParser {
     }
 
     private Object getColumnUnavailableValue(Object value, Column column) {
-        if (value != null) {
-            return value;
-        }
-
-        if (OracleDatabaseSchema.isClobColumn(column) || OracleDatabaseSchema.isBlobColumn(column)) {
+        if (value == null && OracleDatabaseSchema.isLobColumn(column)) {
             return OracleValueConverters.UNAVAILABLE_VALUE;
         }
-
-        return null;
+        return value;
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
@@ -402,6 +402,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
                                 dmlEvent.getDmlEntry().getOldValues(),
                                 dmlEvent.getDmlEntry().getNewValues(),
                                 getSchema().tableFor(event.getTableId()),
+                                getSchema(),
                                 Clock.system());
                     }
                     else {
@@ -413,6 +414,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
                                 dmlEvent.getDmlEntry().getOldValues(),
                                 dmlEvent.getDmlEntry().getNewValues(),
                                 getSchema().tableFor(event.getTableId()),
+                                getSchema(),
                                 Clock.system());
                     }
                     dispatcher.dispatchDataChangeEvent(partition, event.getTableId(), logMinerChangeRecordEmitter);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
@@ -395,6 +395,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
                         // a truncate event is seen by logminer as a DDL event type.
                         // So force this here to be a Truncate Operation.
                         logMinerChangeRecordEmitter = new LogMinerChangeRecordEmitter(
+                                connectorConfig,
                                 partition,
                                 offsetContext,
                                 Envelope.Operation.TRUNCATE,
@@ -405,6 +406,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
                     }
                     else {
                         logMinerChangeRecordEmitter = new LogMinerChangeRecordEmitter(
+                                connectorConfig,
                                 partition,
                                 offsetContext,
                                 dmlEvent.getEventType(),

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -223,7 +223,13 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         dispatcher.dispatchDataChangeEvent(
                 partition,
                 tableId,
-                new XStreamChangeRecordEmitter(partition, offsetContext, lcr, oldChunkValues, chunkValues,
+                new XStreamChangeRecordEmitter(
+                        connectorConfig,
+                        partition,
+                        offsetContext,
+                        lcr,
+                        oldChunkValues,
+                        chunkValues,
                         schema.tableFor(tableId), clock));
     }
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -31,7 +31,6 @@ import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
 
-import oracle.jdbc.OracleTypes;
 import oracle.streams.ChunkColumnValue;
 import oracle.streams.DDLLCR;
 import oracle.streams.DefaultRowLCR;
@@ -205,18 +204,13 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
         // is not explicitly provided in the map is initialized with the unavailable value
         // marker object so its transformed correctly by the value converters.
 
-        // todo: would be useful in the future to track some type of "has-lob" flag on the table
-        // such a flag would allow us to conditionalize this loop and only apply it to tables
-        // which have LOB columns.
-        for (Column column : table.columns()) {
-            if (isLobColumn(column)) {
-                // again Xstream doesn't supply before state for LOB values; explicitly use unavailable value
-                oldChunkValues.put(column.name(), OracleValueConverters.UNAVAILABLE_VALUE);
-                if (!chunkValues.containsKey(column.name())) {
-                    // Column not supplied, initialize with unavailable value marker
-                    LOGGER.trace("\tColumn '{}' not supplied, initialized with unavailable value", column.name());
-                    chunkValues.put(column.name(), OracleValueConverters.UNAVAILABLE_VALUE);
-                }
+        for (Column column : schema.getLobColumnsForTable(table.id())) {
+            // again Xstream doesn't supply before state for LOB values; explicitly use unavailable value
+            oldChunkValues.put(column.name(), OracleValueConverters.UNAVAILABLE_VALUE);
+            if (!chunkValues.containsKey(column.name())) {
+                // Column not supplied, initialize with unavailable value marker
+                LOGGER.trace("\tColumn '{}' not supplied, initialized with unavailable value", column.name());
+                chunkValues.put(column.name(), OracleValueConverters.UNAVAILABLE_VALUE);
             }
         }
 
@@ -230,7 +224,9 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
                         lcr,
                         oldChunkValues,
                         chunkValues,
-                        schema.tableFor(tableId), clock));
+                        schema.tableFor(tableId),
+                        schema,
+                        clock));
     }
 
     private void dispatchSchemaChangeEvent(DDLLCR ddlLcr) throws InterruptedException {
@@ -355,10 +351,6 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
     @Override
     public ChunkColumnValue createChunk() throws StreamsException {
         throw new UnsupportedOperationException("Should never be called");
-    }
-
-    private boolean isLobColumn(Column column) {
-        return column.jdbcType() == OracleTypes.CLOB || column.jdbcType() == OracleTypes.NCLOB || column.jdbcType() == OracleTypes.BLOB;
     }
 
     private void resolveAndDispatchCurrentChunkedRow() {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamChangeRecordEmitter.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import io.debezium.connector.oracle.BaseChangeRecordEmitter;
 import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.data.Envelope.Operation;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
@@ -29,8 +30,8 @@ public class XStreamChangeRecordEmitter extends BaseChangeRecordEmitter<ColumnVa
 
     public XStreamChangeRecordEmitter(OracleConnectorConfig connectorConfig, Partition partition, OffsetContext offset, RowLCR lcr,
                                       Map<String, Object> oldChunkValues, Map<String, Object> newChunkValues,
-                                      Table table, Clock clock) {
-        super(connectorConfig, partition, offset, table, clock, getColumnValues(table, lcr.getOldValues(), oldChunkValues),
+                                      Table table, OracleDatabaseSchema schema, Clock clock) {
+        super(connectorConfig, partition, offset, schema, table, clock, getColumnValues(table, lcr.getOldValues(), oldChunkValues),
               getColumnValues(table, lcr.getNewValues(), newChunkValues));
         this.lcr = lcr;
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamChangeRecordEmitter.java
@@ -8,6 +8,7 @@ package io.debezium.connector.oracle.xstream;
 import java.util.Map;
 
 import io.debezium.connector.oracle.BaseChangeRecordEmitter;
+import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.data.Envelope.Operation;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
@@ -25,16 +26,13 @@ import oracle.streams.RowLCR;
 public class XStreamChangeRecordEmitter extends BaseChangeRecordEmitter<ColumnValue> {
 
     private final RowLCR lcr;
-    private final Map<String, Object> oldChunkValues;
-    private final Map<String, Object> newChunkValues;
 
-    public XStreamChangeRecordEmitter(Partition partition, OffsetContext offset, RowLCR lcr,
+    public XStreamChangeRecordEmitter(OracleConnectorConfig connectorConfig, Partition partition, OffsetContext offset, RowLCR lcr,
                                       Map<String, Object> oldChunkValues, Map<String, Object> newChunkValues,
                                       Table table, Clock clock) {
-        super(partition, offset, table, clock);
+        super(connectorConfig, partition, offset, table, clock, getColumnValues(table, lcr.getOldValues(), oldChunkValues),
+              getColumnValues(table, lcr.getNewValues(), newChunkValues));
         this.lcr = lcr;
-        this.oldChunkValues = oldChunkValues;
-        this.newChunkValues = newChunkValues;
     }
 
     @Override
@@ -53,17 +51,7 @@ public class XStreamChangeRecordEmitter extends BaseChangeRecordEmitter<ColumnVa
         }
     }
 
-    @Override
-    protected Object[] getOldColumnValues() {
-        return getColumnValues(lcr.getOldValues(), oldChunkValues);
-    }
-
-    @Override
-    protected Object[] getNewColumnValues() {
-        return getColumnValues(lcr.getNewValues(), newChunkValues);
-    }
-
-    private Object[] getColumnValues(ColumnValue[] columnValues, Map<String, Object> chunkValues) {
+    private static Object[] getColumnValues(Table table, ColumnValue[] columnValues, Map<String, Object> chunkValues) {
         Object[] values = new Object[table.columns().size()];
         for (ColumnValue columnValue : columnValues) {
             int index = table.columnWithName(columnValue.getColumnName()).position() - 1;
@@ -78,5 +66,4 @@ public class XStreamChangeRecordEmitter extends BaseChangeRecordEmitter<ColumnVa
 
         return values;
     }
-
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/XStreamChangeRecordEmitter.java
@@ -32,7 +32,7 @@ public class XStreamChangeRecordEmitter extends BaseChangeRecordEmitter<ColumnVa
                                       Map<String, Object> oldChunkValues, Map<String, Object> newChunkValues,
                                       Table table, OracleDatabaseSchema schema, Clock clock) {
         super(connectorConfig, partition, offset, schema, table, clock, getColumnValues(table, lcr.getOldValues(), oldChunkValues),
-              getColumnValues(table, lcr.getNewValues(), newChunkValues));
+                getColumnValues(table, lcr.getNewValues(), newChunkValues));
         this.lcr = lcr;
     }
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
@@ -1689,6 +1689,66 @@ public class OracleBlobDataTypesIT extends AbstractConnectorTest {
         }
     }
 
+    @Test
+    @FixFor("DBZ-5295")
+    public void shouldReselectBlobAfterPrimaryKeyChange() throws Exception {
+        TestHelper.dropTable(connection, "dbz5295");
+        try {
+            connection.execute("create table dbz5295 (id numeric(9,0) primary key, data blob)");
+            TestHelper.streamTable(connection, "dbz5295");
+
+            Blob blob = createBlob(part(BIN_DATA, 0, 1024));
+            connection.prepareQuery("INSERT INTO dbz5295 (id,data) values (1,?)", ps -> ps.setBlob(1, blob), null);
+            connection.commit();
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ5295")
+                    .with(OracleConnectorConfig.LOB_ENABLED, true)
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            SourceRecords records = consumeRecordsByTopic(1);
+            List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("DBZ5295"));
+            assertThat(recordsForTopic).hasSize(1);
+
+            SourceRecord record = recordsForTopic.get(0);
+            Struct after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isEqualTo(getByteBufferFromBlob(blob));
+
+            connection.execute("UPDATE dbz5295 set id = 2 where id = 1");
+
+            // The update of the primary key causes a DELETE and a CREATE
+            records = consumeRecordsByTopic(3);
+            recordsForTopic = records.recordsForTopic(topicName("DBZ5295"));
+            assertThat(recordsForTopic).hasSize(3);
+
+            // First event is a delete
+            record = recordsForTopic.get(0);
+            VerifyRecord.isValidDelete(record, "ID", 1);
+            after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after).isNull();
+
+            // Second event is the tombstone
+            record = recordsForTopic.get(1);
+            VerifyRecord.isValidTombstone(record);
+
+            // Third event is the create
+            record = recordsForTopic.get(2);
+            VerifyRecord.isValidInsert(record, "ID", 2);
+            after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(2);
+            assertThat(after.get("DATA")).isEqualTo(getByteBufferFromBlob(blob));
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz5295");
+        }
+    }
+
     private static byte[] part(byte[] buffer, int start, int length) {
         return Arrays.copyOfRange(buffer, start, length);
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
@@ -533,7 +533,6 @@ public class OracleBlobDataTypesIT extends AbstractConnectorTest {
         // 2 deletes + 2 tombstones
         records = consumeRecordsByTopic(4);
         assertThat(records.recordsForTopic(topicName("BLOB_TEST"))).hasSize(4);
-        records.forEach(System.out::println);
 
         record = records.recordsForTopic(topicName("BLOB_TEST")).get(0);
         VerifyRecord.isValidDelete(record, "ID", 2);
@@ -687,7 +686,6 @@ public class OracleBlobDataTypesIT extends AbstractConnectorTest {
         // 2 deletes + 2 tombstones
         records = consumeRecordsByTopic(4);
         assertThat(records.recordsForTopic(topicName("BLOB_TEST"))).hasSize(4);
-        records.forEach(System.out::println);
 
         record = records.recordsForTopic(topicName("BLOB_TEST")).get(0);
         VerifyRecord.isValidDelete(record, "ID", 2);
@@ -875,7 +873,6 @@ public class OracleBlobDataTypesIT extends AbstractConnectorTest {
         // 2 deletes + 2 tombstones
         records = consumeRecordsByTopic(4);
         assertThat(records.recordsForTopic(topicName("BLOB_TEST"))).hasSize(4);
-        records.forEach(System.out::println);
 
         record = records.recordsForTopic(topicName("BLOB_TEST")).get(0);
         VerifyRecord.isValidDelete(record, "ID", 2);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBlobDataTypesIT.java
@@ -1746,6 +1746,75 @@ public class OracleBlobDataTypesIT extends AbstractConnectorTest {
         }
     }
 
+    @Test
+    @FixFor("DBZ-5295")
+    public void shouldReselectBlobAfterPrimaryKeyChangeWithRowDeletion() throws Exception {
+        TestHelper.dropTable(connection, "dbz5295");
+        try {
+            connection.execute("create table dbz5295 (id numeric(9,0) primary key, data blob)");
+            TestHelper.streamTable(connection, "dbz5295");
+
+            Blob blob = createBlob(part(BIN_DATA, 0, 1024));
+            connection.prepareQuery("INSERT INTO dbz5295 (id,data) values (1,?)", ps -> ps.setBlob(1, blob), null);
+            connection.commit();
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ5295")
+                    .with(OracleConnectorConfig.LOB_ENABLED, true)
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            SourceRecords records = consumeRecordsByTopic(1);
+            List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("DBZ5295"));
+            assertThat(recordsForTopic).hasSize(1);
+
+            SourceRecord record = recordsForTopic.get(0);
+            Struct after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isEqualTo(getByteBufferFromBlob(blob));
+
+            // Update the PK and then delete the row within the same transaction
+            connection.executeWithoutCommitting("UPDATE dbz5295 set id = 2 where id = 1");
+            connection.execute("DELETE FROM dbz5295 where id = 2");
+
+            // The update of the primary key causes a DELETE and a CREATE, mingled with a TOMBSTONE
+            records = consumeRecordsByTopic(4);
+            recordsForTopic = records.recordsForTopic(topicName("DBZ5295"));
+            assertThat(recordsForTopic).hasSize(4);
+
+            // First event: DELETE
+            record = recordsForTopic.get(0);
+            VerifyRecord.isValidDelete(record, "ID", 1);
+            after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after).isNull();
+
+            // Second event: TOMBSTONE
+            record = recordsForTopic.get(1);
+            VerifyRecord.isValidTombstone(record);
+
+            // Third event: CREATE
+            record = recordsForTopic.get(2);
+            VerifyRecord.isValidInsert(record, "ID", 2);
+            after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(2);
+            assertThat(after.get("DATA")).isEqualTo(getUnavailableValuePlaceholder(config));
+
+            // Fourth event: DELETE
+            record = recordsForTopic.get(3);
+            VerifyRecord.isValidDelete(record, "ID", 2);
+            Struct before = ((Struct) record.value()).getStruct(Envelope.FieldName.BEFORE);
+            assertThat(before.get("ID")).isEqualTo(2);
+            assertThat(before.get("DATA")).isEqualTo(getUnavailableValuePlaceholder(config));
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz5295");
+        }
+    }
+
     private static byte[] part(byte[] buffer, int start, int length) {
         return Arrays.copyOfRange(buffer, start, length);
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
@@ -2166,6 +2166,76 @@ public class OracleClobDataTypeIT extends AbstractConnectorTest {
         }
     }
 
+    @Test
+    @FixFor("DBZ-5295")
+    public void shouldReselectClobAfterPrimaryKeyChangeWithRowDeletion() throws Exception {
+        TestHelper.dropTable(connection, "dbz5295");
+        try {
+            connection.execute("create table dbz5295 (id numeric(9,0) primary key, data clob, data2 clob)");
+            TestHelper.streamTable(connection, "dbz5295");
+
+            connection.execute("INSERT INTO dbz5295 (id,data,data2) values (1,'Small clob data','Data2')");
+
+            Configuration config = TestHelper.defaultConfig()
+                    .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ5295")
+                    .with(OracleConnectorConfig.LOB_ENABLED, true)
+                    .build();
+
+            start(OracleConnector.class, config);
+            assertConnectorIsRunning();
+
+            waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+            SourceRecords records = consumeRecordsByTopic(1);
+            List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("DBZ5295"));
+            assertThat(recordsForTopic).hasSize(1);
+
+            SourceRecord record = recordsForTopic.get(0);
+            Struct after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(1);
+            assertThat(after.get("DATA")).isEqualTo("Small clob data");
+            assertThat(after.get("DATA2")).isEqualTo("Data2");
+
+            // Update the PK and then delete the row within the same transaction
+            connection.executeWithoutCommitting("UPDATE dbz5295 set id = 2 where id = 1");
+            connection.execute("DELETE FROM dbz5295 where id = 2");
+
+            // The update of the primary key causes a DELETE and a CREATE, mingled with a TOMBSTONE
+            records = consumeRecordsByTopic(4);
+            recordsForTopic = records.recordsForTopic(topicName("DBZ5295"));
+            assertThat(recordsForTopic).hasSize(4);
+
+            // First event: DELETE
+            record = recordsForTopic.get(0);
+            VerifyRecord.isValidDelete(record, "ID", 1);
+            after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after).isNull();
+
+            // Second event: TOMBSTONE
+            record = recordsForTopic.get(1);
+            VerifyRecord.isValidTombstone(record);
+
+            // Third event: CREATE
+            record = recordsForTopic.get(2);
+            VerifyRecord.isValidInsert(record, "ID", 2);
+            after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+            assertThat(after.get("ID")).isEqualTo(2);
+            assertThat(after.get("DATA")).isEqualTo(getUnavailableValuePlaceholder(config));
+            assertThat(after.get("DATA2")).isEqualTo(getUnavailableValuePlaceholder(config));
+
+            // Fourth event: DELETE
+            record = recordsForTopic.get(3);
+            VerifyRecord.isValidDelete(record, "ID", 2);
+            Struct before = ((Struct) record.value()).getStruct(Envelope.FieldName.BEFORE);
+            assertThat(before.get("ID")).isEqualTo(2);
+            assertThat(before.get("DATA")).isEqualTo(getUnavailableValuePlaceholder(config));
+            assertThat(before.get("DATA2")).isEqualTo(getUnavailableValuePlaceholder(config));
+        }
+        finally {
+            TestHelper.dropTable(connection, "dbz5295");
+        }
+    }
+
     private Clob createClob(String data) throws SQLException {
         Clob clob = connection.connection().createClob();
         clob.setString(1, data);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleClobDataTypeIT.java
@@ -649,7 +649,6 @@ public class OracleClobDataTypeIT extends AbstractConnectorTest {
         // 2 deletes + 2 tombstones
         records = consumeRecordsByTopic(4);
         assertThat(records.recordsForTopic(topicName("CLOB_TEST"))).hasSize(4);
-        records.forEach(System.out::println);
 
         record = records.recordsForTopic(topicName("CLOB_TEST")).get(0);
         VerifyRecord.isValidDelete(record, "ID", 2);
@@ -1649,7 +1648,6 @@ public class OracleClobDataTypeIT extends AbstractConnectorTest {
             // but not merged since event merging happens only when LOB is enabled. Xstream handles
             // this automatically hence the reason why it has 1 less event in the stream.
             sourceRecords = consumeRecordsByTopic(logMinerAdapter ? 4 : 3);
-            sourceRecords.allRecordsInOrder().forEach(System.out::println);
             table = sourceRecords.recordsForTopic(topicName("DBZ3645"));
             VerifyRecord.isValidDelete(table.get(0), "ID", 5);
             VerifyRecord.isValidTombstone(table.get(1), "ID", 5);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -38,6 +38,7 @@ import java.util.stream.IntStream;
 
 import javax.management.InstanceNotFoundException;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigValue;
@@ -2810,6 +2811,58 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         assertThat(recordsForTopic).hasSize(1);
         assertInsert(recordsForTopic.get(0), PK_FIELD, 1);
         System.out.println(recordsForTopic.get(0));
+    }
+
+    @Test
+    @FixFor("DBZ-5295")
+    public void shouldReselectToastColumnsOnPrimaryKeyChange() throws Exception {
+        TestHelper.execute(CREATE_TABLES_STMT);
+
+        final String toastValue1 = RandomStringUtils.randomAlphanumeric(10000);
+        final String toastValue2 = RandomStringUtils.randomAlphanumeric(10000);
+
+        TestHelper.execute("CREATE TABLE s1.dbz5295 (pk serial, data text, data2 text, primary key(pk));");
+        TestHelper.execute("ALTER TABLE s1.dbz5295 REPLICA IDENTITY FULL;");
+        TestHelper.execute("INSERT INTO s1.dbz5295 (pk,data,data2) values (1,'" + toastValue1 + "','" + toastValue2 + "');");
+
+        Configuration config = TestHelper.defaultConfig().build();
+        start(PostgresConnector.class, config);
+        waitForStreamingRunning();
+
+        SourceRecords records = consumeRecordsByTopic(1);
+        List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("s1.dbz5295"));
+        assertThat(recordsForTopic).hasSize(1);
+
+        SourceRecord record = recordsForTopic.get(0);
+        Struct after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(after.get("pk")).isEqualTo(1);
+        assertThat(after.get("data")).isEqualTo(toastValue1);
+        assertThat(after.get("data2")).isEqualTo(toastValue2);
+
+        TestHelper.execute("UPDATE s1.dbz5295 SET pk = 2 WHERE pk = 1;");
+
+        // The update of the primary key causes a DELETE and a CREATE, mingled with a TOMBSTONE
+        records = consumeRecordsByTopic(3);
+        recordsForTopic = records.recordsForTopic(topicName("s1.dbz5295"));
+        assertThat(recordsForTopic).hasSize(3);
+
+        // First event: DELETE
+        record = recordsForTopic.get(0);
+        VerifyRecord.isValidDelete(record, "pk", 1);
+        after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(after).isNull();
+
+        // Second event: TOMBSTONE
+        record = recordsForTopic.get(1);
+        VerifyRecord.isValidTombstone(record);
+
+        // Third event: CREATE
+        record = recordsForTopic.get(2);
+        VerifyRecord.isValidInsert(record, "pk", 2);
+        after = ((Struct) record.value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(after.get("pk")).isEqualTo(2);
+        assertThat(after.get("data")).isEqualTo(toastValue1);
+        assertThat(after.get("data2")).isEqualTo(toastValue2);
     }
 
     private Predicate<SourceRecord> stopOnPKPredicate(int pkValue) {


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5295

This PR primarily focuses on two critical points:

1. Reselection of LOB column values when an UPDATE changes the row's primary key
2. Performance improvements by caching the LOB column state in `OracleDatabaseSchema`.

The latter point is similar to the TOAST column handling done with PostgreSQL where instead of needing to iterate the relational `Table` model on each change event, we iterate the model once at registration and cache information about whether the specified table has any LOB columns and use this cache during event processing.  This should improve performance, particularly for tables with larger numbers of columns than for those with fewer columns.

While I was unable to reproduce the same behavior with the PG connector, I did add a test case to the PG connector suite in case just so we have coverage for this going forward to avoid regressions.
