### PR TITLE
Bump docker maven plugin version and allow to use external properties

### DIFF
--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -132,6 +132,10 @@
                         <time>30000</time> <!-- 30 seconds max -->
                       </wait>
                     </run>
+                    <external>
+                      <type>properties</type>
+                      <mode>override</mode>
+                    </external>
                   </image>
                   <!-- A container that initiates the data replica set and adds it as shard to router -->
                   <image>
@@ -155,6 +159,10 @@
                         <time>30000</time> <!-- 30 seconds max -->
                       </wait>
                     </run>
+                    <external>
+                      <type>properties</type>
+                      <mode>override</mode>
+                    </external>
                   </image>
                 </images>
               </configuration>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -209,6 +209,10 @@
                         <targetDir>/</targetDir>
                       </assembly>
                     </build>
+                    <external>
+                      <type>properties</type>
+                      <mode>override</mode>
+                    </external>
                   </image>
                   <image>
                     <!-- A Docker image using a partial MySQL installation maintained by MySQL team
@@ -268,6 +272,10 @@
                           <targetDir>/</targetDir>
                         </assembly>
                     </build>
+                    <external>
+                      <type>properties</type>
+                      <mode>override</mode>
+                    </external>
                   </image>
                   <image>
                     <!-- A Docker image using a partial MySQL installation maintained by MySQL team. -->
@@ -318,6 +326,10 @@
                         <targetDir>/</targetDir>
                       </assembly>
                     </build>
+                    <external>
+                      <type>properties</type>
+                      <mode>override</mode>
+                    </external>
                   </image>
                   <image>
                     <!-- 
@@ -372,6 +384,10 @@
                         <targetDir>/</targetDir>
                       </assembly>
                     </build>
+                    <external>
+                      <type>properties</type>
+                      <mode>override</mode>
+                    </external>
                   </image>
                   <image>
                     <!--
@@ -420,6 +436,10 @@
                         <targetDir>/</targetDir>
                       </assembly>
                     </build>
+                    <external>
+                      <type>properties</type>
+                      <mode>override</mode>
+                    </external>
                   </image>
                 </images>
               </configuration>

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -433,6 +433,10 @@
                                 <time>120000</time> <!-- 2 minutes max -->
                               </wait>
                             </run>
+                            <external>
+                              <type>properties</type>
+                              <mode>override</mode>
+                            </external>
                           </image>
                         </images>
                       </configuration>
@@ -513,6 +517,10 @@
                                             <log>Infinispan Server [0-9a-zA-z.]* started</log>
                                         </wait>
                                     </run>
+                                    <external>
+                                        <type>properties</type>
+                                        <mode>override</mode>
+                                    </external>
                                 </image>
                             </images>
                         </configuration>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -175,6 +175,10 @@
                                    <run>${docker.initimage}</run>
                                  </runCmds>
                             </build>
+                            <external>
+                                <type>properties</type>
+                                <mode>override</mode>
+                            </external>
                         </image>
                     </images>
                 </configuration>

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -140,6 +140,10 @@
                                     <log>SQL Server is now ready for client connections</log>
                                 </wait>
                             </run>
+                            <external>
+                                <type>properties</type>
+                                <mode>override</mode>
+                            </external>
                         </image>
                     </images>
                 </configuration>

--- a/debezium-parent/pom.xml
+++ b/debezium-parent/pom.xml
@@ -17,7 +17,7 @@
 
         <!-- Maven Plugins -->
         <version.google.formatter.plugin>0.4</version.google.formatter.plugin>
-        <version.docker.maven.plugin>0.39.1</version.docker.maven.plugin>
+        <version.docker.maven.plugin>0.40.2</version.docker.maven.plugin>
         <version.protoc.maven.plugin>3.8.0</version.protoc.maven.plugin>
         <version.code.formatter>2.16.0</version.code.formatter>
         <version.impsort>1.6.2</version.impsort>


### PR DESCRIPTION
Allow docker maven plugin external properties to override default or ones specified in `pom.xml`. Also bump docker maven plugin to avoid bug related to multiple images one pom file.

https://issues.redhat.com/browse/DBZ-5657
https://issues.redhat.com/browse/DBZ-5658