### PR TITLE
Dbz 3327 populate empty default value cells in connector properties tables

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/cassandra.adoc
+++ b/documentation/modules/ROOT/pages/connectors/cassandra.adoc
@@ -911,7 +911,7 @@ Cassandra connector has built-in support for JMX metrics. The Cassandra driver a
 |The port used by the HTTP server for ping, health check, and build info
 
 |[[cassandra-property-cassandra-config]]<<cassandra-property-cassandra-config, `cassandra.config`>>
-|
+|No default
 |The absolute path of the YAML config file used by a Cassandra node.
 
 |[[cassandra-property-cassandra-hosts]]<<cassandra-property-cassandra-hosts, `cassandra.hosts`>>
@@ -923,11 +923,11 @@ Cassandra connector has built-in support for JMX metrics. The Cassandra driver a
 |The port used to connect to Cassandra host(s).
 
 |[[cassandra-property-cassandra-username]]<<cassandra-property-cassandra-username, `cassandra.username`>>
-|
+|No default
 |The username used when connecting to Cassandra hosts.
 
 |[[cassandra-property-cassandra-password]]<<cassandra-property-cassandra-password, `cassandra.password`>>
-|
+|No default
 |The password used when connecting to Cassandra hosts.
 
 |[[cassandra-property-cassandra-ssl-enabled]]<<cassandra-property-cassandra-ssl-enabled, `cassandra.ssl.enabled`>>
@@ -935,7 +935,7 @@ Cassandra connector has built-in support for JMX metrics. The Cassandra driver a
 |If set to true, Cassandra connector agent will use SSL to connect to Cassandra node.
 
 |[[cassandra-property-cassandra-ssl-config-path]]<<cassandra-property-cassandra-ssl-config-path, `cassandra.ssl.config.path`>>
-|
+|No default
 |The SSL config file path required for storage node. An example of config file can be found at the bottom of the page.
 
 |[[cassandra-property-commit-log-real-time-processing-enabled]]<<cassandra-property-commit-log-real-time-processing-enabled, `commit.log.real.time.processing.enabled`>>
@@ -947,7 +947,7 @@ Cassandra connector has built-in support for JMX metrics. The Cassandra driver a
 |Only applicable in Cassandra 4 and when real-time streaming is enabled by xref:cassandra-property-commit-log-real-time-processing-enabled[`commit.log.real.time.processing.enabled`]. This config determines the frequency at which commit log index file is polled for updates in offset value.
 
 |[[cassandra-property-commit-log-relocation-dir]]<<cassandra-property-commit-log-relocation-dir, `commit.log.relocation.dir`>>
-|
+|No default
 |The local directory where commit logs get relocated to from cdc_raw dir once processed.
 
 |[[cassandra-property-commit-log-post-processing-enabled]]<<cassandra-property-commit-log-post-processing-enabled, `commit.log.post.processing.enabled`>>
@@ -991,7 +991,7 @@ For example, +
  isbn.schema.name: io.debezium.cassandra.type.Isbn
 
 |[[cassandra-property-offset-backing-store-dir]]<<cassandra-property-offset-backing-store-dir, `offset.backing.store.dir`>>
-|
+|No default
 |The directory to store offset tracking files.
 
 |[[cassandra-property-offset-flush-interval-ms]]<<cassandra-property-offset-flush-interval-ms, `offset.flush.interval.ms`>>
@@ -1041,7 +1041,7 @@ refreshing the cached Cassandra table schemas.
 |Whether deletion events should have a subsequent tombstone event (true) or not (false). It's important to note that in Cassandra, two events with the same key may be updating different columns of a given table. So this could potentially result in records being lost during compaction if they have not been consumed by the consumer yet. In other words, do NOT set this to true if you have Kafka compaction turned on.
 
 |[[cassandra-property-field-exclude-list]]<<cassandra-property-field-exclude-list, `field.exclude.list`>>
-|
+|No default
 |A comma-separated list of fully-qualified names of fields that should be excluded from change event message values. Fully-qualified names for fields are in the form keyspace_name>.<field_name>.<nested_field_name>.
 
 |[[cassandra-property-num-of-change-event-queues]]<<cassandra-property-num-of-change-event-queues, `num.of.change.event.queues`>>
@@ -1054,7 +1054,7 @@ refreshing the cached Cassandra table schemas.
 See xref:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 
 |[[cassandra-property-skipped-operations]]<<cassandra-property-skipped-operations, `+skipped.operations+`>>
-|
+|No default
 | comma-separated list of operation types that will be skipped during streaming.
 The operations include: `c` for inserts/create, `u` for updates, and `d` for deletes.
 By default, no operations are skipped.

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1390,7 +1390,7 @@ During this discovery process, the connector ignores connection values that are 
 After the discovery process completes, when the connector attempts to establish a direct connection to a primary replica set member, the connector then returns to using the standard connection properties,
 and it ignores values in `mongodb.connection.string`.
 However, if credential information is not present elsewhere in the configuration, the connector can extract credential information from the value of the connection string.
-For example, if the `mongodb.user` property is not set, but the connection string includes the MongoDB username, the connector reads the information from the string. 
+For example, if the `mongodb.user` property is not set, but the connection string includes the MongoDB username, the connector reads the information from the string.
 ====
 
 |[[mongodb-property-mongodb-name]]<<mongodb-property-mongodb-name, `+mongodb.name+`>>

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2972,11 +2972,11 @@ The following table describes the `signal` properties.
 |===
 |Property |Default |Description
 |[[{context}-property-signal-kafka-topic]]<<{context}-property-signal-kafka-topic, `+signal.kafka.topic+`>>
-|
+|No default
 |The name of the Kafka topic that the connector monitors for ad hoc signals.
 
 |[[{context}-property-signal-kafka-bootstrap-servers]]<<{context}-property-signal-kafka-bootstrap-servers, `+signal.kafka.bootstrap.servers+`>>
-|
+|No default
 |A list of host/port pairs that the connector uses for establishing an initial connection to the Kafka cluster. Each pair should point to the same Kafka cluster used by the Kafka Connect process.
 
 |[[{context}-property-signal-kafka-poll-timeout-ms]]<<{context}-property-signal-kafka-poll-timeout-ms, `+signal.kafka.poll.timeout.ms+`>>

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -1158,11 +1158,11 @@ The following configuration properties are _required_ unless a default value is 
 |Description
 
 |[[vitess-property-name]]<<vitess-property-name, `+name+`>>
-|
+|No default
 |Unique name for the connector. Attempting to register again with the same name will fail. This property is required by all Kafka Connect connectors.
 
 |[[vitess-property-connector-class]]<<vitess-property-connector-class, `+connector.class+`>>
-|
+|No default
 |The name of the Java class for the connector. Always use a value of `io.debezium.connector.vitess.VitessConnector` for the Vitess connector.
 
 |[[vitess-property-tasks-max]]<<vitess-property-tasks-max, `+tasks.max+`>>
@@ -1170,7 +1170,7 @@ The following configuration properties are _required_ unless a default value is 
 |The maximum number of tasks that should be created for this connector. The Vitess connector can use more than 1 tasks if you enable offset.storage.per.task mode.
 
 |[[vitess-property-database-hostname]]<<vitess-property-database-hostname, `+database.hostname+`>>
-|
+|No default
 |IP address or hostname of the Vitess database server (VTGate).
 
 |[[vitess-property-database-port]]<<vitess-property-database-port, `+database.port+`>>
@@ -1218,7 +1218,7 @@ If set to `true`, you should also consider setting `vitess.gtid` in the configur
 `RDONLY`  represents streaming from the read-only slave MySQL instance.
 
 |[[vitess-property-topic-prefix]]<<vitess-property-topic-prefix, `+topic.prefix+`>>
-|
+|No default
 |Topic prefix that provides a namespace for the particular Vitess database server or cluster in which {prodname} is capturing changes.
 Only alphanumeric characters, hyphens, dots and underscores must be used in the database server logical name.
 The prefix should be unique across all other connectors, since it is used as a topic name prefix for all Kafka topics that receive records from this connector.
@@ -1230,19 +1230,19 @@ If you change the name value, after a restart, instead of continuing to emit eve
 ====
 
 |[[vitess-property-table-include-list]]<<vitess-property-table-include-list, `+table.include.list+`>>
-|
+|No default
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you want to capture. Any table not included in `table.include.list` does not have its changes captured. Each identifier is of the form _keyspace_._tableName_. By default, the connector captures changes in every non-system table in each schema whose changes are being captured. Do not also set the `table.exclude.list` property.
 
 |[[vitess-property-table-exclude.list]]<<vitess-property-table-exclude.list, `+table.exclude.list+`>>
-|
+|No default
 |An optional, comma-separated list of regular expressions that match fully-qualified table identifiers for tables whose changes you *do not* want to capture. Any table not included in `table.exclude.list` has it changes captured. Each identifier is of the form _keyspace_._tableName_. Do not also set the `table.include.list` property.
 
 |[[vitess-property-column-include-list]]<<vitess-property-column-include-list, `+column.include.list+`>>
-|
+|No default
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be included in change event record values. Fully-qualified names for columns are of the form _keyspace_._tableName_._columnName_. Do not also set the `column.exclude.list` property.
 
 |[[vitess-property-column-exclude-list]]<<vitess-property-column-exclude-list, `+column.exclude.list+`>>
-|
+|No default
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of columns that should be excluded from change event record values. Fully-qualified names for columns are of the form _keyspace_._tableName_._columnName_. Do not also set the `column.include.list` property.
 
 |[[vitess-property-tombstones-on-delete]]<<vitess-property-tombstones-on-delete, `+tombstones.on.delete+`>>
@@ -1370,7 +1370,7 @@ For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000
 |Indicates whether field names are sanitized to adhere to xref:{link-avro-serialization}#avro-naming[Avro naming requirements].
 
 |[[vitess-property-skipped-operations]]<<vitess-property-skipped-operations, `+skipped.operations+`>>
-|
+|No default
 | comma-separated list of operation types that will be skipped during streaming.
 The operations include: `c` for inserts/create, `u` for updates, and `d` for deletes.
 By default, no operations are skipped.
@@ -1384,7 +1384,7 @@ By default, no operations are skipped.
 |Control the interval between periodic gPRC keepalive pings for VStream. Defaults to `Long.MAX_VALUE` (disabled).
 
 |[[vitess-property-grpc-headers]]<<vitess-property-grpc-headers, `+vitess.grpc.headers+`>>
-|
+|No default
 |Specify a comma-separated list of gRPC headers. Defaults to empty. The format is: +
  +
 _key1:value1,key2:value2_,... +
@@ -1394,7 +1394,7 @@ For example, +
 `x-envoy-upstream-rq-timeout-ms:0,x-envoy-max-retries:2`
 
 |[[vitess-property-grpc-max-inbound-message-size]]<<vitess-property-grpc-max-inbound-message-size, `+vitess.grpc.max_inbound_message_size+`>>
-|
+|No default
 |Specify the maximum message size in bytes allowed to be received on the channel. +
  +
 Default is 4MiB

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -7,11 +7,11 @@ The following table describes the `schema.history.internal` properties for confi
 |===
 |Property |Default |Description
 |[[{context}-property-database-history-kafka-topic]]<<{context}-property-database-history-kafka-topic, `+schema.history.internal.kafka.topic+`>>
-|
+|No default
 |The full name of the Kafka topic where the connector stores the database schema history.
 
 |[[{context}-property-database-history-kafka-bootstrap-servers]]<<{context}-property-database-history-kafka-bootstrap-servers, `+schema.history.internal.kafka.bootstrap.servers+`>>
-|
+|No default
 |A list of host/port pairs that the connector uses for establishing an initial connection to the Kafka cluster. This connection is used for retrieving the database schema history previously stored by the connector, and for writing each DDL statement read from the source database. Each pair should point to the same Kafka cluster used by the Kafka Connect process.
 
 |[[{context}-property-database-history-kafka-recovery-poll-interval-ms]]<<{context}-property-database-history-kafka-recovery-poll-interval-ms, `+schema.history.internal.kafka.recovery.poll.interval.ms+`>>


### PR DESCRIPTION
[DBZ-3327](https://issues.redhat.com/browse/DBZ-3327) 

Low impact change to certain connector configuration properties tables that inserts the string `No default` when a cell in the **Default**  column of an entry is empty.  
