### PR TITLE
DBZ-4629 Debezium server crashes when no connection to the source db

### DIFF
--- a/debezium-embedded/src/main/java/io/debezium/connector/simple/SimpleSourceConnector.java
+++ b/debezium-embedded/src/main/java/io/debezium/connector/simple/SimpleSourceConnector.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -106,11 +105,12 @@ public class SimpleSourceConnector extends SourceConnector {
 
     public static class SimpleConnectorTask extends SourceTask {
 
+        private static boolean isThrownErrorOnRecord;
+
         private int recordsPerBatch;
         private int errorOnRecord;
-        private Queue<SourceRecord> records;
+        private List<SourceRecord> records;
         private final AtomicBoolean running = new AtomicBoolean();
-        private List<SourceRecord> retryRecords = null;
 
         @Override
         public String version() {
@@ -183,24 +183,20 @@ public class SimpleSourceConnector extends SourceConnector {
                 new CountDownLatch(1).await();
             }
             if (running.get()) {
-                if (retryRecords != null) {
-                    final List<SourceRecord> r = retryRecords;
-                    retryRecords = null;
-                    return r;
-                }
                 // Still running, so process whatever is in the queue ...
                 List<SourceRecord> results = new ArrayList<>();
                 int record = 0;
-                while (record < recordsPerBatch && !records.isEmpty()) {
-                    record++;
-                    final SourceRecord fetchedRecord = records.poll();
+                while (record < recordsPerBatch && record < records.size()) {
+                    final SourceRecord fetchedRecord = records.get(record);
                     final Integer id = ((Struct) (fetchedRecord.key())).getInt32("id");
-                    results.add(fetchedRecord);
-                    if (id == errorOnRecord) {
-                        retryRecords = results;
+                    if (id == errorOnRecord && !isThrownErrorOnRecord) {
+                        isThrownErrorOnRecord = true;
                         throw new RetriableException("Error on record " + errorOnRecord);
                     }
+                    results.add(fetchedRecord);
+                    record++;
                 }
+                records.removeAll(results);
                 return results;
             }
             // No longer running ...

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -196,7 +196,7 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord> {
             .withType(Type.INT)
             .withWidth(Width.SHORT)
             .withImportance(Importance.MEDIUM)
-            .withDefault(0)
+            .withDefault(-1)
             .withValidation(Field::isInteger)
             .withDescription("The maximum number of retries on connection errors before failing (-1 = no limit, 0 = disabled, > 0 = num of retries).");
 

--- a/debezium-embedded/src/test/java/io/debezium/connector/simple/SimpleSourceConnectorOutputTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/connector/simple/SimpleSourceConnectorOutputTest.java
@@ -134,6 +134,16 @@ public class SimpleSourceConnectorOutputTest extends ConnectorOutputTest {
         runConnector("simple-test-e", "src/test/resources/simple/test/e");
     }
 
+    @Test
+    public void shouldRecoverFromRetriableExceptionMaxRetriesIs1() {
+        runConnector("simple-test-f", "src/test/resources/simple/test/f");
+    }
+
+    @Test
+    public void shouldRecoverFromRetriableExceptionMaxRetriesIsNegative1() {
+        runConnector("simple-test-g", "src/test/resources/simple/test/g");
+    }
+
     protected void writeConfigurationFileWithDefaultName(Path dir, Properties props) throws IOException {
         Path configFilePath = dir.resolve(DEFAULT_CONNECTOR_PROPERTIES_FILENAME);
         writeConfigurationFile(configFilePath, props);

--- a/debezium-embedded/src/test/resources/simple/test/f/connector.properties
+++ b/debezium-embedded/src/test/resources/simple/test/f/connector.properties
@@ -1,0 +1,9 @@
+name=simple-test-e
+connector.class=io.debezium.connector.simple.SimpleSourceConnector
+tasks.max=1
+topic.name=test-a
+record.count.per.batch=5
+batch.count=2
+include.timestamp=true
+error.retriable.on=7
+errors.max.retries=1

--- a/debezium-embedded/src/test/resources/simple/test/f/env.properties
+++ b/debezium-embedded/src/test/resources/simple/test/f/env.properties
@@ -1,0 +1,2 @@
+connector.timeout.in.seconds=1
+ignore.fields=VALUE/timestamp

--- a/debezium-embedded/src/test/resources/simple/test/f/expected-records.json
+++ b/debezium-embedded/src/test/resources/simple/test/f/expected-records.json
@@ -1,0 +1,522 @@
+[
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 1
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 1
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 1,
+      "record": 1,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 2
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 2
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 1,
+      "record": 2,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 3
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 3
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 1,
+      "record": 3,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 4
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 4
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 1,
+      "record": 4,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 5
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 5
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 1,
+      "record": 5,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 6
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 6
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 2,
+      "record": 1,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 7
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 7
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 2,
+      "record": 2,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 8
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 8
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 2,
+      "record": 3,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 9
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 9
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 2,
+      "record": 4,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 10
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 10
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 2,
+      "record": 5,
+      "timestamp": null
+    }
+  }
+]

--- a/debezium-embedded/src/test/resources/simple/test/g/connector.properties
+++ b/debezium-embedded/src/test/resources/simple/test/g/connector.properties
@@ -1,0 +1,9 @@
+name=simple-test-e
+connector.class=io.debezium.connector.simple.SimpleSourceConnector
+tasks.max=1
+topic.name=test-a
+record.count.per.batch=5
+batch.count=2
+include.timestamp=true
+error.retriable.on=7
+errors.max.retries=-1

--- a/debezium-embedded/src/test/resources/simple/test/g/env.properties
+++ b/debezium-embedded/src/test/resources/simple/test/g/env.properties
@@ -1,0 +1,2 @@
+connector.timeout.in.seconds=1
+ignore.fields=VALUE/timestamp

--- a/debezium-embedded/src/test/resources/simple/test/g/expected-records.json
+++ b/debezium-embedded/src/test/resources/simple/test/g/expected-records.json
@@ -1,0 +1,522 @@
+[
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 1
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 1
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 1,
+      "record": 1,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 2
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 2
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 1,
+      "record": 2,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 3
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 3
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 1,
+      "record": 3,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 4
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 4
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 1,
+      "record": 4,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 5
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 5
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 1,
+      "record": 5,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 6
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 6
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 2,
+      "record": 1,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 7
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 7
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 2,
+      "record": 2,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 8
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 8
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 2,
+      "record": 3,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 9
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 9
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 2,
+      "record": 4,
+      "timestamp": null
+    }
+  },
+  {
+    "sourcePartition": {
+      "source": "simple"
+    },
+    "sourceOffset": {
+      "id": 10
+    },
+    "topic": "test-a",
+    "kafkaPartition": 1,
+    "keySchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        }
+      ],
+      "optional": false,
+      "name": "simple.key"
+    },
+    "key": {
+      "id": 10
+    },
+    "valueSchema": {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "batch"
+        },
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "record"
+        },
+        {
+          "type" : "int64",
+          "optional" : true,
+          "field": "timestamp"
+        }
+      ],
+      "optional": false,
+      "name": "simple.value"
+    },
+    "value": {
+      "batch": 2,
+      "record": 5,
+      "timestamp": null
+    }
+  }
+]

--- a/documentation/modules/ROOT/pages/development/engine.adoc
+++ b/documentation/modules/ROOT/pages/development/engine.adoc
@@ -433,7 +433,7 @@ The default is a periodic commity policy based upon time intervals.
 |Maximum number of milliseconds to wait for records to flush and partition offset data to be committed to offset storage before cancelling the process and restoring the offset data to be committed in a future attempt. The default is 5 seconds.
 
 |`errors.max.retries`
-|`0`
+|`-1`
 |The maximum number of retries on connection errors before failing (-1 = no limit, 0 = disabled, > 0 = num of retries).
 
 |`errors.retry.delay.initial.ms`

--- a/documentation/modules/ROOT/pages/development/engine.adoc
+++ b/documentation/modules/ROOT/pages/development/engine.adoc
@@ -431,6 +431,18 @@ The default is a periodic commity policy based upon time intervals.
 |`offset.flush.timeout.ms`
 |`5000`
 |Maximum number of milliseconds to wait for records to flush and partition offset data to be committed to offset storage before cancelling the process and restoring the offset data to be committed in a future attempt. The default is 5 seconds.
+
+|`errors.max.retries`
+|`0`
+|The maximum number of retries on connection errors before failing (-1 = no limit, 0 = disabled, > 0 = num of retries).
+
+|`errors.retry.delay.initial.ms`
+|`300`
+|Initial delay (in ms) for retries when encountering connection errors. This value will be doubled upon every retry but won't exceed `errors.retry.delay.max.ms`.
+
+|`errors.retry.delay.max.ms`
+|`10000`
+|Max delay (in ms) between retries when encountering connection errors.
 |===
 
 [[database-history-properties]]


### PR DESCRIPTION
This is a re-make of this older pull request: https://github.com/debezium/debezium/pull/3268

I have one comment, related to the errors.max.retries property. Value of 0 means the mechanism is disabled and it is equivalent to the old behavior, which was swallowing the RetriableException in EmbeddedEngine.