### PR TITLE
[docs] Update the postgres container initialisation example

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -162,6 +162,7 @@ Guy Korland
 Guy Pascarella
 Grzegorz Kołakowski
 Jacob Gminder
+Jakub Zalas
 Jan Doms
 Jan Hendrik Dolling
 Jan Werner

--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -50,7 +50,7 @@
         <version.jmh>1.21</version.jmh>
         <version.mockito>3.0.0</version.mockito>
         <version.awaitility>4.0.1</version.awaitility>
-        <version.testcontainers>1.17.5</version.testcontainers>
+        <version.testcontainers>1.17.6</version.testcontainers>
         <version.jsonpath>2.7.0</version.jsonpath>
         <version.jsonassert>1.5.0</version.jsonassert>
         <version.org.reflections>0.9.12</version.org.reflections>

--- a/documentation/modules/ROOT/pages/integrations/testcontainers.adoc
+++ b/documentation/modules/ROOT/pages/integrations/testcontainers.adoc
@@ -77,7 +77,9 @@ public class DebeziumContainerTest {
             .withNetwork(network); // <2>
 
     public static PostgreSQLContainer<?> postgresContainer =
-            new PostgreSQLContainer<>("debezium/postgres:11")
+            new PostgreSQLContainer<>(
+                    DockerImageName.parse("debezium/postgres:11")
+                        .asCompatibleSubstituteFor("postgres"))
                 .withNetwork(network)
                 .withNetworkAliases("postgres"); // <3>
 


### PR DESCRIPTION
The container needs to be marked as a compatible substitute for the official postgres image. 

Otherwise, with recent versions of testcontainers, the postgres container will fail to initialise with: 

```Failed to verify that image 'debezium/postgres:11' is a compatible substitute for 'postgres'.```