### PR TITLE
DBZ-5616 Use website's stylesheet for the preview

### DIFF
--- a/documentation/.asciidoctorconfig
+++ b/documentation/.asciidoctorconfig
@@ -8,3 +8,11 @@
 
 // Define attributes that are used downstream so that an editor known that they exist and doesn't show them in warnings.
 :product!:
+
+// Use the website's preview stylesheet for the preview.
+// Update to the AsciiDoc plugin for IntelliJ version 0.37.49 or later for the best experience.
+:linkcss:
+:stylesdir: https://debezium.io/documentation/debezium-antora/css
+:stylesheet: preview.css
+
+:source-highlighter: highlightjs


### PR DESCRIPTION
This adds the necessary configuration to have the preview styled like the website for the Antora based documentation. 

Pre-requisites: 
* PR https://github.com/debezium/debezium.github.io/pull/830 merged
* AsciiDoc plugin for IntelliJ updated to 0.37.49 or later
* JCEF preview activated in the AsciiDoc plugin's settings (should be the default for new installations of the plugin)

Then the preview will change for example for `mysql.adoc` as follows:

![image](https://user-images.githubusercontent.com/3957921/190867759-ab6de453-6ea3-46cb-a4f2-984e5212f5b0.png)

Compared to the [original page](https://debezium.io/documentation/reference/2.0/connectors/mysql.html): 

![image](https://user-images.githubusercontent.com/3957921/190867821-d1e08bdd-f04b-46bd-964b-a32d843f2689.png)


