### PR TITLE
DBZ-4213 Use UTF-8 encoding when creating new Strings

### DIFF
--- a/debezium-embedded/src/main/java/io/debezium/embedded/ConvertingEngineBuilder.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/ConvertingEngineBuilder.java
@@ -6,6 +6,7 @@
 package io.debezium.embedded;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.Properties;
 import java.util.function.Consumer;
@@ -173,8 +174,8 @@ public class ConvertingEngineBuilder<R> implements Builder<R> {
                 return isFormat(formatKey, Json.class) && isFormat(formatValue, Json.class)
                         || isFormat(formatValue, CloudEvents.class)
                                 ? (R) new EmbeddedEngineChangeEvent<String, String>(
-                                        key != null ? new String(key) : null,
-                                        value != null ? new String(value) : null,
+                                        key != null ? new String(key, StandardCharsets.UTF_8) : null,
+                                        value != null ? new String(value, StandardCharsets.UTF_8) : null,
                                         record)
                                 : (R) new EmbeddedEngineChangeEvent<byte[], byte[]>(
                                         key,


### PR DESCRIPTION
Running this test with the system property set -Dfile.encoding=ASCII will still succeed.
Running this test with the system property set -Dfile.encoding=ASCII without the fix you can see it fail.