### PR TITLE
DBZ-5422 Update link format and multiple edits

### DIFF
--- a/documentation/modules/ROOT/partials/modules/tutorial/con-introduction-debezium.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/con-introduction-debezium.adoc
@@ -14,5 +14,5 @@ By taking advantage of Kafka's reliable streaming platform, {prodname} makes it 
 Even if your application stops unexpectedly, or loses its connection, it does not miss events that occur during the outage.
 After the application restarts, it resumes reading from the log from the point where it left off.
 
-{prodname} includes multiple connectors, and each of them share similar capabilities.
+{prodname} includes multiple connectors, which share similar capabilities.
 The tutorial that follows focuses on the {link-prefix}:{link-mysql-connector}#debezium-connector-for-mysql[MySQL connector].

--- a/documentation/modules/ROOT/partials/modules/tutorial/con-introduction-debezium.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/con-introduction-debezium.adoc
@@ -1,18 +1,30 @@
-// Metadata created by nebel
-//
-// UserStory:
-
 [id="introduction-debezium"]
 = Introduction to {prodname}
 
 {prodname} is a distributed platform that converts information from your existing databases into event streams, enabling applications to detect, and immediately respond to row-level changes in the databases.
 
-{prodname} is built on top of http://kafka.apache.org[Apache Kafka] and provides {link-kafka-docs}.html#connect[Kafka Connect] compatible connectors that capture changes from database management systems.
-{prodname} records the history of the data changes that occur in a database in Kafka logs.
-Consuming applications can then read each change event record from the log, in order.
-By taking advantage of Kafka's reliable streaming platform, {prodname} makes it possible for your application to easily consume all of the events that occur in a database correctly and completely.
+{prodname} is built on top of http://kafka.apache.org[Apache Kafka] and provides a set of {link-kafka-docs}.html#connect[Kafka Connect] compatible connectors.
+Each of the connectors works with a specific database management system (DBMS).
+Connectors record the history of data changes in the DBMS by detecting changes as they occur, and streaming a record of each change event to the Kafka logs.
+Consuming applications can then read the resulting event records from the log.
+
+By taking advantage of Kafka's reliable streaming platform, {prodname} makes it possible for applications to consume changes that occur in a database correctly and completely.
 Even if your application stops unexpectedly, or loses its connection, it does not miss events that occur during the outage.
 After the application restarts, it resumes reading from the log from the point where it left off.
 
-{prodname} includes multiple connectors, which share similar capabilities.
-The tutorial that follows focuses on the {link-prefix}:{link-mysql-connector}#debezium-connector-for-mysql[MySQL connector].
+The tutorial that follows shows you how to deploy and use the {link-prefix}:{link-mysql-connector}#debezium-connector-for-mysql[{prodname} MySQL connector] with a simple configuration.
+For more information about deploying and using {prodname} connectors, see the connector documentation.
+
+.Additional resources
+ifdef::community[]
+* xref:{link-cassandra-connector}#debezium-connector-for-cassandra[{prodname} connector for Cassandra]
+endif::community[]
+* {link-prefix}:{link-db2-connector}#debezium-connector-for-db2[{prodname} connector for Db2]
+* {link-prefix}:{link-mongodb-connector}#debezium-connector-for-mongodb[{prodname} connector for MongoDB]
+* {link-prefix}:{link-mysql-connector}#debezium-connector-for-mysql[{prodname} connector for MySQL]
+* {link-prefix}:{link-oracle-connector}#debezium-connector-for-oracle[{prodname} connector for Oracle Database]
+* {link-prefix}:{link-postgresql-connector}#debezium-connector-for-postgresql[{prodname} connector for PostgreSQL]
+* {link-prefix}:{link-sqlserver-connector}#debezium-connector-for-sql-server[{prodname} connector for SQL Server]
+ifdef::community[]
+* xref:{link-vitess-connector}#debezium-connector-for-vitess[{prodname} connector for Vitess]
+endif::community[]

--- a/documentation/modules/ROOT/partials/modules/tutorial/con-introduction-debezium.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/con-introduction-debezium.adoc
@@ -5,15 +5,14 @@
 [id="introduction-debezium"]
 = Introduction to {prodname}
 
-{prodname} is a distributed platform that turns your existing databases into event streams,
-so applications can see and respond immediately to each row-level change in the databases.
+{prodname} is a distributed platform that converts information from your existing databases into event streams, enabling applications to detect, and immediately respond to row-level changes in the databases.
 
-{prodname} is built on top of http://kafka.apache.org[Apache Kafka] and provides {link-kafka-docs}.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-{prodname} records the history of data changes in Kafka logs, from where your application consumes them.
-This makes it possible for your application to easily consume all of the events correctly and completely.
-Even if your application stops unexpectedly,
-it will not miss anything:
-when the application restarts, it will resume consuming the events where it left off.
+{prodname} is built on top of http://kafka.apache.org[Apache Kafka] and provides {link-kafka-docs}.html#connect[Kafka Connect] compatible connectors that capture changes from database management systems.
+{prodname} records the history of the data changes that occur in a database in Kafka logs.
+Consuming applications can then read each change event record from the log, in order.
+By taking advantage of Kafka's reliable streaming platform, {prodname} makes it possible for your application to easily consume all of the events that occur in a database correctly and completely.
+Even if your application stops unexpectedly, or loses its connection, it does not miss events that occur during the outage.
+After the application restarts, it resumes reading from the log from the point where it left off.
 
-{prodname} includes multiple connectors.
-In this tutorial, you will use the xref:{link-mysql-connector}[MySQL connector].
+{prodname} includes multiple connectors, and each of them share similar capabilities.
+The tutorial that follows focuses on the {link-prefix}:{link-mysql-connector}#debezium-connector-for-mysql[MySQL connector].

--- a/documentation/modules/ROOT/partials/modules/tutorial/con-introduction-debezium.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/con-introduction-debezium.adoc
@@ -5,12 +5,12 @@
 
 {prodname} is built on top of http://kafka.apache.org[Apache Kafka] and provides a set of {link-kafka-docs}.html#connect[Kafka Connect] compatible connectors.
 Each of the connectors works with a specific database management system (DBMS).
-Connectors record the history of data changes in the DBMS by detecting changes as they occur, and streaming a record of each change event to the Kafka logs.
-Consuming applications can then read the resulting event records from the log.
+Connectors record the history of data changes in the DBMS by detecting changes as they occur, and streaming a record of each change event to a Kafka topic.
+Consuming applications can then read the resulting event records from the Kafka topic.
 
 By taking advantage of Kafka's reliable streaming platform, {prodname} makes it possible for applications to consume changes that occur in a database correctly and completely.
 Even if your application stops unexpectedly, or loses its connection, it does not miss events that occur during the outage.
-After the application restarts, it resumes reading from the log from the point where it left off.
+After the application restarts, it resumes reading from the topic from the point where it left off.
 
 The tutorial that follows shows you how to deploy and use the {link-prefix}:{link-mysql-connector}#debezium-connector-for-mysql[{prodname} MySQL connector] with a simple configuration.
 For more information about deploying and using {prodname} connectors, see the connector documentation.


### PR DESCRIPTION
[DBZ-5422](https://issues.redhat.com/browse/DBZ-5422)

While testing the downstream documentation for Debezium 1.9, the build failed because a cross-reference in the upstream `con-introduction.debezium-adoc` file, which is used as-is in the downstream build, uses a format that is incompatible with the downstream build for two reasons:
* The link uses the `xref` macro to link to a book that in the downstream docs is external to the current context. Downstream, such links require use of the `link` prefix. 
* The link target specifies only a general context, but omits use of a specific anchor id, which is required to target content downstream.
I manually fixed this link in the released downstream documentation. This change is necessary to ensure that the link isn't reverted when fetching upstream files in the future. 

In addition to updating the link format, this change includes updates to improve readability and clarity, and new links to the deployment instructions for each connector.

Tested the upstream and downstream documentation in local builds.

This should be backported to 1.9, JIC, a refresh is required over the next few weeks.