### PR TITLE
DBZ-5229 Restore Kafka-based database history options in SchemaGenerator

### DIFF
--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -229,6 +229,20 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>io.debezium</groupId>
+                <artifactId>debezium-schema-generator</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-connector-metadata</id>
+                        <goals>
+                            <goal>generate-api-spec</goal>
+                        </goals>
+                        <phase>prepare-package</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/debezium-schema-generator/pom.xml
+++ b/debezium-schema-generator/pom.xml
@@ -19,6 +19,10 @@
       <artifactId>debezium-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.debezium</groupId>
+      <artifactId>debezium-storage-kafka</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
     </dependency>

--- a/debezium-schema-generator/src/main/java/io/debezium/schemagenerator/JsonSchemaCreatorService.java
+++ b/debezium-schema-generator/src/main/java/io/debezium/schemagenerator/JsonSchemaCreatorService.java
@@ -19,7 +19,9 @@ import org.eclipse.microprofile.openapi.models.media.Schema;
 
 import io.debezium.config.Field;
 import io.debezium.metadata.ConnectorMetadata;
+import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
 import io.debezium.schemagenerator.schema.Schema.FieldFilter;
+import io.debezium.storage.kafka.history.KafkaDatabaseHistory;
 import io.smallrye.openapi.api.models.media.SchemaImpl;
 
 public class JsonSchemaCreatorService {
@@ -121,42 +123,7 @@ public class JsonSchemaCreatorService {
             orderedPropertiesByCategory.put(category, new TreeMap<>());
         });
 
-        connectorMetadata.getConnectorFields().forEach(field -> {
-            String propertyName = field.name();
-            Field checkedField = checkField(field);
-            if (null != checkedField) {
-                SchemaImpl propertySchema = new SchemaImpl(propertyName);
-                Set<?> allowedValues = checkedField.allowedValues();
-                if (null != allowedValues && !allowedValues.isEmpty()) {
-                    propertySchema.enumeration(new ArrayList<>(allowedValues));
-                }
-                if (checkedField.isRequired()) {
-                    propertySchema.nullable(false);
-                    schema.addRequired(propertyName);
-                }
-                propertySchema.description(checkedField.description());
-                propertySchema.defaultValue(checkedField.defaultValue());
-                JsonSchemaType jsonSchemaType = toJsonSchemaType(checkedField.type());
-                propertySchema.type(jsonSchemaType.schemaType);
-                if (null != jsonSchemaType.format) {
-                    propertySchema.format(jsonSchemaType.format);
-                }
-                propertySchema.title(checkedField.displayName());
-                Map<String, Object> extensions = new HashMap<>();
-                extensions.put("name", checkedField.name()); // @TODO remove "x-name" in favor of map key?
-                Field.GroupEntry groupEntry = checkedField.group();
-                extensions.put("category", groupEntry.getGroup().name());
-                propertySchema.extensions(extensions);
-                SortedMap<Integer, SchemaImpl> groupProperties = orderedPropertiesByCategory.get(groupEntry.getGroup());
-                if (groupProperties.containsKey(groupEntry.getPositionInGroup())) {
-                    errors.add("[ERROR] Position in group \"" + groupEntry.getGroup().name() + "\" for property \""
-                            + propertyName + "\" is used more than once for connector \"" + connectorName + "\".");
-                }
-                else {
-                    groupProperties.put(groupEntry.getPositionInGroup(), propertySchema);
-                }
-            }
-        });
+        connectorMetadata.getConnectorFields().forEach(field -> processField(schema, orderedPropertiesByCategory, field));
 
         Arrays.stream(Field.Group.values()).forEach(
                 group -> orderedPropertiesByCategory.get(group).forEach((position, propertySchema) -> schema.addProperty(propertySchema.getName(), propertySchema)));
@@ -169,5 +136,47 @@ public class JsonSchemaCreatorService {
         schema.additionalPropertiesBoolean(true);
 
         return schema;
+    }
+
+    private void processField(Schema schema, Map<Field.Group, SortedMap<Integer, SchemaImpl>> orderedPropertiesByCategory, Field field) {
+        String propertyName = field.name();
+        Field checkedField = checkField(field);
+        if (null != checkedField) {
+            SchemaImpl propertySchema = new SchemaImpl(propertyName);
+            Set<?> allowedValues = checkedField.allowedValues();
+            if (null != allowedValues && !allowedValues.isEmpty()) {
+                propertySchema.enumeration(new ArrayList<>(allowedValues));
+            }
+            if (checkedField.isRequired()) {
+                propertySchema.nullable(false);
+                schema.addRequired(propertyName);
+            }
+            propertySchema.description(checkedField.description());
+            propertySchema.defaultValue(checkedField.defaultValue());
+            JsonSchemaType jsonSchemaType = toJsonSchemaType(checkedField.type());
+            propertySchema.type(jsonSchemaType.schemaType);
+            if (null != jsonSchemaType.format) {
+                propertySchema.format(jsonSchemaType.format);
+            }
+            propertySchema.title(checkedField.displayName());
+            Map<String, Object> extensions = new HashMap<>();
+            extensions.put("name", checkedField.name()); // @TODO remove "x-name" in favor of map key?
+            Field.GroupEntry groupEntry = checkedField.group();
+            extensions.put("category", groupEntry.getGroup().name());
+            propertySchema.extensions(extensions);
+            SortedMap<Integer, SchemaImpl> groupProperties = orderedPropertiesByCategory.get(groupEntry.getGroup());
+            if (groupProperties.containsKey(groupEntry.getPositionInGroup())) {
+                errors.add("[ERROR] Position in group \"" + groupEntry.getGroup().name() + "\" for property \""
+                        + propertyName + "\" is used more than once for connector \"" + connectorName + "\".");
+            }
+            else {
+                groupProperties.put(groupEntry.getPositionInGroup(), propertySchema);
+            }
+
+            if (propertyName.equals(HistorizedRelationalDatabaseConnectorConfig.DATABASE_HISTORY.name())) {
+                // todo: how to eventually support varied storage modules
+                KafkaDatabaseHistory.ALL_FIELDS.forEach(historyField -> processField(schema, orderedPropertiesByCategory, historyField));
+            }
+        }
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5229

So rather than meddle with what was done in `debezium-core` and `debezium-storage-xxxx` modules, I've opted to simply check whether the connector exposes a `database.history` property and if so, we inject the Kafka-based history fields back into the schema directly.

While this approach is not compatible with any other storage modules, I also think we have a much larger architecture problem we need to think about and design.  Additionally, at the very least, this mitigates the existing problem for components that are based on the schema generator module for now by restoring previous before as it was prior to DBZ-5229.  