### PR TITLE
DBZ-5455  Fixed debezium parse default value bug in JdbcValueConverters convertBigInt method

### DIFF
--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
@@ -925,7 +925,7 @@ public class JdbcValueConverters implements ValueConverterProvider {
                 r.deliver(NumberConversions.getLong((Boolean) data));
             }
             else if (data instanceof String) {
-                r.deliver(Long.valueOf((String) data));
+                r.deliver(Long.valueOf(((String) data).trim()));
             }
         });
     }


### PR DESCRIPTION
issue link: https://issues.redhat.com/browse/DBZ-5455
DBZ-5455 When there are spaces in the Default value of the numeric type in a new table DDL under the same Mysql Host; MySQL can be executed successfully,But debezium return exception Bug Fixed.