### PR TITLE
DBZ-6099: close ResultSet after obtaining REPLICA IDENTITY

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -175,6 +175,7 @@ public class PostgresConnection extends JdbcConnection {
         }, rs -> {
             if (rs.next()) {
                 replIdentity.append(rs.getString(1));
+                rs.close();
             }
             else {
                 LOGGER.warn("Cannot determine REPLICA IDENTITY information for table '{}'", tableId);


### PR DESCRIPTION
The change is pretty straightforward, the issue is described in https://issues.redhat.com/browse/DBZ-6099
Needless to say, I'm open to suggestions. The intention is to help however I can.