### PR TITLE
DBZ-5827 ActivateTracingSpan wrong timestamps reported

### DIFF
--- a/debezium-core/src/main/java/io/debezium/transforms/tracing/ActivateTracingSpan.java
+++ b/debezium-core/src/main/java/io/debezium/transforms/tracing/ActivateTracingSpan.java
@@ -183,8 +183,9 @@ public class ActivateTracingSpan<R extends ConnectRecord<R>> implements Transfor
         try (Scope debeziumScope = tracer.scopeManager().activate(debeziumSpan)) {
             Tags.COMPONENT.set(txLogSpan, TRACING_COMPONENT);
             Tags.COMPONENT.set(debeziumSpan, TRACING_COMPONENT);
-            if (eventTimestamp != null) {
-                txLogSpan.finish(eventTimestamp * 1_000);
+
+            if (processingTimestamp != null) {
+                txLogSpan.finish(processingTimestamp * 1_000);
             }
             else {
                 txLogSpan.finish();


### PR DESCRIPTION
Change txLogSpan to use processingTimestamp for span finish.