### PR TITLE
[docs] Variable name clarified

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -422,6 +422,7 @@ Thomas Aregger
 Thomas Deblock
 Thomas Prelle
 Thomas Thornton
+Tim Loes
 Timo Roeseler
 Tin Nguyen
 Tom Bentley

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -1947,7 +1947,7 @@ FROM performance_schema.global_variables WHERE variable_name='log_bin';
 +
 [source,properties]
 ----
-server-id         = 223344
+server-id         = 223344 # Querying variable is called server_id, e.g. SELECT variable_value FROM information_schema.global_variables WHERE variable_name='server_id';
 log_bin           = mysql-bin
 binlog_format     = ROW
 binlog_row_image  = FULL

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -185,3 +185,4 @@ erdinc,Erdinç Taşkın
 luca.scannapieco,Luca Scannapieco
 sunxiaojian,Sun Xiao Jian
 Sanapalli Lokesh,Lokesh Sanapalli
+TimLoes,Tim Loes


### PR DESCRIPTION
It is necessary to query for server_id instead of server-id, which is being used on the config file.