### PR TITLE
DBZ-4339 MongoDB connector to prefer secondaries

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoCredential;
+import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoClient;
 import com.mongodb.connection.ClusterDescription;
@@ -52,7 +53,7 @@ public class ConnectionContext implements AutoCloseable {
 
     protected final Configuration config;
     protected final MongoClients pool;
-    protected final DelayStrategy primaryBackoffStrategy;
+    protected final DelayStrategy backoffStrategy;
     protected final boolean useHostsAsSeeds;
 
     /**
@@ -109,7 +110,7 @@ public class ConnectionContext implements AutoCloseable {
 
         final int initialDelayInMs = config.getInteger(MongoDbConnectorConfig.CONNECT_BACKOFF_INITIAL_DELAY_MS);
         final long maxDelayInMs = config.getLong(MongoDbConnectorConfig.CONNECT_BACKOFF_MAX_DELAY_MS);
-        this.primaryBackoffStrategy = DelayStrategy.exponential(Duration.ofMillis(initialDelayInMs), Duration.ofMillis(maxDelayInMs));
+        this.backoffStrategy = DelayStrategy.exponential(Duration.ofMillis(initialDelayInMs), Duration.ofMillis(maxDelayInMs));
     }
 
     public void shutdown() {
@@ -208,12 +209,8 @@ public class ConnectionContext implements AutoCloseable {
         return Duration.ofMillis(config.getLong(MongoDbConnectorConfig.MONGODB_POLL_INTERVAL_MS));
     }
 
-    public int maxConnectionAttemptsForPrimary() {
-        return config.getInteger(MongoDbConnectorConfig.MAX_FAILED_CONNECTIONS);
-    }
-
     /**
-     * Obtain a client that will repeated try to obtain a client to the primary node of the replica set, waiting (and using
+     * Obtain a client that will repeatedly try to obtain a client to the primary node of the replica set, waiting (and using
      * this context's back-off strategy) if required until the primary becomes available.
      *
      * @param replicaSet the replica set information; may not be null
@@ -227,20 +224,36 @@ public class ConnectionContext implements AutoCloseable {
     }
 
     /**
-     * Obtain a client that will repeated try to obtain a client to the primary node of the replica set, waiting (and using
-     * this context's back-off strategy) if required until the primary becomes available.
+     * Obtain a client that will repeatedly try to obtain a client to a node of preferred type of the replica set, waiting (and using
+     * this context's back-off strategy) if required until the node becomes available.
      *
      * @param replicaSet the replica set information; may not be null
+     * @param filters the filter configuration
+     * @param errorHandler the function to be called whenever the node is unable to
+     *            {@link MongoPreferredNode#execute(String, Consumer) execute} an operation to completion; may be null
      * @return the client, or {@code null} if no primary could be found for the replica set
      */
-    protected Supplier<MongoClient> primaryClientFor(ReplicaSet replicaSet) {
-        return primaryClientFor(replicaSet, (attempts, remaining, error) -> {
+    public ConnectionContext.MongoPreferredNode preferredFor(ReplicaSet replicaSet, ReadPreference preference, Filters filters,
+                                                             BiConsumer<String, Throwable> errorHandler) {
+        return new ConnectionContext.MongoPreferredNode(this, replicaSet, preference, filters, errorHandler);
+    }
+
+    /**
+     * Obtain a client that will repeatedly try to obtain a client to a node of preferred type of the replica set, waiting (and using
+     * this context's back-off strategy) if required until the node becomes available.
+     *
+     * @param replicaSet the replica set information; may not be null
+     * @return the client, or {@code null} if no node of preferred type could be found for the replica set
+     */
+    protected Supplier<MongoClient> preferredClientFor(ReplicaSet replicaSet, ReadPreference preference) {
+        return preferredClientFor(replicaSet, preference, (attempts, remaining, error) -> {
             if (error == null) {
-                logger().info("Unable to connect to primary node of '{}' after attempt #{} ({} remaining)", replicaSet, attempts, remaining);
+                logger().info("Unable to connect to {} node of '{}' after attempt #{} ({} remaining)", preference.getName(),
+                        replicaSet, attempts, remaining);
             }
             else {
-                logger().error("Error while attempting to connect to primary node of '{}' after attempt #{} ({} remaining): {}", replicaSet,
-                        attempts, remaining, error.getMessage(), error);
+                logger().error("Error while attempting to connect to {} node of '{}' after attempt #{} ({} remaining): {}", preference.getName(),
+                        replicaSet, attempts, remaining, error.getMessage(), error);
             }
         });
     }
@@ -253,18 +266,18 @@ public class ConnectionContext implements AutoCloseable {
      * @param handler the function that will be called when the primary could not be obtained; may not be null
      * @return the client, or {@code null} if no primary could be found for the replica set
      */
-    protected Supplier<MongoClient> primaryClientFor(ReplicaSet replicaSet, PrimaryConnectFailed handler) {
-        Supplier<MongoClient> factory = () -> clientForPrimary(replicaSet);
-        int maxAttempts = maxConnectionAttemptsForPrimary();
+    protected Supplier<MongoClient> preferredClientFor(ReplicaSet replicaSet, ReadPreference preference, PreferredConnectFailed handler) {
+        Supplier<MongoClient> factory = () -> clientForPreferred(replicaSet, preference);
+        int maxAttempts = config.getInteger(MongoDbConnectorConfig.MAX_FAILED_CONNECTIONS);
         return () -> {
             int attempts = 0;
-            MongoClient primary = null;
-            while (primary == null) {
+            MongoClient client = null;
+            while (client == null) {
                 ++attempts;
                 try {
                     // Try to get the primary
-                    primary = factory.get();
-                    if (primary != null) {
+                    client = factory.get();
+                    if (client != null) {
                         break;
                     }
                 }
@@ -272,35 +285,50 @@ public class ConnectionContext implements AutoCloseable {
                     handler.failed(attempts, maxAttempts - attempts, t);
                 }
                 if (attempts > maxAttempts) {
-                    throw new ConnectException("Unable to connect to primary node of '" + replicaSet + "' after " +
-                            attempts + " failed attempts");
+                    throw new ConnectException("Unable to connect to " + preference.getName() + " node of '" + replicaSet +
+                            "' after " + attempts + " failed attempts");
                 }
                 handler.failed(attempts, maxAttempts - attempts, null);
-                primaryBackoffStrategy.sleepWhen(true);
-                continue;
+                backoffStrategy.sleepWhen(true);
             }
-            return primary;
+            return client;
         };
     }
 
     @FunctionalInterface
-    public static interface PrimaryConnectFailed {
+    public static interface PreferredConnectFailed {
         void failed(int attemptNumber, int attemptsRemaining, Throwable error);
     }
 
     /**
      * A supplier of a client that connects only to the primary of a replica set. Operations on the primary will continue
      */
-    public static class MongoPrimary {
+    public static class MongoPrimary extends MongoPreferredNode {
+        protected MongoPrimary(ConnectionContext context, ReplicaSet replicaSet, Filters filters, BiConsumer<String, Throwable> errorHandler) {
+            super(context, replicaSet, ReadPreference.primary(), filters, errorHandler);
+        }
+    }
+
+    /**
+     * A supplier of a client that connects only to node of preferred type from a replica set. Operations on this node will continue
+     */
+    public static class MongoPreferredNode {
         private final ReplicaSet replicaSet;
-        private final Supplier<MongoClient> primaryConnectionSupplier;
+        private final Supplier<MongoClient> connectionSupplier;
         private final Filters filters;
         private final BiConsumer<String, Throwable> errorHandler;
         private final AtomicBoolean running = new AtomicBoolean(true);
+        private final ReadPreference preference;
 
-        protected MongoPrimary(ConnectionContext context, ReplicaSet replicaSet, Filters filters, BiConsumer<String, Throwable> errorHandler) {
+        protected MongoPreferredNode(
+                                     ConnectionContext context,
+                                     ReplicaSet replicaSet,
+                                     ReadPreference preference,
+                                     Filters filters,
+                                     BiConsumer<String, Throwable> errorHandler) {
             this.replicaSet = replicaSet;
-            this.primaryConnectionSupplier = context.primaryClientFor(replicaSet);
+            this.preference = preference;
+            this.connectionSupplier = context.preferredClientFor(replicaSet, preference);
             this.filters = filters;
             this.errorHandler = errorHandler;
         }
@@ -315,35 +343,44 @@ public class ConnectionContext implements AutoCloseable {
         }
 
         /**
-         * Get the address of the primary node, if there is one.
+         * Get read preference of
          *
-         * @return the address of the replica set's primary node, or {@code null} if there is currently no primary
+         * @return the read preference
+         */
+        public ReadPreference getPreference() {
+            return preference;
+        }
+
+        /**
+         * Get the address of the node with preferred type, if there is one.
+         *
+         * @return the address of the replica set's preferred node, or {@code null} if there is currently no node of preferred type
          */
         public ServerAddress address() {
-            return execute("get replica set primary", primary -> {
-                return MongoUtil.getPrimaryAddress(primary);
+            return execute("get replica set " + preference.getName(), client -> {
+                return MongoUtil.getPreferredAddress(client, preference);
             });
         }
 
         /**
-         * Execute the supplied operation using the primary, blocking until a primary is available. Whenever the operation stops
-         * (e.g., if the primary is no longer primary), then restart the operation using the current primary.
+         * Execute the supplied operation using the preferred node, blocking until it is available. Whenever the operation stops
+         * (e.g., if the node is no longer of preferred type), then restart the operation using a current node of that type.
          *
          * @param desc the description of the operation, for logging purposes
-         * @param operation the operation to be performed on the primary.
+         * @param operation the operation to be performed on a node of preferred type.
          */
         public void execute(String desc, Consumer<MongoClient> operation) {
             final Metronome errorMetronome = Metronome.sleeper(PAUSE_AFTER_ERROR, Clock.SYSTEM);
             while (true) {
-                MongoClient primary = primaryConnectionSupplier.get();
+                MongoClient client = connectionSupplier.get();
                 try {
-                    operation.accept(primary);
+                    operation.accept(client);
                     return;
                 }
                 catch (Throwable t) {
                     errorHandler.accept(desc, t);
                     if (!isRunning()) {
-                        throw new ConnectException("Operation failed and MongoDB primary termination requested", t);
+                        throw new ConnectException("Operation failed and MongoDB " + preference.getName() + " termination requested", t);
                     }
                     try {
                         errorMetronome.pause();
@@ -356,24 +393,24 @@ public class ConnectionContext implements AutoCloseable {
         }
 
         /**
-         * Execute the supplied operation using the primary, blocking until a primary is available. Whenever the operation stops
-         * (e.g., if the primary is no longer primary), then restart the operation using the current primary.
+         * Execute the supplied operation using the preferred node, blocking until it is available. Whenever the operation stops
+         * (e.g., if the node is no longer of preferred type), then restart the operation using a current node of that type.
          *
          * @param desc the description of the operation, for logging purposes
-         * @param operation the operation to be performed on the primary
+         * @param operation the operation to be performed on a node of preferred type
          * @return return value of the executed operation
          */
         public <T> T execute(String desc, Function<MongoClient, T> operation) {
             final Metronome errorMetronome = Metronome.sleeper(PAUSE_AFTER_ERROR, Clock.SYSTEM);
             while (true) {
-                MongoClient primary = primaryConnectionSupplier.get();
+                MongoClient client = connectionSupplier.get();
                 try {
-                    return operation.apply(primary);
+                    return operation.apply(client);
                 }
                 catch (Throwable t) {
                     errorHandler.accept(desc, t);
                     if (!isRunning()) {
-                        throw new ConnectException("Operation failed and MongoDB primary termination requested", t);
+                        throw new ConnectException("Operation failed and MongoDB " + preference.getName() + " termination requested", t);
                     }
                     try {
                         errorMetronome.pause();
@@ -386,19 +423,19 @@ public class ConnectionContext implements AutoCloseable {
         }
 
         /**
-         * Execute the supplied operation using the primary, blocking until a primary is available. Whenever the operation stops
-         * (e.g., if the primary is no longer primary), then restart the operation using the current primary.
+         * Execute the supplied operation using the preferred node, blocking until it is available. Whenever the operation stops
+         * (e.g., if the node is no longer of preferred type), then restart the operation using a current node of that type.
          *
          * @param desc the description of the operation, for logging purposes
-         * @param operation the operation to be performed on the primary.
+         * @param operation the operation to be performed on a node of preferred type.
          * @throws InterruptedException if the operation was interrupted
          */
         public void executeBlocking(String desc, BlockingConsumer<MongoClient> operation) throws InterruptedException {
             final Metronome errorMetronome = Metronome.sleeper(PAUSE_AFTER_ERROR, Clock.SYSTEM);
             while (true) {
-                MongoClient primary = primaryConnectionSupplier.get();
+                MongoClient client = connectionSupplier.get();
                 try {
-                    operation.accept(primary);
+                    operation.accept(client);
                     return;
                 }
                 catch (InterruptedException e) {
@@ -407,7 +444,7 @@ public class ConnectionContext implements AutoCloseable {
                 catch (Throwable t) {
                     errorHandler.accept(desc, t);
                     if (!isRunning()) {
-                        throw new ConnectException("Operation failed and MongoDB primary termination requested", t);
+                        throw new ConnectException("Operation failed and MongoDB " + preference.getName() + " termination requested", t);
                     }
                     errorMetronome.pause();
                 }
@@ -415,18 +452,18 @@ public class ConnectionContext implements AutoCloseable {
         }
 
         /**
-         * Use the primary to get the names of all the databases in the replica set, applying the current database
-         * filter configuration. This method will block until a primary can be obtained to get the names of all
+         * Use a node of preferred type to get the names of all the databases in the replica set, applying the current database
+         * filter configuration. This method will block until a node of preferred type can be obtained to get the names of all
          * databases in the replica set.
          *
          * @return the database names; never null but possibly empty
          */
         public Set<String> databaseNames() {
-            return execute("get database names", primary -> {
+            return execute("get database names", client -> {
                 Set<String> databaseNames = new HashSet<>();
 
                 MongoUtil.forEachDatabaseName(
-                        primary,
+                        client,
                         dbName -> {
                             if (filters.databaseFilter().test(dbName)) {
                                 databaseNames.add(dbName);
@@ -438,7 +475,7 @@ public class ConnectionContext implements AutoCloseable {
         }
 
         /**
-         * Use the primary to get the identifiers of all the collections in the replica set, applying the current
+         * Use a node of preferred type to get the identifiers of all the collections in the replica set, applying the current
          * collection filter configuration. This method will block until a primary can be obtained to get the
          * identifiers of all collections in the replica set.
          *
@@ -448,12 +485,12 @@ public class ConnectionContext implements AutoCloseable {
             String replicaSetName = replicaSet.replicaSetName();
 
             // For each database, get the list of collections ...
-            return execute("get collections in databases", primary -> {
+            return execute("get collections in databases", client -> {
                 List<CollectionId> collections = new ArrayList<>();
                 Set<String> databaseNames = databaseNames();
 
                 for (String dbName : databaseNames) {
-                    MongoUtil.forEachCollectionNameInDatabase(primary, dbName, collectionName -> {
+                    MongoUtil.forEachCollectionNameInDatabase(client, dbName, collectionName -> {
                         CollectionId collectionId = new CollectionId(replicaSetName, dbName, collectionName);
 
                         if (filters.collectionFilter().test(collectionId)) {
@@ -484,7 +521,7 @@ public class ConnectionContext implements AutoCloseable {
      * @param replicaSet the replica set information; may not be null
      * @return the client, or {@code null} if no primary could be found for the replica set
      */
-    protected MongoClient clientForPrimary(ReplicaSet replicaSet) {
+    protected MongoClient clientForPreferred(ReplicaSet replicaSet, ReadPreference preference) {
         MongoClient replicaSetClient = clientFor(replicaSet);
         final ClusterDescription clusterDescription = MongoUtil.clusterDescription(replicaSetClient);
         if (clusterDescription.getType() == ClusterType.UNKNOWN) {
@@ -497,9 +534,9 @@ public class ConnectionContext implements AutoCloseable {
                     "' is not a valid replica set and cannot be used");
         }
         // It is a replica set ...
-        ServerAddress primaryAddress = MongoUtil.getPrimaryAddress(replicaSetClient);
-        if (primaryAddress != null) {
-            return pool.clientFor(primaryAddress);
+        ServerAddress preferredAddress = MongoUtil.getPreferredAddress(replicaSetClient, preference);
+        if (preferredAddress != null) {
+            return pool.clientFor(preferredAddress);
         }
         return null;
     }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
@@ -27,12 +27,13 @@ import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.mongodb.ReadPreference;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 
 import io.debezium.connector.SnapshotRecord;
-import io.debezium.connector.mongodb.ConnectionContext.MongoPrimary;
+import io.debezium.connector.mongodb.ConnectionContext.MongoPreferredNode;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.EventDispatcher.SnapshotReceiver;
@@ -181,17 +182,17 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
         final MongoDbOffsetContext offsetContext = (MongoDbOffsetContext) previousOffset;
         try {
             replicaSets.onEachReplicaSet(replicaSet -> {
-                MongoPrimary primary = null;
+                MongoPreferredNode mongo = null;
                 try {
-                    primary = establishConnectionToPrimary(partition, replicaSet);
+                    mongo = establishConnection(partition, replicaSet, ReadPreference.primaryPreferred());
                     final ReplicaSetOffsetContext rsOffsetContext = offsetContext.getReplicaSetOffsetContext(replicaSet);
-                    if (primary != null && isSnapshotExpected(primary, rsOffsetContext)) {
+                    if (mongo != null && isSnapshotExpected(mongo, rsOffsetContext)) {
                         replicaSetSnapshots.add(replicaSet);
                     }
                 }
                 finally {
-                    if (primary != null) {
-                        primary.stop();
+                    if (mongo != null) {
+                        mongo.stop();
                     }
                 }
             });
@@ -210,35 +211,35 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
     }
 
     private void snapshotReplicaSet(ChangeEventSourceContext sourceContext, MongoDbSnapshotContext ctx, ReplicaSet replicaSet) throws InterruptedException {
-        MongoPrimary primaryClient = null;
+        MongoPreferredNode mongo = null;
         try {
-            primaryClient = establishConnectionToPrimary(ctx.partition, replicaSet);
-            if (primaryClient != null) {
-                createDataEvents(sourceContext, ctx, replicaSet, primaryClient);
+            mongo = establishConnection(ctx.partition, replicaSet, ReadPreference.secondaryPreferred());
+            if (mongo != null) {
+                createDataEvents(sourceContext, ctx, replicaSet, mongo);
             }
         }
         finally {
-            if (primaryClient != null) {
-                primaryClient.stop();
+            if (mongo != null) {
+                mongo.stop();
             }
         }
     }
 
-    private MongoPrimary establishConnectionToPrimary(MongoDbPartition partition, ReplicaSet replicaSet) {
-        return connectionContext.primaryFor(replicaSet, taskContext.filters(), (desc, error) -> {
+    private MongoPreferredNode establishConnection(MongoDbPartition partition, ReplicaSet replicaSet, ReadPreference preference) {
+        return connectionContext.preferredFor(replicaSet, preference, taskContext.filters(), (desc, error) -> {
             // propagate authorization failures
             if (error.getMessage() != null && error.getMessage().startsWith(AUTHORIZATION_FAILURE_MESSAGE)) {
                 throw new ConnectException("Error while attempting to " + desc, error);
             }
             else {
                 dispatcher.dispatchConnectorEvent(partition, new DisconnectEvent());
-                LOGGER.error("Error while attempting to {}: ", desc, error.getMessage(), error);
+                LOGGER.error("Error while attempting to {}: {}", desc, error.getMessage(), error);
                 throw new ConnectException("Error while attempting to " + desc, error);
             }
         });
     }
 
-    private boolean isSnapshotExpected(MongoPrimary primaryClient, ReplicaSetOffsetContext offsetContext) {
+    private boolean isSnapshotExpected(MongoPreferredNode mongo, ReplicaSetOffsetContext offsetContext) {
         boolean performSnapshot = true;
         if (offsetContext.hasOffset()) {
             if (LOGGER.isInfoEnabled()) {
@@ -255,8 +256,8 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
                 // same options as other connectors and this is where when_needed functionality would go.
                 // There is no ongoing snapshot, so look to see if our last recorded offset still exists in the oplog.
                 BsonTimestamp lastRecordedTs = offsetContext.lastOffsetTimestamp();
-                BsonTimestamp firstAvailableTs = primaryClient.execute("get oplog position", primary -> {
-                    return SourceInfo.extractEventTimestamp(MongoUtil.getOplogEntry(primary, 1, LOGGER));
+                BsonTimestamp firstAvailableTs = mongo.execute("get oplog position", client -> {
+                    return SourceInfo.extractEventTimestamp(MongoUtil.getOplogEntry(client, 1, LOGGER));
                 });
 
                 if (firstAvailableTs == null) {
@@ -289,16 +290,16 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
         final Map<ReplicaSet, BsonDocument> positions = new LinkedHashMap<>();
         replicaSets.onEachReplicaSet(replicaSet -> {
             LOGGER.info("Determine Snapshot Offset for replica-set {}", replicaSet.replicaSetName());
-            MongoPrimary primaryClient = establishConnectionToPrimary(ctx.partition, replicaSet);
-            if (primaryClient != null) {
+            MongoPreferredNode mongo = establishConnection(ctx.partition, replicaSet, ReadPreference.primaryPreferred());
+            if (mongo != null) {
                 try {
-                    primaryClient.execute("get oplog position", primary -> {
-                        positions.put(replicaSet, MongoUtil.getOplogEntry(primary, -1, LOGGER));
+                    mongo.execute("get oplog position", client -> {
+                        positions.put(replicaSet, MongoUtil.getOplogEntry(client, -1, LOGGER));
                     });
                 }
                 finally {
                     LOGGER.info("Stopping primary client");
-                    primaryClient.stop();
+                    mongo.stop();
                 }
             }
         });
@@ -308,12 +309,12 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
     }
 
     private void createDataEvents(ChangeEventSourceContext sourceContext, MongoDbSnapshotContext snapshotContext, ReplicaSet replicaSet,
-                                  MongoPrimary primaryClient)
+                                  MongoPreferredNode mongo)
             throws InterruptedException {
         SnapshotReceiver<MongoDbPartition> snapshotReceiver = dispatcher.getSnapshotChangeEventReceiver();
         snapshotContext.offset.preSnapshotStart();
 
-        createDataEventsForReplicaSet(sourceContext, snapshotContext, snapshotReceiver, replicaSet, primaryClient);
+        createDataEventsForReplicaSet(sourceContext, snapshotContext, snapshotReceiver, replicaSet, mongo);
 
         snapshotContext.offset.preSnapshotCompletion();
         snapshotReceiver.completeSnapshot();
@@ -326,7 +327,7 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
     private void createDataEventsForReplicaSet(ChangeEventSourceContext sourceContext,
                                                MongoDbSnapshotContext snapshotContext,
                                                SnapshotReceiver<MongoDbPartition> snapshotReceiver,
-                                               ReplicaSet replicaSet, MongoPrimary primaryClient)
+                                               ReplicaSet replicaSet, MongoPreferredNode mongo)
             throws InterruptedException {
 
         final String rsName = replicaSet.replicaSetName();
@@ -339,7 +340,7 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
 
         LOGGER.info("Beginning snapshot of '{}' at {}", rsName, rsOffsetContext.getOffset());
 
-        final List<CollectionId> collections = determineDataCollectionsToBeSnapshotted(primaryClient.collections()).collect(Collectors.toList());
+        final List<CollectionId> collections = determineDataCollectionsToBeSnapshotted(mongo.collections()).collect(Collectors.toList());
         snapshotProgressListener.monitoredDataCollectionsDetermined(snapshotContext.partition, collections);
         if (connectorConfig.getSnapshotMaxThreads() > 1) {
             // Since multiple snapshot threads are to be used, create a thread pool and initiate the snapshot.
@@ -377,7 +378,7 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
                                     snapshotReceiver,
                                     replicaSet,
                                     id,
-                                    primaryClient);
+                                    mongo);
                         }
                     }
                     catch (InterruptedException e) {
@@ -422,7 +423,7 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
                         snapshotReceiver,
                         replicaSet,
                         collectionId,
-                        primaryClient);
+                        mongo);
             }
         }
 
@@ -432,14 +433,14 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
     private void createDataEventsForCollection(ChangeEventSourceContext sourceContext,
                                                MongoDbSnapshotContext snapshotContext,
                                                SnapshotReceiver<MongoDbPartition> snapshotReceiver,
-                                               ReplicaSet replicaSet, CollectionId collectionId, MongoPrimary primaryClient)
+                                               ReplicaSet replicaSet, CollectionId collectionId, MongoPreferredNode mongo)
             throws InterruptedException {
 
         long exportStart = clock.currentTimeInMillis();
         LOGGER.info("\t Exporting data for collection '{}'", collectionId);
 
-        primaryClient.executeBlocking("sync '" + collectionId + "'", primary -> {
-            final MongoDatabase database = primary.getDatabase(collectionId.dbName());
+        mongo.executeBlocking("sync '" + collectionId + "'", client -> {
+            final MongoDatabase database = client.getDatabase(collectionId.dbName());
             final MongoCollection<BsonDocument> collection = database.getCollection(collectionId.name(), BsonDocument.class);
 
             final int batchSize = taskContext.getConnectorConfig().getSnapshotFetchSize();

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
@@ -25,6 +25,7 @@ import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.ChangeStreamIterable;
 import com.mongodb.client.MongoClient;
@@ -35,7 +36,7 @@ import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.client.model.changestream.FullDocumentBeforeChange;
 
-import io.debezium.connector.mongodb.ConnectionContext.MongoPrimary;
+import io.debezium.connector.mongodb.ConnectionContext.MongoPreferredNode;
 import io.debezium.data.Envelope.Operation;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
@@ -106,13 +107,13 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
 
     private void streamChangesForReplicaSet(ChangeEventSourceContext context, MongoDbPartition partition,
                                             ReplicaSet replicaSet, MongoDbOffsetContext offsetContext) {
-        MongoPrimary primaryClient = null;
+        MongoPreferredNode mongo = null;
         try {
-            primaryClient = establishConnectionToPrimary(partition, replicaSet);
-            if (primaryClient != null) {
-                final AtomicReference<MongoPrimary> primaryReference = new AtomicReference<>(primaryClient);
-                primaryClient.execute("read from change stream on '" + replicaSet + "'", primary -> {
-                    readChangeStream(primary, primaryReference.get(), replicaSet, context, offsetContext);
+            mongo = establishConnection(partition, replicaSet, ReadPreference.secondaryPreferred());
+            if (mongo != null) {
+                final AtomicReference<MongoPreferredNode> mongoReference = new AtomicReference<>(mongo);
+                mongo.execute("read from change stream on '" + replicaSet + "'", client -> {
+                    readChangeStream(client, mongoReference.get(), replicaSet, context, offsetContext);
                 });
             }
         }
@@ -121,8 +122,8 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
             errorHandler.setProducerThrowable(t);
         }
         finally {
-            if (primaryClient != null) {
-                primaryClient.stop();
+            if (mongo != null) {
+                mongo.stop();
             }
         }
     }
@@ -157,8 +158,8 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
         executor.shutdown();
     }
 
-    private MongoPrimary establishConnectionToPrimary(MongoDbPartition partition, ReplicaSet replicaSet) {
-        return connectionContext.primaryFor(replicaSet, taskContext.filters(), (desc, error) -> {
+    private MongoPreferredNode establishConnection(MongoDbPartition partition, ReplicaSet replicaSet, ReadPreference preference) {
+        return connectionContext.preferredFor(replicaSet, preference, taskContext.filters(), (desc, error) -> {
             // propagate authorization failures
             if (error.getMessage() != null && error.getMessage().startsWith(AUTHORIZATION_FAILURE_MESSAGE)) {
                 throw new ConnectException("Error while attempting to " + desc, error);
@@ -190,17 +191,17 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
         return includedOperations;
     }
 
-    private void readChangeStream(MongoClient primary, MongoPrimary primaryClient, ReplicaSet replicaSet, ChangeEventSourceContext context,
+    private void readChangeStream(MongoClient client, MongoPreferredNode mongo, ReplicaSet replicaSet, ChangeEventSourceContext context,
                                   MongoDbOffsetContext offsetContext) {
         final ReplicaSetPartition rsPartition = offsetContext.getReplicaSetPartition(replicaSet);
         final ReplicaSetOffsetContext rsOffsetContext = offsetContext.getReplicaSetOffsetContext(replicaSet);
 
         final BsonTimestamp oplogStart = rsOffsetContext.lastOffsetTimestamp();
 
-        ReplicaSetChangeStreamsContext oplogContext = new ReplicaSetChangeStreamsContext(rsPartition, rsOffsetContext, primaryClient, replicaSet);
+        ReplicaSetChangeStreamsContext oplogContext = new ReplicaSetChangeStreamsContext(rsPartition, rsOffsetContext, mongo, replicaSet);
 
-        final ServerAddress primaryAddress = MongoUtil.getPrimaryAddress(primary);
-        LOGGER.info("Reading change stream for '{}' primary {} starting at {}", replicaSet, primaryAddress, oplogStart);
+        final ServerAddress nodeAddress = MongoUtil.getPreferredAddress(client, mongo.getPreference());
+        LOGGER.info("Reading change stream for '{}'/{} from {} starting at {}", replicaSet, mongo.getPreference().getName(), nodeAddress, oplogStart);
 
         Bson filters = Filters.in("operationType", getChangeStreamSkippedOperationsFilter());
         if (rsOffsetContext.lastResumeToken() == null) {
@@ -208,7 +209,7 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
             // It must be filtered-out
             filters = Filters.and(filters, Filters.ne("clusterTime", oplogStart));
         }
-        final ChangeStreamIterable<BsonDocument> rsChangeStream = primary.watch(
+        final ChangeStreamIterable<BsonDocument> rsChangeStream = client.watch(
                 Arrays.asList(Aggregates.match(filters)), BsonDocument.class);
         if (taskContext.getCaptureMode().isFullUpdate()) {
             rsChangeStream.fullDocument(FullDocument.UPDATE_LOOKUP);
@@ -299,16 +300,16 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
         final Map<ReplicaSet, BsonDocument> positions = new LinkedHashMap<>();
         replicaSets.onEachReplicaSet(replicaSet -> {
             LOGGER.info("Determine Snapshot Offset for replica-set {}", replicaSet.replicaSetName());
-            MongoPrimary primaryClient = establishConnectionToPrimary(partition, replicaSet);
-            if (primaryClient != null) {
+            MongoPreferredNode mongo = establishConnection(partition, replicaSet, ReadPreference.primaryPreferred());
+            if (mongo != null) {
                 try {
-                    primaryClient.execute("get oplog position", primary -> {
-                        positions.put(replicaSet, MongoUtil.getOplogEntry(primary, -1, LOGGER));
+                    mongo.execute("get oplog position", client -> {
+                        positions.put(replicaSet, MongoUtil.getOplogEntry(client, -1, LOGGER));
                     });
                 }
                 finally {
                     LOGGER.info("Stopping primary client");
-                    primaryClient.stop();
+                    mongo.stop();
                 }
             }
         });
@@ -320,17 +321,17 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
     /**
      * A context associated with a given replica set oplog read operation.
      */
-    private class ReplicaSetChangeStreamsContext {
+    private static class ReplicaSetChangeStreamsContext {
         private final ReplicaSetPartition partition;
         private final ReplicaSetOffsetContext offset;
-        private final MongoPrimary primary;
+        private final MongoPreferredNode mongo;
         private final ReplicaSet replicaSet;
 
         ReplicaSetChangeStreamsContext(ReplicaSetPartition partition, ReplicaSetOffsetContext offsetContext,
-                                       MongoPrimary primary, ReplicaSet replicaSet) {
+                                       MongoPreferredNode mongo, ReplicaSet replicaSet) {
             this.partition = partition;
             this.offset = offsetContext;
-            this.primary = primary;
+            this.mongo = mongo;
             this.replicaSet = replicaSet;
         }
 
@@ -342,8 +343,8 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
             return offset;
         }
 
-        MongoPrimary getPrimary() {
-            return primary;
+        MongoPreferredNode getMongo() {
+            return mongo;
         }
 
         String getReplicaSetName() {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoUtil.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoUtil.java
@@ -369,26 +369,29 @@ public class MongoUtil {
         return Strings.join(ADDRESS_DELIMITER, addresses);
     }
 
-    protected static ServerAddress getPrimaryAddress(MongoClient client) {
-
+    protected static ServerAddress getPreferredAddress(MongoClient client, ReadPreference preference) {
         ClusterDescription clusterDescription = clusterDescription(client);
 
-        if (!clusterDescription.hasReadableServer(ReadPreference.primaryPreferred())) {
+        if (!clusterDescription.hasReadableServer(preference)) {
             throw new DebeziumException("Unable to use cluster description from MongoDB connection: " + clusterDescription);
         }
 
-        List<ServerDescription> serverDescriptions = clusterDescription.getServerDescriptions();
+        List<ServerDescription> serverDescriptions = preference.choose(clusterDescription);
 
-        if (serverDescriptions == null || serverDescriptions.size() == 0) {
+        if (serverDescriptions.size() == 0) {
             throw new DebeziumException("Unable to read server descriptions from MongoDB connection (Null or empty list).");
         }
 
-        Optional<ServerDescription> primaryDescription = serverDescriptions.stream().filter(ServerDescription::isPrimary).findFirst();
+        Optional<ServerDescription> preferredDescription = serverDescriptions.stream().findFirst();
 
-        return primaryDescription
+        return preferredDescription
                 .map(ServerDescription::getAddress)
                 .map(address -> new ServerAddress(address.getHost(), address.getPort()))
                 .orElseThrow(() -> new DebeziumException("Unable to find primary from MongoDB connection, got '" + serverDescriptions + "'"));
+    }
+
+    protected static ServerAddress getPrimaryAddress(MongoClient client) {
+        return getPreferredAddress(client, ReadPreference.primary());
     }
 
     /**

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoUtil.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoUtil.java
@@ -230,9 +230,9 @@ public class MongoUtil {
         return null;
     }
 
-    public static BsonDocument getOplogEntry(MongoClient primary, int sortOrder, Logger logger) throws MongoQueryException {
+    public static BsonDocument getOplogEntry(MongoClient client, int sortOrder, Logger logger) throws MongoQueryException {
         try {
-            MongoCollection<BsonDocument> oplog = primary.getDatabase("local").getCollection("oplog.rs", BsonDocument.class);
+            MongoCollection<BsonDocument> oplog = client.getDatabase("local").getCollection("oplog.rs", BsonDocument.class);
             return oplog.find().sort(new Document("$natural", sortOrder)).limit(1).first();
         }
         catch (MongoQueryException e) {
@@ -388,10 +388,6 @@ public class MongoUtil {
                 .map(ServerDescription::getAddress)
                 .map(address -> new ServerAddress(address.getHost(), address.getPort()))
                 .orElseThrow(() -> new DebeziumException("Unable to find primary from MongoDB connection, got '" + serverDescriptions + "'"));
-    }
-
-    protected static ServerAddress getPrimaryAddress(MongoClient client) {
-        return getPreferredAddress(client, ReadPreference.primary());
     }
 
     /**

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoUtilIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoUtilIT.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 import org.junit.Test;
 
+import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
 import com.mongodb.connection.ServerDescription;
 
@@ -41,7 +42,7 @@ public class MongoUtilIT extends AbstractMongoIT {
         assertThat(expectedPrimaryAddress).isPresent();
 
         primary.execute("shouldConnect", mongo -> {
-            ServerAddress primaryAddress = MongoUtil.getPrimaryAddress(mongo);
+            ServerAddress primaryAddress = MongoUtil.getPreferredAddress(mongo, ReadPreference.primary());
             assertThat(primaryAddress.getHost()).isEqualTo(expectedPrimaryAddress.map(ServerAddress::getHost).get());
             assertThat(primaryAddress.getPort()).isEqualTo(expectedPrimaryAddress.map(ServerAddress::getPort).get());
         });


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4339

So far this PR does several things

- Generalises `MongoPrimary` to `MongoPreferredNode`
- Oplog positions are read from primary to get latest data (However this can easily be configurable as oplog[ can be read from secondary](https://www.mongodb.com/docs/manual/core/replica-set-oplog/)) 
- Collection names are read from primary as well 
- The actual data reading (event construction) in snapshot is performed against secondary
- Change stream is opened against secondary 


What is missing
- `MongoDbIncrementalSnapshotChangeEventSource` still uses primary 
-  When secondary which is being used to stream changes is promoted to primary the event stream is not recreated
 
This also needs to be tested somehow against a real replica set (what we have in tests is not sufficient). 
