### PR TITLE
DBZ-4818 CloudEvents: Propagate "partitionkey"

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/converters/MySqlCloudEventsMaker.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/converters/MySqlCloudEventsMaker.java
@@ -5,9 +5,12 @@
  */
 package io.debezium.connector.mysql.converters;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.connector.mysql.MySqlPartition;
 import io.debezium.converters.recordandmetadata.RecordAndMetadata;
 import io.debezium.converters.spi.CloudEventsMaker;
 import io.debezium.converters.spi.SerializerType;
@@ -55,5 +58,14 @@ public class MySqlCloudEventsMaker extends CloudEventsMaker {
     @Override
     public Set<String> connectorSpecificSourceFields() {
         return MYSQL_SOURCE_FIELDS;
+    }
+
+    @Override
+    public String cePartitionKey() {
+        Map<String, String> partitionKeys = new MySqlPartition(
+                sourceField(AbstractSourceInfo.SERVER_NAME_KEY).toString(),
+                sourceField(AbstractSourceInfo.DATABASE_NAME_KEY).toString()).getSourcePartition();
+
+        return partitionKeys.keySet().stream().sorted().map(k -> k + ":" + partitionKeys.get(k)).collect(Collectors.joining(";"));
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/converters/OracleCloudEventsMaker.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/converters/OracleCloudEventsMaker.java
@@ -5,9 +5,12 @@
  */
 package io.debezium.connector.oracle.converters;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.connector.oracle.OraclePartition;
 import io.debezium.converters.recordandmetadata.RecordAndMetadata;
 import io.debezium.converters.spi.CloudEventsMaker;
 import io.debezium.converters.spi.SerializerType;
@@ -44,5 +47,14 @@ public class OracleCloudEventsMaker extends CloudEventsMaker {
     @Override
     public Set<String> connectorSpecificSourceFields() {
         return ORACLE_SOURCE_FIELDS;
+    }
+
+    @Override
+    public String cePartitionKey() {
+        Map<String, String> partitionKeys = new OraclePartition(
+                sourceField(AbstractSourceInfo.SERVER_NAME_KEY).toString(),
+                sourceField(AbstractSourceInfo.DATABASE_NAME_KEY).toString()).getSourcePartition();
+
+        return partitionKeys.keySet().stream().sorted().map(k -> k + ":" + partitionKeys.get(k)).collect(Collectors.joining(";"));
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/converters/PostgresCloudEventsMaker.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/converters/PostgresCloudEventsMaker.java
@@ -5,9 +5,12 @@
  */
 package io.debezium.connector.postgresql.converters;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.connector.postgresql.PostgresPartition;
 import io.debezium.converters.recordandmetadata.RecordAndMetadata;
 import io.debezium.converters.spi.CloudEventsMaker;
 import io.debezium.converters.spi.SerializerType;
@@ -48,5 +51,14 @@ public class PostgresCloudEventsMaker extends CloudEventsMaker {
     @Override
     public Set<String> connectorSpecificSourceFields() {
         return POSTGRES_SOURCE_FIELDS;
+    }
+
+    @Override
+    public String cePartitionKey() {
+        Map<String, String> partitionKeys = new PostgresPartition(
+                sourceField(AbstractSourceInfo.SERVER_NAME_KEY).toString(),
+                sourceField(AbstractSourceInfo.DATABASE_NAME_KEY).toString()).getSourcePartition();
+
+        return partitionKeys.keySet().stream().sorted().map(k -> k + ":" + partitionKeys.get(k)).collect(Collectors.joining(";"));
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/converters/SqlServerCloudEventsMaker.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/converters/SqlServerCloudEventsMaker.java
@@ -5,9 +5,12 @@
  */
 package io.debezium.connector.sqlserver.converters;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.connector.sqlserver.SqlServerPartition;
 import io.debezium.converters.recordandmetadata.RecordAndMetadata;
 import io.debezium.converters.spi.CloudEventsMaker;
 import io.debezium.converters.spi.SerializerType;
@@ -46,5 +49,14 @@ public class SqlServerCloudEventsMaker extends CloudEventsMaker {
     @Override
     public Set<String> connectorSpecificSourceFields() {
         return SQLSERVER_SOURCE_FIELDS;
+    }
+
+    @Override
+    public String cePartitionKey() {
+        Map<String, String> partitionKeys = new SqlServerPartition(
+                sourceField(AbstractSourceInfo.SERVER_NAME_KEY).toString(),
+                sourceField(AbstractSourceInfo.DATABASE_NAME_KEY).toString()).getSourcePartition();
+
+        return partitionKeys.keySet().stream().sorted().map(k -> k + ":" + partitionKeys.get(k)).collect(Collectors.joining(";"));
     }
 }

--- a/debezium-core/src/main/java/io/debezium/converters/CloudEventsConverter.java
+++ b/debezium-core/src/main/java/io/debezium/converters/CloudEventsConverter.java
@@ -511,6 +511,10 @@ public class CloudEventsConverter implements Converter, Versioned {
             ceSchemaFromSchema(TransactionMonitor.TRANSACTION_BLOCK_SCHEMA, ceSchemaBuilder, CloudEventsConverter::txExtensionName, true);
         }
 
+        if (maker.cePartitionKey() != null) {
+            ceSchemaBuilder.withSchema(CloudEventsMaker.FieldName.PARTITIONKEY, Schema.STRING_SCHEMA);
+        }
+
         ceSchemaBuilder.withSchema(CloudEventsMaker.FieldName.DATA, dataSchemaType);
 
         Schema ceSchema = ceSchemaBuilder.build();
@@ -533,6 +537,9 @@ public class CloudEventsConverter implements Converter, Versioned {
 
         if (this.openTelemetryTracingAttributesEnable) {
             ceValueBuilder.withValue(CloudEventsMaker.FieldName.TRACE_PARENT, recordAndMetadata.traceParent());
+        }
+        if (maker.cePartitionKey() != null) {
+            ceValueBuilder.withValue(CloudEventsMaker.FieldName.PARTITIONKEY, maker.cePartitionKey());
         }
 
         if (this.extensionAttributesEnable) {

--- a/debezium-core/src/main/java/io/debezium/converters/spi/CloudEventsMaker.java
+++ b/debezium-core/src/main/java/io/debezium/converters/spi/CloudEventsMaker.java
@@ -44,6 +44,8 @@ public abstract class CloudEventsMaker {
         public static final String DATACONTENTTYPE = "datacontenttype";
         public static final String DATASCHEMA = "dataschema";
 
+        public static final String PARTITIONKEY = "partitionkey";
+
         // TODO DBZ-1701 not used
         public static final String SUBJECT = "subject";
         public static final String TIME = "time";
@@ -189,5 +191,14 @@ public abstract class CloudEventsMaker {
 
     protected Object sourceField(String name) {
         return recordAndMetadata.sourceField(name, connectorSpecificSourceFields());
+    }
+
+    /**
+     * Construct the CloudEvent partitionKey following the format of: "id:1234;sub-id:56".
+     *
+     * @return the partitionKey of record.
+     */
+    public String cePartitionKey() {
+        return null;
     }
 }

--- a/debezium-core/src/test/java/io/debezium/converters/CloudEventsConverterTest.java
+++ b/debezium-core/src/test/java/io/debezium/converters/CloudEventsConverterTest.java
@@ -111,6 +111,7 @@ public class CloudEventsConverterTest {
             assertThat(valueJson.get(CloudEventsMaker.FieldName.TRACE_PARENT)).isNull();
             assertThat(valueJson.get(CloudEventsMaker.FieldName.DATACONTENTTYPE)).isNotNull();
             assertThat(valueJson.get(CloudEventsMaker.FieldName.TIME)).isNotNull();
+            assertThat(valueJson.get(CloudEventsMaker.FieldName.PARTITIONKEY)).isNullOrEmpty();
             assertThat(valueJson.get(CloudEventsMaker.FieldName.DATA)).isNotNull();
             msg = "inspecting required CloudEvents extension attributes for Debezium";
             assertThat(valueJson.get("iodebeziumop")).isNotNull();
@@ -210,6 +211,7 @@ public class CloudEventsConverterTest {
             assertThat(valueJson.get(CloudEventsMaker.FieldName.SPECVERSION)).isNotNull();
             assertThat(valueJson.get(CloudEventsMaker.FieldName.DATACONTENTTYPE).asText()).isEqualTo("application/avro");
             assertThat(valueJson.get(CloudEventsMaker.FieldName.DATASCHEMA).asText()).startsWith("http://fake-url/schemas/ids/");
+            assertThat(valueJson.get(CloudEventsMaker.FieldName.PARTITIONKEY)).isNullOrEmpty();
             assertThat(valueJson.get(CloudEventsMaker.FieldName.TYPE)).isNotNull();
             assertThat(valueJson.get(CloudEventsMaker.FieldName.TYPE).asText()).startsWith("io.debezium.connector.");
             assertThat(valueJson.get(CloudEventsMaker.FieldName.TYPE).asText()).endsWith(".DataChangeEvent");
@@ -308,6 +310,8 @@ public class CloudEventsConverterTest {
             assertThat(avroValue.get(CloudEventsMaker.FieldName.TYPE)).isEqualTo("io.debezium.connector." + connectorName + ".DataChangeEvent");
             assertThat(avroValue.get(CloudEventsMaker.FieldName.DATACONTENTTYPE)).isEqualTo("application/avro");
             assertThat(avroValue.getString(CloudEventsMaker.FieldName.DATASCHEMA)).startsWith("http://fake-url/schemas/ids/");
+            assertThat(avroValue.get(CloudEventsMaker.FieldName.PARTITIONKEY)).isNull();
+
             assertThat(avroValue.get(CloudEventsMaker.FieldName.TIME)).isNotNull();
             assertThat(avroValue.get(CloudEventsMaker.FieldName.DATA)).isNotNull();
             msg = "inspecting required CloudEvents extension attributes in the value";

--- a/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
+++ b/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
@@ -83,6 +83,7 @@ In this example, the PostgreSQL connector is configured to use JSON as the Cloud
   "datacontenttype" : "application/json",          // <6>
   "iodebeziumop" : "r",                            // <7>
   "iodebeziumversion" : "{debezium-version}",      // <8>
+  "partitionkey": "server:test_server",            // <9>
   "iodebeziumconnector" : "postgresql",
   "iodebeziumname" : "test_server",
   "iodebeziumtsms" : "1578923739738",
@@ -92,10 +93,10 @@ In this example, the PostgreSQL connector is configured to use JSON as the Cloud
   "iodebeziumtable" : "a",
   "iodebeziumlsn" : "29274832",
   "iodebeziumxmin" : null,
-  "iodebeziumtxid": "565",                       // <9>
+  "iodebeziumtxid": "565",                       // <10>
   "iodebeziumtxtotalorder": "1",
   "iodebeziumtxdatacollectionorder": "1",
-  "data" : {                                       // <10>
+  "data" : {                                       // <11>
     "before" : null,
     "after" : {
       "pk" : 1,
@@ -142,9 +143,12 @@ Possible values are `r` for read, `c` for create, `u` for update, or `d` for del
 |All `source` attributes that are known from {prodname} change events are mapped to CloudEvents extension attributes by using the `iodebezium` prefix for the attribute name.
 
 |9
-|When enabled in the connector, each `transaction` attribute that is known from {prodname} change events is mapped to a CloudEvents extension attribute by using the `iodebeziumtx` prefix for the attribute name.
+|All `source` attributes that are known from {prodname} change events are mapped to CloudEvents extension attributes by using the `iodebezium` prefix for the attribute name.
 
 |10
+|When enabled in the connector, each `transaction` attribute that is known from {prodname} change events is mapped to a CloudEvents extension attribute by using the `iodebeziumtx` prefix for the attribute name.
+
+|11
 |The actual data change.
 Depending on the operation and the connector, the data might contain `before`, `after`, or `patch` fields.
 
@@ -162,6 +166,7 @@ The following example also shows what a CloudEvents change event record emitted 
   "time" : "2020-01-13T14:04:18.597Z",
   "datacontenttype" : "application/avro",          // <1>
   "dataschema" : "http://my-registry/schemas/ids/1", // <2>
+  "partitionkey": "server:test_server",
   "iodebeziumop" : "r",
   "iodebeziumversion" : "{debezium-version}",
   "iodebeziumconnector" : "postgresql",


### PR DESCRIPTION
Resolves issue https://issues.redhat.com/browse/DBZ-4818 which was opened as a follow-up to the initial support for Knative eventing (https://issues.redhat.com/browse/DBZ-2097).

The approach taken was to expose a method `cePartitionKey()` that will default to a null value and not be emitted unless the underlying connector supported partitions by overriding the `io.debezium.pipeline.spi.Partition` interface. This PR relies on the call to `getSourcePartition()` to retrieve the k/v map for the partition components, sorts it, and then emits the results as a semicolon separated string.

A sample CloudEvent would resemble the following:
```json
{
    "id": "name:debeziumtest;lsn:11025469672;txId:10201056",
    "source": "/debezium/postgresql/debeziumtest",
    "specversion": "1.0",
    "type": "io.debezium.postgresql.datachangeevent",
    "time": "2022-12-09T19:11:32.458Z",
    "datacontenttype": "application/json",
    "partitionkey": "server:debeziumtest",
    "iodebeziumop": "r",
    "iodebeziumversion": "2.1.0-SNAPSHOT",
    "iodebeziumconnector": "postgresql",
    "iodebeziumname": "debeziumtest",
    "iodebeziumtsms": "1670613092458",
    "iodebeziumsnapshot": "last",
    "iodebeziumdb": "debeziumtest",
    "iodebeziumsequence": "[null,\"11025469672\"]",
    "iodebeziumschema": "public",
    "iodebeziumtable": "knative_projects",
    "iodebeziumtxId": "10201056",
    "iodebeziumlsn": "11025469672",
    "iodebeziumxmin": null,
    "iodebeziumtxid": null,
    "iodebeziumtxtotalorder": null,
    "iodebeziumtxdatacollectionorder": null,
    "data":
    {
        "schema":
        {
            "type": "struct",
            "fields":
            [
                {
                    "type": "struct",
                    "fields":
                    [
                        {
                            "type": "string",
                            "optional": false,
                            "field": "name"
                        },
                        {
                            "type": "int32",
                            "optional": true,
                            "field": "vote"
                        }
                    ],
                    "optional": true,
                    "name": "debeziumtest.public.knative_projects.Value",
                    "field": "before"
                },
                {
                    "type": "struct",
                    "fields":
                    [
                        {
                            "type": "string",
                            "optional": false,
                            "field": "name"
                        },
                        {
                            "type": "int32",
                            "optional": true,
                            "field": "vote"
                        }
                    ],
                    "optional": true,
                    "name": "debeziumtest.public.knative_projects.Value",
                    "field": "after"
                }
            ],
            "optional": false,
            "name": "io.debezium.connector.mysql.Data"
        },
        "payload":
        {
            "before": null,
            "after":
            {
                "name": "knative",
                "vote": 100
            }
        }
    }
}
```