### PR TITLE
DBZ-6035 Await transactions also in IncrementalSnapshotWithRecompileIT

### DIFF
--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/IncrementalSnapshotWithRecompileIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/IncrementalSnapshotWithRecompileIT.java
@@ -121,4 +121,9 @@ public class IncrementalSnapshotWithRecompileIT extends AbstractIncrementalSnaps
                 .with(SqlServerConnectorConfig.TABLE_INCLUDE_LIST, tableIncludeList)
                 .with(SchemaHistory.STORE_ONLY_CAPTURED_TABLES_DDL, storeOnlyCapturedDdl);
     }
+
+    @Override
+    protected void waitForCdcTransactionPropagation(int expectedTransactions) throws Exception {
+        TestHelper.waitForCdcTransactionPropagation(connection, TestHelper.TEST_DATABASE_1, expectedTransactions);
+    }
 }


### PR DESCRIPTION
Override no-op `waitForCdcTransactionPropagation()` also in `IncrementalSnapshotWithRecompileIT` which also fails very often.

https://issues.redhat.com/browse/DBZ-6035