### PR TITLE
DBZ-5777: Restart SQL Server task on "Cannot continue the execution because the session is in the kill state."

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
@@ -37,6 +37,7 @@ public class SqlServerErrorHandler extends ErrorHandler {
                         || throwable.getMessage().contains("Try the statement later.")
                         || throwable.getMessage().contains("Connection reset")
                         || throwable.getMessage().contains("Socket closed")
+                        || throwable.getMessage().contains("Cannot continue the execution because the session is in the kill state.")
                         || throwable.getMessage().contains("SHUTDOWN is in progress")
                         || throwable.getMessage().contains("The server failed to resume the transaction")
                         || throwable.getMessage().contains("Verify the connection properties")


### PR DESCRIPTION
See [DBZ-5777](https://issues.redhat.com/browse/DBZ-5777).

I only noticed the changes from https://github.com/debezium/debezium/pull/3824 while rebasing this patch from our internal `1.9.5` branch to `main`. If this change is non-essential or too disruptive for `1.9`, please feel free to discard it.