### PR TITLE
DBZ-6153 Refactor Streams deployment content to fix errors

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -5,10 +5,12 @@
 
 :context: db2
 :data-collection: table
+:database-port: 50000
 :mbean-name: {context}
 :connector-file: {context}
 :connector-class: Db2Connector
 :connector-name: Db2
+:include-list-example: public.inventory
 ifdef::community[]
 
 :toc:
@@ -1658,7 +1660,7 @@ include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.a
 [id="using-streams-to-deploy-debezium-db2-connectors"]
 === Using {StreamsName} to deploy a {prodname} Db2 connector
 
-include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[leveloffset=+1]
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-db2-ora-pg-connector.adoc[leveloffset=+1]
 
 // Type: procedure
 // ModuleID: deploying-debezium-db2-connectors
@@ -1826,7 +1828,7 @@ apiVersion: {KafkaConnectApiVersion}
       database.password: Password! // <8>
       database.dbname: mydatabase // <9>
       topic.prefix: fullfillment   // <10>
-      database.include.list: public.inventory   // <11>
+      table.include.list: public.inventory   // <11>
 ----
 +
 .Descriptions of connector configuration settings
@@ -1865,7 +1867,7 @@ apiVersion: {KafkaConnectApiVersion}
 |The logical name of the Db2 instance/cluster, which forms a namespace and is used in the names of the Kafka topics to which the connector writes, the names of Kafka Connect schemas, and the namespaces of the corresponding Avro schema when the xref:{link-avro-serialization}#avro-serialization[Avro Connector] is used.
 
 |11
-|A list of all tables whose changes {prodname} should capture.
+|The connector captures changes from the `public.inventory` table only.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -9,6 +9,7 @@
 :connector-file: {context}
 :connector-class: MongoDb
 :connector-name: MongoDB
+:include-list-example: public.inventory
 ifdef::community[]
 
 :toc:
@@ -1060,7 +1061,7 @@ include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.a
 [id="using-streams-to-deploy-debezium-mongodb-connectors"]
 === Using {StreamsName} to deploy a {prodname} MongoDB connector
 
-include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[leveloffset=+1]
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mongodb-connector.adoc[leveloffset=+1]
 
 // Type: procedure
 [id="deploying-debezium-mongodb-connectors"]

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -5,10 +5,12 @@
 
 :context: mysql
 :data-collection: table
+:database-port: 3306
 :mbean-name: {context}
 :connector-file: {context}
 :connector-class: MySql
 :connector-name: MySQL
+:include-list-example: inventory
 ifdef::community[]
 :toc:
 :toc-placement: macro
@@ -2225,7 +2227,7 @@ include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.a
 //Type: procedure
 [id="using-streams-to-deploy-a-debezium-mysql-connector"]
 === Using {StreamsName} to deploy a {prodname} MySQL connector
-include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[leveloffset=+1]
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mysql-sqlserver-connector.adoc[leveloffset=+1]
 
 // Type: procedure
 // ModuleID: deploying-debezium-mysql-connectors
@@ -2389,7 +2391,7 @@ and captures changes to the `inventory` database.
       database.password: dbz
       database.server.id: 184054  // <5>
       topic.prefix: dbserver1 // <6>
-      database.include.list: inventory  // <7>
+      table.include.list: inventory  // <7>
       schema.history.internal.kafka.bootstrap.servers: my-cluster-kafka-bootstrap:9092  // <8>
       schema.history.internal.kafka.topic: schema-changes.inventory  // <9>
 ----
@@ -2425,7 +2427,7 @@ those tasks will be redistributed to running services.
 This name is used as the prefix for all Kafka topics that receive change event records.
 
 |7
-|Changes in only the `inventory` database are captured.
+|The connector captures changes from the `inventory` table only.
 
 |8
 |The list of Kafka brokers that this connector will use to write and recover DDL statements to the database schema history topic.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -5,9 +5,12 @@
 
 :context: oracle
 :data-collection: table
+:database-port: 1521
 :mbean-name: {context}
+:connector-class: Oracle
 :connector-file: {context}
 :connector-name: Oracle
+:include-list-example: PUBLIC.INVENTORY
 ifdef::community[]
 :toc:
 :toc-placement: macro
@@ -2130,7 +2133,7 @@ include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.a
 // Type: procedure
 [id="using-streams-to-deploy-debezium-oracle-connectors"]
 === Using {StreamsName} to deploy a {prodname} Oracle connector
-include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[leveloffset=+1]
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-db2-ora-pg-connector.adoc[leveloffset=+1]
 
 // Type: procedure
 [id="deploying-debezium-oracle-connectors"]

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -5,10 +5,12 @@
 
 :context: postgresql
 :data-collection: table
+:database-port: 5432
 :mbean-name: postgres
 :connector-file: postgres
 :connector-class: Postgres
 :connector-name: PostgreSQL
+:include-list-example: public.inventory
 ifdef::community[]
 
 :toc:
@@ -2300,7 +2302,7 @@ include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.a
 [id="using-streams-to-deploy-debezium-postgresql-connectors"]
 === Using {StreamsName} to deploy a {prodname} PostgreSQL connector
 
-include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[leveloffset=+1]
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-db2-ora-pg-connector.adoc[leveloffset=+1]
 
 // Type: procedure
 [id="deploying-debezium-postgresql-connectors"]

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -6,10 +6,12 @@
 
 :context: sqlserver
 :data-collection: table
+:database-port: 1433
 :mbean-name: sql_server
 :connector-file: {context}
 :connector-class: SqlServer
 :connector-name: SQL Server
+:include-list-example: dbo.customers
 ifdef::community[]
 
 :toc:
@@ -1784,7 +1786,7 @@ include::{partialsdir}/modules/all-connectors/con-connector-streams-deployment.a
 // Type: procedure
 [id="using-streams-to-deploy-debezium-sqlserver-connectors"]
 === Using {StreamsName} to deploy a {prodname} SQL Server connector
-include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-connector.adoc[leveloffset=+1]
+include::{partialsdir}/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mysql-sqlserver-connector.adoc[leveloffset=+1]
 
 // Type: procedure
 // ModuleID: deploying-debezium-sqlserver-connectors
@@ -1949,7 +1951,7 @@ spec:
     database.password: dbz // <6>
     database.names: testDB1,testDB2 // <7>
     topic.prefix: fullfullment // <8>
-    database.include.list: dbo.customers // <9>
+    table.include.list: dbo.customers // <9>
     schema.history.internal.kafka.bootstrap.servers: my-cluster-kafka-bootstrap:9092 // <10>
     schema.history.internal.kafka.topic: schemahistory.fullfillment // <11>
     database.ssl.truststore: path/to/trust-store // <12>
@@ -1986,7 +1988,7 @@ spec:
 |The topic prefix for the SQL Server instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the xref:{link-avro-serialization}#avro-serialization[Avro converter] is used.
 
 |9
-|A list of all tables whose changes {prodname} should capture.
+|The connector captures changes from the `dbo.customers` table only.
 
 |10
 |The list of Kafka brokers that this connector will use to write and recover DDL statements to the database schema history topic.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-db2-ora-pg-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-db2-ora-pg-connector.adoc
@@ -1,0 +1,116 @@
+With earlier versions of {kafka-streams}, to deploy {ProductName} connectors on OpenShift, you were required to first build a Kafka Connect image for the connector.
+The current preferred method for deploying connectors on OpenShift is to use a build configuration in {kafka-streams} to automatically build a Kafka Connect container image that includes the {prodname} connector plug-ins that you want to use.
+
+During the build process, the {kafka-streams} Operator transforms input parameters in a `KafkaConnect` custom resource, including {prodname} connector definitions, into a Kafka Connect container image.
+The build downloads the necessary artifacts from the Red Hat Maven repository or another configured HTTP server.
+
+The newly created container is pushed to the container registry that is specified in `.spec.build.output`, and is used to deploy a Kafka Connect cluster.
+After {StreamsName} builds the Kafka Connect image, you create `KafkaConnector` custom resources to start the connectors that are included in the build.
+
+.Prerequisites
+* You have access to an OpenShift cluster on which the cluster Operator is installed.
+* The {StreamsName} Operator is running.
+* An Apache Kafka cluster is deployed as documented in link:{LinkDeployStreamsOpenShift}#kafka-cluster-str[{NameDeployStreamsOpenShift}].
+* link:{LinkDeployStreamsOpenShift}#kafka-connect-str[Kafka Connect is deployed on {kafka-streams}]
+* You have a {prodnamefull} license.
+* The link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html-single/cli_tools/index#installing-openshift-cli[OpenShift `oc` CLI] client is installed or you have access to the OpenShift Container Platform web console.
+* Depending on how you intend to store the Kafka Connect build image, you need registry permissions or you must create an ImageStream resource:
++
+To store the build image in an image registry, such as Red Hat Quay.io or Docker Hub::
+** An account and permissions to create and manage images in the registry.
+
+To store the build image as a native OpenShift ImageStream::
+** An link:https://docs.openshift.com/container-platform/latest/openshift_images/images-understand.html#images-imagestream-use_images-understand[ImageStream] resource is deployed to the cluster.
+You must explicitly create an ImageStream for the cluster.
+ImageStreams are not available by default.
+
+.Procedure
+
+. Log in to the OpenShift cluster.
+. Create a {prodname} `KafkaConnect` custom resource (CR) for the connector, or modify an existing one.
+For example, create a `KafkaConnect` CR that specifies the `metadata.annotations` and `spec.build` properties, as shown in the following example.
+Save the file with a name such as `dbz-connect.yaml`.
++
+.A `dbz-connect.yaml` file that defines a `KafkaConnect` custom resource that includes a {prodname} connector
+=====================================================================
+include::../{partialsdir}/modules/all-connectors/ref-deploy-{context}-kafka-connect-yaml.adoc[]
+
+. Apply the `KafkaConnect` build specification to the OpenShift cluster by entering the following command:
++
+[source,shell,options="nowrap"]
+----
+oc create -f dbz-connect.yaml
+----
++
+Based on the configuration specified in the custom resource, the Streams Operator prepares a Kafka Connect image to deploy. +
+After the build completes, the Operator pushes the image to the specified registry or ImageStream, and starts the Kafka Connect cluster.
+The connector artifacts that you listed in the configuration are available in the cluster.
+
+. Create a `KafkaConnector` resource to define an instance of each connector that you want to deploy. +
+For example, create the following `KafkaConnector` CR, and save it as `{context}-inventory-connector.yaml`
++
+.`{context}-inventory-connector.yaml` file that defines the `KafkaConnector` custom resource for a {prodname} connector
+=====================================================================
+include::../{partialsdir}/modules/all-connectors/ref-deploy-{context}-connector-yaml.adoc[]
++
+.Descriptions of connector configuration settings
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|The name of the connector to register with the Kafka Connect cluster.
+
+|2
+|The name of the connector class.
+
+|3
+|The number of tasks that can operate concurrently.
+
+|4
+|The connector’s configuration.
+
+|5
+|The address of the host database instance.
+
+|6
+|The port number of the database instance.
+
+|7
+|The name of the account that {prodname} uses to connect to the database.
+
+|8
+|The password that {prodname} uses to connect to the database user account.
+
+|9
+|The name of the database to capture changes from.
+
+|10
+|The topic prefix for the database instance or cluster. +
+The specified name must be formed only from alphanumeric characters or underscores. +
+Because the topic prefix is used as the prefix for any Kafka topics that receive change events from this connector, the name must be unique among the connectors in the cluster. +
+This namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the xref:{link-avro-serialization}#avro-serialization[Avro connector].
+
+|11
+|The list of tables from which the connector captures change events.
+
+|===
+
+. Create the connector resource by running the following command:
++
+[source,shell,options="nowrap", subs="+attributes,+quotes"]
+----
+oc create -n __<namespace>__ -f __<kafkaConnector>__.yaml
+----
++
+For example,
++
+[source,shell,options="nowrap"]
+----
+oc create -n debezium -f {context}-inventory-connector.yaml
+----
++
+The connector is registered to the Kafka Connect cluster and starts to run against the database that is specified by `spec.config.database.dbname` in the `KafkaConnector` CR.
+After the connector pod is ready, {prodname} is running.
+
+You are now ready to xref:verifying-that-the-debezium-{context}-connector-is-running[verify the {prodname} {connector-name} deployment].

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mongodb-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mongodb-connector.adoc
@@ -1,0 +1,127 @@
+With earlier versions of {kafka-streams}, to deploy {ProductName} connectors on OpenShift, you were required to first build a Kafka Connect image for the connector.
+The current preferred method for deploying connectors on OpenShift is to use a build configuration in {kafka-streams} to automatically build a Kafka Connect container image that includes the {prodname} connector plug-ins that you want to use.
+
+During the build process, the {kafka-streams} Operator transforms input parameters in a `KafkaConnect` custom resource, including {prodname} connector definitions, into a Kafka Connect container image.
+The build downloads the necessary artifacts from the Red Hat Maven repository or another configured HTTP server.
+
+The newly created container is pushed to the container registry that is specified in `.spec.build.output`, and is used to deploy a Kafka Connect cluster.
+After {StreamsName} builds the Kafka Connect image, you create `KafkaConnector` custom resources to start the connectors that are included in the build.
+
+.Prerequisites
+* You have access to an OpenShift cluster on which the cluster Operator is installed.
+* The {StreamsName} Operator is running.
+* An Apache Kafka cluster is deployed as documented in link:{LinkDeployStreamsOpenShift}#kafka-cluster-str[{NameDeployStreamsOpenShift}].
+* link:{LinkDeployStreamsOpenShift}#kafka-connect-str[Kafka Connect is deployed on {kafka-streams}]
+* You have a {prodnamefull} license.
+* The link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-latest-version}/html-single/cli_tools/index#installing-openshift-cli[OpenShift `oc` CLI] client is installed or you have access to the OpenShift Container Platform web console.
+* Depending on how you intend to store the Kafka Connect build image, you need registry permissions or you must create an ImageStream resource:
++
+To store the build image in an image registry, such as Red Hat Quay.io or Docker Hub::
+** An account and permissions to create and manage images in the registry.
+
+To store the build image as a native OpenShift ImageStream::
+** An link:https://docs.openshift.com/container-platform/latest/openshift_images/images-understand.html#images-imagestream-use_images-understand[ImageStream] resource is deployed to the cluster.
+You must explicitly create an ImageStream for the cluster.
+ImageStreams are not available by default.
+
+.Procedure
+
+. Log in to the OpenShift cluster.
+. Create a {prodname} `KafkaConnect` custom resource (CR) for the connector, or modify an existing one.
+For example, create a `KafkaConnect` CR that specifies the `metadata.annotations` and `spec.build` properties, as shown in the following example.
+Save the file with a name such as `dbz-connect.yaml`.
++
+.A `dbz-connect.yaml` file that defines a `KafkaConnect` custom resource that includes a {prodname} connector
+=====================================================================
+include::../{partialsdir}/modules/all-connectors/ref-deploy-{context}-kafka-connect-yaml.adoc[]
+
+. Apply the `KafkaConnect` build specification to the OpenShift cluster by entering the following command:
++
+[source,shell,options="nowrap"]
+----
+oc create -f dbz-connect.yaml
+----
++
+Based on the configuration specified in the custom resource, the Streams Operator prepares a Kafka Connect image to deploy. +
+After the build completes, the Operator pushes the image to the specified registry or ImageStream, and starts the Kafka Connect cluster.
+The connector artifacts that you listed in the configuration are available in the cluster.
+
+. Create a `KafkaConnector` resource to define an instance of each connector that you want to deploy. +
+For example, create the following `KafkaConnector` CR, and save it as `{context}-inventory-connector.yaml`
++
+.`{context}-inventory-connector.yaml` file that defines the `KafkaConnector` custom resource for a {prodname} connector
+=====================================================================
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnector
+metadata:
+  labels:
+    strimzi.io/cluster: debezium-kafka-connect-cluster
+  name: inventory-connector-{context} // <1>
+spec:
+  class: io.debezium.connector.{context}.{connector-class}Connector // <2>
+  tasksMax: 1  // <3>
+  config:  // <4>
+    mongodb.hosts: rs0/192.168.99.100:27017 // <5>
+    mongodb.user: debezium  // <6>
+    mongodb.password: dbz  // <7>
+    topic.prefix: inventory-connector-{context} // <8>
+    collection.include.list: inventory[.]*  // <9>
+----
+=====================================================================
++
+.Descriptions of connector configuration settings
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|The name of the connector to register with the Kafka Connect cluster.
+
+|2
+|The name of the connector class.
+
+|3
+|The number of tasks that can operate concurrently.
+
+|4
+|The connector’s configuration.
+
+|5
+|The address and port number of the host database instance.
+
+|7
+|The name of the account that {prodname} uses to connect to the database.
+
+|8
+|The password that {prodname} uses to connect to the database user account.
+
+|8
+|The topic prefix for the database instance or cluster. +
+The specified name must be formed only from alphanumeric characters or underscores. +
+Because the topic prefix is used as the prefix for any Kafka topics that receive change events from this connector, the name must be unique among the connectors in the cluster. +
+This namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro connector].
+
+|9
+|The names of the {data-collection}s that the connector captures changes from.
+|===
+
+. Create the connector resource by running the following command:
++
+[source,shell,options="nowrap", subs="+attributes,+quotes"]
+----
+oc create -n __<namespace>__ -f __<kafkaConnector>__.yaml
+----
++
+For example,
++
+[source,shell,options="nowrap"]
+----
+oc create -n debezium -f {context}-inventory-connector.yaml
+----
++
+The connector is registered to the Kafka Connect cluster and starts to run against the database that is specified by `spec.config.database.dbname` in the `KafkaConnector` CR.
+After the connector pod is ready, {prodname} is running.
+
+You are now ready to xref:verifying-that-the-debezium-{context}-connector-is-running[verify the {prodname} {connector-name} deployment].

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mysql-sqlserver-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mysql-sqlserver-connector.adoc
@@ -51,30 +51,27 @@ For example, create the following `KafkaConnector` CR, and save it as `{context}
 +
 .`{context}-inventory-connector.yaml` file that defines the `KafkaConnector` custom resource for a {prodname} connector
 =====================================================================
-
 [source,yaml,subs="+attributes"]
 ----
-apiVersion: {KafkaConnectApiVersion}
-kind: KafkaConnector
-metadata:
-  labels:
-    strimzi.io/cluster: debezium-kafka-connect-cluster
-  name: inventory-connector-{context} // <1>
-spec:
-  class: io.debezium.connector.{context}.{connector-class}Connector // <2>
-  tasksMax: 1  // <3>
-  config:  // <4>
-    schema.history.internal.kafka.bootstrap.servers: 'debezium-kafka-cluster-kafka-bootstrap.debezium.svc.cluster.local:9092'
-    schema.history.internal.kafka.topic: schema-changes.inventory
-    database.hostname: {context}.debezium-{context}.svc.cluster.local // <5>
-    database.port: 3306   // <6>
-    database.user: debezium  // <7>
-    database.password: dbz  // <8>
-    database.dbname: mydatabase // <9>
-    topic.prefix: inventory_connector_{context} // <10>
-    database.include.list: public.inventory  // <11>
+    apiVersion: {KafkaConnectApiVersion}
+    kind: KafkaConnector
+    metadata:
+      labels:
+        strimzi.io/cluster: debezium-kafka-connect-cluster
+      name: inventory-connector-{context} // <1>
+    spec:
+      class: io.debezium.connector.{context}.{connector-class}Connector // <2>
+      tasksMax: 1  // <3>
+      config:  // <4>
+        schema.history.internal.kafka.bootstrap.servers: debezium-kafka-cluster-kafka-bootstrap.debezium.svc.cluster.local:9092
+        schema.history.internal.kafka.topic: schema-changes.inventory
+        database.hostname: {context}.debezium-{context}.svc.cluster.local // <5>
+        database.port: {database-port}   // <6>
+        database.user: debezium  // <7>
+        database.password: dbz  // <8>
+        topic.prefix: inventory-connector-{context} // <9>
+        table.include.list: {include-list-example}  // <10>
 ----
-
 =====================================================================
 +
 .Descriptions of connector configuration settings
@@ -101,24 +98,22 @@ spec:
 |The port number of the database instance.
 
 |7
-|The name of the user account through which {prodname} connects to the database.
+|The name of the account that {prodname} uses to connect to the database.
 
 |8
-|The password for the database user account.
+|The password that {prodname} uses to connect to the database user account.
 
 |9
-|The name of the database to capture changes from.
-
-|10
 |The topic prefix for the database instance or cluster. +
 The specified name must be formed only from alphanumeric characters or underscores. +
 Because the topic prefix is used as the prefix for any Kafka topics that receive change events from this connector, the name must be unique among the connectors in the cluster. +
 This namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the xref:{link-avro-serialization}#avro-serialization[Avro connector].
 
-|11
+|10
 |The list of tables from which the connector captures change events.
 
 |===
+
 
 . Create the connector resource by running the following command:
 +

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-connector-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-connector-yaml.adoc
@@ -1,0 +1,1 @@
+include::../{partialsdir}/modules/all-connectors/ref-deploy-db2-ora-connector-yaml.adoc[]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-ora-connector-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-ora-connector-yaml.adoc
@@ -1,0 +1,23 @@
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnector
+metadata:
+  labels:
+    strimzi.io/cluster: debezium-kafka-connect-cluster
+  name: inventory-connector-{context} // <1>
+spec:
+  class: io.debezium.connector.{context}.{connector-class}Connector // <2>
+  tasksMax: 1  // <3>
+  config:  // <4>
+    schema.history.internal.kafka.bootstrap.servers: debezium-kafka-cluster-kafka-bootstrap.debezium.svc.cluster.local:9092
+    schema.history.internal.kafka.topic: schema-changes.inventory
+    database.hostname: {context}.debezium-{context}.svc.cluster.local // <5>
+    database.port: {database-port}   // <6>
+    database.user: debezium  // <7>
+    database.password: dbz  // <8>
+    database.dbname: mydatabase // <9>
+    topic.prefix: inventory-connector-{context} // <10>
+    table.include.list: {include-list-example}  // <11>
+----
+=====================================================================

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-oracle-connector-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-oracle-connector-yaml.adoc
@@ -1,0 +1,1 @@
+include::../{partialsdir}/modules/all-connectors/ref-deploy-db2-ora-connector-yaml.adoc[]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-postgresql-connector-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-postgresql-connector-yaml.adoc
@@ -1,0 +1,21 @@
+[source,yaml,subs="+attributes"]
+----
+apiVersion: {KafkaConnectApiVersion}
+kind: KafkaConnector
+metadata:
+  labels:
+    strimzi.io/cluster: debezium-kafka-connect-cluster
+  name: inventory-connector-{context} // <1>
+spec:
+  class: io.debezium.connector.{context}.{connector-class}Connector // <2>
+  tasksMax: 1  // <3>
+  config:  // <4>
+    database.hostname: {context}.debezium-{context}.svc.cluster.local // <5>
+    database.port: {database-port}   // <6>
+    database.user: debezium  // <7>
+    database.password: dbz  // <8>
+    database.dbname: mydatabase // <9>
+    topic.prefix: inventory-connector-{context} // <10>
+    table.include.list: {include-list-example}  // <11>
+----
+=====================================================================


### PR DESCRIPTION
[DBZ-6153](https://issues.redhat.com/browse/DBZ-6153)

This change fixes errors in the connector YAML file that's included in the downstream documentation for using Streams to deploy connectors. Earlier, I did a band-aid fix on the published 2022.Q4/DBZ 1.9.7 version of the  downstream docs, but this change fixes the errors for the 2.x stream.

Due to differences among the connectors, the YAML example requires small tweaks depending on the context. The differences are not complex, but because of a shortcoming in the docs toolchain, when fetching content from upstream, `ifeval` conditionals are not supported. So to get the required results, I had to refactor the docs. It's a bit of a hack, but it mirrors the structure currently in place for creating the YAML to deploy Kafka Connect. 

Tested in a local downstream build. 
The change applies only to the downstream version of the docs. There are no effects on the upstream content.

Please backport to 2.1.