### PR TITLE
DBZ-5993 Remove superfluous placeholder in log message (MySqlDatabaseSchema)

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDatabaseSchema.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlDatabaseSchema.java
@@ -214,7 +214,7 @@ public class MySqlDatabaseSchema extends HistorizedRelationalDatabaseSchema {
         }
         catch (ParsingException | MultipleParsingExceptions e) {
             if (schemaHistory.skipUnparseableDdlStatements()) {
-                LOGGER.warn("Ignoring unparseable DDL statement '{}': {}", ddlStatements, e);
+                LOGGER.warn("Ignoring unparseable DDL statement '{}'", ddlStatements, e);
             }
             else {
                 throw e;


### PR DESCRIPTION
The warning message emitted when the Debezium Connector for MySQL encounters an unparseable DDL statement contains a superfluous placeholder.

Refs https://issues.redhat.com/browse/DBZ-5993