### PR TITLE
DBZ-5043 Move TOPIC_PREFIX into CommonConnectorConfig

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnector.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnector.java
@@ -67,7 +67,7 @@ import io.debezium.util.Threads;
  * <h2>Use of Topics</h2>
  * The connector will write to a separate topic all of the source records that correspond to a single collection. The topic will
  * be named "{@code <logicalName>.<databaseName>.<collectionName>}", where {@code <logicalName>} is set via the
- * "{@link AbstractTopicNamingStrategy.TOPIC_PREFIX topic.prefix}" configuration property.
+ * "{@link io.debezium.config.CommonConnectorConfig.TOPIC_PREFIX topic.prefix}" configuration property.
  *
  * <h2>Configuration</h2>
  * <p>

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorConfig.java
@@ -32,7 +32,6 @@ import io.debezium.config.Field.ValidationOutput;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.data.Envelope;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.schema.DefaultTopicNamingStrategy;
 import io.debezium.spi.schema.DataCollectionId;
 
@@ -539,7 +538,7 @@ public class MongoDbConnectorConfig extends CommonConnectorConfig {
     private final int cursorMaxAwaitTimeMs;
 
     public MongoDbConnectorConfig(Configuration config) {
-        super(config, config.getString(AbstractTopicNamingStrategy.TOPIC_PREFIX), DEFAULT_SNAPSHOT_FETCH_SIZE);
+        super(config, config.getString(CommonConnectorConfig.TOPIC_PREFIX), DEFAULT_SNAPSHOT_FETCH_SIZE);
 
         String snapshotModeValue = config.getString(MongoDbConnectorConfig.SNAPSHOT_MODE);
         this.snapshotMode = SnapshotMode.parse(snapshotModeValue, MongoDbConnectorConfig.SNAPSHOT_MODE.defaultValueAsString());

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbTaskContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbTaskContext.java
@@ -7,10 +7,10 @@ package io.debezium.connector.mongodb;
 
 import java.util.Collections;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.connector.mongodb.MongoDbConnectorConfig.CaptureMode;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.spi.topic.TopicNamingStrategy;
 
 /**
@@ -29,13 +29,13 @@ public class MongoDbTaskContext extends CdcSourceTaskContext {
      * @param config the configuration
      */
     public MongoDbTaskContext(Configuration config) {
-        super(Module.contextName(), config.getString(AbstractTopicNamingStrategy.TOPIC_PREFIX), Collections::emptySet);
+        super(Module.contextName(), config.getString(CommonConnectorConfig.TOPIC_PREFIX), Collections::emptySet);
 
         this.filters = new Filters(config);
         this.connectorConfig = new MongoDbConnectorConfig(config);
         this.source = new SourceInfo(connectorConfig);
         this.topicNamingStrategy = connectorConfig.getTopicNamingStrategy(MongoDbConnectorConfig.TOPIC_NAMING_STRATEGY);
-        this.serverName = config.getString(AbstractTopicNamingStrategy.TOPIC_PREFIX);
+        this.serverName = config.getString(CommonConnectorConfig.TOPIC_PREFIX);
         this.connectionContext = new ConnectionContext(config);
     }
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/Configurator.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/Configurator.java
@@ -5,9 +5,9 @@
  */
 package io.debezium.connector.mongodb;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.util.Testing;
 
 /**
@@ -35,7 +35,7 @@ public class Configurator {
     }
 
     public Configurator serverName(String serverName) {
-        return with(AbstractTopicNamingStrategy.TOPIC_PREFIX, serverName);
+        return with(CommonConnectorConfig.TOPIC_PREFIX, serverName);
     }
 
     public Configurator hosts(String hosts) {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldBlacklistIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldBlacklistIT.java
@@ -23,8 +23,8 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.InsertOneOptions;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.util.Testing;
 
 public class FieldBlacklistIT extends AbstractMongoConnectorIT {
@@ -1455,7 +1455,7 @@ public class FieldBlacklistIT extends AbstractMongoConnectorIT {
         return TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.FIELD_EXCLUDE_LIST, excludeList)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbA.c1")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, SERVER_NAME)
+                .with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)
                 .build();
     }
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldExcludeListIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldExcludeListIT.java
@@ -22,10 +22,10 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.InsertOneOptions;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mongodb.FieldBlacklistIT.ExpectedUpdate;
 import io.debezium.doc.FixFor;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.util.Testing;
 
 public class FieldExcludeListIT extends AbstractMongoConnectorIT {
@@ -1565,7 +1565,7 @@ public class FieldExcludeListIT extends AbstractMongoConnectorIT {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.FIELD_EXCLUDE_LIST, "*.c1.name,*.c1.active,*.c2.name,*.c2.active")
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbA.c1,dbA.c2")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, SERVER_NAME)
+                .with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)
                 .build();
         context = new MongoDbTaskContext(config);
 
@@ -1596,7 +1596,7 @@ public class FieldExcludeListIT extends AbstractMongoConnectorIT {
         return TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.FIELD_EXCLUDE_LIST, fieldExcludeList)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, database + "." + collection)
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, SERVER_NAME)
+                .with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)
                 .build();
     }
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldRenamesIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldRenamesIT.java
@@ -22,11 +22,11 @@ import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.junit.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mongodb.FieldBlacklistIT.ExpectedUpdate;
 import io.debezium.doc.FixFor;
 import io.debezium.junit.logging.LogInterceptor;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 
 /**
  * @author Chris Cranford
@@ -1827,7 +1827,7 @@ public class FieldRenamesIT extends AbstractMongoConnectorIT {
     private static Configuration getConfiguration(String fieldRenames, String database, String collection) {
         Configuration.Builder builder = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, database + "." + collection)
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, SERVER_NAME);
+                .with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME);
 
         if (fieldRenames != null && !"".equals(fieldRenames.trim())) {
             builder = builder.with(MongoDbConnectorConfig.FIELD_RENAMES, fieldRenames);

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -58,7 +58,6 @@ import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
 import io.debezium.heartbeat.Heartbeat;
 import io.debezium.junit.logging.LogInterceptor;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.schema.DatabaseSchema;
 import io.debezium.util.Collect;
 import io.debezium.util.IoUtil;
@@ -95,7 +94,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         Config result = connector.validate(config.asMap());
 
         assertConfigurationErrors(result, MongoDbConnectorConfig.HOSTS, 1);
-        assertNoConfigurationErrors(result, AbstractTopicNamingStrategy.TOPIC_PREFIX);
+        assertNoConfigurationErrors(result, CommonConnectorConfig.TOPIC_PREFIX);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.USER);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.PASSWORD);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.AUTO_DISCOVER_MEMBERS);
@@ -218,7 +217,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         Config result = connector.validate(config.asMap());
 
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.HOSTS);
-        assertNoConfigurationErrors(result, AbstractTopicNamingStrategy.TOPIC_PREFIX);
+        assertNoConfigurationErrors(result, CommonConnectorConfig.TOPIC_PREFIX);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.USER);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.PASSWORD);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.AUTO_DISCOVER_MEMBERS);
@@ -246,7 +245,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 // .with(MongoDbConnectorConfig.CAPTURE_MODE, CaptureMode.OPLOG)
                 .build();
 
@@ -435,7 +434,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .with(MongoDbConnectorConfig.SKIPPED_OPERATIONS, "u")
                 .build();
 
@@ -523,7 +522,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         // Set up the replication context for connections ...
@@ -555,7 +554,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
                 .with(MongoDbConnectorConfig.AUTH_SOURCE, authDbName)
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         // Set up the replication context for connections ...
@@ -613,7 +612,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.DATABASE_INCLUDE_LIST, "inc")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         // Set up the replication context for connections ...
@@ -680,7 +679,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         // Set up the replication context for connections ...
@@ -749,7 +748,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.dbz865.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         // Set up the replication context for connections ...
@@ -803,7 +802,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.dbz865.my_products")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         // Set up the replication context for connections...
@@ -852,7 +851,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         // Set up the replication context for connections ...
@@ -944,7 +943,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         // Set up the replication context for connections ...
@@ -1043,7 +1042,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         // Set up the replication context for connections ...
@@ -1093,7 +1092,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .with(MongoDbConnectorConfig.SNAPSHOT_FILTER_QUERY_BY_COLLECTION, "dbit.simpletons,dbit.restaurants1,dbit.restaurants4")
                 .with(MongoDbConnectorConfig.SNAPSHOT_FILTER_QUERY_BY_COLLECTION + "." + "dbit.simpletons", "{ \"_id\": { \"$gt\": 4 } }")
                 .with(MongoDbConnectorConfig.SNAPSHOT_FILTER_QUERY_BY_COLLECTION + "." + "dbit.restaurants1",
@@ -1141,7 +1140,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
                 .with(MongoDbConnectorConfig.SNAPSHOT_MODE, MongoDbConnectorConfig.SnapshotMode.INITIAL)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
                 .with(CommonConnectorConfig.SNAPSHOT_MODE_TABLES, "[A-z].*dbit.restaurants1")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         // Set up the replication context for connections ...
@@ -1299,7 +1298,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .with(MongoDbConnectorConfig.MAX_FAILED_CONNECTIONS, 0)
                 .with(MongoDbConnectorConfig.SSL_ENABLED, true)
                 .with(MongoDbConnectorConfig.SERVER_SELECTION_TIMEOUT_MS, 2000)
@@ -1322,7 +1321,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.mhb")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .with(Heartbeat.HEARTBEAT_INTERVAL, "1")
                 .build();
 
@@ -1400,7 +1399,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         context = new MongoDbTaskContext(config);
@@ -1435,7 +1434,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
     public void shouldGenerateRecordForInsertEvent() throws Exception {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         context = new MongoDbTaskContext(config);
@@ -1478,7 +1477,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
     public void shouldGenerateRecordForUpdateEvent() throws Exception {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         context = new MongoDbTaskContext(config);
@@ -1537,7 +1536,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
     public void shouldGeneratorRecordForDeleteEvent() throws Exception {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         context = new MongoDbTaskContext(config);
@@ -1595,7 +1594,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
     public void shouldGenerateRecordForDeleteEventWithoutTombstone() throws Exception {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .with(MongoDbConnectorConfig.TOMBSTONES_ON_DELETE, false)
                 .build();
 
@@ -1646,7 +1645,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
     public void shouldGenerateRecordsWithCorrectlySerializedId() throws Exception {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         context = new MongoDbTaskContext(config);
@@ -1716,7 +1715,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
     public void shouldSupportDbRef2() throws Exception {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         context = new MongoDbTaskContext(config);
@@ -1768,7 +1767,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
     public void shouldReplicateContent() throws Exception {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbA.contacts")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .with(MongoDbConnectorConfig.SNAPSHOT_MODE, MongoDbConnectorConfig.SnapshotMode.INITIAL)
                 .build();
 
@@ -1921,7 +1920,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         // todo: this configuration causes NPE at MongoDbStreamingChangeEventSource.java:143
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbA.contacts")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .with(MongoDbConnectorConfig.SNAPSHOT_MODE, MongoDbConnectorConfig.SnapshotMode.NEVER)
                 .build();
 
@@ -1974,7 +1973,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
     public void shouldGenerateRecordForUpdateEventUsingLegacyV1SourceInfo() throws Exception {
         config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .build();
 
         context = new MongoDbTaskContext(config);

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorWithConnectionStringIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorWithConnectionStringIT.java
@@ -30,11 +30,11 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.InsertOneOptions;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mongodb.ConnectionContext.MongoPrimary;
 import io.debezium.data.Envelope;
 import io.debezium.data.Envelope.Operation;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.util.IoUtil;
 import io.debezium.util.Testing;
 
@@ -64,7 +64,7 @@ public class MongoDbConnectorWithConnectionStringIT extends AbstractMongoConnect
         config = Configuration.from(properties).edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
                 .with(MongoDbConnectorConfig.CONNECTION_STRING, connectionString)
                 .with(MongoDbConnectorConfig.SSL_ENABLED, ssl)
                 .with(MongoDbConnectorConfig.AUTO_DISCOVER_MEMBERS, true)

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/SourceInfoTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/SourceInfoTest.java
@@ -20,9 +20,9 @@ import org.bson.BsonTimestamp;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.AbstractSourceInfoStructMaker;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 
 /**
  * @author Randall Hauch
@@ -37,7 +37,7 @@ public class SourceInfoTest {
     public void beforeEach() {
         source = new SourceInfo(new MongoDbConnectorConfig(
                 Configuration.create()
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "serverX")
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
                         .build()));
     }
 
@@ -86,7 +86,7 @@ public class SourceInfoTest {
         Map<String, String> partition = source.partition(REPLICA_SET_NAME);
         source = new SourceInfo(new MongoDbConnectorConfig(
                 Configuration.create()
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "serverX")
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
                         .build()));
         source.setOffsetFor(partition, offset);
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/TestHelper.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/TestHelper.java
@@ -25,10 +25,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.client.MongoDatabase;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.config.Configuration.Builder;
 import io.debezium.connector.mongodb.ConnectionContext.MongoPrimary;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 
 /**
  * A common test configuration options
@@ -46,7 +46,7 @@ public class TestHelper {
         final Builder cfgBuilder = Configuration.fromSystemProperties("connector.").edit()
                 .withDefault(MongoDbConnectorConfig.HOSTS, "rs0/localhost:27017")
                 .withDefault(MongoDbConnectorConfig.AUTO_DISCOVER_MEMBERS, false)
-                .withDefault(AbstractTopicNamingStrategy.TOPIC_PREFIX, "mongo1");
+                .withDefault(CommonConnectorConfig.TOPIC_PREFIX, "mongo1");
         return cfgBuilder.build();
     }
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/AbstractExtractNewDocumentStateTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/AbstractExtractNewDocumentStateTestIT.java
@@ -14,6 +14,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.After;
 import org.junit.Before;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mongodb.AbstractMongoConnectorIT;
 import io.debezium.connector.mongodb.MongoDbConnector;
@@ -21,7 +22,6 @@ import io.debezium.connector.mongodb.MongoDbConnectorConfig;
 import io.debezium.connector.mongodb.MongoDbTaskContext;
 import io.debezium.connector.mongodb.TestHelper;
 import io.debezium.data.Envelope;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 
 /**
  * Baseline for all integrations tests regarding MongoDB Update Operations
@@ -47,7 +47,7 @@ public abstract class AbstractExtractNewDocumentStateTestIT extends AbstractMong
         Configuration config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, DB_NAME + "." + this.getCollectionName())
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, SERVER_NAME)
+                .with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)
                 .build();
 
         beforeEach(config);
@@ -83,7 +83,7 @@ public abstract class AbstractExtractNewDocumentStateTestIT extends AbstractMong
         Configuration config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, DB_NAME + "." + this.getCollectionName())
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, SERVER_NAME)
+                .with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)
                 .with(MongoDbConnectorConfig.TOMBSTONES_ON_DELETE, false)
                 .build();
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/ExtractNewDocumentStateTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TestRule;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.mongodb.Configurator;
@@ -35,7 +36,6 @@ import io.debezium.connector.mongodb.SourceInfo;
 import io.debezium.doc.FixFor;
 import io.debezium.junit.SkipTestRule;
 import io.debezium.junit.SkipWhenKafkaVersion;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.schema.DefaultTopicNamingStrategy;
 import io.debezium.spi.topic.TopicNamingStrategy;
 
@@ -66,7 +66,7 @@ public class ExtractNewDocumentStateTest {
         filters = new Configurator().createFilters();
         MongoDbConnectorConfig connectorConfig = new MongoDbConnectorConfig(
                 Configuration.create()
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, SERVER_NAME)
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)
                         .build());
         source = new SourceInfo(connectorConfig);
         topicNamingStrategy = DefaultTopicNamingStrategy.create(connectorConfig);

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouterTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouterTestIT.java
@@ -25,13 +25,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mongodb.AbstractMongoConnectorIT;
 import io.debezium.connector.mongodb.MongoDbConnector;
 import io.debezium.connector.mongodb.MongoDbConnectorConfig;
 import io.debezium.connector.mongodb.MongoDbTaskContext;
 import io.debezium.connector.mongodb.TestHelper;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 
 /**
  * Integration tests for {@link MongoEventRouter}
@@ -50,7 +50,7 @@ public class MongoEventRouterTestIT extends AbstractMongoConnectorIT {
         Configuration config = TestHelper.getConfiguration().edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, DB_NAME + "." + this.getCollectionName())
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, SERVER_NAME)
+                .with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)
                 .build();
 
         beforeEach(config);

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -17,6 +17,7 @@ import org.apache.kafka.common.config.ConfigDef.Width;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
 import io.debezium.config.EnumeratedValue;
@@ -34,7 +35,6 @@ import io.debezium.relational.TableId;
 import io.debezium.relational.Tables.TableFilter;
 import io.debezium.relational.history.HistoryRecordComparator;
 import io.debezium.relational.history.SchemaHistory;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.schema.DefaultTopicNamingStrategy;
 import io.debezium.storage.kafka.history.KafkaSchemaHistory;
 import io.debezium.util.Collect;
@@ -963,7 +963,7 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
         super(
                 MySqlConnector.class,
                 config,
-                config.getString(AbstractTopicNamingStrategy.TOPIC_PREFIX),
+                config.getString(CommonConnectorConfig.TOPIC_PREFIX),
                 TableFilter.fromPredicate(MySqlConnectorConfig::isNotBuiltInTable),
                 true,
                 DEFAULT_SNAPSHOT_FETCH_SIZE,

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/BinlogReaderBufferIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/BinlogReaderBufferIT.java
@@ -20,12 +20,12 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.doc.FixFor;
 import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.junit.SkipWhenDatabaseVersion;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.storage.file.history.FileSchemaHistory;
 import io.debezium.util.Testing;
 
@@ -80,7 +80,7 @@ public class BinlogReaderBufferIT extends AbstractConnectorTest {
                 .with(MySqlConnectorConfig.USER, "snapper")
                 .with(MySqlConnectorConfig.PASSWORD, "snapperpass")
                 .with(MySqlConnectorConfig.SERVER_ID, 18765)
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, DATABASE.getServerName())
+                .with(CommonConnectorConfig.TOPIC_PREFIX, DATABASE.getServerName())
                 .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MySqlConnectorConfig.DATABASE_INCLUDE_LIST, DATABASE.getDatabaseName())
                 .with(MySqlConnectorConfig.SCHEMA_HISTORY, FileSchemaHistory.class)
@@ -148,7 +148,7 @@ public class BinlogReaderBufferIT extends AbstractConnectorTest {
                 .with(MySqlConnectorConfig.USER, "snapper")
                 .with(MySqlConnectorConfig.PASSWORD, "snapperpass")
                 .with(MySqlConnectorConfig.SERVER_ID, 18765)
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, DATABASE.getServerName())
+                .with(CommonConnectorConfig.TOPIC_PREFIX, DATABASE.getServerName())
                 .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MySqlConnectorConfig.DATABASE_INCLUDE_LIST, DATABASE.getDatabaseName())
                 .with(MySqlConnectorConfig.SCHEMA_HISTORY, FileSchemaHistory.class)
@@ -209,7 +209,7 @@ public class BinlogReaderBufferIT extends AbstractConnectorTest {
                 .with(MySqlConnectorConfig.USER, "snapper")
                 .with(MySqlConnectorConfig.PASSWORD, "snapperpass")
                 .with(MySqlConnectorConfig.SERVER_ID, 18765)
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, DATABASE.getServerName())
+                .with(CommonConnectorConfig.TOPIC_PREFIX, DATABASE.getServerName())
                 .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MySqlConnectorConfig.DATABASE_INCLUDE_LIST, DATABASE.getDatabaseName())
                 .with(MySqlConnectorConfig.SCHEMA_HISTORY, FileSchemaHistory.class)
@@ -280,7 +280,7 @@ public class BinlogReaderBufferIT extends AbstractConnectorTest {
                 .with(MySqlConnectorConfig.USER, "snapper")
                 .with(MySqlConnectorConfig.PASSWORD, "snapperpass")
                 .with(MySqlConnectorConfig.SERVER_ID, 18765)
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, DATABASE.getServerName())
+                .with(CommonConnectorConfig.TOPIC_PREFIX, DATABASE.getServerName())
                 .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MySqlConnectorConfig.DATABASE_INCLUDE_LIST, DATABASE.getDatabaseName())
                 .with(MySqlConnectorConfig.SCHEMA_HISTORY, FileSchemaHistory.class)

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorIT.java
@@ -54,7 +54,6 @@ import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.relational.RelationalChangeRecordEmitter;
 import io.debezium.relational.RelationalDatabaseSchema;
 import io.debezium.relational.history.SchemaHistory;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.schema.DatabaseSchema;
 import io.debezium.storage.file.history.FileSchemaHistory;
 import io.debezium.storage.kafka.history.KafkaSchemaHistory;
@@ -104,7 +103,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
     @Test
     public void shouldNotStartWithInvalidConfiguration() {
         config = Configuration.create()
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                 .with(KafkaSchemaHistory.TOPIC, "myserver")
                 .with(MySqlConnectorConfig.SCHEMA_HISTORY, FileSchemaHistory.class)
                 .with(FileSchemaHistory.FILE_PATH, SCHEMA_HISTORY_PATH)
@@ -131,7 +130,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         assertConfigurationErrors(result, MySqlConnectorConfig.HOSTNAME, 1);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.PORT);
         assertConfigurationErrors(result, MySqlConnectorConfig.USER, 1);
-        assertNoConfigurationErrors(result, AbstractTopicNamingStrategy.TOPIC_PREFIX);
+        assertNoConfigurationErrors(result, CommonConnectorConfig.TOPIC_PREFIX);
         assertConfigurationErrors(result, MySqlConnectorConfig.SERVER_ID);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.TABLES_IGNORE_BUILTIN);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.DATABASE_INCLUDE_LIST);
@@ -164,7 +163,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
     public void shouldValidateAcceptableConfiguration() {
         Configuration config = DATABASE.defaultJdbcConfigBuilder()
                 .with(MySqlConnectorConfig.SERVER_ID, 18765)
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myServer")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myServer")
                 .with(KafkaSchemaHistory.BOOTSTRAP_SERVERS, "some.host.com")
                 .with(KafkaSchemaHistory.TOPIC, "my.db.history.topic")
                 .with(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
@@ -178,7 +177,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         assertNoConfigurationErrors(result, MySqlConnectorConfig.USER);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.PASSWORD);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.ON_CONNECT_STATEMENTS);
-        assertNoConfigurationErrors(result, AbstractTopicNamingStrategy.TOPIC_PREFIX);
+        assertNoConfigurationErrors(result, CommonConnectorConfig.TOPIC_PREFIX);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.SERVER_ID);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.TABLES_IGNORE_BUILTIN);
         assertNoConfigurationErrors(result, MySqlConnectorConfig.DATABASE_INCLUDE_LIST);
@@ -226,7 +225,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         for (final String acceptableValue : acceptableValues) {
             Configuration config = DATABASE.defaultJdbcConfigBuilder()
                     .with(MySqlConnectorConfig.SERVER_ID, 18765)
-                    .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myServer")
+                    .with(CommonConnectorConfig.TOPIC_PREFIX, "myServer")
                     .with(KafkaSchemaHistory.BOOTSTRAP_SERVERS, "some.host.com")
                     .with(KafkaSchemaHistory.TOPIC, "my.db.history.topic")
                     .with(MySqlConnectorConfig.INCLUDE_SCHEMA_CHANGES, true)
@@ -283,7 +282,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
                 .with(MySqlConnectorConfig.HOSTNAME, System.getProperty("database.replica.hostname", "localhost"))
                 .with(MySqlConnectorConfig.PORT, System.getProperty("database.replica.port", "3306"))
                 .with(MySqlConnectorConfig.SERVER_ID, serverId)
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, DATABASE.getServerName())
+                .with(CommonConnectorConfig.TOPIC_PREFIX, DATABASE.getServerName())
                 .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(dbIncludeListField, DATABASE.getDatabaseName())
                 .with(MySqlConnectorConfig.SCHEMA_HISTORY, FileSchemaHistory.class)
@@ -601,9 +600,9 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
         stopConnector();
 
         // Read the last committed offsets, and verify the binlog coordinates ...
-        final String serverName = config.getString(AbstractTopicNamingStrategy.TOPIC_PREFIX);
+        final String serverName = config.getString(CommonConnectorConfig.TOPIC_PREFIX);
         final MySqlOffsetContext.Loader loader = new MySqlOffsetContext.Loader(new MySqlConnectorConfig(Configuration.create()
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, serverName)
+                .with(CommonConnectorConfig.TOPIC_PREFIX, serverName)
                 .build()));
         final Map<String, String> partition = new MySqlPartition(serverName, DATABASE.getDatabaseName()).getSourcePartition();
         Map<String, ?> lastCommittedOffset = readLastCommittedOffset(config, partition);
@@ -694,7 +693,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
                 .with(MySqlConnectorConfig.HOSTNAME, System.getProperty("database.replica.hostname", "localhost"))
                 .with(MySqlConnectorConfig.PORT, System.getProperty("database.replica.port", "3306"))
                 .with(MySqlConnectorConfig.SERVER_ID, 28765)
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, DATABASE.getServerName())
+                .with(CommonConnectorConfig.TOPIC_PREFIX, DATABASE.getServerName())
                 .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MySqlConnectorConfig.DATABASE_INCLUDE_LIST, DATABASE.getDatabaseName())
                 .with(MySqlConnectorConfig.TABLE_INCLUDE_LIST, DATABASE.getDatabaseName() + ".products")
@@ -742,7 +741,7 @@ public class MySqlConnectorIT extends AbstractConnectorTest {
                 .with(MySqlConnectorConfig.HOSTNAME, System.getProperty("database.replica.hostname", "localhost"))
                 .with(MySqlConnectorConfig.PORT, System.getProperty("database.replica.port", "3306"))
                 .with(MySqlConnectorConfig.SERVER_ID, 28765)
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, DATABASE.getServerName())
+                .with(CommonConnectorConfig.TOPIC_PREFIX, DATABASE.getServerName())
                 .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MySqlConnectorConfig.DATABASE_INCLUDE_LIST, DATABASE.getDatabaseName())
                 .with(MySqlConnectorConfig.TABLE_INCLUDE_LIST, tables)

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlParserIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlParserIT.java
@@ -28,7 +28,6 @@ import io.debezium.connector.mysql.junit.SkipWhenSslModeIsNot;
 import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.util.ContainerImageVersions;
 import io.debezium.util.Testing;
 
@@ -76,7 +75,7 @@ public class MySqlParserIT extends AbstractConnectorTest {
 
     public Configuration.Builder defaultConfig() {
         return Configuration.create()
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myServer1")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myServer1")
                 .with(MySqlConnectorConfig.HOSTNAME, System.getProperty("database.hostname", "localhost"))
                 .with(CommonConnectorConfig.DATABASE_CONFIG_PREFIX + JdbcConfiguration.PORT, mySQLContainer.getMappedPort(3306))
                 .with(MySqlConnectorConfig.USER, "debezium")

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTopicNamingStrategyIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTopicNamingStrategyIT.java
@@ -64,7 +64,7 @@ public class MySqlTopicNamingStrategyIT extends AbstractConnectorTest {
                 .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.INITIAL)
                 .with(MySqlConnectorConfig.TABLE_INCLUDE_LIST, DATABASE.qualifiedTableName(TABLE_NAME))
                 .with(RelationalDatabaseConnectorConfig.INCLUDE_SCHEMA_CHANGES, "true")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "my_prefix")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "my_prefix")
                 .with(AbstractTopicNamingStrategy.TOPIC_DELIMITER, "_")
                 .build();
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTopicNamingStrategyTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlTopicNamingStrategyTest.java
@@ -5,9 +5,9 @@
  */
 package io.debezium.connector.mysql;
 
+import static io.debezium.config.CommonConnectorConfig.TOPIC_PREFIX;
 import static io.debezium.schema.AbstractTopicNamingStrategy.TOPIC_DELIMITER;
 import static io.debezium.schema.AbstractTopicNamingStrategy.TOPIC_HEARTBEAT_PREFIX;
-import static io.debezium.schema.AbstractTopicNamingStrategy.TOPIC_PREFIX;
 import static io.debezium.schema.AbstractTopicNamingStrategy.TOPIC_TRANSACTION;
 import static org.fest.assertions.Assertions.assertThat;
 

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SourceInfoTest.java
@@ -22,12 +22,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.confluent.connect.avro.AvroData;
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.AbstractSourceInfoStructMaker;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
 import io.debezium.document.Document;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 
 public class SourceInfoTest {
 
@@ -46,7 +46,7 @@ public class SourceInfoTest {
     @Before
     public void beforeEach() {
         offsetContext = MySqlOffsetContext.initial(new MySqlConnectorConfig(Configuration.create()
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "server")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "server")
                 .build()));
         source = offsetContext.getSource();
         inTxn = false;
@@ -446,7 +446,7 @@ public class SourceInfoTest {
 
     protected SourceInfo sourceWith(Map<String, String> offset) {
         offsetContext = (MySqlOffsetContext) new MySqlOffsetContext.Loader(new MySqlConnectorConfig(Configuration.create()
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, SERVER_NAME)
+                .with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)
                 .build())).load(offset);
         source = offsetContext.getSource();
         source.databaseEvent("mysql");

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/UniqueDatabase.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/UniqueDatabase.java
@@ -22,9 +22,9 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.config.Configuration.Builder;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.storage.file.history.FileSchemaHistory;
 
 /**
@@ -237,7 +237,7 @@ public class UniqueDatabase {
                 .with(MySqlConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MySqlConnectorConfig.SCHEMA_HISTORY, FileSchemaHistory.class)
                 .with(MySqlConnectorConfig.BUFFER_SIZE_FOR_BINLOG_READER, 10_000)
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, getServerName());
+                .with(CommonConnectorConfig.TOPIC_PREFIX, getServerName());
     }
 
     /**

--- a/debezium-connector-mysql/src/test/java/io/debezium/relational/history/KafkaSchemaHistoryTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/relational/history/KafkaSchemaHistoryTest.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.connector.mysql.MySqlOffsetContext;
@@ -41,7 +42,6 @@ import io.debezium.pipeline.spi.Partition;
 import io.debezium.pipeline.txmetadata.TransactionContext;
 import io.debezium.relational.Tables;
 import io.debezium.relational.ddl.DdlParser;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.storage.kafka.history.KafkaSchemaHistory;
 import io.debezium.text.ParsingException;
 import io.debezium.util.Collect;
@@ -88,7 +88,7 @@ public class KafkaSchemaHistoryTest {
         MySqlPartition source = new MySqlPartition("my-server", "my-db");
         Configuration config = Configuration.empty()
                 .edit()
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "dbserver1").build();
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "dbserver1").build();
 
         position = new MySqlOffsetContext(false, true, new TransactionContext(), new MySqlReadOnlyIncrementalSnapshotContext<>(),
                 new SourceInfo(new MySqlConnectorConfig(config)));

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
 import io.debezium.config.EnumeratedValue;
@@ -44,7 +45,6 @@ import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables.TableFilter;
 import io.debezium.relational.history.HistoryRecordComparator;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.util.Strings;
 
 /**
@@ -573,7 +573,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     private final TransactionSnapshotBoundaryMode logMiningTransactionSnapshotBoundaryMode;
 
     public OracleConnectorConfig(Configuration config) {
-        super(OracleConnector.class, config, config.getString(AbstractTopicNamingStrategy.TOPIC_PREFIX), new SystemTablesPredicate(config),
+        super(OracleConnector.class, config, config.getString(CommonConnectorConfig.TOPIC_PREFIX), new SystemTablesPredicate(config),
                 x -> x.schema() + "." + x.table(), true, ColumnFilterMode.SCHEMA, false);
 
         this.databaseName = toUpperCase(config.getString(DATABASE_NAME));

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
@@ -17,10 +17,10 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.doc.FixFor;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.storage.kafka.history.KafkaSchemaHistory;
 
 public class OracleConnectorConfigTest {
@@ -32,7 +32,7 @@ public class OracleConnectorConfigTest {
 
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
                 Configuration.create()
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                         .with(OracleConnectorConfig.HOSTNAME, "MyHostname")
                         .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
                         .with(OracleConnectorConfig.XSTREAM_SERVER_NAME, "myserver")
@@ -49,7 +49,7 @@ public class OracleConnectorConfigTest {
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
                 Configuration.create()
                         .with(OracleConnectorConfig.CONNECTOR_ADAPTER, "logminer")
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                         .with(OracleConnectorConfig.HOSTNAME, "MyHostname")
                         .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
                         .with(OracleConnectorConfig.USER, "debezium")
@@ -64,7 +64,7 @@ public class OracleConnectorConfigTest {
 
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
                 Configuration.create()
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                         .with(OracleConnectorConfig.URL, "jdbc:oci:thin:@myserver/mydatabase")
                         .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
                         .with(OracleConnectorConfig.XSTREAM_SERVER_NAME, "myserver")
@@ -81,7 +81,7 @@ public class OracleConnectorConfigTest {
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
                 Configuration.create()
                         .with(OracleConnectorConfig.CONNECTOR_ADAPTER, "logminer")
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                         .with(OracleConnectorConfig.URL, "MyHostname")
                         .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
                         .with(OracleConnectorConfig.USER, "debezium")
@@ -97,7 +97,7 @@ public class OracleConnectorConfigTest {
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
                 Configuration.create()
                         .with(OracleConnectorConfig.CONNECTOR_ADAPTER, "logminer")
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                         .with(OracleConnectorConfig.URL,
                                 "jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=192.68.1.11)(PORT=1701))(ADDRESS=(PROTOCOL=TCP)(HOST=192.68.1.12)(PORT=1701))(ADDRESS=(PROTOCOL=TCP)(HOST=192.68.1.13)(PORT=1701))(LOAD_BALANCE = yes)(FAILOVER = on)(CONNECT_DATA =(SERVER = DEDICATED)(SERVICE_NAME = myserver.mydomain.com)(FAILOVER_MODE =(TYPE = SELECT)(METHOD = BASIC)(RETRIES = 3)(DELAY = 5))))")
                         .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
@@ -114,7 +114,7 @@ public class OracleConnectorConfigTest {
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
                 Configuration.create()
                         .with(OracleConnectorConfig.CONNECTOR_ADAPTER, "logminer")
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                         .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
                         .with(OracleConnectorConfig.USER, "debezium")
                         .with(KafkaSchemaHistory.BOOTSTRAP_SERVERS, "localhost:9092")
@@ -128,7 +128,7 @@ public class OracleConnectorConfigTest {
 
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
                 Configuration.create()
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                         .build());
 
         assertEquals(connectorConfig.getLogMiningBatchSizeDefault(), OracleConnectorConfig.DEFAULT_BATCH_SIZE);
@@ -141,7 +141,7 @@ public class OracleConnectorConfigTest {
 
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
                 Configuration.create()
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                         .build());
 
         assertEquals(connectorConfig.getLogMiningSleepTimeDefault(), OracleConnectorConfig.DEFAULT_SLEEP_TIME);
@@ -155,7 +155,7 @@ public class OracleConnectorConfigTest {
     public void validQueryFetchSizeDefaults() throws Exception {
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
                 Configuration.create()
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                         .build());
         assertEquals(connectorConfig.getQueryFetchSize(), 0);
     }
@@ -165,7 +165,7 @@ public class OracleConnectorConfigTest {
     public void validQueryFetchSizeAvailable() throws Exception {
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
                 Configuration.create()
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                         .with(OracleConnectorConfig.QUERY_FETCH_SIZE, 10_000)
                         .build());
         assertEquals(connectorConfig.getQueryFetchSize(), 10_000);
@@ -175,7 +175,7 @@ public class OracleConnectorConfigTest {
     @FixFor("DBZ-2754")
     public void validTransactionRetentionDefaults() throws Exception {
         final Configuration config = Configuration.create()
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                 .build();
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(config);
         assertThat(connectorConfig.getLogMiningTransactionRetention()).isEqualTo(Duration.ZERO);
@@ -187,7 +187,7 @@ public class OracleConnectorConfigTest {
         final Field transactionRetentionField = OracleConnectorConfig.LOG_MINING_TRANSACTION_RETENTION;
 
         Configuration config = Configuration.create()
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                 .with(transactionRetentionField, 3)
                 .build();
 
@@ -209,7 +209,7 @@ public class OracleConnectorConfigTest {
         final Field snapshotLockMode = OracleConnectorConfig.SNAPSHOT_LOCKING_MODE;
 
         Configuration config = Configuration.create().with(snapshotLockMode, "shared")
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                 .build();
         assertThat(config.validateAndRecord(Collections.singletonList(snapshotLockMode), LOGGER::error)).isTrue();
 
@@ -217,7 +217,7 @@ public class OracleConnectorConfigTest {
         assertThat(connectorConfig.getSnapshotLockingMode().usesLocking()).isTrue();
 
         config = Configuration.create()
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                 .with(snapshotLockMode, "none")
                 .build();
 
@@ -235,7 +235,7 @@ public class OracleConnectorConfigTest {
 
         // Test backward compatibility of rac.nodes using no port with database.port
         Configuration config = Configuration.create()
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                 .with(port, "1521")
                 .with(racNodes, "1.2.3.4,1.2.3.5")
                 .build();
@@ -248,7 +248,7 @@ public class OracleConnectorConfigTest {
 
         // Test rac.nodes using combination of with/without port with database.port
         config = Configuration.create()
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                 .with(port, "1521")
                 .with(racNodes, "1.2.3.4,1.2.3.5:1522")
                 .build();
@@ -260,7 +260,7 @@ public class OracleConnectorConfigTest {
 
         // Test rac.nodes using different ports with no database.port
         config = Configuration.create()
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                 .with(racNodes, "1.2.3.4:1523,1.2.3.5:1522")
                 .build();
 
@@ -272,7 +272,7 @@ public class OracleConnectorConfigTest {
 
         // Test rac.nodes using different ports that differ from database.port
         config = Configuration.create()
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "myserver")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "myserver")
                 .with(port, "1521")
                 .with(racNodes, "1.2.3.4:1523,1.2.3.5:1522")
                 .build();

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorTest.java
@@ -20,7 +20,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.debezium.config.CommonConnectorConfig;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 
 public class OracleConnectorTest {
     OracleConnector connector;
@@ -33,7 +32,7 @@ public class OracleConnectorTest {
     @Test
     public void testValidateUnableToConnectNoThrow() {
         Map<String, String> config = new HashMap<>();
-        config.put(AbstractTopicNamingStrategy.TOPIC_PREFIX.name(), "dbserver1");
+        config.put(CommonConnectorConfig.TOPIC_PREFIX.name(), "dbserver1");
         config.put(OracleConnectorConfig.HOSTNAME.name(), "narnia");
         config.put(OracleConnectorConfig.PORT.name(), "4321");
         config.put(OracleConnectorConfig.DATABASE_NAME.name(), "oracle");

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleSchemaHistoryTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleSchemaHistoryTest.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.antlr.OracleDdlParser;
 import io.debezium.connector.oracle.util.TestHelper;
@@ -24,7 +25,6 @@ import io.debezium.relational.ddl.DdlParser;
 import io.debezium.relational.history.AbstractSchemaHistoryTest;
 import io.debezium.relational.history.HistoryRecord;
 import io.debezium.relational.history.TableChanges;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 
 import oracle.jdbc.OracleTypes;
 
@@ -73,7 +73,7 @@ public class OracleSchemaHistoryTest extends AbstractSchemaHistoryTest {
         final OraclePartition source = new OraclePartition(TestHelper.SERVER_NAME, TestHelper.getDatabaseName());
         final Configuration config = Configuration.empty()
                 .edit()
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, TestHelper.SERVER_NAME)
+                .with(CommonConnectorConfig.TOPIC_PREFIX, TestHelper.SERVER_NAME)
                 .build();
         final OracleOffsetContext position = new OracleOffsetContext(new OracleConnectorConfig(config), Scn.valueOf(999),
                 CommitScn.valueOf(999L), null, Scn.valueOf(999), Collections.emptyMap(), false, true, new TransactionContext(),

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SourceInfoTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/SourceInfoTest.java
@@ -14,11 +14,11 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.AbstractSourceInfoStructMaker;
 import io.debezium.data.VerifyRecord;
 import io.debezium.relational.TableId;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 
 public class SourceInfoTest {
 
@@ -28,7 +28,7 @@ public class SourceInfoTest {
     public void beforeEach() {
         final OracleConnectorConfig connectorConfig = new OracleConnectorConfig(
                 Configuration.create()
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "serverX")
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
                         .with(OracleConnectorConfig.DATABASE_NAME, "mydb")
                         .build());
         source = new SourceInfo(connectorConfig);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.connector.oracle.OracleConnection;
@@ -25,7 +26,6 @@ import io.debezium.connector.oracle.OracleConnectorConfig.ConnectorAdapter;
 import io.debezium.connector.oracle.OracleConnectorConfig.LogMiningBufferType;
 import io.debezium.connector.oracle.logminer.processor.infinispan.CacheProvider;
 import io.debezium.jdbc.JdbcConfiguration;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.storage.file.history.FileSchemaHistory;
 import io.debezium.util.Strings;
 import io.debezium.util.Testing;
@@ -161,7 +161,7 @@ public class TestHelper {
             builder.withDefault(OracleConnectorConfig.PDB_NAME, DATABASE);
         }
 
-        return builder.with(AbstractTopicNamingStrategy.TOPIC_PREFIX, SERVER_NAME)
+        return builder.with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)
                 .with(OracleConnectorConfig.SCHEMA_HISTORY, FileSchemaHistory.class)
                 .with(FileSchemaHistory.FILE_PATH, SCHEMA_HISTORY_PATH)
                 .with(OracleConnectorConfig.INCLUDE_SCHEMA_CHANGES, false);
@@ -231,7 +231,7 @@ public class TestHelper {
         jdbcConfiguration.forEach(
                 (field, value) -> builder.with(OracleConnectorConfig.DATABASE_CONFIG_PREFIX + field, value));
 
-        builder.with(AbstractTopicNamingStrategy.TOPIC_PREFIX, SERVER_NAME);
+        builder.with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME);
         return builder;
     }
 
@@ -245,7 +245,7 @@ public class TestHelper {
         jdbcConfiguration.forEach(
                 (field, value) -> builder.with(OracleConnectorConfig.DATABASE_CONFIG_PREFIX + field, value));
 
-        builder.with(AbstractTopicNamingStrategy.TOPIC_PREFIX, SERVER_NAME);
+        builder.with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME);
         return builder;
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -42,7 +42,6 @@ import io.debezium.relational.ColumnFilterMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables.TableFilter;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.util.Strings;
 
 /**
@@ -852,7 +851,7 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     public PostgresConnectorConfig(Configuration config) {
         super(
                 config,
-                config.getString(AbstractTopicNamingStrategy.TOPIC_PREFIX),
+                config.getString(CommonConnectorConfig.TOPIC_PREFIX),
                 new SystemTablesPredicate(),
                 x -> x.schema() + "." + x.table(),
                 DEFAULT_SNAPSHOT_FETCH_SIZE,

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -93,7 +93,6 @@ import io.debezium.junit.logging.LogInterceptor;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.RelationalDatabaseSchema;
 import io.debezium.relational.RelationalSnapshotChangeEventSource;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.schema.DatabaseSchema;
 import io.debezium.util.Strings;
 import io.debezium.util.Testing;
@@ -215,7 +214,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         assertConfigurationErrors(validatedConfig, PostgresConnectorConfig.HOSTNAME, 1);
         assertConfigurationErrors(validatedConfig, PostgresConnectorConfig.USER, 1);
         assertConfigurationErrors(validatedConfig, PostgresConnectorConfig.DATABASE_NAME, 1);
-        assertNoConfigurationErrors(validatedConfig, AbstractTopicNamingStrategy.TOPIC_PREFIX);
+        assertNoConfigurationErrors(validatedConfig, CommonConnectorConfig.TOPIC_PREFIX);
 
         // validate the non required fields
         validateConfigField(validatedConfig, PostgresConnectorConfig.PLUGIN_NAME, LogicalDecoder.DECODERBUFS.getValue());

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresErrorHandlerTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresErrorHandlerTest.java
@@ -11,17 +11,17 @@ import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
 
 import io.debezium.DebeziumException;
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.pipeline.DataChangeEvent;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 
 public class PostgresErrorHandlerTest {
     private static final String A_CLASSIFIED_EXCEPTION = "Database connection failed when writing to copy";
 
     private final PostgresErrorHandler errorHandler = new PostgresErrorHandler(
             new PostgresConnectorConfig(Configuration.create()
-                    .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "postgres")
+                    .with(CommonConnectorConfig.TOPIC_PREFIX, "postgres")
                     .build()),
             new ChangeEventQueue.Builder<DataChangeEvent>().build());
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SourceInfoTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SourceInfoTest.java
@@ -12,12 +12,12 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.AbstractSourceInfoStructMaker;
 import io.debezium.data.VerifyRecord;
 import io.debezium.doc.FixFor;
 import io.debezium.relational.TableId;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.time.Conversions;
 
 /**
@@ -32,7 +32,7 @@ public class SourceInfoTest {
     public void beforeEach() {
         source = new SourceInfo(new PostgresConnectorConfig(
                 Configuration.create()
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "serverX")
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
                         .with(PostgresConnectorConfig.DATABASE_NAME, "serverX")
                         .build()));
         source.update(Conversions.toInstantFromMicros(123_456_789L), new TableId("catalogNameX", "schemaNameX", "tableNameX"));

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/TestHelper.java
@@ -32,6 +32,7 @@ import org.postgresql.jdbc.PgConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig.SecureConnectionMode;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
@@ -39,7 +40,6 @@ import io.debezium.connector.postgresql.connection.PostgresConnection.PostgresVa
 import io.debezium.connector.postgresql.connection.PostgresDefaultValueConverter;
 import io.debezium.connector.postgresql.connection.ReplicationConnection;
 import io.debezium.jdbc.JdbcConfiguration;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.schema.SchemaTopicNamingStrategy;
 import io.debezium.spi.topic.TopicNamingStrategy;
 import io.debezium.util.Throwables;
@@ -257,7 +257,7 @@ public final class TestHelper {
 
     public static JdbcConfiguration defaultJdbcConfig() {
         return JdbcConfiguration.copy(Configuration.fromSystemProperties("database."))
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "dbserver1")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "dbserver1")
                 .withDefault(JdbcConfiguration.DATABASE, "postgres")
                 .withDefault(JdbcConfiguration.HOSTNAME, "localhost")
                 .withDefault(JdbcConfiguration.PORT, 5432)
@@ -270,7 +270,7 @@ public final class TestHelper {
         JdbcConfiguration jdbcConfiguration = defaultJdbcConfig();
         Configuration.Builder builder = Configuration.create();
         jdbcConfiguration.forEach((field, value) -> builder.with(PostgresConnectorConfig.DATABASE_CONFIG_PREFIX + field, value));
-        builder.with(AbstractTopicNamingStrategy.TOPIC_PREFIX, TEST_SERVER)
+        builder.with(CommonConnectorConfig.TOPIC_PREFIX, TEST_SERVER)
                 .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, true)
                 .with(PostgresConnectorConfig.STATUS_UPDATE_INTERVAL_MS, 100)
                 .with(PostgresConnectorConfig.PLUGIN_NAME, decoderPlugin())
@@ -310,7 +310,7 @@ public final class TestHelper {
     protected static SourceInfo sourceInfo() {
         return new SourceInfo(new PostgresConnectorConfig(
                 Configuration.create()
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, TEST_SERVER)
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, TEST_SERVER)
                         .with(PostgresConnectorConfig.DATABASE_NAME, TEST_DATABASE)
                         .build()));
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -18,6 +18,7 @@ import org.apache.kafka.common.config.ConfigDef.Width;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
 import io.debezium.config.EnumeratedValue;
@@ -31,7 +32,6 @@ import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables.TableFilter;
 import io.debezium.relational.history.HistoryRecordComparator;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 
 /**
  * The list of configuration options for SQL Server connector
@@ -334,7 +334,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
     private final boolean optionRecompile;
 
     public SqlServerConnectorConfig(Configuration config) {
-        super(SqlServerConnector.class, config, config.getString(AbstractTopicNamingStrategy.TOPIC_PREFIX), new SystemTablesPredicate(),
+        super(SqlServerConnector.class, config, config.getString(CommonConnectorConfig.TOPIC_PREFIX), new SystemTablesPredicate(),
                 x -> x.schema() + "." + x.table(), true,
                 ColumnFilterMode.SCHEMA, true);
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SourceInfoTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SourceInfoTest.java
@@ -14,11 +14,11 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.AbstractSourceInfoStructMaker;
 import io.debezium.connector.SnapshotRecord;
 import io.debezium.relational.TableId;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 
 public class SourceInfoTest {
 
@@ -28,7 +28,7 @@ public class SourceInfoTest {
     public void beforeEach() {
         final SqlServerConnectorConfig connectorConfig = new SqlServerConnectorConfig(
                 Configuration.create()
-                        .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "serverX")
+                        .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
                         .build());
         source = new SourceInfo(connectorConfig);
         source.setChangeLsn(Lsn.valueOf(new byte[]{ 0x01 }));

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorConfigTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorConfigTest.java
@@ -12,8 +12,8 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.storage.kafka.history.KafkaSchemaHistory;
 
 public class SqlServerConnectorConfigTest {
@@ -38,7 +38,7 @@ public class SqlServerConnectorConfigTest {
 
     private Configuration.Builder defaultConfig() {
         return Configuration.create()
-                .with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "server")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "server")
                 .with(SqlServerConnectorConfig.HOSTNAME, "localhost")
                 .with(SqlServerConnectorConfig.USER, "debezium")
                 .with(KafkaSchemaHistory.BOOTSTRAP_SERVERS, "localhost:9092")

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorTest.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorTest.java
@@ -21,7 +21,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.debezium.config.CommonConnectorConfig;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 
 public class SqlServerConnectorTest {
     SqlServerConnector connector;
@@ -34,7 +33,7 @@ public class SqlServerConnectorTest {
     @Test
     public void testValidateUnableToConnectNoThrow() {
         Map<String, String> config = new HashMap<>();
-        config.put(AbstractTopicNamingStrategy.TOPIC_PREFIX.name(), "dbserver1");
+        config.put(CommonConnectorConfig.TOPIC_PREFIX.name(), "dbserver1");
         config.put(SqlServerConnectorConfig.HOSTNAME.name(), "narnia");
         config.put(SqlServerConnectorConfig.PORT.name(), "4321");
         config.put(SqlServerConnectorConfig.DATABASE_NAMES.name(), "sqlserver");

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -29,6 +29,7 @@ import org.awaitility.core.ConditionTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.sqlserver.Lsn;
 import io.debezium.connector.sqlserver.SqlServerChangeTable;
@@ -41,7 +42,6 @@ import io.debezium.jdbc.JdbcValueConverters;
 import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.TableId;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.storage.file.history.FileSchemaHistory;
 import io.debezium.util.Collect;
 import io.debezium.util.IoUtil;
@@ -125,7 +125,7 @@ public class TestHelper {
         jdbcConfiguration.forEach(
                 (field, value) -> builder.with(SqlServerConnectorConfig.DATABASE_CONFIG_PREFIX + field, value));
 
-        return builder.with(AbstractTopicNamingStrategy.TOPIC_PREFIX, "server1")
+        return builder.with(CommonConnectorConfig.TOPIC_PREFIX, "server1")
                 .with(SqlServerConnectorConfig.SCHEMA_HISTORY, FileSchemaHistory.class)
                 .with(FileSchemaHistory.FILE_PATH, SCHEMA_HISTORY_PATH)
                 .with(RelationalDatabaseConnectorConfig.INCLUDE_SCHEMA_CHANGES, false);

--- a/debezium-core/src/main/java/io/debezium/connector/common/RelationalBaseSourceConnector.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/RelationalBaseSourceConnector.java
@@ -14,9 +14,9 @@ import org.apache.kafka.connect.source.SourceConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.util.Strings;
 
 /**
@@ -34,7 +34,7 @@ public abstract class RelationalBaseSourceConnector extends SourceConnector {
         // Validate all of the individual fields, which is easy since don't make any of the fields invisible ...
         Map<String, ConfigValue> results = validateAllFields(config);
 
-        ConfigValue logicalName = results.get(AbstractTopicNamingStrategy.TOPIC_PREFIX.name());
+        ConfigValue logicalName = results.get(CommonConnectorConfig.TOPIC_PREFIX.name());
         // Get the config values for each of the connection-related fields ...
         ConfigValue hostnameValue = results.get(RelationalDatabaseConnectorConfig.HOSTNAME.name());
         ConfigValue portValue = results.get(RelationalDatabaseConnectorConfig.PORT.name());

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -37,7 +37,6 @@ import io.debezium.relational.Selectors.TableIdToStringMapper;
 import io.debezium.relational.Tables.ColumnNameFilter;
 import io.debezium.relational.Tables.ColumnNameFilterFactory;
 import io.debezium.relational.Tables.TableFilter;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.spi.topic.TopicNamingStrategy;
 import io.debezium.util.SchemaNameAdjuster;
 import io.debezium.util.Strings;
@@ -467,7 +466,7 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
 
     protected static final ConfigDefinition CONFIG_DEFINITION = CommonConnectorConfig.CONFIG_DEFINITION.edit()
             .type(
-                    AbstractTopicNamingStrategy.TOPIC_PREFIX)
+                    CommonConnectorConfig.TOPIC_PREFIX)
             .connector(
                     DECIMAL_HANDLING_MODE,
                     TIME_PRECISION_MODE,

--- a/debezium-core/src/test/java/io/debezium/config/ConfigurationTest.java
+++ b/debezium-core/src/test/java/io/debezium/config/ConfigurationTest.java
@@ -5,10 +5,10 @@
  */
 package io.debezium.config;
 
+import static io.debezium.config.CommonConnectorConfig.TOPIC_PREFIX;
 import static io.debezium.relational.RelationalDatabaseConnectorConfig.COLUMN_EXCLUDE_LIST;
 import static io.debezium.relational.RelationalDatabaseConnectorConfig.COLUMN_INCLUDE_LIST;
 import static io.debezium.relational.RelationalDatabaseConnectorConfig.MSG_KEY_COLUMNS;
-import static io.debezium.schema.AbstractTopicNamingStrategy.TOPIC_PREFIX;
 import static org.fest.assertions.Assertions.assertThat;
 
 import java.util.List;

--- a/debezium-microbenchmark-oracle/src/main/java/io/debezium/performance/connector/oracle/EndToEndPerf.java
+++ b/debezium-microbenchmark-oracle/src/main/java/io/debezium/performance/connector/oracle/EndToEndPerf.java
@@ -43,6 +43,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnector;
@@ -52,7 +53,6 @@ import io.debezium.connector.oracle.OracleConnectorConfig.LogMiningStrategy;
 import io.debezium.connector.oracle.OracleConnectorConfig.SnapshotMode;
 import io.debezium.embedded.EmbeddedEngine;
 import io.debezium.jdbc.JdbcConfiguration;
-import io.debezium.schema.AbstractTopicNamingStrategy;
 import io.debezium.storage.file.history.FileSchemaHistory;
 import io.debezium.util.IoUtil;
 
@@ -236,7 +236,7 @@ public class EndToEndPerf {
             Configuration.Builder builder = Configuration.create();
             jdbcConfiguration.forEach((f, v) -> builder.with(OracleConnectorConfig.DATABASE_CONFIG_PREFIX + f, v));
 
-            return builder.with(AbstractTopicNamingStrategy.TOPIC_PREFIX, SERVER_NAME)
+            return builder.with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)
                     .with(OracleConnectorConfig.PDB_NAME, "ORCLPDB1")
                     .with(OracleConnectorConfig.INCLUDE_SCHEMA_CHANGES, false)
                     .with(OracleConnectorConfig.CONNECTOR_ADAPTER, ConnectorAdapter.LOG_MINER)


### PR DESCRIPTION
`TOPIC_PREFIX` is now mandatory to all connectors therefore it make sense to have it in common config. Beside that, it also makes it more easy to use it in Debezium UI without any workarounds - if the field is not member of the given connector config, the field has to be explicitely added into known fields otherwise is invisible for UI.

https://issues.redhat.com/browse/DBZ-5043