### PR TITLE
DBZ-5661 Fix for Embedded Engine retrying indefinitely even when max retries is 0

### DIFF
--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -864,6 +864,10 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord> {
                                         delayStrategy.sleepWhen(!startedSuccessfully);
                                     }
                                 }
+                                else {
+                                    handlerError = e;
+                                    break;
+                                }
                             }
                             try {
                                 if (changeRecords != null && !changeRecords.isEmpty()) {

--- a/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
+++ b/debezium-embedded/src/main/java/io/debezium/embedded/EmbeddedEngine.java
@@ -865,8 +865,7 @@ public final class EmbeddedEngine implements DebeziumEngine<SourceRecord> {
                                     }
                                 }
                                 else {
-                                    handlerError = e;
-                                    break;
+                                    throw e;
                                 }
                             }
                             try {


### PR DESCRIPTION
## External Links

[DBZ-5661](https://issues.redhat.com/browse/DBZ-5661)

## Description
The changes is to break the indefinite retries upon RetriableException in EmbeddedEngine, when the max retries is set to 0. 

## Notes for Reviewer
This PR is a preliminary fix to the problem running replication using EmbeddedEngine and retrying endlessly on failure. This will break the infinite looping over RetriableException and let the engine exit gracefully when user choose not to retry through below config property set to zero:
`errors.max.retries`
@jpechane, while I will continue to work on [Original PR ](https://github.com/debezium/debezium/pull/3958) to achieve more consistent behaviour for RetriableExceptions between Kafka connectors and EmbeddedEngine, this simple solution unblocks  from the retry loop and enables to use EmbeddedEngine with the above mentioned config property to escape retries in the meantime. 