### PR TITLE
Dbz 5504 remove invalid datatypes from db2 connector doc

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1327,7 +1327,7 @@ Represents the number of milliseconds since the epoch, and does not include time
 
 The `DATETIME` type represents a timestamp without time zone information.
 Such columns are converted into an equivalent Kafka Connect value based on UTC.
-For example, the `DATETIME` value "2018-06-20 15:13:16.945104" is represented by an `io.debezium.time.Timestamp` with the value "1529507596945104".
+For example, the `DATETIME` value "2018-06-20 15:13:16.945104" is represented by an `io.debezium.time.Timestamp` with the value "1529507596000".
 
 The timezone of the JVM running Kafka Connect and {prodname} does not affect this conversion.
 

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1385,19 +1385,6 @@ The `connect.decimal.precision` schema parameter contains an integer that repres
 The `scale` schema parameter contains an integer that represents how many digits the decimal point is shifted.
 The `connect.decimal.precision` schema parameter contains an integer that  represents the precision of the given decimal value.
 
-|`SMALLMONEY`
-|`BYTES`
-|`org.apache.kafka.connect.data.Decimal` +
- +
-The `scale` schema parameter contains an integer that represents how many digits the decimal point iss shifted.
-The `connect.decimal.precision` schema parameter contains an integer that represents the precision of the given decimal value.
-
-|`MONEY`
-|`BYTES`
-|`org.apache.kafka.connect.data.Decimal` +
- +
-The `scale` schema parameter contains an integer that represents how many digits the decimal point is shifted.
-The `connect.decimal.precision` schema parameter contains an integer that represents the precision of the given decimal value.
 |===
 
 // Type: assembly

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -1291,29 +1291,6 @@ Represents the number of nanoseconds past midnight, and does not include timezon
  +
 Represents the number of milliseconds since the epoch, and does not include timezone information.
 
-|`SMALLDATETIME`
-|`INT64`
-|`io.debezium.time.Timestamp` +
- +
-Represents the number of milliseconds since the epoch, and does not include timezone information.
-
-|`DATETIME2(0)`, `DATETIME2(1)`, `DATETIME2(2)`, `DATETIME2(3)`
-|`INT64`
-|`io.debezium.time.Timestamp` +
- +
-Represents the number of milliseconds since the epoch, and does not include timezone information.
-
-|`DATETIME2(4)`, `DATETIME2(5)`, `DATETIME2(6)`
-|`INT64`
-|`io.debezium.time.MicroTimestamp` +
- +
-Represents the number of microseconds since the epoch, and does not include timezone information.
-
-|`DATETIME2(7)`
-|`INT64`
-|`io.debezium.time.NanoTimestamp` +
- +
-Represents the number of nanoseconds past the epoch, and does not include timezone information.
 |===
 
 [[db2-time-precision-mode-connect]]
@@ -1343,24 +1320,14 @@ Represents the number of milliseconds since midnight, and does not include timez
  +
 Represents the number of milliseconds since the epoch, and does not include timezone information.
 
-|`SMALLDATETIME`
-|`INT64`
-|`org.apache.kafka.connect.data.Timestamp` +
- +
-Represents the number of milliseconds since the epoch, and does not include timezone information.
-
-|`DATETIME2`
-|`INT64`
-|`org.apache.kafka.connect.data.Timestamp` +
- +
-Represents the number of milliseconds since the epoch, and does not include timezone information. Db2 allows `P` to be in the range 0-7 to store up to tenth of a microsecond precision, though this mode results in a loss of precision when `P` is greater than 3.
 |===
 
 [[db2-timestamp-types]]
 === Timestamp types
 
-The `DATETIME`, `SMALLDATETIME` and `DATETIME2` types represent a timestamp without time zone information.
-Such columns are converted into an equivalent Kafka Connect value based on UTC. For example, the `DATETIME2` value "2018-06-20 15:13:16.945104" is represented by an `io.debezium.time.MicroTimestamp` with the value "1529507596945104".
+The `DATETIME` type represents a timestamp without time zone information.
+Such columns are converted into an equivalent Kafka Connect value based on UTC.
+For example, the `DATETIME` value "2018-06-20 15:13:16.945104" is represented by an `io.debezium.time.Timestamp` with the value "1529507596945104".
 
 The timezone of the JVM running Kafka Connect and {prodname} does not affect this conversion.
 


### PR DESCRIPTION
[DBZ-5504](https://issues.redhat.com/browse/DBZ-5504)

Replaces #3795, because the original branch had grown too stale. 

Removes invalid `MONEY`, `SMALLMONEY`, `DATETIME2`, and `SMALLDATETIME` entries from the table in _Data type mappings_ section, including the following  `DATETIME2` entries:

>
|`DATETIME2(0)`, `DATETIME2(1)`, `DATETIME2(2)`, `DATETIME2(3)`
|`INT64`
|`io.debezium.time.Timestamp` +
 +
Represents the number of milliseconds since the epoch, and does not include timezone information.

|`DATETIME2(4)`, `DATETIME2(5)`, `DATETIME2(6)`
|`INT64`
|`io.debezium.time.MicroTimestamp` +
 +
Represents the number of microseconds since the epoch, and does not include timezone information.

|`DATETIME2(7)`
|`INT64`
|`io.debezium.time.NanoTimestamp` + 

In the paragraph in the _Timestamp types_ section, I removed references to the invalid SMALLDATETIME` and `DATETIME2 types so that the sentence now references only the `DATETIME` type and the semantic type `io.debezium.time.Timestamp`.  Per [@Naros' comment in the original PR](https://github.com/debezium/debezium/pull/3795#issuecomment-1218041496), the value `1529507596945104` that was used with the `io.debezium.time.MicroTimestamp` semantic type in the original version probably does not make sense with the `io.debezium.time.Timestamp` semantic type. Need to verify this and get input on a valid replacement value. 