### PR TITLE
DBZ-5071 Add support for providing a surrogate key when triggering incremental snapshots

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbIncrementalSnapshotChangeEventSource.java
@@ -334,11 +334,16 @@ public class MongoDbIncrementalSnapshotChangeEventSource
     @Override
     @SuppressWarnings("unchecked")
     public void addDataCollectionNamesToSnapshot(MongoDbPartition partition, List<String> dataCollectionIds,
-                                                 Optional<String> additionalCondition, OffsetContext offsetContext)
+                                                 Optional<String> additionalCondition, Optional<String> queryColumn, OffsetContext offsetContext)
             throws InterruptedException {
         if (additionalCondition != null && additionalCondition.isPresent()) {
             throw new UnsupportedOperationException("Additional condition not supported for MongoDB");
         }
+
+        if (queryColumn != null && queryColumn.isPresent()) {
+            throw new UnsupportedOperationException("Surrogate key not supported for MongoDB");
+        }
+
         context = (IncrementalSnapshotContext<CollectionId>) offsetContext.getIncrementalSnapshotContext();
         final boolean shouldReadChunk = !context.snapshotRunning();
         final String rsName = replicaSets.all().get(0).replicaSetName();
@@ -346,7 +351,7 @@ public class MongoDbIncrementalSnapshotChangeEventSource
                 .stream()
                 .map(x -> rsName + "." + x)
                 .collect(Collectors.toList());
-        final List<DataCollection<CollectionId>> newDataCollectionIds = context.addDataCollectionNamesToSnapshot(dataCollectionIds, null);
+        final List<DataCollection<CollectionId>> newDataCollectionIds = context.addDataCollectionNamesToSnapshot(dataCollectionIds, null, null);
         if (shouldReadChunk) {
             progressListener.snapshotStarted(partition);
             progressListener.monitoredDataCollectionsDetermined(partition, newDataCollectionIds.stream()

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -285,7 +285,8 @@ public class MySqlReadOnlyIncrementalSnapshotChangeEventSource<T extends DataCol
 
     private void addDataCollectionNamesToSnapshot(ExecuteSnapshotKafkaSignal executeSnapshotSignal, MySqlPartition partition, OffsetContext offsetContext)
             throws InterruptedException {
-        super.addDataCollectionNamesToSnapshot(partition, executeSnapshotSignal.getDataCollections(), executeSnapshotSignal.getAdditionalCondition(), offsetContext);
+        super.addDataCollectionNamesToSnapshot(partition, executeSnapshotSignal.getDataCollections(), executeSnapshotSignal.getAdditionalCondition(), null,
+                offsetContext);
         getContext().setSignalOffset(executeSnapshotSignal.getSignalOffset());
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/AbstractSnapshotSignal.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/AbstractSnapshotSignal.java
@@ -20,6 +20,7 @@ public abstract class AbstractSnapshotSignal<P extends Partition> implements Sig
     protected static final String FIELD_DATA_COLLECTIONS = "data-collections";
     protected static final String FIELD_TYPE = "type";
     protected static final String FIELD_ADDITIONAL_CONDITION = "additional-condition";
+    protected static final String FIELD_SURROGATE_KEY = "surrogate-key";
 
     public enum SnapshotType {
         INCREMENTAL

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/DataCollection.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/DataCollection.java
@@ -20,9 +20,12 @@ public class DataCollection<T> {
 
     private Optional<String> additionalCondition;
 
-    public DataCollection(T id, Optional<String> additionalCondition) {
+    private Optional<String> surrogateKey;
+
+    public DataCollection(T id, Optional<String> additionalCondition, Optional<String> surrogateKey) {
         this.id = id;
         this.additionalCondition = additionalCondition == null ? Optional.empty() : additionalCondition;
+        this.surrogateKey = surrogateKey == null ? Optional.empty() : surrogateKey;
     }
 
     public T getId() {
@@ -39,6 +42,14 @@ public class DataCollection<T> {
 
     public void setAdditionalCondition(Optional<String> additionalCondition) {
         this.additionalCondition = additionalCondition;
+    }
+
+    public Optional<String> getSurrogateKey() {
+        return surrogateKey;
+    }
+
+    public void setSurrogateKey(Optional<String> surrogateKey) {
+        this.surrogateKey = surrogateKey;
     }
 
     @Override
@@ -63,6 +74,7 @@ public class DataCollection<T> {
         return "DataCollection{" +
                 "id=" + id +
                 ", additionalCondition=" + additionalCondition +
+                ", queryColumn=" + surrogateKey +
                 '}';
     }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
@@ -31,7 +31,8 @@ public interface IncrementalSnapshotChangeEventSource<P extends Partition, T ext
 
     void init(P partition, OffsetContext offsetContext);
 
-    void addDataCollectionNamesToSnapshot(P partition, List<String> dataCollectionIds, Optional<String> additionalCondition, OffsetContext offsetContext)
+    void addDataCollectionNamesToSnapshot(P partition, List<String> dataCollectionIds, Optional<String> additionalCondition, Optional<String> surrogateKey,
+                                          OffsetContext offsetContext)
             throws InterruptedException;
 
     void stopSnapshot(P partition, List<String> dataCollectionIds, OffsetContext offsetContext);

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
@@ -17,7 +17,7 @@ public interface IncrementalSnapshotContext<T> {
 
     DataCollection<T> nextDataCollection();
 
-    List<DataCollection<T>> addDataCollectionNamesToSnapshot(List<String> dataCollectionIds, Optional<String> additionalCondition);
+    List<DataCollection<T>> addDataCollectionNamesToSnapshot(List<String> dataCollectionIds, Optional<String> additionalCondition, Optional<String> queryColumn);
 
     int dataCollectionsToBeSnapshottedCount();
 

--- a/debezium-server/README.md
+++ b/debezium-server/README.md
@@ -1,6 +1,6 @@
 # Debezium Server
 
-Debezium Server is a standalone Java application built on Qurkus framework.
+Debezium Server is a standalone Java application built on Quarkus framework.
 The application itself contains the `core` module and a set of modules responsible for communication with different target systems.
 
 The per-module integration tests depend on the availability of the external services.


### PR DESCRIPTION
This PR is the follow up of #3462 

For tables that have a composite Primary Key, SQL queries for incremental snaphots perform bad, see Jira ticket. This change allows to provide a surrogate key that will be used for the queries. The key should be unique in order for the snapshot to guarantee consistency.

Notes:
 - MongoDB won't support this feature
 - MySQL Read-Only snapshots don't need support for this? Not sure tho. Let me know if I should add support for it. 
 - How the configuration should look when in the same signal, multiple tables are provided? I know right now the configuration will be taken into account for all tables, but maybe we want per-table configuration? Or in that case, should the user just push multiple signals?