### PR TITLE
DBZ-5857 Migrated MongoDb integration tests to test-containers

### DIFF
--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -115,6 +115,7 @@
         <apicurio.init.timeout>60000</apicurio.init.timeout> <!-- 60 seconds -->
         <!-- Mongo test containers -->
         <mongodb.docker.desktop.ports>27017,27018,27019</mongodb.docker.desktop.ports>
+        <mongodb.replica.size>1</mongodb.replica.size>
     </properties>
     <build>
         <plugins>
@@ -198,6 +199,7 @@
                         <!-- Make these available to the tests via system properties -->
                         <version.mongo.server>${version.mongo.server}</version.mongo.server>
                         <mongodb.docker.desktop.ports>${mongodb.docker.desktop.ports}</mongodb.docker.desktop.ports>
+                        <mongodb.replica.size>${mongodb.replica.size}</mongodb.replica.size>
                         <skipLongRunningTests>${skipLongRunningTests}</skipLongRunningTests>
                     </systemPropertyVariables>
                     <runOrder>${runOrder}</runOrder>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -54,6 +54,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-testing-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
@@ -90,25 +95,16 @@
         </dependency>
     </dependencies>
     <properties>
-        <!-- By default we need to run these 5 containers, although the two init containers exit quickly -->
-        <docker.image>mongo1,mongo-init</docker.image>
-
-        <!-- The command line args passed to each mongod service -->
-        <mongo.data.replicaset.name>rs0</mongo.data.replicaset.name>
-        <mongo.cfg.replicaset.name>cfg</mongo.cfg.replicaset.name>
-        <mongo.data.runOptions>--replSet ${mongo.data.replicaset.name} --oplogSize=2 --enableMajorityReadConcern</mongo.data.runOptions>
-        <mongo.cfg.runOptions>--configsvr --replSet ${mongo.cfg.replicaset.name} --oplogSize=2 --enableMajorityReadConcern</mongo.cfg.runOptions>
-        <mongo.router.runOptions>mongos --configdb ${mongo.cfg.replicaset.name}/config:27019</mongo.router.runOptions>
         <!-- 
         Set this property to 'true' in a profile to skip the integration tests and not even run the Docker containers.
         -->
         <docker.skip>false</docker.skip>
         <docker.exposeContainerInfo>docker.container</docker.exposeContainerInfo>
-        <docker.dbs>mongo:${version.mongo.server},debezium/mongo-initiator:${version.mongo.server}</docker.dbs>
-        <docker.filter>${docker.dbs}</docker.filter>
         <!-- Apicurion container properties -->
         <apicurio.port>8080</apicurio.port>
         <apicurio.init.timeout>60000</apicurio.init.timeout> <!-- 60 seconds -->
+        <!-- Mongo test containers -->
+        <mongodb.docker.desktop.ports>27017,27018,27019</mongodb.docker.desktop.ports>
     </properties>
     <build>
         <plugins>
@@ -121,59 +117,6 @@
                     <verbose>true</verbose>
                     <!--autoPull>always</autoPull-->
                     <images>
-                        <!-- A container for the data server replica set -->
-                        <image>
-                            <name>mongo:${version.mongo.server}</name>
-                            <alias>mongo1</alias>
-                            <run>
-                                <namingStrategy>alias</namingStrategy>
-                                <cmd>${mongo.data.runOptions}</cmd>
-                                <ports>
-                                    <!-- We won't use it thru this port, but we don't want to take 27017 on docker host -->
-                                    <port>27017:27017</port>
-                                </ports>
-                                <log>
-                                    <prefix>mongo1</prefix>
-                                    <enabled>true</enabled>
-                                    <color>yellow</color>
-                                </log>
-                                <wait>
-                                    <log>.*[Ww]aiting for connections.*27017</log> <!-- internal port, multiline matching -->
-                                    <time>30000</time> <!-- 30 seconds max -->
-                                </wait>
-                            </run>
-                            <external>
-                                <type>properties</type>
-                                <mode>override</mode>
-                            </external>
-                        </image>
-                        <!-- A container that initiates the data replica set and adds it as shard to router -->
-                        <image>
-                            <name>debezium/mongo-initiator:${version.mongo.server}</name>
-                            <run>
-                                <namingStrategy>none</namingStrategy>
-                                <env>
-                                    <VERBOSE>true</VERBOSE>
-                                    <REPLICASET>${mongo.data.replicaset.name}</REPLICASET>
-                                </env>
-                                <links>
-                                    <link>mongo1:mongo1</link>
-                                </links>
-                                <log>
-                                    <prefix>mongo-init</prefix>
-                                    <enabled>true</enabled>
-                                    <color>green</color>
-                                </log>
-                                <wait>
-                                    <exit>0</exit>
-                                    <time>30000</time> <!-- 30 seconds max -->
-                                </wait>
-                            </run>
-                            <external>
-                                <type>properties</type>
-                                <mode>override</mode>
-                            </external>
-                        </image>
                         <image>
                             <name>apicurio/apicurio-registry-mem:${version.apicurio}</name>
                             <run>
@@ -243,13 +186,12 @@
                     <enableAssertions>true</enableAssertions>
                     <systemPropertyVariables>
                         <!-- Make these available to the tests via system properties -->
-                        <connector.mongodb.hosts>${mongo.data.replicaset.name}/${docker.host.address}:27017</connector.mongodb.hosts>
-                        <connector.mongodb.members.auto.discover>false</connector.mongodb.members.auto.discover>
-                        <connector.mongodb.name>mongo1</connector.mongodb.name>
                         <version.mongo.server>${version.mongo.server}</version.mongo.server>
+                        <mongodb.docker.desktop.ports>${mongodb.docker.desktop.ports}</mongodb.docker.desktop.ports>
                         <skipLongRunningTests>${skipLongRunningTests}</skipLongRunningTests>
                     </systemPropertyVariables>
                     <runOrder>${runOrder}</runOrder>
+                    <argLine>--add-opens java.base/java.net=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -383,7 +325,7 @@
                 </plugins>
             </build>
             <properties>
-                <docker.filter>${docker.dbs},apicurio/apicurio-registry-mem:${version.apicurio}</docker.filter>
+                <docker.filter>apicurio/apicurio-registry-mem:${version.apicurio}</docker.filter>
             </properties>
         </profile>
     </profiles>

--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -57,6 +57,16 @@
             <groupId>io.debezium</groupId>
             <artifactId>debezium-testing-testcontainers</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-launcher</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>junit-jupiter</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/AbstractBaseMongoIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/AbstractBaseMongoIT.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+
+import io.debezium.connector.mongodb.junit.MongoDbDatabaseProvider;
+import io.debezium.testing.testcontainers.MongoDbReplicaSet;
+import io.debezium.testing.testcontainers.util.DockerUtils;
+import io.debezium.util.Testing;
+
+public class AbstractBaseMongoIT implements Testing {
+
+    protected static MongoDbReplicaSet mongo;
+
+    @BeforeClass
+    public static void beforeAll() {
+        DockerUtils.enableFakeDnsIfRequired();
+        mongo = MongoDbDatabaseProvider.mongoDbReplicaSet();
+        mongo.start();
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        DockerUtils.disableFakeDns();
+        if (mongo != null) {
+            mongo.stop();
+        }
+    }
+
+    protected MongoClient connect() {
+        return MongoClients.create(mongo.getConnectionString());
+    }
+}

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/AbstractMongoConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/AbstractMongoConnectorIT.java
@@ -25,9 +25,13 @@ import javax.management.ObjectName;
 import org.awaitility.Awaitility;
 import org.bson.Document;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 
 import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
@@ -35,9 +39,11 @@ import com.mongodb.client.MongoIterable;
 import com.mongodb.client.model.InsertOneOptions;
 
 import io.debezium.config.Configuration;
-import io.debezium.connector.mongodb.ConnectionContext.MongoPrimary;
+import io.debezium.connector.mongodb.junit.MongoDbDatabaseProvider;
 import io.debezium.embedded.AbstractConnectorTest;
 import io.debezium.junit.logging.LogInterceptor;
+import io.debezium.testing.testcontainers.MongoDbReplicaSet;
+import io.debezium.testing.testcontainers.util.DockerUtils;
 import io.debezium.util.Collect;
 import io.debezium.util.IoUtil;
 import io.debezium.util.Testing;
@@ -52,14 +58,16 @@ public abstract class AbstractMongoConnectorIT extends AbstractConnectorTest {
     // the one and only task we start in the test suite
     private static final int TASK_ID = 0;
 
+    protected static MongoDbReplicaSet mongo;
+
     protected Configuration config;
     protected MongoDbTaskContext context;
     protected LogInterceptor logInterceptor;
 
     @Before
     public void beforeEach() {
-        Testing.Debug.disable();
-        Testing.Print.disable();
+        Debug.disable();
+        Print.disable();
         stopConnector();
         initializeConnectorTestFramework();
     }
@@ -76,6 +84,21 @@ public abstract class AbstractMongoConnectorIT extends AbstractConnectorTest {
         }
     }
 
+    @BeforeClass
+    public static void beforeAll() {
+        DockerUtils.enableFakeDnsIfRequired();
+        mongo = MongoDbDatabaseProvider.mongoDbReplicaSet();
+        mongo.start();
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        DockerUtils.disableFakeDns();
+        if (mongo != null) {
+            mongo.stop();
+        }
+    }
+
     /**
      * Load test documents from the classpath.
      *
@@ -84,7 +107,7 @@ public abstract class AbstractMongoConnectorIT extends AbstractConnectorTest {
      */
     protected List<Document> loadTestDocuments(String pathOnClasspath) {
         final List<Document> documents = new ArrayList<>();
-        try (InputStream stream = Testing.Files.readResourceAsStream(pathOnClasspath)) {
+        try (InputStream stream = Files.readResourceAsStream(pathOnClasspath)) {
             assertThat(stream).isNotNull();
             IoUtil.readLines(stream, line -> {
                 Document document = Document.parse(line);
@@ -113,10 +136,10 @@ public abstract class AbstractMongoConnectorIT extends AbstractConnectorTest {
             return;
         }
 
-        primary().execute("store documents", mongo -> {
+        try (var client = TestHelper.connect(mongo)) {
             Testing.debug("Storing in '" + dbName + "." + collectionName + "' document");
 
-            MongoDatabase db = mongo.getDatabase(dbName);
+            MongoDatabase db = client.getDatabase(dbName);
 
             MongoCollection<Document> collection = db.getCollection(collectionName);
             collection.drop();
@@ -127,7 +150,7 @@ public abstract class AbstractMongoConnectorIT extends AbstractConnectorTest {
                 assertThat(document.size()).isGreaterThan(0);
                 collection.insertOne(document, options);
             }
-        });
+        }
     }
 
     /**
@@ -143,10 +166,10 @@ public abstract class AbstractMongoConnectorIT extends AbstractConnectorTest {
             return;
         }
 
-        primary().execute("store documents", mongo -> {
+        try (var client = TestHelper.connect(mongo)) {
             Testing.debug("Storing in '" + dbName + "." + collectionName + "' document");
 
-            MongoDatabase db = mongo.getDatabase(dbName);
+            MongoDatabase db = client.getDatabase(dbName);
 
             MongoCollection<Document> collection = db.getCollection(collectionName);
 
@@ -156,7 +179,7 @@ public abstract class AbstractMongoConnectorIT extends AbstractConnectorTest {
                 assertThat(document.size()).isGreaterThan(0);
                 collection.insertOne(document, options);
             }
-        });
+        }
     }
 
     /**
@@ -167,19 +190,19 @@ public abstract class AbstractMongoConnectorIT extends AbstractConnectorTest {
      * @param documents the documents to be inserted, can be empty
      */
     protected void insertDocumentsInTx(String dbName, String collectionName, Document... documents) {
-        assertThat(TestHelper.transactionsSupported(primary(), dbName)).isTrue();
+        assertThat(TestHelper.transactionsSupported()).isTrue();
 
-        primary().execute("store documents in tx", mongo -> {
+        try (var client = TestHelper.connect(mongo)) {
             Testing.debug("Storing documents in '" + dbName + "." + collectionName + "'");
             // If the collection does not exist, be sure to create it
-            final MongoDatabase db = mongo.getDatabase(dbName);
+            final MongoDatabase db = client.getDatabase(dbName);
             if (!collectionExists(db, collectionName)) {
                 db.createCollection(collectionName);
             }
 
             final MongoCollection<Document> collection = db.getCollection(collectionName);
 
-            final ClientSession session = mongo.startSession();
+            final ClientSession session = client.startSession();
             try {
                 session.startTransaction();
 
@@ -195,7 +218,7 @@ public abstract class AbstractMongoConnectorIT extends AbstractConnectorTest {
             finally {
                 session.close();
             }
-        });
+        }
     }
 
     /**
@@ -207,13 +230,13 @@ public abstract class AbstractMongoConnectorIT extends AbstractConnectorTest {
      * @param document the document fields to be updated
      */
     protected void updateDocument(String dbName, String collectionName, Document filter, Document document) {
-        primary().execute("update", mongo -> {
+        try (var client = TestHelper.connect(mongo)) {
             Testing.debug("Updating document with filter '" + filter + "' in '" + dbName + "." + collectionName + "'");
 
-            MongoDatabase db = mongo.getDatabase(dbName);
+            MongoDatabase db = client.getDatabase(dbName);
             MongoCollection<Document> collection = db.getCollection(collectionName);
             collection.updateOne(filter, document);
-        });
+        }
     }
 
     /**
@@ -225,15 +248,15 @@ public abstract class AbstractMongoConnectorIT extends AbstractConnectorTest {
      * @param document the document fields to be updated
      */
     protected void updateDocumentsInTx(String dbName, String collectionName, Document filter, Document document) {
-        assertThat(TestHelper.transactionsSupported(primary(), dbName)).isTrue();
+        assertThat(TestHelper.transactionsSupported()).isTrue();
 
-        primary().execute("update documents in tx", mongo -> {
+        try (var client = connect()) {
             Testing.debug("Updating document with filter '" + filter + "' in '" + dbName + "." + collectionName + "'");
 
-            final MongoDatabase db = mongo.getDatabase(dbName);
+            final MongoDatabase db = client.getDatabase(dbName);
             final MongoCollection<Document> collection = db.getCollection(collectionName);
 
-            final ClientSession session = mongo.startSession();
+            final ClientSession session = client.startSession();
             try {
                 session.startTransaction();
 
@@ -244,7 +267,7 @@ public abstract class AbstractMongoConnectorIT extends AbstractConnectorTest {
             finally {
                 session.close();
             }
-        });
+        }
     }
 
     /**
@@ -255,15 +278,15 @@ public abstract class AbstractMongoConnectorIT extends AbstractConnectorTest {
      * @param filter the document filter
      */
     protected void deleteDocuments(String dbName, String collectionName, Document filter) {
-        primary().execute("delete", mongo -> {
-            MongoDatabase db = mongo.getDatabase(dbName);
+        try (var client = connect()) {
+            MongoDatabase db = client.getDatabase(dbName);
             MongoCollection<Document> coll = db.getCollection(collectionName);
             coll.deleteOne(filter);
-        });
+        }
     }
 
-    protected MongoPrimary primary() {
-        return TestHelper.primary(context);
+    protected MongoClient connect() {
+        return MongoClients.create(mongo.getConnectionString());
     }
 
     private static boolean collectionExists(MongoDatabase database, String collectionName) {
@@ -278,13 +301,13 @@ public abstract class AbstractMongoConnectorIT extends AbstractConnectorTest {
     }
 
     protected void storeDocuments(String dbName, String collectionName, String pathOnClasspath) {
-        primary().execute("storing documents", mongo -> {
+        try (var client = connect()) {
             Testing.debug("Storing in '" + dbName + "." + collectionName + "' documents loaded from from '" + pathOnClasspath + "'");
-            MongoDatabase db1 = mongo.getDatabase(dbName);
+            MongoDatabase db1 = client.getDatabase(dbName);
             MongoCollection<Document> coll = db1.getCollection(collectionName);
             coll.drop();
             storeDocuments(coll, pathOnClasspath);
-        });
+        }
     }
 
     protected void storeDocuments(MongoCollection<Document> collection, String pathOnClasspath) {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/AbstractMongoIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/AbstractMongoIT.java
@@ -18,20 +18,20 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.mongodb.ConnectionContext.MongoPrimary;
 import io.debezium.util.Testing;
 
-public abstract class AbstractMongoIT implements Testing {
+public abstract class AbstractMongoIT extends AbstractBaseMongoIT {
 
     protected final static Logger logger = LoggerFactory.getLogger(AbstractMongoIT.class);
 
     protected Configuration config;
     protected MongoDbTaskContext context;
-    protected ReplicaSet replicaSet;
     protected MongoPrimary primary;
+    protected ReplicaSet replicaSet;
 
     @Before
     public void beforeEach() {
         Testing.Print.disable();
         Testing.Debug.disable();
-        useConfiguration(TestHelper.getConfiguration());
+        useConfiguration(TestHelper.getConfiguration(mongo));
     }
 
     /**

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/CloudEventsConverterIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/CloudEventsConverterIT.java
@@ -28,7 +28,7 @@ public class CloudEventsConverterIT extends AbstractMongoConnectorIT {
     @Test
     public void testCorrectFormat() throws Exception {
         Testing.Print.enable();
-        config = TestHelper.getConfiguration()
+        config = TestHelper.getConfiguration(mongo)
                 .edit()
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbA.c1")
                 .with(MongoDbConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
@@ -36,7 +36,7 @@ public class CloudEventsConverterIT extends AbstractMongoConnectorIT {
 
         context = new MongoDbTaskContext(config);
 
-        TestHelper.cleanDatabase(primary(), "dbA");
+        TestHelper.cleanDatabase(mongo, "dbA");
 
         start(MongoDbConnector.class, config);
         assertConnectorIsRunning();

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ConnectionIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ConnectionIT.java
@@ -7,11 +7,13 @@ package io.debezium.connector.mongodb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.kafka.connect.errors.ConnectException;
 import org.bson.BsonTimestamp;
 import org.bson.Document;
 import org.bson.conversions.Bson;
@@ -26,15 +28,34 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.InsertOneOptions;
 
+import io.debezium.config.CommonConnectorConfig;
 import io.debezium.util.Testing;
 
 public class ConnectionIT extends AbstractMongoIT {
 
     @Before
     public void setUp() {
-        TestHelper.cleanDatabase(primary, "dbA");
-        TestHelper.cleanDatabase(primary, "dbB");
-        TestHelper.cleanDatabase(primary, "dbC");
+        TestHelper.cleanDatabase(mongo, "dbA");
+        TestHelper.cleanDatabase(mongo, "dbB");
+        TestHelper.cleanDatabase(mongo, "dbC");
+    }
+
+    @Test(expected = ConnectException.class)
+    public void shouldUseSSL() throws InterruptedException, IOException {
+        // Use the DB configuration to define the connector's configuration ...
+        useConfiguration(config.edit()
+                .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
+                .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "mongo")
+                .with(MongoDbConnectorConfig.MAX_FAILED_CONNECTIONS, 0)
+                .with(MongoDbConnectorConfig.SSL_ENABLED, true)
+                .with(MongoDbConnectorConfig.SERVER_SELECTION_TIMEOUT_MS, 2000)
+                .build());
+
+        primary.executeBlocking("Try SSL connection", mongo -> {
+            primary.stop();
+            mongo.getDatabase("dbit").listCollectionNames().first();
+        });
     }
 
     @Test
@@ -48,33 +69,40 @@ public class ConnectionIT extends AbstractMongoIT {
 
         List<String> dbNames = Arrays.asList("A", "B", "C");
 
-        primary.execute("shouldCreateMovieDatabases", mongo -> {
+        try (var client = connect()) {
             Testing.debug("Getting or creating 'movies' collections");
 
             for (String dbName : dbNames) {
                 // Create a database and a collection in that database ...
-                MongoDatabase db = mongo.getDatabase("db" + dbName);
+                MongoDatabase db = client.getDatabase("db" + dbName);
 
                 // Get or create a collection in that database ...
                 db.getCollection("movies" + dbName);
             }
 
             Testing.debug("Completed getting 'movies' collections");
-        });
+        }
 
-        primary.execute("Add document to movies collections", mongo -> {
+        try (var client = connect()) {
             Testing.debug("Adding document to 'movies' collections");
 
             for (String dbName : dbNames) {
                 // Add a document to that collection ...
-                MongoDatabase db = mongo.getDatabase("db" + dbName);
+                MongoDatabase db = client.getDatabase("db" + dbName);
                 MongoCollection<Document> collection = db.getCollection("movies" + dbName);
                 MongoCollection<Document> movies = collection;
                 InsertOneOptions insertOptions = new InsertOneOptions().bypassDocumentValidation(true);
                 movies.insertOne(Document.parse("{ \"name\":\"Starter Wars\"}"), insertOptions);
                 assertThat(collection.countDocuments()).isEqualTo(1);
+            }
+            Testing.debug("Completed adding documents to 'movies' collections");
+        }
 
+        primary.execute("Add document to movies collections", client -> {
+            for (String dbName : dbNames) {
                 // Read the collection to make sure we can find our document ...
+                MongoDatabase db = client.getDatabase("db" + dbName);
+                MongoCollection<Document> collection = db.getCollection("movies" + dbName);
                 Bson filter = Filters.eq("name", "Starter Wars");
                 FindIterable<Document> movieResults = collection.find(filter);
                 try (MongoCursor<Document> cursor = movieResults.iterator();) {
@@ -82,8 +110,6 @@ public class ConnectionIT extends AbstractMongoIT {
                     assertThat(cursor.tryNext()).isNull();
                 }
             }
-
-            Testing.debug("Completed adding documents to 'movies' collections");
         });
 
         // Now that we've put at least one document into our collection, verify we can see the database and collection ...
@@ -127,11 +153,5 @@ public class ConnectionIT extends AbstractMongoIT {
             BsonTimestamp position = event.get("ts", BsonTimestamp.class);
             assert position != null;
         });
-    }
-
-    @Test
-    public void shouldListDatabases() {
-        Testing.Print.enable();
-        Testing.print("Databases: " + primary.databaseNames());
     }
 }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldRenamesIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/FieldRenamesIT.java
@@ -1599,7 +1599,7 @@ public class FieldRenamesIT extends AbstractMongoConnectorIT {
         config = getConfiguration("*.c1.name:new_name,*.c1.active:new_active");
         context = new MongoDbTaskContext(config);
 
-        TestHelper.cleanDatabase(primary(), "dbA");
+        TestHelper.cleanDatabase(mongo, "dbA");
 
         ObjectId objId = new ObjectId();
         Document obj = new Document("_id", objId);
@@ -1636,7 +1636,7 @@ public class FieldRenamesIT extends AbstractMongoConnectorIT {
         config = getConfiguration("*.c1.name:new_name,*.c1.active:new_active");
         context = new MongoDbTaskContext(config);
 
-        TestHelper.cleanDatabase(primary(), "dbA");
+        TestHelper.cleanDatabase(mongo, "dbA");
 
         ObjectId objId = new ObjectId();
         Document obj = new Document("_id", objId);
@@ -1826,7 +1826,7 @@ public class FieldRenamesIT extends AbstractMongoConnectorIT {
     }
 
     private static Configuration getConfiguration(String fieldRenames, String database, String collection) {
-        Configuration.Builder builder = TestHelper.getConfiguration().edit()
+        Configuration.Builder builder = TestHelper.getConfiguration(mongo).edit()
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, database + "." + collection)
                 .with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)
                 .with(CommonConnectorConfig.SCHEMA_NAME_ADJUSTMENT_MODE, SchemaNameAdjustmentMode.AVRO);
@@ -1847,7 +1847,7 @@ public class FieldRenamesIT extends AbstractMongoConnectorIT {
         config = getConfiguration(fieldRenames, database, collection);
         context = new MongoDbTaskContext(config);
 
-        TestHelper.cleanDatabase(primary(), database);
+        TestHelper.cleanDatabase(mongo, database);
 
         dropAndInsertDocuments(database, collection, document);
 
@@ -1868,7 +1868,7 @@ public class FieldRenamesIT extends AbstractMongoConnectorIT {
         config = getConfiguration(fieldRenames, database, collection);
         context = new MongoDbTaskContext(config);
 
-        TestHelper.cleanDatabase(primary(), database);
+        TestHelper.cleanDatabase(mongo, database);
 
         insertDocuments(database, collection, document);
 
@@ -1917,7 +1917,7 @@ public class FieldRenamesIT extends AbstractMongoConnectorIT {
         config = getConfiguration(renamesList);
         context = new MongoDbTaskContext(config);
 
-        TestHelper.cleanDatabase(primary(), DATABASE_NAME);
+        TestHelper.cleanDatabase(mongo, DATABASE_NAME);
 
         dropAndInsertDocuments(DATABASE_NAME, COLLECTION_NAME, snapshot);
 
@@ -1933,7 +1933,7 @@ public class FieldRenamesIT extends AbstractMongoConnectorIT {
         config = getConfiguration(renamesList);
         context = new MongoDbTaskContext(config);
 
-        TestHelper.cleanDatabase(primary(), DATABASE_NAME);
+        TestHelper.cleanDatabase(mongo, DATABASE_NAME);
 
         logInterceptor = new LogInterceptor(FieldRenamesIT.class);
         start(MongoDbConnector.class, config);

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoMetricsIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoMetricsIT.java
@@ -29,7 +29,7 @@ public class MongoMetricsIT extends AbstractMongoConnectorIT {
     @Test
     public void testLifecycle() throws Exception {
         // Setup
-        this.config = TestHelper.getConfiguration()
+        this.config = TestHelper.getConfiguration(mongo)
                 .edit()
                 .with(MongoDbConnectorConfig.SNAPSHOT_MODE, MongoDbConnectorConfig.SnapshotMode.INITIAL)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
@@ -70,14 +70,14 @@ public class MongoMetricsIT extends AbstractMongoConnectorIT {
     @Test
     public void testSnapshotOnlyMetrics() throws Exception {
         // Setup
-        this.config = TestHelper.getConfiguration()
+        this.config = TestHelper.getConfiguration(mongo)
                 .edit()
                 .with(MongoDbConnectorConfig.SNAPSHOT_MODE, MongoDbConnectorConfig.SnapshotMode.INITIAL)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
                 .build();
         this.context = new MongoDbTaskContext(config);
 
-        TestHelper.cleanDatabase(primary(), "dbit");
+        TestHelper.cleanDatabase(mongo, "dbit");
         storeDocuments("dbit", "restaurants", "restaurants1.json");
 
         // start connector
@@ -112,14 +112,14 @@ public class MongoMetricsIT extends AbstractMongoConnectorIT {
     @Test
     public void testStreamingOnlyMetrics() throws Exception {
         // Setup
-        this.config = TestHelper.getConfiguration()
+        this.config = TestHelper.getConfiguration(mongo)
                 .edit()
                 .with(MongoDbConnectorConfig.SNAPSHOT_MODE, MongoDbConnectorConfig.SnapshotMode.NEVER)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
                 .build();
         this.context = new MongoDbTaskContext(config);
 
-        TestHelper.cleanDatabase(primary(), "dbit");
+        TestHelper.cleanDatabase(mongo, "dbit");
 
         // start connector
         start(MongoDbConnector.class, config);
@@ -154,7 +154,7 @@ public class MongoMetricsIT extends AbstractMongoConnectorIT {
         final String DOCUMENT_ID = "_id";
         final int NUM_RECORDS = 1_000;
 
-        this.config = TestHelper.getConfiguration()
+        this.config = TestHelper.getConfiguration(mongo)
                 .edit()
                 .with(MongoDbConnectorConfig.SNAPSHOT_MODE, MongoDbConnectorConfig.SnapshotMode.NEVER)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbit.*")
@@ -163,7 +163,7 @@ public class MongoMetricsIT extends AbstractMongoConnectorIT {
                 .build();
         this.context = new MongoDbTaskContext(config);
 
-        TestHelper.cleanDatabase(primary(), "dbit");
+        TestHelper.cleanDatabase(mongo, "dbit");
         final Document[] documents = new Document[NUM_RECORDS];
         for (int i = 0; i < NUM_RECORDS; i++) {
             final Document doc = new Document();

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoUtilIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoUtilIT.java
@@ -7,9 +7,12 @@ package io.debezium.connector.mongodb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Optional;
+
 import org.junit.Test;
 
 import com.mongodb.ServerAddress;
+import com.mongodb.connection.ServerDescription;
 
 /**
  * @author Chris Collingwood
@@ -22,10 +25,25 @@ public class MongoUtilIT extends AbstractMongoIT {
                 .with(MongoDbConnectorConfig.AUTO_DISCOVER_MEMBERS, true)
                 .build());
 
+        Optional<ServerAddress> expectedPrimaryAddress;
+
+        try (var client = connect()) {
+            client.listDatabaseNames().first();
+
+            var servers = client.getClusterDescription().getServerDescriptions();
+
+            expectedPrimaryAddress = servers.stream()
+                    .filter(ServerDescription::isPrimary)
+                    .findFirst()
+                    .map(ServerDescription::getAddress);
+        }
+
+        assertThat(expectedPrimaryAddress).isPresent();
+
         primary.execute("shouldConnect", mongo -> {
             ServerAddress primaryAddress = MongoUtil.getPrimaryAddress(mongo);
-            assertThat(primaryAddress.getHost()).isEqualTo("localhost");
-            assertThat(primaryAddress.getPort()).isEqualTo(27017);
+            assertThat(primaryAddress.getHost()).isEqualTo(expectedPrimaryAddress.map(ServerAddress::getHost).get());
+            assertThat(primaryAddress.getPort()).isEqualTo(expectedPrimaryAddress.map(ServerAddress::getPort).get());
         });
     }
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/TransactionMetadataIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/TransactionMetadataIT.java
@@ -29,7 +29,7 @@ public class TransactionMetadataIT extends AbstractMongoConnectorIT {
     @Test
     public void transactionMetadata() throws Exception {
         Testing.Print.enable();
-        config = TestHelper.getConfiguration()
+        config = TestHelper.getConfiguration(mongo)
                 .edit()
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbA.c1")
                 .with(MongoDbConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
@@ -38,9 +38,9 @@ public class TransactionMetadataIT extends AbstractMongoConnectorIT {
 
         context = new MongoDbTaskContext(config);
 
-        TestHelper.cleanDatabase(primary(), "dbA");
+        TestHelper.cleanDatabase(mongo, "dbA");
 
-        if (!TestHelper.transactionsSupported(primary(), "mongo1")) {
+        if (!TestHelper.transactionsSupported()) {
             return;
         }
 
@@ -81,7 +81,7 @@ public class TransactionMetadataIT extends AbstractMongoConnectorIT {
     @FixFor("DBZ-4077")
     public void transactionMetadataWithCustomTopicName() throws Exception {
         Testing.Print.enable();
-        config = TestHelper.getConfiguration()
+        config = TestHelper.getConfiguration(mongo)
                 .edit()
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, "dbA.c1")
                 .with(MongoDbConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL)
@@ -91,9 +91,9 @@ public class TransactionMetadataIT extends AbstractMongoConnectorIT {
 
         context = new MongoDbTaskContext(config);
 
-        TestHelper.cleanDatabase(primary(), "dbA");
+        TestHelper.cleanDatabase(mongo, "dbA");
 
-        if (!TestHelper.transactionsSupported(primary(), "mongo1")) {
+        if (!TestHelper.transactionsSupported()) {
             return;
         }
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/junit/MongoDbDatabaseProvider.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/junit/MongoDbDatabaseProvider.java
@@ -10,6 +10,7 @@ import io.debezium.testing.testcontainers.util.ParsingPortResolver;
 
 public final class MongoDbDatabaseProvider {
 
+    public static final String MONGO_REPLICA_SIZE = "mongodb.replica.size";
     public static final String MONGO_DOCKER_DESKTOP_PORT_PROPERTY = "mongodb.docker.desktop.ports";
 
     // Should be aligned with definition in pom.xm
@@ -23,9 +24,10 @@ public final class MongoDbDatabaseProvider {
     public static MongoDbReplicaSet mongoDbReplicaSet() {
         // will be used only in environment with docker desktop
         var portResolver = ParsingPortResolver.parseProperty(MONGO_DOCKER_DESKTOP_PORT_PROPERTY, MONGO_DOCKER_DESKTOP_PORT_DEFAULT);
+        var replicaSize = Integer.parseInt(System.getProperty(MONGO_REPLICA_SIZE, "1"));
 
         return MongoDbReplicaSet.replicaSet()
-                .memberCount(3)
+                .memberCount(replicaSize)
                 .portResolver(portResolver)
                 .build();
     }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/junit/MongoDbDatabaseProvider.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/junit/MongoDbDatabaseProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb.junit;
+
+import io.debezium.testing.testcontainers.MongoDbReplicaSet;
+import io.debezium.testing.testcontainers.util.ParsingPortResolver;
+
+public final class MongoDbDatabaseProvider {
+
+    public static final String MONGO_DOCKER_DESKTOP_PORT_PROPERTY = "mongodb.docker.desktop.ports";
+
+    // Should be aligned with definition in pom.xm
+    public static final String MONGO_DOCKER_DESKTOP_PORT_DEFAULT = "27017,27018,27019";
+
+    /**
+     * Constructs the default testing MongoDB replica set
+     *
+     * @return MongoDb Replica set
+     */
+    public static MongoDbReplicaSet mongoDbReplicaSet() {
+        // will be used only in environment with docker desktop
+        var portResolver = ParsingPortResolver.parseProperty(MONGO_DOCKER_DESKTOP_PORT_PROPERTY, MONGO_DOCKER_DESKTOP_PORT_DEFAULT);
+
+        return MongoDbReplicaSet.replicaSet()
+                .memberCount(3)
+                .portResolver(portResolver)
+                .build();
+    }
+
+    private MongoDbDatabaseProvider() {
+    }
+}

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/junit/MongoDbDatabaseVersionResolver.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/junit/MongoDbDatabaseVersionResolver.java
@@ -5,11 +5,8 @@
  */
 package io.debezium.connector.mongodb.junit;
 
-import java.util.List;
+import static io.debezium.connector.mongodb.TestHelper.MONGO_VERSION;
 
-import io.debezium.config.Configuration;
-import io.debezium.connector.mongodb.MongoDbTaskContext;
-import io.debezium.connector.mongodb.TestHelper;
 import io.debezium.junit.DatabaseVersionResolver;
 
 /**
@@ -20,12 +17,7 @@ import io.debezium.junit.DatabaseVersionResolver;
 public class MongoDbDatabaseVersionResolver implements DatabaseVersionResolver {
 
     public DatabaseVersion getVersion() {
-        Configuration config = TestHelper.getConfiguration();
-        MongoDbTaskContext context = new MongoDbTaskContext(config);
-
-        List<Integer> version = TestHelper.getVersionArray(TestHelper.primary(context), "mongo1");
-
-        return new DatabaseVersion(version.get(0), version.get(1), version.get(2));
+        return new DatabaseVersion(MONGO_VERSION.get(0), MONGO_VERSION.get(1), MONGO_VERSION.get(2));
     }
 
 }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/AbstractExtractNewDocumentStateTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/AbstractExtractNewDocumentStateTestIT.java
@@ -44,7 +44,7 @@ public abstract class AbstractExtractNewDocumentStateTestIT extends AbstractMong
     @Before
     public void beforeEach() {
         // Use the DB configuration to define the connector's configuration ...
-        Configuration config = TestHelper.getConfiguration().edit()
+        Configuration config = TestHelper.getConfiguration(mongo).edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, DB_NAME + "." + this.getCollectionName())
                 .with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)
@@ -63,7 +63,7 @@ public abstract class AbstractExtractNewDocumentStateTestIT extends AbstractMong
         context = new MongoDbTaskContext(config);
 
         // Cleanup database
-        TestHelper.cleanDatabase(primary(), DB_NAME);
+        TestHelper.cleanDatabase(mongo, DB_NAME);
 
         // Start the connector ...
         start(MongoDbConnector.class, config);
@@ -80,7 +80,7 @@ public abstract class AbstractExtractNewDocumentStateTestIT extends AbstractMong
         afterEach();
 
         // reconfigure and restart
-        Configuration config = TestHelper.getConfiguration().edit()
+        Configuration config = TestHelper.getConfiguration(mongo).edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, DB_NAME + "." + this.getCollectionName())
                 .with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UpdateOperators/AbstractExtractNewDocumentStateUpdateOperatorsTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UpdateOperators/AbstractExtractNewDocumentStateUpdateOperatorsTestIT.java
@@ -7,8 +7,6 @@ package io.debezium.connector.mongodb.transforms.UpdateOperators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.function.Consumer;
-
 import org.apache.kafka.connect.source.SourceRecord;
 import org.bson.Document;
 
@@ -35,19 +33,24 @@ abstract class AbstractExtractNewDocumentStateUpdateOperatorsTestIT extends Abst
     }
 
     SourceRecord executeSimpleUpdateOperation(String updateDocument) throws InterruptedException {
-        primary().execute("insert", createInsertItemDefault(1));
+
+        try (var client = connect()) {
+            createInsertItemDefault(client, 1);
+        }
 
         SourceRecords records = consumeRecordsByTopic(1);
 
         assertThat(records.recordsForTopic(this.topicName())).hasSize(1);
 
-        primary().execute("update", createUpdateOneItem(1, updateDocument));
+        try (var client = connect()) {
+            createUpdateOneItem(client, 1, updateDocument);
+        }
 
         return getUpdateRecord();
     }
 
-    private Consumer<MongoClient> createInsertItemDefault(int id) {
-        return client -> client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
+    private void createInsertItemDefault(MongoClient client, int id) {
+        client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
                 .insertOne(Document.parse("{" +
                         "'_id': " + id + "," +
                         "'dataStr': 'hello'," +
@@ -65,8 +68,8 @@ abstract class AbstractExtractNewDocumentStateUpdateOperatorsTestIT extends Abst
                         "}}"));
     }
 
-    private Consumer<MongoClient> createUpdateOneItem(int id, String document) {
-        return client -> client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
+    private void createUpdateOneItem(MongoClient client, int id, String document) {
+        client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
                 .updateOne(Document.parse(String.format("{'_id' : %d}", id)), Document.parse(document));
     }
 }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UpdateOperators/ExtractNewDocumentStateUpdateFieldOperatorTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/UpdateOperators/ExtractNewDocumentStateUpdateFieldOperatorTestIT.java
@@ -7,8 +7,6 @@ package io.debezium.connector.mongodb.transforms.UpdateOperators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.function.Consumer;
-
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -16,7 +14,6 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.junit.Test;
 
-import com.mongodb.client.MongoClient;
 import com.mongodb.client.model.UpdateOptions;
 
 import io.debezium.connector.mongodb.transforms.ExtractNewDocumentState;
@@ -164,10 +161,11 @@ public class ExtractNewDocumentStateUpdateFieldOperatorTestIT extends AbstractEx
         Bson setOnInsert = Document.parse("{'$setOnInsert': {'onlySetIfInsertDataInt': 789}}");
         UpdateOptions updateOptions = new UpdateOptions();
         updateOptions.upsert(true);
-        Consumer<MongoClient> upsert = client -> client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
-                .updateOne(Document.parse("{'_id' : 2}"), setOnInsert, updateOptions);
 
-        primary().execute("update", upsert);
+        try (var client = connect()) {
+            client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
+                    .updateOne(Document.parse("{'_id' : 2}"), setOnInsert, updateOptions);
+        }
 
         SourceRecord upsertRecord = consumeRecordsByTopic(1).recordsForTopic(this.topicName()).get(0);
 
@@ -182,9 +180,11 @@ public class ExtractNewDocumentStateUpdateFieldOperatorTestIT extends AbstractEx
 
         // Execute a new Upsert with the same ID to ensure the field "onlySetIfInsertDataInt" doesn't change its value
         Bson setOnInsertAndSet = Document.parse("{'$setOnInsert': {'onlySetIfInsertDataInt': 123}, '$set': {'newField': 456}}");
-        Consumer<MongoClient> upsertAndUpdate = client -> client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
-                .updateOne(Document.parse("{'_id' : 2}"), setOnInsertAndSet, updateOptions);
-        primary().execute("update", upsertAndUpdate);
+
+        try (var client = connect()) {
+            client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
+                    .updateOne(Document.parse("{'_id' : 2}"), setOnInsertAndSet, updateOptions);
+        }
 
         SourceRecord updateRecord = getUpdateRecord();
         final SourceRecord transformedUpdate = transformation.apply(updateRecord);

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouterTestIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/transforms/outbox/MongoEventRouterTestIT.java
@@ -47,7 +47,7 @@ public class MongoEventRouterTestIT extends AbstractMongoConnectorIT {
     @Before
     public void beforeEach() {
         // Use the DB configuration to define the connector's configuration ...
-        Configuration config = TestHelper.getConfiguration().edit()
+        Configuration config = TestHelper.getConfiguration(mongo).edit()
                 .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
                 .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, DB_NAME + "." + this.getCollectionName())
                 .with(CommonConnectorConfig.TOPIC_PREFIX, SERVER_NAME)
@@ -77,7 +77,7 @@ public class MongoEventRouterTestIT extends AbstractMongoConnectorIT {
         context = new MongoDbTaskContext(config);
 
         // Cleanup database
-        TestHelper.cleanDatabase(primary(), DB_NAME);
+        TestHelper.cleanDatabase(mongo, DB_NAME);
 
         // Start the connector ...
         start(MongoDbConnector.class, config);
@@ -98,7 +98,7 @@ public class MongoEventRouterTestIT extends AbstractMongoConnectorIT {
 
     @Test
     public void shouldConsumeRecordsFromInsert() throws Exception {
-        primary().execute("insert", client -> {
+        try (var client = connect()) {
             client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
                     .insertOne(new Document()
                             .append("aggregateid", 123L)
@@ -111,7 +111,7 @@ public class MongoEventRouterTestIT extends AbstractMongoConnectorIT {
                                     .append("asset", 100000L)
                                     .append("age", 42)
                                     .append("pets", Arrays.asList("dog", "cat"))));
-        });
+        }
 
         SourceRecords actualRecords = consumeRecordsByTopic(1);
         assertThat(actualRecords.topics().size()).isEqualTo(1);
@@ -137,7 +137,7 @@ public class MongoEventRouterTestIT extends AbstractMongoConnectorIT {
 
     @Test
     public void shouldSendEventTypeAsHeader() throws Exception {
-        primary().execute("insert", client -> {
+        try (var client = connect()) {
             client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
                     .insertOne(new Document()
                             .append("aggregateid", 123L)
@@ -147,7 +147,7 @@ public class MongoEventRouterTestIT extends AbstractMongoConnectorIT {
                                     .append("_id", new ObjectId("000000000000000000000000"))
                                     .append("fullName", "John Doe")
                                     .append("asset", 100000L)));
-        });
+        }
 
         final Map<String, String> config = new HashMap<>();
         config.put(
@@ -177,7 +177,7 @@ public class MongoEventRouterTestIT extends AbstractMongoConnectorIT {
 
     @Test
     public void shouldSendEventTypeAsValue() throws Exception {
-        primary().execute("insert", client -> {
+        try (var client = connect()) {
             client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
                     .insertOne(new Document()
                             .append("aggregateid", 123L)
@@ -188,7 +188,7 @@ public class MongoEventRouterTestIT extends AbstractMongoConnectorIT {
                                     .append("fullName", "John Doe")
                                     .append("asset", 100000L)
                                     .append("age", 42)));
-        });
+        }
 
         final Map<String, String> config = new HashMap<>();
         config.put(
@@ -215,7 +215,7 @@ public class MongoEventRouterTestIT extends AbstractMongoConnectorIT {
 
     @Test
     public void shouldSupportAllFeatures() throws Exception {
-        primary().execute("insert", client -> {
+        try (var client = connect()) {
             client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
                     .insertOne(new Document()
                             .append("_id", new ObjectId("111111111111111111111111"))
@@ -231,7 +231,7 @@ public class MongoEventRouterTestIT extends AbstractMongoConnectorIT {
                                     .append("fullName", "John Doe")
                                     .append("asset", 100000L)
                                     .append("age", 42)));
-        });
+        }
 
         final Map<String, String> config = new HashMap<>();
         config.put(MongoEventRouterConfigDefinition.FIELD_SCHEMA_VERSION.name(), "version");
@@ -278,7 +278,7 @@ public class MongoEventRouterTestIT extends AbstractMongoConnectorIT {
 
     @Test
     public void shouldNotProduceTombstoneEventForNullPayload() throws Exception {
-        primary().execute("insert", client -> {
+        try (var client = connect()) {
             client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
                     .insertOne(new Document()
                             .append("_id", new ObjectId("000000000000000000000000"))
@@ -286,7 +286,7 @@ public class MongoEventRouterTestIT extends AbstractMongoConnectorIT {
                             .append("aggregatetype", "Order")
                             .append("type", "OrderCreated")
                             .append("payload", null));
-        });
+        }
 
         final Map<String, String> config = new HashMap<>();
         config.put(
@@ -321,7 +321,7 @@ public class MongoEventRouterTestIT extends AbstractMongoConnectorIT {
 
     @Test
     public void shouldProduceTombstoneEventForNullPayload() throws Exception {
-        primary().execute("insert", client -> {
+        try (var client = connect()) {
             client.getDatabase(DB_NAME).getCollection(this.getCollectionName())
                     .insertOne(new Document()
                             .append("_id", new ObjectId("000000000000000000000000"))
@@ -329,7 +329,7 @@ public class MongoEventRouterTestIT extends AbstractMongoConnectorIT {
                             .append("aggregatetype", "Order")
                             .append("type", "OrderCreated")
                             .append("payload", null));
-        });
+        }
 
         final Map<String, String> config = new HashMap<>();
         config.put("route.tombstone.on.empty.payload", "true");

--- a/debezium-testing/debezium-testing-testcontainers/pom.xml
+++ b/debezium-testing/debezium-testing-testcontainers/pom.xml
@@ -102,4 +102,16 @@
       </exclusions>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>--add-opens java.base/java.net=ALL-UNNAMED</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbContainer.java
@@ -5,10 +5,13 @@
  */
 package io.debezium.testing.testcontainers;
 
+import static io.debezium.testing.testcontainers.util.DockerUtils.isDockerDesktop;
+import static io.debezium.testing.testcontainers.util.DockerUtils.logDockerDesktopBanner;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.IntStream.range;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.function.Function;
 
 import org.slf4j.Logger;
@@ -65,6 +68,7 @@ public class MongoDbContainer extends GenericContainer<MongoDbContainer> {
         private PortResolver portResolver = new RandomPortResolver();
         private String replicaSet;
         private Network network = Network.SHARED;
+        private boolean skipDockerDesktopLogWarning = false;
 
         public Builder name(String name) {
             this.name = name;
@@ -91,6 +95,11 @@ public class MongoDbContainer extends GenericContainer<MongoDbContainer> {
             return this;
         }
 
+        public Builder skipDockerDesktopLogWarning(boolean skipDockerDesktopLogWarning) {
+            this.skipDockerDesktopLogWarning = skipDockerDesktopLogWarning;
+            return this;
+        }
+
         public MongoDbContainer build() {
             return new MongoDbContainer(this);
         }
@@ -110,6 +119,8 @@ public class MongoDbContainer extends GenericContainer<MongoDbContainer> {
         else {
             this.port = builder.port;
         }
+
+        logDockerDesktopBanner(LOGGER, List.of(name), builder.skipDockerDesktopLogWarning);
 
         withNetwork(builder.network);
         withNetworkAliases(name);
@@ -267,11 +278,6 @@ public class MongoDbContainer extends GenericContainer<MongoDbContainer> {
     protected void containerIsStopped(InspectContainerResponse containerInfo) {
         super.containerIsStopped(containerInfo);
         portResolver.releasePort(port);
-    }
-
-    public static boolean isDockerDesktop() {
-        var info = DockerClientFactory.instance().getInfo();
-        return "docker-desktop".equals(info.getName());
     }
 
     private static boolean isLegacy() {

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbContainer.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.testing.testcontainers;
 
+import static io.debezium.testing.testcontainers.util.DockerUtils.addFakeDnsEntry;
 import static io.debezium.testing.testcontainers.util.DockerUtils.isDockerDesktop;
 import static io.debezium.testing.testcontainers.util.DockerUtils.logDockerDesktopBanner;
 import static java.util.stream.Collectors.joining;
@@ -29,6 +30,7 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.command.SyncDockerCmd;
 import com.github.dockerjava.api.model.ContainerNetwork;
 
+import io.debezium.testing.testcontainers.util.DockerUtils;
 import io.debezium.testing.testcontainers.util.PortResolver;
 import io.debezium.testing.testcontainers.util.RandomPortResolver;
 
@@ -275,8 +277,15 @@ public class MongoDbContainer extends GenericContainer<MongoDbContainer> {
     }
 
     @Override
+    protected void containerIsStarted(InspectContainerResponse containerInfo) {
+        super.containerIsStarted(containerInfo);
+        addFakeDnsEntry(name);
+    }
+
+    @Override
     protected void containerIsStopped(InspectContainerResponse containerInfo) {
         super.containerIsStopped(containerInfo);
+        DockerUtils.removeFakeDnsEntry(name);
         portResolver.releasePort(port);
     }
 

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbReplicaSet.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbReplicaSet.java
@@ -28,6 +28,8 @@ import org.testcontainers.shaded.com.fasterxml.jackson.databind.JsonNode;
 
 import io.debezium.testing.testcontainers.MongoDbContainer.Address;
 import io.debezium.testing.testcontainers.util.MoreStartables;
+import io.debezium.testing.testcontainers.util.PortResolver;
+import io.debezium.testing.testcontainers.util.RandomPortResolver;
 
 /**
  * A MongoDB replica set.
@@ -40,6 +42,7 @@ public class MongoDbReplicaSet implements Startable {
     private final int memberCount;
     private final boolean configServer;
     private final Network network;
+    private final PortResolver portResolver;
 
     private final List<MongoDbContainer> members = new ArrayList<>();
 
@@ -57,6 +60,7 @@ public class MongoDbReplicaSet implements Startable {
         private boolean configServer = false;
 
         private Network network = Network.newNetwork();
+        private PortResolver portResolver = new RandomPortResolver();
 
         public Builder name(String name) {
             this.name = name;
@@ -83,6 +87,11 @@ public class MongoDbReplicaSet implements Startable {
             return this;
         }
 
+        public Builder portResolver(PortResolver portResolver) {
+            this.portResolver = portResolver;
+            return this;
+        }
+
         public MongoDbReplicaSet build() {
             return new MongoDbReplicaSet(this);
         }
@@ -93,12 +102,14 @@ public class MongoDbReplicaSet implements Startable {
         this.memberCount = builder.memberCount;
         this.configServer = builder.configServer;
         this.network = builder.network;
+        this.portResolver = builder.portResolver;
 
         for (int i = 1; i <= memberCount; i++) {
             members.add(node()
                     .network(network)
                     .name(builder.namespace + i)
                     .replicaSet(name)
+                    .portResolver(portResolver)
                     .build());
         }
     }

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/util/DockerUtils.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/util/DockerUtils.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.testing.testcontainers.util;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.testcontainers.DockerClientFactory;
+
+public class DockerUtils {
+
+    public static final String DOCKER_DESKTOP_LOG_SKIP_PROPERTY = "docker.desktop.log.skip";
+
+    public static boolean isDockerDesktop() {
+        var info = DockerClientFactory.instance().getInfo();
+        return "docker-desktop".equals(info.getName());
+    }
+
+    /**
+     * If required logs warning banner about required {@code /etc/hosts} entries
+     * <br/>
+     * The operation is not required and skipped if:
+     * <ul>
+     *     <li>Containers are not running under Docker Desktop</li>
+     *     <li>Skip parameter is {@code true}</li>
+     *     <li>{@link #DOCKER_DESKTOP_LOG_SKIP_PROPERTY} property is {@code true}</li>
+     * </ul>
+     *
+     * @param logger logger used to print the banner
+     * @param hosts list of container hostnames
+     * @param skip if true the operation is skipped
+     */
+    public static void logDockerDesktopBanner(Logger logger, Collection<String> hosts, boolean skip) {
+        var prop = System.getProperty(DOCKER_DESKTOP_LOG_SKIP_PROPERTY, "false");
+        var propertySkip = Boolean.parseBoolean(prop);
+
+        if (propertySkip || skip || !isDockerDesktop()) {
+            return;
+        }
+
+        final var newLine = "\n> ";
+        final var doubleNewLine = newLine.repeat(2);
+
+        var hostEntries = hosts.stream()
+                .map(host -> "127.0.0.1 " + host)
+                .collect(Collectors.joining(newLine));
+
+        var banner = new StringBuilder()
+                .append("\n>>> DOCKER DESKTOP DETECTED <<<")
+                .append(doubleNewLine)
+                .append("Requires the following entries in /etc/hosts or equivalent of your platform")
+                .append(doubleNewLine)
+                .append(hostEntries)
+                .append(newLine)
+                .append("\n>>> Missing entries will likely lead to failures");
+
+        logger.warn(banner.toString());
+    }
+
+    private DockerUtils() {
+        throw new AssertionError("Should not be instantiated");
+    }
+}

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/util/DockerUtils.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/util/DockerUtils.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.testing.testcontainers.util;
 
+import java.net.InetAddress;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
@@ -14,6 +15,7 @@ import org.testcontainers.DockerClientFactory;
 public class DockerUtils {
 
     public static final String DOCKER_DESKTOP_LOG_SKIP_PROPERTY = "docker.desktop.log.skip";
+    public static final String DOCKER_DESKTOP_DISABLE_FAKE_DNS = "docker.desktop.disable.fake.dns";
 
     public static boolean isDockerDesktop() {
         var info = DockerClientFactory.instance().getInfo();
@@ -28,6 +30,7 @@ public class DockerUtils {
      *     <li>Containers are not running under Docker Desktop</li>
      *     <li>Skip parameter is {@code true}</li>
      *     <li>{@link #DOCKER_DESKTOP_LOG_SKIP_PROPERTY} property is {@code true}</li>
+     *     <li>{@link FakeDns} is installed within JVM</li>
      * </ul>
      *
      * @param logger logger used to print the banner
@@ -38,7 +41,7 @@ public class DockerUtils {
         var prop = System.getProperty(DOCKER_DESKTOP_LOG_SKIP_PROPERTY, "false");
         var propertySkip = Boolean.parseBoolean(prop);
 
-        if (propertySkip || skip || !isDockerDesktop()) {
+        if (propertySkip || skip || !isDockerDesktop() || FakeDns.getInstance().isInstalled()) {
             return;
         }
 
@@ -59,6 +62,66 @@ public class DockerUtils {
                 .append("\n>>> Missing entries will likely lead to failures");
 
         logger.warn(banner.toString());
+    }
+
+    /**
+     * Enables {@link FakeDns} on docker desktop (if
+     */
+    public static void enableFakeDnsIfRequired() {
+        var property = System.getProperty(DOCKER_DESKTOP_DISABLE_FAKE_DNS, "false");
+
+        if (isDockerDesktop() && !Boolean.parseBoolean(property)) {
+            FakeDns.getInstance().install();
+        }
+    }
+
+    /**
+     * Disables {@link FakeDns} if enabled
+     */
+    public static void disableFakeDns() {
+        FakeDns.getInstance().restore();
+    }
+
+    /**
+     * If {@link FakeDns} is enabled, maps given hostname to {@link InetAddress#getLoopbackAddress()}
+     *
+     * @param hostname mapped hostname
+     */
+    public static void addFakeDnsEntry(String hostname) {
+        addFakeDnsEntry(hostname, InetAddress.getLoopbackAddress());
+    }
+
+    /**
+     * If {@link FakeDns} is enabled, maps given hostname to given address
+     *
+     * @param hostname mapped hostname
+     * @param address resolution address
+     */
+    public static void addFakeDnsEntry(String hostname, InetAddress address) {
+        if (FakeDns.getInstance().isInstalled()) {
+            FakeDns.getInstance().addResolution(hostname, address);
+        }
+    }
+
+    /**
+     * If {@link FakeDns} is enabled, remove mapping of given hostname to {@link InetAddress#getLoopbackAddress()}
+     *
+     * @param hostname mapped hostname
+     */
+    public static void removeFakeDnsEntry(String hostname) {
+        removeFakeDnsEntry(hostname, InetAddress.getLoopbackAddress());
+    }
+
+    /**
+     * If {@link FakeDns} is enabled, remove given mapping
+     *
+     * @param hostname mapped hostname
+     * @param address resolution address
+     */
+    public static void removeFakeDnsEntry(String hostname, InetAddress address) {
+        if (FakeDns.getInstance().isInstalled()) {
+            FakeDns.getInstance().removeResolution(hostname, address);
+        }
     }
 
     private DockerUtils() {

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/util/FakeDns.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/util/FakeDns.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.testing.testcontainers.util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Fake DNS resolver which allows tests to work well with testcontainer under Docker Desktop
+ *
+ * Adaptation of  https://github.com/CorfuDB/CorfuDB/blob/master/it/src/main/java/org/corfudb/universe/universe/docker/FakeDns.java
+ */
+public class FakeDns {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FakeDns.class);
+
+    private static final FakeDns instance = new FakeDns();
+
+    private final Map<String, InetAddress> forwardResolutions = new HashMap<>();
+
+    private Object originalNameService = null;
+
+    /**
+     * whether the fake resolver has been installed
+     */
+    private boolean installed = false;
+
+    private FakeDns() {
+    }
+
+    public static FakeDns getInstance() {
+        return instance;
+    }
+
+    public void addResolution(String hostname, InetAddress ip) {
+        synchronized (this) {
+            forwardResolutions.put(hostname, ip);
+        }
+        LOGGER.info("Added dns resolution: {} -> {}", hostname, ip);
+    }
+
+    public void removeResolution(String hostname, InetAddress ip) {
+        synchronized (this) {
+            forwardResolutions.remove(hostname, ip);
+        }
+        LOGGER.info("Removed dns resolution: {} -> {}", hostname, ip);
+    }
+
+    public synchronized boolean isInstalled() {
+        return installed;
+    }
+
+    /**
+     * Install the fake DNS resolver into the Java runtime.
+     */
+    public FakeDns install() {
+        synchronized (this) {
+            if (installed) {
+                return this;
+            }
+            try {
+                originalNameService = installDns();
+            }
+            catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+            installed = true;
+        }
+        LOGGER.info("FakeDns is now ENABLED in JVM Runtime");
+        return this;
+    }
+
+    /**
+     * Restore default DNS resolver in Java runtime.
+     **/
+    public FakeDns restore() {
+        synchronized (this) {
+            if (!installed) {
+                return this;
+            }
+            try {
+                restoreDns(originalNameService);
+            }
+            catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+            installed = false;
+        }
+        LOGGER.info("FakeDns is now DISABLED in JVM Runtime");
+        return this;
+    }
+
+    private Object installDns()
+            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, ClassNotFoundException, NoSuchFieldException {
+        // Override the NameService in Java 9 or later.
+        final Class<?> nameServiceInterface = Class.forName("java.net.InetAddress$NameService");
+        Field field = InetAddress.class.getDeclaredField("nameService");
+
+        // Get the default NameService to fall back to.
+        Method method = InetAddress.class.getDeclaredMethod("createNameService");
+        method.setAccessible(true);
+        Object fallbackNameService = method.invoke(null);
+
+        // Install a wrapping NameService proxy instance
+        Object installedNameService = Proxy.newProxyInstance(
+                nameServiceInterface.getClassLoader(),
+                new Class<?>[]{ nameServiceInterface },
+                new NameServiceListener(fallbackNameService));
+
+        // Set the NameService on the InetAddress field
+        field.setAccessible(true);
+        field.set(InetAddress.class, installedNameService);
+
+        return fallbackNameService;
+    }
+
+    private void restoreDns(Object nameService)
+            throws IllegalAccessException, NoSuchFieldException {
+        Field field = InetAddress.class.getDeclaredField("nameService");
+        field.setAccessible(true);
+        field.set(InetAddress.class, nameService);
+    }
+
+    public static <T extends Throwable> void propagateIfPossible(Throwable throwable, Class<T> declaredType) throws T {
+        if (declaredType.isInstance(throwable)) {
+            throw declaredType.cast(throwable);
+        }
+    }
+
+    /**
+     * NameServiceListener with a NameService implementation to fallback to.
+     */
+    private class NameServiceListener implements InvocationHandler {
+
+        private final Object fallbackNameService;
+
+        /**
+         * Creates {@link NameServiceListener} with fallback NameService
+         * The parameter is untyped as {@code java.net.InetAddress$NameService} is private
+         *
+         * @param fallbackNameService fallback NameService
+         */
+        NameServiceListener(Object fallbackNameService) {
+            this.fallbackNameService = fallbackNameService;
+        }
+
+        private InetAddress[] lookupAllHostAddr(String host) throws UnknownHostException {
+            InetAddress inetAddress;
+
+            synchronized (FakeDns.this) {
+                inetAddress = forwardResolutions.get(host);
+            }
+            if (inetAddress != null) {
+                return new InetAddress[]{ inetAddress };
+            }
+
+            return invokeFallBackMethod("lookupAllHostAddr", InetAddress[].class, host);
+        }
+
+        private String getHostByAddr(byte[] addr) throws UnknownHostException {
+            return invokeFallBackMethod("getHostsByAddr", String.class, addr);
+        }
+
+        private <T, P> T invokeFallBackMethod(String methodName, Class<T> returnType, P param) throws UnknownHostException {
+            try {
+                Method method = fallbackNameService
+                        .getClass()
+                        .getDeclaredMethod(methodName, param.getClass());
+
+                method.setAccessible(true);
+                var result = method.invoke(fallbackNameService, param);
+                return returnType.cast(result);
+            }
+            catch (ReflectiveOperationException | SecurityException e) {
+                propagateIfPossible(e.getCause(), UnknownHostException.class);
+                throw new AssertionError("unexpected reflection issue", e);
+            }
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            switch (method.getName()) {
+                case "lookupAllHostAddr":
+                    return lookupAllHostAddr((String) args[0]);
+                case "getHostByAddr":
+                    return getHostByAddr((byte[]) args[0]);
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+    }
+}

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/util/ParsingPortResolver.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/util/ParsingPortResolver.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.testing.testcontainers.util;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Extension of {@link PooledPortResolver} able to parse ports from either {@link String} value or system property
+ */
+public class ParsingPortResolver extends PooledPortResolver {
+
+    /**
+     * Creates port resolver form given property
+     *
+     * @param property property name
+     * @throws NullPointerException when property is undefined or {@code null}
+     * @return port resolver
+     */
+    public static ParsingPortResolver parseProperty(String property) {
+        return parseProperty(property, null);
+    }
+
+    /**
+     * Creates port resolver form given property
+     *
+     * @param property property name
+     * @throws NullPointerException when property is undefined or {@code null}
+     * @return port resolver
+     */
+    public static ParsingPortResolver parseProperty(String property, String defaultValue) {
+        var value = System.getProperty(property, defaultValue);
+        Objects.requireNonNull(value, "Property '" + property + "' is either undefined or null");
+        return new ParsingPortResolver(System.getProperty(property, defaultValue));
+    }
+
+    /**
+     * Creates port resolver, using build-in strategies to parse the value
+     *
+     * @param value given value
+     */
+    public ParsingPortResolver(String value) {
+        this(value, new ListParseStrategy(), new RangeParseStrategy());
+    }
+
+    /**
+     * Creates port resolver, using first usable strategy to parse the value
+     *
+     * @param value given value
+     * @param strategies parsing strategies
+     */
+    public ParsingPortResolver(String value, ParseStrategy... strategies) {
+        this(value, matchingStrategy(value, strategies));
+    }
+
+    /**
+     * Creates port resolver, using given strategy to parse the value
+     *
+     * @param value given value
+     * @param strategy parsing strategy
+     */
+    public ParsingPortResolver(String value, ParseStrategy strategy) {
+        super(strategy.parse(value));
+    }
+
+    private static ParseStrategy matchingStrategy(String value, ParseStrategy... strategies) {
+        return Arrays.stream(strategies)
+                .filter(s -> s.matches(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No applicable parsing strategy"));
+    }
+
+    /**
+     * Base class for property parsing strategy
+     */
+    public static abstract class ParseStrategy {
+        protected final Pattern pattern;
+
+        /**
+         * @param pattern regex pattern describing parseable values
+         */
+        public ParseStrategy(Pattern pattern) {
+            this.pattern = pattern;
+        }
+
+        /**
+         * Checks if value can be parsed
+         *
+         * @param value given value
+         * @return true if value can be parsed, false otherwise
+         */
+        public boolean matches(String value) {
+            return pattern.asMatchPredicate().test(value);
+        }
+
+        /**
+         * Parses ports from value
+         *
+         * @param value given value
+         * @throws IllegalArgumentException if given value cannot be parsed
+         * @return set of ports
+         */
+        public Set<Integer> parse(String value) {
+            var matcher = pattern.matcher(value);
+
+            if (!matcher.matches()) {
+                throw new IllegalArgumentException("Invalid value '" + value + "'");
+            }
+            return doParse(matcher, value);
+        }
+
+        protected abstract Set<Integer> doParse(Matcher matcher, String value);
+    }
+
+    /**
+     * Parses ports from comma separated list of numbers. E.g. {@code 8080,8081,8083}
+     */
+    public static final class ListParseStrategy extends ParseStrategy {
+        public static final Pattern PATTERN = Pattern.compile("^\\d+(,\\d+)*$");
+
+        public ListParseStrategy() {
+            super(PATTERN);
+        }
+
+        @Override
+        protected Set<Integer> doParse(Matcher matcher, String value) {
+            return Arrays.stream(value.split(","))
+                    .map(Integer::parseInt)
+                    .collect(Collectors.toSet());
+        }
+    }
+
+    /**
+     * Parses ports from a closed range of number. E.g. {@code 8080:8083}
+     */
+    public static final class RangeParseStrategy extends ParseStrategy {
+        public static final Pattern PATTERN = Pattern.compile("^(?<from>\\d+):(?<to>\\d+)$");
+
+        public RangeParseStrategy() {
+            super(PATTERN);
+        }
+
+        @Override
+        protected Set<Integer> doParse(Matcher matcher, String value) {
+            var from = Integer.parseInt(matcher.group("from"));
+            var to = Integer.parseInt(matcher.group("to"));
+
+            return IntStream.rangeClosed(from, to)
+                    .boxed()
+                    .collect(Collectors.toSet());
+        }
+
+    }
+}

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/util/PooledPortResolver.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/util/PooledPortResolver.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.testing.testcontainers.util;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolves ports from given pool
+ */
+public class PooledPortResolver implements PortResolver {
+    private final Logger LOGGER = LoggerFactory.getLogger(PooledPortResolver.class);
+
+    protected final Set<Integer> ports = new HashSet<>();
+    protected final Set<Integer> usedPorts = new HashSet<>();
+
+    /**
+     * Creates port resolver backed by given port pool
+     *
+     * @param ports set of available ports
+     */
+    public PooledPortResolver(Set<Integer> ports) {
+        if (ports == null || ports.isEmpty()) {
+            throw new IllegalStateException("Expected a non empty set of ports");
+        }
+
+        this.ports.addAll(ports);
+    }
+
+    @Override
+    public synchronized int resolveFreePort() {
+        var port = ports.stream()
+                .filter(Predicate.not(usedPorts::contains))
+                .findFirst();
+        port.ifPresent(usedPorts::add);
+        return port.orElseThrow(() -> new IllegalStateException("No free ports remaining"));
+    }
+
+    @Override
+    public synchronized void releasePort(int port) {
+        usedPorts.remove(port);
+    }
+}

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/util/PortResolver.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/util/PortResolver.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.testing.testcontainers.util;
+
+/**
+ *  Port resolver
+ */
+public interface PortResolver {
+
+    /**
+     * Resolves a free port
+     *
+     * @throws IllegalStateException when no port can be resolved
+     * @return free port
+     */
+    int resolveFreePort();
+
+    void releasePort(int port);
+}

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/util/RandomPortResolver.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/util/RandomPortResolver.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.testing.testcontainers.util;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+/**
+ * A port resolver which provides a random free port
+ * <p>
+ * Due to the naive implementation this may be prone
+ * <ul>
+ *     <li>Allocation race conditions</li>
+ *     <li>TCP ports stuck in TIME_WAIT state </li>
+ * </ul>
+ */
+public class RandomPortResolver implements PortResolver {
+    @Override
+    public int resolveFreePort() {
+        try (var serverSocket = new ServerSocket(0)) {
+            return serverSocket.getLocalPort();
+        }
+        catch (IOException e) {
+            return -1;
+        }
+    }
+
+    @Override
+    public void releasePort(int port) {
+        // no-op
+    }
+}

--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/MongoDbReplicaSetTest.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/MongoDbReplicaSetTest.java
@@ -15,7 +15,9 @@ import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.bson.BsonDocument;
 import org.bson.Document;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -32,6 +34,7 @@ import com.mongodb.client.model.changestream.ChangeStreamDocument;
 import com.mongodb.connection.ServerDescription;
 import com.mongodb.internal.selector.ReadPreferenceServerSelector;
 
+import io.debezium.testing.testcontainers.util.DockerUtils;
 import io.debezium.testing.testcontainers.util.ParsingPortResolver;
 import io.debezium.testing.testcontainers.util.PooledPortResolver;
 
@@ -43,6 +46,16 @@ public class MongoDbReplicaSetTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbReplicaSetTest.class);
 
     public static final String MONGO_DOCKER_DESKTOP_PORT_PROPERTY = "mongodb.docker.desktop.ports";
+
+    @BeforeAll
+    static void setupAll() {
+        DockerUtils.enableFakeDnsIfRequired();
+    }
+
+    @AfterAll
+    static void tearDownAll() {
+        DockerUtils.disableFakeDns();
+    }
 
     @AfterEach
     void tearDown() {

--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/MongoDbShardedClusterTest.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/MongoDbShardedClusterTest.java
@@ -13,6 +13,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.assertj.core.api.ListAssert;
 import org.bson.Document;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,12 +26,24 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 
+import io.debezium.testing.testcontainers.util.DockerUtils;
+
 /**
  * @see <a href="https://issues.redhat.com/browse/DBZ-5857">DBZ-5857</a>
  */
 public class MongoDbShardedClusterTest {
 
     private final static Logger LOGGER = LoggerFactory.getLogger(MongoDbShardedClusterTest.class);
+
+    @BeforeAll
+    static void setupAll() {
+        DockerUtils.enableFakeDnsIfRequired();
+    }
+
+    @AfterAll
+    static void tearDownAll() {
+        DockerUtils.disableFakeDns();
+    }
 
     @Test
     public void testCluster() {

--- a/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/MongoDbShardedClusterTest.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/test/java/io/debezium/testing/testcontainers/MongoDbShardedClusterTest.java
@@ -15,6 +15,7 @@ import org.assertj.core.api.ListAssert;
 import org.bson.Document;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +32,7 @@ import io.debezium.testing.testcontainers.util.DockerUtils;
 /**
  * @see <a href="https://issues.redhat.com/browse/DBZ-5857">DBZ-5857</a>
  */
+@Disabled
 public class MongoDbShardedClusterTest {
 
     private final static Logger LOGGER = LoggerFactory.getLogger(MongoDbShardedClusterTest.class);


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5857

WIP -- the following needs to be addressed

- [x] Repeatable RS startup on Docker Desktop 
- [x] Oplog size settings when starting replica sets (does not seem to be required by the tests at the moment)
- [x] Ability to set readConcern majority on replica set (This is always true since mongo 5.0 and enabled by default prior, so nothing we need to tweak currently)
- [x] Investigate and fix failures in `debezium-testing-testcontainers`

The items above should be address as part of `debezium-testing/debezium-testing-testcontainres` modul rather than in mongodb. 

This PR should be processed before #4071  in order to ensure proper test coverage as current approach with single node replica set is not sufficient.