### PR TITLE
DBZ-5458 Remove conditionals surrounding Oracle ad hoc/incremental refs

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -203,9 +203,7 @@ ifdef::community[]
 * MongoDB
 endif::community[]
 * MySQL
-ifdef::community[]
 * Oracle
-endif::community[]
 * PostgreSQL
 * SQL Server
 
@@ -238,9 +236,7 @@ ifdef::community[]
 * xref:{link-mongodb-connector}#mongodb-ad-hoc-snapshot[MongoDB connector ad hoc snapshots]
 endif::community[]
 * xref:{link-mysql-connector}#mysql-ad-hoc-snapshots[MySQL connector ad hoc snapshots]
-ifdef::community[]
 * xref:{link-oracle-connector}#oracle-ad-hoc-snapshots[Oracle connector ad hoc snapshots]
-endif::community[]
 * xref:{link-postgresql-connector}#postgresql-ad-hoc-snapshots[PostgreSQL connector ad hoc snapshots]
 * xref:{link-sqlserver-connector}#sqlserver-ad-hoc-snapshots[SQL Server connector ad hoc snapshots]
 
@@ -257,9 +253,7 @@ ifdef::community[]
 * MongoDB
 endif::community[]
 * MySQL
-ifdef::community[]
 * Oracle
-endif::community[]
 * PostgreSQL
 * SQL Server
 
@@ -310,8 +304,6 @@ ifdef::community[]
 * xref:{link-mongodb-connector}#mongodb-incremental-snapshots[MongoDB connector incremental snapshots]
 endif::community[]
 * xref:{link-mysql-connector}#mysql-incremental-snapshots[MySQL connector incremental snapshots]
-ifdef::community[]
 * xref:{link-oracle-connector}#oracle-incremental-snapshots[Oracle connector incremental snapshots]
-endif::community[]
 * xref:{link-postgresql-connector}#postgresql-incremental-snapshots[PostgreSQL connector incremental snapshots]
 * xref:{link-sqlserver-connector}#sqlserver-incremental-snapshots[SQL Server connector incremental snapshots]


### PR DESCRIPTION
[DBZ-5458](https://issues.redhat.com/browse/DBZ-5458)

Removes `community` conditional delimiters around references to Oracle connector ad hoc and incremental snapshots.

Changes tested in local Antora build, and a local downstream documentation build.

Please backport this change to 1.9. Thanks!