### PR TITLE
DBZ-5544 Support BASE64_URL_SAFE in BinaryHandlingMode

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlBinaryModeIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlBinaryModeIT.java
@@ -175,4 +175,44 @@ public class MySqlBinaryModeIT extends AbstractConnectorTest {
         // Check that all records are valid, can be serialized and deserialized ...
         sourceRecords.forEach(this::validate);
     }
+
+    @Test
+    @FixFor("DBZ-5544")
+    public void shouldReceiveBase64UrlSafeBinary() throws SQLException, InterruptedException {
+        // Use the DB configuration to define the connector's configuration ...
+        config = DATABASE.defaultConfig()
+                .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.NEVER)
+                .with(MySqlConnectorConfig.BINARY_HANDLING_MODE, BinaryHandlingMode.BASE64_URL_SAFE)
+                .build();
+
+        // Start the connector ...
+        start(MySqlConnector.class, config);
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Consume all of the events due to startup and initialization of the database
+        // ---------------------------------------------------------------------------------------------------------------
+        // Testing.Debug.enable();
+        int createDatabaseCount = 1;
+        int createTableCount = 1;
+        int insertCount = 1;
+        SourceRecords sourceRecords = consumeRecordsByTopic(createDatabaseCount + createTableCount + insertCount);
+        stopConnector();
+        assertThat(sourceRecords).isNotNull();
+
+        List<SourceRecord> topicSourceRecords = sourceRecords.recordsForTopic(DATABASE.topicForTable("dbz_1814_binary_mode_test"));
+        assertThat(topicSourceRecords).hasSize(1);
+
+        SourceRecord topicSourceRecord = topicSourceRecords.get(0);
+        Struct kafkaDataStructure = (Struct) ((Struct) topicSourceRecord.value()).get("after");
+        String expectedValue = "AQID";
+        assertEquals(expectedValue, kafkaDataStructure.get("blob_col"));
+        assertEquals(expectedValue, kafkaDataStructure.get("tinyblob_col"));
+        assertEquals(expectedValue, kafkaDataStructure.get("mediumblob_col"));
+        assertEquals(expectedValue, kafkaDataStructure.get("longblob_col"));
+        assertEquals(expectedValue, kafkaDataStructure.get("binary_col"));
+        assertEquals(expectedValue, kafkaDataStructure.get("varbinary_col"));
+
+        // Check that all records are valid, can be serialized and deserialized ...
+        sourceRecords.forEach(this::validate);
+    }
 }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBinaryModeIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleBinaryModeIT.java
@@ -79,6 +79,14 @@ public class OracleBinaryModeIT extends AbstractConnectorTest {
         assertEquals(expectedValue, data.get("BLOB_COL"));
     }
 
+    @Test
+    public void shouldReceiveBase64UrlSafeBinary() throws InterruptedException {
+        Struct data = consume(BinaryHandlingMode.BASE64_URL_SAFE);
+
+        String expectedValue = "AQID";
+        assertEquals(expectedValue, data.get("BLOB_COL"));
+    }
+
     private Struct consume(BinaryHandlingMode binaryMode) throws InterruptedException {
         final Configuration config = TestHelper.defaultConfig()
                 .with(OracleConnectorConfig.SNAPSHOT_MODE, OracleConnectorConfig.SnapshotMode.INITIAL)

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/LogicalDecodingMessageMonitor.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/LogicalDecodingMessageMonitor.java
@@ -50,6 +50,7 @@ public class LogicalDecodingMessageMonitor {
     private final String topicName;
     private final BinaryHandlingMode binaryMode;
     private final Encoder base64Encoder;
+    private final Encoder base64UrlSafeEncoder;
 
     /**
      * The key schema; a struct like this:
@@ -70,6 +71,7 @@ public class LogicalDecodingMessageMonitor {
         this.topicName = connectorConfig.getLogicalName() + LOGICAL_DECODING_MESSAGE_TOPIC_SUFFIX;
         this.binaryMode = connectorConfig.binaryHandlingMode();
         this.base64Encoder = Base64.getEncoder();
+        this.base64UrlSafeEncoder = Base64.getUrlEncoder();
 
         this.keySchema = SchemaBuilder.struct()
                 .name(schemaNameAdjuster.adjust("io.debezium.connector.postgresql.MessageKey"))
@@ -123,6 +125,8 @@ public class LogicalDecodingMessageMonitor {
         switch (binaryMode) {
             case BASE64:
                 return new String(base64Encoder.encode(content), StandardCharsets.UTF_8);
+            case BASE64_URL_SAFE:
+                return new String(base64UrlSafeEncoder.encode(content), StandardCharsets.UTF_8);
             case HEX:
                 return HexConverter.convertToHexString(content);
             case BYTES:

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -1101,6 +1101,11 @@ public class PostgresValueConverter extends JdbcValueConverters {
     }
 
     @Override
+    protected Object convertBinaryToBase64UrlSafe(Column column, Field fieldDefn, Object data) {
+        return super.convertBinaryToBase64UrlSafe(column, fieldDefn, (data instanceof PGobject) ? ((PGobject) data).getValue() : data);
+    }
+
+    @Override
     protected Object convertBinaryToHex(Column column, Field fieldDefn, Object data) {
         return super.convertBinaryToHex(column, fieldDefn, (data instanceof PGobject) ? ((PGobject) data).getValue() : data);
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/AbstractRecordsProducerTest.java
@@ -420,12 +420,20 @@ public abstract class AbstractRecordsProducerTest extends AbstractConnectorTest 
         return Arrays.asList(new SchemaAndValueField("ba", Schema.OPTIONAL_STRING_SCHEMA, "AQID"));
     }
 
+    protected List<SchemaAndValueField> schemaAndValueForByteaBase64UrlSafe() {
+        return Arrays.asList(new SchemaAndValueField("ba", Schema.OPTIONAL_STRING_SCHEMA, "AQID"));
+    }
+
     protected List<SchemaAndValueField> schemaAndValueForUnknownColumnBytes() {
         return Arrays.asList(new SchemaAndValueField("ccircle", Schema.OPTIONAL_BYTES_SCHEMA, ByteBuffer.wrap("<(10.0,20.0),10.0>".getBytes(StandardCharsets.UTF_8))));
     }
 
     protected List<SchemaAndValueField> schemaAndValueForUnknownColumnBase64() {
         return Arrays.asList(new SchemaAndValueField("ccircle", Schema.OPTIONAL_STRING_SCHEMA, "PCgxMC4wLDIwLjApLDEwLjA+"));
+    }
+
+    protected List<SchemaAndValueField> schemaAndValueForUnknownColumnBase64UrlSafe() {
+        return Arrays.asList(new SchemaAndValueField("ccircle", Schema.OPTIONAL_STRING_SCHEMA, "PCgxMC4wLDIwLjApLDEwLjA-"));
     }
 
     protected List<SchemaAndValueField> schemaAndValueForUnknownColumnHex() {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -1243,6 +1243,16 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
     }
 
     @Test
+    @FixFor("DBZ-5544")
+    public void shouldReceiveByteaBase64UrlSafeString() throws Exception {
+        TestHelper.executeDDL("postgres_create_tables.ddl");
+
+        startConnector(config -> config.with(PostgresConnectorConfig.BINARY_HANDLING_MODE, PostgresConnectorConfig.BinaryHandlingMode.BASE64_URL_SAFE));
+
+        assertInsert(INSERT_BYTEA_BINMODE_STMT, 1, schemaAndValueForByteaBase64UrlSafe());
+    }
+
+    @Test
     @FixFor("DBZ-1814")
     public void shouldReceiveByteaHexString() throws Exception {
         TestHelper.executeDDL("postgres_create_tables.ddl");
@@ -1271,6 +1281,17 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
                 .with(PostgresConnectorConfig.BINARY_HANDLING_MODE, BinaryHandlingMode.BASE64));
 
         assertInsert(INSERT_CIRCLE_STMT, 1, schemaAndValueForUnknownColumnBase64());
+    }
+
+    @Test
+    @FixFor("DBZ-5544")
+    public void shouldReceiveUnknownTypeAsBase64UrlSafe() throws Exception {
+        TestHelper.executeDDL("postgres_create_tables.ddl");
+
+        startConnector(config -> config.with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true)
+                .with(PostgresConnectorConfig.BINARY_HANDLING_MODE, BinaryHandlingMode.BASE64_URL_SAFE));
+
+        assertInsert(INSERT_CIRCLE_STMT, 1, schemaAndValueForUnknownColumnBase64UrlSafe());
     }
 
     @Test

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerBinaryModeIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerBinaryModeIT.java
@@ -78,6 +78,15 @@ public class SqlServerBinaryModeIT extends AbstractConnectorTest {
         assertEquals(expectedValue, data.get("varbinary_col"));
     }
 
+    @Test
+    public void shouldReceiveBase64UrlSafeBinary() throws InterruptedException {
+        Struct data = consume(BinaryHandlingMode.BASE64_URL_SAFE);
+
+        String expectedValue = "AQID";
+        assertEquals(expectedValue, data.get("binary_col"));
+        assertEquals(expectedValue, data.get("varbinary_col"));
+    }
+
     private Struct consume(BinaryHandlingMode binaryMode) throws InterruptedException {
         final Configuration config = TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SqlServerConnectorConfig.SnapshotMode.INITIAL)

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -187,6 +187,11 @@ public abstract class CommonConnectorConfig {
         BASE64("base64", SchemaBuilder::string),
 
         /**
+         * Represent binary values as base64-url-safe-encoded string
+         */
+        BASE64_URL_SAFE("base64-url-safe", SchemaBuilder::string),
+
+        /**
          * Represents binary values as hex-encoded (base16) string
          */
         HEX("hex", SchemaBuilder::string);

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -488,6 +488,7 @@ public abstract class CommonConnectorConfig {
             .withDescription("Specify how binary (blob, binary, etc.) columns should be represented in change events, including: "
                     + "'bytes' represents binary data as byte array (default); "
                     + "'base64' represents binary data as base64-encoded string; "
+                    + "'base64-url-safe' represents binary data as base64-url-safe-encoded string; "
                     + "'hex' represents binary data as hex-encoded (base16) string");
 
     public static final Field SCHEMA_NAME_ADJUSTMENT_MODE = Field.create("schema.name.adjustment.mode")

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -1471,17 +1471,17 @@ a|_n/a_
 |`BINARY(M)]`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
+Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`VARBINARY(M)]`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
+Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`TINYBLOB`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
+Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`TINYTEXT`
 |`STRING`
@@ -1490,7 +1490,7 @@ a|_n/a_
 |`BLOB`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting. +
+Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting. +
 Only values with a size of up to 2GB are supported. It is recommended to externalize large column values, using the claim check pattern.
 
 |`TEXT`
@@ -1501,7 +1501,7 @@ Only values with a size of up to 2GB are supported. It is recommended to externa
 |`MEDIUMBLOB`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
+Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`MEDIUMTEXT`
 |`STRING`
@@ -1510,7 +1510,7 @@ a|_n/a_
 |`LONGBLOB`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting. +
+Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting. +
 Only values with a size of up to 2GB are supported. It is recommended to externalize large column values, using the claim check pattern.
 
 |`LONGTEXT`
@@ -2686,6 +2686,8 @@ However, it's best to use the minimum number that are required to specify a uniq
 `bytes` represents binary data as a byte array. +
  +
 `base64` represents binary data as a base64-encoded String. +
+ +
+`base64-url-safe` represents binary data as a base64-url-safe-encoded String. +
  +
 `hex` represents binary data as a hex-encoded (base16) String.
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -1327,7 +1327,7 @@ The following table describes how the connector maps binary and character large 
 
 |`BLOB`
 |`BYTES`
-|Either the raw bytes (the default), a base64-encoded String, or a hex-encoded String, based on the xref:oracle-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
+|Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:oracle-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`CLOB`
 |`STRING`
@@ -2708,7 +2708,7 @@ Hashing strategy version 2 should be used to ensure fidelity if the value is bei
 
 |[[oracle-property-binary-handling-mode]]<<oracle-property-binary-handling-mode, `+binary.handling.mode+`>>
 |bytes
-|Specifies how binary (`blob`) columns should be represented in change events, including: `bytes` represents binary data as byte array (default), `base64` represents binary data as base64-encoded String, `hex` represents binary data as hex-encoded (base16) String
+|Specifies how binary (`blob`) columns should be represented in change events, including: `bytes` represents binary data as byte array (default), `base64` represents binary data as base64-encoded String, `base64-url-safe` represents binary data as base64-url-safe-encoded String, `hex` represents binary data as hex-encoded (base16) String
 
 
 |[[oracle-property-schema-name-adjustment-mode]]<<oracle-property-schema-name-adjustment-mode,`+schema.name.adjustment.mode+`>>

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -1442,7 +1442,7 @@ The string representation of the interval value that follows the pattern `P<year
 |`BYTES` or `STRING`
 |n/a +
  +
-Either the raw bytes (the default), a base64-encoded string, or a hex-encoded string, based on the connector's xref:postgresql-property-binary-handling-mode[binary handling mode] setting. +
+Either the raw bytes (the default), a base64-encoded string, or a base64-url-safe-encoded String, or a hex-encoded string, based on the connector's xref:postgresql-property-binary-handling-mode[binary handling mode] setting. +
  +
 Debezium only supports Postgres `bytea_output` configuration of value `hex`. See this link:https://www.postgresql.org/docs/current/datatype-binary.html[documentation on Postgres binary data types].
 
@@ -2865,6 +2865,8 @@ However, it's best to use the minimum number that are required to specify a uniq
 `bytes` represents binary data as  byte array. +
  +
 `base64` represents binary data as base64-encoded strings. +
+ +
+`base64-url-safe` represents binary data as base64-url-safe-encoded strings. +
  +
 `hex` represents binary data as hex-encoded (base16) strings.
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2280,7 +2280,7 @@ However, it's best to use the minimum number that are required to specify a uniq
 
 |[[sqlserver-property-binary-handling-mode]]<<sqlserver-property-binary-handling-mode, `+binary.handling.mode+`>>
 |bytes
-|Specifies how binary (`binary`, `varbinary`) columns should be represented in change events, including: `bytes` represents binary data as byte array (default), `base64` represents binary data as base64-encoded String, `hex` represents binary data as hex-encoded (base16) String
+|Specifies how binary (`binary`, `varbinary`) columns should be represented in change events, including: `bytes` represents binary data as byte array (default), `base64` represents binary data as base64-encoded String, `base64-url-safe` represents binary data as base64-url-safe-encoded String, `hex` represents binary data as hex-encoded (base16) String
 
 |[[sqlserver-property-schema-name-adjustment-mode]]<<sqlserver-property-schema-name-adjustment-mode,`+schema.name.adjustment.mode+`>>
 |avro


### PR DESCRIPTION
Background
* For high-volume processing, Relational Databases typically store UUIDs as binary(16) type. This is usually used as a unique identifier and can be exposed in the URL. Therefore, the Base64 Url Safe Encoding method should be user-selectable.
* Debezium JdbcValueConverters.java support BASE64 BinaryHandlingMode. But it is not url safe.

Purpose
* Support BASE64_URL_SAFE in BinaryHandlingMode 

Jira
* https://issues.redhat.com/browse/DBZ-5544