### PR TITLE
DBZ-5576 Initial .asciidoctorconfig file to improve editing experience

### DIFF
--- a/documentation/.asciidoctorconfig
+++ b/documentation/.asciidoctorconfig
@@ -1,0 +1,10 @@
+// This file provides hints for an IDE how to render the preview, for example, in IntelliJ.
+// This is mostly intended to define attributes.
+// Read more at: https://intellij-asciidoc-plugin.ahus1.de/docs/users-guide/features/advanced/asciidoctorconfig-file.html
+
+// Duplicate values for the preview that are defined in another repository in the Antora playbook
+:prodname: Debezium
+:jira-url: 'https://issues.redhat.com'
+
+// Define attributes that are used downstream so that an editor known that they exist and doesn't show them in warnings.
+:product!:


### PR DESCRIPTION
This sets some attributes for the preview to make the gap between the IDE and the real site smaller, and to reduce the number of warnings shown in the editor as those attributes are now known to the IDE.

The changes in the `antora.yml` make the `community` attribute a soft-set attribute so that it can be overwritten when writing the docs as needed, for example in an `.asciidoctorconfig` file.

Before: 

![image](https://user-images.githubusercontent.com/3957921/187961746-bb9a57f2-4c19-4690-85bb-6d694437e280.png)

After: 

![image](https://user-images.githubusercontent.com/3957921/187961555-6f4f2475-7566-4a17-885c-aa50d756efe1.png)

