### PR TITLE
DBZ-5651 More reliable wait strategy for DebeziumContainer 

### DIFF
--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/DebeziumContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/DebeziumContainer.java
@@ -44,7 +44,7 @@ public class DebeziumContainer extends GenericContainer<DebeziumContainer> {
     private static final String DEBEZIUM_NIGHTLY_TAG = "nightly";
 
     private static final int KAFKA_CONNECT_PORT = 8083;
-    private static final Duration DEBEZIUM_CONTAINER_STARTUP_TIMEOUT = Duration.ofMinutes(5);
+    private static final Duration DEBEZIUM_CONTAINER_STARTUP_TIMEOUT = Duration.ofSeconds(waitTimeForRecords() * 30);
     private static final String TEST_PROPERTY_PREFIX = "debezium.test.";
     public static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
     protected static final ObjectMapper MAPPER = new ObjectMapper();


### PR DESCRIPTION
Reasoning: There original strategy is scrapping logs, but there is a race between "Session key updated" being logged and Kafka Connect REST interface being up. Hence, on slow machines the KC REST `/connectors` interface was occasionally replying with HTTP 404.