### PR TITLE
DBZ-5882 Fix Debezium scripting archive url in downstream deploy example

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-kafka-connect-yaml.adoc
@@ -26,11 +26,11 @@ spec:
       - name: debezium-connector-{connector-file}
         artifacts:
           - type: zip // <6>
-            url: {red-hat-maven-repository}debezium/debezium-connector-{connector-file}/{debezium-version}-redhat-__<build_number>__/debezium-connector-{connector-file}-{debezium-version}-redhat-__<build_number>__-plugin.zip  // <7>
+            url: {red-hat-maven-repository}debezium/debezium-connector-{connector-file}/{debezium-version}-redhat-{debezium-build-number}/debezium-connector-{connector-file}-{debezium-version}-redhat-{debezium-build-number}-plugin.zip  // <7>
           - type: zip
-            url: {red-hat-maven-repository}apicurio/apicurio-registry-distro-connect-converter/{registry-version}-redhat-_<build-number>_/apicurio-registry-distro-connect-converter-{registry-version}-redhat-_<build-number>_.zip // <8>
+            url: {red-hat-maven-repository}apicurio/apicurio-registry-distro-connect-converter/{registry-maven-version}-redhat-__<build-number>__/apicurio-registry-distro-connect-converter-{registry-maven-version}-redhat-__<build-number>__.zip  // <8>
           - type: zip
-            url: {red-hat-maven-repository}debezium/debezium-scripting/{debezium-version}/debezium-scripting-{debezium-version}.zip // <9>
+            url: {red-hat-maven-repository}debezium/debezium-scripting/{debezium-version}-redhat-{debezium-build-number}/debezium-scripting-{debezium-version}-redhat-{debezium-build-number}.zip // <9>
           - type: jar
             url: https://repo1.maven.org/maven2/org/codehaus/groovy/groovy/{groovy-version}/groovy-{groovy-version}.jar  // <10>
           - type: jar

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-oracle-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-oracle-kafka-connect-yaml.adoc
@@ -26,11 +26,11 @@ spec:
       - name: debezium-connector-{connector-file}
         artifacts:
           - type: zip // <6>
-            url: {red-hat-maven-repository}debezium/debezium-connector-{connector-file}/{debezium-version}-redhat-__<build_number>__/debezium-connector-{connector-file}-{debezium-version}-redhat-__<build_number>__-plugin.zip  // <7>
+            url: {red-hat-maven-repository}debezium/debezium-connector-{connector-file}/{debezium-version}-redhat-{debezium-build-number}/debezium-connector-{connector-file}-{debezium-version}-redhat-{debezium-build-number}-plugin.zip  // <7>
           - type: zip
-            url: {red-hat-maven-repository}apicurio/apicurio-registry-distro-connect-converter/{registry-version}-redhat-_<build-number>_/apicurio-registry-distro-connect-converter-{registry-version}-redhat-_<build-number>_.zip // <8>
+            url: {red-hat-maven-repository}apicurio/apicurio-registry-distro-connect-converter/{registry-maven-version}-redhat-__<build-number>__/apicurio-registry-distro-connect-converter-{registry-maven-version}-redhat-__<build-number>__.zip  // <8>
           - type: zip
-            url: {red-hat-maven-repository}debezium/debezium-scripting/{debezium-version}/debezium-scripting-{debezium-version}.zip // <9>
+            url: {red-hat-maven-repository}debezium/debezium-scripting/{debezium-version}-redhat-{debezium-build-number}/debezium-scripting-{debezium-version}-redhat-{debezium-build-number}.zip // <9>
           - type: jar
             url: https://repo1.maven.org/maven2/org/codehaus/groovy/groovy/{groovy-version}/groovy-{groovy-version}.jar  // <10>
           - type: jar

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-deploy-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-deploy-kafka-connect-yaml.adoc
@@ -25,11 +25,11 @@ spec:
       - name: debezium-connector-{connector-file}
         artifacts:
           - type: zip // <6>
-            url: {red-hat-maven-repository}debezium/debezium-connector-{connector-file}/{debezium-version}-redhat-__<build_number>__/debezium-connector-{connector-file}-{debezium-version}-redhat-__<build_number>__-plugin.zip  // <7>
+            url: {red-hat-maven-repository}debezium/debezium-connector-{connector-file}/{debezium-version}-redhat-{debezium-build-number}/debezium-connector-{connector-file}-{debezium-version}-redhat-{debezium-build-number}-plugin.zip  // <7>
           - type: zip
-            url: {red-hat-maven-repository}apicurio/apicurio-registry-distro-connect-converter/{registry-version}-redhat-_<build-number>_/apicurio-registry-distro-connect-converter-{registry-version}-redhat-_<build-number>_.zip // <8>
+            url: {red-hat-maven-repository}apicurio/apicurio-registry-distro-connect-converter/{registry-maven-version}-redhat-__<build-number>__/apicurio-registry-distro-connect-converter-{registry-maven-version}-redhat-__<build-number>__.zip  // <8>
           - type: zip
-            url: {red-hat-maven-repository}debezium/debezium-scripting/{debezium-version}/debezium-scripting-{debezium-version}.zip // <9>
+            url: {red-hat-maven-repository}debezium/debezium-scripting/{debezium-version}-redhat-{debezium-build-number}/debezium-scripting-{debezium-version}-redhat-{debezium-build-number}.zip // <9>
           - type: jar
             url: https://repo1.maven.org/maven2/org/codehaus/groovy/groovy/{groovy-version}/groovy-{groovy-version}.jar  // <10>
           - type: jar


### PR DESCRIPTION
[DBZ-5883](https://issues.redhat.com/browse/DBZ-5883)

Appends missing build number string to Maven URL for the Debezium scripting archive to YAML example in the  instructions for using Streams to deploy connectors.
Also implements new downstream attributes for assigning the  build number for the Debezium release and for the Apicurio registry release.

This change is targeted solely at the downstream product version of the documentation and has no effect on the community version of the documentation.

A separate change to implement this correction was merged to the downstream documentation repository.