### PR TITLE
Add stubbed snapshot status notification

### DIFF
--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -38,6 +38,8 @@ import io.debezium.heartbeat.Heartbeat;
 import io.debezium.heartbeat.HeartbeatConnectionProvider;
 import io.debezium.heartbeat.HeartbeatErrorHandler;
 import io.debezium.heartbeat.HeartbeatImpl;
+import io.debezium.pipeline.source.snapshot.SnapshotNotificationImpl;
+import io.debezium.pipeline.source.snapshot.SnapshotStatusNotification;
 import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.schema.SchemaNameAdjuster;
 import io.debezium.schema.SchemaTopicNamingStrategy;
@@ -1043,6 +1045,10 @@ public abstract class CommonConnectorConfig {
             return Heartbeat.DEFAULT_NOOP_HEARTBEAT;
         }
         return new HeartbeatImpl(getHeartbeatInterval(), topicNamingStrategy.heartbeatTopic(), getLogicalName(), schemaNameAdjuster);
+    }
+
+    public SnapshotStatusNotification createSnapshotStatusNotification(TopicNamingStrategy topicNamingStrategy, SchemaNameAdjuster schemaNameAdjuster) {
+        return new SnapshotNotificationImpl();
     }
 
     public static int validateTopicName(Configuration config, Field field, Field.ValidationOutput problems) {

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/SnapshotNotificationImpl.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/SnapshotNotificationImpl.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.snapshot;
+
+import java.util.Map;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.function.BlockingConsumer;
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
+
+public class SnapshotNotificationImpl implements SnapshotStatusNotification {
+    @Override
+    public void updateStatus(Map<String, ?> partition, IncrementalSnapshotContext context, SnapshotStatus status, BlockingConsumer<SourceRecord> consumer)
+            throws InterruptedException {
+
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/SnapshotStatus.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/SnapshotStatus.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.snapshot;
+
+public enum SnapshotStatus {
+    STARTED,
+    ABORTED,
+    PAUSED,
+    RESUMED,
+    COMPLETED
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/SnapshotStatusNotification.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/SnapshotStatusNotification.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.source.snapshot;
+
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.config.Field;
+import io.debezium.function.BlockingConsumer;
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
+
+public interface SnapshotStatusNotification extends AutoCloseable {
+
+    String DEFAULT_SNAPSHOT_NOTIFICATION_TOPIC_PROPERTY_NAME = "snapshot.status.notification.topic";
+
+    Field SNAPSHOT_NOTIFICATION_TOPIC = Field.create(DEFAULT_SNAPSHOT_NOTIFICATION_TOPIC_PROPERTY_NAME)
+            .withDisplayName("Topic name to send the snapshot notifications messages to.")
+            .withType(ConfigDef.Type.STRING)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 0))
+            .withWidth(ConfigDef.Width.MEDIUM)
+            .withImportance(ConfigDef.Importance.LOW)
+            .withDescription("The topic name to send snapshot notification messages to. If not provided, not messages would be sent.");
+
+    void updateStatus(Map<String, ?> partition, IncrementalSnapshotContext context, SnapshotStatus status, BlockingConsumer<SourceRecord> consumer)
+            throws InterruptedException;
+
+    @Override
+    default void close() throws Exception {
+
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
@@ -34,7 +34,7 @@ public interface IncrementalSnapshotChangeEventSource<P extends Partition, T ext
     void addDataCollectionNamesToSnapshot(P partition, List<String> dataCollectionIds, Optional<String> additionalCondition, OffsetContext offsetContext)
             throws InterruptedException;
 
-    void stopSnapshot(P partition, List<String> dataCollectionIds, OffsetContext offsetContext);
+    void stopSnapshot(P partition, List<String> dataCollectionIds, OffsetContext offsetContext) throws InterruptedException;
 
     default void processHeartbeat(P partition, OffsetContext offsetContext) throws InterruptedException {
     }


### PR DESCRIPTION
Inspired by this PR: [DBZ-5632](https://github.com/debezium/debezium/pull/3901)
Related to: https://issues.redhat.com/browse/DBZ-5464

Add a stubbed version of the rough API interface for sending snapshot status update through kafka connect to a metadata topic. This's a bit far from a generic central metadata topic that can receive different types of messages, but I think we can refactor the `SnapshotStatusNotification` easily if the overall mechanism/initial direction seems reasonable. The overall direction that I'm thinking is to:
- have a handler in `EventDispatcher` that dispatch events similar to how it dispatch heartbeat events 
- Then other pieces of the code and use `EventDispatcher` to dispatch different types of events that implement an `Interface`.
  - Question: what information metadata should be provide?
    - I'm thinking it'll be generic information (s.g. `SourceParititon`) and context specific information (e.g. `SnapshotStatus`)

I hope to get some early feedback to make sure I'm on the right track before going deeper.

@jcechace @jpechane 