### PR TITLE
DBZ-5967: Fix negative partition number in ComputePartition SMT

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/partitions/ComputePartition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/partitions/ComputePartition.java
@@ -80,7 +80,7 @@ public class ComputePartition<R extends ConnectRecord<R>> implements Transformat
         smtManager.validate(config, Field.setOf(PARTITION_TABLE_FIELD_NAME_MAPPINGS_FIELD, FIELD_TABLE_PARTITION_NUM_MAPPINGS_FIELD));
 
         fieldNameByTable = ComputePartitionConfigDefinition.parseMappings(config.getStrings(PARTITION_TABLE_FIELD_NAME_MAPPINGS_FIELD, LIST_SEPARATOR));
-        numberOfPartitionsByTable = ComputePartitionConfigDefinition.parseIntMappings(config.getStrings(FIELD_TABLE_PARTITION_NUM_MAPPINGS_FIELD, LIST_SEPARATOR));
+        numberOfPartitionsByTable = ComputePartitionConfigDefinition.parseParititionMappings(config.getStrings(FIELD_TABLE_PARTITION_NUM_MAPPINGS_FIELD, LIST_SEPARATOR));
 
         checkConfigurationConsistency();
 
@@ -90,7 +90,7 @@ public class ComputePartition<R extends ConnectRecord<R>> implements Transformat
     private void checkConfigurationConsistency() {
 
         if (numberOfPartitionsByTable.size() != fieldNameByTable.size()) {
-            throw new ConnectException(String.format("Unable to validate config. %s and %s has different number of table defined",
+            throw new ComputePartitionException(String.format("Unable to validate config. %s and %s has different number of table defined",
                     FIELD_TABLE_PARTITION_NUM_MAPPINGS_CONF, FIELD_TABLE_FIELD_NAME_MAPPINGS_CONF));
         }
 
@@ -98,8 +98,9 @@ public class ComputePartition<R extends ConnectRecord<R>> implements Transformat
         intersection.retainAll(fieldNameByTable.keySet());
 
         if (intersection.size() != numberOfPartitionsByTable.size()) {
-            throw new ConnectException(String.format("Unable to validate config. %s and %s has different tables defined", FIELD_TABLE_PARTITION_NUM_MAPPINGS_CONF,
-                    FIELD_TABLE_FIELD_NAME_MAPPINGS_CONF));
+            throw new ComputePartitionException(
+                    String.format("Unable to validate config. %s and %s has different tables defined", FIELD_TABLE_PARTITION_NUM_MAPPINGS_CONF,
+                            FIELD_TABLE_FIELD_NAME_MAPPINGS_CONF));
         }
 
         if (numberOfPartitionsByTable.containsValue(0)) {

--- a/debezium-core/src/main/java/io/debezium/transforms/partitions/ComputePartitionConfigDefinition.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/partitions/ComputePartitionConfigDefinition.java
@@ -6,6 +6,8 @@
 
 package io.debezium.transforms.partitions;
 
+import static io.debezium.transforms.partitions.ComputePartitionConfigDefinition.FIELD_TABLE_PARTITION_NUM_MAPPINGS_CONF;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +75,7 @@ public class ComputePartitionConfigDefinition {
         return 0;
     }
 
-    static Map<String, Integer> parseIntMappings(List<String> mappings) {
+    static Map<String, Integer> parseParititionMappings(List<String> mappings) {
 
         final Map<String, Integer> m = new HashMap<>();
         for (String mapping : mappings) {
@@ -82,7 +84,12 @@ public class ComputePartitionConfigDefinition {
                 throw new ComputePartitionException("Invalid mapping: " + mapping);
             }
             try {
-                int value = Integer.parseInt(parts[1]);
+                final int value = Integer.parseInt(parts[1]);
+                if (value <= 0) {
+                    throw new ComputePartitionException(
+                            String.format("Unable to validate config. %s: partition number for '%s' must be positive",
+                                    FIELD_TABLE_PARTITION_NUM_MAPPINGS_CONF, parts[0]));
+                }
                 m.put(parts[0], value);
             }
             catch (NumberFormatException e) {

--- a/debezium-core/src/main/java/io/debezium/transforms/partitions/ComputePartitionException.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/partitions/ComputePartitionException.java
@@ -9,6 +9,9 @@ package io.debezium.transforms.partitions;
 import io.debezium.DebeziumException;
 
 public class ComputePartitionException extends DebeziumException {
+
+    private static final long serialVersionUID = -1317267303694502915L;
+
     public ComputePartitionException() {
         super();
     }


### PR DESCRIPTION
- Fix negative partition number in ComputePartition SMT
- Improved check on configuration consistency to avoid 0 as the partition number.