### PR TITLE
DBZ-6039: Reset history recovery attempt counter upon success

### DIFF
--- a/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
+++ b/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java
@@ -358,6 +358,7 @@ public class KafkaSchemaHistory extends AbstractSchemaHistory {
                 }
                 else {
                     LOGGER.debug("Processed {} records from database schema history", numRecordsProcessed);
+                    recoveryAttempts = 0;
                 }
             } while (lastProcessedOffset < endOffset - 1);
         }

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-connector-configuration-database-history-properties.adoc
@@ -27,8 +27,8 @@ The following table describes the `schema.history.internal` properties for confi
 |An integer value that specifies the maximum number of milliseconds the connector should wait while create kafka history topic using Kafka admin client.
 
 |[[{context}-property-database-history-kafka-recovery-attempts]]<<{context}-property-database-history-kafka-recovery-attempts, `+schema.history.internal.kafka.recovery.attempts+`>>
-|`4`
-|The maximum number of times that the connector should try to read persisted history data before the connector recovery fails with an error. The maximum amount of time to wait after receiving no data is `recovery.attempts` x `recovery.poll.interval.ms`.
+|`100`
+|The maximum number of times that the connector should try to read persisted history data before the connector recovery fails with an error. The maximum amount of time to wait after receiving no data is `recovery.attempts` × `recovery.poll.interval.ms`.
 
 |[[{context}-property-database-history-skip-unparseable-ddl]]<<{context}-property-database-history-skip-unparseable-ddl, `+schema.history.internal.skip.unparseable.ddl+`>>
 |`false`


### PR DESCRIPTION
Additionally, update the documentation to reflect the actual default value: https://github.com/debezium/debezium/blob/48136e08c3f23257523c97dcec668e69463a715e/debezium-storage/debezium-storage-kafka/src/main/java/io/debezium/storage/kafka/history/KafkaSchemaHistory.java#L145-L147