### PR TITLE
DBZ-6152: Remove hardcoded list of system database exclusions that are not required for change streaming

### DIFF
--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ChangeStreamPipelineFactoryTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ChangeStreamPipelineFactoryTest.java
@@ -41,8 +41,6 @@ public class ChangeStreamPipelineFactoryTest {
         // Given:
         given(connectorConfig.getSkippedOperations())
                 .willReturn(EnumSet.of(Envelope.Operation.TRUNCATE)); // The default
-        given(filterConfig.getBuiltInDbNames())
-                .willCallRealMethod();
         given(filterConfig.getCollectionIncludeList())
                 .willReturn("dbit.*");
         given(rsOffsetContext.lastResumeToken())
@@ -72,18 +70,12 @@ public class ChangeStreamPipelineFactoryTest {
                         "{\n" +
                         "  \"$match\" : {\n" +
                         "    \"$and\" : [ {\n" +
-                        "      \"$and\" : [ {\n" +
-                        "        \"ns.db\" : {\n" +
-                        "          \"$nin\" : [ \"admin\", \"config\", \"local\" ]\n" +
+                        "      \"namespace\" : {\n" +
+                        "        \"$regularExpression\" : {\n" +
+                        "          \"pattern\" : \"dbit.*\",\n" +
+                        "          \"options\" : \"i\"\n" +
                         "        }\n" +
-                        "      }, {\n" +
-                        "        \"namespace\" : {\n" +
-                        "          \"$regularExpression\" : {\n" +
-                        "            \"pattern\" : \"dbit.*\",\n" +
-                        "            \"options\" : \"i\"\n" +
-                        "          }\n" +
-                        "        }\n" +
-                        "      } ]\n" +
+                        "      }\n" +
                         "    }, {\n" +
                         "      \"operationType\" : {\n" +
                         "        \"$in\" : [ \"insert\", \"update\", \"replace\", \"delete\" ]\n" +


### PR DESCRIPTION
### [DBZ-6152](https://issues.redhat.com/browse/DBZ-6152): Removes hardcoded list of system database exclusions that are not required for change streaming

Idea is to remove unnecessary processing in the aggregation pipeline, to generally simplify the code and make it easier to understand when viewing a pipeline. See Jira for additional details.