### PR TITLE
DBZ-5879 Support retrying database connection failures during connector start

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotSourceIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/SnapshotSourceIT.java
@@ -617,7 +617,12 @@ public class SnapshotSourceIT extends AbstractConnectorTest {
 
         // Start the connector ...
         AtomicReference<Throwable> exception = new AtomicReference<>();
-        start(MySqlConnector.class, config, (success, message, error) -> exception.set(error));
+        start(MySqlConnector.class, config, (success, message, error) -> {
+            exception.set(error);
+        });
+
+        // a poll is required in order to get the connector to initiate the snapshot
+        waitForConnectorShutdown("mysql", DATABASE.getServerName());
 
         throw (RuntimeException) exception.get();
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -1736,8 +1736,10 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         start(PostgresConnector.class, config);
         assertConnectorIsRunning();
 
+        waitForConnectorShutdown("postgres", TestHelper.TEST_SERVER);
+
         // Stop the connector, verify that no snapshot was performed
-        stopConnector(value -> assertThat(logInterceptor.containsMessage("Previous initial snapshot completed, no snapshot will be performed")).isTrue());
+        assertThat(logInterceptor.containsMessage("Previous initial snapshot completed, no snapshot will be performed")).isTrue();
     }
 
     @Test

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -1691,7 +1691,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
 
     @Test
     @FixFor("DBZ-1437")
-    public void shouldPeformSnapshotOnceForInitialOnlySnapshotMode() throws Exception {
+    public void shouldPerformSnapshotOnceForInitialOnlySnapshotMode() throws Exception {
         // This captures all logged messages, allowing us to verify log message was written.
         final LogInterceptor logInterceptor = new LogInterceptor(InitialOnlySnapshotter.class);
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -2080,7 +2080,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
 
         final LogInterceptor logInterceptor = new LogInterceptor(SqlServerConnectorIT.class);
         start(SqlServerConnector.class, config);
-        assertConnectorNotRunning();
+        waitForConnectorShutdown("sqlserver", TestHelper.TEST_SERVER_NAME);
         assertThat(logInterceptor.containsStacktraceElement(
                 "The db history topic or its content is fully or partially missing. Please check database schema history topic configuration and re-execute the snapshot."))
                 .isTrue();

--- a/debezium-core/pom.xml
+++ b/debezium-core/pom.xml
@@ -72,6 +72,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -92,6 +97,12 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${version.kafka.scala}</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+<!--            <version>${version.kafka}</version>-->
+<!--            <scope>test</scope>-->
         </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>

--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -53,7 +53,7 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
     private static final Duration MAX_POLL_PERIOD_IN_MILLIS = Duration.ofMillis(TimeUnit.HOURS.toMillis(1));
     private Configuration config;
 
-    protected enum State {
+    public enum State {
         RESTARTING,
         RUNNING,
         INITIAL,
@@ -381,7 +381,7 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
     }
 
     @VisibleForTesting
-    State getState() {
+    public State getState() {
         stateLock.lock();
         try {
             return state.get();

--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.annotation.SingleThreadAccess;
+import io.debezium.annotation.VisibleForTesting;
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
@@ -50,13 +51,16 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseSourceTask.class);
     private static final Duration INITIAL_POLL_PERIOD_IN_MILLIS = Duration.ofMillis(TimeUnit.SECONDS.toMillis(5));
     private static final Duration MAX_POLL_PERIOD_IN_MILLIS = Duration.ofMillis(TimeUnit.HOURS.toMillis(1));
+    private Configuration config;
 
     protected enum State {
+        RESTARTING,
         RUNNING,
-        STOPPED;
+        INITIAL,
+        STOPPED
     }
 
-    private final AtomicReference<State> state = new AtomicReference<State>(State.STOPPED);
+    private final AtomicReference<State> state = new AtomicReference<>(State.INITIAL);
 
     /**
      * Used to ensure that start(), stop() and commitRecord() calls are serialized.
@@ -64,11 +68,6 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
     private final ReentrantLock stateLock = new ReentrantLock();
 
     private volatile ElapsedTimeStrategy restartDelay;
-
-    /**
-     * Raw connector properties, kept here so they can be passed again in case of a restart.
-     */
-    private volatile Map<String, String> props;
 
     /**
      * The change event source coordinator for those connectors adhering to the new
@@ -112,13 +111,8 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
         stateLock.lock();
 
         try {
-            if (!state.compareAndSet(State.STOPPED, State.RUNNING)) {
-                LOGGER.info("Connector has already been started");
-                return;
-            }
-
-            this.props = props;
-            Configuration config = Configuration.from(props);
+            state.set(State.INITIAL);
+            config = Configuration.from(props);
             retriableRestartWait = config.getDuration(CommonConnectorConfig.RETRIABLE_RESTART_WAIT, ChronoUnit.MILLIS);
             // need to reset the delay or you only get one delayed restart
             restartDelay = null;
@@ -132,8 +126,6 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
                     LOGGER.info("   {} = {}", propName, propValue);
                 });
             }
-
-            this.coordinator = start(config);
         }
         finally {
             stateLock.unlock();
@@ -145,7 +137,8 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
     }
 
     /**
-     * Called once when starting this source task.
+     * Called when starting this source task.  This method can throw a {@link RetriableException} to indicate
+     * that the task should attempt to retry the start later.
      *
      * @param config
      *            the task configuration; implementations should wrap it in a dedicated implementation of
@@ -155,18 +148,19 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
 
     @Override
     public final List<SourceRecord> poll() throws InterruptedException {
-        boolean started = startIfNeededAndPossible();
-
-        // in backoff period after a retriable exception
-        if (!started) {
-            // WorkerSourceTask calls us immediately after we return the empty list.
-            // This turns into a throttling so we need to make a pause before we return
-            // the control back.
-            Metronome.parker(Duration.of(2, ChronoUnit.SECONDS), Clock.SYSTEM).pause();
-            return Collections.emptyList();
-        }
 
         try {
+            boolean started = startIfNeededAndPossible();
+
+            // in backoff period after a retriable exception
+            if (!started) {
+                // WorkerSourceTask calls us immediately after we return the empty list.
+                // This turns into a throttling so we need to make a pause before we return
+                // the control back.
+                Metronome.parker(Duration.of(2, ChronoUnit.SECONDS), Clock.SYSTEM).pause();
+                return Collections.emptyList();
+            }
+
             final List<SourceRecord> records = doPoll();
             logStatistics(records);
             return records;
@@ -227,22 +221,46 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
     private boolean startIfNeededAndPossible() {
         stateLock.lock();
 
+        boolean result;
         try {
-            if (state.get() == State.RUNNING) {
-                return true;
+            State currentState = state.get();
+            if (currentState == State.RUNNING) {
+                result = true;
             }
-            else if (restartDelay != null && restartDelay.hasElapsed()) {
-                start(props);
-                return true;
+            else if (currentState == State.RESTARTING) {
+                // we're in restart mode... check if it's time to restart
+                if (restartDelay.hasElapsed()) {
+                    LOGGER.info("Attempting to restart task.");
+                    this.coordinator = start(config);
+                    LOGGER.info("Successfully restarted task");
+                    result = true;
+                }
+                else {
+                    LOGGER.info("Awaiting end of restart backoff period after a retriable error");
+                    result = false;
+                }
+            }
+            else if (currentState == State.INITIAL) {
+                LOGGER.info("Attempting to start task");
+                this.coordinator = start(config);
+                LOGGER.info("Successfully started task");
+                result = true;
             }
             else {
-                LOGGER.info("Awaiting end of restart backoff period after a retriable error");
-                return false;
+                LOGGER.warn("Attempting to start task but task has been stopped.");
+                result = false;
+            }
+
+            if (currentState != State.RUNNING && result) {
+                // we successfully started, clear restart state
+                restartDelay = null;
+                state.set(State.RUNNING);
             }
         }
         finally {
             stateLock.unlock();
         }
+        return result;
     }
 
     @Override
@@ -254,10 +272,9 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
         stateLock.lock();
 
         try {
-            if (!state.compareAndSet(State.RUNNING, State.STOPPED)) {
-                LOGGER.info("Connector has already been stopped");
-                return;
-            }
+            // if (!state.compareAndSet(State.RUNNING, State.STOPPED)) {
+            // LOGGER.info("Connector is already stopped.");
+            // }
 
             if (restart) {
                 LOGGER.warn("Going to restart connector after {} sec. after a retriable exception", retriableRestartWait.getSeconds());
@@ -269,6 +286,7 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
             try {
                 if (coordinator != null) {
                     coordinator.stop();
+                    coordinator = null;
                 }
             }
             catch (InterruptedException e) {
@@ -279,9 +297,15 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
 
             doStop();
 
-            if (restart && restartDelay == null) {
-                restartDelay = ElapsedTimeStrategy.constant(Clock.system(), retriableRestartWait.toMillis());
-                restartDelay.hasElapsed();
+            if (restart) {
+                state.set(State.RESTARTING);
+                if (restartDelay == null) {
+                    restartDelay = ElapsedTimeStrategy.constant(Clock.system(), retriableRestartWait.toMillis());
+                    restartDelay.hasElapsed();
+                }
+            }
+            else {
+                state.set(State.STOPPED);
             }
         }
         finally {
@@ -354,5 +378,16 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
         }
 
         return Offsets.of(offsets);
+    }
+
+    @VisibleForTesting
+    State getState() {
+        stateLock.lock();
+        try {
+            return state.get();
+        }
+        finally {
+            stateLock.unlock();
+        }
     }
 }

--- a/debezium-core/src/test/java/io/debezium/connector/common/BaseSourceTaskTest.java
+++ b/debezium-core/src/test/java/io/debezium/connector/common/BaseSourceTaskTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.kafka.connect.errors.RetriableException;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.source.SourceTaskContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.config.Field;
+import io.debezium.pipeline.ChangeEventSourceCoordinator;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Partition;
+
+public class BaseSourceTaskTest {
+
+    private final MyBaseSourceTask baseSourceTask = new MyBaseSourceTask();
+
+    @Before
+    public void setup() {
+        baseSourceTask.initialize(mock(SourceTaskContext.class));
+    }
+
+    @Test
+    public void verifyTaskStartsAndStops() throws InterruptedException {
+
+        baseSourceTask.start(new HashMap<>());
+        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getState());
+        baseSourceTask.poll();
+        assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getState());
+        baseSourceTask.stop();
+        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getState());
+
+        assertEquals(1, baseSourceTask.startCount.get());
+        assertEquals(1, baseSourceTask.stopCount.get());
+        verify(baseSourceTask.coordinator).stop();
+    }
+
+    @Test
+    public void verifyStartAndStopWithoutPolling() {
+        baseSourceTask.initialize(mock(SourceTaskContext.class));
+        baseSourceTask.start(new HashMap<>());
+        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getState());
+        baseSourceTask.stop();
+        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getState());
+
+        assertEquals(0, baseSourceTask.startCount.get());
+        assertEquals(1, baseSourceTask.stopCount.get());
+    }
+
+    @Test
+    public void verifyTaskCanBeStartedAfterStopped() throws InterruptedException {
+
+        baseSourceTask.start(new HashMap<>());
+        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getState());
+        baseSourceTask.poll();
+        assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getState());
+        baseSourceTask.stop();
+        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getState());
+        baseSourceTask.start(new HashMap<>());
+        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getState());
+        baseSourceTask.poll();
+        assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getState());
+        baseSourceTask.stop();
+        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getState());
+
+        assertEquals(2, baseSourceTask.startCount.get());
+        assertEquals(2, baseSourceTask.stopCount.get());
+        verify(baseSourceTask.coordinator, times(2)).stop();
+    }
+
+    @Test
+    public void verifyTaskRestartsSuccessfully() throws InterruptedException {
+        MyBaseSourceTask baseSourceTask = new MyBaseSourceTask() {
+            @Override
+            protected ChangeEventSourceCoordinator<Partition, OffsetContext> start(Configuration config) {
+                ChangeEventSourceCoordinator<Partition, OffsetContext> result = super.start(config);
+                if (startCount.get() < 3) {
+                    throw new RetriableException("Retry " + startCount.get());
+                }
+
+                return result;
+            }
+        };
+
+        baseSourceTask.initialize(mock(SourceTaskContext.class));
+        Map<String, String> config = Map.of(
+                CommonConnectorConfig.RETRIABLE_RESTART_WAIT.name(), "1" // wait 1ms between restarts
+        );
+        baseSourceTask.start(config);
+        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getState());
+        pollAndIgnoreRetryException(baseSourceTask);
+        assertEquals(BaseSourceTask.State.RESTARTING, baseSourceTask.getState());
+        sleep(100); // wait 10ms in order to satisfy retriable wait
+        pollAndIgnoreRetryException(baseSourceTask);
+        assertEquals(BaseSourceTask.State.RESTARTING, baseSourceTask.getState());
+        sleep(100); // wait 10ms in order to satisfy retriable wait
+        baseSourceTask.poll();
+        assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getState());
+        baseSourceTask.stop();
+        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getState());
+
+        assertEquals(3, baseSourceTask.startCount.get());
+        assertEquals(3, baseSourceTask.stopCount.get());
+        verify(baseSourceTask.coordinator, times(1)).stop();
+    }
+
+    @Test
+    public void verifyOutOfOrderPollDoesNotStartTask() throws InterruptedException {
+        baseSourceTask.start(new HashMap<>());
+        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getState());
+        baseSourceTask.stop();
+        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getState());
+        baseSourceTask.poll();
+        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getState());
+
+        assertEquals(0, baseSourceTask.startCount.get());
+        assertEquals(1, baseSourceTask.stopCount.get());
+    }
+
+    private static void pollAndIgnoreRetryException(BaseSourceTask<Partition, OffsetContext> baseSourceTask) throws InterruptedException {
+        try {
+            baseSourceTask.poll();
+        }
+        catch (RetriableException e) {
+            // nothing to do
+        }
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException();
+        }
+    }
+
+    public static class MyBaseSourceTask extends BaseSourceTask<Partition, OffsetContext> {
+        final List<SourceRecord> records = new ArrayList<>();
+        final AtomicInteger startCount = new AtomicInteger();
+        final AtomicInteger stopCount = new AtomicInteger();
+
+        @SuppressWarnings("unchecked")
+        final ChangeEventSourceCoordinator<Partition, OffsetContext> coordinator = mock(ChangeEventSourceCoordinator.class);
+
+        @Override
+        protected ChangeEventSourceCoordinator<Partition, OffsetContext> start(Configuration config) {
+            startCount.incrementAndGet();
+            return coordinator;
+        }
+
+        @Override
+        protected List<SourceRecord> doPoll() {
+            return records;
+        }
+
+        @Override
+        protected void doStop() {
+            stopCount.incrementAndGet();
+        }
+
+        @Override
+        protected Iterable<Field> getAllConfigurationFields() {
+            return List.of(Field.create("f1"));
+        }
+
+        @Override
+        public String version() {
+            return "1.0";
+        }
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/connector/common/BaseSourceTaskTest.java
+++ b/debezium-core/src/test/java/io/debezium/connector/common/BaseSourceTaskTest.java
@@ -42,11 +42,11 @@ public class BaseSourceTaskTest {
     public void verifyTaskStartsAndStops() throws InterruptedException {
 
         baseSourceTask.start(new HashMap<>());
-        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getTaskState());
         baseSourceTask.poll();
-        assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getTaskState());
         baseSourceTask.stop();
-        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getTaskState());
 
         assertEquals(1, baseSourceTask.startCount.get());
         assertEquals(1, baseSourceTask.stopCount.get());
@@ -57,9 +57,9 @@ public class BaseSourceTaskTest {
     public void verifyStartAndStopWithoutPolling() {
         baseSourceTask.initialize(mock(SourceTaskContext.class));
         baseSourceTask.start(new HashMap<>());
-        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getTaskState());
         baseSourceTask.stop();
-        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getTaskState());
 
         assertEquals(0, baseSourceTask.startCount.get());
         assertEquals(1, baseSourceTask.stopCount.get());
@@ -69,17 +69,17 @@ public class BaseSourceTaskTest {
     public void verifyTaskCanBeStartedAfterStopped() throws InterruptedException {
 
         baseSourceTask.start(new HashMap<>());
-        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getTaskState());
         baseSourceTask.poll();
-        assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getTaskState());
         baseSourceTask.stop();
-        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getTaskState());
         baseSourceTask.start(new HashMap<>());
-        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getTaskState());
         baseSourceTask.poll();
-        assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getTaskState());
         baseSourceTask.stop();
-        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getTaskState());
 
         assertEquals(2, baseSourceTask.startCount.get());
         assertEquals(2, baseSourceTask.stopCount.get());
@@ -105,17 +105,17 @@ public class BaseSourceTaskTest {
                 CommonConnectorConfig.RETRIABLE_RESTART_WAIT.name(), "1" // wait 1ms between restarts
         );
         baseSourceTask.start(config);
-        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getTaskState());
         pollAndIgnoreRetryException(baseSourceTask);
-        assertEquals(BaseSourceTask.State.RESTARTING, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.RESTARTING, baseSourceTask.getTaskState());
         sleep(100); // wait 10ms in order to satisfy retriable wait
         pollAndIgnoreRetryException(baseSourceTask);
-        assertEquals(BaseSourceTask.State.RESTARTING, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.RESTARTING, baseSourceTask.getTaskState());
         sleep(100); // wait 10ms in order to satisfy retriable wait
         baseSourceTask.poll();
-        assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.RUNNING, baseSourceTask.getTaskState());
         baseSourceTask.stop();
-        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getTaskState());
 
         assertEquals(3, baseSourceTask.startCount.get());
         assertEquals(3, baseSourceTask.stopCount.get());
@@ -125,11 +125,11 @@ public class BaseSourceTaskTest {
     @Test
     public void verifyOutOfOrderPollDoesNotStartTask() throws InterruptedException {
         baseSourceTask.start(new HashMap<>());
-        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.INITIAL, baseSourceTask.getTaskState());
         baseSourceTask.stop();
-        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getTaskState());
         baseSourceTask.poll();
-        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getState());
+        assertEquals(BaseSourceTask.State.STOPPED, baseSourceTask.getTaskState());
 
         assertEquals(0, baseSourceTask.startCount.get());
         assertEquals(1, baseSourceTask.stopCount.get());

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -438,7 +438,7 @@ public abstract class AbstractConnectorTest implements Testing {
                         .alias("Task has attempted to initialize coordinator")
                         .pollInterval(100, TimeUnit.MILLISECONDS)
                         .atMost(waitTimeForRecords() * 30L, TimeUnit.SECONDS)
-                        .until(() -> baseSourceTask.getState() != BaseSourceTask.State.INITIAL);
+                        .until(() -> baseSourceTask.getTaskState() != BaseSourceTask.State.INITIAL);
 
             }
         });


### PR DESCRIPTION


Reworked when task requests start from subclasses
Add support for restarting