### PR TITLE
DBZ-2595 Removes unused documentation variables in `antora.yml`

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -73,10 +73,8 @@ The current `antora.yml` component descriptor looks similar to the following:
 asciidoc:
   attributes:
     debezium-version: '1.1.0.Final'
-    debezium-dev-version: '1.2'
     debezium-kafka-version: '2.4.0'
     debezium-docker-label: '1.1'
-    install-version: '1.1'
     assemblies: '../assemblies'
     modules: '../../modules'
     mysql-connector-plugin-download: 'https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/1.1.0.Final/debezium-connector-mysql-1.1.0.Final-plugin.tar.gz'

--- a/documentation/antora.yml
+++ b/documentation/antora.yml
@@ -9,12 +9,10 @@ nav:
 asciidoc:
   attributes:
     debezium-version: '2.0.0.Alpha3'
-    debezium-dev-version: '2.0'
     debezium-kafka-version: '3.1.0'
     debezium-docker-label: '1.9'
     DockerKafkaConnect: registry.redhat.io/amq7/amq-streams-kafka-28-rhel8:1.8.0
     groovy-version: '3.0.11'
-    install-version: '1.9'
     assemblies: '../assemblies'
     modules: '../../modules'
     mysql-version: '8.0'

--- a/documentation/modules/ROOT/pages/install.adoc
+++ b/documentation/modules/ROOT/pages/install.adoc
@@ -6,8 +6,6 @@
 :sectanchors:
 :linkattrs:
 :icons: font
-:install-version: {debezium-version}
-:install-dev-version: {debezium-dev-version}
 
 There are several ways to install and use {prodname} connectors, so we've documented a few of the most common ways to do this.
 


### PR DESCRIPTION
[DBZ-2595](https://issues.redhat.com/browse/DBZ-2595)

Updates upstream `antora.yml`,  `DOCUMENTATION.MD`, and `install.adoc` files to remove references to unused version variables.

Tested in local Antora build.
This change does not affect the downstream documentation. 

No need to backport this change.