### PR TITLE
DBZ-5629 Correctly setting task id for MongoDbTaskContext

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbTaskContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbTaskContext.java
@@ -29,7 +29,7 @@ public class MongoDbTaskContext extends CdcSourceTaskContext {
      * @param config the configuration
      */
     public MongoDbTaskContext(Configuration config) {
-        super(Module.contextName(), config.getString(CommonConnectorConfig.TOPIC_PREFIX), Collections::emptySet);
+        super(Module.contextName(), config.getString(CommonConnectorConfig.TOPIC_PREFIX), config.getString(MongoDbConnectorConfig.TASK_ID), Collections::emptySet);
 
         this.filters = new Filters(config);
         this.connectorConfig = new MongoDbConnectorConfig(config);

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbTaskContextTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbTaskContextTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.util.Testing;
+
+public class MongoDbTaskContextTest implements Testing {
+    private Configuration config;
+    private MongoDbTaskContext context;
+
+    @Before
+    public void setup() {
+        this.config = Configuration.create()
+                .with(MongoDbConnectorConfig.HOSTS, "rs0/localhost:27017")
+                .with(MongoDbConnectorConfig.TASK_ID, 42)
+                .with(MongoDbConnectorConfig.TOPIC_PREFIX, "bistromath")
+                .with(MongoDbConnectorConfig.HOSTS, "dummy")
+                .with(MongoDbConnectorConfig.CAPTURE_MODE, MongoDbConnectorConfig.CaptureMode.CHANGE_STREAMS)
+                .build();
+        this.context = new MongoDbTaskContext(config);
+    }
+
+    @Test
+    public void shouldConfigureCommonTaskPropertiesFromConfig() {
+        assertThat(context.getTaskId()).isEqualTo(config.getString(MongoDbConnectorConfig.TASK_ID));
+        assertThat(context.getConnectorName()).isEqualTo(config.getString(CommonConnectorConfig.TOPIC_PREFIX));
+        assertThat(context.getConnectorType()).isEqualTo(Module.contextName());
+    }
+
+    @Test
+    public void shouldConfigureMongoDbTaskPropertiesFromConfig() {
+        assertThat(context.getConnectorConfig().getConfig()).isEqualTo(config);
+        assertThat(context.getCaptureMode()).isEqualTo(MongoDbConnectorConfig.CaptureMode.CHANGE_STREAMS);
+        assertThat(context.getConnectionContext().config).isEqualTo(config);
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5629

Root cause of the issue seems to be the use of default task ID. This in turn leads to the same name of the mbean for each task. 