### PR TITLE
Run tests with Apicurio

### DIFF
--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -363,6 +363,19 @@
                     <name>apicurio</name>
                 </property>
             </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <use.apicurio>true</use.apicurio>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
             <properties>
                 <docker.filter>${docker.dbs},apicurio/apicurio-registry-mem:${version.apicurio}</docker.filter>
             </properties>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
         <version>2.1.0-SNAPSHOT</version>
-	<relativePath>../debezium-parent/pom.xml</relativePath>
+        <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-connector-mongodb</artifactId>
@@ -103,90 +104,90 @@
     <build>
         <plugins>
             <plugin>
-              <groupId>io.fabric8</groupId>
-              <artifactId>docker-maven-plugin</artifactId>
-              <configuration>
-                <watchInterval>500</watchInterval>
-                <logDate>default</logDate>
-                <verbose>true</verbose>
-                <!--autoPull>always</autoPull-->
-                <images>
-                  <!-- A container for the data server replica set -->
-                  <image>
-                    <name>mongo:${version.mongo.server}</name>
-                    <alias>mongo1</alias>
-                    <run>
-                      <namingStrategy>alias</namingStrategy>
-                      <cmd>${mongo.data.runOptions}</cmd>
-                      <ports>
-                        <!-- We won't use it thru this port, but we don't want to take 27017 on docker host -->
-                        <port>27017:27017</port> 
-                      </ports>
-                      <log>
-                        <prefix>mongo1</prefix>
-                        <enabled>true</enabled>
-                        <color>yellow</color>
-                      </log>
-                      <wait>
-                        <log>.*[Ww]aiting for connections.*27017</log> <!-- internal port, multiline matching -->
-                        <time>30000</time> <!-- 30 seconds max -->
-                      </wait>
-                    </run>
-                    <external>
-                      <type>properties</type>
-                      <mode>override</mode>
-                    </external>
-                  </image>
-                  <!-- A container that initiates the data replica set and adds it as shard to router -->
-                  <image>
-                    <name>debezium/mongo-initiator:${version.mongo.server}</name>
-                    <run>
-                      <namingStrategy>none</namingStrategy>
-                      <env>
-                        <VERBOSE>true</VERBOSE>
-                        <REPLICASET>${mongo.data.replicaset.name}</REPLICASET>
-                      </env>
-                      <links>
-                        <link>mongo1:mongo1</link>
-                      </links>
-                      <log>
-                        <prefix>mongo-init</prefix>
-                        <enabled>true</enabled>
-                        <color>green</color>
-                      </log>
-                      <wait>
-                        <exit>0</exit>
-                        <time>30000</time> <!-- 30 seconds max -->
-                      </wait>
-                    </run>
-                    <external>
-                      <type>properties</type>
-                      <mode>override</mode>
-                    </external>
-                  </image>
-                </images>
-              </configuration>
-              <!--
-              Connect this plugin to the maven lifecycle around the integration-test phase:
-              start the container in pre-integration-test and stop it in post-integration-test.
-              -->
-              <executions>
-                <execution>
-                  <id>start</id>
-                  <phase>pre-integration-test</phase>
-                  <goals>
-                    <goal>build</goal>
-                    <goal>start</goal>
-                  </goals>
-                </execution>
-                <execution>
-                  <id>stop</id>
-                  <phase>post-integration-test</phase>
-                  <goals>
-                    <goal>stop</goal>
-                  </goals>
-                </execution>
-              </executions>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <watchInterval>500</watchInterval>
+                    <logDate>default</logDate>
+                    <verbose>true</verbose>
+                    <!--autoPull>always</autoPull-->
+                    <images>
+                        <!-- A container for the data server replica set -->
+                        <image>
+                            <name>mongo:${version.mongo.server}</name>
+                            <alias>mongo1</alias>
+                            <run>
+                                <namingStrategy>alias</namingStrategy>
+                                <cmd>${mongo.data.runOptions}</cmd>
+                                <ports>
+                                    <!-- We won't use it thru this port, but we don't want to take 27017 on docker host -->
+                                    <port>27017:27017</port>
+                                </ports>
+                                <log>
+                                    <prefix>mongo1</prefix>
+                                    <enabled>true</enabled>
+                                    <color>yellow</color>
+                                </log>
+                                <wait>
+                                    <log>.*[Ww]aiting for connections.*27017</log> <!-- internal port, multiline matching -->
+                                    <time>30000</time> <!-- 30 seconds max -->
+                                </wait>
+                            </run>
+                            <external>
+                                <type>properties</type>
+                                <mode>override</mode>
+                            </external>
+                        </image>
+                        <!-- A container that initiates the data replica set and adds it as shard to router -->
+                        <image>
+                            <name>debezium/mongo-initiator:${version.mongo.server}</name>
+                            <run>
+                                <namingStrategy>none</namingStrategy>
+                                <env>
+                                    <VERBOSE>true</VERBOSE>
+                                    <REPLICASET>${mongo.data.replicaset.name}</REPLICASET>
+                                </env>
+                                <links>
+                                    <link>mongo1:mongo1</link>
+                                </links>
+                                <log>
+                                    <prefix>mongo-init</prefix>
+                                    <enabled>true</enabled>
+                                    <color>green</color>
+                                </log>
+                                <wait>
+                                    <exit>0</exit>
+                                    <time>30000</time> <!-- 30 seconds max -->
+                                </wait>
+                            </run>
+                            <external>
+                                <type>properties</type>
+                                <mode>override</mode>
+                            </external>
+                        </image>
+                    </images>
+                </configuration>
+                <!--
+                Connect this plugin to the maven lifecycle around the integration-test phase:
+                start the container in pre-integration-test and stop it in post-integration-test.
+                -->
+                <executions>
+                    <execution>
+                        <id>start</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <!-- 
             Unlike surefire, the failsafe plugin ensures 'post-integration-test' phase always runs, even
@@ -315,21 +316,21 @@
                 <docker.skip>true</docker.skip>
             </properties>
         </profile>
-      <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            Do not perform any Docker-related functionality
-            To use, specify "-DskipITs" on the Maven command line.
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
-      <profile>
-        <id>skip-integration-tests</id>
-        <activation>
-          <activeByDefault>false</activeByDefault>
-          <property>
-            <name>skipITs</name>
-          </property>
-        </activation>
-        <properties>
-          <docker.skip>true</docker.skip>
-        </properties>
-      </profile>
+        <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              Do not perform any Docker-related functionality
+              To use, specify "-DskipITs" on the Maven command line.
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+        <profile>
+            <id>skip-integration-tests</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>skipITs</name>
+                </property>
+            </activation>
+            <properties>
+                <docker.skip>true</docker.skip>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -100,6 +100,11 @@
         -->
         <docker.skip>false</docker.skip>
         <docker.exposeContainerInfo>docker.container</docker.exposeContainerInfo>
+        <docker.dbs>mongo:${version.mongo.server},debezium/mongo-initiator:${version.mongo.server}</docker.dbs>
+        <docker.filter>${docker.dbs}</docker.filter>
+        <!-- Apicurion container properties -->
+        <apicurio.port>8080</apicurio.port>
+        <apicurio.init.timeout>60000</apicurio.init.timeout> <!-- 60 seconds -->
     </properties>
     <build>
         <plugins>
@@ -164,6 +169,24 @@
                                 <type>properties</type>
                                 <mode>override</mode>
                             </external>
+                        </image>
+                        <image>
+                            <name>apicurio/apicurio-registry-mem:${version.apicurio}</name>
+                            <run>
+                                <namingStrategy>none</namingStrategy>
+                                <ports>
+                                    <port>${apicurio.port}:8080</port>
+                                </ports>
+                                <log>
+                                    <prefix>apicurio</prefix>
+                                    <enabled>true</enabled>
+                                    <color>blue</color>
+                                </log>
+                                <wait>
+                                    <log>.*apicurio-registry-app.*started in.*</log>
+                                    <time>${apicurio.init.timeout}</time>
+                                </wait>
+                            </run>
                         </image>
                     </images>
                 </configuration>
@@ -330,6 +353,18 @@
             </activation>
             <properties>
                 <docker.skip>true</docker.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>apicurio</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>apicurio</name>
+                </property>
+            </activation>
+            <properties>
+                <docker.filter>${docker.dbs},apicurio/apicurio-registry-mem:${version.apicurio}</docker.filter>
             </properties>
         </profile>
     </profiles>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -140,6 +140,8 @@
         <mysql.ssl.port>3306</mysql.ssl.port>
         <mysql.replica.port>3306</mysql.replica.port> <!-- by default use primary as 'replica' -->
         <mysql.init.timeout>60000</mysql.init.timeout> <!-- 60 seconds -->
+        <apicurio.port>8080</apicurio.port>
+        <apicurio.init.timeout>60000</apicurio.init.timeout> <!-- 60 seconds -->
         <!--
         By default, we should use the docker image maintained by the MySQL team. This property is changed with different profiles.
         However, we run one container with GTIDs and one without.
@@ -442,6 +444,24 @@
                                 <type>properties</type>
                                 <mode>override</mode>
                             </external>
+                        </image>
+                        <image>
+                            <name>apicurio/apicurio-registry-mem:${version.apicurio}</name>
+                            <run>
+                                <namingStrategy>none</namingStrategy>
+                                <ports>
+                                    <port>${apicurio.port}:8080</port>
+                                </ports>
+                                <log>
+                                    <prefix>apicurio</prefix>
+                                    <enabled>true</enabled>
+                                    <color>blue</color>
+                                </log>
+                                <wait>
+                                    <log>.*apicurio-registry-app.*started in.*</log>
+                                    <time>${apicurio.init.timeout}</time>
+                                </wait>
+                            </run>
                         </image>
                     </images>
                 </configuration>
@@ -817,6 +837,18 @@
                 <database.port>${mysql.ssl.port}</database.port>
                 <database.replica.port>${mysql.ssl.port}</database.replica.port>
                 <docker.initimage>ln -s /usr/share/zoneinfo/Pacific/Pago_Pago /etc/localtime</docker.initimage>
+            </properties>
+        </profile>
+        <profile>
+            <id>apicurio</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>apicurio</name>
+                </property>
+            </activation>
+            <properties>
+                <docker.filter>${docker.dbs},apicurio/apicurio-registry-mem:${version.apicurio}</docker.filter>
             </properties>
         </profile>
     </profiles>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -144,7 +144,8 @@
         By default, we should use the docker image maintained by the MySQL team. This property is changed with different profiles.
         However, we run one container with GTIDs and one without.
         -->
-        <docker.filter>debezium/mysql-server-test-database</docker.filter>
+        <docker.dbs>debezium/mysql-server-test-database</docker.dbs>
+        <docker.filter>${docker.dbs}</docker.filter>
         <docker.skip>false</docker.skip>
         <docker.initimage>rm -f /etc/localtime; ln -s /usr/share/zoneinfo/US/Samoa /etc/localtime</docker.initimage>
     </properties>
@@ -565,9 +566,9 @@
             </activation>
             <properties>
                 <!-- Run multiple images at the same time, but use different ports for all MySQL servers -->
-                <docker.filter>
+                <docker.dbs>
                     debezium/mysql-server-test-database,debezium/mysql-server-gtids-test-database,debezium/mysql-server-gtids-test-database-replica,debezium/percona-server-test-database,debezium/mysql-server-test-database-ssl
-                </docker.filter>
+                </docker.dbs>
                 <mysql.port>4301</mysql.port>
                 <mysql.gtid.port>4302</mysql.gtid.port>
                 <mysql.gtid.replica.port>4303</mysql.gtid.replica.port>
@@ -746,7 +747,7 @@
             </activation>
             <properties>
                 <!-- Docker properties -->
-                <docker.filter>debezium/mysql-server-gtids-test-database</docker.filter>
+                <docker.dbs>debezium/mysql-server-gtids-test-database</docker.dbs>
                 <!-- Integration test properties -->
                 <database.port>${mysql.gtid.port}</database.port>
                 <database.replica.port>${mysql.gtid.port}</database.replica.port>
@@ -766,7 +767,7 @@
             </activation>
             <properties>
                 <!-- Docker properties -->
-                <docker.filter>debezium/percona-server-test-database</docker.filter>
+                <docker.dbs>debezium/percona-server-test-database</docker.dbs>
                 <!-- Integration test properties -->
                 <database.port>${mysql.percona.port}</database.port>
                 <database.replica.port>${mysql.percona.port}</database.replica.port>
@@ -791,7 +792,7 @@
                 <!-- Docker properties -->
                 <mysql.gtid.port>3306</mysql.gtid.port>
                 <mysql.gtid.replica.port>4306</mysql.gtid.replica.port>
-                <docker.filter>debezium/mysql-server-gtids-test-database,debezium/mysql-server-gtids-test-database-replica</docker.filter>
+                <docker.dbs>debezium/mysql-server-gtids-test-database,debezium/mysql-server-gtids-test-database-replica</docker.dbs>
                 <!-- Integration test properties -->
                 <database.port>${mysql.gtid.port}</database.port>
                 <database.replica.port>${mysql.gtid.replica.port}</database.replica.port>
@@ -811,7 +812,7 @@
             </activation>
             <properties>
                 <!-- Docker properties -->
-                <docker.filter>debezium/mysql-server-test-database-ssl</docker.filter>
+                <docker.dbs>debezium/mysql-server-test-database-ssl</docker.dbs>
                 <!-- Integration test properties -->
                 <database.port>${mysql.ssl.port}</database.port>
                 <database.replica.port>${mysql.ssl.port}</database.replica.port>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -103,6 +103,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-utils-converter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
         <version>2.1.0-SNAPSHOT</version>
-	<relativePath>../debezium-parent/pom.xml</relativePath>
+        <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-connector-mysql</artifactId>
@@ -150,320 +151,320 @@
     <build>
         <plugins>
             <plugin>
-              <groupId>io.fabric8</groupId>
-              <artifactId>docker-maven-plugin</artifactId>
-              <configuration>
-                <watchInterval>500</watchInterval>
-                <logDate>default</logDate>
-                <verbose>true</verbose>
-                <imagePullPolicy>IfNotPresent</imagePullPolicy>
-                <images>
-                  <!--
-                  Images based on "mysql/mysql-server" Docker image
-                  -->
-                  <image>
-                    <!-- A Docker image using a partial MySQL installation maintained by MySQL team. -->
-                    <name>debezium/mysql-server-test-database</name>
-                    <run>
-                      <namingStrategy>none</namingStrategy>
-                      <env>
-                        <MYSQL_ROOT_PASSWORD>debezium-rocks</MYSQL_ROOT_PASSWORD>
-                        <MYSQL_DATABASE>mysql</MYSQL_DATABASE> <!-- database created upon init -->
-                        <MYSQL_USER>${mysql.user}</MYSQL_USER>
-                        <MYSQL_PASSWORD>${mysql.password}</MYSQL_PASSWORD>
-                      </env>
-                      <ports>
-                        <port>${mysql.port}:3306</port>
-                      </ports>
-                      <log>
-                        <prefix>mysql</prefix>
-                        <enabled>true</enabled>
-                        <color>yellow</color>
-                      </log>
-                      <wait>
-                        <log>MySQL init process done. Ready for start up.(?s)(.*)mysqld: ready for connections.</log>
-                        <time>${mysql.init.timeout}</time>
-                      </wait>
-                    </run>
-                    <build>
-                      <from>mysql/mysql-server:${version.mysql.server}</from>
-                      <runCmds>
-                        <run>${docker.initimage}</run>
-                      </runCmds>
-                      <assembly>
-                        <inline>
-                          <fileSets>
-                            <fileSet>
-                              <directory>${project.basedir}/src/test/docker/server</directory>
-                              <includes>
-                                <include>my.cnf</include>
-                              </includes>
-                              <outputDirectory>etc/mysql</outputDirectory>
-                            </fileSet>
-                            <fileSet>
-                              <directory>${project.basedir}/src/test/docker/init</directory>
-                              <outputDirectory>docker-entrypoint-initdb.d</outputDirectory>
-                            </fileSet>
-                          </fileSets>
-                        </inline>
-                        <targetDir>/</targetDir>
-                      </assembly>
-                    </build>
-                    <external>
-                      <type>properties</type>
-                      <mode>override</mode>
-                    </external>
-                  </image>
-                  <image>
-                    <!-- A Docker image using a partial MySQL installation maintained by MySQL team
-                     that enable mysql ssl connection -->
-                    <name>debezium/mysql-server-test-database-ssl</name>
-                    <run>
-                      <namingStrategy>none</namingStrategy>
-                      <env>
-                        <MYSQL_ROOT_PASSWORD>debezium-rocks</MYSQL_ROOT_PASSWORD>
-                        <MYSQL_DATABASE>mysql</MYSQL_DATABASE> <!-- database created upon init -->
-                        <MYSQL_USER>${mysql.user}</MYSQL_USER>
-                        <MYSQL_PASSWORD>${mysql.password}</MYSQL_PASSWORD>
-                      </env>
-                      <ports>
-                        <port>${mysql.ssl.port}:3306</port>
-                      </ports>
-                      <volumes>
-                        <bind>
-                          <volume>${project.basedir}/src/test/resources/ssl-certs:/etc/certs</volume>
-                        </bind>
-                      </volumes>
-                      <log>
-                        <prefix>mysql</prefix>
-                        <enabled>true</enabled>
-                        <color>yellow</color>
-                      </log>
-                      <wait>
-                        <log>MySQL init process done. Ready for start up.(?s)(.*)mysqld: ready for connections.</log>
-                        <time>${mysql.init.timeout}</time>
-                      </wait>
-                    </run>
-                    <build>
-                      <from>mysql/mysql-server:${version.mysql.server}</from>
-                        <runCmds>
-                          <run>${docker.initimage}</run>
-                        </runCmds>
-                        <assembly>
-                          <inline>
-                            <fileSets>
-                              <fileSet>
-                                <directory>${project.basedir}/src/test/docker/server-ssl</directory>
-                                <includes>
-                                  <include>my.cnf</include>
-                                </includes>
-                                <outputDirectory>etc/mysql</outputDirectory>
-                              </fileSet>
-                              <fileSet>
-                                <directory>${project.basedir}/src/test/docker/init</directory>
-                                <outputDirectory>docker-entrypoint-initdb.d</outputDirectory>
-                              </fileSet>
-                              <fileSet>
-                                <directory>${project.basedir}/src/test/docker/init-ssl</directory>
-                                <outputDirectory>docker-entrypoint-initdb.d</outputDirectory>
-                              </fileSet>
-                            </fileSets>
-                          </inline>
-                          <targetDir>/</targetDir>
-                        </assembly>
-                    </build>
-                    <external>
-                      <type>properties</type>
-                      <mode>override</mode>
-                    </external>
-                  </image>
-                  <image>
-                    <!-- A Docker image using a partial MySQL installation maintained by MySQL team. -->
-                    <name>debezium/mysql-server-gtids-test-database</name>
-                    <alias>database-gtids</alias>
-                    <run>
-                      <namingStrategy>alias</namingStrategy>
-                      <env>
-                        <MYSQL_ROOT_PASSWORD>debezium-rocks</MYSQL_ROOT_PASSWORD>
-                        <MYSQL_DATABASE>mysql</MYSQL_DATABASE> <!-- database created upon init -->
-                        <MYSQL_USER>${mysql.user}</MYSQL_USER>
-                        <MYSQL_PASSWORD>${mysql.password}</MYSQL_PASSWORD>
-                      </env>
-                      <ports>
-                        <port>${mysql.gtid.port}:3306</port>
-                      </ports>
-                      <log>
-                        <prefix>mysql-gtids</prefix>
-                        <enabled>true</enabled>
-                        <color>cyan</color>
-                      </log>
-                      <wait>
-                        <log>MySQL init process done. Ready for start up.(?s)(.*)mysqld: ready for connections.</log>
-                        <time>${mysql.init.timeout}</time>
-                      </wait>
-                    </run>
-                    <build>
-                      <from>mysql/mysql-server:${version.mysql.server}</from>
-                      <runCmds>
-                        <run>${docker.initimage}</run>
-                      </runCmds>
-                      <assembly>
-                        <inline>
-                          <fileSets>
-                            <fileSet>
-                              <directory>${project.basedir}/src/test/docker/server-gtids</directory>
-                              <includes>
-                                <include>my.cnf</include>
-                              </includes>
-                              <outputDirectory>etc/mysql</outputDirectory>
-                            </fileSet>
-                            <fileSet>
-                              <directory>${project.basedir}/src/test/docker/init</directory>
-                              <outputDirectory>docker-entrypoint-initdb.d</outputDirectory>
-                            </fileSet>
-                          </fileSets>
-                        </inline>
-                        <targetDir>/</targetDir>
-                      </assembly>
-                    </build>
-                    <external>
-                      <type>properties</type>
-                      <mode>override</mode>
-                    </external>
-                  </image>
-                  <image>
-                    <!-- 
-                    A Docker image using a MySQL installation maintained by MySQL team
-                    that is a replica of `debezium/mysql-server-gtids-test-database`
-                    -->
-                    <name>debezium/mysql-server-gtids-test-database-replica</name>
-                    <run>
-                      <namingStrategy>none</namingStrategy>
-                      <env>
-                        <MYSQL_ROOT_PASSWORD>debezium-rocks</MYSQL_ROOT_PASSWORD>
-                        <MYSQL_USER>${mysql.replica.user}</MYSQL_USER>
-                        <MYSQL_PASSWORD>${mysql.replica.password}</MYSQL_PASSWORD>
-                      </env>
-                      <links>
-                        <link>database-gtids</link>
-                      </links>
-                      <ports>
-                        <port>${mysql.gtid.replica.port}:3306</port>
-                      </ports>
-                      <log>
-                        <prefix>mysql-gtids-replica</prefix>
-                        <enabled>true</enabled>
-                        <color>magenta</color>
-                      </log>
-                      <wait>
-                        <log>MySQL init process done. Ready for start up.(?s)(.*)mysqld: ready for connections.</log>
-                        <time>${mysql.init.timeout}</time>
-                      </wait>
-                    </run>
-                    <build>
-                      <from>mysql/mysql-server:${version.mysql.server}</from>
-                      <runCmds>
-                        <run>${docker.initimage}</run>
-                      </runCmds>
-                      <assembly>
-                        <inline>
-                          <fileSets>
-                            <fileSet>
-                              <directory>${project.basedir}/src/test/docker/server-replica</directory>
-                              <includes>
-                                <include>my.cnf</include>
-                              </includes>
-                              <outputDirectory>etc/mysql</outputDirectory>
-                            </fileSet>
-                            <fileSet>
-                              <directory>${project.basedir}/src/test/docker/init-replica</directory>
-                              <outputDirectory>docker-entrypoint-initdb.d</outputDirectory>
-                            </fileSet>
-                          </fileSets>
-                        </inline>
-                        <targetDir>/</targetDir>
-                      </assembly>
-                    </build>
-                    <external>
-                      <type>properties</type>
-                      <mode>override</mode>
-                    </external>
-                  </image>
-                  <image>
-                    <!--
-                    A Docker image using a Percona Server installation
-                    -->
-                    <name>debezium/percona-server-test-database</name>
-                    <run>
-                      <namingStrategy>none</namingStrategy>
-                      <env>
-                        <MYSQL_ROOT_PASSWORD>debezium-rocks</MYSQL_ROOT_PASSWORD>
-                        <MYSQL_USER>${mysql.user}</MYSQL_USER>
-                        <MYSQL_PASSWORD>${mysql.password}</MYSQL_PASSWORD>
-                        <TZ>Pacific/Pago_Pago</TZ>
-                      </env>
-                      <ports>
-                        <port>${mysql.percona.port}:3306</port>
-                      </ports>
-                      <log>
-                        <prefix>percona-server</prefix>
-                        <enabled>true</enabled>
-                        <color>magenta</color>
-                      </log>
-                      <wait>
-                        <log>MySQL init process done. Ready for start up.(?s)(.*)mysqld: ready for connections.</log>
-                        <time>${mysql.init.timeout}</time>
-                      </wait>
-                    </run>
-                    <build>
-                      <from>percona/percona-server:${version.mysql.server}</from>
-                      <assembly>
-                        <inline>
-                          <fileSets>
-                            <fileSet>
-                              <directory>${project.basedir}/src/test/docker/server</directory>
-                              <includes>
-                                <include>my.cnf</include>
-                              </includes>
-                              <outputDirectory>etc/mysql</outputDirectory>
-                            </fileSet>
-                            <fileSet>
-                              <directory>${project.basedir}/src/test/docker/init</directory>
-                              <outputDirectory>docker-entrypoint-initdb.d</outputDirectory>
-                            </fileSet>
-                          </fileSets>
-                        </inline>
-                        <targetDir>/</targetDir>
-                      </assembly>
-                    </build>
-                    <external>
-                      <type>properties</type>
-                      <mode>override</mode>
-                    </external>
-                  </image>
-                </images>
-              </configuration>
-              <!--
-              Connect this plugin to the maven lifecycle around the integration-test phase:
-              start the container in pre-integration-test and stop it in post-integration-test.
-              -->
-              <executions>
-                <execution>
-                  <id>start</id>
-                  <phase>pre-integration-test</phase>
-                  <goals>
-                    <goal>build</goal>
-                    <goal>start</goal>
-                  </goals>
-                </execution>
-                <execution>
-                  <id>stop</id>
-                  <phase>post-integration-test</phase>
-                  <goals>
-                    <goal>stop</goal>
-                  </goals>
-                </execution>
-              </executions>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <configuration>
+                    <watchInterval>500</watchInterval>
+                    <logDate>default</logDate>
+                    <verbose>true</verbose>
+                    <imagePullPolicy>IfNotPresent</imagePullPolicy>
+                    <images>
+                        <!--
+                        Images based on "mysql/mysql-server" Docker image
+                        -->
+                        <image>
+                            <!-- A Docker image using a partial MySQL installation maintained by MySQL team. -->
+                            <name>debezium/mysql-server-test-database</name>
+                            <run>
+                                <namingStrategy>none</namingStrategy>
+                                <env>
+                                    <MYSQL_ROOT_PASSWORD>debezium-rocks</MYSQL_ROOT_PASSWORD>
+                                    <MYSQL_DATABASE>mysql</MYSQL_DATABASE> <!-- database created upon init -->
+                                    <MYSQL_USER>${mysql.user}</MYSQL_USER>
+                                    <MYSQL_PASSWORD>${mysql.password}</MYSQL_PASSWORD>
+                                </env>
+                                <ports>
+                                    <port>${mysql.port}:3306</port>
+                                </ports>
+                                <log>
+                                    <prefix>mysql</prefix>
+                                    <enabled>true</enabled>
+                                    <color>yellow</color>
+                                </log>
+                                <wait>
+                                    <log>MySQL init process done. Ready for start up.(?s)(.*)mysqld: ready for connections.</log>
+                                    <time>${mysql.init.timeout}</time>
+                                </wait>
+                            </run>
+                            <build>
+                                <from>mysql/mysql-server:${version.mysql.server}</from>
+                                <runCmds>
+                                    <run>${docker.initimage}</run>
+                                </runCmds>
+                                <assembly>
+                                    <inline>
+                                        <fileSets>
+                                            <fileSet>
+                                                <directory>${project.basedir}/src/test/docker/server</directory>
+                                                <includes>
+                                                    <include>my.cnf</include>
+                                                </includes>
+                                                <outputDirectory>etc/mysql</outputDirectory>
+                                            </fileSet>
+                                            <fileSet>
+                                                <directory>${project.basedir}/src/test/docker/init</directory>
+                                                <outputDirectory>docker-entrypoint-initdb.d</outputDirectory>
+                                            </fileSet>
+                                        </fileSets>
+                                    </inline>
+                                    <targetDir>/</targetDir>
+                                </assembly>
+                            </build>
+                            <external>
+                                <type>properties</type>
+                                <mode>override</mode>
+                            </external>
+                        </image>
+                        <image>
+                            <!-- A Docker image using a partial MySQL installation maintained by MySQL team
+                             that enable mysql ssl connection -->
+                            <name>debezium/mysql-server-test-database-ssl</name>
+                            <run>
+                                <namingStrategy>none</namingStrategy>
+                                <env>
+                                    <MYSQL_ROOT_PASSWORD>debezium-rocks</MYSQL_ROOT_PASSWORD>
+                                    <MYSQL_DATABASE>mysql</MYSQL_DATABASE> <!-- database created upon init -->
+                                    <MYSQL_USER>${mysql.user}</MYSQL_USER>
+                                    <MYSQL_PASSWORD>${mysql.password}</MYSQL_PASSWORD>
+                                </env>
+                                <ports>
+                                    <port>${mysql.ssl.port}:3306</port>
+                                </ports>
+                                <volumes>
+                                    <bind>
+                                        <volume>${project.basedir}/src/test/resources/ssl-certs:/etc/certs</volume>
+                                    </bind>
+                                </volumes>
+                                <log>
+                                    <prefix>mysql</prefix>
+                                    <enabled>true</enabled>
+                                    <color>yellow</color>
+                                </log>
+                                <wait>
+                                    <log>MySQL init process done. Ready for start up.(?s)(.*)mysqld: ready for connections.</log>
+                                    <time>${mysql.init.timeout}</time>
+                                </wait>
+                            </run>
+                            <build>
+                                <from>mysql/mysql-server:${version.mysql.server}</from>
+                                <runCmds>
+                                    <run>${docker.initimage}</run>
+                                </runCmds>
+                                <assembly>
+                                    <inline>
+                                        <fileSets>
+                                            <fileSet>
+                                                <directory>${project.basedir}/src/test/docker/server-ssl</directory>
+                                                <includes>
+                                                    <include>my.cnf</include>
+                                                </includes>
+                                                <outputDirectory>etc/mysql</outputDirectory>
+                                            </fileSet>
+                                            <fileSet>
+                                                <directory>${project.basedir}/src/test/docker/init</directory>
+                                                <outputDirectory>docker-entrypoint-initdb.d</outputDirectory>
+                                            </fileSet>
+                                            <fileSet>
+                                                <directory>${project.basedir}/src/test/docker/init-ssl</directory>
+                                                <outputDirectory>docker-entrypoint-initdb.d</outputDirectory>
+                                            </fileSet>
+                                        </fileSets>
+                                    </inline>
+                                    <targetDir>/</targetDir>
+                                </assembly>
+                            </build>
+                            <external>
+                                <type>properties</type>
+                                <mode>override</mode>
+                            </external>
+                        </image>
+                        <image>
+                            <!-- A Docker image using a partial MySQL installation maintained by MySQL team. -->
+                            <name>debezium/mysql-server-gtids-test-database</name>
+                            <alias>database-gtids</alias>
+                            <run>
+                                <namingStrategy>alias</namingStrategy>
+                                <env>
+                                    <MYSQL_ROOT_PASSWORD>debezium-rocks</MYSQL_ROOT_PASSWORD>
+                                    <MYSQL_DATABASE>mysql</MYSQL_DATABASE> <!-- database created upon init -->
+                                    <MYSQL_USER>${mysql.user}</MYSQL_USER>
+                                    <MYSQL_PASSWORD>${mysql.password}</MYSQL_PASSWORD>
+                                </env>
+                                <ports>
+                                    <port>${mysql.gtid.port}:3306</port>
+                                </ports>
+                                <log>
+                                    <prefix>mysql-gtids</prefix>
+                                    <enabled>true</enabled>
+                                    <color>cyan</color>
+                                </log>
+                                <wait>
+                                    <log>MySQL init process done. Ready for start up.(?s)(.*)mysqld: ready for connections.</log>
+                                    <time>${mysql.init.timeout}</time>
+                                </wait>
+                            </run>
+                            <build>
+                                <from>mysql/mysql-server:${version.mysql.server}</from>
+                                <runCmds>
+                                    <run>${docker.initimage}</run>
+                                </runCmds>
+                                <assembly>
+                                    <inline>
+                                        <fileSets>
+                                            <fileSet>
+                                                <directory>${project.basedir}/src/test/docker/server-gtids</directory>
+                                                <includes>
+                                                    <include>my.cnf</include>
+                                                </includes>
+                                                <outputDirectory>etc/mysql</outputDirectory>
+                                            </fileSet>
+                                            <fileSet>
+                                                <directory>${project.basedir}/src/test/docker/init</directory>
+                                                <outputDirectory>docker-entrypoint-initdb.d</outputDirectory>
+                                            </fileSet>
+                                        </fileSets>
+                                    </inline>
+                                    <targetDir>/</targetDir>
+                                </assembly>
+                            </build>
+                            <external>
+                                <type>properties</type>
+                                <mode>override</mode>
+                            </external>
+                        </image>
+                        <image>
+                            <!--
+                            A Docker image using a MySQL installation maintained by MySQL team
+                            that is a replica of `debezium/mysql-server-gtids-test-database`
+                            -->
+                            <name>debezium/mysql-server-gtids-test-database-replica</name>
+                            <run>
+                                <namingStrategy>none</namingStrategy>
+                                <env>
+                                    <MYSQL_ROOT_PASSWORD>debezium-rocks</MYSQL_ROOT_PASSWORD>
+                                    <MYSQL_USER>${mysql.replica.user}</MYSQL_USER>
+                                    <MYSQL_PASSWORD>${mysql.replica.password}</MYSQL_PASSWORD>
+                                </env>
+                                <links>
+                                    <link>database-gtids</link>
+                                </links>
+                                <ports>
+                                    <port>${mysql.gtid.replica.port}:3306</port>
+                                </ports>
+                                <log>
+                                    <prefix>mysql-gtids-replica</prefix>
+                                    <enabled>true</enabled>
+                                    <color>magenta</color>
+                                </log>
+                                <wait>
+                                    <log>MySQL init process done. Ready for start up.(?s)(.*)mysqld: ready for connections.</log>
+                                    <time>${mysql.init.timeout}</time>
+                                </wait>
+                            </run>
+                            <build>
+                                <from>mysql/mysql-server:${version.mysql.server}</from>
+                                <runCmds>
+                                    <run>${docker.initimage}</run>
+                                </runCmds>
+                                <assembly>
+                                    <inline>
+                                        <fileSets>
+                                            <fileSet>
+                                                <directory>${project.basedir}/src/test/docker/server-replica</directory>
+                                                <includes>
+                                                    <include>my.cnf</include>
+                                                </includes>
+                                                <outputDirectory>etc/mysql</outputDirectory>
+                                            </fileSet>
+                                            <fileSet>
+                                                <directory>${project.basedir}/src/test/docker/init-replica</directory>
+                                                <outputDirectory>docker-entrypoint-initdb.d</outputDirectory>
+                                            </fileSet>
+                                        </fileSets>
+                                    </inline>
+                                    <targetDir>/</targetDir>
+                                </assembly>
+                            </build>
+                            <external>
+                                <type>properties</type>
+                                <mode>override</mode>
+                            </external>
+                        </image>
+                        <image>
+                            <!--
+                            A Docker image using a Percona Server installation
+                            -->
+                            <name>debezium/percona-server-test-database</name>
+                            <run>
+                                <namingStrategy>none</namingStrategy>
+                                <env>
+                                    <MYSQL_ROOT_PASSWORD>debezium-rocks</MYSQL_ROOT_PASSWORD>
+                                    <MYSQL_USER>${mysql.user}</MYSQL_USER>
+                                    <MYSQL_PASSWORD>${mysql.password}</MYSQL_PASSWORD>
+                                    <TZ>Pacific/Pago_Pago</TZ>
+                                </env>
+                                <ports>
+                                    <port>${mysql.percona.port}:3306</port>
+                                </ports>
+                                <log>
+                                    <prefix>percona-server</prefix>
+                                    <enabled>true</enabled>
+                                    <color>magenta</color>
+                                </log>
+                                <wait>
+                                    <log>MySQL init process done. Ready for start up.(?s)(.*)mysqld: ready for connections.</log>
+                                    <time>${mysql.init.timeout}</time>
+                                </wait>
+                            </run>
+                            <build>
+                                <from>percona/percona-server:${version.mysql.server}</from>
+                                <assembly>
+                                    <inline>
+                                        <fileSets>
+                                            <fileSet>
+                                                <directory>${project.basedir}/src/test/docker/server</directory>
+                                                <includes>
+                                                    <include>my.cnf</include>
+                                                </includes>
+                                                <outputDirectory>etc/mysql</outputDirectory>
+                                            </fileSet>
+                                            <fileSet>
+                                                <directory>${project.basedir}/src/test/docker/init</directory>
+                                                <outputDirectory>docker-entrypoint-initdb.d</outputDirectory>
+                                            </fileSet>
+                                        </fileSets>
+                                    </inline>
+                                    <targetDir>/</targetDir>
+                                </assembly>
+                            </build>
+                            <external>
+                                <type>properties</type>
+                                <mode>override</mode>
+                            </external>
+                        </image>
+                    </images>
+                </configuration>
+                <!--
+                Connect this plugin to the maven lifecycle around the integration-test phase:
+                start the container in pre-integration-test and stop it in post-integration-test.
+                -->
+                <executions>
+                    <execution>
+                        <id>start</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <!-- 
             Unlike surefire, the failsafe plugin ensures 'post-integration-test' phase always runs, even
@@ -504,8 +505,8 @@
                 </executions>
             </plugin>
             <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-assembly-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>io.debezium</groupId>
@@ -563,13 +564,15 @@
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
-              <!-- Run multiple images at the same time, but use different ports for all MySQL servers -->
-              <docker.filter>debezium/mysql-server-test-database,debezium/mysql-server-gtids-test-database,debezium/mysql-server-gtids-test-database-replica,debezium/percona-server-test-database,debezium/mysql-server-test-database-ssl</docker.filter>
-              <mysql.port>4301</mysql.port>
-              <mysql.gtid.port>4302</mysql.gtid.port>
-              <mysql.gtid.replica.port>4303</mysql.gtid.replica.port>
-              <mysql.percona.port>4304</mysql.percona.port>
-              <mysql.ssl.port>4305</mysql.ssl.port>
+                <!-- Run multiple images at the same time, but use different ports for all MySQL servers -->
+                <docker.filter>
+                    debezium/mysql-server-test-database,debezium/mysql-server-gtids-test-database,debezium/mysql-server-gtids-test-database-replica,debezium/percona-server-test-database,debezium/mysql-server-test-database-ssl
+                </docker.filter>
+                <mysql.port>4301</mysql.port>
+                <mysql.gtid.port>4302</mysql.gtid.port>
+                <mysql.gtid.replica.port>4303</mysql.gtid.replica.port>
+                <mysql.percona.port>4304</mysql.percona.port>
+                <mysql.ssl.port>4305</mysql.ssl.port>
             </properties>
             <build>
                 <plugins>
@@ -700,120 +703,120 @@
             </build>
         </profile>
 
-      <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            Do not perform any Docker-related functionality
-            To use, specify "-DskipITs" on the Maven command line.
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
-      <profile>
-        <id>skip-integration-tests</id>
-        <activation>
-          <activeByDefault>false</activeByDefault>
-          <property>
-            <name>skipITs</name>
-          </property>
-        </activation>
-        <properties>
-          <docker.skip>true</docker.skip>
-        </properties>
-      </profile>
-      <profile>
-        <id>quick</id>
-        <activation>
-          <activeByDefault>false</activeByDefault>
-          <property>
-            <name>quick</name>
-          </property>
-        </activation>
-        <properties>
-          <skipITs>true</skipITs>
-          <docker.skip>true</docker.skip>
-        </properties>
-      </profile>
-      <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            Use the alternative Docker image for MySQL.
-            To use, specify "-Dmysql-gtids" or -Pmysql-gtids on the Maven command line.
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
-      <profile>
-        <id>mysql-gtids</id>
-        <activation>
-          <activeByDefault>false</activeByDefault>
-          <property>
-            <name>mysql-gtids</name>
-          </property>
-        </activation>
-        <properties>
-          <!-- Docker properties -->
-          <docker.filter>debezium/mysql-server-gtids-test-database</docker.filter>
-          <!-- Integration test properties -->
-          <database.port>${mysql.gtid.port}</database.port>
-          <database.replica.port>${mysql.gtid.port}</database.replica.port>
-        </properties>
-      </profile>
-      <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            Use the Docker image for Percona Server.
-            To use, specify "-Dpercona-server" or -Ppercona-server on the Maven command line.
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
-            <profile>
-              <id>percona-server</id>
-              <activation>
+        <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              Do not perform any Docker-related functionality
+              To use, specify "-DskipITs" on the Maven command line.
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+        <profile>
+            <id>skip-integration-tests</id>
+            <activation>
                 <activeByDefault>false</activeByDefault>
                 <property>
-                  <name>percona-server</name>
+                    <name>skipITs</name>
                 </property>
-              </activation>
-              <properties>
+            </activation>
+            <properties>
+                <docker.skip>true</docker.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>quick</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>quick</name>
+                </property>
+            </activation>
+            <properties>
+                <skipITs>true</skipITs>
+                <docker.skip>true</docker.skip>
+            </properties>
+        </profile>
+        <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              Use the alternative Docker image for MySQL.
+              To use, specify "-Dmysql-gtids" or -Pmysql-gtids on the Maven command line.
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+        <profile>
+            <id>mysql-gtids</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>mysql-gtids</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- Docker properties -->
+                <docker.filter>debezium/mysql-server-gtids-test-database</docker.filter>
+                <!-- Integration test properties -->
+                <database.port>${mysql.gtid.port}</database.port>
+                <database.replica.port>${mysql.gtid.port}</database.replica.port>
+            </properties>
+        </profile>
+        <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              Use the Docker image for Percona Server.
+              To use, specify "-Dpercona-server" or -Ppercona-server on the Maven command line.
+              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+        <profile>
+            <id>percona-server</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>percona-server</name>
+                </property>
+            </activation>
+            <properties>
                 <!-- Docker properties -->
                 <docker.filter>debezium/percona-server-test-database</docker.filter>
                 <!-- Integration test properties -->
                 <database.port>${mysql.percona.port}</database.port>
                 <database.replica.port>${mysql.percona.port}</database.replica.port>
                 <docker.initimage>ln -s /usr/share/zoneinfo/Pacific/Pago_Pago /etc/localtime</docker.initimage>
-              </properties>
-            </profile>
-            <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            Use the Docker image for a MySQL replica of another MySQL server 
-            configured to use GTIDs. To use, specify "-Dmysql-replica" 
-            or -Pmysql-replica on the Maven command line.
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+            </properties>
+        </profile>
+        <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        Use the Docker image for a MySQL replica of another MySQL server
+        configured to use GTIDs. To use, specify "-Dmysql-replica"
+        or -Pmysql-replica on the Maven command line.
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 
-      <profile>
-        <id>mysql-replica</id>
-        <activation>
-          <activeByDefault>false</activeByDefault>
-          <property>
-            <name>mysql-replica</name>
-          </property>
-        </activation>
-        <properties>
-          <!-- Docker properties -->
-          <mysql.gtid.port>3306</mysql.gtid.port>
-          <mysql.gtid.replica.port>4306</mysql.gtid.replica.port>
-          <docker.filter>debezium/mysql-server-gtids-test-database,debezium/mysql-server-gtids-test-database-replica</docker.filter>
-          <!-- Integration test properties -->
-          <database.port>${mysql.gtid.port}</database.port>
-          <database.replica.port>${mysql.gtid.replica.port}</database.replica.port>
-        </properties>
-      </profile>
-      <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-      Use the alternative Docker image for MySQL.
-      To use, specify "-Dmysql-ssl" or -Pmysql-ssl on the Maven command line.
-      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
-      <profile>
-        <id>mysql-ssl</id>
-        <activation>
-          <activeByDefault>false</activeByDefault>
-          <property>
-            <name>mysql-ssl</name>
-          </property>
-        </activation>
-        <properties>
-          <!-- Docker properties -->
-          <docker.filter>debezium/mysql-server-test-database-ssl</docker.filter>
-          <!-- Integration test properties -->
-          <database.port>${mysql.ssl.port}</database.port>
-          <database.replica.port>${mysql.ssl.port}</database.replica.port>
-          <docker.initimage>ln -s /usr/share/zoneinfo/Pacific/Pago_Pago /etc/localtime</docker.initimage>
-        </properties>
-      </profile>
+        <profile>
+            <id>mysql-replica</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>mysql-replica</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- Docker properties -->
+                <mysql.gtid.port>3306</mysql.gtid.port>
+                <mysql.gtid.replica.port>4306</mysql.gtid.replica.port>
+                <docker.filter>debezium/mysql-server-gtids-test-database,debezium/mysql-server-gtids-test-database-replica</docker.filter>
+                <!-- Integration test properties -->
+                <database.port>${mysql.gtid.port}</database.port>
+                <database.replica.port>${mysql.gtid.replica.port}</database.replica.port>
+            </properties>
+        </profile>
+        <!--  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        Use the alternative Docker image for MySQL.
+        To use, specify "-Dmysql-ssl" or -Pmysql-ssl on the Maven command line.
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+        <profile>
+            <id>mysql-ssl</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>mysql-ssl</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- Docker properties -->
+                <docker.filter>debezium/mysql-server-test-database-ssl</docker.filter>
+                <!-- Integration test properties -->
+                <database.port>${mysql.ssl.port}</database.port>
+                <database.replica.port>${mysql.ssl.port}</database.replica.port>
+                <docker.initimage>ln -s /usr/share/zoneinfo/Pacific/Pago_Pago /etc/localtime</docker.initimage>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -852,6 +852,19 @@
                     <name>apicurio</name>
                 </property>
             </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <use.apicurio>true</use.apicurio>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
             <properties>
                 <docker.filter>${docker.dbs},apicurio/apicurio-registry-mem:${version.apicurio}</docker.filter>
             </properties>

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDecimalIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDecimalIT.java
@@ -48,7 +48,6 @@ public class MySqlDecimalIT extends AbstractConnectorTest {
         DATABASE.createAndInitialize();
         initializeConnectorTestFramework();
         Testing.Files.delete(SCHEMA_HISTORY_PATH);
-        skipAvroValidation(); // https://github.com/confluentinc/schema-registry/issues/1693
     }
 
     @After

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MysqlDefaultValueIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MysqlDefaultValueIT.java
@@ -72,7 +72,6 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
         DATABASE.createAndInitialize();
         initializeConnectorTestFramework();
         Testing.Files.delete(SCHEMA_HISTORY_PATH);
-        skipAvroValidation(); // https://github.com/confluentinc/schema-registry/issues/1693
     }
 
     @After

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -580,6 +580,19 @@
                     <name>apicurio</name>
                 </property>
             </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <use.apicurio>true</use.apicurio>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
             <properties>
                 <docker.filter>${docker.dbs},apicurio/apicurio-registry-mem:${version.apicurio}</docker.filter>
             </properties>

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
         <version>2.1.0-SNAPSHOT</version>
-	<relativePath>../debezium-parent/pom.xml</relativePath>
+        <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-connector-oracle</artifactId>
@@ -44,8 +45,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-              <groupId>org.antlr</groupId>
-              <artifactId>antlr4-runtime</artifactId>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
@@ -406,61 +407,61 @@
             <build>
                 <plugins>
                     <plugin>
-                      <groupId>io.fabric8</groupId>
-                      <artifactId>docker-maven-plugin</artifactId>
-                      <configuration>
-                        <watchInterval>500</watchInterval>
-                        <logDate>default</logDate>
-                        <verbose>true</verbose>
-                        <!--autoPull>always</autoPull-->
-                        <images>
-                          <!-- A container for the data server replica set -->
-                          <image>
-                            <name>quay.io/rh_integration/dbz-oracle:${version.oracle.server}</name>
-                            <alias>oracle1</alias>
-                            <run>
-                              <namingStrategy>alias</namingStrategy>
-                              <ports>
-                                <port>1521:1521</port> 
-                              </ports>
-                              <log>
-                                <prefix>oracle1</prefix>
-                                <enabled>true</enabled>
-                                <color>yellow</color>
-                              </log>
-                              <wait>
-                                <log>DONE: Executing user defined scripts</log>
-                                <time>120000</time> <!-- 2 minutes max -->
-                              </wait>
-                            </run>
-                            <external>
-                              <type>properties</type>
-                              <mode>override</mode>
-                            </external>
-                          </image>
-                        </images>
-                      </configuration>
-                      <!--
-                      Connect this plugin to the maven lifecycle around the integration-test phase:
-                      start the container in pre-integration-test and stop it in post-integration-test.
-                      -->
-                      <executions>
-                        <execution>
-                          <id>start</id>
-                          <phase>pre-integration-test</phase>
-                          <goals>
-                            <goal>build</goal>
-                            <goal>start</goal>
-                          </goals>
-                        </execution>
-                        <execution>
-                          <id>stop</id>
-                          <phase>post-integration-test</phase>
-                          <goals>
-                            <goal>stop</goal>
-                          </goals>
-                        </execution>
-                      </executions>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <watchInterval>500</watchInterval>
+                            <logDate>default</logDate>
+                            <verbose>true</verbose>
+                            <!--autoPull>always</autoPull-->
+                            <images>
+                                <!-- A container for the data server replica set -->
+                                <image>
+                                    <name>quay.io/rh_integration/dbz-oracle:${version.oracle.server}</name>
+                                    <alias>oracle1</alias>
+                                    <run>
+                                        <namingStrategy>alias</namingStrategy>
+                                        <ports>
+                                            <port>1521:1521</port>
+                                        </ports>
+                                        <log>
+                                            <prefix>oracle1</prefix>
+                                            <enabled>true</enabled>
+                                            <color>yellow</color>
+                                        </log>
+                                        <wait>
+                                            <log>DONE: Executing user defined scripts</log>
+                                            <time>120000</time> <!-- 2 minutes max -->
+                                        </wait>
+                                    </run>
+                                    <external>
+                                        <type>properties</type>
+                                        <mode>override</mode>
+                                    </external>
+                                </image>
+                            </images>
+                        </configuration>
+                        <!--
+                        Connect this plugin to the maven lifecycle around the integration-test phase:
+                        start the container in pre-integration-test and stop it in post-integration-test.
+                        -->
+                        <executions>
+                            <execution>
+                                <id>start</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>start</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>stop</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -146,7 +146,12 @@
         <oracle.infinispan.password>admin</oracle.infinispan.password>
         <docker.skip>false</docker.skip>
         <docker.showLogs>true</docker.showLogs>
+        <docker.dbs>quay.io/rh_integration/dbz-oracle:${version.oracle.server}</docker.dbs>
+        <docker.filter>${docker.dbs}</docker.filter>
         <connector.assembly.ref>connector-distribution</connector.assembly.ref>
+        <!-- Apicurion container properties -->
+        <apicurio.port>8080</apicurio.port>
+        <apicurio.init.timeout>60000</apicurio.init.timeout> <!-- 60 seconds -->
     </properties>
 
     <build>
@@ -439,6 +444,24 @@
                                         <mode>override</mode>
                                     </external>
                                 </image>
+                                <image>
+                                    <name>apicurio/apicurio-registry-mem:${version.apicurio}</name>
+                                    <run>
+                                        <namingStrategy>none</namingStrategy>
+                                        <ports>
+                                            <port>${apicurio.port}:8080</port>
+                                        </ports>
+                                        <log>
+                                            <prefix>apicurio</prefix>
+                                            <enabled>true</enabled>
+                                            <color>blue</color>
+                                        </log>
+                                        <wait>
+                                            <log>.*apicurio-registry-app.*started in.*</log>
+                                            <time>${apicurio.init.timeout}</time>
+                                        </wait>
+                                    </run>
+                                </image>
                             </images>
                         </configuration>
                         <!--
@@ -548,6 +571,18 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>apicurio</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>apicurio</name>
+                </property>
+            </activation>
+            <properties>
+                <docker.filter>${docker.dbs},apicurio/apicurio-registry-mem:${version.apicurio}</docker.filter>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -30,11 +30,17 @@
         <docker.skip>false</docker.skip>
         <docker.showLogs>true</docker.showLogs>
         <docker.initimage>ln -fs /usr/share/zoneinfo/US/Samoa /etc/localtime &amp;&amp; echo timezone=US/Samoa &gt;&gt; ${postgres.config.file}</docker.initimage>
+        <docker.dbs>debezium/postgres-server-test-database</docker.dbs>
+        <docker.filter>${docker.dbs}</docker.filter>
 
         <protobuf.output.directory>${project.basedir}/generated-sources</protobuf.output.directory>
 
         <!-- We're tracking the API changes of the SPI. -->
         <revapi.skip>false</revapi.skip>
+
+        <!-- Apicurion container properties -->
+        <apicurio.port>8080</apicurio.port>
+        <apicurio.init.timeout>60000</apicurio.init.timeout> <!-- 60 seconds -->
     </properties>
 
     <dependencies>
@@ -180,6 +186,24 @@
                                 <type>properties</type>
                                 <mode>override</mode>
                             </external>
+                        </image>
+                        <image>
+                            <name>apicurio/apicurio-registry-mem:${version.apicurio}</name>
+                            <run>
+                                <namingStrategy>none</namingStrategy>
+                                <ports>
+                                    <port>${apicurio.port}:8080</port>
+                                </ports>
+                                <log>
+                                    <prefix>apicurio</prefix>
+                                    <enabled>true</enabled>
+                                    <color>blue</color>
+                                </log>
+                                <wait>
+                                    <log>.*apicurio-registry-app.*started in.*</log>
+                                    <time>${apicurio.init.timeout}</time>
+                                </wait>
+                            </run>
                         </image>
                     </images>
                 </configuration>
@@ -409,6 +433,18 @@
             <properties>
                 <postgres.system.lang>${cs_CZ.iso-8859-2}</postgres.system.lang>
                 <postgres.encoding>LATIN2</postgres.encoding>
+            </properties>
+        </profile>
+        <profile>
+            <id>apicurio</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>apicurio</name>
+                </property>
+            </activation>
+            <properties>
+                <docker.filter>${docker.dbs},apicurio/apicurio-registry-mem:${version.apicurio}</docker.filter>
             </properties>
         </profile>
     </profiles>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
         <version>2.1.0-SNAPSHOT</version>
-	<relativePath>../debezium-parent/pom.xml</relativePath>
+        <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-connector-postgres</artifactId>
@@ -171,9 +172,9 @@
                             </run>
                             <build>
                                 <from>${postgres.image}</from>
-                                 <runCmds>
-                                   <run>${docker.initimage}</run>
-                                 </runCmds>
+                                <runCmds>
+                                    <run>${docker.initimage}</run>
+                                </runCmds>
                             </build>
                             <external>
                                 <type>properties</type>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -443,6 +443,19 @@
                     <name>apicurio</name>
                 </property>
             </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <use.apicurio>true</use.apicurio>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
             <properties>
                 <docker.filter>${docker.dbs},apicurio/apicurio-registry-mem:${version.apicurio}</docker.filter>
             </properties>

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -346,6 +346,19 @@
                     <name>apicurio</name>
                 </property>
             </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <use.apicurio>true</use.apicurio>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
             <properties>
                 <docker.filter>${docker.dbs},apicurio/apicurio-registry-mem:${version.apicurio}</docker.filter>
             </properties>

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -21,9 +21,13 @@
         <sqlserver.user>sa</sqlserver.user>
         <sqlserver.password>Password!</sqlserver.password>
         <sqlserver.dbname>testDB</sqlserver.dbname>
-        <docker.filter>mcr.microsoft.com/mssql/server:2019-latest</docker.filter>
+        <docker.dbs>mcr.microsoft.com/mssql/server:2019-latest</docker.dbs>
+        <docker.filter>${docker.dbs}</docker.filter>
         <docker.skip>false</docker.skip>
         <docker.showLogs>true</docker.showLogs>
+        <!-- Apicurion container properties -->
+        <apicurio.port>8080</apicurio.port>
+        <apicurio.init.timeout>60000</apicurio.init.timeout> <!-- 60 seconds -->
     </properties>
 
     <dependencies>
@@ -145,6 +149,24 @@
                                 <type>properties</type>
                                 <mode>override</mode>
                             </external>
+                        </image>
+                        <image>
+                            <name>apicurio/apicurio-registry-mem:${version.apicurio}</name>
+                            <run>
+                                <namingStrategy>none</namingStrategy>
+                                <ports>
+                                    <port>${apicurio.port}:8080</port>
+                                </ports>
+                                <log>
+                                    <prefix>apicurio</prefix>
+                                    <enabled>true</enabled>
+                                    <color>blue</color>
+                                </log>
+                                <wait>
+                                    <log>.*apicurio-registry-app.*started in.*</log>
+                                    <time>${apicurio.init.timeout}</time>
+                                </wait>
+                            </run>
                         </image>
                     </images>
                 </configuration>
@@ -314,6 +336,18 @@
             </activation>
             <properties>
                 <docker.skip>true</docker.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>apicurio</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>apicurio</name>
+                </property>
+            </activation>
+            <properties>
+                <docker.filter>${docker.dbs},apicurio/apicurio-registry-mem:${version.apicurio}</docker.filter>
             </properties>
         </profile>
     </profiles>

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <groupId>io.debezium</groupId>
         <artifactId>debezium-parent</artifactId>
         <version>2.1.0-SNAPSHOT</version>
-	<relativePath>../debezium-parent/pom.xml</relativePath>
+        <relativePath>../debezium-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>debezium-connector-sqlserver</artifactId>

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -113,6 +113,11 @@
             <artifactId>kafka-connect-avro-converter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-utils-converter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/debezium-core/src/test/java/io/debezium/data/VerifyRecord.java
+++ b/debezium-core/src/test/java/io/debezium/data/VerifyRecord.java
@@ -8,7 +8,10 @@ package io.debezium.data;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
 import java.math.BigDecimal;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -34,6 +37,7 @@ import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.json.JsonDeserializer;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.storage.Converter;
 import org.assertj.core.api.Assertions;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -69,16 +73,28 @@ public class VerifyRecord {
         void assertEquals(String pathToField, Object actualValue, Object expectedValue);
     }
 
+    private static final String APICURIO_URL = "http://localhost:8080/apis/registry/v2";
+
     private static final JsonConverter keyJsonConverter = new JsonConverter();
     private static final JsonConverter valueJsonConverter = new JsonConverter();
     private static final JsonDeserializer keyJsonDeserializer = new JsonDeserializer();
     private static final JsonDeserializer valueJsonDeserializer = new JsonDeserializer();
 
-    private static final MockSchemaRegistryClient schemaRegistry = new MockSchemaRegistryClient();
-    private static final AvroConverter avroKeyConverter = new AvroConverter(schemaRegistry);
-    private static final AvroConverter avroValueConverter = new AvroConverter(schemaRegistry);
+    private static final boolean useApicurio = isApucurioAvailable();
+    private static Converter avroKeyConverter;
+    private static Converter avroValueConverter;
 
     static {
+        if (useApicurio) {
+            avroKeyConverter = new io.apicurio.registry.utils.converter.AvroConverter();
+            avroValueConverter = new io.apicurio.registry.utils.converter.AvroConverter();
+        }
+        else {
+            MockSchemaRegistryClient schemaRegistry = new MockSchemaRegistryClient();
+            avroKeyConverter = new AvroConverter(schemaRegistry);
+            avroValueConverter = new AvroConverter(schemaRegistry);
+        }
+
         Map<String, Object> config = new HashMap<>();
         config.put("schemas.enable", Boolean.TRUE.toString());
         config.put("schemas.cache.size", String.valueOf(100));
@@ -88,7 +104,15 @@ public class VerifyRecord {
         valueJsonDeserializer.configure(config, false);
 
         config = new HashMap<>();
-        config.put("schema.registry.url", "http://fake-url");
+        if (useApicurio) {
+            config.put("apicurio.registry.url", APICURIO_URL);
+            config.put("apicurio.registry.auto-register", true);
+            config.put("apicurio.registry.find-latest", true);
+        }
+        else {
+            config.put("schema.registry.url", "http://fake-url");
+        }
+
         avroKeyConverter.configure(config, false);
         avroValueConverter.configure(config, false);
     }
@@ -823,7 +847,6 @@ public class VerifyRecord {
             assertEquals(setVersion(avroValueWithSchema, null).value(), setVersion(record.value(), null));
             msg = "comparing value to its schema";
             schemaMatchesStruct(avroValueWithSchema);
-
         }
         catch (Throwable t) {
             Testing.Print.enable();
@@ -1263,4 +1286,17 @@ public class VerifyRecord {
         }
         return struct;
     }
+
+    public static boolean isApucurioAvailable() {
+        try {
+            HttpURLConnection conn = (HttpURLConnection) new URL(APICURIO_URL).openConnection();
+            conn.setRequestMethod("HEAD");
+            int respCode = conn.getResponseCode();
+            return respCode == 200;
+        }
+        catch (IOException e) {
+            return false;
+        }
+    }
+
 }

--- a/debezium-core/src/test/java/io/debezium/data/VerifyRecord.java
+++ b/debezium-core/src/test/java/io/debezium/data/VerifyRecord.java
@@ -8,10 +8,7 @@ package io.debezium.data;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
-import java.io.IOException;
 import java.math.BigDecimal;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -1288,15 +1285,8 @@ public class VerifyRecord {
     }
 
     public static boolean isApucurioAvailable() {
-        try {
-            HttpURLConnection conn = (HttpURLConnection) new URL(APICURIO_URL).openConnection();
-            conn.setRequestMethod("HEAD");
-            int respCode = conn.getResponseCode();
-            return respCode == 200;
-        }
-        catch (IOException e) {
-            return false;
-        }
+        String useApicurio = System.getProperty("use.apicurio");
+        return useApicurio != null && useApicurio.equalsIgnoreCase("true");
     }
 
 }

--- a/debezium-embedded/pom.xml
+++ b/debezium-embedded/pom.xml
@@ -74,6 +74,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-utils-converter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <scope>test</scope>

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -891,7 +891,6 @@ public abstract class AbstractConnectorTest implements Testing {
 
     /**
      * Disable record validation using Avro converter.
-     * Introduced to workaround https://github.com/confluentinc/schema-registry/issues/1693
      */
     protected void skipAvroValidation() {
         skipAvroValidation = true;


### PR DESCRIPTION
Run tests with Apicurio registry. Create separate profile which, if activated, starts Apicurio registry container. If the Apicurio registry is available, use it in the tests instead of in-memory Confluent registry. Otherwise fall back to Confluent registry.

https://issues.redhat.com/browse/DBZ-2131