### PR TITLE
DBZ-6033 dbz-server-pulsar support non-default tenant and namespace

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -299,6 +299,7 @@ Mike Graham
 Mike Kamornikov
 Mikhail Dubrovin
 Mincong Huang
+Ming Luo
 Mohamed Pudukulathan
 Mohammad Yousuf Minhaj Zia
 Moira Tagle

--- a/debezium-server/debezium-server-pulsar/src/main/java/io/debezium/server/pulsar/PulsarChangeConsumer.java
+++ b/debezium-server/debezium-server-pulsar/src/main/java/io/debezium/server/pulsar/PulsarChangeConsumer.java
@@ -59,6 +59,12 @@ public class PulsarChangeConsumer extends BaseChangeConsumer implements Debezium
     @ConfigProperty(name = PROP_PREFIX + "null.key", defaultValue = "default")
     String nullKey;
 
+    @ConfigProperty(name = PROP_PREFIX + "tenant", defaultValue = "public")
+    String pulsarTenant;
+
+    @ConfigProperty(name = PROP_PREFIX + "namespace", defaultValue = "default")
+    String pulsarNamespace;
+
     @PostConstruct
     void connect() {
         final Config config = ConfigProvider.getConfig();
@@ -92,17 +98,18 @@ public class PulsarChangeConsumer extends BaseChangeConsumer implements Debezium
     }
 
     private Producer<?> createProducer(String topicName, Object value) {
+        final String topicFullName = pulsarTenant + "/" + pulsarNamespace + "/" + topicName;
         try {
             if (value instanceof String) {
                 return pulsarClient.newProducer(Schema.STRING)
                         .loadConf(producerConfig)
-                        .topic(topicName)
+                        .topic(topicFullName)
                         .create();
             }
             else {
                 return pulsarClient.newProducer()
                         .loadConf(producerConfig)
-                        .topic(topicName)
+                        .topic(topicFullName)
                         .create();
             }
         }

--- a/documentation/modules/ROOT/pages/operations/debezium-server.adoc
+++ b/documentation/modules/ROOT/pages/operations/debezium-server.adoc
@@ -761,6 +761,14 @@ The `topic` is set by Debezium.
 |Tables without primary key sends messages with `null` key.
 This is not supported by Pulsar so a surrogate key must be used.
 
+|[[pulsar-tenant]]<<pulsar-tenant, `debezium.sink.pusar.tenant`>>
+|`public`
+|The target tenant used to deliver the message.
+
+|[[pulsar-namespace]]<<pulsar-namespace, `debezium.sink.pusar.namespace`>>
+|`default`
+|The target namespace used to deliver the message.
+
 |===
 
 ===== Injection points


### PR DESCRIPTION
To address Jira https://issues.redhat.com/browse/DBZ-6033

This PR supports non-default Pulsar tenant and namespace in Debezium Server. 

In Pulsar, a topic without tenant/namespace implicitly defaults the public tenant and the default namespace. This is what the current implementation is. This feature is required for Pulsar's multiple tenant deployment, so that the debezium server can produce messages to non-default tenant and namespaces.