### PR TITLE
DBZ-5906 Correct additional-conditions default in adhoc snapshots doc

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -525,7 +525,7 @@ See the next section for more details.
 The format of the names is the same as for xref:#{context}-property-signal-data-collection[signal.data.collection] configuration option.
 
 |`additional-condition`
-|Optional.Empty
+|_N/A_
 | An optional string, which specifies a condition based on the column(s) of the {data-collection}(s), to capture a
 subset of the contents of the {data-collection}(s).
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
@@ -45,7 +45,7 @@ The format of the names is the same as for the `signal.data.collection` configur
 
 ifeval::['{context}' != 'mongodb']
 |`additional-condition`
-|Optional.Empty
+|_N/A_
 | An optional string, which specifies a condition based on the column(s) of the {data-collection}(s), to capture a
 subset of the contents of the {data-collection}(s).
 endif::[]


### PR DESCRIPTION
[DBZ-5906](https://issues.redhat.com/browse/DBZ-5906)

This change corrects the `additional-conditions` argument that was listed as the default value in the documentation for ad hoc incremental snapshots and MySQL ad hoc read-only incremental snapshots.

Tested in a local Antora build.