### PR TITLE
DBZ-5715 MongoDB router uses collection not table in names

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -9,6 +9,7 @@ Adrian Kreuziger
 Ahmed Eljami
 Aidas
 Akshath Patkar
+Alberto Martino
 Aleksejs Sibanovs
 Alex Mansell
 Alex Soto

--- a/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
@@ -259,7 +259,7 @@ To emit the `eventType` field value in the outbox message header, configure the 
 ----
 transforms=outbox,...
 transforms.outbox.type=io.debezium.transforms.outbox.EventRouter
-transforms.outbox.table.fields.additional.placement=eventType:header:type
+transforms.outbox.collection.fields.additional.placement=eventType:header:type
 ----
 
 The result will be a header on the Kafka message with `type` as its key, and the value of the `eventType` field as its value.
@@ -270,7 +270,7 @@ To emit the `eventType` field value in the outbox message envelope, configure th
 ----
 transforms=outbox,...
 transforms.outbox.type=io.debezium.transforms.outbox.EventRouter
-transforms.outbox.table.fields.additional.placement=eventType:envelope:type
+transforms.outbox.collection.fields.additional.placement=eventType:envelope:type
 ----
 
 To control which partition the outbox message is produced on, configure the SMT like this:
@@ -279,7 +279,7 @@ To control which partition the outbox message is produced on, configure the SMT 
 ----
 transforms=outbox,...
 transforms.outbox.type=io.debezium.transforms.outbox.EventRouter
-transforms.outbox.table.fields.additional.placement=partitionField:partition
+transforms.outbox.collection.fields.additional.placement=partitionField:partition
 ----
 
 Note that for the `partition` placement, adding an alias will have no effect.


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5715
For the MongoDB Outbox Event router the property:
`transforms.outbox.table.fields.additional.placement` doesn't works because the Mongo event router looks to the property `transforms.outbox.collection.fields.additional.placement` to expose additional fields.