### PR TITLE
DBZ-5743 Example Change the validFullname replacement rule

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -461,3 +461,4 @@ Inki Hwang
 合龙 张
 Phạm Ngọc Thắng
 Moustapha Mahfoud
+周民帅

--- a/debezium-core/src/main/java/io/debezium/util/SchemaNameAdjuster.java
+++ b/debezium-core/src/main/java/io/debezium/util/SchemaNameAdjuster.java
@@ -310,6 +310,7 @@ public interface SchemaNameAdjuster {
         }
         else {
             sb.append(replacement.replace(c));
+            sb.append((int)c);
             changed = true;
         }
         for (int i = 1; i != proposedName.length(); ++i) {
@@ -319,6 +320,7 @@ public interface SchemaNameAdjuster {
             }
             else {
                 sb.append(replacement.replace(c));
+                sb.append((int)c);
                 changed = true;
             }
         }

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -165,3 +165,4 @@ rajdangwal,Rajendra Dangwal
 Sage-Pierce,Sage Pierce
 joschi,Jochen Schalanda
 janjwerner-confluent,Jan Werner
+SimonChou12138,周民帅


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5743

It is uniquely encoded through Unicode's hexadecimal to decimal counterpart, preserving the topic language while conforming to the kafka naming conventions. Avoid the situation that topic names are the same when special characters of the same length are replaced with _