### PR TITLE
DBZ-4490 Fix randomly failing updatePrimaryKeyWithRestartInMiddle test

### DIFF
--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -528,10 +528,13 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         // Testing.Print.enable();
         // Wait for snapshot completion
-        consumeRecordsByTopic(1);
+        TestHelper.waitForDatabaseSnapshotToBeCompleted(TestHelper.TEST_DATABASE_1);
+        final SourceRecords snapshotRecords = consumeRecordsByTopic(1);
+        Assertions.assertThat(snapshotRecords.allRecordsInOrder()).hasSize(1);
 
         connection.execute("INSERT INTO tableb VALUES(1, 'b')");
-        consumeRecordsByTopic(1);
+        final SourceRecords insertRecords = consumeRecordsByTopic(1);
+        Assertions.assertThat(insertRecords.allRecordsInOrder()).hasSize(1);
 
         connection.setAutoCommit(false);
 


### PR DESCRIPTION
Fix randomly failing
SqlServerConnectorIT#updatePrimaryKeyWithRestartInMiddle.

It seems the main source of instability in slow environments is consuming snapshot record. It's actually not consumed and as the test assumes exact order of messages, it leads to failures.

Wait for snapshot to be completed using mbean server. Also add more asserts to make clear where is the issue if the test continues to fail.

https://issues.redhat.com/browse/DBZ-4490