### PR TITLE
Corrected variable name

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -1947,7 +1947,7 @@ FROM performance_schema.global_variables WHERE variable_name='log_bin';
 +
 [source,properties]
 ----
-server-id         = 223344
+server_id         = 223344
 log_bin           = mysql-bin
 binlog_format     = ROW
 binlog_row_image  = FULL


### PR DESCRIPTION
At least on Google Cloud MySQL server the variable is called server_id instead of server-id.