### PR TITLE
Support for multi schema table setups

### DIFF
--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -1164,6 +1164,12 @@ public class JdbcConnection implements AutoCloseable {
                     totalTables++;
                     TableId tableId = new TableId(catalogName, schemaName, tableName);
                     if (tableFilter == null || tableFilter.isIncluded(tableId)) {
+                        if (schemaNamePattern == null) {
+                            tableId = new TableId(
+                                    catalogName,
+                                    null,
+                                    tableName);
+                        }
                         tableIds.add(tableId);
                         attributesByTable.putAll(getAttributeDetails(tableId));
                     }


### PR DESCRIPTION
WHAT : Support for multi schema table setups where schemaNamePattern is null for the table inclusion list defined in the properties to narrow down the column retrieval from so many schemas for the same table to rather fetch the column metadata only once for multi schema databases. 

WHY : Reduce engine startup -> Ready to listen/stream to a greater extent for DBs with multiple schemas setup. Rather than looping over all schemas for the same table, just to fetch table metadata once.