### PR TITLE
DBZ-5577 Fix `database.server.id` documentation's default value

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2438,7 +2438,7 @@ The connector is also unable to recover its database schema history topic.
 ====
 
 |[[mysql-property-database-server-id]]<<mysql-property-database-server-id, `+database.server.id+`>>
-|_random_
+|No default
 |A numeric ID of this database client, which must be unique across all currently-running database processes in the MySQL cluster. This connector joins the MySQL database cluster as another server (with this unique ID) so it can read the binlog.
 
 |[[mysql-property-database-include-list]]<<mysql-property-database-include-list, `+database.include.list+`>>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5577