### PR TITLE
DBZ-5774 Upgrade to Quarkus 2.14.CR1

### DIFF
--- a/debezium-quarkus-outbox/runtime/pom.xml
+++ b/debezium-quarkus-outbox/runtime/pom.xml
@@ -30,9 +30,9 @@
         </dependency>
         <!-- Needed specifically for AdditionalJaxbMappingProducerImpl usage -->
         <dependency>
-            <groupId>org.jboss</groupId>
+            <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
-            <version>2.4.0.Final</version>
+            <version>3.0.1</version>
         </dependency>
         <!-- Needed primarily for @Incubating annotation -->
         <dependency>

--- a/debezium-quarkus-outbox/runtime/pom.xml
+++ b/debezium-quarkus-outbox/runtime/pom.xml
@@ -32,7 +32,6 @@
         <dependency>
             <groupId>io.smallrye</groupId>
             <artifactId>jandex</artifactId>
-            <version>3.0.1</version>
         </dependency>
         <!-- Needed primarily for @Incubating annotation -->
         <dependency>

--- a/debezium-server/debezium-server-pravega/pom.xml
+++ b/debezium-server/debezium-server-pravega/pom.xml
@@ -9,7 +9,8 @@
   <artifactId>debezium-server-pravega</artifactId>
   <name>Debezium Server Pravega Sink Adapter</name>
   <properties>
-    <netty.version>4.1.52.Final</netty.version>
+    <!-- IMPORTANT: This must be aligned with the netty shipped with Quarkus, specified in debezium-build-parent -->
+    <netty.version>4.1.82.Final</netty.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -36,38 +37,47 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-common</artifactId>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http2</artifactId>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-socks</artifactId>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler-proxy</artifactId>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
+      <version>${netty.version}</version>
     </dependency>
 
     <!-- Testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
 
         <!-- Quarkus -->
         <!-- Must be aligned with Apicurio version below -->
-        <quarkus.version>2.11.0.Final</quarkus.version>
+        <quarkus.version>2.14.0.CR1</quarkus.version>
 
         <!-- Apicurio -->
         <version.apicurio>2.2.5.Final</version.apicurio>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5774

- [x] Source jandex version from Quarkus BOM

In regards to the upstream PR requirements of https://github.com/quarkusio/quarkus-platform/pull/673