### PR TITLE
DBZ-6069 Remove problematic links

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -48,7 +48,7 @@ Information and procedures for using a {prodname} Oracle connector are organized
   * xref:deployment-of-debezium-oracle-connectors[]
   * xref:descriptions-of-debezium-oracle-connector-configuration-properties[]
   * xref:monitoring-debezium-oracle-connector-performance[]
-  * xref:how-debezium-oracle-connectors-handle-faults-and-problems[]
+  * xref:oracle-frequently-asked-questions[]
 endif::product[]
 
 // Type: assembly

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -106,7 +106,6 @@ Details are in the following topics:
 * xref:how-debezium-postgresql-connectors-perform-database-snapshots[]
 * xref:how-debezium-postgresql-connectors-stream-change-event-records[]
 * xref:default-names-of-kafka-topics-that-receive-debezium-postgresql-change-event-records[]
-* xref:metadata-in-debezium-postgresql-change-event-records[]
 * xref:debezium-postgresql-connector-generated-events-that-represent-transaction-boundaries[]
 
 endif::product[]

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2139,8 +2139,9 @@ The following configuration properties are _required_ unless a default value is 
 |[[sqlserver-property-tasks-max]]<<sqlserver-property-tasks-max, `+tasks.max+`>>
 |`1`
 |Specifies the maximum number of tasks that the connector can use to capture data from the database instance.
+ifdef::community[]
 If the xref:sqlserver-property-database-names[`database.names`] list contains more than one element, you can increase the value of this property to a number less than or equal to the number of elements in the list.
-
+endif::community[]
 |[[sqlserver-property-database-hostname]]<<sqlserver-property-database-hostname, `+database.hostname+`>>
 |No default
 |IP address or hostname of the SQL Server database server.


### PR DESCRIPTION
[DBZ-6069](https://issues.redhat.com/browse/DBZ-6069)

Update connector files to remove or update links that could not be resolved in the downstream version of the docs.

Tested in a local Antora build (no effect on the community version of the doc) and a local downstream build.

Please backport this change to 2.1.