### PR TITLE
DBZ-5739 Postgres connector results in silent data loss if replication slot is recreated

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -331,6 +331,7 @@ Plugaru Tudor
 Poonam Meghnani
 Pradeep Mamillapalli
 Prannoy Mittal
+Praveen Burgu
 Preethi Sadagopan
 pushpavanthar
 Qishang Zhong

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
@@ -29,6 +29,7 @@ import io.debezium.data.Envelope.Operation;
 import io.debezium.function.Predicates;
 import io.debezium.pipeline.spi.ChangeRecordEmitter;
 import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Partition;
 import io.debezium.relational.Column;
 import io.debezium.relational.ColumnEditor;
 import io.debezium.relational.RelationalChangeRecordEmitter;
@@ -37,6 +38,7 @@ import io.debezium.relational.TableEditor;
 import io.debezium.relational.TableId;
 import io.debezium.relational.TableSchema;
 import io.debezium.schema.DataCollectionSchema;
+import io.debezium.spi.schema.DataCollectionId;
 import io.debezium.util.Clock;
 import io.debezium.util.Strings;
 
@@ -234,8 +236,8 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter<P
         }
     }
 
-    static Optional<DataCollectionSchema> updateSchema(PostgresPartition partition, TableId tableId, ChangeRecordEmitter<PostgresPartition> changeRecordEmitter) {
-        return ((PostgresChangeRecordEmitter) changeRecordEmitter).newTable(tableId);
+    static Optional<DataCollectionSchema> updateSchema(Partition partition, DataCollectionId tableId, ChangeRecordEmitter<PostgresPartition> changeRecordEmitter) {
+        return ((PostgresChangeRecordEmitter) changeRecordEmitter).newTable((TableId) tableId);
     }
 
     private boolean schemaChanged(List<ReplicationMessage.Column> columns, Table table) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -506,6 +506,16 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                     "Whether or not to drop the logical replication slot when the connector finishes orderly. " +
                             "By default the replication is kept so that on restart progress can resume from the last recorded location");
 
+    public static final Field SLOT_SEEK_TO_KNOWN_OFFSET = Field.create("slot.seek.to.known.offset.on.start")
+            .withDisplayName("Seek to last know offset on the replication slot")
+            .withType(Type.BOOLEAN)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED_REPLICATION, 3))
+            .withDefault(false)
+            .withImportance(Importance.HIGH)
+            .withDescription(
+                    "Whether or not to seek to the last known offset on the replication slot." +
+                            "Enabling this option results in startup failure if the slot is re-created instead of data loss.");
+
     public static final Field PUBLICATION_NAME = Field.create("publication.name")
             .withDisplayName("Publication")
             .withType(Type.STRING)
@@ -892,6 +902,10 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         }
         // Return default value
         return getConfig().getBoolean(DROP_SLOT_ON_STOP);
+    }
+
+    public boolean slotSeekToKnownOffsetOnStart() {
+        return getConfig().getBoolean(SLOT_SEEK_TO_KNOWN_OFFSET);
     }
 
     public String publicationName() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -506,16 +506,6 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
                     "Whether or not to drop the logical replication slot when the connector finishes orderly. " +
                             "By default the replication is kept so that on restart progress can resume from the last recorded location");
 
-    public static final Field SLOT_SEEK_TO_KNOWN_OFFSET = Field.create("slot.seek.to.known.offset.on.start")
-            .withDisplayName("Seek to last know offset on the replication slot")
-            .withType(Type.BOOLEAN)
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED_REPLICATION, 3))
-            .withDefault(false)
-            .withImportance(Importance.HIGH)
-            .withDescription(
-                    "Whether or not to seek to the last known offset on the replication slot." +
-                            "Enabling this option results in startup failure if the slot is re-created instead of data loss.");
-
     public static final Field PUBLICATION_NAME = Field.create("publication.name")
             .withDisplayName("Publication")
             .withType(Type.STRING)
@@ -902,10 +892,6 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         }
         // Return default value
         return getConfig().getBoolean(DROP_SLOT_ON_STOP);
-    }
-
-    public boolean slotSeekToKnownOffsetOnStart() {
-        return getConfig().getBoolean(SLOT_SEEK_TO_KNOWN_OFFSET);
     }
 
     public String publicationName() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -352,8 +352,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     }
 
     protected void validateSlotIsInExpectedState(Lsn lsn) throws SQLException, PSQLException {
-        try {
-            Statement stmt = pgConnection().createStatement();
+        try (Statement stmt = pgConnection().createStatement()) {
             String seekCommand = String.format(
                     "SELECT pg_replication_slot_advance('%s', '%s')",
                     slotName,

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -325,6 +325,31 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             LOGGER.debug("starting streaming from LSN '{}'", lsn);
         }
 
+        if (connectorConfig.slotSeekToKnownOffsetOnStart()) {
+            try {
+                Statement stmt = pgConnection().createStatement();
+                String seekCommand = String.format(
+                        "SELECT pg_replication_slot_advance('%s', '%s')",
+                        slotName,
+                        lsn.asString());
+                LOGGER.info("Seeking to {} on the replication slot with command {}", lsn, seekCommand);
+                stmt.execute(seekCommand);
+            }
+            catch (PSQLException e) {
+                if (e.getMessage().matches("ERROR: function pg_replication_slot_advance.*does not exist(.|\\n)*")) {
+                    LOGGER.warn("Postgres server doesn't support the command pg_replication_slot_advance(). Not seeking to last known offset.");
+                }
+                else if (e.getMessage().matches("ERROR: cannot advance replication slot to.*")) {
+                    throw new DebeziumException(
+                            String.format("Cannot seek to the last known offset '%s' on replication slot '%s'. Error from server: %s", lsn.asString(), slotName,
+                                    e.getMessage()));
+                }
+                else {
+                    throw e;
+                }
+            }
+        }
+
         final int maxRetries = connectorConfig.maxRetries();
         final Duration delay = connectorConfig.retryDelay();
         int tryCount = 0;

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -351,7 +351,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
         }
     }
 
-    protected void validateSlotIsInExpectedState(Lsn lsn) throws SQLException, PSQLException {
+    protected void validateSlotIsInExpectedState(Lsn lsn) throws SQLException {
         try (Statement stmt = pgConnection().createStatement()) {
             String seekCommand = String.format(
                     "SELECT pg_replication_slot_advance('%s', '%s')",
@@ -370,7 +370,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                                 e.getMessage()));
             }
             else {
-                throw e;
+                throw new DebeziumException(e);
             }
         }
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
@@ -171,6 +171,10 @@ public class WalPositionLocator {
         return lastEventStoredLsn;
     }
 
+    public Lsn getLastCommitStoredLsn() {
+        return lastCommitStoredLsn;
+    }
+
     @Override
     public String toString() {
         return "WalPositionLocator [lastCommitStoredLsn=" + lastCommitStoredLsn + ", lastEventStoredLsn="

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DebeziumEngineIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/DebeziumEngineIT.java
@@ -68,6 +68,7 @@ public class DebeziumEngineIT {
     public void before() throws SQLException {
         OFFSET_STORE_PATH.getParent().toFile().mkdirs();
         OFFSET_STORE_PATH.toFile().delete();
+        TestHelper.dropDefaultReplicationSlot();
         TestHelper.dropAllSchemas();
         TestHelper.execute(
                 "CREATE SCHEMA engine;",
@@ -244,6 +245,7 @@ public class DebeziumEngineIT {
                 OFFSET_STORE_PATH.toAbsolutePath().toString());
         props.setProperty("offset.flush.interval.ms", "3000");
         props.setProperty("converter.schemas.enable", "false");
+        props.setProperty("slot.drop.on.stop", "false");
         props.setProperty("offset.storage",
                 TestOffsetStore.class.getName());
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/IncrementalSnapshotIT.java
@@ -60,11 +60,10 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
     protected Configuration.Builder config() {
         return TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.getValue())
-                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
                 .with(PostgresConnectorConfig.SIGNAL_DATA_COLLECTION, "s1.debezium_signal")
                 .with(PostgresConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 10)
                 .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "s1")
-                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, false)
                 .with(RelationalDatabaseConnectorConfig.MSG_KEY_COLUMNS, "s1.a42:pk1,pk2,pk3,pk4")
                 // DBZ-4272 required to allow dropping columns just before an incremental snapshot
                 .with("database.autosave", "conservative");
@@ -81,11 +80,10 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Postg
         }
         return TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.getValue())
-                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
                 .with(PostgresConnectorConfig.SIGNAL_DATA_COLLECTION, "s1.debezium_signal")
                 .with(PostgresConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, 10)
                 .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "s1")
-                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, false)
                 .with(RelationalDatabaseConnectorConfig.MSG_KEY_COLUMNS, "s1.a42:pk1,pk2,pk3,pk4")
                 .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, tableIncludeList)
                 // DBZ-4272 required to allow dropping columns just before an incremental snapshot

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -1372,7 +1372,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         TestHelper.execute(SETUP_TABLES_STMT);
         Configuration config = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.NEVER.getValue())
-                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE)
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
                 .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s1.a")
                 .with(PostgresConnectorConfig.PROVIDE_TRANSACTION_METADATA, true)
                 .build();

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -2151,7 +2151,10 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
 
         TestHelper.execute(SETUP_TABLES_STMT);
         TestHelper.execute(INSERT_STMT);
-        Configuration config = TestHelper.defaultConfig().with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "s2").build();
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SCHEMA_INCLUDE_LIST, "s2")
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
+                .build();
 
         // Start connector, verify that it does not log no captured tables warning
         start(PostgresConnector.class, config);
@@ -2626,6 +2629,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         Configuration.Builder initalConfigBuilder = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.PUBLICATION_NAME, "cdc")
                 .with(PostgresConnectorConfig.TABLE_INCLUDE_LIST, "s2.a")
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
                 .with(PostgresConnectorConfig.PUBLICATION_AUTOCREATE_MODE, PostgresConnectorConfig.AutoCreateMode.FILTERED.getValue());
 
         start(PostgresConnector.class, initalConfigBuilder.build());

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/RecordsStreamProducerIT.java
@@ -256,6 +256,7 @@ public class RecordsStreamProducerIT extends AbstractRecordsProducerTest {
 
         startConnector(config -> config
                 .with(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES, true)
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE)
                 .with(PostgresConnectorConfig.SCHEMA_EXCLUDE_LIST, "postgis"));
 
         TestHelper.execute("CREATE TABLE t0 (pk SERIAL, d INTEGER, PRIMARY KEY(pk));");

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/ReplicationConnectionIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/ReplicationConnectionIT.java
@@ -86,7 +86,6 @@ public class ReplicationConnectionIT {
 
     @Test(expected = DebeziumException.class)
     public void shouldNotAllowMultipleReplicationSlotsOnTheSameDBSlotAndPlugin() throws Exception {
-        LogInterceptor interceptor = new LogInterceptor(PostgresReplicationConnection.class);
         // create a replication connection which should be dropped once it's closed
         try (ReplicationConnection conn1 = TestHelper.createForReplication("test1", true)) {
             conn1.startStreaming(new WalPositionLocator());
@@ -95,7 +94,7 @@ public class ReplicationConnectionIT {
                 fail("Should not be able to create 2 replication connections on the same db, plugin and slot");
             }
             catch (Exception e) {
-                assertTrue(interceptor.containsWarnMessage("and retrying, attempt number 2 over 2"));
+                assertTrue(e.getCause().getMessage().contains("ERROR: replication slot \"test1\" is active"));
                 throw e;
             }
         }


### PR DESCRIPTION
closes https://issues.redhat.com/projects/DBZ/issues/DBZ-5739

Detect replication slot recreation and fail the connector if we can't seek to the last known offset. We use the function `pg_replication_slot_advance` to seek to a specific location, which is available from Postgres 11 onwards. 