### PR TITLE
DBZ-5479 Retry MongoNodeIsRecoveringException when failover

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -433,3 +433,4 @@ Mark Allanson
 Rahul Khanna
 Pengwei Dou
 Zhongqiang Gong
+Inki Hwang

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbErrorHandler.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbErrorHandler.java
@@ -26,7 +26,8 @@ public class MongoDbErrorHandler extends ErrorHandler {
             while ((cause != null) && (cause != throwable)) {
                 if (cause instanceof com.mongodb.MongoSocketException ||
                         cause instanceof com.mongodb.MongoTimeoutException ||
-                        cause instanceof com.mongodb.MongoExecutionTimeoutException) {
+                        cause instanceof com.mongodb.MongoExecutionTimeoutException ||
+                        cause instanceof com.mongodb.MongoNodeIsRecoveringException) {
                     return true;
                 }
                 else {

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -147,3 +147,4 @@ ProofOfPizza,Chai Stofkoper
 kanha gupta,Kanha Gupta
 gongzhongqiang,Zhongqiang Gong
 doupengwei,Pengwei Dou
+fisache,Inki Hwang


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5479

## Bug report
Debezium connector task is not retried when failover in mongodb 5

I tested mongo debezium connector for failover in mongo 4 and 5.

In case of 4, when failover, the task is retried successfully with MongoSocketOpenException on tail

but, in case of 5, the task is not retried with MongoNodeIsRecoveringException on tail

it looks mongo didn't close socket when primary failover in 5 version like recovery mode.

follow [this doc about the exception](https://mongodb.github.io/mongo-java-driver/3.6/javadoc/com/mongodb/MongoNodeIsRecoveringException.html)

then, we need to retry the exception

## What Debezium connector do you use and what version?
v1.8.0.Final