### PR TITLE
DBZ-4488: Allow SQL Server connectors to set a maximum number of retriable exception restarts

### DIFF
--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceCoordinator.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceCoordinator.java
@@ -42,7 +42,7 @@ public class SqlServerChangeEventSourceCoordinator extends ChangeEventSourceCoor
     private final Clock clock;
     private final Duration pollInterval;
 
-    private AtomicBoolean firstStreamingIterationCompletedSuccessfully;
+    private final AtomicBoolean firstStreamingIterationCompletedSuccessfully = new AtomicBoolean(false);
 
     public SqlServerChangeEventSourceCoordinator(Offsets<SqlServerPartition, SqlServerOffsetContext> previousOffsets, ErrorHandler errorHandler,
                                                  Class<? extends SourceConnector> connectorType,
@@ -54,7 +54,6 @@ public class SqlServerChangeEventSourceCoordinator extends ChangeEventSourceCoor
                                                  Clock clock) {
         super(previousOffsets, errorHandler, connectorType, connectorConfig, changeEventSourceFactory,
                 changeEventSourceMetricsFactory, eventDispatcher, schema);
-        this.firstStreamingIterationCompletedSuccessfully = new AtomicBoolean(false);
         this.clock = clock;
         this.pollInterval = connectorConfig.getPollInterval();
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorConfig.java
@@ -263,7 +263,7 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.LOW)
             .withDefault(DEFAULT_MAX_RETRIES)
-            .withValidation(Field::isPositiveInteger)
+            .withValidation(Field::isInteger)
             .withDescription(
                     "The maximum number of retries on connection errors before failing (-1 = no limit, 0 = disabled, > 0 = num of retries).");
 
@@ -323,7 +323,8 @@ public class SqlServerConnectorConfig extends HistorizedRelationalDatabaseConnec
                     SCHEMA_NAME_ADJUSTMENT_MODE,
                     INCREMENTAL_SNAPSHOT_OPTION_RECOMPILE,
                     INCREMENTAL_SNAPSHOT_CHUNK_SIZE,
-                    INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES)
+                    INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES,
+                    MAX_RETRIES)
             .excluding(
                     SCHEMA_INCLUDE_LIST,
                     SCHEMA_EXCLUDE_LIST)

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -97,8 +97,12 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
                 .loggingContextSupplier(() -> taskContext.configureLoggingContext(CONTEXT_NAME))
                 .build();
 
-        int retries = (errorHandler == null) ? 0 : errorHandler.getRetries();
-        errorHandler = new SqlServerErrorHandler(connectorConfig, queue, retries, connectorConfig.getMaxRetries());
+        if (errorHandler == null) {
+            errorHandler = new SqlServerErrorHandler(connectorConfig, queue, connectorConfig.getMaxRetries());
+        }
+        else {
+            errorHandler.initialize(connectorConfig, queue, connectorConfig.getMaxRetries());
+        }
 
         final SqlServerEventMetadataProvider metadataProvider = new SqlServerEventMetadataProvider();
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -97,7 +97,8 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
                 .loggingContextSupplier(() -> taskContext.configureLoggingContext(CONTEXT_NAME))
                 .build();
 
-        errorHandler = new SqlServerErrorHandler(connectorConfig, queue);
+        int retries = (errorHandler == null) ? 0 : errorHandler.getRetries();
+        errorHandler = new SqlServerErrorHandler(connectorConfig, queue, retries, connectorConfig.getMaxRetries());
 
         final SqlServerEventMetadataProvider metadataProvider = new SqlServerEventMetadataProvider();
 
@@ -134,6 +135,11 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
         final List<SourceRecord> sourceRecords = records.stream()
                 .map(DataChangeEvent::getRecord)
                 .collect(Collectors.toList());
+
+        // Reset the retries if all partitions have streamed without exceptions at least once after a restart
+        if (coordinator.getErrorHandler().getRetries() > 0 && ((SqlServerChangeEventSourceCoordinator) coordinator).firstStreamingIterationCompletedSuccessfully()) {
+            coordinator.getErrorHandler().resetRetries();
+        }
 
         return sourceRecords;
     }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
@@ -20,8 +20,8 @@ import io.debezium.util.Collect;
  */
 public class SqlServerErrorHandler extends ErrorHandler {
 
-    public SqlServerErrorHandler(SqlServerConnectorConfig connectorConfig, ChangeEventQueue<?> queue) {
-        super(SqlServerConnector.class, connectorConfig, queue);
+    public SqlServerErrorHandler(SqlServerConnectorConfig connectorConfig, ChangeEventQueue<?> queue, int retries, int maxRetries) {
+        super(SqlServerConnector.class, connectorConfig, queue, retries, maxRetries);
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerErrorHandler.java
@@ -20,8 +20,8 @@ import io.debezium.util.Collect;
  */
 public class SqlServerErrorHandler extends ErrorHandler {
 
-    public SqlServerErrorHandler(SqlServerConnectorConfig connectorConfig, ChangeEventQueue<?> queue, int retries, int maxRetries) {
-        super(SqlServerConnector.class, connectorConfig, queue, retries, maxRetries);
+    public SqlServerErrorHandler(SqlServerConnectorConfig connectorConfig, ChangeEventQueue<?> queue, int maxRetries) {
+        super(SqlServerConnector.class, connectorConfig, queue, maxRetries);
     }
 
     @Override

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerConnectorIT.java
@@ -2860,7 +2860,7 @@ public class SqlServerConnectorIT extends AbstractConnectorTest {
             scenario.run();
 
             final String message1 = "1 of 1 retries will be attempted";
-            final String message2 = "The maximum number of retries: 1 has been attempted";
+            final String message2 = "The maximum number of 1 retries has been attempted";
             Awaitility.await()
                     .alias("Checking for maximum restart messages")
                     .pollInterval(100, TimeUnit.MILLISECONDS)

--- a/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
+++ b/debezium-core/src/main/java/io/debezium/connector/common/BaseSourceTask.java
@@ -73,7 +73,7 @@ public abstract class BaseSourceTask<P extends Partition, O extends OffsetContex
      * The change event source coordinator for those connectors adhering to the new
      * framework structure, {@code null} for legacy-style connectors.
      */
-    private ChangeEventSourceCoordinator<P, O> coordinator;
+    protected ChangeEventSourceCoordinator<P, O> coordinator;
 
     /**
      * The latest offsets that have been acknowledged by the Kafka producer. Will be

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -222,6 +222,10 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
         }
     }
 
+    public ErrorHandler getErrorHandler() {
+        return errorHandler;
+    }
+
     public class ChangeEventSourceContextImpl implements ChangeEventSourceContext {
 
         @Override

--- a/debezium-core/src/main/java/io/debezium/pipeline/ErrorHandler.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ErrorHandler.java
@@ -23,27 +23,24 @@ public class ErrorHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ErrorHandler.class);
 
-    private final ChangeEventQueue<?> queue;
-    private final AtomicReference<Throwable> producerThrowable;
-    private final CommonConnectorConfig connectorConfig;
-    private final int maxRetries;
+    private ChangeEventQueue<?> queue;
+    private AtomicReference<Throwable> producerThrowable;
+    private CommonConnectorConfig connectorConfig;
+    private int maxRetries;
     private int retries;
 
     public ErrorHandler(Class<? extends SourceConnector> connectorType, CommonConnectorConfig connectorConfig,
                         ChangeEventQueue<?> queue) {
-        this(connectorType, connectorConfig, queue, 0, -1);
+        this(connectorType, connectorConfig, queue, -1);
     }
 
     /**
      * Allows a connector that supports setting maximum retries to set the current retries attempts and the maximum retries
      */
     public ErrorHandler(Class<? extends SourceConnector> connectorType, CommonConnectorConfig connectorConfig,
-                        ChangeEventQueue<?> queue, int retries, int maxRetries) {
-        this.connectorConfig = connectorConfig;
-        this.queue = queue;
-        this.producerThrowable = new AtomicReference<>();
-        this.retries = retries;
-        this.maxRetries = maxRetries;
+                        ChangeEventQueue<?> queue, int maxRetries) {
+        this.initialize(connectorConfig, queue, maxRetries);
+        this.retries = 0;
     }
 
     public void setProducerThrowable(Throwable producerThrowable) {
@@ -65,6 +62,13 @@ public class ErrorHandler {
                 queue.producerException(new ConnectException("An exception occurred in the change event producer. This connector will be stopped.", producerThrowable));
             }
         }
+    }
+
+    public void initialize(CommonConnectorConfig connectorConfig, ChangeEventQueue<?> queue, int maxRetries) {
+        this.connectorConfig = connectorConfig;
+        this.queue = queue;
+        this.producerThrowable = new AtomicReference<>();
+        this.maxRetries = maxRetries;
     }
 
     public Throwable getProducerThrowable() {


### PR DESCRIPTION
This reuses the `errors.max.retries` configuration parameter name from the `EmbeddedEngine` for SQL Server connectors to configure the maximum number of retries.