### PR TITLE
DBZ-5811,DBZ-5914 Don't manipulate with LSN when LSN flushing LSN is …

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -353,7 +353,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
 
     protected void validateSlotIsInExpectedState(WalPositionLocator walPosition) throws SQLException {
         Lsn lsn = walPosition.getLastCommitStoredLsn() != null ? walPosition.getLastCommitStoredLsn() : walPosition.getLastEventStoredLsn();
-        if (lsn == null) {
+        if (lsn == null || !connectorConfig.isFlushLsnOnSource()) {
             return;
         }
         try (Statement stmt = pgConnection().createStatement()) {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -2435,8 +2435,6 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         TestHelper.createDefaultReplicationSlot();
         TestHelper.execute(SETUP_TABLES_STMT);
 
-        final SlotState slotAtTheBeginning = getDefaultReplicationSlot();
-
         final Configuration.Builder configBuilder = TestHelper.defaultConfig()
                 .with(PostgresConnectorConfig.SLOT_NAME, ReplicationConnection.Builder.DEFAULT_SLOT_NAME)
                 .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, "false");
@@ -2449,9 +2447,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         assertThat(actualRecords.allRecordsInOrder().size()).isEqualTo(2);
 
         stopConnector();
-
         final SlotState slotAfterSnapshot = getDefaultReplicationSlot();
-        Assert.assertEquals(slotAtTheBeginning.slotLastFlushedLsn(), slotAfterSnapshot.slotLastFlushedLsn());
 
         TestHelper.execute("INSERT INTO s2.a (aa,bb) VALUES (1, 'test');");
         TestHelper.execute("UPDATE s2.a SET aa=2, bb='hello' WHERE pk=2;");


### PR DESCRIPTION
…disabled

Befre we start streamig, we adjust `confirmed_flush_lsn` in Postgres to the position where we determined that the streaming should start. When user disables LSN flushing, which is not desired as it's the user reponsibility to flush LSN in Postgres.

Also adjust related tests, as when LSN flushing is not disabled, flushed LSN in Postgres may change (as we e.g. determined start of streaming from offset or from `xlogpos`) and can result in the test failure. When flushing is enabled, only LSNs after start of streaming can be compared.

https://issues.redhat.com/browse/DBZ-5811
https://issues.redhat.com/browse/DBZ-5914