### PR TITLE
[docs] Removing redundant TX ids from CloudEvents docs

### DIFF
--- a/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
+++ b/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
@@ -80,7 +80,6 @@ The following example shows what a CloudEvents change event record emitted by a 
   "iodebeziumdb" : "postgres",
   "iodebeziumschema" : "s1",
   "iodebeziumtable" : "a",
-  "iodebeziumtxId" : "565",
   "iodebeziumlsn" : "29274832",
   "iodebeziumxmin" : null,
   "iodebeziumtxid": "565",                           <9>


### PR DESCRIPTION
@jpechane, @Naros, a small fix to the CE docs. The id is there another time on line 86.