### PR TITLE
DBZ-5852:Snapshotter#snapshotCompleted is invoked regardless of snaps…

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
@@ -381,10 +381,6 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
         return SchemaChangeEvent.ofSnapshotCreate(snapshotContext.partition, snapshotContext.offset, snapshotContext.catalogName, table);
     }
 
-    @Override
-    protected void complete(SnapshotContext<MySqlPartition, MySqlOffsetContext> snapshotContext) {
-    }
-
     /**
      * Generate a valid MySQL query string for the specified table and columns
      *

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -276,7 +276,7 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
     }
 
     @Override
-    protected void complete(SnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext) {
+    public void close() {
         if (connectorConfig.getPdbName() != null) {
             jdbcConnection.resetSessionToCdb();
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSnapshotChangeEventSource.java
@@ -208,8 +208,13 @@ public class PostgresSnapshotChangeEventSource extends RelationalSnapshotChangeE
     }
 
     @Override
-    protected void complete(SnapshotContext<PostgresPartition, PostgresOffsetContext> snapshotContext) {
+    protected void completed(SnapshotContext<PostgresPartition, PostgresOffsetContext> snapshotContext) {
         snapshotter.snapshotCompleted();
+    }
+
+    @Override
+    protected void aborted(SnapshotContext<PostgresPartition, PostgresOffsetContext> snapshotContext) {
+        snapshotter.snapshotAborted();
     }
 
     /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/Snapshotter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/spi/Snapshotter.java
@@ -96,9 +96,16 @@ public interface Snapshotter {
     }
 
     /**
-     * Lifecycle hook called once the snapshot phase is finished.
+     * Lifecycle hook called once the snapshot phase is successful.
      */
     default void snapshotCompleted() {
+        // no operation
+    }
+
+    /**
+     * Lifecycle hook called once the snapshot phase is aborted.
+     */
+    default void snapshotAborted() {
         // no operation
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomLifecycleHookTestSnapshot.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomLifecycleHookTestSnapshot.java
@@ -13,8 +13,16 @@ public class CustomLifecycleHookTestSnapshot extends AlwaysSnapshotter {
     private static final String INSERT_SNAPSHOT_COMPLETE_STATE = "INSERT INTO s1.lifecycle_state (hook, state) " +
             "VALUES ('snapshotComplete', 'complete');";
 
+    private static final String INSERT_SNAPSHOT_ABORTED_STATE = "INSERT INTO s1.lifecycle_state (hook, state) " +
+            "VALUES ('snapshotComplete', 'aborted');";
+
     @Override
     public void snapshotCompleted() {
         TestHelper.execute(INSERT_SNAPSHOT_COMPLETE_STATE);
+    }
+
+    @Override
+    public void snapshotAborted() {
+        TestHelper.execute(INSERT_SNAPSHOT_ABORTED_STATE);
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -3134,6 +3134,57 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
                         .containsMessage("Postgres server doesn't support the command pg_replication_slot_advance(). Not seeking to last known offset."));
     }
 
+    @Test
+    @FixFor("DBZ-5852")
+    public void shouldInvokeSnapshotterAbortedMethod() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        // insert another set of rows so we can stop at certain point
+        String setupStmt = SETUP_TABLES_STMT + INSERT_STMT + INSERT_STMT + INSERT_STMT;
+        TestHelper.execute(setupStmt);
+
+        TestHelper.execute(
+                "CREATE TABLE s1.lifecycle_state (hook text, state text, PRIMARY KEY(hook));");
+
+        Configuration.Builder configBuilder = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.MAX_BATCH_SIZE, 1)
+                .with(PostgresConnectorConfig.MAX_QUEUE_SIZE, 2)
+                .with(PostgresConnectorConfig.MAX_RETRIES, 1)
+                .with(PostgresConnectorConfig.POLL_INTERVAL_MS, 60 * 1000)
+                .with(PostgresConnectorConfig.SNAPSHOT_FETCH_SIZE, 1)
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.CUSTOM.getValue())
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE_CLASS, CustomLifecycleHookTestSnapshot.class.getName())
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.FALSE);
+
+        EmbeddedEngine.CompletionCallback completionCallback = (success, message, error) -> {
+            if (error != null) {
+                latch.countDown();
+            }
+            else {
+                fail("A controlled exception was expected....");
+            }
+        };
+
+        start(PostgresConnector.class, configBuilder.build(), completionCallback, stopOnPKPredicate(1));
+
+        // wait until we know we've raised the exception at startup AND the engine has been shutdown
+        if (!latch.await(TestHelper.waitTimeForRecords() * 5, TimeUnit.SECONDS)) {
+            fail("did not reach stop condition in time");
+        }
+
+        try (PostgresConnection connection = TestHelper.create()) {
+            List<String> snapshotCompleteState = connection.queryAndMap(
+                    "SELECT state FROM s1.lifecycle_state WHERE hook like 'snapshotComplete'",
+                    rs -> {
+                        final List<String> ret = new ArrayList<>();
+                        while (rs.next()) {
+                            ret.add(rs.getString(1));
+                        }
+                        return ret;
+                    });
+            assertEquals(Collections.singletonList("aborted"), snapshotCompleteState);
+        }
+    }
+
     private Predicate<SourceRecord> stopOnPKPredicate(int pkValue) {
         return record -> {
             Struct key = (Struct) record.key();

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerSnapshotChangeEventSource.java
@@ -233,7 +233,16 @@ public class SqlServerSnapshotChangeEventSource extends RelationalSnapshotChange
     }
 
     @Override
-    protected void complete(SnapshotContext<SqlServerPartition, SqlServerOffsetContext> snapshotContext) {
+    protected void completed(SnapshotContext<SqlServerPartition, SqlServerOffsetContext> snapshotContext) {
+        close(snapshotContext);
+    }
+
+    @Override
+    protected void aborted(SnapshotContext<SqlServerPartition, SqlServerOffsetContext> snapshotContext) {
+        close(snapshotContext);
+    }
+
+    private void close(SnapshotContext<SqlServerPartition, SqlServerOffsetContext> snapshotContext) {
         try {
             jdbcConnection.connection().setTransactionIsolation(((SqlServerSnapshotContext) snapshotContext).isolationLevelBeforeStart);
             LOGGER.info("Removing locking timeout");

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/AbstractSnapshotChangeEventSource.java
@@ -33,7 +33,7 @@ import io.debezium.util.Threads;
  *
  * @author Chris Cranford
  */
-public abstract class AbstractSnapshotChangeEventSource<P extends Partition, O extends OffsetContext> implements SnapshotChangeEventSource<P, O> {
+public abstract class AbstractSnapshotChangeEventSource<P extends Partition, O extends OffsetContext> implements SnapshotChangeEventSource<P, O>, AutoCloseable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSnapshotChangeEventSource.class);
 
@@ -86,14 +86,16 @@ public abstract class AbstractSnapshotChangeEventSource<P extends Partition, O e
         }
         finally {
             LOGGER.info("Snapshot - Final stage");
-            complete(ctx);
+            close();
 
             if (completedSuccessfully) {
                 LOGGER.info("Snapshot completed");
+                completed(ctx);
                 snapshotProgressListener.snapshotCompleted(partition);
             }
             else {
                 LOGGER.warn("Snapshot was not completed successfully, it will be re-executed upon connector restart");
+                aborted(ctx);
                 snapshotProgressListener.snapshotAborted(partition);
             }
         }
@@ -164,9 +166,27 @@ public abstract class AbstractSnapshotChangeEventSource<P extends Partition, O e
      * Completes the snapshot, doing any required clean-up (resource disposal etc.).
      * The snapshot may have run successfully or have been aborted at this point.
      *
+     */
+    @Override
+    public void close() {
+    }
+
+    /**
+     * Completes the snapshot, doing any required clean-up (resource disposal etc.).
+     * The snapshot have run successfully at this point.
+     *
      * @param snapshotContext snapshot context
      */
-    protected void complete(SnapshotContext<P, O> snapshotContext) {
+    protected void completed(SnapshotContext<P, O> snapshotContext) {
+    }
+
+    /**
+     * Completes the snapshot, doing any required clean-up (resource disposal etc.).
+     * The snapshot is aborted at this point.
+     *
+     * @param snapshotContext snapshot context
+     */
+    protected void aborted(SnapshotContext<P, O> snapshotContext) {
     }
 
     /**


### PR DESCRIPTION
Added two lifecycle methods `completed(...)` and `aborted(...)` to AbstractSnapshotChangeEventSource.java to perform any cleanup required specific to snapshot complete or aborted. 

Also, Override `completed` method in `PostgresSnapshotChangeEventSource.java` as complete is calling `snapshotter.snapshotCompleted()`

Common cleanup regardless of snapshot result should be done in `complete(...)` method (like in oracle or sql server connector)
