### PR TITLE
DBZ-5497 Skip truncate operations by default

### DIFF
--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorTest.java
@@ -7,6 +7,8 @@ package io.debezium.connector.mongodb;
 
 import static org.fest.assertions.Assertions.assertThat;
 
+import java.util.Arrays;
+
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.ConfigKey;
 import org.apache.kafka.connect.connector.Connector;
@@ -37,6 +39,9 @@ public class MongoDbConnectorTest {
             assertThat(key.type).isEqualTo(expected.type());
             if (expected.equals(MongoDbConnectorConfig.TOPIC_NAMING_STRATEGY)) {
                 assertThat(((Class<?>) key.defaultValue).getName()).isEqualTo((String) expected.defaultValue());
+            }
+            else if (expected.type() == ConfigDef.Type.LIST && key.defaultValue != null) {
+                assertThat(key.defaultValue).isEqualTo(Arrays.asList(expected.defaultValue()));
             }
             else {
                 assertThat(key.defaultValue).isEqualTo(expected.defaultValue());

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorTest.java
@@ -7,6 +7,8 @@ package io.debezium.connector.mysql;
 
 import static org.fest.assertions.Assertions.assertThat;
 
+import java.util.Arrays;
+
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.ConfigKey;
 import org.apache.kafka.connect.connector.Connector;
@@ -37,6 +39,9 @@ public class MySqlConnectorTest {
             if (expected.equals(MySqlConnectorConfig.DATABASE_HISTORY) || expected.equals(MySqlConnectorConfig.JDBC_DRIVER)
                     || expected.equals(MySqlConnectorConfig.TOPIC_NAMING_STRATEGY)) {
                 assertThat(((Class<?>) key.defaultValue).getName()).isEqualTo((String) expected.defaultValue());
+            }
+            else if (expected.type() == ConfigDef.Type.LIST && key.defaultValue != null) {
+                assertThat(key.defaultValue).isEqualTo(Arrays.asList(expected.defaultValue()));
             }
             else if (!expected.equals(MySqlConnectorConfig.SERVER_ID)) {
                 assertThat(key.defaultValue).isEqualTo(expected.defaultValue());

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorIT.java
@@ -996,6 +996,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
 
             final Configuration config = TestHelper.defaultConfig()
                     .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM.TRUNCATE_DDL")
+                    .with(OracleConnectorConfig.SKIPPED_OPERATIONS, "none") // do not skip truncates
                     .build();
 
             // Perform a basic startup & initial snapshot of data
@@ -1056,7 +1057,6 @@ public class OracleConnectorIT extends AbstractConnectorTest {
 
             final Configuration config = TestHelper.defaultConfig()
                     .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM.TRUNCATE_DDL")
-                    .with(OracleConnectorConfig.SKIPPED_OPERATIONS, "t") // Filter out truncate operations.
                     .build();
 
             // Perform a basic startup & initial snapshot of data
@@ -3750,6 +3750,7 @@ public class OracleConnectorIT extends AbstractConnectorTest {
             Configuration config = TestHelper.defaultConfig()
                     .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "DEBEZIUM\\.DBZ4953")
                     .with(OracleConnectorConfig.LOB_ENABLED, true)
+                    .with(OracleConnectorConfig.SKIPPED_OPERATIONS, "none") // do not skip truncates
                     .build();
 
             start(OracleConnector.class, config);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -842,13 +842,6 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
             .withDefault(2)
             .withDescription("Number of fractional digits when money type is converted to 'precise' decimal number.");
 
-    // With the deprecation of TruncateHandlingMode and an attempt to fold that into skipped operations,
-    // the PostgreSQL flavor of skipped operations will skip TRUNCATE by default to align with legacy
-    // behavior of TruncateHandlingMode. This way we can emit boot-up warnings in preparation of the
-    // overall behavior change in a future release.
-    public static final Field SKIPPED_OPERATIONS = CommonConnectorConfig.SKIPPED_OPERATIONS
-            .withDefault("t");
-
     private final LogicalDecodingMessageFilter logicalDecodingMessageFilter;
     private final HStoreHandlingMode hStoreHandlingMode;
     private final IntervalHandlingMode intervalHandlingMode;

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorTest.java
@@ -7,6 +7,7 @@ package io.debezium.connector.sqlserver;
 
 import static org.fest.assertions.Assertions.assertThat;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -70,6 +71,9 @@ public class SqlServerConnectorTest {
             assertThat(key.type).isEqualTo(expected.type());
             if (expected.equals(SqlServerConnectorConfig.DATABASE_HISTORY) || expected.equals(CommonConnectorConfig.TOPIC_NAMING_STRATEGY)) {
                 assertThat(((Class<?>) key.defaultValue).getName()).isEqualTo((String) expected.defaultValue());
+            }
+            else if (expected.type() == ConfigDef.Type.LIST && key.defaultValue != null) {
+                assertThat(key.defaultValue).isEqualTo(Arrays.asList(expected.defaultValue()));
             }
             assertThat(key.dependents).isEqualTo(expected.dependents());
             assertThat(key.width).isNotNull();

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -469,9 +469,10 @@ public abstract class CommonConnectorConfig {
             .withWidth(Width.SHORT)
             .withImportance(Importance.LOW)
             .withValidation(CommonConnectorConfig::validateSkippedOperation)
+            .withDefault("t")
             .withDescription(
                     "The comma-separated list of operations to skip during streaming, defined as: 'c' for inserts/create; 'u' for updates; 'd' for deletes, 't' for truncates, and 'none' to indicate nothing skipped. "
-                            + "By default, no operations will be skipped.");
+                            + "By default, only truncate operations will be skipped.");
 
     public static final Field BINARY_HANDLING_MODE = Field.create("binary.handling.mode")
             .withDisplayName("Binary Handling")

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3103,7 +3103,7 @@ You can configure the connector to skip the following types of operations:
 * `d` (delete)
 * `t` (truncate)
 
-By default, no operations are skipped.
+By default, only truncate operations are skipped.
 
 |[[oracle-property-signal-data-collection]]<<oracle-property-signal-data-collection,`+signal.data.collection+`>>
 |No default value


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5497

**Changes**
* Promote truncate skip default from PostgreSQL to core library
* Adjust behavior for Oracle with truncates skipped by default

Sibling PR for Vitess repository - https://github.com/debezium/debezium-connector-vitess/pull/93