### PR TITLE
[DBZ-3653] Set Transaction Isloation mode for incremental snapshot

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -153,6 +153,7 @@ Ganesh Ramasubramanian
 Giljae Joo
 Gilles Vaquez
 Giovanni De Stefano
+Govinda Sakhare
 Grant Cooksey
 Guillaume Rosauro
 Guillaume Smet

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorConfigTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlConnectorConfigTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+
+public class MySqlConnectorConfigTest {
+
+    @Test
+    public void testDefaultTransactionIsolationMode() {
+        MySqlConnectorConfig mySqlConnectorConfig = new MySqlConnectorConfig(Configuration.create().build());
+        assertThat(mySqlConnectorConfig.getDefaultTransactionIsolationLevel()).isEqualTo(Connection.TRANSACTION_REPEATABLE_READ);
+    }
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleConnectorConfigTest.java
@@ -10,9 +10,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.sql.Connection;
 import java.time.Duration;
 import java.util.Collections;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -225,6 +227,44 @@ public class OracleConnectorConfigTest {
 
         connectorConfig = new OracleConnectorConfig(config);
         assertThat(connectorConfig.getSnapshotLockingMode().usesLocking()).isFalse();
+    }
+
+    @Test
+    public void testDefaultTransactionIsolationMode() {
+        OracleConnectorConfig oracleConnectorConfig = new OracleConnectorConfig(Configuration.create().build());
+        assertThat(oracleConnectorConfig.getDefaultTransactionIsolationLevel()).isEqualTo(Connection.TRANSACTION_REPEATABLE_READ);
+    }
+
+    @Test
+    public void testReadCommittedSnapshotIsolationConfig() {
+        Configuration configuration = Configuration.create().with("incremental.snapshot.isolation.mode", "read_committed").build();
+        OracleConnectorConfig oracleConnectorConfig = new OracleConnectorConfig(configuration);
+        Assertions.assertThat(oracleConnectorConfig.getIncrementalSnapshotTransactionIsolationLevel())
+                .isEqualTo(Connection.TRANSACTION_READ_COMMITTED);
+    }
+
+    @Test
+    public void testReadUncommittedSnapshotIsolationConfig() {
+        Configuration configuration = Configuration.create().with("incremental.snapshot.isolation.mode", "read_uncommitted").build();
+        OracleConnectorConfig oracleConnectorConfig = new OracleConnectorConfig(configuration);
+        Assertions.assertThat(oracleConnectorConfig.getIncrementalSnapshotTransactionIsolationLevel())
+                .isEqualTo(Connection.TRANSACTION_READ_UNCOMMITTED);
+    }
+
+    @Test
+    public void testRepeatedReadSnapshotIsolationConfig() {
+        Configuration configuration = Configuration.create().with("incremental.snapshot.isolation.mode", "repeated_read").build();
+        OracleConnectorConfig oracleConnectorConfig = new OracleConnectorConfig(configuration);
+        Assertions.assertThat(oracleConnectorConfig.getIncrementalSnapshotTransactionIsolationLevel())
+                .isEqualTo(Connection.TRANSACTION_REPEATABLE_READ);
+    }
+
+    @Test
+    public void testSerializableSnapshotIsolationConfig() {
+        Configuration configuration = Configuration.create().with("incremental.snapshot.isolation.mode", "serializable").build();
+        OracleConnectorConfig oracleConnectorConfig = new OracleConnectorConfig(configuration);
+        Assertions.assertThat(oracleConnectorConfig.getIncrementalSnapshotTransactionIsolationLevel())
+                .isEqualTo(Connection.TRANSACTION_SERIALIZABLE);
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorConfigTest.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorConfigTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.postgresql;
+
+import java.sql.Connection;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+
+public class PostgresConnectorConfigTest {
+
+    @Test
+    public void testDefaultTransactionIsolationMode() {
+        PostgresConnectorConfig postgresConnectorConfig = new PostgresConnectorConfig(Configuration.create().build());
+        Assertions.assertThat(postgresConnectorConfig.getDefaultTransactionIsolationLevel()).isEqualTo(Connection.TRANSACTION_READ_COMMITTED);
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -322,6 +322,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
             jdbcConnection.commit();
             context.startNewChunk();
             emitWindowOpen();
+            setTransactionIsolationLevel(connectorConfig.getIncrementalSnapshotTransactionIsolationLevel());
             while (context.snapshotRunning()) {
                 if (isTableInvalid(partition)) {
                     continue;
@@ -497,6 +498,8 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
                     closeWindow(partition, context.currentChunkId(), offsetContext);
 
                     progressListener.snapshotAborted(partition);
+                    // reset transaction isolation level to default
+                    setTransactionIsolationLevel(connectorConfig.getDefaultTransactionIsolationLevel());
                 }
                 catch (InterruptedException e) {
                     LOGGER.warn("Failed to stop snapshot successfully.", e);
@@ -634,6 +637,16 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
             throw new DebeziumException("Snapshotting of table " + currentTable.id() + " failed", e);
         }
         return true;
+    }
+
+    private void setTransactionIsolationLevel(int transactionIsolationLevel) {
+        try {
+            LOGGER.debug("Transaction level set to {}", transactionIsolationLevel);
+            this.jdbcConnection.connection().setTransactionIsolation(transactionIsolationLevel);
+        }
+        catch (SQLException e) {
+            throw new DebeziumException("Unexpected error while setting transaction level");
+        }
     }
 
     private boolean checkSchemaChanges(ResultSet rs) throws SQLException {

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -150,7 +150,7 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
     /**
      * The set of predefined snapshot isolation mode options.
      */
-    public static enum SnapshotIsolationMode implements EnumeratedValue {
+    public enum SnapshotIsolationMode implements EnumeratedValue {
 
         /**
          * This mode uses REPEATABLE READ isolation level. This mode will avoid taking any table
@@ -182,7 +182,7 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
 
         private final String value;
 
-        private SnapshotIsolationMode(String value) {
+        SnapshotIsolationMode(String value) {
             this.value = value;
         }
 

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -6,6 +6,7 @@
 package io.debezium.relational;
 
 import java.math.BigDecimal;
+import java.sql.Connection;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
@@ -18,6 +19,7 @@ import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Width;
 
+import io.debezium.DebeziumException;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.ConfigDefinition;
 import io.debezium.config.Configuration;
@@ -138,6 +140,85 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
          */
         public static DecimalHandlingMode parse(String value, String defaultValue) {
             DecimalHandlingMode mode = parse(value);
+            if (mode == null && defaultValue != null) {
+                mode = parse(defaultValue);
+            }
+            return mode;
+        }
+    }
+
+    /**
+     * The set of predefined snapshot isolation mode options.
+     */
+    public static enum SnapshotIsolationMode implements EnumeratedValue {
+
+        /**
+         * This mode uses REPEATABLE READ isolation level. This mode will avoid taking any table
+         * locks during the snapshot process, except schema snapshot phase where exclusive table
+         * locks are acquired for a short period.  Since phantom reads can occur, it does not fully
+         * guarantee consistency.
+         */
+        REPEATABLE_READ("repeatable_read"),
+
+        /**
+         * This mode uses READ COMMITTED isolation level. This mode does not take any table locks during
+         * the snapshot process. In addition, it does not take any long-lasting row-level locks, like
+         * in repeatable read isolation level. Snapshot consistency is not guaranteed.
+         */
+        READ_COMMITTED("read_committed"),
+
+        /**
+         * This mode uses READ UNCOMMITTED isolation level. This mode takes neither table locks nor row-level locks
+         * during the snapshot process.  This way other transactions are not affected by initial snapshot process.
+         * However, snapshot consistency is not guaranteed.
+         */
+        READ_UNCOMMITTED("read_uncommitted"),
+
+        /**
+         * This mode uses SERIALIZABLE isolation level. This mode takes table locks during the snapshot process.
+         * This way other transactions will be blocked until snapshot is completed. However, snapshot consistency is not guaranteed.
+         */
+        SERIALIZABLE("serializable");
+
+        private final String value;
+
+        private SnapshotIsolationMode(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value the configuration property value; may not be null
+         * @return the matching option, or null if no match is found
+         */
+        public static SnapshotIsolationMode parse(String value) {
+            if (value == null) {
+                return null;
+            }
+            value = value.trim();
+            for (SnapshotIsolationMode option : SnapshotIsolationMode.values()) {
+                if (option.getValue().equalsIgnoreCase(value)) {
+                    return option;
+                }
+            }
+            return null;
+        }
+
+        /**
+         * Determine if the supplied value is one of the predefined options.
+         *
+         * @param value the configuration property value; may not be null
+         * @param defaultValue the default value; may be null
+         * @return the matching option, or null if no match is found and the non-null default is invalid
+         */
+        public static SnapshotIsolationMode parse(String value, String defaultValue) {
+            SnapshotIsolationMode mode = parse(value);
             if (mode == null && defaultValue != null) {
                 mode = parse(defaultValue);
             }
@@ -454,6 +535,23 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
                     + " If you are excluding a lot of tables the default behavior should work well.")
             .withDefault(false);
 
+    public static final Field INCREMENTAL_SNAPSHOT_ISOLATION_MODE = Field.create("incremental.snapshot.isolation.mode")
+            .withDisplayName("Incremental Snapshot isolation mode")
+            .withEnum(SnapshotIsolationMode.class, SnapshotIsolationMode.REPEATABLE_READ)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 10))
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.LOW)
+            .withDescription("Controls which transaction isolation level is used and how long the connector locks the captured tables. "
+                    + "The default is '" + SnapshotIsolationMode.REPEATABLE_READ.getValue()
+                    + "', which means that repeatable read isolation level is used. In addition, exclusive locks are taken only during schema snapshot. "
+                    + "Using a value of '" + SnapshotIsolationMode.SERIALIZABLE.getValue()
+                    + "' ensures that the connector holds the exclusive lock (and thus prevents any reads and updates) for captured table during the snapshot duration. "
+                    + "When '" + SnapshotIsolationMode.READ_COMMITTED.getValue()
+                    + "' is specified, connector runs the incremental snapshot in READ COMMITTED isolation level. No long-running locks are taken, so that incremental snapshot does not prevent "
+                    + "other transactions from updating table rows. Snapshot consistency is not guaranteed."
+                    + "In '" + SnapshotIsolationMode.READ_UNCOMMITTED.getValue()
+                    + "' mode neither table nor row-level locks are acquired, but connector does not guarantee snapshot consistency.");
+
     public static final Field UNAVAILABLE_VALUE_PLACEHOLDER = Field.create("unavailable.value.placeholder")
             .withDisplayName("Unavailable value placeholder")
             .withType(Type.STRING)
@@ -470,7 +568,8 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
             .connector(
                     DECIMAL_HANDLING_MODE,
                     TIME_PRECISION_MODE,
-                    SNAPSHOT_LOCK_TIMEOUT_MS)
+                    SNAPSHOT_LOCK_TIMEOUT_MS,
+                    INCREMENTAL_SNAPSHOT_ISOLATION_MODE)
             .events(
                     COLUMN_INCLUDE_LIST,
                     COLUMN_EXCLUDE_LIST,
@@ -500,6 +599,7 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
     private final TableIdToStringMapper tableIdMapper;
     private final JdbcConfiguration jdbcConfig;
     private final String heartbeatActionQuery;
+    private final SnapshotIsolationMode incrementalSnapshotIsolationMode;
 
     protected RelationalDatabaseConnectorConfig(Configuration config, TableFilter systemTablesFilter,
                                                 TableIdToStringMapper tableIdMapper, int defaultSnapshotFetchSize,
@@ -509,7 +609,8 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
         this.temporalPrecisionMode = TemporalPrecisionMode.parse(config.getString(TIME_PRECISION_MODE));
         this.keyMapper = CustomKeyMapper.getInstance(config.getString(MSG_KEY_COLUMNS), tableIdMapper);
         this.tableIdMapper = tableIdMapper;
-
+        this.incrementalSnapshotIsolationMode = SnapshotIsolationMode.parse(config.getString(INCREMENTAL_SNAPSHOT_ISOLATION_MODE),
+                INCREMENTAL_SNAPSHOT_ISOLATION_MODE.defaultValueAsString());
         this.jdbcConfig = JdbcConfiguration.adapt(
                 config.subset(DATABASE_CONFIG_PREFIX, true).merge(config.subset(DRIVER_CONFIG_PREFIX, true)));
 
@@ -538,6 +639,39 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
 
     public RelationalTableFilters getTableFilters() {
         return tableFilters;
+    }
+
+    /**
+     * Returns the default Transaction Isolation Level.
+     */
+    public int getDefaultTransactionIsolationLevel() {
+        SnapshotIsolationMode defaultSnapshotIsolationLevel = SnapshotIsolationMode.parse(INCREMENTAL_SNAPSHOT_ISOLATION_MODE.defaultValueAsString());
+        return getTransactionIsolationLevel(defaultSnapshotIsolationLevel);
+    }
+
+    /**
+     * Returns the Incremental Snapshot Transaction Isolation Level.
+     */
+    public int getIncrementalSnapshotTransactionIsolationLevel() {
+        return getTransactionIsolationLevel(this.incrementalSnapshotIsolationMode);
+    }
+
+    public int getTransactionIsolationLevel(SnapshotIsolationMode snapshotIsolationMode) {
+        if (snapshotIsolationMode == SnapshotIsolationMode.READ_COMMITTED) {
+            return Connection.TRANSACTION_READ_COMMITTED;
+        }
+        else if (snapshotIsolationMode == SnapshotIsolationMode.READ_UNCOMMITTED) {
+            return Connection.TRANSACTION_READ_UNCOMMITTED;
+        }
+        else if (snapshotIsolationMode == SnapshotIsolationMode.REPEATABLE_READ) {
+            return Connection.TRANSACTION_REPEATABLE_READ;
+        }
+        else if (snapshotIsolationMode == SnapshotIsolationMode.SERIALIZABLE) {
+            return Connection.TRANSACTION_SERIALIZABLE;
+        }
+        else {
+            throw new DebeziumException("Default Isolation Level is not set");
+        }
     }
 
     /**

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2398,6 +2398,23 @@ However, larger chunk sizes also require more memory to buffer the snapshot data
 Adjust the chunk size to a value that provides the best performance in your environment.
 
 
+|[[db2-property-incremental-snapshot-isolation-mode]]<<db2-property-incremental-snapshot-isolation-mode, `+incremental.snapshot.isolation.mode+`>>
+|_read_committed_
+|Mode to control which transaction isolation level is used for tables that are designated for capture.
+The following values are supported:
+
+* `read_uncommitted`
+* `read_committed`
+* `repeatable_read`
+* `serializable`
+
+The `read_committed` and `read_uncommitted` modes do not prevent other transactions from updating table rows during incremental snapshot.
+The `serializable` and `repeatable_read` modes do prevent concurrent updates. +
+
+Mode choice also affects data consistency. Only `serializable` mode guarantee full consistency, that is, incremental snapshot and streaming logs constitute a linear history.
+In case of `repeatable_read` and `read_committed` modes, it might happen that, for instance, a record added appears twice - once in incremental snapshot and once in streaming phase. Nonetheless, that consistency level should do for data mirroring.
+For `read_uncommitted` there are no data consistency guarantees at all (some data might be lost or corrupted).
+
 |[[db2-property-topic-naming-strategy]]<<db2-property-topic-naming-strategy, `topic.naming.strategy`>>
 |`io.debezium.schema.SchemaTopicNamingStrategy`
 |The name of the TopicNamingStrategy class that should be used to determine the topic name for data change, schema change, transaction, heartbeat event etc., defaults to `SchemaTopicNamingStrategy`.

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -3134,6 +3134,23 @@ Increasing the chunk size provides greater efficiency, because the snapshot runs
 However, larger chunk sizes also require more memory to buffer the snapshot data.
 Adjust the chunk size to a value that provides the best performance in your environment.
 
+|[[mysql-property-incremental-snapshot-isolation-mode]]<<mysql-property-incremental-snapshot-isolation-mode, `+incremental.snapshot.isolation.mode+`>>
+|_repeatable_read_
+|Mode to control which transaction isolation level is used for tables that are designated for capture.
+The following values are supported:
+
+* `read_uncommitted`
+* `read_committed`
+* `repeatable_read`
+* `serializable`
+
+The `read_committed` and `read_uncommitted` modes do not prevent other transactions from updating table rows during incremental snapshot.
+The `serializable` and `repeatable_read` modes do prevent concurrent updates. +
+
+Mode choice also affects data consistency. Only `serializable` mode guarantee full consistency, that is, incremental snapshot and streaming logs constitute a linear history.
+In case of `repeatable_read` and `read_committed` modes, it might happen that, for instance, a record added appears twice - once in incremental snapshot and once in streaming phase. Nonetheless, that consistency level should do for data mirroring.
+For `read_uncommitted` there are no data consistency guarantees at all (some data might be lost or corrupted).
+
 ifdef::community[]
 |[[mysql-property-read-only]]<<mysql-property-read-only, `+read.only+`>>
 |`false`

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3307,6 +3307,23 @@ Increasing the chunk size provides greater efficiency, because the snapshot runs
 However, larger chunk sizes also require more memory to buffer the snapshot data.
 Adjust the chunk size to a value that provides the best performance in your environment.
 
+|[[oracle-property-incremental-snapshot-isolation-mode]]<<oracle-property-incremental-snapshot-isolation-mode, `+incremental.snapshot.isolation.mode+`>>
+|_repeatable_read_
+|Mode to control which transaction isolation level is used for tables that are designated for capture.
+The following values are supported:
+
+* `read_uncommitted`
+* `read_committed`
+* `repeatable_read`
+* `serializable`
+
+The `read_committed` and `read_uncommitted` modes do not prevent other transactions from updating table rows during incremental snapshot.
+The `serializable` and `repeatable_read` modes do prevent concurrent updates. +
+
+Mode choice also affects data consistency. Only `serializable` mode guarantee full consistency, that is, incremental snapshot and streaming logs constitute a linear history.
+In case of `repeatable_read` and `read_committed` modes, it might happen that, for instance, a record added appears twice - once in incremental snapshot and once in streaming phase. Nonetheless, that consistency level should do for data mirroring.
+For `read_uncommitted` there are no data consistency guarantees at all (some data might be lost or corrupted).
+
 |[[oracle-property-topic-naming-strategy]]<<oracle-property-topic-naming-strategy, `topic.naming.strategy`>>
 |`io.debezium.schema.SchemaTopicNamingStrategy`
 |The name of the TopicNamingStrategy class that should be used to determine the topic name for data change, schema change, transaction, heartbeat event etc., defaults to `SchemaTopicNamingStrategy`.

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3253,6 +3253,23 @@ Increasing the chunk size provides greater efficiency, because the snapshot runs
 However, larger chunk sizes also require more memory to buffer the snapshot data.
 Adjust the chunk size to a value that provides the best performance in your environment.
 
+|[[postgresql-property-incremental-snapshot-isolation-mode]]<<postgresql-property-incremental-snapshot-isolation-mode, `+incremental.snapshot.isolation.mode+`>>
+|_read_committed_
+|Mode to control which transaction isolation level is used for tables that are designated for capture.
+The following values are supported:
+
+* `read_uncommitted`
+* `read_committed`
+* `repeatable_read`
+* `serializable`
+
+The `read_committed` and `read_uncommitted` modes do not prevent other transactions from updating table rows during incremental snapshot.
+The `serializable` and `repeatable_read` modes do prevent concurrent updates. +
+
+Mode choice also affects data consistency. Only `serializable` mode guarantee full consistency, that is, incremental snapshot and streaming logs constitute a linear history.
+In case of `repeatable_read` and `read_committed` modes, it might happen that, for instance, a record added appears twice - once in incremental snapshot and once in streaming phase. Nonetheless, that consistency level should do for data mirroring.
+For `read_uncommitted` there are no data consistency guarantees at all (some data might be lost or corrupted).
+
 |[[postgresql-property-xmin-fetch-interval-ms]]<<postgresql-property-xmin-fetch-interval-ms, `+xmin.fetch.interval.ms+`>>
 |`0`
 |How often, in milliseconds, the XMIN will be read from the replication slot.

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2617,6 +2617,23 @@ Increasing the chunk size provides greater efficiency, because the snapshot runs
 However, larger chunk sizes also require more memory to buffer the snapshot data.
 Adjust the chunk size to a value that provides the best performance in your environment.
 
+|[[db2-property-incremental-snapshot-isolation-mode]]<<db2-property-incremental-snapshot-isolation-mode, `+incremental.snapshot.isolation.mode+`>>
+|_read_committed_
+|Mode to control which transaction isolation level is used for tables that are designated for capture.
+The following values are supported:
+
+* `read_uncommitted`
+* `read_committed`
+* `repeatable_read`
+* `serializable`
+
+The `read_committed` and `read_uncommitted` modes do not prevent other transactions from updating table rows during incremental snapshot.
+The `serializable` and `repeatable_read` modes do prevent concurrent updates. +
+
+Mode choice also affects data consistency. Only `serializable` mode guarantee full consistency, that is, incremental snapshot and streaming logs constitute a linear history.
+In case of `repeatable_read` and `read_committed` modes, it might happen that, for instance, a record added appears twice - once in incremental snapshot and once in streaming phase. Nonetheless, that consistency level should do for data mirroring.
+For `read_uncommitted` there are no data consistency guarantees at all (some data might be lost or corrupted).
+
 |[[sqlserver-property-max-iteration-transactions]]<<sqlserver-property-max-iteration-transactions, `+max.iteration.transactions+`>>
 |0
 |Specifies the maximum number of transactions per iteration to be used to reduce the memory footprint when streaming changes from multiple tables in a database.

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -179,3 +179,4 @@ Raul Estrada,Raúl Estrada
 xiaowu,Wu Zhenhua
 yoheimuta,Yohei Yoshimuta
 nancyxu123,Nancy Xu
+govi20,Govinda Sakhare


### PR DESCRIPTION
Add support for `incremental.snapshot.isolation.mode` for Postgres, Oracle, and MySQL connectors and set isolation mode based on this new connector config value during the incremental snapshot if it's not set then use the default translation level

- [x] Add the `incremental.snapshot.isolation.mode` property in connectors and set isolation level before starting incremental snapshot
- [x] Update Docs for this configuration
- [x] Write test cases

https://issues.redhat.com/browse/DBZ-3653