### PR TITLE
DBZ-5889 Run integration tests in specified order

### DIFF
--- a/debezium-connect-rest-extension/pom.xml
+++ b/debezium-connect-rest-extension/pom.xml
@@ -86,6 +86,7 @@
                 <skipLongRunningTests>${skipLongRunningTests}</skipLongRunningTests>
                 <maven.home>${maven.home}</maven.home>
               </systemPropertyVariables>
+              <runOrder>${runOrder}</runOrder>
             </configuration>
           </execution>
         </executions>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -244,6 +244,7 @@
                         <version.mongo.server>${version.mongo.server}</version.mongo.server>
                         <skipLongRunningTests>${skipLongRunningTests}</skipLongRunningTests>
                     </systemPropertyVariables>
+                    <runOrder>${runOrder}</runOrder>
                 </configuration>
             </plugin>
             <plugin>

--- a/debezium-connector-mysql/pom.xml
+++ b/debezium-connector-mysql/pom.xml
@@ -512,7 +512,7 @@
                         <database.replica.port>${mysql.replica.port}</database.replica.port>
                         <skipLongRunningTests>${skipLongRunningTests}</skipLongRunningTests>
                     </systemPropertyVariables>
-                    <runOrder>alphabetical</runOrder>
+                    <runOrder>${runOrder}</runOrder>
                 </configuration>
                 <executions>
                     <execution>
@@ -653,7 +653,7 @@
                                 <database.ssl.mode>disabled</database.ssl.mode>
                                 <skipLongRunningTests>false</skipLongRunningTests>
                             </systemPropertyVariables>
-                            <runOrder>alphabetical</runOrder>
+                            <runOrder>${runOrder}</runOrder>
                         </configuration>
                         <executions>
                             <!-- First run the integration tests with the non-GTID server alone -->

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -232,6 +232,7 @@
                         <database.connection.adapter>${adapter.name}</database.connection.adapter>
                         <log.mining.buffer.type>${log.mining.buffer.type.name}</log.mining.buffer.type>
                     </systemPropertyVariables>
+                    <runOrder>${runOrder}</runOrder>
                 </configuration>
             </plugin>
             <plugin>

--- a/debezium-connector-postgres/pom.xml
+++ b/debezium-connector-postgres/pom.xml
@@ -263,6 +263,7 @@
                         <plugin.name>${decoder.plugin.name}</plugin.name>
                         <skipLongRunningTests>${skipLongRunningTests}</skipLongRunningTests>
                     </systemPropertyVariables>
+                    <runOrder>${runOrder}</runOrder>
                 </configuration>
             </plugin>
             <plugin>

--- a/debezium-connector-sqlserver/pom.xml
+++ b/debezium-connector-sqlserver/pom.xml
@@ -226,6 +226,7 @@
                         <database.trustServerCertificate>true</database.trustServerCertificate>
                         <skipLongRunningTests>${skipLongRunningTests}</skipLongRunningTests>
                     </systemPropertyVariables>
+                    <runOrder>${runOrder}</runOrder>
                 </configuration>
             </plugin>
             <plugin>

--- a/debezium-parent/pom.xml
+++ b/debezium-parent/pom.xml
@@ -55,6 +55,9 @@
         <!-- Skip the API checks by default. Let the modules opt in. -->
         <revapi.skip>true</revapi.skip>
 
+        <!-- Order in which Maven Failsafe plugin runs integration tests, the default is in alphabetical order -->
+        <runOrder>alphabetical</runOrder>
+
     </properties>
 
     <dependencyManagement>

--- a/debezium-quarkus-outbox/integration-tests/pom.xml
+++ b/debezium-quarkus-outbox/integration-tests/pom.xml
@@ -137,6 +137,9 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <runOrder>${runOrder}</runOrder>
+                        </configuration>
                         <executions>
                             <execution>
                                 <goals>

--- a/debezium-server/debezium-server-core/pom.xml
+++ b/debezium-server/debezium-server-core/pom.xml
@@ -151,6 +151,7 @@
                         <test.type>IT</test.type>
                         <test.apicurio>false</test.apicurio>
                     </systemProperties>
+                    <runOrder>${runOrder}</runOrder>
                 </configuration>
             </plugin>
         </plugins>
@@ -170,6 +171,7 @@
                         <configuration>
                             <skipTests>${skipITs}</skipTests>
                             <enableAssertions>true</enableAssertions>
+                            <runOrder>${runOrder}</runOrder>
                         </configuration>
                         <executions>
                             <execution>
@@ -233,6 +235,7 @@
                         <configuration>
                             <skipTests>${skipITs}</skipTests>
                             <enableAssertions>true</enableAssertions>
+                            <runOrder>${runOrder}</runOrder>
                         </configuration>
                         <executions>
                             <execution>
@@ -296,6 +299,7 @@
                                 <test.apicurio.converter.format>json</test.apicurio.converter.format>
                                 <test.apicurio>true</test.apicurio>
                             </systemPropertyVariables>
+                            <runOrder>${runOrder}</runOrder>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -315,6 +319,7 @@
                                 <test.apicurio.converter.format>avro</test.apicurio.converter.format>
                                 <test.apicurio>true</test.apicurio>
                             </systemPropertyVariables>
+                            <runOrder>${runOrder}</runOrder>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -334,6 +339,7 @@
                                 <debezium.format.key>protobuf</debezium.format.key>
                                 <debezium.format.value>protobuf</debezium.format.value>
                             </systemPropertyVariables>
+                            <runOrder>${runOrder}</runOrder>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/debezium-server/debezium-server-eventhubs/pom.xml
+++ b/debezium-server/debezium-server-eventhubs/pom.xml
@@ -124,6 +124,7 @@
                     <systemProperties>
                         <test.type>IT</test.type>
                     </systemProperties>
+                    <runOrder>${runOrder}</runOrder>
                 </configuration>
             </plugin>
         </plugins>

--- a/debezium-server/debezium-server-http/pom.xml
+++ b/debezium-server/debezium-server-http/pom.xml
@@ -126,6 +126,7 @@
                     <systemProperties>
                         <test.type>IT</test.type>
                     </systemProperties>
+                    <runOrder>${runOrder}</runOrder>
                 </configuration>
             </plugin>
             <plugin>

--- a/debezium-server/debezium-server-kafka/pom.xml
+++ b/debezium-server/debezium-server-kafka/pom.xml
@@ -79,6 +79,7 @@
                     <systemProperties>
                         <test.type>IT</test.type>
                     </systemProperties>
+                    <runOrder>${runOrder}</runOrder>
                 </configuration>
             </plugin>
         </plugins>

--- a/debezium-server/debezium-server-kinesis/pom.xml
+++ b/debezium-server/debezium-server-kinesis/pom.xml
@@ -125,6 +125,7 @@
                     <systemProperties>
                         <test.type>IT</test.type>
                     </systemProperties>
+                    <runOrder>${runOrder}</runOrder>
                 </configuration>
             </plugin>
         </plugins>

--- a/debezium-server/debezium-server-nats-jetstream/pom.xml
+++ b/debezium-server/debezium-server-nats-jetstream/pom.xml
@@ -121,6 +121,7 @@
                     <systemProperties>
                         <test.type>IT</test.type>
                     </systemProperties>
+                    <runOrder>${runOrder}</runOrder>
                 </configuration>
             </plugin>
         </plugins>

--- a/debezium-server/debezium-server-nats-streaming/pom.xml
+++ b/debezium-server/debezium-server-nats-streaming/pom.xml
@@ -125,6 +125,7 @@
                     <systemProperties>
                         <test.type>IT</test.type>
                     </systemProperties>
+                    <runOrder>${runOrder}</runOrder>
                 </configuration>
             </plugin>
         </plugins>

--- a/debezium-server/debezium-server-pravega/pom.xml
+++ b/debezium-server/debezium-server-pravega/pom.xml
@@ -141,6 +141,7 @@
                                 <debezium.sink.pravega.scope>testc.inventory.customers</debezium.sink.pravega.scope>
                                 <debezium.sink.pravega.transaction>false</debezium.sink.pravega.transaction>
                             </systemPropertyVariables>
+                            <runOrder>${runOrder}</runOrder>
                         </configuration>
                     </execution>
                     <execution>
@@ -154,6 +155,7 @@
                                 <debezium.sink.pravega.scope>testc.inventory.customers</debezium.sink.pravega.scope>
                                 <debezium.sink.pravega.transaction>true</debezium.sink.pravega.transaction>
                             </systemPropertyVariables>
+                            <runOrder>${runOrder}</runOrder>
                         </configuration>
                     </execution>
                     <execution>

--- a/debezium-server/debezium-server-pubsub/pom.xml
+++ b/debezium-server/debezium-server-pubsub/pom.xml
@@ -138,6 +138,7 @@
                     <systemProperties>
                         <test.type>IT</test.type>
                     </systemProperties>
+                    <runOrder>${runOrder}</runOrder>
                 </configuration>
             </plugin>
         </plugins>

--- a/debezium-server/debezium-server-pulsar/pom.xml
+++ b/debezium-server/debezium-server-pulsar/pom.xml
@@ -127,6 +127,7 @@
                         <test.type>IT</test.type>
                         <pulsar.port.native>${pulsar.port.native}</pulsar.port.native>
                     </systemProperties>
+                    <runOrder>${runOrder}</runOrder>
                 </configuration>
             </plugin>
         </plugins>

--- a/debezium-server/debezium-server-redis/pom.xml
+++ b/debezium-server/debezium-server-redis/pom.xml
@@ -137,6 +137,7 @@
                     <systemProperties>
                         <test.type>IT</test.type>
                     </systemProperties>
+                    <runOrder>${runOrder}</runOrder>
                 </configuration>
             </plugin>
         </plugins>

--- a/debezium-testing/debezium-testing-system/pom.xml
+++ b/debezium-testing/debezium-testing-system/pom.xml
@@ -443,6 +443,7 @@
               <skipTests>${skipITs}</skipTests>
               <enableAssertions>true</enableAssertions>
               <trimStackTrace>false</trimStackTrace>
+              <runOrder>${runOrder}</runOrder>
               <systemPropertyVariables>
                 <test.wait.scale>1</test.wait.scale>
 


### PR DESCRIPTION
Run the tests alwyas in thr same order to make it more easy to debug failures. If needed, the order can be changed (e.g. to `random`) by overriding propeperty `runOrder`.

https://issues.redhat.com/browse/DBZ-5889