### PR TITLE
DBZ-5907 Fix Oracle transaction event undo

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/memory/MemoryTransaction.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/memory/MemoryTransaction.java
@@ -54,13 +54,16 @@ public class MemoryTransaction extends AbstractTransaction {
     }
 
     public boolean removeEventWithRowId(String rowId) {
-        return events.removeIf(event -> {
+        // Should always iterate from the back of the event queue and remove the last that matches row-id.
+        for (int i = events.size() - 1; i >= 0; i--) {
+            final LogMinerEvent event = events.get(i);
             if (event.getRowId().equals(rowId)) {
+                events.remove(i);
                 LOGGER.trace("Undo applied for event {}.", event);
                 return true;
             }
-            return false;
-        });
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5907

This PR correctly performs transaction event undo by only reversing the last event in the transaction event queue that matches the row-id, rather than undoing all events with the same row-id.

@jpechane I would suggest we consider backporting this to 2.0 and/or 2.1.