### PR TITLE
DBZ-6113: Fix negative remaining reconnect attempts

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -135,6 +135,7 @@ Eric Weaver
 Eric S. Kreiseir
 Erik Malm
 Ethan Zou
+Eugene Abramchuk
 Ewen Cheslack-Postava
 Ezer Karavani
 Fabian Aussems

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
@@ -273,7 +273,7 @@ public class ConnectionContext implements AutoCloseable {
             int attempts = 0;
             MongoClient client = null;
             while (client == null) {
-                ++attempts;
+                attempts++;
                 try {
                     // Try to get the primary
                     client = factory.get();

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ConnectionContext.java
@@ -284,7 +284,7 @@ public class ConnectionContext implements AutoCloseable {
                 catch (Throwable t) {
                     handler.failed(attempts, maxAttempts - attempts, t);
                 }
-                if (attempts > maxAttempts) {
+                if (attempts >= maxAttempts) {
                     throw new ConnectException("Unable to connect to " + preference.getName() + " node of '" + replicaSet +
                             "' after " + attempts + " failed attempts");
                 }


### PR DESCRIPTION
This change respects current max attempts but avoids possible negative attempts (current behaviour): 

`Error while attempting to connect to primaryPreferred node of '###' after attempt #17 (-1 remaining)`

Also adjusts incorrect max reconnection attempts (was [actual max attempts]+1)