### PR TITLE
DBZ-6130 Remove references to using properties files to configure SMTs

### DIFF
--- a/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
@@ -137,7 +137,8 @@ Similarly, instead of dropping the tombstone record, you can configure the event
 // Title: Configuration of {prodname} event flattening transformation
 == Configuration
 
-Configure the {prodname} event flattening SMT in a Kafka Connect source or sink connector by adding the SMT configuration details to your connector's configuration. To obtain the default behavior, in a `.properties` file, you would specify something like the following:
+Configure the {prodname} event flattening SMT in a Kafka Connect source or sink connector by adding the SMT configuration details to your connector's configuration.
+For example, to obtain the default behavior of the transformation, add it to the connector configuration without specifying any options, as in the following example:
 
 [source]
 ----

--- a/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-outbox-event-router.adoc
@@ -172,7 +172,8 @@ One example could be a field `eventType` which conveys a user-defined value that
 [[basic-mongodb-outbox-configuration]]
 == Basic configuration
 
-To configure a {prodname} connector to support the outbox pattern, configure the `outbox.EventRouter` SMT. The following example shows the basic configuration for the SMT in a `.properties` file:
+To configure a {prodname} MongoDB connector to support the outbox pattern, configure the `outbox.MongoEventRouter` SMT.
+To obtain the default behavior of the SMT, add it to the connector configuration without specifying any options, as in the following example:
 
 [source]
 ----

--- a/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
@@ -179,7 +179,8 @@ One example could be a column `eventType` which conveys a user-defined value tha
 [[basic-outbox-configuration]]
 == Basic configuration
 
-To configure a {prodname} connector to support the outbox pattern, configure the `outbox.EventRouter` SMT. For example, the basic configuration in a `.properties` file looks like this:
+To configure a {prodname} connector to support the outbox pattern, configure the `outbox.EventRouter` SMT.
+To obtain the default behavior of the SMT, add it to the connector configuration without specifying any options, as in the following example:
 
 [source]
 ----

--- a/documentation/modules/ROOT/pages/transformations/topic-routing.adoc
+++ b/documentation/modules/ROOT/pages/transformations/topic-routing.adoc
@@ -61,7 +61,7 @@ To route change event records for multiple physical tables to the same topic, co
 * The tables for which to route records. These tables must all have the same schema.
 * The destination topic name.
 
-For example, configuration in a `.properties` file looks like this:
+The connector configuration in the following example sets several options for the topic routing SMT:
 
 [source]
 ----


### PR DESCRIPTION
[DBZ-6130](https://issues.redhat.com/browse/DBZ-6130)

Updates SMT docs to refer to adding SMTs settings via the connector configuration rather than via `.properties` files.