### PR TITLE
DBZ-5915: correctly determine the startStreamingLsn

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
@@ -71,6 +71,12 @@ public class WalPositionLocator {
             // We can resume streaming from it
             if (currentLsn.equals(lastEventStoredLsn)) {
                 // BEGIN and first message after change have the same LSN
+                if (txStartLsn != null) {
+                    // start from the BEGIN tx; prevent skipping of unprocessed event after BEGIN
+                    // may reprocess the event after the BEGIN
+                    startStreamingLsn = txStartLsn;
+                    return Optional.of(startStreamingLsn);
+                }
                 return Optional.empty();
             }
             lsnAfterLastEventStoredLsn = currentLsn;


### PR DESCRIPTION
Addressing https://issues.redhat.com/browse/DBZ-5915

The LSN of the `BEGIN` message is same as the message following it.
If the `lastEventStoredLsn` corresponds to the `BEGIN` message, we are skipping the message following it because the LSN is same. This is causing data loss if the following message corresponds to any DML statement.

Proposed solution:
While looking for `lsnAfterLastEventStoredLsn`, instead of skipping the LSN which is same as the `lastEventStoredLsn` we set the `startStreamingLsn` as `txStartLsn` and return it. This will prevent the data loss.
In some cases, where the `lastEventStoredLsn` belongs to the message following the `BEGIN` message, it could lead to duplication of the message following the `BEGIN` message, which I think is fine.