### PR TITLE
DBZ-5555 Adds conditional to hide read.only property in downstream doc

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1970,7 +1970,7 @@ include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deplo
 endif::product[]
 
 // Type: reference
-// Title: Description of {prodname} Db2 connector configuration properties
+// Title: Descriptions of {prodname} Db2 connector configuration properties
 // ModuleID: descriptions-of-debezium-db2-connector-configuration-properties
 [[db2-connector-properties]]
 === Connector properties

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1341,7 +1341,7 @@ include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deplo
 endif::product[]
 
 // Type: reference
-// Title: Description of {prodname} MongoDB connector configuration properties
+// Title: Descriptions of {prodname} MongoDB connector configuration properties
 [[mongodb-connector-properties]]
 === Connector properties
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2374,7 +2374,7 @@ include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deplo
 endif::product[]
 
 // Type: reference
-// Title: Description of {prodname} MySQL connector configuration properties
+// Title: Descriptions of {prodname} MySQL connector configuration properties
 // ModuleID: descriptions-of-debezium-mysql-connector-configuration-properties
 [[mysql-connector-properties]]
 === Connector properties
@@ -2913,9 +2913,11 @@ Increasing the chunk size provides greater efficiency, because the snapshot runs
 However, larger chunk sizes also require more memory to buffer the snapshot data.
 Adjust the chunk size to a value that provides the best performance in your environment.
 
+ifdef::community[]
 |[[mysql-property-read-only]]<<mysql-property-read-only, `+read.only+`>>
 |`false`
 |Switch to alternative incremental snapshot watermarks implementation to avoid writes to signal data collection
+endif::community[]
 
 |[[mysql-property-provide-transaction-metadata]]<<mysql-property-provide-transaction-metadata, `provide.transaction.metadata`>>
 |`false`

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2563,7 +2563,7 @@ include::{partialsdir}/modules/all-connectors/proc-verifying-the-connector-deplo
 endif::product[]
 
 // Type: reference
-// Title: Description of {prodname} PostgreSQL connector configuration properties
+// Title: Descriptions of {prodname} PostgreSQL connector configuration properties
 // ModuleID: descriptions-of-debezium-postgresql-connector-configuration-properties
 [[postgresql-connector-properties]]
 === Connector properties


### PR DESCRIPTION
[DBZ-5555 ](https://issues.redhat.com/browse/DBZ-5555)

The `read.only` property for the MySQL connector currently applies to the community version of the connector only, but the property table entry `mysql.adoc` was not conditionalized, with the result that the property is listed in the downstream documentation. 
This change adds a conditional directive to filter the entry for the so that it is not rendered in the downstream documentation.  
I've also updated the ModuleID declarations for the **Connector properties** topics in several of the connector docs for consistency.
Tested in a local Antora build.
Separately, I've updated files in the downstream documentation repository, and will stage those for publishing to update the 1.9 product documentation.
None of these changes are visible in the upstream version of the documentation.