### PR TITLE
DBZ-5996 Debezium truncating micro/nanosecond part if it is all zeros

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -8,6 +8,7 @@ Adham
 Adrian Kreuziger
 Ahmed Eljami
 Aidas
+Akshansh Jain
 Akshath Patkar
 Alberto Martino
 Aleksejs Sibanovs

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlAntlrDdlParserTest.java
@@ -3122,7 +3122,7 @@ public class MySqlAntlrDdlParserTest {
 
         Table table = tables.forTable(new TableId(null, null, "my_table"));
         ZonedDateTime zdt = ZonedDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC);
-        String isoEpoch = ZonedTimestamp.toIsoString(zdt, ZoneOffset.UTC, MySqlValueConverters::adjustTemporal);
+        String isoEpoch = ZonedTimestamp.toIsoString(zdt, ZoneOffset.UTC, MySqlValueConverters::adjustTemporal, null);
 
         assertThat(table.columnWithName("ts_col").isOptional()).isEqualTo(false);
         assertThat(table.columnWithName("ts_col").hasDefaultValue()).isEqualTo(true);
@@ -3277,7 +3277,7 @@ public class MySqlAntlrDdlParserTest {
     }
 
     private String toIsoString(String timestamp) {
-        return ZonedTimestamp.toIsoString(Timestamp.valueOf(timestamp).toInstant().atZone(ZoneId.systemDefault()), null);
+        return ZonedTimestamp.toIsoString(Timestamp.valueOf(timestamp).toInstant().atZone(ZoneId.systemDefault()), null, null);
     }
 
     /**

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDefaultValueTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDefaultValueTest.java
@@ -392,11 +392,11 @@ public class MySqlDefaultValueTest {
         assertThat(getColumnSchema(table, "B").defaultValue()).isEqualTo("1970-01-01T00:00:00Z");
         assertThat(getColumnSchema(table, "C").defaultValue()).isEqualTo("1970-01-01T00:00:00Z");
         assertThat(getColumnSchema(table, "D").defaultValue())
-                .isEqualTo(ZonedTimestamp.toIsoString(LocalDateTime.of(2018, 6, 26, 12, 34, 56, 0).atZone(ZoneId.systemDefault()), null));
+                .isEqualTo(ZonedTimestamp.toIsoString(LocalDateTime.of(2018, 6, 26, 12, 34, 56, 0).atZone(ZoneId.systemDefault()), null, null));
         assertThat(getColumnSchema(table, "E").defaultValue())
-                .isEqualTo(ZonedTimestamp.toIsoString(LocalDateTime.of(2018, 6, 26, 12, 34, 56, 0).atZone(ZoneId.systemDefault()), null));
+                .isEqualTo(ZonedTimestamp.toIsoString(LocalDateTime.of(2018, 6, 26, 12, 34, 56, 0).atZone(ZoneId.systemDefault()), null, null));
         assertThat(getColumnSchema(table, "F").defaultValue())
-                .isEqualTo(ZonedTimestamp.toIsoString(LocalDateTime.of(2018, 6, 26, 12, 34, 56, 780_000_000).atZone(ZoneId.systemDefault()), null));
+                .isEqualTo(ZonedTimestamp.toIsoString(LocalDateTime.of(2018, 6, 26, 12, 34, 56, 780_000_000).atZone(ZoneId.systemDefault()), null, null));
         assertThat(getColumnSchema(table, "G").defaultValue()).isEqualTo(Date.from(Instant.ofEpochMilli(0)));
         assertThat(getColumnSchema(table, "H").defaultValue()).isEqualTo((Date.from(Instant.ofEpochMilli(0))));
         assertThat(getColumnSchema(table, "I").defaultValue()).isEqualTo((Date.from(Instant.ofEpochMilli(0))));

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlValueConvertersTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlValueConvertersTest.java
@@ -25,7 +25,11 @@ import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
 import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcValueConverters;
 import io.debezium.jdbc.TemporalPrecisionMode;
-import io.debezium.relational.*;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import io.debezium.relational.ValueConverter;
 import io.debezium.relational.ddl.DdlParser;
 
 /**

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MysqlDefaultValueIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MysqlDefaultValueIT.java
@@ -689,7 +689,7 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         String value1 = "1970-01-01 00:00:01";
         ZonedDateTime t = java.sql.Timestamp.valueOf(value1).toInstant().atZone(ZoneId.systemDefault());
-        String isoString = ZonedTimestamp.toIsoString(t, ZoneId.systemDefault(), MySqlValueConverters::adjustTemporal);
+        String isoString = ZonedTimestamp.toIsoString(t, ZoneId.systemDefault(), MySqlValueConverters::adjustTemporal, null);
         assertThat(schemaB.defaultValue()).isEqualTo(isoString);
 
         String value2 = "2018-01-03 00:00:10";
@@ -716,7 +716,7 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
         assertThat(schemaM.defaultValue()).isEqualTo(Duration.ofHours(123).plus(123456, ChronoUnit.MICROS).toNanos() / 1_000);
         // current timestamp will be replaced with epoch timestamp
         ZonedDateTime t5 = ZonedDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC);
-        String isoString5 = ZonedTimestamp.toIsoString(t5, ZoneOffset.UTC, MySqlValueConverters::adjustTemporal);
+        String isoString5 = ZonedTimestamp.toIsoString(t5, ZoneOffset.UTC, MySqlValueConverters::adjustTemporal, null);
         assertThat(schemaJ.defaultValue()).isEqualTo(
                 MySqlTestConnection.forTestDatabase(DATABASE.getDatabaseName())
                         .databaseAsserts()
@@ -758,7 +758,7 @@ public class MysqlDefaultValueIT extends AbstractConnectorTest {
 
         String value1 = "1970-01-01 00:00:01";
         ZonedDateTime t = java.sql.Timestamp.valueOf(value1).toInstant().atZone(ZoneId.systemDefault());
-        String isoString = ZonedTimestamp.toIsoString(t, ZoneId.systemDefault(), MySqlValueConverters::adjustTemporal);
+        String isoString = ZonedTimestamp.toIsoString(t, ZoneId.systemDefault(), MySqlValueConverters::adjustTemporal, null);
         assertThat(schemaB.defaultValue()).isEqualTo(isoString);
 
         LocalDateTime localDateTimeC = LocalDateTime.from(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").parse("2018-01-03 00:00:10"));

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
@@ -139,7 +139,8 @@ public class JdbcValueConverters implements ValueConverterProvider {
         this.fallbackTimestampWithTimeZone = ZonedTimestamp.toIsoString(
                 OffsetDateTime.of(LocalDate.ofEpochDay(0), LocalTime.MIDNIGHT, defaultOffset),
                 defaultOffset,
-                adjuster);
+                adjuster,
+                null);
         this.fallbackTimeWithTimeZone = ZonedTime.toIsoString(
                 OffsetTime.of(LocalTime.MIDNIGHT, defaultOffset),
                 defaultOffset,
@@ -389,7 +390,7 @@ public class JdbcValueConverters implements ValueConverterProvider {
     protected Object convertTimestampWithZone(Column column, Field fieldDefn, Object data) {
         return convertValue(column, fieldDefn, data, fallbackTimestampWithTimeZone, (r) -> {
             try {
-                r.deliver(ZonedTimestamp.toIsoString(data, defaultOffset, adjuster));
+                r.deliver(ZonedTimestamp.toIsoString(data, defaultOffset, adjuster, column.length()));
             }
             catch (IllegalArgumentException e) {
             }

--- a/debezium-core/src/main/java/io/debezium/time/ZonedTimestamp.java
+++ b/debezium-core/src/main/java/io/debezium/time/ZonedTimestamp.java
@@ -58,7 +58,8 @@ public class ZonedTimestamp {
      * from 0-9 digits in the nanosecond part.
      */
     private static DateTimeFormatter getDateTimeFormatter(Integer fractionalWidth) {
-        if (fractionalWidth == null || fractionalWidth == 0) {
+        // TIMESTAMP type passes fractionalWidth as -1.
+        if (fractionalWidth == null || fractionalWidth <= 0) {
             return FORMATTER;
         }
 

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -180,3 +180,4 @@ xiaowu,Wu Zhenhua
 yoheimuta,Yohei Yoshimuta
 nancyxu123,Nancy Xu
 govi20,Govinda Sakhare
+akshansh,Akshansh Jain


### PR DESCRIPTION
# Bug report
For bug reports, provide this information, please:

### What Debezium connector do you use and what version?
Connector: MySqlSourceConnector
Version: 1.9.7.FINAL

### What is the connector configuration?
time.precision.mode is default.

### What is the captured database version and mode of deployment?
MySql 8.0.30 Source distribution
AWS RDS.

### What behaviour do you see and expect?
Database has field with type as timestamp(6). When debezium produces the field's value to kafka, it truncates any leading zeros there might be in the nano/microsecond part. If the value contains only zeros in the nano/microsecond part, then the whole part is excluded.

For ex.

2023-01-11 12:30:00.123123 --> 2023-01-11T12:30:00.123123Z

2023-01-11 12:30:00.123000 --> 2023-01-11T12:30:00.123Z

2023-01-11 12:30:00.000000 --> 2023-01-11T12:30:00Z

This breaks the sink connectors which expect the date time type to be in the format yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'. 

Expected was that the leading zeros should not get truncated, so that all the datetimes have consistent format.

2023-01-11 12:30:00.123123 --> 2023-01-11T12:30:00.123123Z

2023-01-11 12:30:00.123000 --> 2023-01-11T12:30:00.123000Z

2023-01-11 12:30:00.000000 --> 2023-01-11T12:30:00000Z

### Do you see the same behaviour using the latest relesead Debezium version?
Yes.

Issue link: https://issues.redhat.com/browse/DBZ-5996