### PR TITLE
DBZ-4329 Don't send fileds with obsolete values

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresEventMetadataProvider.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresEventMetadataProvider.java
@@ -45,10 +45,14 @@ class PostgresEventMetadataProvider implements EventMetadataProvider {
         if (source == null) {
             return null;
         }
-        Long xmin = sourceInfo.getInt64(SourceInfo.XMIN_KEY);
+        final Long xmin = sourceInfo.getInt64(SourceInfo.XMIN_KEY);
+        final Long lsn = sourceInfo.getInt64(SourceInfo.LSN_KEY);
+        if (lsn == null) {
+            return null;
+        }
 
         Map<String, String> r = Collect.hashMapOf(
-                SourceInfo.LSN_KEY, Long.toString(sourceInfo.getInt64(SourceInfo.LSN_KEY)));
+                SourceInfo.LSN_KEY, Long.toString(lsn));
         if (xmin != null) {
             r.put(SourceInfo.XMIN_KEY, Long.toString(xmin));
         }
@@ -64,6 +68,10 @@ class PostgresEventMetadataProvider implements EventMetadataProvider {
         if (source == null) {
             return null;
         }
-        return Long.toString(sourceInfo.getInt64(SourceInfo.TXID_KEY));
+        Long txId = sourceInfo.getInt64(SourceInfo.TXID_KEY);
+        if (txId == null) {
+            return null;
+        }
+        return Long.toString(txId);
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSourceInfoStructMaker.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSourceInfoStructMaker.java
@@ -10,6 +10,7 @@ import org.apache.kafka.connect.data.Struct;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.connector.AbstractSourceInfoStructMaker;
+import io.debezium.connector.SnapshotRecord;
 
 public class PostgresSourceInfoStructMaker extends AbstractSourceInfoStructMaker<SourceInfo> {
 
@@ -41,14 +42,16 @@ public class PostgresSourceInfoStructMaker extends AbstractSourceInfoStructMaker
         Struct result = super.commonStruct(sourceInfo);
         result.put(SourceInfo.SCHEMA_NAME_KEY, sourceInfo.schemaName());
         result.put(SourceInfo.TABLE_NAME_KEY, sourceInfo.tableName());
-        if (sourceInfo.txId() != null) {
-            result.put(SourceInfo.TXID_KEY, sourceInfo.txId());
-        }
-        if (sourceInfo.lsn() != null) {
-            result.put(SourceInfo.LSN_KEY, sourceInfo.lsn().asLong());
-        }
-        if (sourceInfo.xmin() != null) {
-            result.put(SourceInfo.XMIN_KEY, sourceInfo.xmin());
+        if (sourceInfo.snapshot() != SnapshotRecord.INCREMENTAL) {
+            if (sourceInfo.txId() != null) {
+                result.put(SourceInfo.TXID_KEY, sourceInfo.txId());
+            }
+            if (sourceInfo.lsn() != null) {
+                result.put(SourceInfo.LSN_KEY, sourceInfo.lsn().asLong());
+            }
+            if (sourceInfo.xmin() != null) {
+                result.put(SourceInfo.XMIN_KEY, sourceInfo.xmin());
+            }
         }
         return result;
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/SourceInfo.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/SourceInfo.java
@@ -133,7 +133,6 @@ public final class SourceInfo extends BaseSourceInfo {
         return this;
     }
 
-    // TODO https://issues.redhat.com/browse/DBZ-4329, make this call the method above, so to reset the attributes not provided here
     protected SourceInfo update(Instant timestamp, TableId tableId) {
         this.timestamp = timestamp;
         if (tableId != null && tableId.schema() != null) {


### PR DESCRIPTION
During incremental snapshot fields `xmin`, `lsn` and `txId` are not
updated and therefore we stream obsolete values from previous records
in `source` struct. Don't include these obsolete value in the `source`
struct during incremental snapshot.

https://issues.redhat.com/browse/DBZ-4329