### PR TITLE
DBZ-6023 [doc] Documentation for `surrogate-key` field 

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
@@ -53,7 +53,7 @@ endif::[]
 ifeval::['{context}' != 'mongodb']
 |`surrogate-key`
 |_N/A_
-| An optional string, which represents a column name that will be used during the snapshot process as a primary key of the {data-collection}(s).
+| An optional string that specifies the column name that the connector uses as the primary key of a {data-collection} during the snapshot process.
 endif::[]
 
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
@@ -50,6 +50,12 @@ ifeval::['{context}' != 'mongodb']
 subset of the contents of the {data-collection}(s).
 endif::[]
 
+ifeval::['{context}' != 'mongodb']
+|`surrogate-key`
+|_N/A_
+| An optional string, which represents a column name that will be used during the snapshot process as a primary key of the {data-collection}(s).
+endif::[]
+
 |===
 
 .Triggering an ad hoc snapshot

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot.adoc
@@ -60,7 +60,8 @@ values ('ad-hoc-1',   // <2>
     'execute-snapshot',  // <3>
     '{"data-collections": ["schema1.table1", "schema2.table2"], // <4>
     "type":"incremental"}, // <5>
-    "additional-condition":"color=blue"}'); // <6>
+    "additional-condition":"color=blue"}, // <6>
+    "surrogate-key":"tenant-id"}'); // <7>
 ----
 end::sql-based-snapshot[]
 
@@ -130,7 +131,7 @@ subset of the contents of the {data-collection}s.
 For more information about the `additional-condition` parameter, see xref:{context}-incremental-snapshots-additional-condition[].
 |7
 |`surrogate-key`
-|An optional string, which specifies a column name to use as the primary key for the snapshot. This allows to override the default primary key of the table.
+|An optional string that specifies the column name that the connector uses as the primary key for snapshots.
 |===
 
 [id="{context}-incremental-snapshots-additional-condition"]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot.adoc
@@ -48,7 +48,7 @@ tag::sql-based-snapshot[]
 +
 [source,sql,indent=0,subs="+attributes,+quotes"]
 ----
-INSERT INTO _<signalTable>_ (id, type, data) VALUES (_'<id>'_, _'<snapshotType>'_, '{"data-collections": ["_<tableName>_","_<tableName>_"],"type":"_<snapshotType>_","additional-condition":"_<additional-condition>_"}');
+INSERT INTO _<signalTable>_ (id, type, data) VALUES (_'<id>'_, _'<snapshotType>'_, '{"data-collections": ["_<tableName>_","_<tableName>_"],"type":"_<snapshotType>_","additional-condition":"_<additional-condition>_","surrogate-key":"_<surrogate-key>_"}');
 ----
 +
 For example,
@@ -128,6 +128,9 @@ If you do not specify a value, the connector runs an incremental snapshot.
 | An optional string, which specifies a condition based on the column(s) of the {data-collection}(s), to capture a
 subset of the contents of the {data-collection}s.
 For more information about the `additional-condition` parameter, see xref:{context}-incremental-snapshots-additional-condition[].
+|7
+|`surrogate-key`
+|An optional string, which specifies a column name to use as the primary key for the snapshot. This allows to override the default primary key of the table.
 |===
 
 [id="{context}-incremental-snapshots-additional-condition"]


### PR DESCRIPTION
- Document the new added field inside the `execute-snapshot` signal record in #4207