### PR TITLE
DBZ-5626 Do the snapshot also in case of schema history errors

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -731,7 +731,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         /**
          * Performs a snapshot of data and schema upon each connector start.
          */
-        ALWAYS("always", true, true, false),
+        ALWAYS("always", true, true, true),
 
         /**
          * Perform a snapshot of data and schema upon initial startup of a connector.


### PR DESCRIPTION
`ALWAYS` should mean always and also this should be in line with Postgres `ALWAYS` option.

https://issues.redhat.com/browse/DBZ-5626