### PR TITLE
DBZ-6131: Support change stream filtering using MongoDBs aggregation pipeline step.

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ChangeStreamPipeline.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ChangeStreamPipeline.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import com.mongodb.BasicDBObject;
+
+/**
+ * A change stream aggregation pipeline, used to modify the output of a MongoDB change stream.
+ *
+ * @see <a href="https://www.mongodb.com/docs/manual/changeStreams/#modify-change-stream-output.">Modify Change Stream Output</a>
+ */
+public class ChangeStreamPipeline {
+
+    private final List<? extends Bson> stages;
+
+    public ChangeStreamPipeline(String json) {
+        this.stages = parse(json);
+    }
+
+    public ChangeStreamPipeline(List<? extends Bson> stages) {
+        this.stages = stages;
+    }
+
+    public ChangeStreamPipeline(Bson... stages) {
+        this(List.of(stages));
+    }
+
+    public List<? extends Bson> getStages() {
+        return stages;
+    }
+
+    /**
+     * Creates a new pipeline that is a combination of the current and supplied pipeline stages in serial.
+     *
+     * @param pipeline the pipeline to add in serial.
+     * @return the combined pipeline
+     */
+    public ChangeStreamPipeline then(ChangeStreamPipeline pipeline) {
+        var stages = new ArrayList<Bson>();
+        stages.addAll(this.getStages());
+        stages.addAll(pipeline.getStages());
+        return new ChangeStreamPipeline(stages);
+    }
+
+    public String toString() {
+        return format(stages);
+    }
+
+    private static String format(List<? extends Bson> stages) {
+        return new BasicDBObject("stages", stages)
+                .toBsonDocument()
+                .getArray("stages")
+                .getValues()
+                .toString();
+    }
+
+    private static List<? extends Bson> parse(String json) {
+        if (json == null || json.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // Top-level for `parse` must be a document not a list, hence this trick
+        return Document.parse("{stages: " + json + "}")
+                .getList("stages", Document.class);
+    }
+
+}

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Filters.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/Filters.java
@@ -125,15 +125,17 @@ public final class Filters {
         private final String fieldRenames;
         private final String fieldExcludeList;
         private final String signalDataCollection;
+        private final ChangeStreamPipeline userPipeline;
 
         public FilterConfig(Configuration config) {
-            this.dbIncludeList = resolve(config, MongoDbConnectorConfig.DATABASE_INCLUDE_LIST);
-            this.dbExcludeList = resolve(config, MongoDbConnectorConfig.DATABASE_EXCLUDE_LIST);
-            this.collectionIncludeList = resolve(config, MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST);
-            this.collectionExcludeList = resolve(config, MongoDbConnectorConfig.COLLECTION_EXCLUDE_LIST);
-            this.fieldRenames = resolve(config, MongoDbConnectorConfig.FIELD_RENAMES);
-            this.fieldExcludeList = resolve(config, MongoDbConnectorConfig.FIELD_EXCLUDE_LIST);
-            this.signalDataCollection = resolve(config, MongoDbConnectorConfig.SIGNAL_DATA_COLLECTION);
+            this.dbIncludeList = resolveString(config, MongoDbConnectorConfig.DATABASE_INCLUDE_LIST);
+            this.dbExcludeList = resolveString(config, MongoDbConnectorConfig.DATABASE_EXCLUDE_LIST);
+            this.collectionIncludeList = resolveString(config, MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST);
+            this.collectionExcludeList = resolveString(config, MongoDbConnectorConfig.COLLECTION_EXCLUDE_LIST);
+            this.fieldRenames = resolveString(config, MongoDbConnectorConfig.FIELD_RENAMES);
+            this.fieldExcludeList = resolveString(config, MongoDbConnectorConfig.FIELD_EXCLUDE_LIST);
+            this.signalDataCollection = resolveString(config, MongoDbConnectorConfig.SIGNAL_DATA_COLLECTION);
+            this.userPipeline = resolveChangeStreamPipeline(config, MongoDbConnectorConfig.CURSOR_PIPELINE);
         }
 
         public String getDbIncludeList() {
@@ -168,21 +170,30 @@ public final class Filters {
             return BUILT_IN_DB_NAMES;
         }
 
-        private static String resolve(Configuration config, Field key) {
+        public ChangeStreamPipeline getUserPipeline() {
+            return userPipeline;
+        }
+
+        private static String resolveString(Configuration config, Field key) {
             return normalize(config.getString(key));
         }
 
-        private static String normalize(String value) {
-            if (value == null) {
+        private static ChangeStreamPipeline resolveChangeStreamPipeline(Configuration config, Field field) {
+            var text = config.getString(field);
+            return new ChangeStreamPipeline(text);
+        }
+
+        private static String normalize(String text) {
+            if (text == null) {
                 return null;
             }
 
-            value = value.trim();
-            if (value.isEmpty()) {
+            text = text.trim();
+            if (text.isEmpty()) {
                 return null;
             }
 
-            return value;
+            return text;
         }
 
     }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
@@ -18,7 +18,6 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
 import org.bson.BsonTimestamp;
-import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -179,8 +178,9 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
         final ServerAddress nodeAddress = MongoUtil.getPreferredAddress(client, mongo.getPreference());
         LOGGER.info("Reading change stream for '{}'/{} from {} starting at {}", replicaSet, mongo.getPreference().getName(), nodeAddress, oplogStart);
 
-        final List<Bson> pipeline = new ChangeStreamPipelineFactory(rsOffsetContext, taskContext.getConnectorConfig(), taskContext.filters().getConfig()).create();
-        final ChangeStreamIterable<BsonDocument> rsChangeStream = client.watch(pipeline, BsonDocument.class);
+        final ChangeStreamPipeline pipeline = new ChangeStreamPipelineFactory(rsOffsetContext, taskContext.getConnectorConfig(), taskContext.filters().getConfig())
+                .create();
+        final ChangeStreamIterable<BsonDocument> rsChangeStream = client.watch(pipeline.getStages(), BsonDocument.class);
         if (taskContext.getCaptureMode().isFullUpdate()) {
             rsChangeStream.fullDocument(FullDocument.UPDATE_LOOKUP);
         }

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -1669,6 +1669,12 @@ A value of `0` disables this behavior.
 |30000 (30 seconds)
 |The number of milliseconds the driver will wait to select a server before it times out and throws an error.
 
+|[[mongodb-property-cursor-pipeline]]<<mongodb-property-cursor-pipeline, `+cursor.pipeline+`>>
+|No default
+|When streaming changes, this setting applies processing to change stream events as part of the standard MongoDB aggregation stream pipeline. A pipeline is a MongoDB aggregation pipeline composed of instructions to the database to filter or transform data. This can be used customize the data that the connector consumes.
+The value of this property must be an array of permitted https://www.mongodb.com/docs/manual/changeStreams/#modify-change-stream-output[aggregation pipeline stages] in JSON format.
+Note that this is appended after the internal pipeline used to support the connector (e.g. filtering operation types, database names, collection names, etc.).
+
 |[[mongodb-property-cursor-max-await-time-ms]]<<mongodb-property-cursor-max-await-time-ms, `+cursor.max.await.time.ms+`>>
 |`0`
 |Specifies the maximum number of milliseconds the oplog/change stream cursor will wait for the server to produce a result before causing an execution timeout exception.


### PR DESCRIPTION
### [DBZ-6131](https://issues.redhat.com/browse/DBZ-6131): Support change stream filtering using MongoDB's aggregation pipeline step

MongoDB Kafka Source Connector's [pipeline](https://www.mongodb.com/docs/kafka-connector/current/source-connector/configuration-properties/change-stream/#std-label-source-configuration-change-stream) property allows a user to configure:

> An array of aggregation pipelines to run in your change stream.

For example:

```json
[{"$match": { "$and": [{"operationType": "insert"}, {"fullDocument.eventId": 1404 }] } }]
```

This PR adds this capability to the Debezium MongoDB connector for change stream mode. New docs:
<img width="1623" alt="image" src="https://user-images.githubusercontent.com/2717578/221467136-9f6767f1-eea0-4e8b-a28d-adc032d61623.png">

### Resources
Some related resources:

- https://www.mongodb.com/docs/kafka-connector/current/source-connector/configuration-properties/change-stream/#std-label-source-configuration-change-stream
- https://github.com/mongodb/mongo-kafka/blob/41d7f8760d6785c488fba408736c2e480ccddfa5/src/main/java/com/mongodb/kafka/connect/source/MongoCopyDataManager.java#L187
