### PR TITLE
DBZ-6006 prepare mongodb extract new document state smt doc for use downstream

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -272,23 +272,33 @@ If the connector's tasks terminate unexpectedly, however, then the tasks may hav
 
 [NOTE]
 ====
-When everything is operating nominally, Kafka consumers will actually see every message *_exactly once_*. However, when things go wrong Kafka can only guarantee consumers will see every message *_at least once_*. Therefore, your consumers need to anticipate seeing messages more than once.
+When all components in a Kafka pipeline operate nominally, Kafka consumers receive every message *_exactly once_*.
+However, when things go wrong, Kafka can only guarantee that consumers receive every message *_at least once_*.
+To avoid unexpected results, consumers must be able to handle duplicate messages.
 ====
 
-As mentioned above, the connector tasks always use the replica set's primary node to stream changes from the oplog, ensuring that the connector sees the most up-to-date operations as possible and can capture the changes with lower latency than if secondaries were to be used instead. When the replica set elects a new primary, the connector immediately stops streaming changes, connects to the new primary, and starts streaming changes from the new primary node at the same position. Likewise, if the connector experiences any problems communicating with the replica set members, it tries to reconnect, by using exponential backoff so as to not overwhelm the replica set, and once connected it continues streaming changes from where it last left off. In this way, the connector is able to dynamically adjust to changes in replica set membership and automatically handle communication failures.
+As mentioned earlier, the connector tasks always use the replica set's primary node to stream changes from the oplog, ensuring that the connector sees the most up-to-date operations as possible and can capture the changes with lower latency than if secondaries were to be used instead.
+When the replica set elects a new primary, the connector immediately stops streaming changes, connects to the new primary, and starts streaming changes from the new primary node at the same position.
+Likewise, if the connector experiences any problems communicating with the replica set members, it tries to reconnect, by using exponential backoff so as to not overwhelm the replica set, and once connected it continues streaming changes from where it last left off.
+In this way, the connector is able to dynamically adjust to changes in replica set membership and automatically handle communication failures.
 
 To summarize, the MongoDB connector continues running in most situations. Communication problems might cause the connector to wait until the problems are resolved.
 
 // Type: concept
+// ModuleID: mongodb-support-for-populating-the-before-state-in-debezium-change-events
+// Title: MongoDB support for populating the `before` field in {prodname} change event
 [[mongodb-pre-image-support]]
 === Pre-image support
-Starting in MongoDB 6.0, you can configure change stream to emit pre-image to populate the `before` field for Mongo change events. To utilize pre-image, you need to first enable `changeStreamPreAndPostImages` for a collection using
-`db.createCollection()`, `create`, or `collMod`. And configure `capture.mode` as one of the `*_with_pre_image` options.
+In MongoDB 6.0 and later, you can configure change streams to emit the pre-image state of a document to populate the `before` field for MongoDB change events.
+To enable the use of pre-images in MongoDB, you must set the `changeStreamPreAndPostImages` for a collection by using `db.createCollection()`, `create`, or `collMod`.
+To enable the {prodname} MongoDB to include pre-images in change events, set the `capture.mode` for the connector to one of the `*_with_pre_image` options.
 
 [NOTE]
-.Size limits on Mong change stream events
+.Size limits on MongoDB change stream events
 ====
-Since the size of Mongo change stream event is limited to 16 megabytes, enabling pre-image will increase the likelihood of hitting this limit and cause failure. To avoid that, please refer to Mongo's https://www.mongodb.com/docs/manual/changeStreams/#change-streams-with-document-pre--and-post-images/[official documentation] for recommendation and details.
+The size of a MongoDB change stream event is limited to 16 megabytes.
+The use of pre-images thus increases the likelihood of exceeding this threshold, which can lead to failures.
+For information about how to avoid exceeding the change stream limit, see the https://www.mongodb.com/docs/manual/changeStreams/#change-streams-with-document-pre--and-post-images/[MongoDB documentation].
 ====
 
 // Type: concept
@@ -750,7 +760,12 @@ However, by using the xref:{link-avro-serialization}#avro-serialization[Avro con
 
 |6
 |`after`
-|An optional field that specifies the state of the document after the event occurred. In this example, the `after` field contains the values of the new document's `\_id`, `first_name`, `last_name`, and `email` fields. The `after` value is always a string. By convention, it contains a JSON representation of the document. MongoDB's oplog entries contain the full state of a document only for _create_ events and also for `update` events, when the `capture.mode` option is set to `change_streams_update_full`; in other words, a _create_ event is the only kind of event that contains an _after_ field regardless of `capture.mode` option.
+|An optional field that specifies the state of the document after the event occurred.
+In this example, the `after` field contains the values of the new document's `\_id`, `first_name`, `last_name`, and `email` fields.
+The `after` value is always a string.
+By convention, it contains a JSON representation of the document.
+MongoDB oplog entries contain the full state of a document only for _create_ events and also for `update` events, when the `capture.mode` option is set to `change_streams_update_full`;
+in other words, a _create_ event is the only kind of event that contains an _after_ field regardless of `capture.mode` option.
 
 |7
 |`source`
@@ -786,7 +801,12 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 === _update_ events
 
 ==== Change streams capture mode
-The value of a change event for an update in the sample `customers` collection has the same schema as a _create_ event for that collection. Likewise, the event value's payload has the same structure. However, the event value payload contains different values in an _update_ event. An _update_ event does have an `after` value only if the `capture.mode` option is set to `change_streams_update_full`. A `before` value would be provided if the `capture.mode` option is set to one of the `*_with_pre_image` option. There is a new structured field `updateDescription` with a few additional fields in this case:
+The value of a change event for an update in the sample `customers` collection has the same schema as a _create_ event for that collection.
+Likewise, the event value's payload has the same structure.
+However, the event value payload contains different values in an _update_ event.
+An _update_ event includes an `after` value only if the `capture.mode` option is set to `change_streams_update_full`.
+A `before` value is provided if the `capture.mode` option is set to one of the `*_with_pre_image` option.
+There is a new structured field `updateDescription` with a few additional fields in this case:
 
 * `updatedFields` is a string field that contains the JSON representation of the updated document fields with their values
 
@@ -849,7 +869,7 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 |`before`
 |Contains the JSON string representation of the actual MongoDB document before change.
 +
-An _update_ event value does not contain an `before` field if the capture mode is not set to one of the`*_with_preimage` options.
+An _update_ event value does not contain an `before` field if the capture mode is not set to one of the `*_with_preimage` options.
 
 |4
 |`after`
@@ -932,7 +952,7 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 |`before`
 |Contains the JSON string representation of the actual MongoDB document before change.
 +
-An _update_ event value does not contain an `before` field if the capture mode is not set to one of the`*_with_preimage` options.
+An _update_ event value does not contain an `before` field if the capture mode is not set to one of the `*_with_preimage` options.
 
 |4
 |`source`
@@ -1428,7 +1448,34 @@ When the connector starts, it skips the snapshot process and immediately begins 
 
 |[[mongodb-property-capture-mode]]<<mongodb-property-capture-mode, `+capture.mode+`>>
 |`change_streams_update_full`
-|Specifies the method used to capture changes from the MongoDB server. The default is *change_streams_update_full*, and specifies that the connector captures changes via MongoDB Change Streams mechanism, and that _update_ events should contain the full document. The *change_streams* mode will use the same capturing method, but _update_ events won't contain the full document. To capture pre-image, you can use the pre-image version of the previous two capture modes - *change_streams_update_full_with_pre_image* and *change_streams_with_pre_image*.
+|Specifies the method that the connector uses to capture `update` event changes from a MongoDB server.
+Set this property to one of the following values:
+
+`change_streams`:: `update` event messages do not include the full document.
+Messages do not include a field that represents the state of the document `before` the change.
+
+`change_streams_update_full`:: `update` event messages include the full document.
+Messages do not include a `before` field that represents the state of the document before the update.
+The event message returns the full state of the document in the `after` field.
++
+[NOTE]
+====
+In some situations, when `capture.mode` is configured to return full documents, the `updateDescription` and `after` fields of the update event message might report inconsistent values.
+Such discrepancies can result after multiple updates are applied to a document in rapid succession.
+The connector requests the full document from the MongoDB database only after it receives the update described in the event's `updateDescription` field.
+If a later update modifies the source document before the connector can retrieve it from the database, the connector receives the document that is modified by this later update.
+
+When you configure `capture.mode` to return the full document, you might notice a discrepancy between the content in the `updateDescription` and `after` fields of the message.
+Discrepancies can result when multiple changes are applied to a document in rapid succession.
+Because the connector submits the request for the full document only after an update is applied, later updates can modify the source document after the update that is described in the `updateDescription` field.
+The full document that the connector then receives in response to its query reflects the result of the later change.
+====
+
+`change_streams_update_full_with_pre_image`::
+`update` event event messages include the full document, and include a field that represents the state of the document `before` the change.
+
+`change_streams_with_pre_image`::
+`update` events do not include the full document, but include a field that represents the state of the document `before` the change.
 
 |[[mongodb-property-snapshot-include-collection-list]]<<mongodb-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>
 | All collections specified in `collection.include.list`

--- a/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
@@ -14,23 +14,28 @@
 
 toc::[]
 
-ifdef::community[]
-[NOTE]
-====
-This single message transformation (SMT) is supported for only the SQL database connectors. For the MongoDB connector, see the xref:{link-mongodb-event-flattening}[documentation for the MongoDB equivalent to this SMT].
-====
-endif::community[]
 
-A {prodname} data change event has a complex structure that provides a wealth of information. Kafka records that convey {prodname} change events contain all of this information.
-However, parts of a Kafka ecosystem might expect Kafka records that provide a flat structure of field names and values.
-To provide this kind of record, {prodname} provides the event flattening single message transformation (SMT). Configure this transformation when consumers need Kafka records that have a format that is simpler than Kafka records that contain {prodname} change events.
+{prodname} connectors emits data change messages to represent each operation that they capture from a source database.
+The messages that a connector sends to Apache Kafka have a complex structure that faithfully represent the details of the original database event.
+
+Although this complex message format accurately details information about changes that happen in the system, the format might not be suitable for some downstream consumers.
+Sink connectors, or other parts of the Kafka ecosystem might require messages that are formatted so that field names and values are presented in a simplified, flattened structure.
+
+To simplify the format of the event records that the {prodname} connectors produce, you can use the {prodname} event flattening single message transformation (SMT).
+Configure the transformation to support consumers that require Kafka records to be in a format that is simpler than the default format that that the connector produces.
+Depending on your particular use case, you can apply the SMT to a {prodname} connector, or to a sink connector that consumes messages that the {prodname} connector produces.
+To enable Apache Kafka to retain the {prodname} change event messages in their original format, configure the SMT for a sink connector.
 
 The event flattening transformation is a
 link:https://kafka.apache.org/documentation/#connect_transforms[Kafka Connect SMT].
 
-ifdef::product[]
-This transformation is available to only SQL database connectors.
+[NOTE]
+====
+The information in this chapter describes the event flattening single message transformation (SMT) for {prodname} SQL-based database connectors.
+For information about an equivalent SMT for the {prodname} MongoDB connector, see {link-prefix}:{link-mongodb-event-flattening}#mongodb-new-document-state-extraction[MongoDB New Document State Extraction].
+====
 
+ifdef::product[]
 The following topics provide details:
 
 * xref:description-of-debezium-change-event-structure[]
@@ -50,15 +55,15 @@ Each event consists of three parts:
 
 * Metadata, which includes but is not limited to:
 
-** The operation that made the change
-** Source information such as the names of the database and table where the change was made
-** Time stamp for when the change was made
-** Optional transaction information
+** The type of operation that changed the data.
+** Source information, such as the names of the database and the table in which the change occurred.
+** Timestamp that identifies when the change was made.
+** Optional transaction information.
 
 * Row data before the change
 * Row data after the change
 
-For example, part of the structure of an `UPDATE` change event looks like this:
+The following example shows part of the message structure for an `UPDATE` change event:
 
 [source,json,indent=0]
 ----
@@ -79,13 +84,15 @@ For example, part of the structure of an `UPDATE` change event looks like this:
 }
 ----
 
+For more information about the change event structure for a connector, see
+ifdef::product[]
+the documentation for the connector.
+endif::product[]
 ifdef::community[]
-More details about change event structure are provided in
-xref:{link-connectors}[the documentation for each connector].
+xref:{link-connectors}[the documentation for the connector].
 endif::community[]
 
-This complex format provides the most information about changes happening in the system.
-However, other connectors or other parts of the Kafka ecosystem usually expect the data in a simple format like this:
+After the event flattening SMT processes the message in the previous example, it simplifies the message format, resulting in the message in the following example:
 
 [source,json,indent=0]
 ----
@@ -94,8 +101,6 @@ However, other connectors or other parts of the Kafka ecosystem usually expect t
 	"field2" : "newvalue2"
 }
 ----
-
-To provide the needed Kafka record format for consumers, configure the event flattening SMT.
 
 // Type: concept
 // ModuleID: behavior-of-debezium-event-flattening-transformation
@@ -125,7 +130,7 @@ Instead of dropping the record that contains the `before` row data, you can conf
 
 * Keep the record in the stream and edit it to have a `value` field that contains the key/value pairs that were in the `before` field with an added `"__deleted": "true"` entry.
 
-Similary, instead of dropping the tombstone record, you can configure the event flattening SMT to keep the tombstone record in the stream.
+Similarly, instead of dropping the tombstone record, you can configure the event flattening SMT to keep the tombstone record in the stream.
 
 // Type: concept
 // ModuleID: configuration-of-debezium-event-flattening-transformation
@@ -177,7 +182,8 @@ To apply the transformation to a subset of events, you can define xref:options-f
 // Title: Example of adding {prodname} metadata to the Kafka record
 == Adding metadata
 
-The event flattening SMT can add original, change event metadata to the simplified Kafka record. For example, you might want the simplified record's header or value to contain any of the following:
+You can configure the event flattening SMT to add original change event metadata to the simplified Kafka record.
+For example, you might want the simplified record's header or value to contain any of the following:
 
 * The type of operation that made the change
 * The name of the database or table that was changed

--- a/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
@@ -1,4 +1,8 @@
 :page-aliases: configuration/mongodb-event-flattening.adoc
+// Category: debezium-using
+// Type: assembly
+// ModuleID: extracting-source-document-after-state-from-debezium-mongodb-change-events
+// Title: Extracting the source document `after` state from {prodname} MongoDB change events
 [id="mongodb-new-document-state-extraction"]
 = MongoDB New Document State Extraction
 
@@ -9,57 +13,165 @@
 :source-highlighter: highlight.js
 
 toc::[]
+The {prodname} MongoDB connector emits data change messages to represent each operation that occurs in a MongoDB collection.
+The complex structure of these event messages faithfully represent the details of the original database event.
+However, some downstream consumers might not be able to process the messages in their original format.
+For example, to represent nested documents in a data collection, the connector emits an event message in a format that includes nested fields.
+To support sink connectors, or other consumers that cannot process the hierarchical format of the original messages, you can use the {prodname} MongoDB event flattening (ExtractNewDocumentState) single message transformation (SMT).
+The SMT simplifies the structure of the original messages, and can modify messages in other ways to make data easier to process.
+
+The event flattening transformation is a link:https://kafka.apache.org/documentation/#connect_transforms[Kafka Connect SMT].
 
 [NOTE]
 ====
-This SMT is supported only for the MongoDB connector.
-See xref:{link-event-flattening}[Extracting source record `after` state from {prodname} change events] for the relational database equivalent to this SMT.
+The information in this chapter describes the event flattening single message transformation (SMT) for {prodname} MongoDB connectors only.
+For information about an equivalent SMT for use with relational databases, see the {link-prefix}:{link-event-flattening}#new-record-state-extraction[documentation for the New Record State Extraction SMT].
 ====
 
-The {prodname} MongoDB connector generates the data in a form of a complex message structure.
-The message consists of two parts:
+ifdef::product[]
+The following topics provide details:
 
-* operation and metadata
-* for inserts, the whole data after the insert has been executed; for updates a patch element describing the altered fields
+* xref:description-of-debezium-mongodb-change-event-structure[]
+* xref:behavior-of-debezium-mongodb-event-flattening-transformation[]
+* xref:configuration-of-the-debezium-mongodb-event-flattening-transformation[]
+* xref:options-for-encoding-arrays-in-mongodb-event-messages[]
+* xref:flattening-nested-structures-in-a-mongodb-event-message[]
+* xref:how-the-debezium-mongodb-connector-reports-the-names-of-fields-removed-by-unset-operations[]
+* xref:mongodb-event-flattening-determining-the-type-of-the-original-database-operation[]
+* xref:using-the-mongodb-event-flattening-smt-to-add-debezium-metadata-to-kafka-records[]
+* xref:options-for-applying-the-mongodb-extract-new-document-state-transformation-selectively[]
+* xref:configuration-options-for-the-debezium-mongodb-event-flattening-transformation[]
+* xref:debezium-event-flattening-smt-for-mongodb-known-limitations[]
+endif::product[]
 
-The `after` and `patch` elements are Strings containing JSON representations of the inserted/altered data.
-E.g. the general message structure for a insert event looks like this:
+// Type: concept
+// ModuleID: description-of-debezium-mongodb-change-event-structure
+// Title: Description of {prodname} MongoDB change event structure
+== Change event structure
+
+The {prodname} MongoDB connector generates change events that have a complex structure.
+Each event message includes the following parts:
+
+Source metadata:: Includes, but is not limited to the following fields:
+
+* Type of the operation that changed data in the collection (create/insert, update, or delete).
+* Name of the database and collection in which the change occurred.
+* Timestamp that identifies when the change was made.
+* Optional transaction information.
+
+Document data::
+`before` data:::
+This field is present in environments that run MongoDB 6.0 and later when the `capture.mode` for the {prodname} connector is set to one of the following values:
+* `change_streams_with_pre_image`.
+* `change_streams_update_full_with_pre_image`.
++
+For more information, see {link-prefix}:{link-mongodb-connector}#[mongodb-pre-image-support[MongoDB pre-image support]
+
+`after` data:::
+JSON strings that represent the values that are present in a document after the current operation.
+The presence of an `after` field in an event message depends on the type of event and the connector configuration.
+A `create` event for a MongoDB `insert` operation always contain an `after` field, regardless of the `capture.mode` setting.
+For `update` events, the `after` field is present only when `capture.mode` is set to one of the following values:
+* `change_streams_update_full`
+* `change_streams_update_full_with_pre_image`.
++
+[NOTE]
+====
+The `after` value in a change event message does not necessarily represent the state of a document immediately following the event.
+The value is not calculated dynamically; instead, after the connector captures a change event, it  queries the collection to retrieve the current value of the document.
+
+For example, imagine a situation in which multiple operations, `a`, `b`, and `c` modify a document in quick succession.
+When the connector processes, change `a`, it queries the collection for the full document.
+In the meantime, changes `b` and `c` occur.
+When the connector receives a response to its query for the full document for change `a`, it might receive a version of the document that is based on the subsequent changes for `b` or `c`.
+For more information, see the documentation for the {link-prefix}:{link-mongodb-connector}#mongodb-property-capture-mode[`capture.mode`] property.
+====
+
+The following fragment shows the basic structure of a `create` change event that the connector emits after a MongoDB `insert` operation:
 
 [source,json,indent=0]
 ----
 {
-  "op": "r",
+  "op": "c",
   "after": "{\"field1\":\"newvalue1\",\"field2\":\"newvalue1\"}",
   "source": { ... }
 }
 ----
 
-More details about the message structure are provided in xref:{link-mongodb-connector}[the documentation] of the MongoDB connector.
-
-While this structure is a good fit to represent changes to MongoDB's schemaless collections,
-it is not understood by existing sink connectors such as the Confluent JDBC sink connector.
-
-Therefore {prodname} provides a {link-kafka-docs}/#connect_transforms[a single message transformation] (SMT)
-which converts the `after`/`patch` information from the MongoDB CDC events into a structure suitable for consumption by existing sink connectors.
-To do so, the SMT parses the JSON strings and reconstructs properly typed Kafka Connect
-(comprising the correct message payload and schema) records from that,
-which then can be consumed by connectors such as the JDBC sink connector.
-
-Using JSON as visualization of the emitted record structure, the event from above would like this:
+The complex format of the `after` field in the preceding example provides detailed information about changes that occur in the source database.
+However, some consumers cannot process messages that contain nested values.
+To convert the complex nested fields of the original message into a simpler, more universally compatible structure, use the event flattening SMT for MongoDB.
+The SMT flattens the structure of nested fields in a message, as shown in the following example:
 
 [source,json,indent=0]
 ----
 {
-	"field1" : "newvalue1",
-	"field2" : "newvalue2"
+  "field1" : "newvalue1",
+  "field2" : "newvalue2"
 }
 ----
 
-The SMT should be applied on a sink connector.
+For more information about the default structure of messages produced by the {prodname} MongoDB connector, see the {link-prefix}:{link-mongodb-connector}#debezium-connector-for-mongodb[connector documentation].
 
+// Type: concept
+// ModuleID: behavior-of-debezium-mongodb-event-flattening-transformation
+// Title: Behavior of the {prodname} MongoDB event flattening transformation
+[[event-flattening-behavior]]
+== Behavior
+
+The event flattening SMT for MongoDB extracts the `after` field from `create` or `update` change event messages emitted by the {prodname} MongoDB connector.
+After the SMT processes the original change event message, it generates a simplified version that contains only the contents of the `after` field.
+
+Depending on your use case, you can apply the ExtractNewDocumentState SMT to the {prodname} MongoDB connector, or to a sink connector that consumes messages that the {prodname} connector produces.
+If you apply the SMT to the {prodname} MongoDB connector, the SMT modifies messages that the connector emits before they are sent to Apache Kafka.
+To ensure that Kafka retains the complete {prodname} change event message in its original format, apply the SMT to a sink connector.
+
+When you use the event flattening SMT to process a message emitted from a MongoDB connector, the SMT converts the structure of the records in the original message into properly typed Kafka Connect records that can be consumed by a typical sink connector.
+For example, the SMT converts the JSON strings that represent the `after` information in the original message into schema structures that any consumer can process.
+
+Optionally, you can configure the event flattening SMT for MongoDB to modify messages in other ways during processing.
+For more information, see xref:mongodb-event-flattening-configuration[].
+
+// Type: concept
+// ModuleID: configuration-of-the-debezium-mongodb-event-flattening-transformation
+// Title: Configuration of the {prodname} MongoDB event flattening transformation
+[id="mongodb-event-flattening-configuration"]
 == Configuration
 
-The configuration is a part of sink task connector and is expressed in a set of properties:
+Configure the event flattening (ExtractNewDocumentState) SMT for MongoDB for sink connectors that consume the messages emitted by the {prodname} MongoDB connector.
+
+ifdef::product[]
+The following topics provide details:
+
+* xref:example-basic-configuration-of-the-mongodb-event-flattening-transformation[]
+* xref:options-for-encoding-arrays-in-mongodb-event-messages[]
+* xref:flattening-nested-structures-in-a-mongodb-event-message[]
+* xref:how-the-debezium-mongodb-connector-reports-the-names-of-fields-removed-by-unset-operations[]
+* xref:mongodb-event-flattening-determining-the-type-of-the-original-database-operation[]
+* xref:using-the-mongodb-event-flattening-smt-to-add-debezium-metadata-to-kafka-records[]
+* xref:options-for-applying-the-mongodb-extract-new-document-state-transformation-selectively[]
+* xref:configuration-options-for-the-debezium-mongodb-event-flattening-transformation[]
+endif::product[]
+
+// Type: concept
+// Title: Example: Basic configuration of the {prodname} MongoDB event flattening-transformation
+// ModuleID: example-basic-configuration-of-the-mongodb-event-flattening-transformation
+[id="mongodb-event-flattening-basic-configuration"]
+=== Basic configuration
+
+To obtain the default behavior of the SMT, add the SMT to the configuration of a sink connector without specifying any options, as in the following example:
+
+[source]
+----
+transforms=unwrap,...
+transforms.unwrap.type=io.debezium.connector.mongodb.transforms.ExtractNewDocumentState
+----
+
+As with any Kafka Connect connector configuration, you can set `transforms=` to multiple, comma-separated, SMT aliases.
+Kafka Connect applies the transformations that you specify in the order in which they are listed.
+
+You can set multiple options for a connector that uses the MongoDB event flattening SMT.
+The following example shows a configuration that sets the xref:mongodb-extract-new-record-state-drop-tombstones[`drop.tombstones`], xref:mongodb-extract-new-record-state-delete-handling-mode[`delete.handling.mode`], and xref:mongodb-extract-new-record-state-add-headers[`add.headers`] options for a connector:
 
 [source]
 ----
@@ -70,16 +182,23 @@ transforms.unwrap.delete.handling.mode=drop
 transforms.unwrap.add.headers=op
 ----
 
+For more information about the configuration options in the preceding example, see xref:mongodb-extract-new-record-state-configuration-options[]
+
 .Customizing the configuration
 The connector might emit many types of event messages (for example, heartbeat messages, tombstone messages, or metadata messages about transactions).
 To apply the transformation to a subset of events, you can define xref:options-for-applying-the-transformation-selectively[an SMT predicate statement that selectively applies the transformation] to specific events only.
 
-=== Array encoding
+// Type: concept
+// ModuleID: options-for-encoding-arrays-in-mongodb-event-messages
+// Title: Options for encoding arrays in MongoDB event messages
+[id="mongodb-event-flattening-array-encoding"]
+== Array encoding
 
-The SMT converts MongoDB arrays into arrays as defined by Apache Connect (or Apache Avro) schema.
-The problem is that such arrays must contains elements of the same type.
-MongoDB allows the user to store elements of heterogeneous types into the same array.
-To bypass this impedance mismatch it is possible to encode the array in two different ways using `array.encoding` configuration option.
+By default, the event flattening SMT converts MongoDB arrays into arrays that are compatible with Apache Kafka Connect, or Apache Avro schemas.
+While MongoDB arrays can contain multiple types of elements, all elements in a Kafka array must be of the same type.
+
+To ensure that the SMT encodes arrays in a way that meets the needs of your environment, you can specify the xref:mongodb-extract-new-record-state-array-encoding[`array.encoding`] configuration option.
+The following example shows the configuration for setting the array encoding:
 
 [source]
 ----
@@ -88,15 +207,21 @@ transforms.unwrap.type=io.debezium.connector.mongodb.transforms.ExtractNewDocume
 transforms.unwrap.array.encoding=<array|document>
 ----
 
-Value `array` (the default) will encode arrays as the array datatype.
-It is user's responsibility to ensure that all elements for a given array instance are of the same type.
-This option is a restricting one but offers easy processing of arrays by downstream clients.
+Depending on the configuration, the SMT processes each instance of an array in the source message by using one of the following encoding methods:
 
-Value `document` will convert the array into a *struct* of *structs* in the similar way as done by http://bsonspec.org/[BSON serialization].
-The main *struct* contains fields named `_0`, `_1`, `_2` etc. where the name represents the index of the element in the array.
-Every element is then passed as the value for the given field.
+array encoding:: If `array.encoding` is set to `array` (the default), the SMT encodes uses the `array` datatype to encode arrays in the original message.
+To ensure correct processing, all elements in an array instance must be of the same type.
+This option is a restricting one, but it enables downstream clients to easily process arrays.
 
-Let's suppose an example source MongoDB document with array with heterogeneous types
+document encoding:: If `array.encoding` is set to `document`, the SMT converts each array in the source into a *struct* of *structs*, in a manner that is similar to http://bsonspec.org/[BSON serialization].
+The main *struct* contains fields named `_0`, `_1`, `_2`, and so on, where each field name represents the index of an element in the original array.
+The SMT populates each of these index fields with the values that it retrieves for the equivalent element in the source array.
+Index names are prefixed with underscores, because Avro encoding prohibits field names that begin with a numeric character.
+
+The following example shows how the {prodname} MongoDB connector represents a database document that contains an array that includes heterogeneous data types:
+
+.Example: Document encoding of an array that contains multiple data types
+====
 [source,json,indent=0]
 ----
 {
@@ -114,7 +239,8 @@ Let's suppose an example source MongoDB document with array with heterogeneous t
 }
 ----
 
-This document will be encoded as
+If the `array.encoding` is set to `document`, the SMT converts the preceding document into the following format:
+
 [source,json,indent=0]
 ----
 {
@@ -131,16 +257,29 @@ This document will be encoded as
     }
 }
 ----
+====
+The `document` encoding option enables the SMT to process arbitrary arrays that are comprised of heterogeneous elements.
+However, before you use this option, always verify that the sink connector and other downstream consumers are capable of processing arrays that contain multiple data types.
 
-This option allows you to process arbitrary arrays but the consumer need to know how to properly handle them.
 
-_Note: The underscore in index names is present because Avro encoding requires field names not to start with digit._
+// Type: concept
+// ModuleID: flattening-nested-structures-in-a-mongodb-event-message
+// Title: Flattening nested structures in a MongoDB event message
+[id="flattening-nested-structures-in-a-mongodb-event-message"]
+== Nested structure flattening
 
-=== Nested structure flattening
+When a database operation involves an embedded document, the {prodname} MongoDB connector emits a Kafka event record that has a structure that reflects the hierarchical structure of the original document.
+That is, the event message represents nested documents as a set of nested field structure.
+In environments where downstream connectors cannot process messages that contain nested structures, you can configure the event flattening SMT to flatten hierarchical structures in the message.
+A flat message structure is better suited to table-like storage.
 
-When a MongoDB document contains a nested document (structure) it is faithfully encoded as a nested structure field.
-If the sink connector does support only flat structure it is possible to flatten the internal structure into a flat one with a consistent field naming.
-To enable this feature the option `flatten.struct` must be set to `true`.
+To configure the SMT to flatten nested structures, set the xref:mongodb-extract-new-record-state-flatten-struct[`flatten.struct`] configuration option to `true`.
+In the converted message, field names are constructed to be consistent with the document source.
+The SMT renames each flattened field by concatenating the name of the parent document field with the name of the nested document field.
+A delimiter that is defined by the xref:mongodb-extract-new-record-state-flatten-struct-delimiter[`flatten.struct.delimiter`] option separates the components of the name.
+The default value of `struct.delimiter` is an underscore character (`_`).
+
+The following example shows the configuration for specifying whether the SMT flattens nested structures:
 
 [source]
 ----
@@ -150,10 +289,9 @@ transforms.unwrap.flatten.struct=<true|false>
 transforms.unwrap.flatten.struct.delimiter=<string>
 ----
 
-The resulting flat document will consist of fields whose names are created by joining the name of the parent field and the name of the fields in the nested document.
-Those elements are separated with string defined by an option `struct.delimiter` by default set to the _underscore_.
+The following example shows an event message that is emitted by the MongoDB connector.
+The message includes a field for a document `a` that contains fields for two nested documents, `b` and `c`:
 
-Let's suppose an example source MongoDB document with a field with a nested document
 [source,json,indent=0]
 ----
 {
@@ -166,7 +304,8 @@ Let's suppose an example source MongoDB document with a field with a nested docu
 }
 ----
 
-Such document will be encoded as
+The message in the following example shows the output after the SMT for MongoDB flattens the nested structures in the preceding message:
+
 [source,json,indent=0]
 ----
 {
@@ -177,22 +316,53 @@ Such document will be encoded as
 }
 ----
 
-This option allows you to convert a hierarchical document into a flat structure suitable for a table-like storage.
+In the resulting message, the `b` and `c` fields that were nested in the original message are flattened and renamed.
+The renamed fields are formed by concatenating the name of the parent document `a` with the names of the nested documents: `a_b` and `a_c`.
+The components of the new field names are separated by an underscore character, as defined by the setting of the xref:mongodb-extract-new-record-state-flatten-struct-delimiter[`struct.delimiter`] configuration property,
 
-=== MongoDB `$unset` handling
 
-MongoDB allows `$unset` operations that remove a certain field from a document. Because the collections are schemaless, it becomes hard to inform consumers/sinkers about the field that is now missing. The approach that {prodname} uses is to set the field being removed to a null value.
+// Type: concept
+// Title: How the {prodname} MongoDB connector reports the names of fields removed by `$unset` operations
+// ModuleID: how-the-debezium-mongodb-connector-reports-the-names-of-fields-removed-by-unset-operations
+[id="mongodb-$unset-handling"]
+== MongoDB `$unset` handling
 
-Given the operation
+In MongoDB, the `$unset` operator and the `$rename` operator both remove fields from a document.
+Because MongoDB collections are schemaless, after an update removes fields from a document, it's not possible to infer the name of the missing field from the updated document.
+To support sink connectors or other consumers that might require information about removed fields, {prodname} emits update messages that include a `removedFields` element that lists the names of the deleted fields.
+
+The following example shows part of an update message for an operation that results in the removal of the field `a`:
+
 [source,json,indent=0]
 ----
-{
-    "after":null,
-    "patch":"{\"$unset\" : {\"a\" : true}}"
+"payload": {
+  "op": "u",
+  "ts_ms": "...",
+  "before": "{ ... }",
+  "after": "{ ... }",
+  "updateDescription": {
+    "removedFields": ["a"],
+    "updatedFields": null,
+    "truncatedArrays": null
+  }
 }
 ----
 
-The final encoding will look like
+In the preceding example, the `before` and `after` represent the state of the source document before and after the document was updated.
+These fields are present in the event message that a connector emits only if the `capture.mode` for the connector is set as described in the following list:
+
+`before` field:: Provides the state of the document before the change.
+This field is present only when `capture.mode` is set to one of the following values:
+** `change_streams_with_pre_image`
+** `change_streams_update_full_with_pre_image`.
+
+`after` field:: Provides the full state of the document after a change.
+This field is present only when `capture.mode` is set to one of the following values:
+** `change_streams_update_full`
+** `change_streams_update_full_with_pre_image`.
+
+Assuming a connector that is configured to capture full documents, when the `ExtractNewDocumentState` SMT receives an `update` message for an `$unset` event, the SMT re-encodes the message by representing the removed field has a `null` value, as shown in the following example:
+
 [source,json,indent=0]
 ----
 {
@@ -201,14 +371,30 @@ The final encoding will look like
 }
 ----
 
-Note that other MongoDB operations might cause an `$unset` internally, `$rename` is one example.
+For connectors that are not configured to capture full documents, when the SMT receives an update event for an `$unset` operation, it produces the following output message:
 
-=== Determine original operation
+[source,json,indent=0]
+----
+{
+   "a": null
+}
+----
 
-When a message is flattened the final result does not show whether it was an insert, update or first read. (Deletions can be detected via tombstones or rewrites, see xref:{link-mongodb-event-flattening}#mongodb-extract-new-record-state-configuration-options[Configuration options].)
+// Type: procedure
+// Title: Determining the type of the original database operation
+[id="mongodb-event-flattening-determining-the-type-of-the-original-database-operation"]
+== Determine original operation
 
-To solve this problem, you can propagate the original operation either as a field added to message value or as a header property,
-e.g. like so to use a header property:
+After the SMT flattens an event message, the resulting message no longer indicates whether the operation that generated the event was of type `create`, `update` or initial snapshot `read`.
+Typically, you can identify `delete` operations by configuring the connectors to expose information about the tombstone or rewrite events that accompany a deletion.
+For more information about configuring the connector to expose information about tombstones and rewrites in event messages, see the xref:mongodb-extract-new-record-state-drop-tombstones[`drop.tombstones`] and xref:mongodb-extract-new-record-state-delete-handling-mode[`delete.handling.mode`] properties.
+
+To report the type of a database operation in an event message, the SMT can add an `op` field to one of the following elements:
+
+* The event message body.
+* A message header.
+
+For example, to add a header property that shows the type of the original operation, add the transform, and then add the `add.headers` property to the connector configuration, as in the following example:
 
 [source]
 ----
@@ -217,16 +403,22 @@ transforms.unwrap.type=io.debezium.connector.mongodb.transforms.ExtractNewDocume
 transforms.unwrap.add.headers=op
 ----
 
-The possible values are the ones from the `op` field of xref:{link-mongodb-connector}#mongodb-change-events-value[MongoDB connector change events].
+Based on the preceding configuration, the SMT reports the event type by adding an `op` header to the message and assigning it a string value to identify the type of the operation.
+The assigned string value is based on the `op` field value in the original {link-prefix}:{link-mongodb-connector}#mongodb-events[MongoDB change event message].
 
-=== Adding metadata fields
+// Type: concept
+// ModuleID: using-the-mongodb-event-flattening-smt-to-add-debezium-metadata-to-kafka-records
+// Title: Using the MongoDB event flattening SMT to add {prodname} metadata to Kafka records
+== Adding metadata fields
 
-The SMT can optionally add metadata fields from the original change event's to the final flattened record (prefixed with "__").
-This ability to add metadata to the event record makes it possible to include content such as the name of the collection associated with the change event, or such connector-specific fields as the replica set name.
-Currently, only fields from change event sub-structures `source`, `transaction` and `updateDescription` can be added.
-For more information about the MongoDB change event structure, see xref:{link-mongodb-connector}[the documentation] for the MongoDB connector.
+The event flattening SMT for MongoDB can add metadata fields from the original change event message to the simplified message.
+The added metadata fields are prefixed with a double underscore (`"__"`).
+Adding metadata to the event record makes it possible to include content such as the name of the collection in which a change event occurred, or to include connector-specific fields, such as a replica set name.
+Currently, the SMT can add fields from the following change event sub-structures only: `source`, `transaction` and `updateDescription`.
 
-For example, you might specify the following configuration to add a replica set name (`rs`) and the collection name for a change event to the final flattened event record:
+For more information about the MongoDB change event structure, see the {link-prefix}:{link-mongodb-connector}#debezium-connector-for-mongodb[MongoDB connector documentation].
+
+For example, you might specify the following configuration to add the replica set name (`rs`) and the collection name for a change event to the final flattened event record:
 
 ----
 transforms=unwrap,...
@@ -240,7 +432,7 @@ The preceding configuration results in the following content being added to the 
 { "__rs" : "rs0", "__collection" : "my-collection", ... }
 ----
 
-For `DELETE` events, the option to add metadata fields is supported only if the `delete.handling.mode` option is set to `rewrite`.
+If you want the SMT to add metadata fields to `delete` events, set the value of the xref:mongodb-extract-new-record-state-delete-handling-mode[`delete.handling.mode`] option to `rewrite`.
 
 // Type: concept
 // Title: Options for applying the MongoDB extract new document state transformation selectively
@@ -253,58 +445,123 @@ Because the structure of these other messages differs from the structure of the 
 
 For more information about how to apply the SMT selectively, see xref:{link-smt-predicates}#applying-transformations-selectively[Configure an SMT predicate for the transformation].
 
+// Type: reference
+// ModuleID: configuration-options-for-the-debezium-mongodb-event-flattening-transformation
+// Title: Configuration options for the {prodname} event flattening transformation for MongoDB
 [[mongodb-extract-new-record-state-configuration-options]]
 == Configuration options
+
+The following table describes the configuration options for the MongoDB event flattening SMT.
+
 [cols="30%a,25%a,45%a"]
 |===
 |Property |Default |Description
 
 |[[mongodb-extract-new-record-state-array-encoding]]<<mongodb-extract-new-record-state-array-encoding, `array.encoding`>>
 |`array`
-|The SMT converts MongoDB arrays into arrays as defined by Apache Connect (or Apache Avro) schema.
+|Specifies the format that the SMT uses when it encodes arrays that it reads from the original event message.
+Set one of the following options:
+
+`array`::
+The SMT uses the `array` datatype to encode MongoDB arrays into a format that is compatible with Apache Kafka Connect or Apache Avro schemas.
+If you set this option, verify that the elements in each array instance are of the same type.
+Although MongoDB allows arrays to contain multiple data types, some downstream clients cannot process arrays.
+
+`document`::
+The SMT converts each MongoDB array into a *struct* of *structs*, in a manner that is similar to http://bsonspec.org/[BSON serialization].
+The main *struct* contains fields with the names `_0`, `_1`, `_2`, and so forth.
+To comply with Avro naming standards, the SMT prefixes the numeric name of each index field with an underscore.
+Each of the numeric field names represents the index of an element in the original array.
+The SMT populates each of these index fields with the value that it retrieves from the source document for the designated array element.
+
+For more information about the `array.coding` option, see the xref:mongodb-event-flattening-array-encoding[options for encoding arrays in MongoDB event messages].
 
 |[[mongodb-extract-new-record-state-flatten-struct]]<<mongodb-extract-new-record-state-flatten-struct, `flatten.struct`>>
 |`false`
-|The SMT flattens structs by concatenating the fields into plain properties, using a configurable delimiter.
+|The SMT flattens structures (structs) in the original event message by concatenating the names of nested properties in the message, separated by a configurable delimiter, to form a simple field name.
 
 |[[mongodb-extract-new-record-state-flatten-struct-delimiter]]<<mongodb-extract-new-record-state-flatten-struct-delimiter, `flatten.struct.delimiter`>>
 |`_`
-|Delimiter to concat between field names from the input record when generating field names for the output record. Only applies when `flatten.struct` is set to `true`
+|When `flatten.struct` is set to `true`, specifies the delimiter that the transformation inserts between field names that it concatenates from the input record to generate field names in the output record.
 
 |[[mongodb-extract-new-record-state-drop-tombstones]]<<mongodb-extract-new-record-state-drop-tombstones, `drop.tombstones`>>
 |`true`
-|The SMT removes the tombstone generated by {prodname} from the stream.
+|{prodname} generates a tombstone record for each `delete` operation.
+The default behavior is that event flattening SMT removes tombstone records from the stream.
+To retain tombstone records in the stream, specify `drop.tombstones=false`.
 
 |[[mongodb-extract-new-record-state-delete-handling-mode]]<<mongodb-extract-new-record-state-delete-handling-mode, `delete.handling.mode`>>
 |`drop`
-|The SMT can `drop`, `rewrite` or pass delete records (`none`). The `rewrite` mode will add a `__deleted` field set to `true` or `false` depending on the represented operation.
+|Specifies how the SMT handles the change event records that {prodname} generates for `delete` operations.
+Set one of the following options:
+
+`drop`:: The SMT removes records for `delete` operations from the event stream.
+`none`:: The SMT retains the original change event record from the event stream.
+The record contains only `"value": "null"`.
+`rewrite`:: The SMT retains a modified version of the change event record from the stream.
+To provide another way to indicate that the record was deleted, the modified record includes a `value` field that contains the key/value pairs that were from the original record, and adds `+__deleted: true+` to the `value`. +
+ +
+If you set the `rewrite` option, you might find that the updated, simplified records for `DELETE` operations are sufficient for tracking deleted records.
+In such a case, you might want the SMT to xref:mongodb-extract-new-record-state-drop-tombstones[drop tombstone records].
 
 |[[mongodb-extract-new-record-state-add-headers-prefix]]<<mongodb-extract-new-record-state-add-headers-prefix, `add.headers.prefix`>>
 |__ (double-underscore)
 |Set this optional string to prefix a header.
 
 |[[mongodb-extract-new-record-state-add-headers]]<<mongodb-extract-new-record-state-add-headers, `add.headers`>>
-|
-|Specify a list of metadata fields to add to header of the flattened message.
-In case of duplicate field names (e.g. "ts_ms" exists twice), the struct should be specified to get the correct field (e.g. "source.ts_ms").
-The fields will be prefixed with `pass:[__]` or `pass:[__]<struct>pass:[__]`, depending on the specification of the struct.
-Please use a comma separated list without spaces.
+|No default
+|Specifies a comma-separated list, with no spaces, of metadata fields that you want the SMT to add to the header of simplified messages.
+When the original message contains duplicate field names, you can identify the specific field to modify by providing the name of the struct together with the name of the field, for example, `source.ts_ms`.
+
+Optionally, you can override the original name of a field and assign it a new name by adding an entry in the following format to the list: +
+
+`__<field_name>__:__<new_field_name>__`. +
+
+For example:
+
+```
+version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP
+```
+
+The new name values that you specify are case-sensitive. +
+ +
+When the SMT adds metadata fields to the header of the simplified message, it prefixes each metadata field name with a double underscore.
+For a struct specification, the SMT also inserts an underscore between the struct name and the field name. +
+ +
+If you specify a field that is not in the change event original message, the SMT does not add the field to the header.
 
 |[[mongodb-extract-new-record-state-add-fields-prefix]]<<mongodb-extract-new-record-state-add-fields-prefix, `add.fields.prefix`>>
 |__ (double-underscore)
-|Set this optional string to prefix a field.
+|Specifies an optional string to prefix to a field name.
 
 |[[mongodb-extract-new-record-state-add-fields]]<<mongodb-extract-new-record-state-add-fields, `add.fields`>>
-|
-|Specify a list of metadata fields to add to the flattened message.
-In case of duplicate field names (e.g. "ts_ms" exists twice), the struct should be specified to get the correct field (e.g. "source.ts_ms").
-The fields will be prefixed with `pass:[__]` or `pass:[__]<struct>pass:[__]`, depending on the specification of the struct.
-Please use a comma separated list without spaces.
+|No default
+|Set this option to a comma-separated list, with no spaces, of metadata fields to add to the `value` element of the simplified Kafka message.
+When the original message contains duplicate field names, you can identify the specific field to modify by providing the name of the struct together with the name of the field, for example, `source.ts_ms`.
+ +
+Optionally, you can override the original name of a field and assign it a new name by adding an entry in the following format to the list: +
+
+`__<field_name>__:__<new_field_name>__`. +
+
+For example:
+
+```
+version:VERSION, connector:CONNECTOR, source.ts_ms:EVENT_TIMESTAMP
+```
+
+The new name values that you specify are case-sensitive. +
+
+When the SMT adds metadata fields to the `value` element of the simplified message, it prefixes each metadata field name with a double underscore.
+For a struct specification, the SMT also inserts an underscore between the struct name and the field name. +
+ +
+If you specify a field that is not present in the original change event message, the SMT still adds the specified field to the `value` element of the modified message.
 
 |===
 
+[id="debezium-event-flattening-smt-for-mongodb-known-limitations"]
 == Known limitations
 
-* Feeding data changes from a schemaless store such as MongoDB to strictly schema-based datastores such as a relational database can by definition work within certain limits only.
-Specifically, all fields of documents within one collection with the same name must be of the same type. Otherwise, no consistent column definition can be derived in the target database.
-* Arrays will be restored in the emitted Kafka Connect record correctly, but they are not supported by sink connector just expecting a "flat" message structure.
+* Because MongoDB is a schemaless database, to ensure consistent column definitions when you use {prodname} to stream changes to a schema-based data relational database, fields within a collection that have the same name must store the same type of data.
+
+* Configure the SMT to produce messages in the format that is compatible with the sink connector.
+  If a sink connector requires a "flat" message structure, but it receives a message that encodes an array in the source MongoDB document as a struct of structs, the sink connector cannot process the message.


### PR DESCRIPTION
[DBZ-6006](https://issues.redhat.com/browse/DBZ-6006)

Edits to prepare the SMT doc for downstream use. Includes changes to related content in the doc for the  SQL-based version of the SMT and the MongoDB connector doc. 

Tested in local Antora build and local downstream build.
The downstream build initially failed due to unrelated linking errors present in the Oracle, PG, and SQL Server connector files. I'll open a separate issue to fix those problems.

Please backport this change to 2.1. 