### PR TITLE
DBZ-3866 Add internal read-only LogMiner support

### DIFF
--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -127,6 +127,7 @@
     <properties>
         <adapter.name>logminer</adapter.name>
         <log.mining.buffer.type.name>memory</log.mining.buffer.type.name>
+        <log.mining.read.only.mode>false</log.mining.read.only.mode>
         <version.oracle.server>19.3.0</version.oracle.server>
 
         <!--
@@ -206,6 +207,10 @@
                             <name>log.mining.buffer.type</name>
                             <value>${log.mining.buffer.type.name}</value>
                         </property>
+                        <property>
+                            <name>internal.log.mining.read.only</name>
+                            <value>${log.mining.read.only.mode}</value>
+                        </property>
                     </systemProperties>
                 </configuration>
             </plugin>
@@ -234,6 +239,7 @@
                     <systemPropertyVariables>
                         <database.connection.adapter>${adapter.name}</database.connection.adapter>
                         <log.mining.buffer.type>${log.mining.buffer.type.name}</log.mining.buffer.type>
+                        <internal.log.mining.read.only>${log.mining.read.only.mode}</internal.log.mining.read.only>
                     </systemPropertyVariables>
                     <runOrder>${runOrder}</runOrder>
                 </configuration>
@@ -630,6 +636,15 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>oracle-read-only</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <log.mining.read.only.mode>true</log.mining.read.only.mode>
+            </properties>
         </profile>
     </profiles>
 </project>

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -40,6 +40,7 @@ import io.debezium.connector.oracle.Scn;
 import io.debezium.connector.oracle.logminer.logwriter.CommitLogWriterFlushStrategy;
 import io.debezium.connector.oracle.logminer.logwriter.LogWriterFlushStrategy;
 import io.debezium.connector.oracle.logminer.logwriter.RacCommitLogWriterFlushStrategy;
+import io.debezium.connector.oracle.logminer.logwriter.ReadOnlyLogWriterFlushStrategy;
 import io.debezium.connector.oracle.logminer.processor.LogMinerEventProcessor;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.pipeline.ErrorHandler;
@@ -850,6 +851,9 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
      * @return the strategy to be used to flush Oracle's LGWR process, never {@code null}.
      */
     private LogWriterFlushStrategy resolveFlushStrategy() {
+        if (connectorConfig.isLogMiningReadOnly()) {
+            return new ReadOnlyLogWriterFlushStrategy();
+        }
         if (connectorConfig.isRacSystem()) {
             return new RacCommitLogWriterFlushStrategy(connectorConfig, jdbcConfiguration, streamingMetrics);
         }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/logwriter/ReadOnlyLogWriterFlushStrategy.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/logwriter/ReadOnlyLogWriterFlushStrategy.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.logminer.logwriter;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.Scn;
+
+/**
+ * A simple strategy that performs no operations to attempt to flush the Oracle redo
+ * log writer buffers (LGWR) because the connection is operating in read-only mode.
+ *
+ * @author Chris Cranford
+ */
+public class ReadOnlyLogWriterFlushStrategy implements LogWriterFlushStrategy {
+    @Override
+    public String getHost() {
+        throw new DebeziumException("Not applicable when using read-only flushing strategy");
+    }
+
+    @Override
+    public void flush(Scn currentScn) throws InterruptedException {
+        // no operation
+    }
+
+    @Override
+    public void close() throws Exception {
+        // no operation
+    }
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/junit/SkipOnReadOnly.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/junit/SkipOnReadOnly.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation used to skip a given test if the session is marked as read-only.
+ *
+ * @author Chris Cranford
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+public @interface SkipOnReadOnly {
+    /**
+     * Specifies the reason why the test is being skipped.
+     */
+    String reason() default "";
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/junit/SkipTestDependingOnReadOnly.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/junit/SkipTestDependingOnReadOnly.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.junit;
+
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.junit.AnnotationBasedTestRule;
+
+/**
+ * JUnit rule that skips a test based on the {@link SkipOnReadOnly} annotation on
+ * either a test method or test class.
+ *
+ * @author Chris Cranford
+ */
+public class SkipTestDependingOnReadOnly extends AnnotationBasedTestRule {
+
+    private static final Configuration config = TestHelper.defaultConfig().build();
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        SkipOnReadOnly skipOnReadOnly = hasAnnotation(description, SkipOnReadOnly.class);
+        if (skipOnReadOnly != null) {
+            if (config.getBoolean(OracleConnectorConfig.LOG_MINING_READ_ONLY)) {
+                String reasonForSkipping = "Read Only: " + skipOnReadOnly.reason();
+                return emptyStatement(reasonForSkipping, description);
+            }
+        }
+        return base;
+    }
+}

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/FlushStrategyIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/FlushStrategyIT.java
@@ -23,8 +23,10 @@ import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnector;
 import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.junit.SkipOnReadOnly;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
 import io.debezium.connector.oracle.junit.SkipTestDependingOnDatabaseOptionRule;
+import io.debezium.connector.oracle.junit.SkipTestDependingOnReadOnly;
 import io.debezium.connector.oracle.junit.SkipWhenAdapterNameIsNot;
 import io.debezium.connector.oracle.logminer.logwriter.CommitLogWriterFlushStrategy;
 import io.debezium.connector.oracle.util.TestHelper;
@@ -37,12 +39,15 @@ import io.debezium.util.Testing;
  * @author Chris Cranford
  */
 @SkipWhenAdapterNameIsNot(value = SkipWhenAdapterNameIsNot.AdapterName.LOGMINER, reason = "Flush strategy only applies to LogMiner implementation")
+@SkipOnReadOnly(reason = "Test expects flush table, not applicable during read only.")
 public class FlushStrategyIT extends AbstractConnectorTest {
 
     @Rule
     public final TestRule skipAdapterRule = new SkipTestDependingOnAdapterNameRule();
     @Rule
     public final TestRule skipOptionRule = new SkipTestDependingOnDatabaseOptionRule();
+    @Rule
+    public final TestRule skipReadOnly = new SkipTestDependingOnReadOnly();
 
     private static OracleConnection connection;
 

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/util/TestHelper.java
@@ -140,6 +140,11 @@ public class TestHelper {
             // Tests will always use the online catalog strategy due to speed.
             builder.withDefault(OracleConnectorConfig.LOG_MINING_STRATEGY, "online_catalog");
 
+            final Boolean readOnly = Boolean.parseBoolean(System.getProperty(OracleConnectorConfig.LOG_MINING_READ_ONLY.name()));
+            if (readOnly) {
+                builder.with(OracleConnectorConfig.LOG_MINING_READ_ONLY, readOnly);
+            }
+
             final String bufferTypeName = System.getProperty(OracleConnectorConfig.LOG_MINING_BUFFER_TYPE.name());
             final LogMiningBufferType bufferType = LogMiningBufferType.parse(bufferTypeName);
             if (bufferType.isInfinispan()) {


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3866

This explicitly removes the writing of the flush table to support read-only logical standby connections with LogMiner only.  I have configured the option for triggering read-only to be internal, `internal.log.mining.read.only`, as this is highly experimental.

