### PR TITLE
DBZ-4669 Remove duplicate plug-in version properties from debezium-parent POM

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -262,8 +262,9 @@ Marc Zbyszynski
 Marek Winkler
 Mario Mueller
 Mariusz Strzelecki
-Mark Drilling
 Mark Bereznitsky
+Mark Drilling
+Mark Lambert
 Martin Medek
 Martin Sillence
 Matt Beary

--- a/debezium-parent/pom.xml
+++ b/debezium-parent/pom.xml
@@ -16,14 +16,9 @@
     <properties>
 
         <!-- Maven Plugins -->
-        <version.google.formatter.plugin>0.4</version.google.formatter.plugin>
         <version.docker.maven.plugin>0.40.2</version.docker.maven.plugin>
-        <version.protoc.maven.plugin>3.8.0</version.protoc.maven.plugin>
         <version.code.formatter>2.16.0</version.code.formatter>
         <version.impsort>1.6.2</version.impsort>
-        <version.revapi.plugin>0.11.5</version.revapi.plugin>
-        <version.jandex>1.0.8</version.jandex>
-        <version.revapi-java.plugin>0.21.0</version.revapi-java.plugin>
 
         <!-- Dockerfiles -->
         <docker.maintainer>Debezium community</docker.maintainer>

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -168,3 +168,4 @@ janjwerner-confluent,Jan Werner
 enzo-cappa,Enzo Cappa
 zhanghelong,Helong Zhang
 Théophile Helleboid - chtitux,Théophile Helleboid
+dude0001,Mark Lambert


### PR DESCRIPTION
The removed plug-in version properties are duplicates of the same properties in parent POM debezium-build-parent and should not be needed.

There are some plug-in version properties still in debezium-parent that are duplicated by name from debezium-build-parent, but differ in version. I wasn't comfortable removing those without further direction as it would change the version of the plug-in in debezium-parent. I also checked all other POMs that are parented to debezium-build-parent and did not find any other duplicates like this. Local `./mvnw clean verify -DskipITs` build is passing. I'm having issues running integration tests locally and still troubleshooting that.