### PR TITLE
DBZ-5612 Remove records from being logged at all levels

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/signal/KafkaSignalThread.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/signal/KafkaSignalThread.java
@@ -136,7 +136,7 @@ public class KafkaSignalThread<T extends DataCollectionId> {
                     return;
                 }
                 catch (final Exception e) {
-                    Throwables.logErrorAndTraceRecord(LOGGER, "Skipped signal due to an error", e, record);
+                    Throwables.logErrorAndTraceRecord(LOGGER, record, "Skipped signal due to an error", e);
                 }
             }
         }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/signal/KafkaSignalThread.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/signal/KafkaSignalThread.java
@@ -135,7 +135,7 @@ public class KafkaSignalThread<T extends DataCollectionId> {
                     return;
                 }
                 catch (final Exception e) {
-                    LOGGER.error("Skipped signal due to an error '{}'", record, e);
+                    LOGGER.error("Skipped signal due to an error", e);
                 }
             }
         }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/signal/KafkaSignalThread.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/signal/KafkaSignalThread.java
@@ -37,6 +37,7 @@ import io.debezium.pipeline.signal.StopSnapshot;
 import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Collect;
 import io.debezium.util.Threads;
+import io.debezium.util.Throwables;
 
 /**
  * The class responsible for processing of signals delivered to Debezium via a dedicated Kafka topic.
@@ -135,7 +136,7 @@ public class KafkaSignalThread<T extends DataCollectionId> {
                     return;
                 }
                 catch (final Exception e) {
-                    LOGGER.error("Skipped signal due to an error", e);
+                    Throwables.logErrorAndTraceRecord(LOGGER, "Skipped signal due to an error", e, record);
                 }
             }
         }

--- a/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
+++ b/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
@@ -205,7 +205,7 @@ public class ChangeEventQueue<T extends Sizeable> implements ChangeEventQueueMet
     }
 
     protected void doEnqueue(T record) throws InterruptedException {
-        if (LOGGER.isDebugEnabled()) {
+        if (LOGGER.isTraceEnabled()) {
             LOGGER.trace("Enqueuing source record '{}'", record);
         }
 

--- a/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
+++ b/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
@@ -206,7 +206,7 @@ public class ChangeEventQueue<T extends Sizeable> implements ChangeEventQueueMet
 
     protected void doEnqueue(T record) throws InterruptedException {
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Enqueuing source record");
+            LOGGER.trace("Enqueuing source record '{}'", record);
         }
 
         try {

--- a/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
+++ b/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
@@ -206,7 +206,7 @@ public class ChangeEventQueue<T extends Sizeable> implements ChangeEventQueueMet
 
     protected void doEnqueue(T record) throws InterruptedException {
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Enqueuing source record '{}'", record);
+            LOGGER.debug("Enqueuing source record");
         }
 
         try {

--- a/debezium-core/src/main/java/io/debezium/util/Throwables.java
+++ b/debezium-core/src/main/java/io/debezium/util/Throwables.java
@@ -27,8 +27,13 @@ public class Throwables {
         }
     }
 
-    public static void logErrorAndTraceRecord(Logger logger, String message, Exception e, Object record) {
+    public static void logErrorAndTraceRecord(Logger logger, Object record, String message, Throwable e) {
         logger.error(message, e);
-        LOGGER.trace("Source of error is {}", record);
+        LOGGER.trace("Source of error is record '{}'", record);
+    }
+
+    public static void logErrorAndTraceRecord(Logger logger, Object record, String message, Object... arguments) {
+        logger.error(message, arguments);
+        LOGGER.trace("Source of error is record '{}'", record);
     }
 }

--- a/debezium-core/src/main/java/io/debezium/util/Throwables.java
+++ b/debezium-core/src/main/java/io/debezium/util/Throwables.java
@@ -5,12 +5,17 @@
  */
 package io.debezium.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Functionality for dealing with {@link Throwable}s.
  *
  * @author Gunnar Morling
  */
 public class Throwables {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Throwables.class);
 
     public static Throwable getRootCause(Throwable throwable) {
         while (true) {
@@ -20,5 +25,10 @@ public class Throwables {
             }
             throwable = cause;
         }
+    }
+
+    public static void logErrorAndTraceRecord(Logger logger, String message, Exception e, Object record) {
+        logger.error(message, e);
+        LOGGER.trace("Source of error is {}", record);
     }
 }

--- a/debezium-core/src/test/java/io/debezium/kafka/KafkaCluster.java
+++ b/debezium-core/src/test/java/io/debezium/kafka/KafkaCluster.java
@@ -780,7 +780,7 @@ public class KafkaCluster {
                         ProducerRecord<K, V> record = messageSupplier.get();
                         producer.send(record);
                         producer.flush();
-                        LOGGER.debug("Producer {}: sent message", producerName);
+                        LOGGER.debug("Producer {}: sent message {}", producerName, record);
                     }
                 }
                 finally {
@@ -926,7 +926,7 @@ public class KafkaCluster {
                     consumer.subscribe(new ArrayList<>(topics));
                     while (continuation.getAsBoolean()) {
                         consumer.poll(10).forEach(record -> {
-                            LOGGER.debug("Consumer {}: consuming message", clientId);
+                            LOGGER.debug("Consumer {}: consuming message {}", clientId, record);
                             consumerFunction.accept(record);
                             if (offsetCommitCallback != null) {
                                 consumer.commitAsync(offsetCommitCallback);

--- a/debezium-core/src/test/java/io/debezium/kafka/KafkaCluster.java
+++ b/debezium-core/src/test/java/io/debezium/kafka/KafkaCluster.java
@@ -780,7 +780,7 @@ public class KafkaCluster {
                         ProducerRecord<K, V> record = messageSupplier.get();
                         producer.send(record);
                         producer.flush();
-                        LOGGER.debug("Producer {}: sent message {}", producerName, record);
+                        LOGGER.debug("Producer {}: sent message", producerName);
                     }
                 }
                 finally {
@@ -926,7 +926,7 @@ public class KafkaCluster {
                     consumer.subscribe(new ArrayList<>(topics));
                     while (continuation.getAsBoolean()) {
                         consumer.poll(10).forEach(record -> {
-                            LOGGER.debug("Consumer {}: consuming message {}", clientId, record);
+                            LOGGER.debug("Consumer {}: consuming message", clientId);
                             consumerFunction.accept(record);
                             if (offsetCommitCallback != null) {
                                 consumer.commitAsync(offsetCommitCallback);

--- a/debezium-server/debezium-server-redis/src/main/java/io/debezium/server/redis/RedisSchemaHistory.java
+++ b/debezium-server/debezium-server-redis/src/main/java/io/debezium/server/redis/RedisSchemaHistory.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import io.debezium.util.Throwables;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -150,7 +151,7 @@ public final class RedisSchemaHistory extends AbstractSchemaHistory {
             line = writer.write(record.document());
         }
         catch (IOException e) {
-            LOGGER.error("Failed to convert record to string", e);
+            Throwables.logErrorAndTraceRecord(LOGGER, "Failed to convert record to string", e, record);
             throw new SchemaHistoryException("Unable to write database schema history record");
         }
 

--- a/debezium-server/debezium-server-redis/src/main/java/io/debezium/server/redis/RedisSchemaHistory.java
+++ b/debezium-server/debezium-server-redis/src/main/java/io/debezium/server/redis/RedisSchemaHistory.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
-import io.debezium.util.Throwables;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +31,7 @@ import io.debezium.relational.history.SchemaHistoryException;
 import io.debezium.relational.history.SchemaHistoryListener;
 import io.debezium.util.Collect;
 import io.debezium.util.DelayStrategy;
+import io.debezium.util.Throwables;
 
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.StreamEntryID;
@@ -151,7 +151,7 @@ public final class RedisSchemaHistory extends AbstractSchemaHistory {
             line = writer.write(record.document());
         }
         catch (IOException e) {
-            Throwables.logErrorAndTraceRecord(LOGGER, "Failed to convert record to string", e, record);
+            Throwables.logErrorAndTraceRecord(LOGGER, record, "Failed to convert record to string", e);
             throw new SchemaHistoryException("Unable to write database schema history record");
         }
 

--- a/debezium-server/debezium-server-redis/src/main/java/io/debezium/server/redis/RedisSchemaHistory.java
+++ b/debezium-server/debezium-server-redis/src/main/java/io/debezium/server/redis/RedisSchemaHistory.java
@@ -150,7 +150,7 @@ public final class RedisSchemaHistory extends AbstractSchemaHistory {
             line = writer.write(record.document());
         }
         catch (IOException e) {
-            LOGGER.error("Failed to convert record to string: {}", record, e);
+            LOGGER.error("Failed to convert record to string", e);
             throw new SchemaHistoryException("Unable to write database schema history record");
         }
 

--- a/debezium-storage/debezium-storage-file/src/main/java/io/debezium/storage/file/history/FileSchemaHistory.java
+++ b/debezium-storage/debezium-storage-file/src/main/java/io/debezium/storage/file/history/FileSchemaHistory.java
@@ -124,7 +124,7 @@ public final class FileSchemaHistory extends AbstractSchemaHistory {
                         historyWriter.newLine();
                     }
                     catch (IOException e) {
-                        logger.error("Failed to add record to history at {}: {}", path, record, e);
+                        logger.error("Failed to add record to history at {}", path, e);
                         return;
                     }
                 }
@@ -133,7 +133,7 @@ public final class FileSchemaHistory extends AbstractSchemaHistory {
                 }
             }
             catch (IOException e) {
-                logger.error("Failed to convert record to string: {}", record, e);
+                logger.error("Failed to convert record to string", e);
             }
         });
     }

--- a/debezium-storage/debezium-storage-file/src/main/java/io/debezium/storage/file/history/FileSchemaHistory.java
+++ b/debezium-storage/debezium-storage-file/src/main/java/io/debezium/storage/file/history/FileSchemaHistory.java
@@ -125,7 +125,7 @@ public final class FileSchemaHistory extends AbstractSchemaHistory {
                         historyWriter.newLine();
                     }
                     catch (IOException e) {
-                        Throwables.logErrorAndTraceRecord(logger, "Failed to add record to history at " + path, e, record);
+                        Throwables.logErrorAndTraceRecord(logger, record, "Failed to add record to history at {}", path, e);
                         return;
                     }
                 }
@@ -134,7 +134,7 @@ public final class FileSchemaHistory extends AbstractSchemaHistory {
                 }
             }
             catch (IOException e) {
-                Throwables.logErrorAndTraceRecord(logger, "Failed to convert record to string", e, record);
+                Throwables.logErrorAndTraceRecord(logger, record, "Failed to convert record to string", e);
             }
         });
     }

--- a/debezium-storage/debezium-storage-file/src/main/java/io/debezium/storage/file/history/FileSchemaHistory.java
+++ b/debezium-storage/debezium-storage-file/src/main/java/io/debezium/storage/file/history/FileSchemaHistory.java
@@ -34,6 +34,7 @@ import io.debezium.relational.history.SchemaHistoryException;
 import io.debezium.relational.history.SchemaHistoryListener;
 import io.debezium.util.Collect;
 import io.debezium.util.FunctionalReadWriteLock;
+import io.debezium.util.Throwables;
 
 /**
  * A {@link SchemaHistory} implementation that stores the schema history in a local file.
@@ -124,7 +125,7 @@ public final class FileSchemaHistory extends AbstractSchemaHistory {
                         historyWriter.newLine();
                     }
                     catch (IOException e) {
-                        logger.error("Failed to add record to history at {}", path, e);
+                        Throwables.logErrorAndTraceRecord(logger, "Failed to add record to history at " + path, e, record);
                         return;
                     }
                 }
@@ -133,7 +134,7 @@ public final class FileSchemaHistory extends AbstractSchemaHistory {
                 }
             }
             catch (IOException e) {
-                logger.error("Failed to convert record to string", e);
+                Throwables.logErrorAndTraceRecord(logger, "Failed to convert record to string", e, record);
             }
         });
     }

--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -344,10 +344,10 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
                         }
                     }
                     catch (final IOException e) {
-                        LOGGER.error("Error while deserializing history record '{}'", record, e);
+                        LOGGER.error("Error while deserializing history record", e);
                     }
                     catch (final Exception e) {
-                        LOGGER.error("Unexpected exception while processing record '{}'", record, e);
+                        LOGGER.error("Unexpected exception while processing record", e);
                         throw e;
                     }
                 }

--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -68,6 +68,7 @@ import io.debezium.relational.history.SchemaHistoryException;
 import io.debezium.relational.history.SchemaHistoryListener;
 import io.debezium.util.Collect;
 import io.debezium.util.Threads;
+import io.debezium.util.Throwables;
 
 /**
  * A {@link SchemaHistory} implementation that records schema changes as normal {@link SourceRecord}s on the specified topic,
@@ -344,10 +345,10 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
                         }
                     }
                     catch (final IOException e) {
-                        LOGGER.error("Error while deserializing history record", e);
+                        Throwables.logErrorAndTraceRecord(LOGGER, "Error while deserializing history record", e, record);
                     }
                     catch (final Exception e) {
-                        LOGGER.error("Unexpected exception while processing record", e);
+                        Throwables.logErrorAndTraceRecord(LOGGER, "Unexpected exception while processing record", e, record);
                         throw e;
                     }
                 }

--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -345,10 +345,10 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
                         }
                     }
                     catch (final IOException e) {
-                        Throwables.logErrorAndTraceRecord(LOGGER, "Error while deserializing history record", e, record);
+                        Throwables.logErrorAndTraceRecord(LOGGER, record, "Error while deserializing history record", e);
                     }
                     catch (final Exception e) {
-                        Throwables.logErrorAndTraceRecord(LOGGER, "Unexpected exception while processing record", e, record);
+                        Throwables.logErrorAndTraceRecord(LOGGER, record, "Unexpected exception while processing record", e);
                         throw e;
                     }
                 }


### PR DESCRIPTION
### Problem
Looks like the connector logs records at certain points which may contain sensitive user information. 

### Solution
This PR aims to prevent records from being logged at all logging levels.

### Testing
No tests required.