### PR TITLE
DBZ-5739 Handle permission error from RDS Postgres

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -369,7 +369,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
                 LOGGER.info("Postgres server doesn't support the command pg_replication_slot_advance(). Not seeking to last known offset.");
             }
             else if (e.getMessage().matches("ERROR: must be superuser or replication role to use replication slots(.|\\n)*")) {
-                LOGGER.warn("Unable to use pg_replication_slot_advance() function. The Postgres server is likely on an old RDS version: " + e.getMessage());
+                LOGGER.warn("Unable to use pg_replication_slot_advance() function. The Postgres server is likely on an old RDS version", e);
             }
             else if (e.getMessage().matches("ERROR: cannot advance replication slot to.*")) {
                 throw new DebeziumException(

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -368,6 +368,9 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
             if (e.getMessage().matches("ERROR: function pg_replication_slot_advance.*does not exist(.|\\n)*")) {
                 LOGGER.info("Postgres server doesn't support the command pg_replication_slot_advance(). Not seeking to last known offset.");
             }
+            else if (e.getMessage().matches("ERROR: must be superuser or replication role to use replication slots(.|\\n)*")) {
+                LOGGER.warn("Unable to use pg_replication_slot_advance() function. The Postgres server is likely on an old RDS version: " + e.getMessage());
+            }
             else if (e.getMessage().matches("ERROR: cannot advance replication slot to.*")) {
                 throw new DebeziumException(
                         String.format("Cannot seek to the last known offset '%s' on replication slot '%s'. Error from server: %s", lsn.asString(), slotName,


### PR DESCRIPTION
Certain versions of RDS Postgres (e.g. RDS Postgres 12.3) are returning the following error when using the `pg_replication_slot_advance()` even though the user has superuser or replication roles. Since we can't use the function on these versions, catch and ignore these errors when validating the replication slot. This function works on RDS Postgres 12.5 for the same user.

```
ERROR:  must be superuser or replication role to use replication slots 
```