### PR TITLE
DBZ-5763 disabling connection encryption for SqlServer connections 

### DIFF
--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/databases/sqlserver/OcpSqlServerController.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/databases/sqlserver/OcpSqlServerController.java
@@ -50,8 +50,8 @@ public class OcpSqlServerController extends OcpSqlDatabaseController {
 
     @Override
     public String getPublicDatabaseUrl() {
-        return "jdbc:" + getDatabaseType() + "://" + getPublicDatabaseHostname() + ":" + getPublicDatabasePort();
-
+        return "jdbc:" + getDatabaseType() + "://" + getPublicDatabaseHostname() + ":" + getPublicDatabasePort()
+                + ";encrypt=false";
     }
 
     public void initialize() throws InterruptedException {


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5763

This is fix for ocp connections, for test-containers it needs further investigation 