### PR TITLE
DBZ-5429: Modify documentation for initial_only flag

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2199,6 +2199,8 @@ For example, +
  +
 `initial` - For tables in capture mode, the connector takes a snapshot of the schema for the table and the data in the table. This is useful for populating Kafka topics with a complete representation of the data. +
  +
+`initial_only` - Takes a snapshot of structure and data like initial but instead does not transition into streaming changes once the snapshot has completed. +
+ +
 `schema_only` - For tables in capture mode, the connector takes a snapshot of only the schema for the table. This is useful when only the changes that are happening from now on need to be emitted to Kafka topics. After the snapshot is complete, the connector continues by reading change events from the database's redo logs.
 
 |[[db2-property-snapshot-isolation-mode]]<<db2-property-snapshot-isolation-mode, `+snapshot.isolation.mode+`>>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5429

This complements the actual change made for the Db2 connector.

Db2 PR: https://github.com/debezium/debezium-connector-db2/pull/65