### PR TITLE
DBZ-6116: Support String type for key in Mongo incremental snapshot

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbIncrementalSnapshotChangeEventSource.java
@@ -521,6 +521,9 @@ public class MongoDbIncrementalSnapshotChangeEventSource
             case OBJECT_ID:
                 key = documentId.asObjectId().getValue();
                 break;
+            case STRING:
+                key = documentId.asString().getValue();
+                break;
             default:
                 throw new IllegalStateException("Unsupported type of document id");
         }

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/IncrementalSnapshotIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/IncrementalSnapshotIT.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -389,6 +390,12 @@ public class IncrementalSnapshotIT extends AbstractMongoConnectorIT {
     public void snapshotOnlyObjectId() throws Exception {
         ObjectId firstKey = new ObjectId();
         snapshotOnly(firstKey, k -> new ObjectId());
+    }
+
+    @Test
+    public void snapshotOnlyString() throws Exception {
+        Supplier<String> keySupplier = () -> java.util.UUID.randomUUID().toString();
+        snapshotOnly(keySupplier.get(), k -> keySupplier.get());
     }
 
     @Test

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -234,6 +234,13 @@ For more information about support scope, see link:https://access.redhat.com/sup
 endif::product[]
 include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot.adoc[leveloffset=+3]
 
+[WARNING]
+====
+Incremental snapshots requires the primary key to be stably ordered. However, `String` may not guarantees stable ordering as encodings and special characters
+can lead to unexpected behaviour (https://www.mongodb.com/docs/manual/reference/bson-types/#ref-sort-string-internationalization-id3/[Mongo sort `String`]).
+Please consider using other types for the primary key when performing incremental snapshots.
+====
+
 [NOTE]
 ====
 Incremental snapshots are currently supported for single replica set deployments only.


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6116
follow up PR on https://github.com/debezium/debezium/pull/4239

@jcechace @jpechane 