### PR TITLE
DBZ-2028: Reduce number of database connection creations during PG tests

### DIFF
--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomLifecycleHookTestSnapshot.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/CustomLifecycleHookTestSnapshot.java
@@ -6,6 +6,7 @@
 
 package io.debezium.connector.postgresql;
 
+import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.connector.postgresql.snapshot.AlwaysSnapshotter;
 
 public class CustomLifecycleHookTestSnapshot extends AlwaysSnapshotter {
@@ -15,6 +16,8 @@ public class CustomLifecycleHookTestSnapshot extends AlwaysSnapshotter {
 
     @Override
     public void snapshotCompleted() {
-        TestHelper.execute(INSERT_SNAPSHOT_COMPLETE_STATE);
+        try (PostgresConnection connection = TestHelper.create()) {
+            TestHelper.execute(connection, INSERT_SNAPSHOT_COMPLETE_STATE);
+        }
     }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/OutboxEventRouterIT.java
@@ -9,10 +9,13 @@ package io.debezium.connector.postgresql;
 import java.util.UUID;
 
 import org.apache.kafka.connect.data.Schema;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.data.Json;
 import io.debezium.data.Uuid;
 import io.debezium.jdbc.JdbcConnection;
@@ -38,11 +41,23 @@ public class OutboxEventRouterIT extends AbstractEventRouterTest<PostgresConnect
             "  payload       jsonb" +
             ");";
 
+    private static PostgresConnection defaultConnection;
+
+    @BeforeClass
+    public static void beforeClass() {
+        defaultConnection = TestHelper.create();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        defaultConnection.close();
+    }
+
     @Before
     @Override
     public void beforeEach() throws Exception {
         TestHelper.dropDefaultReplicationSlot();
-        TestHelper.dropPublication();
+        TestHelper.dropPublication(defaultConnection);
         super.beforeEach();
     }
 
@@ -93,8 +108,8 @@ public class OutboxEventRouterIT extends AbstractEventRouterTest<PostgresConnect
 
     @Override
     protected void createTable() throws Exception {
-        TestHelper.execute(SETUP_OUTBOX_SCHEMA);
-        TestHelper.execute(SETUP_OUTBOX_TABLE);
+        TestHelper.execute(defaultConnection, SETUP_OUTBOX_SCHEMA);
+        TestHelper.execute(defaultConnection, SETUP_OUTBOX_TABLE);
     }
 
     @Override
@@ -141,20 +156,20 @@ public class OutboxEventRouterIT extends AbstractEventRouterTest<PostgresConnect
 
     @Override
     protected void alterTableWithExtra4Fields() throws Exception {
-        TestHelper.execute("ALTER TABLE outboxsmtit.outbox add version int not null;");
-        TestHelper.execute("ALTER TABLE outboxsmtit.outbox add somebooltype boolean not null;");
-        TestHelper.execute("ALTER TABLE outboxsmtit.outbox add createdat timestamp without time zone not null;");
-        TestHelper.execute("ALTER TABLE outboxsmtit.outbox add is_deleted boolean default false;");
+        TestHelper.execute(defaultConnection, "ALTER TABLE outboxsmtit.outbox add version int not null;");
+        TestHelper.execute(defaultConnection, "ALTER TABLE outboxsmtit.outbox add somebooltype boolean not null;");
+        TestHelper.execute(defaultConnection, "ALTER TABLE outboxsmtit.outbox add createdat timestamp without time zone not null;");
+        TestHelper.execute(defaultConnection, "ALTER TABLE outboxsmtit.outbox add is_deleted boolean default false;");
     }
 
     @Override
     protected void alterTableWithTimestampField() throws Exception {
-        TestHelper.execute("ALTER TABLE outboxsmtit.outbox add createdat timestamp without time zone not null;");
+        TestHelper.execute(defaultConnection, "ALTER TABLE outboxsmtit.outbox add createdat timestamp without time zone not null;");
     }
 
     @Override
     protected void alterTableModifyPayload() throws Exception {
-        TestHelper.execute("ALTER TABLE outboxsmtit.outbox ALTER COLUMN payload SET DATA TYPE VARCHAR(1000);");
+        TestHelper.execute(defaultConnection, "ALTER TABLE outboxsmtit.outbox ALTER COLUMN payload SET DATA TYPE VARCHAR(1000);");
     }
 
     @Override

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotWithOverridesProducerIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/SnapshotWithOverridesProducerIT.java
@@ -13,11 +13,14 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.connect.source.SourceRecord;
 import org.assertj.core.api.Assertions;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig.SnapshotMode;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
 
 /**
  * Integration test for {@link io.debezium.connector.postgresql.PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE}
@@ -42,14 +45,26 @@ public class SnapshotWithOverridesProducerIT extends AbstractRecordsProducerTest
             "INSERT INTO over.t2 VALUES (102);" +
             "INSERT INTO over.t2 VALUES (103);";
 
+    private static PostgresConnection defaultConnection;
+
+    @BeforeClass
+    public static void beforeClass() {
+        defaultConnection = TestHelper.create();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        defaultConnection.close();
+    }
+
     @Before
     public void before() throws SQLException {
-        TestHelper.dropAllSchemas();
+        TestHelper.dropAllSchemas(defaultConnection);
     }
 
     @Test
     public void shouldUseOverriddenSelectStatementDuringSnapshotting() throws Exception {
-        TestHelper.execute(STATEMENTS);
+        TestHelper.execute(defaultConnection, STATEMENTS);
 
         buildProducer(TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE, "over.t1")
@@ -67,7 +82,7 @@ public class SnapshotWithOverridesProducerIT extends AbstractRecordsProducerTest
 
     @Test
     public void shouldUseMultipleOverriddenSelectStatementsDuringSnapshotting() throws Exception {
-        TestHelper.execute(STATEMENTS);
+        TestHelper.execute(defaultConnection, STATEMENTS);
 
         buildProducer(TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE, "over.t1,over.t2")

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresConnectionIT.java
@@ -20,6 +20,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.postgresql.jdbc.PgConnection;
@@ -37,6 +39,18 @@ import io.debezium.util.Testing;
  * @author Horia Chiorean (hchiorea@redhat.com)
  */
 public class PostgresConnectionIT {
+
+    private static PostgresConnection defaultConnection;
+
+    @BeforeClass
+    public static void beforeClass() {
+        defaultConnection = TestHelper.create();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        defaultConnection.close();
+    }
 
     @After
     public void after() {
@@ -95,7 +109,7 @@ public class PostgresConnectionIT {
         String statement = "DROP SCHEMA IF EXISTS public CASCADE;" +
                 "CREATE SCHEMA public;" +
                 "CREATE TABLE test(pk serial, PRIMARY KEY (pk));";
-        TestHelper.execute(statement);
+        TestHelper.execute(defaultConnection, statement);
         try (PostgresConnection connection = TestHelper.create()) {
             assertEquals(ServerInfo.ReplicaIdentity.DEFAULT, connection.readReplicaIdentityInfo(TableId.parse("public.test")));
         }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresDefaultValueConverterIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/connection/PostgresDefaultValueConverterIT.java
@@ -13,8 +13,10 @@ import java.sql.Types;
 import java.util.Optional;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import io.debezium.config.Configuration;
@@ -28,13 +30,25 @@ import io.debezium.relational.RelationalDatabaseConnectorConfig.DecimalHandlingM
 
 public class PostgresDefaultValueConverterIT {
 
+    private static PostgresConnection defaultConnection;
+
     private PostgresConnection postgresConnection;
     private PostgresValueConverter postgresValueConverter;
     private PostgresDefaultValueConverter postgresDefaultValueConverter;
 
+    @BeforeClass
+    public static void beforeClass() {
+        defaultConnection = TestHelper.create();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        defaultConnection.close();
+    }
+
     @Before
     public void before() throws SQLException {
-        TestHelper.dropAllSchemas();
+        TestHelper.dropAllSchemas(defaultConnection);
 
         postgresConnection = TestHelper.create();
 


### PR DESCRIPTION
This commit moves majority of the connection management under test classes and prepares grounds for further improvements.
According to simple println in constructor of the connection
- Originally there was 5440 connection to the database created during PG tests
- Now the number is 1771 

While further improvements are possible.