### PR TITLE
DBZ-5855: IllegalStateException is thrown if task is recovering while other tasks are running

### DIFF
--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -370,7 +370,7 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
         // The end offset should never change during recovery; doing this check here just as - a rather weak - attempt
         // to spot other connectors that share the same history topic accidentally
         if (previousEndOffset != null && !previousEndOffset.equals(endOffset)) {
-            throw new IllegalStateException("Detected changed end offset of database schema history topic (previous: "
+            LOGGER.warn("Detected changed end offset of database schema history topic (previous: "
                     + previousEndOffset + ", current: " + endOffset
                     + "). Make sure that the same history topic isn't shared by multiple connector instances.");
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5855

- The PR only removes "end offset was modified" check as it doesn't fit multi task model and may cause issues. 
- The PR doesn't introduce / suggest any alternative