### PR TITLE
DBZ-5201: Add support for server-side filtering of replica set change streams

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ChangeStreamPipelineFactory.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ChangeStreamPipelineFactory.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Field;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.changestream.OperationType;
+
+import io.debezium.connector.mongodb.Filters.FilterConfig;
+import io.debezium.data.Envelope;
+
+/**
+ * A factory to produce a MongoDB change stream pipeline expression.
+ */
+class ChangeStreamPipelineFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ChangeStreamPipelineFactory.class);
+
+    private final ReplicaSetOffsetContext rsOffsetContext;
+    private final MongoDbConnectorConfig connectorConfig;
+    private final FilterConfig filterConfig;
+
+    ChangeStreamPipelineFactory(ReplicaSetOffsetContext rsOffsetContext, MongoDbConnectorConfig connectorConfig, FilterConfig filterConfig) {
+        this.rsOffsetContext = rsOffsetContext;
+        this.connectorConfig = connectorConfig;
+        this.filterConfig = filterConfig;
+    }
+
+    List<Bson> create() {
+        // Resolve the leaf filters
+        var filters = Stream
+                .of(
+                        createCollectionFilter(filterConfig),
+                        createOperationTypeFilter(connectorConfig),
+                        createClusterTimeFilter(rsOffsetContext))
+                .flatMap(Optional::stream)
+                .collect(toList());
+
+        // Combine
+        var andFilter = Filters.and(filters);
+        var matchFilter = Aggregates.match(andFilter);
+
+        // Pipeline
+        // Note that change streams cannot use indexes:
+        // - https://www.mongodb.com/docs/manual/administration/change-streams-production-recommendations/#indexes-and-performance
+        // Note that `$addFields` must be used over `$set`/ `$unset` to support MongoDB 4.0 which doesn't support these operators:
+        // - https://www.mongodb.com/docs/manual/changeStreams/#modify-change-stream-output
+        var pipeline = List.of(
+                // Materialize a "namespace" field so that we can do qualified collection name matching per
+                // the configuration requirements
+                // Note that per the docs, if `$ns` doesn't exist, `$concat` will return `null`
+                addFields("namespace", concat("$ns.db", ".", "$ns.coll")),
+
+                // Filter the documents
+                matchFilter,
+
+                // This is required to prevent driver `ChangeStreamDocument` deserialization issues:
+                // > Caused by: org.bson.codecs.configuration.CodecConfigurationException:
+                // > Failed to decode 'ChangeStreamDocument'. Decoding 'namespace' errored with:
+                // > readStartDocument can only be called when CurrentBSONType is DOCUMENT, not when CurrentBSONType is STRING.
+                addFields("namespace", "$$REMOVE"));
+
+        LOGGER.info("Change stream pipeline: {}", new BasicDBObject("pipeline", pipeline).toBsonDocument().toJson());
+        return pipeline;
+    }
+
+    private static Optional<Bson> createCollectionFilter(FilterConfig filterConfig) {
+        // Database filters
+        var dbFilters = Optional.<Bson> empty();
+        if (filterConfig.getDbIncludeList() != null) {
+            dbFilters = Optional.of(Filters.regex("ns.db", filterConfig.getDbIncludeList().replaceAll(",", "|"), "i"));
+        }
+        else if (filterConfig.getDbExcludeList() != null) {
+            dbFilters = Optional.of(Filters.regex("ns.db", "(?!" + filterConfig.getDbExcludeList().replaceAll(",", "|") + ")", "i"));
+        }
+
+        // TODO: This should be removed since, from https://www.mongodb.com/docs/manual/changeStreams/:
+        // > non-system collections across all databases except for `admin`, `local`, and `config`
+        var excludedBuiltInDbs = Optional.<Bson> empty();
+        if (filterConfig.getBuiltInDbNames() != null) {
+            excludedBuiltInDbs = Optional.of(Filters.nin("ns.db", filterConfig.getBuiltInDbNames()));
+        }
+
+        // Collection filters
+        var collectionsFilters = Optional.<Bson> empty();
+        if (filterConfig.getCollectionIncludeList() != null) {
+            collectionsFilters = Optional
+                    .of(Filters.regex("namespace", filterConfig.getCollectionIncludeList().replaceAll(",", "|"), "i"));
+        }
+        else if (filterConfig.getCollectionExcludeList() != null) {
+            collectionsFilters = Optional
+                    .of(Filters.regex("namespace", "(?!" + filterConfig.getCollectionExcludeList().replaceAll(",", "|") + ")", "i"));
+        }
+        var includedSignalCollectionFilters = Optional.<Bson> empty();
+        if (filterConfig.getSignalDataCollection() != null) {
+            includedSignalCollectionFilters = Optional.of(Filters.eq("namespace", filterConfig.getSignalDataCollection()));
+        }
+
+        // Combined filters
+        return andFilters(
+                excludedBuiltInDbs,
+                dbFilters,
+                orFilters(
+                        includedSignalCollectionFilters,
+                        collectionsFilters));
+    }
+
+    private static Optional<Bson> createOperationTypeFilter(MongoDbConnectorConfig connectorConfig) {
+        // Per https://debezium.io/documentation/reference/stable/connectors/mongodb.html#mongodb-property-skipped-operations
+        // > The supported operations include:
+        // > - 'c' for inserts/create
+        // > - 'u' for updates/replace,
+        // > - 'd' for deletes,
+        // > - 't' for truncates, and
+        // > - 'none' to not skip any operations.
+        // > By default, 'truncate' operations are skipped (not emitted by this connector).
+        // However, 'truncate' is not supported since it doesn't exist as a
+        // [MongoDB change type](https://www.mongodb.com/docs/manual/reference/change-events/). Also note that
+        // support for 'none' effectively implies 'c', 'u', 'd'
+
+        // First, begin by including all the supported Debezium change events
+        var includedOperations = new ArrayList<OperationType>();
+        includedOperations.add(OperationType.INSERT);
+        includedOperations.add(OperationType.UPDATE);
+        includedOperations.add(OperationType.REPLACE);
+        includedOperations.add(OperationType.DELETE);
+
+        // Next, remove any implied by the configuration
+        var skippedOperations = connectorConfig.getSkippedOperations();
+        if (skippedOperations.contains(Envelope.Operation.CREATE)) {
+            includedOperations.remove(OperationType.INSERT);
+        }
+        if (skippedOperations.contains(Envelope.Operation.UPDATE)) {
+            includedOperations.remove(OperationType.UPDATE);
+            includedOperations.remove(OperationType.REPLACE);
+        }
+        if (skippedOperations.contains(Envelope.Operation.DELETE)) {
+            includedOperations.remove(OperationType.DELETE);
+        }
+
+        return Optional.of(Filters.in("operationType", includedOperations.stream()
+                .map(OperationType::getValue)
+                .collect(toList())));
+    }
+
+    private static Optional<Bson> createClusterTimeFilter(ReplicaSetOffsetContext rsOffsetContext) {
+        if (rsOffsetContext.lastResumeToken() != null) {
+            return Optional.empty();
+        }
+
+        // After snapshot the oplogStart points to the last change snapshotted, so it must filtered-out to
+        // prevent duplicates
+        return Optional.of(Filters.ne("clusterTime", rsOffsetContext.lastOffsetTimestamp()));
+    }
+
+    @SafeVarargs
+    private static Optional<Bson> andFilters(Optional<Bson>... filters) {
+        var resolved = resolveFilters(filters);
+        if (resolved.isEmpty()) {
+            return Optional.empty();
+        }
+        else if (resolved.size() == 1) {
+            return Optional.of(resolved.get(0));
+        }
+        else {
+            return Optional.of(Filters.and(resolved));
+        }
+    }
+
+    @SafeVarargs
+    private static Optional<Bson> orFilters(Optional<Bson>... filters) {
+        var resolved = resolveFilters(filters);
+        if (resolved.isEmpty()) {
+            return Optional.empty();
+        }
+        else if (resolved.size() == 1) {
+            return Optional.of(resolved.get(0));
+        }
+        else {
+            return Optional.of(Filters.or(resolved));
+        }
+    }
+
+    @SafeVarargs
+    private static List<Bson> resolveFilters(Optional<Bson>... filters) {
+        return Stream.of(filters)
+                .flatMap(Optional::stream)
+                .collect(toList());
+    }
+
+    private static Bson regexMatch(String regex, String options, Bson input) {
+        return new BasicDBObject("$regexMatch", new BasicDBObject()
+                .append("input", input)
+                .append("regex", regex)
+                .append("options", options));
+    }
+
+    private static Bson concat(Object... expressions) {
+        return new BasicDBObject("$concat", List.of(expressions));
+    }
+
+    private static Bson set(String name, Bson expression) {
+        return Aggregates.set(new Field<>(name, expression));
+    }
+
+    private static Bson unset(String name) {
+        return new BasicDBObject("$unset", List.of(name));
+    }
+
+    private static Bson addFields(String name, Object expression) {
+        return new BasicDBObject("$addFields", new BasicDBObject(name, expression));
+    }
+}

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSetOffsetContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSetOffsetContext.java
@@ -12,6 +12,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.bson.BsonDocument;
 import org.bson.BsonTimestamp;
 
+import com.mongodb.client.MongoChangeStreamCursor;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 
 import io.debezium.annotation.ThreadSafe;
@@ -99,6 +100,10 @@ public class ReplicaSetOffsetContext extends CommonOffsetContext<SourceInfo> {
     public void readEvent(CollectionId collectionId, Instant timestamp) {
         sourceInfo.collectionEvent(replicaSetName, collectionId, 0L);
         sourceInfo.lastOffset(replicaSetName);
+    }
+
+    public void noEvent(MongoChangeStreamCursor<?> cursor) {
+        sourceInfo.noEvent(replicaSetName, cursor);
     }
 
     public void changeStreamEvent(ChangeStreamDocument<BsonDocument> changeStreamEvent) {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ResumeTokens.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ResumeTokens.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
+import org.bson.BsonValue;
+
+import io.debezium.util.HexConverter;
+
+/**
+ * Utilities for working with MongoDB <a href="https://www.mongodb.com/docs/manual/changeStreams/#std-label-change-stream-resume">resume tokens</a>.
+ * <p>
+ * Adaptation of <a href="https://github.com/mongodb/mongo-kafka/blob/master/src/main/java/com/mongodb/kafka/connect/util/ResumeTokenUtils.java">ResumeTokenUtils</a>
+ */
+public final class ResumeTokens {
+
+    public static BsonTimestamp getTimestamp(BsonDocument resumeToken) {
+        BsonValue data = getData(resumeToken);
+        byte[] dataBytes = getDataBytes(data);
+        ByteBuffer dataBuffer = ByteBuffer.wrap(dataBytes).order(ByteOrder.BIG_ENDIAN);
+
+        // Cast to an int then remove the sign bit to get the unsigned value
+        int canonicalType = ((int) dataBuffer.get()) & 0xff;
+        if (canonicalType != 130) {
+            throw new IllegalArgumentException("Expected canonical type equal to 130, but found " + canonicalType);
+        }
+
+        long timestampAsLong = dataBuffer.asLongBuffer().get();
+        return new BsonTimestamp(timestampAsLong);
+    }
+
+    public static BsonValue getData(BsonDocument resumeToken) {
+        if (!resumeToken.containsKey("_data")) {
+            throw new IllegalArgumentException("Expected _data field in resume token");
+        }
+
+        return resumeToken.get("_data");
+    }
+
+    private static byte[] getDataBytes(BsonValue data) {
+        // From: https://www.mongodb.com/docs/v4.2/changeStreams/#resume-tokens :
+        // > MongoDB Version Feature Compatibility Version Resume Token _data Type
+        // > MongoDB 4.2 and later “4.2” or “4.0” Hex-encoded string (v1)
+        // > MongoDB 4.0.7 and later “4.0” or “3.6” Hex-encoded string (v1)
+        // > MongoDB 4.0.6 and earlier “4.0” Hex-encoded string (v0)
+        // > MongoDB 4.0.6 and earlier “3.6” BinData
+        // > MongoDB 3.6 “3.6” BinData
+        //
+        if (data.isString()) {
+            String hexString = data.asString().getValue();
+            return HexConverter.convertFromHex(hexString);
+        }
+        else if (data.isBinary()) {
+            return data.asBinary().getData();
+        }
+        else {
+            throw new IllegalArgumentException(
+                    "Expected binary or string for _data field in resume token but found " + data.getBsonType());
+        }
+    }
+
+    private ResumeTokens() {
+        throw new AssertionError(getClass().getName() + " should not be instantiated");
+    }
+
+}

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ChangeStreamPipelineFactoryTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ChangeStreamPipelineFactoryTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.io.IOException;
+import java.util.EnumSet;
+
+import org.bson.BsonTimestamp;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.debezium.connector.mongodb.Filters.FilterConfig;
+import io.debezium.data.Envelope;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ChangeStreamPipelineFactoryTest {
+
+    @InjectMocks
+    private ChangeStreamPipelineFactory sut;
+
+    @Mock
+    private ReplicaSetOffsetContext rsOffsetContext;
+    @Mock
+    private MongoDbConnectorConfig connectorConfig;
+    @Mock
+    private FilterConfig filterConfig;
+
+    @Test
+    public void testCreate() {
+        // Given:
+        given(connectorConfig.getSkippedOperations())
+                .willReturn(EnumSet.of(Envelope.Operation.TRUNCATE)); // The default
+        given(filterConfig.getBuiltInDbNames())
+                .willCallRealMethod();
+        given(filterConfig.getCollectionIncludeList())
+                .willReturn("dbit.*");
+        given(rsOffsetContext.lastResumeToken())
+                .willReturn(null);
+        given(rsOffsetContext.lastOffsetTimestamp())
+                .willReturn(new BsonTimestamp(0L));
+
+        // When:
+        var pipeline = sut.create();
+
+        // Then:
+        assertThat(pipeline)
+                .hasSize(3);
+        assertThat(pipeline)
+                .element(0)
+                .satisfies((stage) -> assertJsonEquals(stage.toBsonDocument().toJson(), "" +
+                        "{\n" +
+                        "  \"$addFields\" : {\n" +
+                        "    \"namespace\" : {\n" +
+                        "      \"$concat\" : [ \"$ns.db\", \".\", \"$ns.coll\" ]\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}"));
+        assertThat(pipeline)
+                .element(1)
+                .satisfies((stage) -> assertJsonEquals(stage.toBsonDocument().toJson(), "" +
+                        "{\n" +
+                        "  \"$match\" : {\n" +
+                        "    \"$and\" : [ {\n" +
+                        "      \"$and\" : [ {\n" +
+                        "        \"ns.db\" : {\n" +
+                        "          \"$nin\" : [ \"admin\", \"config\", \"local\" ]\n" +
+                        "        }\n" +
+                        "      }, {\n" +
+                        "        \"namespace\" : {\n" +
+                        "          \"$regularExpression\" : {\n" +
+                        "            \"pattern\" : \"dbit.*\",\n" +
+                        "            \"options\" : \"i\"\n" +
+                        "          }\n" +
+                        "        }\n" +
+                        "      } ]\n" +
+                        "    }, {\n" +
+                        "      \"operationType\" : {\n" +
+                        "        \"$in\" : [ \"insert\", \"update\", \"replace\", \"delete\" ]\n" +
+                        "      }\n" +
+                        "    }, {\n" +
+                        "      \"clusterTime\" : {\n" +
+                        "        \"$ne\" : {\n" +
+                        "          \"$timestamp\" : {\n" +
+                        "            \"t\" : 0,\n" +
+                        "            \"i\" : 0\n" +
+                        "          }\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    } ]\n" +
+                        "  }\n" +
+                        "}"));
+        assertThat(pipeline)
+                .element(2)
+                .satisfies((stage) -> assertJsonEquals(stage.toBsonDocument().toJson(), "" +
+                        "{\n" +
+                        "  \"$addFields\" : {\n" +
+                        "    \"namespace\" : \"$$REMOVE\"\n" +
+                        "  }\n" +
+                        "}"));
+    }
+
+    private static void assertJsonEquals(String actual, String expected) {
+        try {
+            var mapper = new ObjectMapper();
+            actual = mapper.readTree(actual).toPrettyString();
+            expected = mapper.readTree(expected).toPrettyString();
+            assertThat(actual).isEqualTo(expected);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -1549,8 +1549,9 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         final Integer monitoredOrd = (Integer) monitoredOffset.get(SourceInfo.ORDER);
         assertThat(records.recordsForTopic("__debezium-heartbeat.mongo")).hasSize(1);
         final Map<String, ?> hbAfterMonitoredOffset = records.recordsForTopic("__debezium-heartbeat.mongo").get(0).sourceOffset();
-        assertThat(monitoredTs).isEqualTo((Integer) hbAfterMonitoredOffset.get(SourceInfo.TIMESTAMP));
-        assertThat(monitoredOrd).isEqualTo((Integer) hbAfterMonitoredOffset.get(SourceInfo.ORDER));
+
+        // Change events are sent on empty cursor `getMore` batches. The first empty batch happens prior to the first monitored event
+        assertThat(monitoredTs).isGreaterThanOrEqualTo((Integer) hbAfterMonitoredOffset.get(SourceInfo.TIMESTAMP));
 
         try (var client = connect()) {
             MongoDatabase db1 = client.getDatabase("dbit");

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1628,8 +1628,8 @@ Disabled by default.
 |[[mongodb-property-skipped-operations]]<<mongodb-property-skipped-operations, `+skipped.operations+`>>
 |`t`
 |A comma-separated list of operation types that will be skipped during streaming.
-The operations include: `c` for inserts/create, `u` for updates, `d` for deletes, `t` for truncates, and `none` to not skip any operations.
-By default, truncate operations are skipped (not emitted by this connector).
+The operations include: `c` for inserts/create, `u` for updates/replace, `d` for deletes, `t` for truncates, and `none` to not skip any aforementioned operations.
+By default, for consistency with other Debezium connectors, truncate operations are skipped (not emitted by this connector). However, since MongoDB https://www.mongodb.com/docs/manual/reference/change-events/#operation-types[does not support] truncate change events, this is effectively the same as specifying `none`.
 
 |[[mongodb-property-snapshot-collection-filter-overrides]]<<mongodb-property-snapshot-collection-filter-overrides, `+snapshot.collection.filter.overrides+`>>
 |No default


### PR DESCRIPTION
### [DBZ-5201](https://issues.redhat.com/browse/DBZ-5102): Add support for server-side filtering of replica set change streams

This change migrates from doing client-side filtering of streaming change events to performing it server-side via MongoDB's support for aggregation pipelines. This can drastically cut down on the amount of data sent between the client and server. In addition, a new approach to heartbeating has been added which relies on the `postBatchResumeToken` to advance the the cursor even when no changes occur on the pipeline.