### PR TITLE
DBZ-5333 Caused by: java.io.EOFException: Failed to read next byte from position 2005308603

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlErrorHandler.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlErrorHandler.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.connector.mysql;
 
+import java.io.EOFException;
 import java.sql.SQLException;
 
 import com.github.shyiko.mysql.binlog.network.ServerException;
@@ -35,6 +36,10 @@ public class MySqlErrorHandler extends ErrorHandler {
         else if (throwable instanceof ServerException) {
             final ServerException sql = (ServerException) throwable;
             return SQL_CODE_TOO_MANY_CONNECTIONS.equals(sql.getSqlState());
+        }
+        else if (throwable instanceof EOFException) {
+            // Retry with reading binlog error
+            return throwable.getMessage().contains("Failed to read next byte from position");
         }
         else if (throwable instanceof DebeziumException && throwable.getCause() != null) {
             return isRetriable(throwable.getCause());


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5333

This reading byte issue should happen occasionally, the `MySqlErrorHandler` handle following exception message to restart connector is good approach.

`Caused by: java.io.EOFException: Failed to read next byte from position 2005308603`