### PR TITLE
DBZ-3594 Warn when obtaning table schema which should be alread present

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
@@ -959,6 +959,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
                                                                           EventDispatcher<OraclePartition, TableId> dispatcher)
             throws SQLException, InterruptedException {
 
+        LOGGER.warn("Obtaining schema for table {}, which should be already loaded, this may signal potential bug in fetching table schemas.", tableId);
         final String tableDdl;
         try {
             tableDdl = getTableMetadataDdl(tableId);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -168,6 +168,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
                 return;
             }
 
+            LOGGER.warn("Obtaining schema for table {}, which should be already loaded, this may signal potential bug in fetching table schemas.", tableId);
             final String tableDdl;
             try {
                 tableDdl = getTableMetadataDdl(tableId);

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -871,13 +870,6 @@ public abstract class CommonConnectorConfig {
 
     public EnumSet<Envelope.Operation> getSkippedOperations() {
         return skippedOperations;
-    }
-
-    @Deprecated
-    public Set<String> legacyGetDataCollectionsToBeSnapshotted() {
-        return Optional.ofNullable(config.getString(SNAPSHOT_MODE_TABLES))
-                .map(tables -> Strings.setOf(tables, Function.identity()))
-                .orElseGet(Collections::emptySet);
     }
 
     public Set<Pattern> getDataCollectionsToBeSnapshotted() {


### PR DESCRIPTION
Also remove deprecated unused method for handling `SNAPSHOT_MODE_TABLES` option.

https://issues.redhat.com/browse/DBZ-3594