### PR TITLE
DBZ-5439 Add transaction id associate with commit scn

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -439,3 +439,4 @@ Zhongqiang Gong
 Inki Hwang
 崔世杰
 合龙 张
+Phạm Ngọc Thắng

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/CommitScn.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/CommitScn.java
@@ -9,7 +9,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -96,7 +95,7 @@ public class CommitScn implements Comparable<Scn> {
     public boolean hasCommitAlreadyBeenHandled(LogMinerEventRow row) {
         final RedoThreadCommitScn commitScn = redoThreadCommitScns.get(row.getThread());
         if (commitScn != null) {
-            Set<String> txIds = commitScn.getTxIds();
+            final Set<String> txIds = commitScn.getTxIds();
             return commitScn.getCommitScn().compareTo(row.getScn()) > 0 ||
                     (commitScn.getCommitScn().compareTo(row.getScn()) == 0 && txIds.contains(row.getTransactionId()));
         }
@@ -116,18 +115,13 @@ public class CommitScn implements Comparable<Scn> {
     public void recordCommit(LogMinerEventRow row) {
         final RedoThreadCommitScn redoCommitScn = redoThreadCommitScns.get(row.getThread());
         if (redoCommitScn != null) {
-            Scn prevCommitScn = redoCommitScn.getCommitScn();
-            if (!Objects.equals(prevCommitScn, row.getScn())) {
-                redoCommitScn.resetTxIds();
+            if (redoCommitScn.getCommitScn().compareTo(row.getScn()) == 0) {
+                redoCommitScn.getTxIds().add(row.getTransactionId());
+                return;
             }
-            redoCommitScn.getTxIds().add(row.getTransactionId());
-            redoCommitScn.setCommitScn(row.getScn());
-            redoCommitScn.setRsId(row.getRsId());
-            redoCommitScn.setSsn(row.getSsn());
         }
-        else {
-            redoThreadCommitScns.put(row.getThread(), new RedoThreadCommitScn(row));
-        }
+
+        redoThreadCommitScns.put(row.getThread(), new RedoThreadCommitScn(row));
     }
 
     /**
@@ -182,12 +176,6 @@ public class CommitScn implements Comparable<Scn> {
                 if (redoThreadCommitScn.getCommitScn() != null && !redoThreadCommitScn.getCommitScn().isNull()) {
                     sourceInfoStruct.put(SourceInfo.COMMIT_SCN_KEY, redoThreadCommitScn.getCommitScn().toString());
                 }
-
-                if (redoThreadCommitScn.getRsId() != null) {
-                    sourceInfoStruct.put(ROLLBACK_SEGMENT_ID_KEY, redoThreadCommitScn.getRsId());
-                }
-
-                sourceInfoStruct.put(SQL_SEQUENCE_NUMBER_KEY, redoThreadCommitScn.getSsn());
                 sourceInfoStruct.put(REDO_THREAD_KEY, redoThreadCommitScn.getThread());
             }
         }
@@ -240,7 +228,7 @@ public class CommitScn implements Comparable<Scn> {
     public static CommitScn valueOf(Long value) {
         final Set<RedoThreadCommitScn> scns = new HashSet<>();
         if (value != null) {
-            scns.add(new RedoThreadCommitScn(1, Scn.valueOf(value), null, 0, new HashSet<>()));
+            scns.add(new RedoThreadCommitScn(1, Scn.valueOf(value), new HashSet<>()));
         }
         return new CommitScn(scns);
     }
@@ -256,6 +244,10 @@ public class CommitScn implements Comparable<Scn> {
         if (value instanceof String) {
             return CommitScn.valueOf((String) value);
         }
+        // todo:
+        // Much like the parsing handler in the RedOThreadCommitScn class, the same question applies here.
+        // When we do consider removing this behavior? The migration of Long to String occurred in the
+        // 1.5.0.Final release, can we drop this in 2.0?
         else if (value != null) {
             // This might be a legacy offset being read when the values were Long data types.
             // In this case, we can assume that the redo thread is 1 and explicitly create a
@@ -267,9 +259,7 @@ public class CommitScn implements Comparable<Scn> {
     }
 
     public static SchemaBuilder schemaBuilder(SchemaBuilder schemaBuilder) {
-        return schemaBuilder.field(ROLLBACK_SEGMENT_ID_KEY, Schema.OPTIONAL_STRING_SCHEMA)
-                .field(SQL_SEQUENCE_NUMBER_KEY, Schema.OPTIONAL_INT32_SCHEMA)
-                .field(REDO_THREAD_KEY, Schema.OPTIONAL_INT32_SCHEMA);
+        return schemaBuilder.field(REDO_THREAD_KEY, Schema.OPTIONAL_INT32_SCHEMA);
     }
 
     /**
@@ -291,23 +281,19 @@ public class CommitScn implements Comparable<Scn> {
 
         private final int thread;
         private Scn commitScn;
-        private String rsId;
-        private int ssn;
         private Set<String> txIds;
 
         public RedoThreadCommitScn(int thread) {
-            this(thread, Scn.NULL, null, 0, Collections.emptySet());
+            this(thread, Scn.NULL, Collections.emptySet());
         }
 
         public RedoThreadCommitScn(LogMinerEventRow row) {
-            this(row.getThread(), row.getScn(), row.getRsId(), row.getSsn(), Collections.singleton(row.getTransactionId()));
+            this(row.getThread(), row.getScn(), Collections.singleton(row.getTransactionId()));
         }
 
-        public RedoThreadCommitScn(int thread, Scn commitScn, String rsId, int ssn, Set<String> txIds) {
+        public RedoThreadCommitScn(int thread, Scn commitScn, Set<String> txIds) {
             this.thread = thread;
             this.commitScn = commitScn;
-            this.rsId = rsId;
-            this.ssn = ssn;
             // Use TreeSet to guarantee a deterministic output order in offsets.
             this.txIds = new TreeSet<>(txIds);
         }
@@ -324,22 +310,6 @@ public class CommitScn implements Comparable<Scn> {
             this.commitScn = commitScn;
         }
 
-        public String getRsId() {
-            return rsId;
-        }
-
-        public void setRsId(String rsId) {
-            this.rsId = rsId;
-        }
-
-        public int getSsn() {
-            return ssn;
-        }
-
-        public void setSsn(int ssn) {
-            this.ssn = ssn;
-        }
-
         public Set<String> getTxIds() {
             return txIds;
         }
@@ -349,7 +319,7 @@ public class CommitScn implements Comparable<Scn> {
         }
 
         public String getFormattedString() {
-            return commitScn.toString() + ":" + (rsId != null ? rsId : "") + ":" + ssn + ":" + thread + ":" + Strings.join("-", txIds);
+            return commitScn.toString() + ":" + thread + ":" + Strings.join("-", txIds);
         }
 
         public static RedoThreadCommitScn valueOf(String value) {
@@ -358,27 +328,31 @@ public class CommitScn implements Comparable<Scn> {
                 // Reading a legacy commit_scn entry that has only the SCN bit
                 // Create the redo thread entry with thread 1.
                 // There is only ever a single redo thread commit entry in this use case.
-                return new RedoThreadCommitScn(1, Scn.valueOf(parts[0]), null, 0, new HashSet<>());
+                return new RedoThreadCommitScn(1, Scn.valueOf(parts[0]), new HashSet<>());
+            }
+            // todo:
+            // The 4-part logic was back ported to Debezium 1.9.5 and the 3-part will be to 1.9.6.
+            // We need to decide at what point do we want to eliminate this backward compatibility logic
+            // and document what version a user must upgrade to as an "intermediate". For this use case,
+            // we could treat 2.0.0.Final as the intermediate and remove the legacy parsing support in
+            // 2.1.0.Final, meaning users upgrading from prior to 1.9.6 will be required to jump first
+            // to 2.0 and then to 2.1?
+            else if (parts.length == 3) {
+                // The V2 redo-thread based commit scn entry, consisting of 3 parts
+                final Scn scn = Scn.valueOf(parts[0]);
+                final int thread = Integer.parseInt(parts[1]);
+                Set<String> txIds = new HashSet<>();
+                if (!parts[2].isEmpty()) {
+                    Collections.addAll(txIds, parts[2].split("-"));
+                }
+                return new RedoThreadCommitScn(thread, scn, txIds);
             }
             else if (parts.length == 4) {
-                // The new redo-thread based commit scn entry
+                // The V1 redo-thread based commit scn entry, consisting of 4 parts.
+                // Parts at index 1 and 2 are no longer used.
                 final Scn scn = Scn.valueOf(parts[0]);
-                final String rsId = parts[1];
-                final int ssn = Integer.parseInt(parts[2]);
                 final int thread = Integer.parseInt(parts[3]);
-                return new RedoThreadCommitScn(thread, scn, rsId, ssn, new HashSet<>());
-            }
-            else if (parts.length == 5) {
-                // The new redo-thread based commit scn entry
-                final Scn scn = Scn.valueOf(parts[0]);
-                final String rsId = parts[1];
-                final int ssn = Integer.parseInt(parts[2]);
-                final int thread = Integer.parseInt(parts[3]);
-                Set<String> txIds = new HashSet<>();
-                if (!parts[4].isEmpty()) {
-                    Collections.addAll(txIds, parts[4].split("-"));
-                }
-                return new RedoThreadCommitScn(thread, scn, rsId, ssn, txIds);
+                return new RedoThreadCommitScn(thread, scn, new HashSet<>());
             }
             throw new DebeziumException("An unexpected redo thread commit scn entry: '" + value + "'");
         }
@@ -388,8 +362,6 @@ public class CommitScn implements Comparable<Scn> {
             return "RedoThreadCommitScn{" +
                     "thread=" + thread +
                     ", commitScn=" + commitScn +
-                    ", rsId='" + rsId + '\'' +
-                    ", ssn=" + ssn +
                     ", txIds=" + txIds +
                     '}';
         }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/CommitScn.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/CommitScn.java
@@ -14,13 +14,13 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-import io.debezium.util.Strings;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 
 import io.debezium.DebeziumException;
 import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
+import io.debezium.util.Strings;
 
 /**
  * Represents either a single or a collection of commit {@link Scn} positions that collectively

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/CommitScn.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/CommitScn.java
@@ -356,7 +356,16 @@ public class CommitScn implements Comparable<Scn> {
                 // Create the redo thread entry with thread 1.
                 // There is only ever a single redo thread commit entry in this use case.
                 return new RedoThreadCommitScn(1, Scn.valueOf(parts[0]), null, 0, new HashSet<>());
-            } else if (parts.length == 5) {
+            }
+            else if (parts.length == 4) {
+                // The new redo-thread based commit scn entry
+                final Scn scn = Scn.valueOf(parts[0]);
+                final String rsId = parts[1];
+                final int ssn = Integer.parseInt(parts[2]);
+                final int thread = Integer.parseInt(parts[3]);
+                return new RedoThreadCommitScn(thread, scn, rsId, ssn, new HashSet<>());
+            }
+            else if (parts.length == 5) {
                 // The new redo-thread based commit scn entry
                 final Scn scn = Scn.valueOf(parts[0]);
                 final String rsId = parts[1];

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/CommitScn.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/CommitScn.java
@@ -9,10 +9,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import io.debezium.util.Strings;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -92,7 +94,9 @@ public class CommitScn implements Comparable<Scn> {
     public boolean hasCommitAlreadyBeenHandled(LogMinerEventRow row) {
         final RedoThreadCommitScn commitScn = redoThreadCommitScns.get(row.getThread());
         if (commitScn != null) {
-            return commitScn.getCommitScn().compareTo(row.getScn()) >= 0;
+            Set<String> txIds = commitScn.getTxIds();
+            return commitScn.getCommitScn().compareTo(row.getScn()) > 0 ||
+                    (commitScn.getCommitScn().compareTo(row.getScn()) == 0 && txIds.contains(row.getTransactionId()));
         }
         return false;
     }
@@ -105,6 +109,16 @@ public class CommitScn implements Comparable<Scn> {
     public void recordCommit(LogMinerEventRow row) {
         final RedoThreadCommitScn redoCommitScn = redoThreadCommitScns.get(row.getThread());
         if (redoCommitScn != null) {
+            Scn prevCommitScn = redoCommitScn.getCommitScn();
+            if (Objects.equals(prevCommitScn, row.getScn())) {
+                Set<String> txIds = redoCommitScn.getTxIds();
+                txIds.add(row.getTransactionId());
+            }
+            else {
+                Set<String> txIds = new HashSet<>();
+                txIds.add(row.getTransactionId());
+                redoCommitScn.setTxIds(txIds);
+            }
             redoCommitScn.setCommitScn(row.getScn());
             redoCommitScn.setRsId(row.getRsId());
             redoCommitScn.setSsn(row.getSsn());
@@ -224,7 +238,7 @@ public class CommitScn implements Comparable<Scn> {
     public static CommitScn valueOf(Long value) {
         final Set<RedoThreadCommitScn> scns = new HashSet<>();
         if (value != null) {
-            scns.add(new RedoThreadCommitScn(1, Scn.valueOf(value), null, 0));
+            scns.add(new RedoThreadCommitScn(1, Scn.valueOf(value), null, 0, new HashSet<>()));
         }
         return new CommitScn(scns);
     }
@@ -277,20 +291,22 @@ public class CommitScn implements Comparable<Scn> {
         private Scn commitScn;
         private String rsId;
         private int ssn;
+        private Set<String> txIds;
 
         public RedoThreadCommitScn(int thread) {
-            this(thread, Scn.NULL, null, 0);
+            this(thread, Scn.NULL, null, 0, new HashSet<>());
         }
 
         public RedoThreadCommitScn(LogMinerEventRow row) {
-            this(row.getThread(), row.getScn(), row.getRsId(), row.getSsn());
+            this(row.getThread(), row.getScn(), row.getRsId(), row.getSsn(), new HashSet<>());
         }
 
-        public RedoThreadCommitScn(int thread, Scn commitScn, String rsId, int ssn) {
+        public RedoThreadCommitScn(int thread, Scn commitScn, String rsId, int ssn, Set<String> txIds) {
             this.thread = thread;
             this.commitScn = commitScn;
             this.rsId = rsId;
             this.ssn = ssn;
+            this.txIds = txIds;
         }
 
         public int getThread() {
@@ -321,25 +337,36 @@ public class CommitScn implements Comparable<Scn> {
             this.ssn = ssn;
         }
 
+        public Set<String> getTxIds() {
+            return txIds;
+        }
+
+        public void setTxIds(Set<String> txIds) {
+            this.txIds = txIds;
+        }
+
         public String getFormattedString() {
-            return commitScn.toString() + ":" + (rsId != null ? rsId : "") + ":" + ssn + ":" + thread;
+            return commitScn.toString() + ":" + (rsId != null ? rsId : "") + ":" + ssn + ":" + thread + ":" + Strings.join("-", txIds);
         }
 
         public static RedoThreadCommitScn valueOf(String value) {
-            final String[] parts = value.split(":");
+            final String[] parts = value.split(":", -1);
             if (parts.length == 1) {
                 // Reading a legacy commit_scn entry that has only the SCN bit
                 // Create the redo thread entry with thread 1.
                 // There is only ever a single redo thread commit entry in this use case.
-                return new RedoThreadCommitScn(1, Scn.valueOf(parts[0]), null, 0);
-            }
-            else if (parts.length == 4) {
+                return new RedoThreadCommitScn(1, Scn.valueOf(parts[0]), null, 0, new HashSet<>());
+            } else if (parts.length == 5) {
                 // The new redo-thread based commit scn entry
                 final Scn scn = Scn.valueOf(parts[0]);
                 final String rsId = parts[1];
                 final int ssn = Integer.parseInt(parts[2]);
                 final int thread = Integer.parseInt(parts[3]);
-                return new RedoThreadCommitScn(thread, scn, rsId, ssn);
+                Set<String> txIds = new HashSet<>();
+                if (!parts[4].isEmpty()) {
+                    Collections.addAll(txIds, parts[4].split("-"));
+                }
+                return new RedoThreadCommitScn(thread, scn, rsId, ssn, txIds);
             }
             throw new DebeziumException("An unexpected redo thread commit scn entry: '" + value + "'");
         }
@@ -351,6 +378,7 @@ public class CommitScn implements Comparable<Scn> {
                     ", commitScn=" + commitScn +
                     ", rsId='" + rsId + '\'' +
                     ", ssn=" + ssn +
+                    ", txIds=" + txIds +
                     '}';
         }
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleOffsetContext.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleOffsetContext.java
@@ -269,6 +269,14 @@ public class OracleOffsetContext extends CommonOffsetContext<SourceInfo> {
         sourceInfo.setRedoThread(redoThread);
     }
 
+    public void setRsId(String rsId) {
+        sourceInfo.setRsId(rsId);
+    }
+
+    public void setSsn(int ssn) {
+        sourceInfo.setSsn(ssn);
+    }
+
     @Override
     public boolean isSnapshotRunning() {
         return sourceInfo.isSnapshot() && !snapshotCompleted;

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSourceInfoStructMaker.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSourceInfoStructMaker.java
@@ -24,7 +24,9 @@ public class OracleSourceInfoStructMaker extends AbstractSourceInfoStructMaker<S
                 .field(SourceInfo.TXID_KEY, Schema.OPTIONAL_STRING_SCHEMA)
                 .field(SourceInfo.EVENT_SCN_KEY, Schema.OPTIONAL_STRING_SCHEMA)
                 .field(SourceInfo.COMMIT_SCN_KEY, Schema.OPTIONAL_STRING_SCHEMA)
-                .field(SourceInfo.LCR_POSITION_KEY, Schema.OPTIONAL_STRING_SCHEMA))
+                .field(SourceInfo.LCR_POSITION_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                .field(CommitScn.ROLLBACK_SEGMENT_ID_KEY, Schema.OPTIONAL_STRING_SCHEMA)
+                .field(CommitScn.SQL_SEQUENCE_NUMBER_KEY, Schema.OPTIONAL_INT32_SCHEMA))
                 .field(SourceInfo.USERNAME_KEY, Schema.OPTIONAL_STRING_SCHEMA).build();
     }
 
@@ -49,6 +51,11 @@ public class OracleSourceInfoStructMaker extends AbstractSourceInfoStructMaker<S
         if (sourceInfo.getUserName() != null) {
             ret.put(SourceInfo.USERNAME_KEY, sourceInfo.getUserName());
         }
+        if (sourceInfo.getRsId() != null) {
+            ret.put(CommitScn.ROLLBACK_SEGMENT_ID_KEY, sourceInfo.getRsId());
+        }
+
+        ret.put(CommitScn.SQL_SEQUENCE_NUMBER_KEY, sourceInfo.getSsn());
 
         final CommitScn commitScn = sourceInfo.getCommitScn();
         if (commitScn != null) {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/SourceInfo.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/SourceInfo.java
@@ -35,6 +35,8 @@ public class SourceInfo extends BaseSourceInfo {
     private Instant sourceTime;
     private Set<TableId> tableIds;
     private Integer redoThread;
+    private String rsId;
+    private int ssn;
 
     protected SourceInfo(OracleConnectorConfig connectorConfig) {
         super(connectorConfig);
@@ -86,6 +88,22 @@ public class SourceInfo extends BaseSourceInfo {
 
     public void setUserName(String userName) {
         this.userName = userName;
+    }
+
+    public String getRsId() {
+        return rsId;
+    }
+
+    public void setRsId(String rsId) {
+        this.rsId = rsId;
+    }
+
+    public int getSsn() {
+        return ssn;
+    }
+
+    public void setSsn(int ssn) {
+        this.ssn = ssn;
     }
 
     public Instant getSourceTime() {

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/CommitScnTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/CommitScnTest.java
@@ -54,7 +54,7 @@ public class CommitScnTest {
     }
 
     @Test
-    @FixFor("DBZ-5245")
+    @FixFor({ "DBZ-5245", "DBZ-5439" })
     public void shouldParseCommitScnThatIsString() throws Exception {
         // Test parsing with only SCN value in the string
         CommitScn commitScn = CommitScn.valueOf("12345");
@@ -78,6 +78,18 @@ public class CommitScnTest {
         assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(12345L));
         assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:00241f.00093ff0.0010:0:1:");
 
+        // Test parsing with new multi-part SCN with transaction ids, single value
+        commitScn = CommitScn.valueOf("12345:00241f.00093ff0.0010:0:1:123456789-234567890");
+        assertThat(commitScn).isNotNull();
+        assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(12345L));
+        assertThat(commitScn.getCommitScnForAllRedoThreads()).hasSize(1);
+        assertThat(commitScn.getCommitScnForAllRedoThreads().keySet()).containsOnly(1);
+        assertThat(commitScn.getCommitScnForAllRedoThreads().get(1)).isEqualTo(Scn.valueOf(12345L));
+        assertThat(commitScn.getCommitScnForRedoThread(1)).isEqualTo(Scn.valueOf(12345L));
+        assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(12345L));
+        assertThat(commitScn.getRedoThreadCommitScn(1).getTxIds()).containsOnly("123456789", "234567890");
+        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:00241f.00093ff0.0010:0:1:123456789-234567890");
+
         // Test parsing with new multi-part SCN, multi value
         commitScn = CommitScn.valueOf("12345:00241f.00093ff0.0010:0:1,678901:1253ef.123457ee0.abcd:0:2");
         assertThat(commitScn).isNotNull();
@@ -90,10 +102,25 @@ public class CommitScnTest {
         assertThat(commitScn.getCommitScnForRedoThread(2)).isEqualTo(Scn.valueOf(678901L));
         assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(678901L));
         assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:00241f.00093ff0.0010:0:1:,678901:1253ef.123457ee0.abcd:0:2:");
+
+        // Test parsing with new multi-part SCN with transaction ids, multi value
+        commitScn = CommitScn.valueOf("12345:00241f.00093ff0.0010:0:1:23456-78901,678901:1253ef.123457ee0.abcd:0:2:12345-67890");
+        assertThat(commitScn).isNotNull();
+        assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(678901L));
+        assertThat(commitScn.getCommitScnForAllRedoThreads()).hasSize(2);
+        assertThat(commitScn.getCommitScnForAllRedoThreads().keySet()).containsOnly(1, 2);
+        assertThat(commitScn.getCommitScnForAllRedoThreads().get(1)).isEqualTo(Scn.valueOf(12345L));
+        assertThat(commitScn.getCommitScnForAllRedoThreads().get(2)).isEqualTo(Scn.valueOf(678901L));
+        assertThat(commitScn.getCommitScnForRedoThread(1)).isEqualTo(Scn.valueOf(12345L));
+        assertThat(commitScn.getCommitScnForRedoThread(2)).isEqualTo(Scn.valueOf(678901L));
+        assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(678901L));
+        assertThat(commitScn.getRedoThreadCommitScn(1).getTxIds()).containsOnly("23456", "78901");
+        assertThat(commitScn.getRedoThreadCommitScn(2).getTxIds()).containsOnly("12345", "67890");
+        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:00241f.00093ff0.0010:0:1:23456-78901,678901:1253ef.123457ee0.abcd:0:2:12345-67890");
     }
 
     @Test
-    @FixFor("DBZ-5245")
+    @FixFor({ "DBZ-5245", "DBZ-5439" })
     public void shouldSetCommitScnAcrossAllRedoThreads() throws Exception {
         // Test no redo thread data
         CommitScn commitScn = CommitScn.valueOf((String) null);
@@ -115,6 +142,14 @@ public class CommitScnTest {
         assertThat(commitScn.getCommitScnForAllRedoThreads()).hasSize(1);
         assertThat(commitScn.getCommitScnForRedoThread(1)).isEqualTo(Scn.valueOf(23456L));
 
+        // Test with a single redo record, with transaction ids
+        commitScn = CommitScn.valueOf("12345:00241f.00093ff0.0010:0:1:12345-67890");
+        commitScn.setCommitScnOnAllThreads(Scn.valueOf(23456L));
+        assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(23456L));
+        assertThat(commitScn.getCommitScnForAllRedoThreads()).hasSize(1);
+        assertThat(commitScn.getRedoThreadCommitScn(1).getTxIds()).containsOnly("12345", "67890");
+        assertThat(commitScn.getCommitScnForRedoThread(1)).isEqualTo(Scn.valueOf(23456L));
+
         // Test with a multi redo record
         commitScn = CommitScn.valueOf("12345:00241f.00093ff0.0010:0:1,678901:1253ef.123457ee0.abcd:0:2");
         commitScn.setCommitScnOnAllThreads(Scn.valueOf(23456L));
@@ -122,6 +157,16 @@ public class CommitScnTest {
         assertThat(commitScn.getCommitScnForAllRedoThreads()).hasSize(2);
         assertThat(commitScn.getCommitScnForRedoThread(1)).isEqualTo(Scn.valueOf(23456L));
         assertThat(commitScn.getCommitScnForRedoThread(2)).isEqualTo(Scn.valueOf(23456L));
+
+        // Test with a multi redo record, with transaction ids
+        commitScn = CommitScn.valueOf("12345:00241f.00093ff0.0010:0:1:12345-67890,678901:1253ef.123457ee0.abcd:0:2:23456-78901");
+        commitScn.setCommitScnOnAllThreads(Scn.valueOf(23456L));
+        assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(23456L));
+        assertThat(commitScn.getCommitScnForAllRedoThreads()).hasSize(2);
+        assertThat(commitScn.getCommitScnForRedoThread(1)).isEqualTo(Scn.valueOf(23456L));
+        assertThat(commitScn.getCommitScnForRedoThread(2)).isEqualTo(Scn.valueOf(23456L));
+        assertThat(commitScn.getRedoThreadCommitScn(1).getTxIds()).containsOnly("12345", "67890");
+        assertThat(commitScn.getRedoThreadCommitScn(2).getTxIds()).containsOnly("23456", "78901");
     }
 
     @Test

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/CommitScnTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/CommitScnTest.java
@@ -50,7 +50,7 @@ public class CommitScnTest {
         assertThat(commitScn.getCommitScnForAllRedoThreads().get(1)).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getCommitScnForRedoThread(1)).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(12345L));
-        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345::0:1:");
+        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:1:");
     }
 
     @Test
@@ -65,7 +65,7 @@ public class CommitScnTest {
         assertThat(commitScn.getCommitScnForAllRedoThreads().get(1)).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getCommitScnForRedoThread(1)).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(12345L));
-        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345::0:1:");
+        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:1:");
 
         // Test parsing with new multi-part SCN, single value
         commitScn = CommitScn.valueOf("12345:00241f.00093ff0.0010:0:1");
@@ -76,10 +76,10 @@ public class CommitScnTest {
         assertThat(commitScn.getCommitScnForAllRedoThreads().get(1)).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getCommitScnForRedoThread(1)).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(12345L));
-        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:00241f.00093ff0.0010:0:1:");
+        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:1:");
 
         // Test parsing with new multi-part SCN with transaction ids, single value
-        commitScn = CommitScn.valueOf("12345:00241f.00093ff0.0010:0:1:123456789-234567890");
+        commitScn = CommitScn.valueOf("12345:1:123456789-234567890");
         assertThat(commitScn).isNotNull();
         assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getCommitScnForAllRedoThreads()).hasSize(1);
@@ -88,7 +88,7 @@ public class CommitScnTest {
         assertThat(commitScn.getCommitScnForRedoThread(1)).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getRedoThreadCommitScn(1).getTxIds()).containsOnly("123456789", "234567890");
-        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:00241f.00093ff0.0010:0:1:123456789-234567890");
+        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:1:123456789-234567890");
 
         // Test parsing with new multi-part SCN, multi value
         commitScn = CommitScn.valueOf("12345:00241f.00093ff0.0010:0:1,678901:1253ef.123457ee0.abcd:0:2");
@@ -101,10 +101,10 @@ public class CommitScnTest {
         assertThat(commitScn.getCommitScnForRedoThread(1)).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getCommitScnForRedoThread(2)).isEqualTo(Scn.valueOf(678901L));
         assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(678901L));
-        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:00241f.00093ff0.0010:0:1:,678901:1253ef.123457ee0.abcd:0:2:");
+        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:1:,678901:2:");
 
         // Test parsing with new multi-part SCN with transaction ids, multi value
-        commitScn = CommitScn.valueOf("12345:00241f.00093ff0.0010:0:1:23456-78901,678901:1253ef.123457ee0.abcd:0:2:12345-67890");
+        commitScn = CommitScn.valueOf("12345:1:23456-78901,678901:2:12345-67890");
         assertThat(commitScn).isNotNull();
         assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(678901L));
         assertThat(commitScn.getCommitScnForAllRedoThreads()).hasSize(2);
@@ -116,7 +116,7 @@ public class CommitScnTest {
         assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(678901L));
         assertThat(commitScn.getRedoThreadCommitScn(1).getTxIds()).containsOnly("23456", "78901");
         assertThat(commitScn.getRedoThreadCommitScn(2).getTxIds()).containsOnly("12345", "67890");
-        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:00241f.00093ff0.0010:0:1:23456-78901,678901:1253ef.123457ee0.abcd:0:2:12345-67890");
+        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:1:23456-78901,678901:2:12345-67890");
     }
 
     @Test
@@ -143,7 +143,7 @@ public class CommitScnTest {
         assertThat(commitScn.getCommitScnForRedoThread(1)).isEqualTo(Scn.valueOf(23456L));
 
         // Test with a single redo record, with transaction ids
-        commitScn = CommitScn.valueOf("12345:00241f.00093ff0.0010:0:1:12345-67890");
+        commitScn = CommitScn.valueOf("12345:1:12345-67890");
         commitScn.setCommitScnOnAllThreads(Scn.valueOf(23456L));
         assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(23456L));
         assertThat(commitScn.getCommitScnForAllRedoThreads()).hasSize(1);
@@ -159,7 +159,7 @@ public class CommitScnTest {
         assertThat(commitScn.getCommitScnForRedoThread(2)).isEqualTo(Scn.valueOf(23456L));
 
         // Test with a multi redo record, with transaction ids
-        commitScn = CommitScn.valueOf("12345:00241f.00093ff0.0010:0:1:12345-67890,678901:1253ef.123457ee0.abcd:0:2:23456-78901");
+        commitScn = CommitScn.valueOf("12345:1:12345-67890,678901:2:23456-78901");
         commitScn.setCommitScnOnAllThreads(Scn.valueOf(23456L));
         assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(23456L));
         assertThat(commitScn.getCommitScnForAllRedoThreads()).hasSize(2);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/CommitScnTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/CommitScnTest.java
@@ -50,7 +50,7 @@ public class CommitScnTest {
         assertThat(commitScn.getCommitScnForAllRedoThreads().get(1)).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getCommitScnForRedoThread(1)).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(12345L));
-        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345::0:1");
+        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345::0:1:");
     }
 
     @Test
@@ -65,7 +65,7 @@ public class CommitScnTest {
         assertThat(commitScn.getCommitScnForAllRedoThreads().get(1)).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getCommitScnForRedoThread(1)).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(12345L));
-        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345::0:1");
+        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345::0:1:");
 
         // Test parsing with new multi-part SCN, single value
         commitScn = CommitScn.valueOf("12345:00241f.00093ff0.0010:0:1");
@@ -76,7 +76,7 @@ public class CommitScnTest {
         assertThat(commitScn.getCommitScnForAllRedoThreads().get(1)).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getCommitScnForRedoThread(1)).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(12345L));
-        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:00241f.00093ff0.0010:0:1");
+        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:00241f.00093ff0.0010:0:1:");
 
         // Test parsing with new multi-part SCN, multi value
         commitScn = CommitScn.valueOf("12345:00241f.00093ff0.0010:0:1,678901:1253ef.123457ee0.abcd:0:2");
@@ -89,7 +89,7 @@ public class CommitScnTest {
         assertThat(commitScn.getCommitScnForRedoThread(1)).isEqualTo(Scn.valueOf(12345L));
         assertThat(commitScn.getCommitScnForRedoThread(2)).isEqualTo(Scn.valueOf(678901L));
         assertThat(commitScn.getMaxCommittedScn()).isEqualTo(Scn.valueOf(678901L));
-        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:00241f.00093ff0.0010:0:1,678901:1253ef.123457ee0.abcd:0:2");
+        assertThat(encodedCommitScn(commitScn)).isEqualTo("12345:00241f.00093ff0.0010:0:1:,678901:1253ef.123457ee0.abcd:0:2:");
     }
 
     @Test

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
@@ -95,7 +95,7 @@ public class OracleOffsetContextTest {
         // Write values out as Debezium 1.9
         Map<String, ?> writeValues = offsetContext.getOffset();
         assertThat(writeValues.get(SourceInfo.SCN_KEY)).isEqualTo("745688898023");
-        assertThat(writeValues.get(SourceInfo.COMMIT_SCN_KEY)).isEqualTo("745688898024::0:1:");
+        assertThat(writeValues.get(SourceInfo.COMMIT_SCN_KEY)).isEqualTo("745688898024:1:");
         assertThat(writeValues.get(OracleOffsetContext.SNAPSHOT_PENDING_TRANSACTIONS_KEY)).isNull();
         assertThat(writeValues.get(OracleOffsetContext.SNAPSHOT_SCN_KEY)).isNull();
 
@@ -105,7 +105,7 @@ public class OracleOffsetContextTest {
         // Write values out as Debezium 1.9
         writeValues = offsetContext.getOffset();
         assertThat(writeValues.get(SourceInfo.SCN_KEY)).isEqualTo("745688898023");
-        assertThat(writeValues.get(SourceInfo.COMMIT_SCN_KEY)).isEqualTo("745688898024::0:1:");
+        assertThat(writeValues.get(SourceInfo.COMMIT_SCN_KEY)).isEqualTo("745688898024:1:");
         assertThat(writeValues.get(OracleOffsetContext.SNAPSHOT_PENDING_TRANSACTIONS_KEY)).isNull();
         assertThat(writeValues.get(OracleOffsetContext.SNAPSHOT_SCN_KEY)).isNull();
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleOffsetContextTest.java
@@ -95,7 +95,7 @@ public class OracleOffsetContextTest {
         // Write values out as Debezium 1.9
         Map<String, ?> writeValues = offsetContext.getOffset();
         assertThat(writeValues.get(SourceInfo.SCN_KEY)).isEqualTo("745688898023");
-        assertThat(writeValues.get(SourceInfo.COMMIT_SCN_KEY)).isEqualTo("745688898024::0:1");
+        assertThat(writeValues.get(SourceInfo.COMMIT_SCN_KEY)).isEqualTo("745688898024::0:1:");
         assertThat(writeValues.get(OracleOffsetContext.SNAPSHOT_PENDING_TRANSACTIONS_KEY)).isNull();
         assertThat(writeValues.get(OracleOffsetContext.SNAPSHOT_SCN_KEY)).isNull();
 
@@ -105,7 +105,7 @@ public class OracleOffsetContextTest {
         // Write values out as Debezium 1.9
         writeValues = offsetContext.getOffset();
         assertThat(writeValues.get(SourceInfo.SCN_KEY)).isEqualTo("745688898023");
-        assertThat(writeValues.get(SourceInfo.COMMIT_SCN_KEY)).isEqualTo("745688898024::0:1");
+        assertThat(writeValues.get(SourceInfo.COMMIT_SCN_KEY)).isEqualTo("745688898024::0:1:");
         assertThat(writeValues.get(OracleOffsetContext.SNAPSHOT_PENDING_TRANSACTIONS_KEY)).isNull();
         assertThat(writeValues.get(OracleOffsetContext.SNAPSHOT_SCN_KEY)).isNull();
     }

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -125,5 +125,15 @@
                 </includes>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>15</source>
+                    <target>15</target>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -153,3 +153,4 @@ comil4444,崔世杰
 BetaCat,合龙 张
 tjwornjs,Seo Jae-kwon
 druud,Ruud H.G. van Tol
+thangdc94,Phạm Ngọc Thắng


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5439

Hi @thangdc94 I've reworked your PR by addressing the following outstanding items.  To avoid conflicts with your current branch, I've elected to open up this new PR based on my fork instead but with your commits cherry-picked.

1. Fixed your commit with your missing GH email address.
2. Used `TreeSet` rather than `HashSet` to guarantee output order of the formatted string
3. Removed `RS_ID` and `SSN` from the `CommitScn`, they're still part of the source info block, but not in the offsets.