### PR TITLE
[docs] Revert "DBZ-5817 removing mongodb.name references from docs"

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -203,7 +203,7 @@ For more information, see the https://docs.mongodb.com/manual/core/replica-set-a
 [[mongodb-logical-connector-name]]
 === Logical connector name
 
-The connector configuration property `topic.prefix` serves as a _logical name_ for the MongoDB replica set or sharded cluster.
+The connector configuration property `mongodb.name` serves as a _logical name_ for the MongoDB replica set or sharded cluster.
 The connector uses the logical name in a number of ways: as the prefix for all topic names, and as a unique identifier when recording the oplog/change stream position of each replica set.
 
 You should give each MongoDB connector a unique logical name that meaningfully describes the source MongoDB system.
@@ -318,7 +318,7 @@ To summarize, the MongoDB connector continues running in most situations. Commun
 === Topic names
 
 The MongoDB connector writes events for all insert, update, and delete operations to documents in each collection to a single Kafka topic.
-The name of the Kafka topics always takes the form _logicalName_._databaseName_._collectionName_, where _logicalName_ is the xref:{link-mongodb-connector}#mongodb-logical-connector-name[logical name] of the connector as specified with the `topic.prefix` configuration property, _databaseName_ is the name of the database where the operation occurred, and _collectionName_ is the name of the MongoDB collection in which the affected document existed.
+The name of the Kafka topics always takes the form _logicalName_._databaseName_._collectionName_, where _logicalName_ is the xref:{link-mongodb-connector}#mongodb-logical-connector-name[logical name] of the connector as specified with the `mongodb.name` configuration property, _databaseName_ is the name of the database where the operation occurred, and _collectionName_ is the name of the MongoDB collection in which the affected document existed.
 
 For example, consider a MongoDB replica set with an `inventory` database that contains four collections: `products`, `products_on_hand`, `customers`, and `orders`.
 If the connector monitoring this database were given a logical name of `fulfillment`, then the connector would produce events on these four Kafka topics:
@@ -399,8 +399,8 @@ The following example shows a typical message:
 }
 ----
 
-Unless overridden via the xref:{link-mongodb-connector}#mongodb-property-topic-transaction[`topic.transaction`] option,
-transaction events are written to the topic named xref:mongodb-property-topic-prefix[`_<topic.prefix>_`]`.transaction`.
+Unless overridden via the xref:{link-mongodb-connector}#mongodb-property-transaction-topic[`transaction.topic`] option,
+transaction events are written to the topic named `_database.server.name_.transaction`.
 
 .Change data event enrichment
 When transaction metadata is enabled, the data message `Envelope` is enriched with a new `transaction` field.
@@ -1286,7 +1286,7 @@ apiVersion: {KafkaConnectApiVersion}
     class: io.debezium.connector.mongodb.MongoDbConnector // <2>
     config:
      mongodb.hosts: rs0/192.168.99.100:27017 // <3>
-     topic.prefix: fulfillment // <4>
+     mongodb.name: fulfillment // <4>
      collection.include.list: inventory[.]* // <5>
 ----
 <1> The name that is used to register the connector with Kafka Connect.
@@ -1323,7 +1323,7 @@ Optionally, you can filter out collections that are not needed.
   "config": {
     "connector.class": "io.debezium.connector.mongodb.MongoDbConnector", // <2>
     "mongodb.hosts": "rs0/192.168.99.100:27017", // <3>
-    "topic.prefix": "fullfillment", // <4>
+    "mongodb.name": "fullfillment", // <4>
     "collection.include.list": "inventory[.]*" // <5>
   }
 }
@@ -1419,8 +1419,8 @@ It is mandatory to provide the current primary address.
 This limitation will be removed in the next {prodname} release.
 ====
 
-|[[mongodb-property-topic-prefix]]<<mongodb-property-topic-prefix, `+topic.prefix+`>>
-|No default
+|[[mongodb-property-mongodb-name]]<<mongodb-property-mongodb-name, `+mongodb.name+`>>
+|
 |A unique name that identifies the connector and/or MongoDB replica set or sharded cluster that this connector monitors.
 Each server should be monitored by at most one {prodname} connector, since this server name prefixes all persisted Kafka topics emanating from the MongoDB replica set or cluster.
 Use only alphanumeric characters, hyphens, dots and underscores to form the name.


### PR DESCRIPTION
This reverts commit 4dba1503a7da96f84f6bb9b6ae7e0477223bae84 which wasn't supposed to be backported to 1.9 