### PR TITLE
DBZ-5975 Remove note that indicates SMT is under active development.

### DIFF
--- a/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
@@ -12,12 +12,6 @@ toc::[]
 
 [NOTE]
 ====
-This single message transformation (SMT) is under active development right now, so the emitted message structure or other details may still change as development progresses.
-Please see below for a descriptions of known limitations of this transformation.
-====
-
-[NOTE]
-====
 This SMT is supported only for the MongoDB connector.
 See xref:{link-event-flattening}[Extracting source record `after` state from {prodname} change events] for the relational database equivalent to this SMT.
 ====


### PR DESCRIPTION
[DBZ-5975](https://issues.redhat.com/browse/DBZ-5975)

Brings the MongoDB version of the SMT level with the SQL-based version by removing the statement that implies that the SMT is still incubating. 

Tested in a local Antora build. 

