### PR TITLE
Dbz 5976

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/GtidSet.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/GtidSet.java
@@ -41,7 +41,7 @@ public final class GtidSet {
      * @param gtids the string representation of the GTIDs.
      */
     public GtidSet(String gtids) {
-        gtids = gtids.replaceAll("\n", "").replaceAll("\r", "");
+        gtids = gtids.replace("\n", "").replace("\r", "");
         new com.github.shyiko.mysql.binlog.GtidSet(gtids).getUUIDSets().forEach(uuidSet -> {
             uuidSetsByServerId.put(uuidSet.getUUID(), new UUIDSet(uuidSet));
         });

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlOffsetContext.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlOffsetContext.java
@@ -267,7 +267,7 @@ public class MySqlOffsetContext extends CommonOffsetContext<SourceInfo> {
     public void setCompletedGtidSet(String gtidSet) {
         if (gtidSet != null && !gtidSet.trim().isEmpty()) {
             // Remove all the newline chars that exist in the GTID set string ...
-            String trimmedGtidSet = gtidSet.replaceAll("\n", "").replaceAll("\r", "");
+            String trimmedGtidSet = gtidSet.replace("\n", "").replace("\r", "");
             this.currentGtidSet = trimmedGtidSet;
             this.restartGtidSet = trimmedGtidSet;
         }
@@ -292,7 +292,7 @@ public class MySqlOffsetContext extends CommonOffsetContext<SourceInfo> {
         sourceInfo.startGtid(gtid);
         if (gtidSet != null && !gtidSet.trim().isEmpty()) {
             // Remove all the newline chars that exist in the GTID set string ...
-            String trimmedGtidSet = gtidSet.replaceAll("\n", "").replaceAll("\r", "");
+            String trimmedGtidSet = gtidSet.replace("\n", "").replace("\r", "");
             // Set the GTID set that we'll use if restarting BEFORE successful completion of the events in this GTID ...
             this.restartGtidSet = this.currentGtidSet != null ? this.currentGtidSet : trimmedGtidSet;
             // Record the GTID set that includes the current transaction ...

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
@@ -405,7 +405,7 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
         // Replace comma to backslash followed by comma (this escape sequence implies comma is part of the option)
         // Replace backlash+single-quote to a single-quote.
         // Replace double single-quote to a single-quote.
-        return option.replaceAll(",", "\\\\,").replaceAll("\\\\'", "'").replaceAll("''", "'");
+        return option.replaceAll(",", "\\\\,").replaceAll("\\\\'", "'").replace("''", "'");
     }
 
     public MySqlValueConverters getConverters() {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -511,7 +511,7 @@ public class PostgresConnection extends JdbcConnection {
     @Override
     public String quotedColumnIdString(String columnName) {
         if (columnName.contains("\"")) {
-            columnName = columnName.replaceAll("\"", "\"\"");
+            columnName = columnName.replace("\"", "\"\"");
         }
 
         return super.quotedColumnIdString(columnName);

--- a/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/kafka/ConnectorConfigBuilder.java
+++ b/debezium-testing/debezium-testing-system/src/main/java/io/debezium/testing/system/tools/kafka/ConnectorConfigBuilder.java
@@ -34,7 +34,7 @@ public class ConnectorConfigBuilder {
     }
 
     public String getDbServerName() {
-        return connectorName.replaceAll("-", "_");
+        return connectorName.replace('-', '_');
     }
 
     public ConnectorConfigBuilder put(String key, Object value) {


### PR DESCRIPTION
ReplaceAll use regex under the hood. As a nature of regex, it may slow. We can  use "replace" method rather than "replaceAll" as much as possible in order to do better perform 