### PR TITLE
DBZ-5396 Add support for connector-specific relational model attributes

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/CreateTableParserListener.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/CreateTableParserListener.java
@@ -81,7 +81,7 @@ public class CreateTableParserListener extends MySqlParserBaseListener {
         TableId originalTableId = parser.parseQualifiedTableId(ctx.tableName(1).fullId());
         Table original = parser.databaseTables().forTable(originalTableId);
         if (original != null) {
-            parser.databaseTables().overwriteTable(tableId, original.columns(), original.primaryKeyColumnNames(), original.defaultCharsetName());
+            parser.databaseTables().overwriteTable(tableId, original.columns(), original.primaryKeyColumnNames(), original.defaultCharsetName(), original.attributes());
             parser.signalCreateTable(tableId, ctx);
         }
         super.exitCopyCreateTable(ctx);

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
@@ -217,7 +217,7 @@ public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChange
                             .collect(Collectors.toList());
 
                     snapshotContext.tables.overwriteTable(sourceTable.id(), cdcEnabledSourceColumns,
-                            cdcEnabledPkColumns, sourceTable.defaultCharsetName());
+                            cdcEnabledPkColumns, sourceTable.defaultCharsetName(), sourceTable.attributes());
                 }
             });
         }

--- a/debezium-core/src/main/java/io/debezium/relational/Attribute.java
+++ b/debezium-core/src/main/java/io/debezium/relational/Attribute.java
@@ -5,6 +5,9 @@
  */
 package io.debezium.relational;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
 import io.debezium.annotation.Immutable;
 
 /**
@@ -36,6 +39,63 @@ public interface Attribute {
      * @return the value of the attribute, may be null
      */
     String value();
+
+    /**
+     * Get the attribute value as a string value.
+     *
+     * @return the attribute value converted to a {@link String}, may be null
+     */
+    String asString();
+
+    /**
+     * Get the attribute value as an integer value.
+     *
+     * @return the attribute value converted to an {@link Integer}, may be null
+     */
+    Integer asInteger();
+
+    /**
+     * Get the attribute value as a long value.
+     *
+     * @return the attribute value converted to a {@link Long}, may be null
+     */
+    Long asLong();
+
+    /**
+     * Get the attribute value as a boolean value.
+     * This conversion is based on {@link Boolean#parseBoolean(String)} semantics.
+     *
+     * @return the attribute value converted to a {@link Boolean}, may be null
+     */
+    Boolean asBoolean();
+
+    /**
+     * Get the attribute value as a big integer value.
+     *
+     * @return the attribute value converted to a {@link BigInteger}, may be null
+     */
+    BigInteger asBigInteger();
+
+    /**
+     * Get the attribute value as a big decimal value.
+     *
+     * @return the attribute value converted to a {@link BigDecimal}, may be null
+     */
+    BigDecimal asBigDecimal();
+
+    /**
+     * Get the attribute value as a float value.
+     *
+     * @return the attribute value converted to a {@link Float}, may be null
+     */
+    Float asFloat();
+
+    /**
+     * Get the attribute value as a double value.
+     *
+     * @return the attribute value converted to a {@link Double}, may be null
+     */
+    Double asDouble();
 
     /**
      * Obtain an editor that contains the same information as this attribute.

--- a/debezium-core/src/main/java/io/debezium/relational/Attribute.java
+++ b/debezium-core/src/main/java/io/debezium/relational/Attribute.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import io.debezium.annotation.Immutable;
+
+/**
+ * An immutable attribute associated with a relational table.
+ *
+ * @author Chris Cranford
+ */
+@Immutable
+public interface Attribute {
+    /**
+     * Obtain an attribute editor that can be used to define an attribute.
+     *
+     * @return the editor; never null
+     */
+    static AttributeEditor editor() {
+        return new AttributeEditorImpl();
+    }
+
+    /**
+     * The attribute name.
+     *
+     * @return the name of the attribute, never null
+     */
+    String name();
+
+    /**
+     * The attribute value.
+     *
+     * @return the value of the attribute, may be null
+     */
+    String value();
+
+    /**
+     * Obtain an editor that contains the same information as this attribute.
+     *
+     * @return the editor; never null
+     */
+    AttributeEditor edit();
+}

--- a/debezium-core/src/main/java/io/debezium/relational/AttributeEditor.java
+++ b/debezium-core/src/main/java/io/debezium/relational/AttributeEditor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import io.debezium.annotation.NotThreadSafe;
+
+/**
+ * An editor for {@link Attribute} instances.
+ *
+ * @author Chris Cranford
+ */
+@NotThreadSafe
+public interface AttributeEditor {
+    /**
+     * Get the name of the attribute.
+     *
+     * @return the attribute name; may be null if not set
+     */
+    String name();
+
+    /**
+     * Get the value of the attribute.
+     *
+     * @return the attribute value; may be null if not set
+     */
+    String value();
+
+    /**
+     * Set the name of the attribute.
+     *
+     * @param name the attribute name
+     * @return this editor so callers can chain methods together
+     */
+    AttributeEditor name(String name);
+
+    /**
+     * Set the value of the attribute.
+     *
+     * @param value the attribute value
+     * @return this editor so callers can chain methods together
+     */
+    AttributeEditor value(String value);
+
+    /**
+     * Obtain an immutable attribute definition representing the current state of this editor.
+     * Typically, an editor is created and used to build an attribute, and then discarded. However, this editor
+     * with its current state can be reused after this method, since the resulting attribute definition no
+     * longer refers to any of the data used in this editor.
+     *
+     * @return the immutable attribute definition; never null
+     */
+    Attribute create();
+}

--- a/debezium-core/src/main/java/io/debezium/relational/AttributeEditor.java
+++ b/debezium-core/src/main/java/io/debezium/relational/AttributeEditor.java
@@ -5,6 +5,9 @@
  */
 package io.debezium.relational;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
 import io.debezium.annotation.NotThreadSafe;
 
 /**
@@ -29,6 +32,63 @@ public interface AttributeEditor {
     String value();
 
     /**
+     * Get the attribute value as a string value.
+     *
+     * @return the attribute value converted to a {@link String}, may be null
+     */
+    String asString();
+
+    /**
+     * Get the attribute value as an integer value.
+     *
+     * @return the attribute value converted to an {@link Integer}, may be null
+     */
+    Integer asInteger();
+
+    /**
+     * Get the attribute value as a long value.
+     *
+     * @return the attribute value converted to a {@link Long}, may be null
+     */
+    Long asLong();
+
+    /**
+     * Get the attribute value as a boolean value.
+     * This conversion is based on {@link Boolean#parseBoolean(String)} semantics.
+     *
+     * @return the attribute value converted to a {@link Boolean}, may be null
+     */
+    Boolean asBoolean();
+
+    /**
+     * Get the attribute value as a big integer value.
+     *
+     * @return the attribute value converted to a {@link BigInteger}, may be null
+     */
+    BigInteger asBigInteger();
+
+    /**
+     * Get the attribute value as a big decimal value.
+     *
+     * @return the attribute value converted to a {@link BigDecimal}, may be null
+     */
+    BigDecimal asBigDecimal();
+
+    /**
+     * Get the attribute value as a float value.
+     *
+     * @return the attribute value converted to a {@link Float}, may be null
+     */
+    Float asFloat();
+
+    /**
+     * Get the attribute value as a double value.
+     *
+     * @return the attribute value converted to a {@link Double}, may be null
+     */
+    Double asDouble();
+
+    /**
      * Set the name of the attribute.
      *
      * @param name the attribute name
@@ -42,7 +102,7 @@ public interface AttributeEditor {
      * @param value the attribute value
      * @return this editor so callers can chain methods together
      */
-    AttributeEditor value(String value);
+    AttributeEditor value(Object value);
 
     /**
      * Obtain an immutable attribute definition representing the current state of this editor.

--- a/debezium-core/src/main/java/io/debezium/relational/AttributeEditorImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/AttributeEditorImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+/**
+ * @author Chris Cranford
+ */
+final class AttributeEditorImpl implements AttributeEditor {
+
+    private String name;
+    private String value;
+
+    protected AttributeEditorImpl() {
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public AttributeEditor name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public AttributeEditor value(String value) {
+        this.value = value;
+        return this;
+    }
+
+    @Override
+    public Attribute create() {
+        return new AttributeImpl(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return create().toString();
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/relational/AttributeEditorImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/AttributeEditorImpl.java
@@ -5,7 +5,14 @@
  */
 package io.debezium.relational;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import io.debezium.DebeziumException;
+
 /**
+ * Implementation of the {@link AttributeEditor} contract.
+ *
  * @author Chris Cranford
  */
 final class AttributeEditorImpl implements AttributeEditor {
@@ -27,14 +34,83 @@ final class AttributeEditorImpl implements AttributeEditor {
     }
 
     @Override
+    public String asString() {
+        return value;
+    }
+
+    @Override
+    public Integer asInteger() {
+        return value == null ? null : Integer.parseInt(value);
+    }
+
+    @Override
+    public Long asLong() {
+        return value == null ? null : Long.parseLong(value);
+    }
+
+    @Override
+    public Boolean asBoolean() {
+        return value == null ? null : Boolean.parseBoolean(value);
+    }
+
+    @Override
+    public BigInteger asBigInteger() {
+        return value == null ? null : new BigInteger(value);
+    }
+
+    @Override
+    public BigDecimal asBigDecimal() {
+        return value == null ? null : new BigDecimal(value);
+    }
+
+    @Override
+    public Float asFloat() {
+        return value == null ? null : Float.parseFloat(value);
+    }
+
+    @Override
+    public Double asDouble() {
+        return value == null ? null : Double.parseDouble(value);
+    }
+
+    @Override
     public AttributeEditor name(String name) {
         this.name = name;
         return this;
     }
 
     @Override
-    public AttributeEditor value(String value) {
-        this.value = value;
+    public AttributeEditor value(Object value) {
+        if (value == null) {
+            this.value = null;
+        }
+        else if (value instanceof String) {
+            this.value = (String) value;
+        }
+        else if (value instanceof Integer) {
+            this.value = Integer.toString((Integer) value);
+        }
+        else if (value instanceof Long) {
+            this.value = Long.toString((Long) value);
+        }
+        else if (value instanceof Boolean) {
+            this.value = Boolean.toString((Boolean) value);
+        }
+        else if (value instanceof BigInteger) {
+            this.value = value.toString();
+        }
+        else if (value instanceof BigDecimal) {
+            this.value = value.toString();
+        }
+        else if (value instanceof Float) {
+            this.value = Float.toString((Float) value);
+        }
+        else if (value instanceof Double) {
+            this.value = Double.toString((Double) value);
+        }
+        else {
+            throw new DebeziumException(value.getClass().getName() + " cannot be used for attribute values");
+        }
         return this;
     }
 

--- a/debezium-core/src/main/java/io/debezium/relational/AttributeImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/AttributeImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import java.util.Objects;
+
+/**
+ * Relational model implementation of {@link Attribute}.
+ *
+ * @author Chris Cranford
+ */
+final class AttributeImpl implements Attribute {
+
+    private final String name;
+    private final String value;
+
+    public AttributeImpl(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj instanceof Attribute) {
+            AttributeImpl attribute = (AttributeImpl) obj;
+            return Objects.equals(name, attribute.name) && Objects.equals(value, attribute.value);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return "name='" + name + "', value='" + value + "'";
+    }
+
+    @Override
+    public AttributeEditor edit() {
+        return Attribute.editor().name(name()).value(value());
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/relational/AttributeImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/AttributeImpl.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.relational;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Objects;
 
 /**
@@ -30,6 +32,46 @@ final class AttributeImpl implements Attribute {
     @Override
     public String value() {
         return value;
+    }
+
+    @Override
+    public String asString() {
+        return value;
+    }
+
+    @Override
+    public Integer asInteger() {
+        return value == null ? null : Integer.parseInt(value);
+    }
+
+    @Override
+    public Long asLong() {
+        return value == null ? null : Long.parseLong(value);
+    }
+
+    @Override
+    public Boolean asBoolean() {
+        return value == null ? null : Boolean.parseBoolean(value);
+    }
+
+    @Override
+    public BigInteger asBigInteger() {
+        return value == null ? null : new BigInteger(value);
+    }
+
+    @Override
+    public BigDecimal asBigDecimal() {
+        return value == null ? null : new BigDecimal(value);
+    }
+
+    @Override
+    public Float asFloat() {
+        return value == null ? null : Float.parseFloat(value);
+    }
+
+    @Override
+    public Double asDouble() {
+        return value == null ? null : Double.parseDouble(value);
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/relational/NoOpTableEditorImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/NoOpTableEditorImpl.java
@@ -133,6 +133,31 @@ final class NoOpTableEditorImpl implements TableEditor {
     }
 
     @Override
+    public List<Attribute> attributes() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Attribute attributeWithName(String attributeName) {
+        return null;
+    }
+
+    @Override
+    public TableEditor addAttribute(Attribute attribute) {
+        return this;
+    }
+
+    @Override
+    public TableEditor addAttributes(List<Attribute> attributes) {
+        return this;
+    }
+
+    @Override
+    public TableEditor removeAttribute(String attributeName) {
+        return this;
+    }
+
+    @Override
     public String toString() {
         return create().toString();
     }
@@ -143,6 +168,7 @@ final class NoOpTableEditorImpl implements TableEditor {
             throw new IllegalStateException("Unable to create a table from an editor that has no table ID");
         }
         List<Column> columns = new ArrayList<>();
-        return new TableImpl(id, columns, primaryKeyColumnNames(), defaultCharsetName, comment);
+        List<Attribute> attributes = new ArrayList<>();
+        return new TableImpl(id, columns, primaryKeyColumnNames(), defaultCharsetName, comment, attributes);
     }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/Table.java
+++ b/debezium-core/src/main/java/io/debezium/relational/Table.java
@@ -103,6 +103,20 @@ public interface Table {
     String comment();
 
     /**
+     * Get the attributes of the table.
+     * @return the table attributes; may be null if not set
+     */
+    List<Attribute> attributes();
+
+    /**
+     * Get the definition for an attribute in this table with the supplied name.
+     *
+     * @param name the case-insensitive name of the attribute
+     * @return the attribute definition, or null if there is no attribute with the given name
+     */
+    Attribute attributeWithName(String name);
+
+    /**
      * Determine if the named column is part of the primary key.
      *
      * @param columnName the name of the column

--- a/debezium-core/src/main/java/io/debezium/relational/TableEditor.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableEditor.java
@@ -240,6 +240,47 @@ public interface TableEditor {
     boolean hasUniqueValues();
 
     /**
+     * Get the definitions for the attributes in this table. The resulting list should not be modified directly;
+     * instead, the attributes definitions should be defined with {@link #addAttribute(Attribute)} or
+     * {@link #removeAttribute(String)}.
+     *
+     * @return the list of attribute definitions; never null
+     */
+    List<Attribute> attributes();
+
+    /**
+     * Get the definition for the attribute in this table with the supplied name. The case of the supplied name does not matter.
+     *
+     * @param attributeName the attribute name
+     * @return the attribute definition; or null if no attribute exists with the given name
+     */
+    Attribute attributeWithName(String attributeName);
+
+    /**
+     * Add a new attribute to this table.
+     *
+     * @param attribute the definition for the attribute to be added
+     * @return this editor so callers can chain methods together
+     */
+    TableEditor addAttribute(Attribute attribute);
+
+    /**
+     * Add attributes to this table.
+     *
+     * @param attributes the list of attribute definitions to be added
+     * @return this editor so callers can chain methods together
+     */
+    TableEditor addAttributes(List<Attribute> attributes);
+
+    /**
+     * Remove an attribute from this table.
+     *
+     * @param attributeName the name of the attribute to be removed
+     * @return this editor so callers can chain methods togethe
+     */
+    TableEditor removeAttribute(String attributeName);
+
+    /**
      * Obtain an immutable table definition representing the current state of this editor. This editor can be reused
      * after this method, since the resulting table definition no longer refers to any of the data used in this editor.
      *

--- a/debezium-core/src/main/java/io/debezium/relational/TableEditorImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableEditorImpl.java
@@ -21,6 +21,7 @@ class TableEditorImpl implements TableEditor {
     private boolean uniqueValues = false;
     private String defaultCharsetName;
     private String comment;
+    private LinkedHashMap<String, Attribute> attributes = new LinkedHashMap<>();
 
     protected TableEditorImpl() {
     }
@@ -232,6 +233,40 @@ class TableEditorImpl implements TableEditor {
         return this;
     }
 
+    @Override
+    public List<Attribute> attributes() {
+        return Collections.unmodifiableList(new ArrayList<>(attributes.values()));
+    }
+
+    @Override
+    public Attribute attributeWithName(String attributeName) {
+        return attributes.get(attributeName.toLowerCase());
+    }
+
+    @Override
+    public TableEditor addAttribute(Attribute attribute) {
+        if (attribute != null) {
+            attributes.put(attribute.name().toLowerCase(), attribute);
+        }
+        return this;
+    }
+
+    @Override
+    public TableEditor addAttributes(List<Attribute> attributes) {
+        for (Attribute attribute : attributes) {
+            addAttribute(attribute);
+        }
+        return this;
+    }
+
+    @Override
+    public TableEditor removeAttribute(String attributeName) {
+        if (attributeName != null) {
+            attributes.remove(attributeName.toLowerCase());
+        }
+        return this;
+    }
+
     protected void updatePositions() {
         AtomicInteger position = new AtomicInteger(1);
         sortedColumns.replaceAll((name, defn) -> {
@@ -265,6 +300,7 @@ class TableEditorImpl implements TableEditor {
             columns.add(column);
         });
         updatePrimaryKeys();
-        return new TableImpl(id, columns, primaryKeyColumnNames(), defaultCharsetName, comment);
+        List<Attribute> attributes = new ArrayList<>(this.attributes.values());
+        return new TableImpl(id, columns, primaryKeyColumnNames(), defaultCharsetName, comment, attributes);
     }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/TableImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/TableImpl.java
@@ -22,14 +22,15 @@ final class TableImpl implements Table {
     private final Map<String, Column> columnsByLowercaseName;
     private final String defaultCharsetName;
     private final String comment;
+    private final List<Attribute> attributes;
 
     @PackagePrivate
     TableImpl(Table table) {
-        this(table.id(), table.columns(), table.primaryKeyColumnNames(), table.defaultCharsetName(), table.comment());
+        this(table.id(), table.columns(), table.primaryKeyColumnNames(), table.defaultCharsetName(), table.comment(), table.attributes());
     }
 
     @PackagePrivate
-    TableImpl(TableId id, List<Column> sortedColumns, List<String> pkColumnNames, String defaultCharsetName, String comment) {
+    TableImpl(TableId id, List<Column> sortedColumns, List<String> pkColumnNames, String defaultCharsetName, String comment, List<Attribute> attributes) {
         this.id = id;
         this.columnDefs = Collections.unmodifiableList(sortedColumns);
         this.pkColumnNames = pkColumnNames == null ? Collections.emptyList() : Collections.unmodifiableList(pkColumnNames);
@@ -40,6 +41,7 @@ final class TableImpl implements Table {
         this.columnsByLowercaseName = Collections.unmodifiableMap(defsByLowercaseName);
         this.defaultCharsetName = defaultCharsetName;
         this.comment = comment;
+        this.attributes = attributes;
     }
 
     @Override
@@ -77,6 +79,19 @@ final class TableImpl implements Table {
     @Override
     public String comment() {
         return comment;
+    }
+
+    @Override
+    public List<Attribute> attributes() {
+        return attributes;
+    }
+
+    @Override
+    public Attribute attributeWithName(String name) {
+        if (attributes == null) {
+            return null;
+        }
+        return attributes.stream().filter(a -> name.equalsIgnoreCase(a.name())).findFirst().orElse(null);
     }
 
     @Override
@@ -118,6 +133,11 @@ final class TableImpl implements Table {
         sb.append(prefix).append("primary key: ").append(primaryKeyColumnNames()).append(System.lineSeparator());
         sb.append(prefix).append("default charset: ").append(defaultCharsetName()).append(System.lineSeparator());
         sb.append(prefix).append("comment: ").append(comment()).append(System.lineSeparator());
+        sb.append(prefix).append("attributes: {").append(System.lineSeparator());
+        for (Attribute attribute : attributes) {
+            sb.append(prefix).append("  ").append(attribute).append(System.lineSeparator());
+        }
+        sb.append(prefix).append("}").append(System.lineSeparator());
     }
 
     @Override

--- a/debezium-core/src/main/java/io/debezium/relational/Tables.java
+++ b/debezium-core/src/main/java/io/debezium/relational/Tables.java
@@ -179,16 +179,18 @@ public final class Tables {
      * @param columnDefs the list of column definitions; may not be null or empty
      * @param primaryKeyColumnNames the list of the column names that make up the primary key; may be null or empty
      * @param defaultCharsetName the name of the character set that should be used by default
+     * @param attributes the list of attribute definitions; may not be null or empty
      * @return the previous table definition, or null if there was no prior table definition
      */
     public Table overwriteTable(TableId tableId, List<Column> columnDefs, List<String> primaryKeyColumnNames,
-                                String defaultCharsetName) {
+                                String defaultCharsetName, List<Attribute> attributes) {
         return lock.write(() -> {
             Table updated = Table.editor()
                     .tableId(tableId)
                     .addColumns(columnDefs)
                     .setPrimaryKeyNames(primaryKeyColumnNames)
                     .setDefaultCharsetName(defaultCharsetName)
+                    .addAttributes(attributes)
                     .create();
 
             Table existing = tablesByTableId.get(tableId);
@@ -251,7 +253,7 @@ public final class Tables {
             }
             tablesByTableId.remove(existing.id());
             TableImpl updated = new TableImpl(newTableId, existing.columns(),
-                    existing.primaryKeyColumnNames(), existing.defaultCharsetName(), existing.comment());
+                    existing.primaryKeyColumnNames(), existing.defaultCharsetName(), existing.comment(), existing.attributes());
             try {
                 return tablesByTableId.put(updated.id(), updated);
             }
@@ -276,7 +278,7 @@ public final class Tables {
             Table updated = changer.apply(existing);
             if (updated != existing) {
                 tablesByTableId.put(tableId, new TableImpl(tableId, updated.columns(),
-                        updated.primaryKeyColumnNames(), updated.defaultCharsetName(), updated.comment()));
+                        updated.primaryKeyColumnNames(), updated.defaultCharsetName(), updated.comment(), updated.attributes()));
             }
             changes.add(tableId);
             return existing;

--- a/debezium-core/src/main/java/io/debezium/relational/history/JsonTableChangeSerializer.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/JsonTableChangeSerializer.java
@@ -14,6 +14,7 @@ import io.debezium.document.Array;
 import io.debezium.document.Array.Entry;
 import io.debezium.document.Document;
 import io.debezium.document.Value;
+import io.debezium.relational.Attribute;
 import io.debezium.relational.Column;
 import io.debezium.relational.ColumnEditor;
 import io.debezium.relational.Table;
@@ -50,6 +51,14 @@ public class JsonTableChangeSerializer implements TableChanges.TableChangesSeria
         }
         document.setDocument("table", toDocument(tableChange.getTable()));
         document.setString("comment", tableChange.getTable().comment());
+
+        List<Document> attributes = tableChange.getTable().attributes()
+                .stream()
+                .map(this::toDocument)
+                .collect(Collectors.toList());
+
+        document.setArray("attributes", Array.create(attributes));
+
         return document;
     }
 
@@ -102,6 +111,13 @@ public class JsonTableChangeSerializer implements TableChanges.TableChangesSeria
                 .map(List::toArray)
                 .ifPresent(enums -> document.setArray("enumValues", enums));
 
+        return document;
+    }
+
+    private Document toDocument(Attribute attribute) {
+        final Document document = Document.create();
+        document.setString("name", attribute.name());
+        document.setString("value", attribute.value());
         return document;
     }
 
@@ -190,6 +206,12 @@ public class JsonTableChangeSerializer implements TableChanges.TableChangesSeria
                     return columnEditor.create();
                 })
                 .forEach(editor::addColumn);
+
+        document.getOrCreateArray("attributes")
+                .streamValues()
+                .map(Value::asDocument)
+                .map(v -> Attribute.editor().name(v.getString("name")).value(v.getString("value")).create())
+                .forEach(editor::addAttribute);
 
         editor.setPrimaryKeyNames(document.getArray("primaryKeyColumnNames")
                 .streamValues()

--- a/debezium-core/src/main/java/io/debezium/relational/history/JsonTableChangeSerializer.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/JsonTableChangeSerializer.java
@@ -52,13 +52,6 @@ public class JsonTableChangeSerializer implements TableChanges.TableChangesSeria
         document.setDocument("table", toDocument(tableChange.getTable()));
         document.setString("comment", tableChange.getTable().comment());
 
-        List<Document> attributes = tableChange.getTable().attributes()
-                .stream()
-                .map(this::toDocument)
-                .collect(Collectors.toList());
-
-        document.setArray("attributes", Array.create(attributes));
-
         return document;
     }
 
@@ -74,6 +67,13 @@ public class JsonTableChangeSerializer implements TableChanges.TableChangesSeria
                 .collect(Collectors.toList());
 
         document.setArray("columns", Array.create(columns));
+
+        List<Document> attributes = table.attributes()
+                .stream()
+                .map(this::toDocument)
+                .collect(Collectors.toList());
+
+        document.setArray("attributes", Array.create(attributes));
 
         return document;
     }

--- a/debezium-core/src/test/java/io/debezium/relational/TableEditorTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/TableEditorTest.java
@@ -21,12 +21,14 @@ public class TableEditorTest {
     private TableEditor editor;
     private Table table;
     private ColumnEditor columnEditor;
+    private AttributeEditor attributeEditor;
 
     @Before
     public void beforeEach() {
         editor = Table.editor();
         table = null;
         columnEditor = Column.editor();
+        attributeEditor = Attribute.editor();
     }
 
     @Test
@@ -34,6 +36,12 @@ public class TableEditorTest {
         assertThat(editor.columnWithName("any")).isNull();
         assertThat(editor.columns()).isEmpty();
         assertThat(editor.primaryKeyColumnNames()).isEmpty();
+    }
+
+    @Test
+    public void shouldNotHaveAnyAttributesIfEmpty() {
+        assertThat(editor.attributeWithName("any")).isNull();
+        assertThat(editor.attributes()).isEmpty();
     }
 
     @Test(expected = IllegalStateException.class)

--- a/debezium-core/src/test/java/io/debezium/relational/TableTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/TableTest.java
@@ -20,6 +20,7 @@ public class TableTest {
     private Column c2;
     private Column c3;
     private Column c4;
+    private Attribute a1;
 
     @Before
     public void beforeEach() {
@@ -44,11 +45,13 @@ public class TableTest {
                                 .optional(true)
                                 .create())
                 .setPrimaryKeyNames("C1", "C2")
+                .addAttribute(Attribute.editor().name("A1").value("12345").create())
                 .create();
         c1 = table.columnWithName("C1");
         c2 = table.columnWithName("C2");
         c3 = table.columnWithName("C3");
         c4 = table.columnWithName("C4");
+        a1 = table.attributeWithName("A1");
     }
 
     @Test
@@ -57,6 +60,7 @@ public class TableTest {
         assertThat(c2).isNotNull();
         assertThat(c3).isNotNull();
         assertThat(c4).isNotNull();
+        assertThat(a1).isNotNull();
     }
 
     @Test
@@ -65,6 +69,11 @@ public class TableTest {
         assertThat(c2.name()).isEqualTo("C2");
         assertThat(c3.name()).isEqualTo("C3");
         assertThat(c4.name()).isEqualTo("C4");
+    }
+
+    @Test
+    public void shouldHaveAttributesWithNames() {
+        assertThat(a1.name()).isEqualTo("A1");
     }
 
     @Test
@@ -87,11 +96,21 @@ public class TableTest {
     }
 
     @Test
+    public void shouldHaveAttributes() {
+        assertThat(table.attributes()).containsExactly(a1);
+    }
+
+    @Test
     public void shouldFindColumnsByNameWithExactCase() {
         assertThat(table.columnWithName("C1")).isSameAs(c1);
         assertThat(table.columnWithName("C2")).isSameAs(c2);
         assertThat(table.columnWithName("C3")).isSameAs(c3);
         assertThat(table.columnWithName("C4")).isSameAs(c4);
+    }
+
+    @Test
+    public void shouldFindAttributesByNameWithExactCase() {
+        assertThat(table.attributeWithName("A1")).isSameAs(a1);
     }
 
     @Test
@@ -103,9 +122,20 @@ public class TableTest {
     }
 
     @Test
+    public void shouldFindAttributesByNameWithWrongCase() {
+        assertThat(table.attributeWithName("a1")).isSameAs(a1);
+    }
+
+    @Test
     public void shouldNotFindNonExistantColumnsByName() {
         assertThat(table.columnWithName("c1 ")).isNull();
         assertThat(table.columnWithName("wrong")).isNull();
+    }
+
+    @Test
+    public void shouldNotFindNonExistentAttributesByName() {
+        assertThat(table.attributeWithName("a1 ")).isNull();
+        assertThat(table.attributeWithName("wrong")).isNull();
     }
 
     @Test

--- a/debezium-core/src/test/java/io/debezium/relational/history/HistoryRecordTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/history/HistoryRecordTest.java
@@ -108,7 +108,15 @@ public class HistoryRecordTest {
                 .get(1).asDocument();
 
         assertThat(secondColumn.get("defaultValueExpression")).isEqualTo("1");
-        // System.out.println(record);
+
+        Document firstAttribute = deserialized.tableChanges()
+                .get(0).asDocument()
+                .getDocument("table")
+                .getArray("attributes")
+                .get(0).asDocument();
+
+        assertThat(firstAttribute.get("name")).isEqualTo("object_id");
+        assertThat(firstAttribute.get("value")).isEqualTo("12345");
 
         final TableChangesSerializer<Array> tableChangesSerializer = new JsonTableChangeSerializer();
         assertThat((Object) tableChangesSerializer.deserialize(deserialized.tableChanges(), true)).isEqualTo(tableChanges);

--- a/debezium-core/src/test/java/io/debezium/relational/history/HistoryRecordTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/history/HistoryRecordTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import io.debezium.document.Array;
 import io.debezium.document.Document;
 import io.debezium.document.DocumentReader;
+import io.debezium.relational.Attribute;
 import io.debezium.relational.Column;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
@@ -73,6 +74,8 @@ public class HistoryRecordTest {
                         .create())
                 .setPrimaryKeyNames("first")
                 .setComment("table comment")
+                .addAttribute(Attribute.editor().name("object_id").value("12345").create())
+                .addAttribute(Attribute.editor().name("other").value("test").create())
                 .create();
 
         TableChanges tableChanges = new TableChanges().create(table);

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -342,6 +342,11 @@ The message contains a logical representation of the table schema.
               "autoIncremented": false,
               "generated": false
             }
+          ],
+          "attributes": [ // <10>
+            {
+              "customAttribute": "attributeValue"
+            }
           ]
         }
       }
@@ -399,6 +404,10 @@ a|Describes the kind of change. The value is one of the following:
 |9
 |`columns`
 |Metadata for each column in the changed table.
+
+|10
+|`attributes`
+|Custom attribute metadata for each table change.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -281,6 +281,11 @@ The message contains a logical representation of the table schema.
                 "autoIncremented": false,
                 "generated": false
             }
+          ],
+          "attributes": [ <11>
+            {
+              "customAttribute": "attributeValue"
+            }
           ]
         }
       }
@@ -351,6 +356,10 @@ In the case of a table rename, this identifier is a concatenation of `_<old>_,_<
 |10
 |`columns`
 |Metadata for each column in the changed table.
+
+|11
+|`attributes`
+|Custom attribute metadata for each table change.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -329,6 +329,11 @@ The message contains a logical representation of the table schema.
               "autoIncremented": false,
               "generated": false
             }
+          ],
+          "attributes": [ // <10>
+            {
+              "customAttribute": "attributeValue"
+            }
           ]
         }
       }
@@ -385,6 +390,10 @@ In the case of a table rename, this identifier is a concatenation of `_<old>_,_<
 |9
 |`columns`
 |Metadata for each column in the changed table.
+
+|10
+|`attributes`
+|Custom attribute metadata for each table change.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -346,6 +346,11 @@ The message contains a logical representation of the table schema.
               "autoIncremented": false,
               "generated": false
             }
+          ],
+          "attributes": [ // <10>
+            {
+              "customAttribute": "attributeValue"
+            }
           ]
         }
       }
@@ -403,6 +408,10 @@ a|Describes the kind of change. The value is one of the following:
 |9
 |`columns`
 |Metadata for each column in the changed table.
+
+|10
+|`attributes`
+|Custom attribute metadata for each table change.
 
 |===
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5396

So this is an early draft of the connector-specific relational model attribute support I need for DBZ-3401.  I'd prefer to get some early feedback on the approach in case there are some suggestions or preferences we'd like to take before I get too far into the details and incorporate this into DBZ-3401.

**Why is this needed**
I want to move to a situation where `log.mining.strategy` is no longer a requirement.  Instead, the Oracle connector will use the existing `online_catalog` as the default mode of operation, reducing the overhead on the database and increasing the performance for all Oracle users.  

For this mode to work reliably, we need to be able to support resolving the table/column names for LogMiner redo records when LogMiner fails to do this on its own.  We will do this by matching the redo record's numeric object id with the object id reference we have stored in the connector's database schema relational model.

**What's changed**
This PR introduces a new field called `attributes` both in the JSON-based schema history record and also as a part of the relational model domain object, `Table`.  These attributes are effectively a string-baed key/value tuple.  The purpose of these tuples is entirely driven by the connector and can effectively store anything.

During `JdbcConnection#readSchema`, I've added a hook that allows the connector the ability to resolve a set of attributes for the given `TableId`, and those will be added to the relational model when the `Table` domain object is constructed.  This satisfies the initial set of these from the JDBC schema call.  In addition, the JSON-based schema history serializer has been adjusted to both read and write these values to the schema change events.  This will allow the persistence of these values across restarts and hydrate these at restart time based on the current known table structures and mappings.

- [x] Update other connector repositories based on API changes
- [x] Update documentation