### PR TITLE
Use TCCL to load configuration classes by default

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -15,6 +15,7 @@ Alex Soto
 Alexander Iskuskov
 Alexander Kovryga
 Alexander Schwartz
+Alexey Loubyansky
 Alexey Miroshnikov
 Alfusainey Jallow
 Alisa Houskova

--- a/debezium-core/src/main/java/io/debezium/config/Configuration.java
+++ b/debezium-core/src/main/java/io/debezium/config/Configuration.java
@@ -1440,7 +1440,7 @@ public interface Configuration {
      *         configuration but the value could not be converted to an existing class with a zero-argument constructor
      */
     default <T> T getInstance(String key, Class<T> type) {
-        return getInstance(key, type, () -> getClass().getClassLoader());
+        return getInstance(key, type, () -> Thread.currentThread().getContextClassLoader());
     }
 
     /**
@@ -1468,7 +1468,7 @@ public interface Configuration {
      *         configuration but the value could not be converted to an existing class with a zero-argument constructor
      */
     default <T> T getInstance(String key, Class<T> clazz, Configuration configuration) {
-        return Instantiator.getInstance(getString(key), () -> getClass().getClassLoader(), configuration);
+        return Instantiator.getInstance(getString(key), () -> Thread.currentThread().getContextClassLoader(), configuration);
     }
 
     /**
@@ -1480,7 +1480,7 @@ public interface Configuration {
      *         configuration but the value could not be converted to an existing class with a zero-argument constructor
      */
     default <T> T getInstance(Field field, Class<T> clazz) {
-        return getInstance(field, clazz, () -> getClass().getClassLoader());
+        return getInstance(field, clazz, () -> Thread.currentThread().getContextClassLoader());
     }
 
     /**
@@ -1508,7 +1508,7 @@ public interface Configuration {
      *         configuration but the value could not be converted to an existing class with a zero-argument constructor
      */
     default <T> T getInstance(Field field, Class<T> clazz, Configuration configuration) {
-        return Instantiator.getInstance(getString(field), () -> getClass().getClassLoader(), configuration);
+        return Instantiator.getInstance(getString(field), () -> Thread.currentThread().getContextClassLoader(), configuration);
     }
 
     /**
@@ -1522,7 +1522,7 @@ public interface Configuration {
      *         configuration but the value could not be converted to an existing class with a zero-argument constructor
      */
     default <T> T getInstance(Field field, Class<T> clazz, Properties props) {
-        return Instantiator.getInstanceWithProperties(getString(field), () -> getClass().getClassLoader(), props);
+        return Instantiator.getInstanceWithProperties(getString(field), () -> Thread.currentThread().getContextClassLoader(), props);
     }
 
     /**


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5561

Unless there is a specific reason to use getClass().getClassLoader() as the default class loader, Thread.currentThread().getContextClassLoader() would be a safer default from the integration perspective with environments that define their own classloading policies.

The original issue was reported in Quarkus [quarkusio/quarkus#27565](https://github.com/quarkusio/quarkus/issues/27565). When a project contains a custom converter implementation, the CommonConnectorConfig in the Debezium core (which is an external project dependency) loading converter classes may fail with a class loading exception. What happens in in this case is Quarkus loads the local project dependencies in a classloader that is higher in the hierarchy than the classloader loading the core Debezium classes, making the CommonConnectorConfig to look for converter implementations among the core Debezium classes and the system classloader, which may lead to a failure.

Any objections? Thanks.