### PR TITLE
DBZ-5835 Replaces references to obsolete downstream docs attribute

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/avro.adoc
+++ b/documentation/modules/ROOT/pages/configuration/avro.adoc
@@ -215,7 +215,7 @@ pass:quotes[*tree ./my-plugins/*]
 
 . Add the Avro converter to the directory that contains the {prodname} connector that you want to configure to use Avro serialization:
 
-.. Go to the link:{DebeziumDownload} and download the {registry} Kafka Connect zip file.
+.. Go to the link:{LinkDebeziumDownloads}[{NameDebeziumDownloads}] and download the {registry} Kafka Connect zip file.
 .. Extract the archive into the desired {prodname} connector directory.
 
 +

--- a/documentation/modules/ROOT/pages/transformations/content-based-routing.adoc
+++ b/documentation/modules/ROOT/pages/transformations/content-based-routing.adoc
@@ -87,7 +87,7 @@ The following procedure applies if you build your Kafka Connect container image 
 If you use {StreamsName} to create the Kafka Connect image, follow the instructions in the deployment topic for your connector.
 
 .Procedure
-. From a browser, open the link:{DebeziumDownload}, and download the {prodname} scripting SMT archive (`debezium-scripting-{debezium-version}.tar.gz`).
+. From a browser, open the link:{LinkDebeziumDownloads}[{NameDebeziumDownloads}], and download the {prodname} scripting SMT archive (`debezium-scripting-{debezium-version}.tar.gz`).
 . Extract the contents of the archive into the {prodname} plug-in directories of your Kafka Connect environment.
 . Obtain a JSR-223 script engine implementation and add its contents to the {prodname} plug-in directories of your Kafka Connect environment.
 . Restart the Kafka Connect process to pick up the new JAR files.

--- a/documentation/modules/ROOT/pages/transformations/filtering.adoc
+++ b/documentation/modules/ROOT/pages/transformations/filtering.adoc
@@ -85,7 +85,7 @@ The following procedure applies if you build your Kafka Connect container image 
 If you use {StreamsName} to create the Kafka Connect image, follow the instructions in the deployment topic for your connector.
 
 .Procedure
-. From a browser, open the link:{DebeziumDownload}, and download the {prodname} scripting SMT archive (`debezium-scripting-{debezium-version}.tar.gz`).
+. From a browser, open the link:{LinkDebeziumDownloads}[{NameDebeziumDownloads}], and download the {prodname} scripting SMT archive (`debezium-scripting-{debezium-version}.tar.gz`).
 . Extract the contents of the archive into the {prodname} plug-in directories of your Kafka Connect environment.
 . Obtain a JSR-223 script engine implementation and add its contents to the {prodname} plug-in directories of your Kafka Connect environment.
 . Restart the Kafka Connect process to pick up the new JAR files.


### PR DESCRIPTION
[DBZ-5835](https://issues.redhat.com/browse/DBZ-5835)

Replaces three instances of a superseded attribute in content that is conditionalized for downstream use only. This change has no effect on the community version of the documentation.

