### PR TITLE
DBZ-5546 Add missing value format in debezium-server doc

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -436,3 +436,4 @@ Pengwei Dou
 Zhongqiang Gong
 Inki Hwang
 崔世杰
+合龙 张

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -293,7 +293,7 @@ By default the output is in JSON format but an arbitrary implementation of Kafka
 
 |[[debezium-format-value]]<<debezium-format-value, `debezium.format.value`>>
 |`json`
-|The name of the output format for value, one of `json`/`avro`/`protobuf`.
+|The name of the output format for value, one of `json`/`avro`/`protobuf`/`eventclouds`.
 
 |[[debezium-format-value-props]]<<debezium-format-value-props, `debezium.format.value.*`>>
 |

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -150,3 +150,4 @@ doupengwei,Pengwei Dou
 fisache,Inki Hwang
 ggaborg,Gabor Andras
 comil4444,崔世杰
+BetaCat,合龙 张


### PR DESCRIPTION
Add missing value format type `eventclouds`  ([code ref](https://github.com/debezium/debezium/blob/539d9a39588bfecf75513433b2e51f5eaf81571c/debezium-server/debezium-server-core/src/main/java/io/debezium/server/DebeziumServer.java#L186)) for debezium-server doc.