### PR TITLE
DBZ-5748 Remove note that refers to incremental snapshots as TP feature

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-monitoring-incremental-snapshot-metrics.adoc
@@ -25,10 +25,3 @@ The connector also provides the following additional snapshot metrics when an in
 |The upper bound of the primary key set of the currently snapshotted table.
 
 |===
-
-ifdef::product[]
-[IMPORTANT]
-====
-Incremental snapshots is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[https://access.redhat.com/support/offerings/techpreview].
-====
-endif::product[]


### PR DESCRIPTION
[DBZ-5748](https://issues.redhat.com/browse/DBZ-5748)

Deletes from the shared snapshot metrics file an incremental snapshots Tech Preview note that was intended for removal when the feature was promoted to GA in the previous 2022.Q3 downstream release .  A[ separate commit in the downstream docs repo ](https://gitlab.cee.redhat.com/red-hat-integration-documentation/integration/-/merge_requests/993)removes the note from the published downstream documentation.  