### PR TITLE
[docs] Removing obsolete ZK reference from tutorial

### DIFF
--- a/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-kafka-connect.adoc
+++ b/documentation/modules/ROOT/partials/modules/tutorial/proc-starting-kafka-connect.adoc
@@ -19,7 +19,7 @@ This command runs a new container using the {debezium-docker-label} version of t
 
 [source,shell,options="nowrap",subs="+attributes"]
 ----
-$ docker run -it --rm --name connect -p 8083:8083 -e GROUP_ID=1 -e CONFIG_STORAGE_TOPIC=my_connect_configs -e OFFSET_STORAGE_TOPIC=my_connect_offsets -e STATUS_STORAGE_TOPIC=my_connect_statuses --link zookeeper:zookeeper --link kafka:kafka --link mysql:mysql quay.io/debezium/connect:{debezium-docker-label}
+$ docker run -it --rm --name connect -p 8083:8083 -e GROUP_ID=1 -e CONFIG_STORAGE_TOPIC=my_connect_configs -e OFFSET_STORAGE_TOPIC=my_connect_offsets -e STATUS_STORAGE_TOPIC=my_connect_statuses --link kafka:kafka --link mysql:mysql quay.io/debezium/connect:{debezium-docker-label}
 ----
 
 `-it`:: The container is interactive,
@@ -29,7 +29,7 @@ which means the terminal's standard input and output are attached to the contain
 `-p 8083:8083`:: Maps port `8083` in the container to the same port on the Docker host.
 This enables applications outside of the container to use Kafka Connect's REST API to set up and manage new container instances.
 `-e CONFIG_STORAGE_TOPIC=my_connect_configs -e OFFSET_STORAGE_TOPIC=my_connect_offsets -e STATUS_STORAGE_TOPIC=my_connect_statuses`:: Sets environment variables required by the {prodname} image.
-`--link zookeeper:zookeeper --link kafka:kafka --link mysql:mysql`:: Links the container to the containers that are running ZooKeeper, Kafka, and the MySQL server.
+`--link kafka:kafka --link mysql:mysql`:: Links the container to the containers that are running Kafka and the MySQL server.
 --
 
 ifdef::community[]


### PR DESCRIPTION
@Naros another one. No link from KC to ZK is needed nowadays.