### PR TITLE
DBZ-5490 Document the case when `message.key.columns` is set and `REPLICA IDENTITY` of the tables is not `FULL`.

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2926,6 +2926,9 @@ For the `purchaseorders` tables in any schema, the columns `pk3` and `pk4` serve
 
 There is no limit to the number of columns that you use to create custom message keys.
 However, it's best to use the minimum number that are required to specify a unique key.
+
+Note that having this property set and `REPLICA IDENTITY` set to `DEFAULT` on the tables, will cause the tombstone events to not be created properly if the key columns are not part of the primary key of the table. +
+Setting `REPLICA IDENTITY` to `FULL` is the only solution.
 |[[postgresql-publication-autocreate-mode]]<<postgresql-publication-autocreate-mode, `+publication.autocreate.mode+`>>
 |_all_tables_
 |Applies only when streaming changes by using link:https://www.postgresql.org/docs/current/sql-createpublication.html[the `pgoutput` plug-in].


### PR DESCRIPTION
It breaks tombstone events to have the proper key created because non-primary key columns will be null, and their values in the key will also be null.