### PR TITLE
DBZ-5661 Fix for Embedded Engine retrying indefinitely even when max retries is 0

### DIFF
--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -313,6 +313,7 @@ public abstract class CommonConnectorConfig {
     private static final String CONVERTER_TYPE_SUFFIX = ".type";
     public static final long DEFAULT_RETRIABLE_RESTART_WAIT = 10000L;
     public static final long DEFAULT_MAX_QUEUE_SIZE_IN_BYTES = 0; // In case we don't want to pass max.queue.size.in.bytes;
+    public static final int DEFAULT_RETRIABLE_MAX_RETRIES = -1;
 
     public static final Field TOPIC_PREFIX = Field.create("topic.prefix")
             .withDisplayName("Topic prefix")
@@ -337,6 +338,16 @@ public abstract class CommonConnectorConfig {
             .withDescription(
                     "Time to wait before restarting connector after retriable exception occurs. Defaults to " + DEFAULT_RETRIABLE_RESTART_WAIT + "ms.")
             .withValidation(Field::isPositiveLong);
+
+    public static final Field RETRIABLE_RESTART_MAX_RETRIES = Field.create("errors.max.retries")
+            .withDisplayName("The maximum number of retries")
+            .withType(Type.INT)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.MEDIUM)
+            .withDefault(DEFAULT_RETRIABLE_MAX_RETRIES)
+            .withValidation(Field::isInteger)
+            .withDescription("The maximum number of retries upon retriable exception before failing (-1 = no " +
+                    "limit, 0 = disabled, > 0 = num of retries).");
 
     public static final Field TOMBSTONES_ON_DELETE = Field.create("tombstones.on.delete")
             .withDisplayName("Change the behaviour of Debezium with regards to delete operations")

--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -83,6 +83,8 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
     private final Map<Map<String, ?>, Map<String, ?>> lastOffsets = new HashMap<>();
 
     private Duration retriableRestartWait;
+    private Integer retriableRestartMaxRetries;
+    private Integer retriableRestartTotalRetries = CommonConnectorConfig.DEFAULT_RETRIABLE_MAX_RETRIES;
 
     private final ElapsedTimeStrategy pollOutputDelay;
     private final Clock clock = Clock.system();
@@ -118,6 +120,7 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
 
             this.props = props;
             Configuration config = Configuration.from(props);
+            retriableRestartMaxRetries = config.getInteger(CommonConnectorConfig.RETRIABLE_RESTART_MAX_RETRIES);
             retriableRestartWait = config.getDuration(CommonConnectorConfig.RETRIABLE_RESTART_WAIT, ChronoUnit.MILLIS);
             // need to reset the delay or you only get one delayed restart
             restartDelay = null;
@@ -210,15 +213,19 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
      * Starts this connector in case it has been stopped after a retriable error,
      * and the backoff period has passed.
      */
-    private boolean startIfNeededAndPossible() {
+    private boolean startIfNeededAndPossible() throws InterruptedException {
         stateLock.lock();
 
         try {
             if (state.get() == State.RUNNING) {
                 return true;
             }
+            else if (retriableRestartTotalRetries >= retriableRestartMaxRetries) {
+                throw new InterruptedException("Max limit of retries to start the connector has reached");
+            }
             else if (restartDelay != null && restartDelay.hasElapsed()) {
                 start(props);
+                retriableRestartTotalRetries++;
                 return true;
             }
             else {

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -864,12 +864,6 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord> {
                                         delayStrategy.sleepWhen(!startedSuccessfully);
                                     }
                                 }
-                                else {
-                                    // As maxRetries is 0, do not retry restarting and stop the work. This will break
-                                    // the infinite looping for retries.
-                                    handlerError = e;
-                                    break;
-                                }
                             }
                             try {
                                 if (changeRecords != null && !changeRecords.isEmpty()) {

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -863,7 +863,8 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord> {
                                         }
                                         delayStrategy.sleepWhen(!startedSuccessfully);
                                     }
-                                } else {
+                                }
+                                else {
                                     // As maxRetries is 0, do not retry restarting and stop the work.
                                     // This will break the infinite looping for retries.
                                     handlerError = e;

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -863,6 +863,11 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord> {
                                         }
                                         delayStrategy.sleepWhen(!startedSuccessfully);
                                     }
+                                } else {
+                                    // As maxRetries is 0, do not retry restarting and stop the work.
+                                    // This will break the infinite looping for retries.
+                                    handlerError = e;
+                                    break;
                                 }
                             }
                             try {

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -865,8 +865,8 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord> {
                                     }
                                 }
                                 else {
-                                    // As maxRetries is 0, do not retry restarting and stop the work.
-                                    // This will break the infinite looping for retries.
+                                    // As maxRetries is 0, do not retry restarting and stop the work. This will break
+                                    // the infinite looping for retries.
                                     handlerError = e;
                                     break;
                                 }


### PR DESCRIPTION
## External Links

[DBZ-5661](https://issues.redhat.com/browse/DBZ-5661)

## Description
The changes is to break the indefinite retries upon RetriableException in EmbeddedEngine, when the max retries is set to 0. 

## Notes for Reviewer

As mentioned in the ticket DBZ-5661, the EmbeddedEngine does not respect the property `errors.max.retries`. It is required to stop retrying to restart the task if the property is set to 0.