### PR TITLE
DBZ-5122 Include Oracle Debezium Connector in Debezium Server distribution

### DIFF
--- a/debezium-server/debezium-server-dist/pom.xml
+++ b/debezium-server/debezium-server-dist/pom.xml
@@ -64,14 +64,18 @@
                     <groupId>io.debezium</groupId>
                     <artifactId>debezium-connector-sqlserver</artifactId>
                 </dependency>
-		<dependency>
+                <dependency>
+                    <groupId>io.debezium</groupId>
+                    <artifactId>debezium-connector-oracle</artifactId>
+                </dependency>
+                <dependency>
                     <groupId>io.debezium</groupId>
                     <artifactId>debezium-scripting</artifactId>
                 </dependency>
-		<dependency>
+                <dependency>
                     <groupId>io.debezium</groupId>
                     <artifactId>debezium-scripting-languages</artifactId>
-		    <type>pom</type>
+                    <type>pom</type>
                 </dependency>
                 <dependency>
                     <groupId>io.debezium</groupId>

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -52,6 +52,11 @@ debezium-server/
 ----
 
 The server is started using `run.sh` script, dependencies are stored in the `lib` directory, and the directory `conf` contains configuration files.
+[NOTE]
+====
+In case of using the Oracle connector you will have to add to the `lib` directory the ORACLE JDBC driver (if using XStream also the XStream API files),
+explained here: xref:{link-oracle-connector}#obtaining-oracle-jdbc-driver-and-xstreams-api-files[Obtaining the Oracle JDBC driver and XStream API files]
+====
 
 == Configuration
 


### PR DESCRIPTION
DBZ-5122 Include Oracle Debezium Connector in Debezium Server distribution

also checked the lib folder of Debezium Server distribution for duplicate libraries with different version and there is none