### PR TITLE
[docs] Fix `max.queue.size` default value in postgres connector documentation

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -448,3 +448,4 @@ Inki Hwang
 崔世杰
 合龙 张
 Phạm Ngọc Thắng
+Moustapha Mahfoud

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3012,7 +3012,7 @@ In the resulting snapshot, the connector includes only the records for which `de
 |Positive integer value that specifies the maximum size of each batch of events that the connector processes.
 
 |[[postgresql-property-max-queue-size]]<<postgresql-property-max-queue-size, `+max.queue.size+`>>
-|`20240`
+|`8192`
 |Positive integer value that specifies the maximum number of records that the blocking queue can hold.
 When {prodname} reads events streamed from the database, it places the events in the blocking queue before it writes them to Kafka.
 The blocking queue can provide backpressure for reading change events from the database

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -156,3 +156,4 @@ druud,Ruud H.G. van Tol
 thangdc94,Phạm Ngọc Thắng
 debjeetsarkar,Debjeet Sarkar
 nicholas-fwang,Inki Hwang
+gmouss,Moustapha Mahfoud


### PR DESCRIPTION
[docs] Fixed the `max.queue.size` default value in the docs for the postgres connector.