### PR TITLE
DBZ-5630: Unquote double quotes from default values on MySQL

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/DefaultValueParserListener.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/DefaultValueParserListener.java
@@ -94,7 +94,8 @@ public class DefaultValueParserListener extends MySqlParserBaseListener {
     }
 
     private String unquote(String stringLiteral) {
-        if (stringLiteral != null && stringLiteral.startsWith("'") && stringLiteral.endsWith("'")) {
+        if (stringLiteral != null && ((stringLiteral.startsWith("'") && stringLiteral.endsWith("'"))
+                || (stringLiteral.startsWith("\"") && stringLiteral.endsWith("\"")))) {
             return stringLiteral.substring(1, stringLiteral.length() - 1);
         }
         return stringLiteral;

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDefaultValueTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDefaultValueTest.java
@@ -597,6 +597,7 @@ public class MySqlDefaultValueTest {
                 + "c3 bigint not null default .12345,\n"
                 + "c4 smallint not null default 100.52345,\n"
                 + "c5 int not null default '-.789',\n"
+                + "c6 decimal(26,6) default \"1\",\n"
                 + "PRIMARY KEY (`id`)\n"
                 + ")";
         parser.parse(ddl, tables);
@@ -611,6 +612,7 @@ public class MySqlDefaultValueTest {
         assertThat(getColumnSchema(schema, "c3").defaultValue()).isEqualTo(0L);
         assertThat(getColumnSchema(schema, "c4").defaultValue()).isEqualTo(Short.valueOf("101"));
         assertThat(getColumnSchema(schema, "c5").defaultValue()).isEqualTo(-1);
+        assertThat(getColumnSchema(schema, "c6").defaultValue()).isEqualTo(1.0);
     }
 
     private Schema getColumnSchema(Table table, String column) {


### PR DESCRIPTION
Besides single quotes for string literals, MySQL allows double quotes.