### PR TITLE
Cleanup setting of the last snapshot record

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/SourceInfo.java
@@ -13,7 +13,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import io.debezium.annotation.NotThreadSafe;
-import io.debezium.connector.SnapshotRecord;
 import io.debezium.connector.common.BaseSourceInfo;
 import io.debezium.data.Envelope;
 import io.debezium.document.Document;
@@ -321,10 +320,5 @@ public final class SourceInfo extends BaseSourceInfo {
             return databaseName;
         }
         return tableId.catalog();
-    }
-
-    @Deprecated
-    public boolean isLastSnapshot() {
-        return snapshot() == SnapshotRecord.LAST;
     }
 }


### PR DESCRIPTION
This PR doesn't replace setting of the last snapshot record with doing so in heartbeat message, but only removes setting of the last snapshot event in MySQL connector where it's done twice. Setting last snapshot record once snapshot is finished doesn't seems to be possible without bigger changes as we send the event immediately. If we decide to proceed further, the most easy way seems to be to do in the same way as MySQL - buffer the events and change the last one once we are done. This is also suggested in [DBZ-3113](https://issues.redhat.com/browse/DBZ-3113).

https://issues.redhat.com/browse/DBZ-5047