### PR TITLE
[docs] Updating default poll.intervall.ms in PG connector docs

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3156,7 +3156,7 @@ For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000
 
 |[[postgresql-property-poll-interval-ms]]<<postgresql-property-poll-interval-ms, `+poll.interval.ms+`>>
 |`500`
-|Positive integer value that specifies the number of milliseconds the connector should wait for new change events to appear before it starts processing a batch of events. Defaults to 1000 milliseconds, or 1 second.
+|Positive integer value that specifies the number of milliseconds the connector should wait for new change events to appear before it starts processing a batch of events. Defaults to 500 milliseconds.
 
 |[[postgresql-property-include-unknown-datatypes]]<<postgresql-property-include-unknown-datatypes, `+include.unknown.datatypes+`>>
 |`false`


### PR DESCRIPTION
Hey @jpechane, just noticed this inconsistency in the docs. The actual default is [500ms indeed](https://github.com/debezium/debezium/blob/c781832f41b34461c601879f22e8b0089cce7067/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java#L310).