### PR TITLE
DBZ-6129 Upgrade to Quarkus 3.0.0.Final

### DIFF
--- a/debezium-assembly-descriptors/src/main/resources/assemblies/connector-distribution-no-infinispan.xml
+++ b/debezium-assembly-descriptors/src/main/resources/assemblies/connector-distribution-no-infinispan.xml
@@ -27,7 +27,9 @@
 
               <!-- Exclude Infinispan and dependencies  -->
               <exclude>org.infinispan:infinispan-core:*</exclude>
+              <exclude>org.infinispan:infinispan-core-jakarta:*</exclude>
               <exclude>org.infinispan:infinispan-client-hotrod:*</exclude>
+              <exclude>org.infinispan:infinispan-client-hotrod-jakarta:*</exclude>
 
               <!-- Exclude dependencies with incorrect scope -->
               <exclude>org.checkerframework:checker-qual:*</exclude>

--- a/debezium-bom/pom.xml
+++ b/debezium-bom/pom.xml
@@ -416,12 +416,12 @@
             <!-- Oracle dependencies -->
             <dependency>
                 <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-core</artifactId>
+                <artifactId>infinispan-core-jakarta</artifactId>
                 <version>${version.infinispan}</version>
             </dependency>
             <dependency>
                 <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-client-hotrod</artifactId>
+                <artifactId>infinispan-client-hotrod-jakarta</artifactId>
                 <version>${version.infinispan}</version>
             </dependency>
             <dependency>

--- a/debezium-connector-oracle/pom.xml
+++ b/debezium-connector-oracle/pom.xml
@@ -49,11 +49,11 @@
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-core</artifactId>
+            <artifactId>infinispan-core-jakarta</artifactId>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
-            <artifactId>infinispan-client-hotrod</artifactId>
+            <artifactId>infinispan-client-hotrod-jakarta</artifactId>
         </dependency>
         <dependency>
             <groupId>org.infinispan.protostream</groupId>

--- a/debezium-parent/pom.xml
+++ b/debezium-parent/pom.xml
@@ -115,7 +115,7 @@
                     <artifactId>impsort-maven-plugin</artifactId>
                     <version>${version.impsort}</version>
                     <configuration>
-                        <groups>java.,javax.,org.,com.,io.</groups>
+                        <groups>java.,jakarta.,javax.,org.,com.,io.</groups>
                         <staticGroups>*</staticGroups>
                         <staticAfter>false</staticAfter>
                         <skip>${format.skip}</skip>

--- a/debezium-quarkus-outbox-common/deployment/src/main/java/io/debezium/outbox/quarkus/deployment/OutboxCommonProcessor.java
+++ b/debezium-quarkus-outbox-common/deployment/src/main/java/io/debezium/outbox/quarkus/deployment/OutboxCommonProcessor.java
@@ -12,9 +12,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
 
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmHibernateMapping;
 import org.jboss.jandex.ClassInfo;

--- a/debezium-quarkus-outbox-common/deployment/src/main/java/io/debezium/outbox/quarkus/deployment/OutboxEventHbmWriter.java
+++ b/debezium-quarkus-outbox-common/deployment/src/main/java/io/debezium/outbox/quarkus/deployment/OutboxEventHbmWriter.java
@@ -7,6 +7,7 @@ package io.debezium.outbox.quarkus.deployment;
 
 import static io.debezium.outbox.quarkus.internal.OutboxConstants.OUTBOX_ENTITY_FULLNAME;
 
+import java.time.Instant;
 import java.util.UUID;
 
 import org.hibernate.boot.jaxb.hbm.spi.JaxbHbmBasicAttributeType;
@@ -172,7 +173,9 @@ public class OutboxEventHbmWriter {
             attribute.setTypeAttribute("converted::" + config.timestamp.converter.get());
         }
         else {
-            attribute.setTypeAttribute("Instant");
+            // Hibernate 6.x expects full qualified class names for this whereas Hibernate 5.x had
+            // a registered type for "Instant" that did the direct mapping without package names.
+            attribute.setTypeAttribute(Instant.class.getName());
         }
 
         final JaxbHbmColumnType column = new JaxbHbmColumnType();

--- a/debezium-quarkus-outbox-common/runtime/src/main/java/io/debezium/outbox/quarkus/internal/AdditionalJaxbMappingProducerImpl.java
+++ b/debezium-quarkus-outbox-common/runtime/src/main/java/io/debezium/outbox/quarkus/internal/AdditionalJaxbMappingProducerImpl.java
@@ -22,9 +22,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
 
 import org.hibernate.boot.jaxb.Origin;
 import org.hibernate.boot.jaxb.SourceType;

--- a/debezium-quarkus-outbox-common/runtime/src/main/java/io/debezium/outbox/quarkus/internal/AdditionalJaxbMappingProducerImpl.java
+++ b/debezium-quarkus-outbox-common/runtime/src/main/java/io/debezium/outbox/quarkus/internal/AdditionalJaxbMappingProducerImpl.java
@@ -5,6 +5,7 @@
  */
 package io.debezium.outbox.quarkus.internal;
 
+import static io.debezium.outbox.quarkus.internal.OutboxConstants.CONTRIBUTOR;
 import static io.debezium.outbox.quarkus.internal.OutboxConstants.OUTBOX_ENTITY_HBMXML;
 
 import java.io.BufferedInputStream;
@@ -83,7 +84,7 @@ public class AdditionalJaxbMappingProducerImpl implements AdditionalJaxbMappingP
                         logOutboxMapping(mapping);
 
                         LOGGER.info("Contributed XML mapping for entity: {}", mapping.getClazz().get(0).getEntityName());
-                        return Collections.singletonList(new MappingDocument(mapping, origin, buildingContext));
+                        return Collections.singletonList(new MappingDocument(CONTRIBUTOR, mapping, origin, buildingContext));
                     }
                 }
             }

--- a/debezium-quarkus-outbox-common/runtime/src/main/java/io/debezium/outbox/quarkus/internal/JsonNodeAttributeConverter.java
+++ b/debezium-quarkus-outbox-common/runtime/src/main/java/io/debezium/outbox/quarkus/internal/JsonNodeAttributeConverter.java
@@ -7,7 +7,7 @@ package io.debezium.outbox.quarkus.internal;
 
 import java.io.IOException;
 
-import javax.persistence.AttributeConverter;
+import jakarta.persistence.AttributeConverter;
 
 import org.hibernate.HibernateException;
 

--- a/debezium-quarkus-outbox-common/runtime/src/main/java/io/debezium/outbox/quarkus/internal/OutboxConstants.java
+++ b/debezium-quarkus-outbox-common/runtime/src/main/java/io/debezium/outbox/quarkus/internal/OutboxConstants.java
@@ -12,6 +12,7 @@ package io.debezium.outbox.quarkus.internal;
  */
 public final class OutboxConstants {
 
+    public static final String CONTRIBUTOR = "debezium-outbox";
     public static final String OUTBOX_ENTITY_HBMXML = "META-INF/OutboxEvent.hbm.xml";
     public static final String OUTBOX_ENTITY_FULLNAME = "io.debezium.outbox.quarkus.internal.OutboxEvent";
 

--- a/debezium-quarkus-outbox-reactive/integration-tests/src/main/java/io/debezium/outbox/reactive/quarkus/it/MyService.java
+++ b/debezium-quarkus-outbox-reactive/integration-tests/src/main/java/io/debezium/outbox/reactive/quarkus/it/MyService.java
@@ -8,8 +8,8 @@ package io.debezium.outbox.reactive.quarkus.it;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 import io.debezium.outbox.reactive.quarkus.internal.DebeziumOutboxHandler;
 import io.smallrye.mutiny.Uni;

--- a/debezium-quarkus-outbox-reactive/integration-tests/src/main/java/io/debezium/outbox/reactive/quarkus/it/TestEntity.java
+++ b/debezium-quarkus-outbox-reactive/integration-tests/src/main/java/io/debezium/outbox/reactive/quarkus/it/TestEntity.java
@@ -5,9 +5,9 @@
  */
 package io.debezium.outbox.reactive.quarkus.it;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 
 /**
  * This entity class is merely a placeholder to address two concerns:

--- a/debezium-quarkus-outbox-reactive/integration-tests/src/main/java/io/debezium/outbox/reactive/quarkus/it/UpperCaseAttributeConverter.java
+++ b/debezium-quarkus-outbox-reactive/integration-tests/src/main/java/io/debezium/outbox/reactive/quarkus/it/UpperCaseAttributeConverter.java
@@ -7,7 +7,7 @@ package io.debezium.outbox.reactive.quarkus.it;
 
 import java.util.Locale;
 
-import javax.persistence.AttributeConverter;
+import jakarta.persistence.AttributeConverter;
 
 /**
  * An {@link AttributeConverter} that converters the input string to upper-case at persistence time

--- a/debezium-quarkus-outbox-reactive/integration-tests/src/test/java/io/debezium/outbox/reactive/quarkus/it/AbstractOutboxTest.java
+++ b/debezium-quarkus-outbox-reactive/integration-tests/src/test/java/io/debezium/outbox/reactive/quarkus/it/AbstractOutboxTest.java
@@ -14,7 +14,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.hibernate.metamodel.spi.MetamodelImplementor;
 import org.hibernate.persister.entity.EntityPersister;

--- a/debezium-quarkus-outbox-reactive/integration-tests/src/test/java/io/debezium/outbox/reactive/quarkus/it/OutboxTest.java
+++ b/debezium-quarkus-outbox-reactive/integration-tests/src/test/java/io/debezium/outbox/reactive/quarkus/it/OutboxTest.java
@@ -13,7 +13,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.junit.jupiter.api.Test;

--- a/debezium-quarkus-outbox-reactive/runtime/pom.xml
+++ b/debezium-quarkus-outbox-reactive/runtime/pom.xml
@@ -45,7 +45,7 @@
                 </plugin>
                 <plugin>
                     <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                    <artifactId>quarkus-extension-maven-plugin</artifactId>
                     <version>${quarkus.version}</version>
                     <executions>
                         <execution>
@@ -68,7 +68,7 @@
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/debezium-quarkus-outbox-reactive/runtime/src/main/java/io/debezium/outbox/reactive/quarkus/internal/AbstractEventDispatcher.java
+++ b/debezium-quarkus-outbox-reactive/runtime/src/main/java/io/debezium/outbox/reactive/quarkus/internal/AbstractEventDispatcher.java
@@ -9,7 +9,7 @@ import static io.debezium.outbox.quarkus.internal.OutboxConstants.OUTBOX_ENTITY_
 
 import java.util.Map;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.tuple.DynamicMapInstantiator;

--- a/debezium-quarkus-outbox-reactive/runtime/src/main/java/io/debezium/outbox/reactive/quarkus/internal/DebeziumOutboxHandler.java
+++ b/debezium-quarkus-outbox-reactive/runtime/src/main/java/io/debezium/outbox/reactive/quarkus/internal/DebeziumOutboxHandler.java
@@ -5,8 +5,8 @@
  */
 package io.debezium.outbox.reactive.quarkus.internal;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 import io.debezium.outbox.quarkus.ExportedEvent;
 import io.debezium.outbox.reactive.quarkus.DebeziumCustomCodec;

--- a/debezium-quarkus-outbox-reactive/runtime/src/main/java/io/debezium/outbox/reactive/quarkus/internal/DebeziumTracerEventDispatcher.java
+++ b/debezium-quarkus-outbox-reactive/runtime/src/main/java/io/debezium/outbox/reactive/quarkus/internal/DebeziumTracerEventDispatcher.java
@@ -7,8 +7,8 @@ package io.debezium.outbox.reactive.quarkus.internal;
 
 import java.util.Map;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/debezium-quarkus-outbox-reactive/runtime/src/main/java/io/debezium/outbox/reactive/quarkus/internal/DefaultEventDispatcher.java
+++ b/debezium-quarkus-outbox-reactive/runtime/src/main/java/io/debezium/outbox/reactive/quarkus/internal/DefaultEventDispatcher.java
@@ -5,7 +5,7 @@
  */
 package io.debezium.outbox.reactive.quarkus.internal;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/debezium-quarkus-outbox/integration-tests/src/main/java/io/debezium/outbox/quarkus/it/MyService.java
+++ b/debezium-quarkus-outbox/integration-tests/src/main/java/io/debezium/outbox/quarkus/it/MyService.java
@@ -8,10 +8,10 @@ package io.debezium.outbox.quarkus.it;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Event;
-import javax.inject.Inject;
-import javax.transaction.Transactional;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 
 import io.debezium.outbox.quarkus.ExportedEvent;
 

--- a/debezium-quarkus-outbox/integration-tests/src/main/java/io/debezium/outbox/quarkus/it/TestEntity.java
+++ b/debezium-quarkus-outbox/integration-tests/src/main/java/io/debezium/outbox/quarkus/it/TestEntity.java
@@ -5,9 +5,9 @@
  */
 package io.debezium.outbox.quarkus.it;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 
 /**
  * This entity class is merely a placeholder to address two concerns:

--- a/debezium-quarkus-outbox/integration-tests/src/main/java/io/debezium/outbox/quarkus/it/UpperCaseAttributeConverter.java
+++ b/debezium-quarkus-outbox/integration-tests/src/main/java/io/debezium/outbox/quarkus/it/UpperCaseAttributeConverter.java
@@ -7,7 +7,7 @@ package io.debezium.outbox.quarkus.it;
 
 import java.util.Locale;
 
-import javax.persistence.AttributeConverter;
+import jakarta.persistence.AttributeConverter;
 
 /**
  * An {@link AttributeConverter} that converters the input string to upper-case at persistence time

--- a/debezium-quarkus-outbox/integration-tests/src/test/java/io/debezium/outbox/quarkus/it/AbstractOutboxTest.java
+++ b/debezium-quarkus-outbox/integration-tests/src/test/java/io/debezium/outbox/quarkus/it/AbstractOutboxTest.java
@@ -13,8 +13,8 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
 
-import javax.inject.Inject;
-import javax.persistence.EntityManager;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
 
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.metamodel.spi.MetamodelImplementor;

--- a/debezium-quarkus-outbox/integration-tests/src/test/java/io/debezium/outbox/quarkus/it/OutboxTest.java
+++ b/debezium-quarkus-outbox/integration-tests/src/test/java/io/debezium/outbox/quarkus/it/OutboxTest.java
@@ -12,8 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.Instant;
 import java.util.Map;
 
-import javax.inject.Inject;
-import javax.persistence.EntityManager;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
 
 import org.junit.jupiter.api.Test;
 

--- a/debezium-quarkus-outbox/runtime/pom.xml
+++ b/debezium-quarkus-outbox/runtime/pom.xml
@@ -41,7 +41,7 @@
                 </plugin>
                 <plugin>
                     <groupId>io.quarkus</groupId>
-                    <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                    <artifactId>quarkus-extension-maven-plugin</artifactId>
                     <version>${quarkus.version}</version>
                     <executions>
                         <execution>
@@ -64,7 +64,7 @@
             </plugin>
             <plugin>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/debezium-quarkus-outbox/runtime/src/main/java/io/debezium/outbox/quarkus/internal/AbstractEventDispatcher.java
+++ b/debezium-quarkus-outbox/runtime/src/main/java/io/debezium/outbox/quarkus/internal/AbstractEventDispatcher.java
@@ -9,8 +9,8 @@ import static io.debezium.outbox.quarkus.internal.OutboxConstants.OUTBOX_ENTITY_
 
 import java.util.Map;
 
-import javax.inject.Inject;
-import javax.persistence.EntityManager;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
 
 import org.hibernate.Session;
 

--- a/debezium-quarkus-outbox/runtime/src/main/java/io/debezium/outbox/quarkus/internal/DebeziumTracerEventDispatcher.java
+++ b/debezium-quarkus-outbox/runtime/src/main/java/io/debezium/outbox/quarkus/internal/DebeziumTracerEventDispatcher.java
@@ -7,9 +7,9 @@ package io.debezium.outbox.quarkus.internal;
 
 import java.util.Map;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/debezium-quarkus-outbox/runtime/src/main/java/io/debezium/outbox/quarkus/internal/DefaultEventDispatcher.java
+++ b/debezium-quarkus-outbox/runtime/src/main/java/io/debezium/outbox/quarkus/internal/DefaultEventDispatcher.java
@@ -5,8 +5,8 @@
  */
 package io.debezium.outbox.quarkus.internal;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/debezium-quarkus-outbox/runtime/src/main/java/io/debezium/outbox/quarkus/internal/EventDispatcher.java
+++ b/debezium-quarkus-outbox/runtime/src/main/java/io/debezium/outbox/quarkus/internal/EventDispatcher.java
@@ -5,7 +5,7 @@
  */
 package io.debezium.outbox.quarkus.internal;
 
-import javax.enterprise.event.Observes;
+import jakarta.enterprise.event.Observes;
 
 import io.debezium.outbox.quarkus.ExportedEvent;
 

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <!-- Quarkus -->
         <!-- Must be aligned with Apicurio version below -->
         <!-- Debezium Server Pravega must use the same Netty version as the one used by Quarkus -->
-        <quarkus.version>3.0.0.CR2</quarkus.version>
+        <quarkus.version>3.0.0.Final</quarkus.version>
 
         <!-- Apicurio -->
         <version.apicurio>2.4.1.Final</version.apicurio>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <!-- Quarkus -->
         <!-- Must be aligned with Apicurio version below -->
         <!-- Debezium Server Pravega must use the same Netty version as the one used by Quarkus -->
-        <quarkus.version>3.0.0.Alpha4</quarkus.version>
+        <quarkus.version>3.0.0.CR1</quarkus.version>
 
         <!-- Apicurio -->
         <version.apicurio>2.4.1.Final</version.apicurio>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <!-- Quarkus -->
         <!-- Must be aligned with Apicurio version below -->
         <!-- Debezium Server Pravega must use the same Netty version as the one used by Quarkus -->
-        <quarkus.version>2.16.3.Final</quarkus.version>
+        <quarkus.version>3.0.0.Alpha4</quarkus.version>
 
         <!-- Apicurio -->
         <version.apicurio>2.4.1.Final</version.apicurio>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <!-- Quarkus -->
         <!-- Must be aligned with Apicurio version below -->
         <!-- Debezium Server Pravega must use the same Netty version as the one used by Quarkus -->
-        <quarkus.version>3.0.0.CR1</quarkus.version>
+        <quarkus.version>3.0.0.CR2</quarkus.version>
 
         <!-- Apicurio -->
         <version.apicurio>2.4.1.Final</version.apicurio>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6129

- [ ] Apply future alpha/CR builds
- [x] Fix `OutboxIT` (reactive/non-reactive) test failure, attempting to use CDI beans, which is no longer supported.
- [x] Upgrade `debezium-server` repository to Quarkus 3 (https://github.com/debezium/debezium-server/pull/8)
- [x] Verify Oracle connector Infinispan Integration with Jakarta EE artifacts