### PR TITLE
DBZ-5650 Support set statement in mariadb

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -293,7 +293,7 @@ Nenad Stojanovikj
 Nick Murray
 Niels Pardon
 Nikhil Benesch
-Niro Levy
+Nir Levy
 Nishant Singh
 Nitin Agarwal
 Nitin Chhabra

--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlLexer.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlLexer.g4
@@ -232,7 +232,7 @@ WITH:                                'WITH';
 WRITE:                               'WRITE';
 XOR:                                 'XOR';
 ZEROFILL:                            'ZEROFILL';
-
+STATEMENT:                           'STATEMENT';
 
 // DATA TYPE Keywords
 

--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -42,9 +42,9 @@ sqlStatements
     ;
 
 sqlStatement
-    : ddlStatement | dmlStatement | transactionStatement
+    : setStatementFor? (ddlStatement | dmlStatement | transactionStatement // setStatementFor is is MariaDB-specific only
     | replicationStatement | preparedStatement
-    | administrationStatement | utilityStatement
+    | administrationStatement | utilityStatement)
     ;
 
 emptyStatement
@@ -2827,3 +2827,6 @@ functionNameBase
     // MariaDB
     | LASTVAL | NEXTVAL | SETVAL
     ;
+
+// MariaDB statements
+setStatementFor: SET STATEMENT ID EQUAL_SYMBOL constant (COMMA ID EQUAL_SYMBOL constant)* FOR; // MariaDB-specific only

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_create.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/ddl_create.sql
@@ -535,3 +535,9 @@ CREATE SEQUENCE if NOT EXISTS workdb.s2 START=1 CYCLE MINVALUE=10000 MAXVALUE=99
 CREATE OR REPLACE SEQUENCE if NOT EXISTS s2 START=100 CACHE 1000;
 CREATE SEQUENCE `seq_8b4d1cdf-377e-4021-aef3-f7c9846903fc` INCREMENT BY 1 START WITH 1;
 #end
+
+#begin
+-- From MariaDB 10.1.2, pre-query variables are supported
+-- src: https://mariadb.com/kb/en/set-statement/
+SET STATEMENT max_statement_time=60 FOR CREATE TABLE some_table (val int);
+#end

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/dml_select.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/dml_select.sql
@@ -213,3 +213,9 @@ FROM
     ORDER BY amount DESC LIMIT 1)
   AS max_sale;
 #end
+
+#begin
+-- From MariaDB 10.1.2, pre-query variables are supported
+-- src: https://mariadb.com/kb/en/set-statement/
+SET STATEMENT some_statement=60 FOR SELECT a FROM some_table;
+#end

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -159,3 +159,4 @@ nicholas-fwang,Inki Hwang
 gmouss,Moustapha Mahfoud
 avis408,Avinash Vishwakarma
 nirolevy,Niro Levy
+nirlevy,Nir Levy


### PR DESCRIPTION
[DBZ-5650](https://issues.redhat.com/browse/DBZ-5650)

From MariaDB 10.1.2, pre-query variables are supported
src: https://mariadb.com/kb/en/set-statement/