### PR TITLE
DBZ-4829 : Update mysql.adoc

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -260,6 +260,7 @@ Linh Nguyen Hoang
 Listman Gamboa
 Liu Hanlin
 Liu Lang Wa
+Lokesh Sanapalli
 Luca Scannapieco
 Luis Garcés-Erice
 Lukas Krejci

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -3144,6 +3144,10 @@ endif::community[]
 |`false`
 |Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See xref:{link-mysql-connector}#mysql-transaction-metadata[Transaction metadata] for details.
 
+|[[mysql-property-event-processing-failure-handling-mode]]<<mysql-property-event-processing-failure-handling-mode, `event.processing.failure.handling.mode`>>
+|`fail`
+|Specify how failures during processing of events (i.e. when encountering a corrupted event) should be handled. By default, `fail` mode raises an exception indicating the problematic event and its position, causing the connector to be stopped. `warn` mode does not raise the exception, instead the problematic event and its position will be logged and the event will be skipped. `ignore` mode ignores the problematic event completely with no logging.
+
 |[[mysql-property-topic-naming-strategy]]<<mysql-property-topic-naming-strategy, `topic.naming.strategy`>>
 |`io.debezium.schema.DefaultTopicNamingStrategy`
 |The name of the TopicNamingStrategy class that should be used to determine the topic name for data change, schema change, transaction, heartbeat event etc., defaults to `DefaultTopicNamingStrategy`.

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -184,4 +184,4 @@ akshansh,Akshansh Jain
 erdinc,Erdinç Taşkın
 luca.scannapieco,Luca Scannapieco
 sunxiaojian,Sun Xiao Jian
-lokesh1729,Lokesh Sanapalli
+Sanapalli Lokesh,Lokesh Sanapalli

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -184,3 +184,4 @@ akshansh,Akshansh Jain
 erdinc,Erdinç Taşkın
 luca.scannapieco,Luca Scannapieco
 sunxiaojian,Sun Xiao Jian
+lokesh1729,Lokesh Sanapalli


### PR DESCRIPTION
The configuration `event.processing.failure.handling.mode` property is not present in the documentation but I see it is present in the common configuration in code - https://sourcegraph.com/github.com/debezium/debezium/-/blob/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java?L400

This PR adds the configuration to the documentation