### PR TITLE
DBZ-5496: Improve compatibility with Azure SQL

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnector.java
@@ -152,6 +152,7 @@ public class SqlServerConnector extends RelationalBaseSourceConnector {
     }
 
     private SqlServerConnection connect(SqlServerConnectorConfig sqlServerConfig) {
-        return new SqlServerConnection(sqlServerConfig.getJdbcConfig(), null, Collections.emptySet());
+        return new SqlServerConnection(sqlServerConfig.getJdbcConfig(), null, Collections.emptySet(),
+                sqlServerConfig.useSingleDatabase());
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -26,6 +26,7 @@ import io.debezium.config.Field;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.document.Document;
+import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.relational.ColumnFilterMode;
 import io.debezium.relational.HistorizedRelationalDatabaseConnectorConfig;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
@@ -374,6 +375,21 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
 
     public String getInstanceName() {
         return instanceName;
+    }
+
+    public boolean useSingleDatabase() {
+        return this.databaseNames.size() == 1;
+    }
+
+    @Override
+    public JdbcConfiguration getJdbcConfig() {
+        JdbcConfiguration config = super.getJdbcConfig();
+        if (useSingleDatabase()) {
+            config = JdbcConfiguration.adapt(config.edit()
+                    .with(JdbcConfiguration.DATABASE, databaseNames.get(0))
+                    .build());
+        }
+        return config;
     }
 
     public SnapshotIsolationMode getSnapshotIsolationMode() {

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -71,9 +71,10 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
                 connectorConfig.getTemporalPrecisionMode(), connectorConfig.binaryHandlingMode());
 
         dataConnection = new SqlServerConnection(connectorConfig.getJdbcConfig(), valueConverters,
-                connectorConfig.getSkippedOperations(), connectorConfig.getOptionRecompile());
+                connectorConfig.getSkippedOperations(), connectorConfig.useSingleDatabase(),
+                connectorConfig.getOptionRecompile());
         metadataConnection = new SqlServerConnection(connectorConfig.getJdbcConfig(), valueConverters,
-                connectorConfig.getSkippedOperations());
+                connectorConfig.getSkippedOperations(), connectorConfig.useSingleDatabase());
 
         this.schema = new SqlServerDatabaseSchema(connectorConfig, metadataConnection.getDefaultValueConverter(), valueConverters, topicNamingStrategy,
                 schemaNameAdjuster);

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectionIT.java
@@ -457,6 +457,24 @@ public class SqlServerConnectionIT {
         }
     }
 
+    @Test
+    @FixFor("DBZ-5496")
+    public void shouldConnectToASingleDatabase() throws Exception {
+        TestHelper.createTestDatabase();
+        try (SqlServerConnection connection = TestHelper.testConnection()) {
+            Assertions.assertThat(connection.connection().getCatalog()).isEqualTo(TestHelper.TEST_DATABASE_1);
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-5496")
+    public void shouldNotConnectToAnyOfMultipleDatabase() throws Exception {
+        TestHelper.createTestDatabases(TestHelper.TEST_DATABASE_1, TestHelper.TEST_DATABASE_2);
+        try (SqlServerConnection connection = TestHelper.multiPartitionTestConnection()) {
+            Assertions.assertThat(connection.connection().getCatalog()).isEqualTo("master");
+        }
+    }
+
     private long toMillis(OffsetDateTime datetime) {
         return datetime.toInstant().toEpochMilli();
     }

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/util/TestHelper.java
@@ -237,7 +237,8 @@ public class TestHelper {
 
     public static SqlServerConnection adminConnection() {
         return new SqlServerConnection(TestHelper.defaultJdbcConfig(),
-                new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE, null), Collections.emptySet());
+                new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE, null),
+                Collections.emptySet(), false);
     }
 
     public static SqlServerConnection testConnection() {
@@ -262,13 +263,14 @@ public class TestHelper {
 
     public static SqlServerConnection testConnection(JdbcConfiguration config) {
         return new SqlServerConnection(config,
-                new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE, null), Collections.emptySet());
+                new SqlServerValueConverters(JdbcValueConverters.DecimalMode.PRECISE, TemporalPrecisionMode.ADAPTIVE, null),
+                Collections.emptySet(), false);
     }
 
     public static SqlServerConnection testConnectionWithOptionRecompile() {
         JdbcConfiguration config = JdbcConfiguration.adapt(defaultJdbcConfig()
                 .edit()
-                .with(JdbcConfiguration.ON_CONNECT_STATEMENTS, "USE [" + TEST_DATABASE_1 + "]")
+                .with(JdbcConfiguration.DATABASE, TEST_DATABASE_1)
                 .build());
 
         return new SqlServerConnection(config,


### PR DESCRIPTION
If the SQL Server connector is configured to capture changes from a single database, pass it to the JDBC connection string in order to bypass the limitation of Azure SQL which does not allow switching between databases within a single connection.

See the [documentation](https://docs.microsoft.com/en-us/sql/t-sql/language-elements/use-transact-sql?view=sql-server-ver15#arguments) for more details.

All the tests that use the default configuration (the majority of them) will now use the single-database connection, so no additional tests should be necessary.

UPD: we can actually test that if the connection is passed a single database, it is the current database. Otherwise, `master` should be the current database (which will hold true unless overridden for the Debezium login, i.e. reliable enough).