### PR TITLE
DBZ-6064 masking sensitive information in connection string on close

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
@@ -116,7 +116,7 @@ public class ConnectionContext implements AutoCloseable {
     public void shutdown() {
         try {
             // Closing all connections ...
-            logger().info("Closing all connections to {}", connectionSeed());
+            logger().info("Closing all connections to {}", maskedConnectionSeed());
             pool.clear();
         }
         catch (Throwable e) {


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6064

Also double checked the usage of ``connectionSeed()`` method, it's now not used in any logs.