### PR TITLE
DBZ-5930: Add the doc for vitess snapshot.mode

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -69,9 +69,7 @@ This snapshot feature is built on link:https://vitess.io/docs/design-docs/vrepli
 
 [NOTE]
 ====
-In Vitess 15 or earlier, it is not possible to resume `VStream Copy.`
-Starting in Vitess 16, it will support resuming this initial copy phase if it's interrupted for any reason.
-This will allow the Vitess connector to implement restarting the snapshot where it last left off.
+Automatic retry of a failed snapshot is expected to be available in a future release.
 ====
 
 // Type: concept

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -61,7 +61,10 @@ To optimally configure and run a {prodname} Vitess connector, it is helpful to u
 [[vitess-snapshot]]
 === Snapshot
 
-Most MySQL servers are configured to not retain the complete history of the database in the binary logs. This means that the connector would be unable to see the entire history of the database by reading only the binary logs. Consequently, the first time that the connector starts, it performs an initial consistent snapshot of the database. You can change this behavior by setting the xref:{link-vitess-connector}#vitess-property-snapshot-mode[`snapshot.mode` connector configuration property] to a value other than `initial`.
+Typically, a MySQL servers is not configured to retain the complete history of the database in the binary logs. 
+As a result, the connector is unable to read the entire history of the database from the binary logs. 
+For this reason, the first time that the connector starts, it performs an initial consistent snapshot of the database. 
+You can change this behavior by setting the xref:{link-vitess-connector}#vitess-property-snapshot-mode[`snapshot.mode` connector configuration property] to a value other than `initial`.
 This snapshot feature is built on link:https://vitess.io/docs/design-docs/vreplication/vstream/vscopy/[VStream Copy] introduced in version 7.0.
 
 [NOTE]

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -41,7 +41,10 @@ Thus, when the connector connects to a database for the first time, it performs 
 After the connector completes the snapshot, it continues streaming changes from the exact point at which the snapshot was made. 
 In this way, the connector starts with a consistent view of all of the data, and does not omit any changes that were made while the snapshot was being taken.
 
-The connector is tolerant of failures. As the connector reads changes and produces events, it records the VGTID position for each event. If the connector stops for any reason (including communication failures, network problems, or crashes), upon restart the connector continues reading the WAL where it last left off. This does not include snapshots. If the connector stops during a snapshot, upon restart the connector does not continue performing snapshots where it last left off.
+The connector is tolerant of failures. 
+As the connector reads changes and produces events, it records the VGTID position for each event. 
+If the connector stops for any reason (including communication failures, network problems, or crashes), after the connectors restarts, it continues reading the WAL from the point at which it stopped. 
+This behavior does not apply to snapshots. If the connector stops during a snapshot, after a restart, the connector does not continue performing snapshots where it last left off.
 We'll talk later about how the connector behaves xref:{link-vitess-connector}#vitess-when-things-go-wrong[when things go wrong].
 
 // Type: assembly

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -15,7 +15,7 @@ toc::[]
 {prodname}'s Vitess connector captures row-level changes in the shards of a Vitess link:https://vitess.io/docs/concepts/keyspace/[keyspace].
 For information about the Vitess versions that are compatible with this connector, see the link:https://debezium.io/releases/[{prodname} release overview].
 
-The connector does not support snapshot feature at the moment. The first time it connects to a Vitess cluster, it starts from the current VGTID location of the keyspace and continuously captures row-level changes that insert, update, and delete database content and that were committed to a Vitess keyspace. The connector generates data change event records and streams them to Kafka topics. For each table, the default behavior is that the connector streams all generated events to a separate Kafka topic for that table. Applications and services consume data change event records from that topic.
+The first time it connects to a Vitess cluster, the connector takes a consistent snapshot of the keyspace. After that snapshot is complete, the connector continuously captures row-level changes that insert, update, and delete database content and that were committed to a Vitess keyspace. The connector generates data change event records and streams them to Kafka topics. For each table, the default behavior is that the connector streams all generated events to a separate Kafka topic for that table. Applications and services consume data change event records from that topic.
 
 // Type: concept
 // Title: Overview of {prodname} Vitess connector
@@ -31,7 +31,10 @@ The connector gives you the flexibility to choose to subscribe to the `MASTER` n
 
 The connector produces a change event for every row-level insert, update, and delete operation that was captured and sends change event records for each table in a separate Kafka topic. Client applications read the Kafka topics that correspond to the database tables of interest, and can react to every row-level event they receive from those topics.
 
-The connector is tolerant of failures. As the connector reads changes and produces events, it records the VGTID position for each event. If the connector stops for any reason (including communication failures, network problems, or crashes), upon restart the connector continues reading the WAL where it last left off.
+The underlying MySQL normally purges binary logs after some period of time. This means that the connector does not have the complete history of all changes that have been made to the database. Therefore, when the connector first connects to a particular database, it starts by performing a consistent snapshot of each of the database. After the connector completes the snapshot, it continues streaming changes from the exact point at which the snapshot was made. This way, the connector starts with a consistent view of all of the data, and does not omit any changes that were made while the snapshot was being taken.
+
+The connector is tolerant of failures. As the connector reads changes and produces events, it records the VGTID position for each event. If the connector stops for any reason (including communication failures, network problems, or crashes), upon restart the connector continues reading the WAL where it last left off. This does not include snapshots. If the connector stops during a snapshot, upon restart the connector does not continue performing snapshots where it last left off.
+We'll talk later about how the connector behaves xref:{link-vitess-connector}#vitess-when-things-go-wrong[when things go wrong].
 
 // Type: assembly
 // ModuleID: how-debezium-vitess-connectors-work
@@ -39,7 +42,23 @@ The connector is tolerant of failures. As the connector reads changes and produc
 [[how-the-vitess-connector-works]]
 == How the connector works
 
-To optimally configure and run a {prodname} Vitess connector, it is helpful to understand how the connector streams change events, determines Kafka topic names, and uses metadata.
+To optimally configure and run a {prodname} Vitess connector, it is helpful to understand how the connector performs snapshots, streams change events, determines Kafka topic names, and uses metadata.
+
+// Type: concept
+// ModuleID: how-debezium-vitess-connectors-perform-snapshot
+// Title: How {prodname} Vitess connectors perform a snapshot
+[[vitess-snapshot]]
+=== Snapshot
+
+Most MySQL servers are configured to not retain the complete history of the database in the binary logs. This means that the connector would be unable to see the entire history of the database by reading only the binary logs. Consequently, the first time that the connector starts, it performs an initial consistent snapshot of the database. You can change this behavior by setting the xref:{link-vitess-connector}#vitess-property-snapshot-mode[`snapshot.mode` connector configuration property] to a value other than `initial`.
+This snapshot feature is built on link:https://vitess.io/docs/design-docs/vreplication/vstream/vscopy/[VStream Copy] introduced in version 7.0.
+
+[NOTE]
+====
+In Vitess 15 or earlier, it is not possible to resume `VStream Copy.`
+Starting in Vitess 16, it will support resuming this initial copy phase if it's interrupted for any reason.
+This will allow the Vitess connector to implement restarting the snapshot where it last left off.
+====
 
 // Type: concept
 // ModuleID: how-debezium-vitess-connectors-stream-change-event-records
@@ -500,7 +519,7 @@ The following example shows the value portion of a change event that the connect
             "connector": "vitess",
             "name": "my_sharded_connector",
             "ts_ms": 1559033904863,
-            "snapshot": true,
+            "snapshot": false,
             "db": "",
             "keyspace": "commerce",
             "table": "customers",
@@ -560,7 +579,7 @@ a|Mandatory field that describes the source metadata for the event. This field c
 * {prodname} version
 * Connector type and name
 * Database (a.k.a keyspace) and table that contains the new row
-* If the event was part of a snapshot
+* If the event was part of a snapshot (always `false`)
 * Offset of the operation in the database binlog
 * Timestamp for when the change was made in the database
 
@@ -608,7 +627,7 @@ The value of a change event for an update in the sample `customers` table has th
             "connector": "vitess",
             "name": "my_sharded_connector",
             "ts_ms": 1559033904863,
-            "snapshot": null,
+            "snapshot": false,
             "db": "",
             "keyspace": "commerce",
             "table": "customers",
@@ -640,7 +659,7 @@ a|Mandatory field that describes the source metadata for the event. The `source`
 * {prodname} version
 * Connector type and name
 * Database (a.k.a keyspace) and table that contains the new row
-* If the event was part of a snapshot
+* If the event was part of a snapshot (always `false`)
 * Offset of the operation in the database log
 * Timestamp for when the change was made in the database
 
@@ -683,7 +702,7 @@ The value in a _delete_ change event has the same `schema` portion as _create_ a
             "connector": "vitess",
             "name": "my_sharded_connector",
             "ts_ms": 1559033904863,
-            "snapshot": null,
+            "snapshot": false,
             "db": "",
             "keyspace": "commerce",
             "table": "customers",
@@ -715,7 +734,7 @@ a|Mandatory field that describes the source metadata for the event. In a _delete
 * {prodname} version
 * Connector type and name
 * Database (a.k.a keyspace) and table that contains the new row
-* If the event was part of a snapshot
+* If the event was part of a snapshot (always `false`)
 * Offset of the operation in the database log
 * Timestamp for when the change was made in the database
 
@@ -1293,6 +1312,17 @@ If `table_a` has a an `id` column, and `regex_1` is `^i` (matches any column tha
 
 * `none` does not apply any adjustment. +
 * `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
+
+|[[vitess-property-snapshot-mode]]<<vitess-property-snapshot-mode,`+snapshot.mode+`>>
+|initial
+|Specifies the criteria for performing a snapshot when the connector starts.
+Set the property to one of the following values:
+
+`initial`::
+When the connector starts, if it does not detect a value in its offsets topic, it performs a snapshot of the database.
+
+`never`::
+When the connector starts, it skips the snapshot process and immediately begins to stream change events for operations that the database records to the binary logs.
 |===
 
 [id="vitess-advanced-configuration-properties"]
@@ -1508,6 +1538,14 @@ As the connector generates change events, the Kafka Connect framework records th
 If the connector is gracefully stopped, the database can continue to be used. Any changes are recorded in the Vitess binlog. When the connector restarts, it resumes streaming changes where it left off. That is, it generates change event records for all database changes that were made while the connector was stopped.
 
 A properly configured Kafka cluster is able to handle massive throughput. Kafka Connect is written according to Kafka best practices, and given enough resources a Kafka Connect connector can also handle very large numbers of database change events. Because of this, after being stopped for a while, when a {prodname} connector restarts, it is very likely to catch up with the database changes that were made while it was stopped. How quickly this happens depends on the capabilities and performance of Kafka and the volume of changes being made to the data in Vitess.
+
+[id="vitess-connector-failed-before-finishing-the-snapshot"]
+=== Connector fails before finishing the snapshot
+
+The connector does not support retrying the snapshot automatically at the moment.
+If the connector is restarted with the previous offset, the connector skips the snapshot process and immediately begins to stream change events.
+
+Consequently, to recover from the failure, link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector/[remove the connector offsets manually] and start the connector.
 
 [id="limitations-with-earlier-vitess-versions"]
 === Limitations with earlier Vitess versions

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -15,7 +15,11 @@ toc::[]
 {prodname}'s Vitess connector captures row-level changes in the shards of a Vitess link:https://vitess.io/docs/concepts/keyspace/[keyspace].
 For information about the Vitess versions that are compatible with this connector, see the link:https://debezium.io/releases/[{prodname} release overview].
 
-The first time it connects to a Vitess cluster, the connector takes a consistent snapshot of the keyspace. After that snapshot is complete, the connector continuously captures row-level changes that insert, update, and delete database content and that were committed to a Vitess keyspace. The connector generates data change event records and streams them to Kafka topics. For each table, the default behavior is that the connector streams all generated events to a separate Kafka topic for that table. Applications and services consume data change event records from that topic.
+When the connector first connects to a Vitess cluster, it takes a consistent snapshot of the keyspace. 
+After that snapshot is complete, the connector continuously captures row-level changes that are committed to a Vitess keyspace to insert, update, or delete database content. 
+The connector generates data change event records and streams them to Kafka topics. 
+For each table, the default behavior is that the connector streams all generated events to a separate Kafka topic for that table. 
+Applications and services can then consume data change event records from the resulting topic.
 
 // Type: concept
 // Title: Overview of {prodname} Vitess connector

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -1553,7 +1553,7 @@ A properly configured Kafka cluster is able to handle massive throughput. Kafka 
 [id="vitess-connector-failed-before-finishing-the-snapshot"]
 === Connector fails before finishing the snapshot
 
-The connector does not support retrying the snapshot automatically at the moment.
+If a snapshot fails to complete, the connector does not automatically reattempt the snapshot.
 If the connector is restarted with the previous offset, the connector skips the snapshot process and immediately begins to stream change events.
 
 Consequently, to recover from the failure, link:https://debezium.io/documentation/faq/#how_to_remove_committed_offsets_for_a_connector/[remove the connector offsets manually] and start the connector.

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -35,7 +35,11 @@ The connector gives you the flexibility to choose to subscribe to the `MASTER` n
 
 The connector produces a change event for every row-level insert, update, and delete operation that was captured and sends change event records for each table in a separate Kafka topic. Client applications read the Kafka topics that correspond to the database tables of interest, and can react to every row-level event they receive from those topics.
 
-The underlying MySQL normally purges binary logs after some period of time. This means that the connector does not have the complete history of all changes that have been made to the database. Therefore, when the connector first connects to a particular database, it starts by performing a consistent snapshot of each of the database. After the connector completes the snapshot, it continues streaming changes from the exact point at which the snapshot was made. This way, the connector starts with a consistent view of all of the data, and does not omit any changes that were made while the snapshot was being taken.
+The underlying MySQL implementation in Vitess purges binary logs based on some configurable period of time. 
+Because the contents of the binlog might not be complete, the connector requires another mechanism to ensure that it captures the complete content of a particular database.
+Thus, when the connector connects to a database for the first time, it performs a consistent snapshot of the database. 
+After the connector completes the snapshot, it continues streaming changes from the exact point at which the snapshot was made. 
+In this way, the connector starts with a consistent view of all of the data, and does not omit any changes that were made while the snapshot was being taken.
 
 The connector is tolerant of failures. As the connector reads changes and produces events, it records the VGTID position for each event. If the connector stops for any reason (including communication failures, network problems, or crashes), upon restart the connector continues reading the WAL where it last left off. This does not include snapshots. If the connector stops during a snapshot, upon restart the connector does not continue performing snapshots where it last left off.
 We'll talk later about how the connector behaves xref:{link-vitess-connector}#vitess-when-things-go-wrong[when things go wrong].

--- a/documentation/modules/ROOT/pages/connectors/vitess.adoc
+++ b/documentation/modules/ROOT/pages/connectors/vitess.adoc
@@ -61,7 +61,7 @@ To optimally configure and run a {prodname} Vitess connector, it is helpful to u
 [[vitess-snapshot]]
 === Snapshot
 
-Typically, a MySQL servers is not configured to retain the complete history of the database in the binary logs. 
+Typically, a MySQL server is not configured to retain the complete history of the database in the binary logs.
 As a result, the connector is unable to read the entire history of the database from the binary logs. 
 For this reason, the first time that the connector starts, it performs an initial consistent snapshot of the database. 
 You can change this behavior by setting the xref:{link-vitess-connector}#vitess-property-snapshot-mode[`snapshot.mode` connector configuration property] to a value other than `initial`.


### PR DESCRIPTION
Vitess connector finally supports the snapshot feature.
And the snapshot.mode specifies the criteria for performing a snapshot when the connector starts.