### PR TITLE
DBZ-5632 Incremental snapshot completion notifications

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbIncrementalSnapshotChangeEventSource.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.mongodb;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -387,10 +388,11 @@ public class MongoDbIncrementalSnapshotChangeEventSource
                         nextDataCollection(partition);
                     }
                     else {
-                        if (context.removeDataCollectionFromSnapshot(dataCollectionId)) {
-                            LOGGER.info("Removed '{}' from incremental snapshot collection list.", collectionId);
+                        Collection<DataCollection<CollectionId>> removedDataCollections = context.removeDataCollectionFromSnapshot(dataCollectionId);
+                        for (DataCollection<CollectionId> removedDataCollection : removedDataCollections) {
+                            LOGGER.info("Removed '{}' from incremental snapshot collection list.", removedDataCollection.getId());
                         }
-                        else {
+                        if (removedDataCollections.isEmpty()) {
                             LOGGER.warn("Could not remove '{}', collection is not part of the incremental snapshot.", collectionId);
                         }
                     }

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -38,6 +38,7 @@ import io.debezium.heartbeat.Heartbeat;
 import io.debezium.heartbeat.HeartbeatConnectionProvider;
 import io.debezium.heartbeat.HeartbeatErrorHandler;
 import io.debezium.heartbeat.HeartbeatImpl;
+import io.debezium.pipeline.notification.SnapshotStatusNotifications;
 import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.schema.SchemaTopicNamingStrategy;
 import io.debezium.spi.converter.ConvertedField;
@@ -731,6 +732,12 @@ public abstract class CommonConnectorConfig {
 
     public int getIncrementalSnashotChunkSize() {
         return incrementalSnapshotChunkSize;
+    }
+
+    public SnapshotStatusNotifications getSnapshotStatusNotifications() {
+        SnapshotStatusNotifications notifications = config.getInstance(SnapshotStatusNotifications.SNAPSHOT_NOTIFICATIONS_CLASS, SnapshotStatusNotifications.class);
+        notifications.configure(config);
+        return notifications;
     }
 
     public boolean shouldProvideTransactionMetadata() {

--- a/debezium-core/src/main/java/io/debezium/pipeline/notification/KafkaSnapshotStatusNotifications.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/notification/KafkaSnapshotStatusNotifications.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.notification;
+
+import java.util.UUID;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.config.Field;
+import io.debezium.document.Document;
+import io.debezium.pipeline.source.snapshot.incremental.DataCollection;
+import io.debezium.spi.schema.DataCollectionId;
+
+public class KafkaSnapshotStatusNotifications<T extends DataCollectionId> implements SnapshotStatusNotifications<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaSnapshotStatusNotifications.class);
+
+    public static final Field TOPIC = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "kafka.topic")
+            .withDisplayName("Snapshot notifications topic name")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("The name of the topic for the snapshot status notifications")
+            .withValidation(forKafka(Field::isRequired));
+
+    public static final Field BOOTSTRAP_SERVERS = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "kafka.bootstrap.servers")
+            .withDisplayName("Kafka broker addresses")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("A list of host/port pairs that the connector will use for establishing the initial "
+                    + "connection to the Kafka cluster for retrieving signals to the connector."
+                    + "This should point to the same Kafka cluster used by the Kafka Connect process.")
+            .withValidation(forKafka(Field::isRequired));
+
+    public static final String STATUS = "status";
+    public static final String DATA_COLLECTION = "data-collection";
+    public static final String ID = "id";
+    public static final String TYPE = "type";
+    public static final String INCREMENTAL_SNAPSHOT = "incremental-snapshot";
+    public static final String ADDITIONAL_CONDITION = "additional-condition";
+
+    public static Field.Set ALL_FIELDS = Field.setOf(TOPIC, BOOTSTRAP_SERVERS);
+
+    private static final String PRODUCER_PREFIX = CONFIGURATION_FIELD_PREFIX_STRING + "producer.";
+
+    /**
+     * The one and only partition of the notifications topic.
+     */
+    private static final Integer PARTITION = 0;
+    private String topicName;
+    private volatile KafkaProducer<String, String> producer;
+
+    @Override
+    public void configure(Configuration config) {
+        if (!config.validateAndRecord(ALL_FIELDS, LOGGER::error)) {
+            throw new ConnectException("Error configuring an instance of " + getClass().getSimpleName() + "; check the logs for details");
+        }
+        this.topicName = config.getString(TOPIC);
+        String bootstrapServers = config.getString(BOOTSTRAP_SERVERS);
+        String notificationsName = config.getString("snapshot-status-notifications", UUID.randomUUID().toString());
+        Configuration producerConfig = config.subset(PRODUCER_PREFIX, true).edit()
+                .withDefault(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+                .withDefault(ProducerConfig.CLIENT_ID_CONFIG, notificationsName)
+                .withDefault(ProducerConfig.ACKS_CONFIG, 1)
+                .withDefault(ProducerConfig.RETRIES_CONFIG, 1) // may result in duplicate messages, but that's okay
+                .withDefault(ProducerConfig.BATCH_SIZE_CONFIG, 1024 * 32) // 32KB
+                .withDefault(ProducerConfig.LINGER_MS_CONFIG, 0)
+                .withDefault(ProducerConfig.BUFFER_MEMORY_CONFIG, 1024 * 1024) // 1MB
+                .withDefault(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+                .withDefault(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+                .withDefault(ProducerConfig.MAX_BLOCK_MS_CONFIG, 10_000) // wait at most this if we can't reach Kafka
+                .build();
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("KafkaSnapshotStatusNotifications Producer config: {}", producerConfig.withMaskedPasswords());
+        }
+        this.producer = new KafkaProducer<>(producerConfig.asProperties());
+    }
+
+    @Override
+    public void snapshotCompleted(String connectorName, DataCollection<T> dataCollection, SnapshotCompletionStatus status) {
+        Document value = toDocument(dataCollection, status);
+        send(connectorName, value);
+    }
+
+    private void send(String key, Document value) {
+        if (producer == null) {
+            throw new IllegalStateException("No producer is available. Ensure that 'configure()' is called configure before 'send()'.");
+        }
+        LOGGER.trace("Sending snapshot status notification into Kafka: {}-{}", key, value);
+        try {
+            ProducerRecord<String, String> produced = new ProducerRecord<>(topicName, PARTITION, key, value.toString());
+            producer.send(produced);
+        }
+        catch (Exception e) {
+            LOGGER.error("Failed sending snapshot status notification into Kafka: {}-{}", key, value, e);
+        }
+    }
+
+    private static Field.Validator forKafka(final Field.Validator validator) {
+        return (config, field, problems) -> {
+            final String notifications = config.getString(SnapshotStatusNotifications.SNAPSHOT_NOTIFICATIONS_CLASS);
+            return KafkaSnapshotStatusNotifications.class.getName().equals(notifications) ? validator.validate(config, field, problems) : 0;
+        };
+    }
+
+    private Document toDocument(DataCollection<T> dataCollection, SnapshotCompletionStatus status) {
+        Document document = Document.create();
+        document.setString(ID, UUID.randomUUID().toString());
+        document.setString(TYPE, INCREMENTAL_SNAPSHOT);
+        document.setString(DATA_COLLECTION, dataCollection.getId().identifier());
+        dataCollection.getAdditionalCondition().ifPresent(s -> document.setString(ADDITIONAL_CONDITION, s));
+        document.setString(STATUS, status.name());
+        return document;
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/notification/LogSnapshotStatusNotifications.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/notification/LogSnapshotStatusNotifications.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.notification;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.Configuration;
+import io.debezium.pipeline.source.snapshot.incremental.DataCollection;
+import io.debezium.spi.schema.DataCollectionId;
+
+public class LogSnapshotStatusNotifications<T extends DataCollectionId> implements SnapshotStatusNotifications<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogSnapshotStatusNotifications.class);
+
+    @Override
+    public void configure(Configuration config) {
+
+    }
+
+    @Override
+    public void snapshotCompleted(String connectorName, DataCollection<T> dataCollection, SnapshotCompletionStatus status) {
+        LOGGER.info("Snapshot of the {} completed on connector {}", dataCollection, connectorName);
+    }
+
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/notification/SnapshotCompletionStatus.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/notification/SnapshotCompletionStatus.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.notification;
+
+public enum SnapshotCompletionStatus {
+    EMPTY,
+    NO_PRIMARY_KEY,
+    SQL_EXCEPTION,
+    STOPPED,
+    SUCCEEDED,
+    UNKNOWN_SCHEMA
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/notification/SnapshotStatusNotifications.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/notification/SnapshotStatusNotifications.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.notification;
+
+import org.apache.kafka.common.config.ConfigDef;
+
+import io.debezium.config.Configuration;
+import io.debezium.config.Field;
+import io.debezium.pipeline.source.snapshot.incremental.DataCollection;
+import io.debezium.spi.schema.DataCollectionId;
+
+public interface SnapshotStatusNotifications<T extends DataCollectionId> {
+    String CONFIGURATION_FIELD_PREFIX_STRING = "snapshot.status.notifications.";
+
+    Field SNAPSHOT_NOTIFICATIONS_CLASS = Field.create(CONFIGURATION_FIELD_PREFIX_STRING + "class")
+            .withDisplayName("Snapshot notifications class")
+            .withType(ConfigDef.Type.CLASS)
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withInvisibleRecommender()
+            .withDescription("The name of the SnapshotStatusNotifications class that should be used to output the snapshot status updates. "
+                    + "The configuration properties for the snapshot notifications are prefixed with the '"
+                    + CONFIGURATION_FIELD_PREFIX_STRING + "' string.")
+            .withDefault(LogSnapshotStatusNotifications.class.getName());
+
+    void configure(Configuration config);
+
+    void snapshotCompleted(String connectorName, DataCollection<T> dataCollection, SnapshotCompletionStatus status);
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/DataCollection.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/DataCollection.java
@@ -20,6 +20,11 @@ public class DataCollection<T> {
 
     private Optional<String> additionalCondition;
 
+    public DataCollection(T id) {
+        this.id = id;
+        this.additionalCondition = Optional.empty();
+    }
+
     public DataCollection(T id, Optional<String> additionalCondition) {
         this.id = id;
         this.additionalCondition = additionalCondition == null ? Optional.empty() : additionalCondition;

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.pipeline.source.snapshot.incremental;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -63,7 +64,9 @@ public interface IncrementalSnapshotContext<T> {
 
     void setSchemaVerificationPassed(boolean schemaVerificationPassed);
 
+    Collection<DataCollection<T>> getDataCollectionsToSnapshot();
+
     void stopSnapshot();
 
-    boolean removeDataCollectionFromSnapshot(String dataCollectionId);
+    Collection<DataCollection<T>> removeDataCollectionFromSnapshot(String dataCollectionId);
 }

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2384,6 +2384,11 @@ For example, if the topic prefix is `fulfillment`, the default topic name is `fu
 
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 
+[id="debezium-db2-connector-snapshot-status-notifications-properties"]
+==== {prodname} connector snapshot status notifications configuration properties
+
+include::{partialsdir}/modules/all-connectors/ref-connector-configuration-snapshot-status-notifications-properties.adoc[leveloffset=+1]
+
 [id="debezium-db2-connector-pass-through-database-driver-configuration-properties"]
 ==== {prodname} connector pass-through database driver configuration properties
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2958,6 +2958,11 @@ For example, if the topic prefix is `fulfillment`, the default topic name is `fu
 
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 
+[id="debezium-mysql-connector-snapshot-status-notifications-properties"]
+==== {prodname} connector snapshot status notifications configuration properties
+
+include::{partialsdir}/modules/all-connectors/ref-connector-configuration-snapshot-status-notifications-properties.adoc[leveloffset=+1]
+
 [id="debezium-{context}-connector-kafka-signals-configuration-properties"]
 ==== {prodname} connector Kafka signals configuration properties
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3153,6 +3153,10 @@ For example, if the topic prefix is `fulfillment`, the default topic name is `fu
 ==== {prodname} Oracle connector database schema history configuration properties
 include::../../partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 
+[id="debezium-oracle-connector-snapshot-status-notifications-properties"]
+==== {prodname} Oracle connector snapshot status notifications configuration properties
+include::../../partials/modules/all-connectors/ref-connector-configuration-snapshot-status-notifications-properties.adoc[leveloffset=+1]
+
 [id="debezium-oracle-connector-pass-through-database-driver-configuration-properties"]
 ==== {prodname} Oracle connector pass-through database driver configuration properties
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2554,6 +2554,11 @@ For more information, see xref:sqlserver-transaction-metadata[Transaction Metada
 
 include::{partialsdir}/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc[leveloffset=+1]
 
+[id="debezium-sqlserver-connector-snapshot-status-notifications-properties"]
+==== {prodname} SQL Server connector snapshot status notifications configuration properties
+
+include::{partialsdir}/modules/all-connectors/ref-connector-configuration-snapshot-status-notifications-properties.adoc[leveloffset=+1]
+
 [id="debezium-sqlserver-connector-pass-through-database-driver-configuration-properties"]
 ==== {prodname} SQL Server connector pass-through database driver configuration properties
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
@@ -273,3 +273,18 @@ Currently, the only valid option is `incremental`. +
 Specifying a `type` value in the SQL query that you submit to the signaling {data-collection} is required. +
 If you do not specify a value, the signal will not stop the incremental snapshot.
 |===
+
+==== Snapshot status notifications
+
+It's possible to configure connector to send incremental snapshot completion notifications into a Kafka topic.
+See xref:debezium-{context}-connector-snapshot-status-notifications-properties[snapshot status notifications configuration properties]
+
+Notifications format:
+
+----
+Key = `test_connector`
+
+Value = `{"id" : "1b8d98f4-53ec-4beb-aa14-73ea35f185e7", "type":"incremental-snapshot", "data-collections": "schema1.table1", "additional-condition" : "updated_at>='2022-09-20'", "status" : "SUCCEEDED"}`
+----
+
+All status values are defined in link:https://github.com/debezium/debezium/blob/main/debezium-core/src/main/java/io/debezium/pipeline/notification/SnapshotCompletionStatus.java[SnapshotCompletionStatus enum].

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-snapshot-status-notifications-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-snapshot-status-notifications-properties.adoc
@@ -1,0 +1,41 @@
+{prodname} provides a set of `snapshot.status.notifications.*` properties that allow to configure notifications for incremental snapshots.
+
+The following table describes the `snapshot.status.notifications` properties for configuring the {prodname} connector.
+
+.Connector snapshot status notifications configuration properties
+[cols="33%a,17%a,50%a",options="header",subs="+attributes"]
+|===
+|Property |Default |Description
+|[[{context}-property-snapshot-status-notifications-class]]<<{context}-property-snapshot-status-notifications-class, `+snapshot.status.notifications.class+`>>
+|`io.debezium.pipeline.notification.LogSnapshotStatusNotifications`
+|The SnapshotStatusNotifications implementation that should be used to output the snapshot status updates. The default is `io.debezium.pipeline.notification.LogSnapshotStatusNotifications` which writes snapshot statuses into connector's log.  Alternative implementation is `io.debezium.pipeline.notification.KafkaSnapshotStatusNotifications` which writes snapshot statuses into a Kafka topic.
+
+|[[{context}-property-snapshot-status-notifications-kafka-topic]]<<{context}-property-snapshot-status-notifications-kafka-topic, `+snapshot.status.notifications.kafka.topic+`>>
+|
+|The full name of the Kafka topic where the connector writes the snapshot status notifications.
+
+|[[{context}-property-snapshot-status-notifications-kafka-bootstrap-servers]]<<{context}-property-snapshot-status-notifications-kafka-bootstrap-servers, `+snapshot.status.notifications.kafka.bootstrap.servers+`>>
+|
+|A list of host/port pairs that the connector uses for establishing connection to the Kafka cluster. This connection is used for writing snapshot status notifications. Each pair should point to the same Kafka cluster used by the Kafka Connect process.
+|===
+
+[id="{context}-pass-through-snapshot-status-notifications-properties-for-configuring-producer"]
+.Pass-through snapshot status notifications properties for configuring Kafka producer
+{empty} +
+{prodname} relies on a Kafka producer to write snapshot status notifications to the Kafka topic.
+You can define the configuration for the Kafka producer by assigning values to a set of pass-through configuration properties that begin with the `snapshot.status.notifications.producer.\*` prefix.
+The pass-through producer properties control a range of behaviors, such as how these clients secure connections with the Kafka broker, as shown in the following example:
+
+[source,indent=0]
+----
+snapshot.status.notifications.producer.security.protocol=SSL
+snapshot.status.notifications.producer.ssl.keystore.location=/var/private/ssl/kafka.server.keystore.jks
+snapshot.status.notifications.producer.ssl.keystore.password=test1234
+snapshot.status.notifications.producer.ssl.truststore.location=/var/private/ssl/kafka.server.truststore.jks
+snapshot.status.notifications.producer.ssl.truststore.password=test1234
+snapshot.status.notifications.producer.ssl.key.password=test1234
+----
+
+{prodname} strips the prefix from the property name before it passes the property to the Kafka client.
+
+See the Kafka documentation for more details about link:https://kafka.apache.org/documentation.html#producerconfigs[Kafka producer configuration properties].


### PR DESCRIPTION
Added an optional configuration property to switch between logging snapshot completion status (`LogSnapshotStatusNotifications` - default) and sending the notification into a Kafka topic (`KafkaSnapshotStatusNotifications`).

A Kafka notification format:

Key = `test_connector` 
Value = `{"id" : "1b8d98f4-53ec-4beb-aa14-73ea35f185e7", "type":"incremental-snapshot", "data-collections": "schema1.table1", "additional-condition" : "updated_at>='2022-09-20'", "status" : "SUCCEEDED"}`

Snapshot completion statuses:
```
EMPTY,
NO_PRIMARY_KEY,
SQL_EXCEPTION,
STOPPED,
SUCCEEDED,
UNKNOWN_SCHEMA
```

Closes: https://issues.redhat.com/browse/DBZ-5632