### PR TITLE
DBZ-6094 Reduce frequency of "Transaction already processed" debug message

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
@@ -379,10 +379,12 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
 
         final Scn commitScn = row.getScn();
         if (offsetContext.getCommitScn().hasCommitAlreadyBeenHandled(row)) {
-            final Scn lastCommittedScn = offsetContext.getCommitScn().getCommitScnForRedoThread(row.getThread());
-            LOGGER.debug("Transaction {} has already been processed. "
-                    + "Offset Commit SCN {}, Transaction Commit SCN {}, Last Seen Commit SCN {}.",
-                    transactionId, offsetContext.getCommitScn(), commitScn, lastCommittedScn);
+            if (transaction.getNumberOfEvents() > 0) {
+                final Scn lastCommittedScn = offsetContext.getCommitScn().getCommitScnForRedoThread(row.getThread());
+                LOGGER.debug("Transaction {} has already been processed. "
+                        + "Offset Commit SCN {}, Transaction Commit SCN {}, Last Seen Commit SCN {}.",
+                        transactionId, offsetContext.getCommitScn(), commitScn, lastCommittedScn);
+            }
             removeTransactionAndEventsFromCache(transaction);
             metrics.setActiveTransactions(getTransactionCache().size());
             return;


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6094

It's possible the connector sees "empty transactions" where we have a START and a matching COMMIT/ROLLBACK, but all the DML operations within the transaction were filtered out due to the include/exclude filters.  In this case, there is no reason to log information about that transaction being skipped and this should help reduce the frequency of this message after a connector restart where there is a large number of transactions with no relevant DML events.