### PR TITLE
DBZ-5244 Retry all communication exceptions by default

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbErrorHandler.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbErrorHandler.java
@@ -5,8 +5,14 @@
  */
 package io.debezium.connector.mongodb;
 
+import java.io.IOException;
+import java.util.Set;
+
+import com.mongodb.MongoException;
+
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.pipeline.ErrorHandler;
+import io.debezium.util.Collect;
 
 /**
  * Error handler for MongoDB.
@@ -20,22 +26,7 @@ public class MongoDbErrorHandler extends ErrorHandler {
     }
 
     @Override
-    protected boolean isRetriable(Throwable throwable) {
-        if (throwable instanceof org.apache.kafka.connect.errors.ConnectException) {
-            Throwable cause = throwable.getCause();
-            while ((cause != null) && (cause != throwable)) {
-                if (cause instanceof com.mongodb.MongoSocketException ||
-                        cause instanceof com.mongodb.MongoTimeoutException ||
-                        cause instanceof com.mongodb.MongoExecutionTimeoutException ||
-                        cause instanceof com.mongodb.MongoNodeIsRecoveringException) {
-                    return true;
-                }
-                else {
-                    cause = cause.getCause();
-                }
-            }
-        }
-
-        return false;
+    protected Set<Class<? extends Exception>> communicationExceptions() {
+        return Collect.unmodifiableSet(IOException.class, MongoException.class);
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlErrorHandler.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlErrorHandler.java
@@ -5,14 +5,13 @@
  */
 package io.debezium.connector.mysql;
 
-import java.io.EOFException;
+import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Set;
 
-import com.github.shyiko.mysql.binlog.network.ServerException;
-
-import io.debezium.DebeziumException;
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.pipeline.ErrorHandler;
+import io.debezium.util.Collect;
 
 /**
  * Error handler for MySQL.
@@ -21,29 +20,12 @@ import io.debezium.pipeline.ErrorHandler;
  */
 public class MySqlErrorHandler extends ErrorHandler {
 
-    private static final String SQL_CODE_TOO_MANY_CONNECTIONS = "08004";
-
     public MySqlErrorHandler(MySqlConnectorConfig connectorConfig, ChangeEventQueue<?> queue) {
         super(MySqlConnector.class, connectorConfig, queue);
     }
 
     @Override
-    protected boolean isRetriable(Throwable throwable) {
-        if (throwable instanceof SQLException) {
-            final SQLException sql = (SQLException) throwable;
-            return SQL_CODE_TOO_MANY_CONNECTIONS.equals(sql.getSQLState());
-        }
-        else if (throwable instanceof ServerException) {
-            final ServerException sql = (ServerException) throwable;
-            return SQL_CODE_TOO_MANY_CONNECTIONS.equals(sql.getSqlState());
-        }
-        else if (throwable instanceof EOFException) {
-            // Retry with reading binlog error
-            return throwable.getMessage().contains("Failed to read next byte from position");
-        }
-        else if (throwable instanceof DebeziumException && throwable.getCause() != null) {
-            return isRetriable(throwable.getCause());
-        }
-        return false;
+    protected Set<Class<? extends Exception>> communicationExceptions() {
+        return Collect.unmodifiableSet(IOException.class, SQLException.class);
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresErrorHandler.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresErrorHandler.java
@@ -5,12 +5,10 @@
  */
 package io.debezium.connector.postgresql;
 
+import java.io.IOException;
+import java.sql.SQLException;
 import java.util.Set;
 
-import org.postgresql.util.PSQLException;
-
-import io.debezium.DebeziumException;
-import io.debezium.annotation.Immutable;
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.util.Collect;
@@ -22,39 +20,18 @@ import io.debezium.util.Collect;
  */
 public class PostgresErrorHandler extends ErrorHandler {
 
-    @Immutable
-    private static final Set<String> RETRIABLE_EXCEPTION_MESSSAGES = Collect.unmodifiableSet(
-            "Database connection failed when writing to copy",
-            "Database connection failed when reading from copy",
-            "An I/O error occurred while sending to the backend",
-            "ERROR: could not open relation with OID",
-            "This connection has been closed",
-            "terminating connection due to unexpected postmaster exit",
-            "terminating connection due to administrator command");
-
     public PostgresErrorHandler(PostgresConnectorConfig connectorConfig, ChangeEventQueue<?> queue) {
         super(PostgresConnector.class, connectorConfig, queue);
     }
 
     @Override
-    protected boolean isRetriable(Throwable throwable) {
-        if (isRetriablePsqlException(throwable)) {
-            return true;
-        }
-        else if (throwable instanceof DebeziumException) {
-            return isRetriablePsqlException(throwable.getCause());
-        }
-        return false;
+    protected Set<Class<? extends Exception>> communicationExceptions() {
+        return Collect.unmodifiableSet(IOException.class, SQLException.class);
     }
 
-    public boolean isRetriablePsqlException(Throwable throwable) {
-        if (throwable != null && throwable instanceof PSQLException && throwable.getMessage() != null) {
-            for (String messageText : RETRIABLE_EXCEPTION_MESSSAGES) {
-                if (throwable.getMessage().contains(messageText)) {
-                    return true;
-                }
-            }
-        }
-        return false;
+    // Introduced for testing only
+    @Override
+    protected boolean isRetriable(Throwable throwable) {
+        return super.isRetriable(throwable);
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresErrorHandlerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresErrorHandlerTest.java
@@ -31,8 +31,8 @@ public class PostgresErrorHandlerTest {
     }
 
     @Test
-    public void psqlExceptionWithNullErrorMesdsageNotRetryable() {
-        PSQLException testException = new PSQLException(null, PSQLState.CONNECTION_FAILURE);
+    public void nonCommunicationExceptionNotRetryable() {
+        Exception testException = new NullPointerException();
         Assertions.assertThat(errorHandler.isRetriable(testException)).isFalse();
     }
 
@@ -42,10 +42,10 @@ public class PostgresErrorHandlerTest {
     }
 
     @Test
-    public void unclassifiedPSQLExceptionIsNotRetryable() {
-        PSQLException testException = new PSQLException(
-                "definitely not a postgres error", PSQLState.CONNECTION_FAILURE);
-        Assertions.assertThat(errorHandler.isRetriable(testException)).isFalse();
+    public void encapsulatedPSQLExceptionIsRetriable() {
+        Exception testException = new IllegalArgumentException(
+                new PSQLException("definitely not a postgres error", PSQLState.CONNECTION_FAILURE));
+        Assertions.assertThat(errorHandler.isRetriable(testException)).isTrue();
     }
 
     @Test

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
@@ -5,10 +5,13 @@
  */
 package io.debezium.connector.sqlserver;
 
-import com.microsoft.sqlserver.jdbc.SQLServerException;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Set;
 
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.pipeline.ErrorHandler;
+import io.debezium.util.Collect;
 
 /**
  * Error handler for SQL Server.
@@ -22,28 +25,7 @@ public class SqlServerErrorHandler extends ErrorHandler {
     }
 
     @Override
-    protected boolean isRetriable(Throwable throwable) {
-        if (!(throwable instanceof SQLServerException) && throwable.getCause() instanceof SQLServerException) {
-            throwable = throwable.getCause();
-        }
-
-        return throwable instanceof SQLServerException
-                && (throwable.getMessage().contains("Connection timed out (Read failed)")
-                        || throwable.getMessage().contains("Connection timed out (Write failed)")
-                        || throwable.getMessage().contains("The connection has been closed.")
-                        || throwable.getMessage().contains("The connection is closed.")
-                        || throwable.getMessage().contains("The login failed.")
-                        || throwable.getMessage().contains("Server is in script upgrade mode.")
-                        || throwable.getMessage().contains("Try the statement later.")
-                        || throwable.getMessage().contains("Connection reset")
-                        || throwable.getMessage().contains("Socket closed")
-                        || throwable.getMessage().contains("SHUTDOWN is in progress")
-                        || throwable.getMessage().contains("The server failed to resume the transaction")
-                        || throwable.getMessage().contains("Verify the connection properties")
-                        || throwable.getMessage().contains("Broken pipe (Write failed)")
-                        || throwable.getMessage()
-                                .startsWith("An insufficient number of arguments were supplied for the procedure or function cdc.fn_cdc_get_all_changes_")
-                        || throwable.getMessage()
-                                .endsWith("was deadlocked on lock resources with another process and has been chosen as the deadlock victim. Rerun the transaction."));
+    protected Set<Class<? extends Exception>> communicationExceptions() {
+        return Collect.unmodifiableSet(IOException.class, SQLException.class);
     }
 }

--- a/debezium-core/src/main/java/io/debezium/util/Collect.java
+++ b/debezium-core/src/main/java/io/debezium/util/Collect.java
@@ -77,7 +77,7 @@ public class Collect {
         return Collections.unmodifiableSet(newSet);
     }
 
-    @SuppressWarnings("unchecked")
+    @SafeVarargs
     public static <T> Set<T> unmodifiableSet(T... values) {
         return unmodifiableSet(arrayListOf(values));
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-5244

We've originally decided to retry everything by default. Thinking about that let's try to limit it to set of exceptions that are usually related to communications like IOException, SqlException etc.