### PR TITLE
Fallback to restart_lsn in Postgres connector if confirmed_flush_lsn …

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -23,6 +23,7 @@ Alfusainey Jallow
 Alisa Houskova
 Amit Sela
 Aman Garg
+Anatolii Popov
 Anders Engström
 Andrea Cosentino
 Andreas Bergmeier


### PR DESCRIPTION
Fallback to restart_lsn in Postgres connector if confirmed_flush_lsn is NULL and no long-running transactions were committed during timeout.

Sometimes there is a situation when after recovery Postgres replication slot does not have `confirmed_flush_lsn`. In our case this situation is caused by migration from one node to another and after restoration it is possible to advance `restart_lsn` value but not `confirmed_flush_lsn`.
So Debezium tries to fetch the replication slots from Postgres and filter out the slots that do not have `confirmed_flush_lsn` set initially retrying and waiting for potential long-running transactions to be committed as described in DBZ-862 and then fails with an exception when the amount of retries is exhausted.
To solve this the suggestion is to fall back to `restart_lsn` in this case.