### PR TITLE
DBZ-5987 Refactor snapshotting to use change streams instead of oplog

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ChangeStreamPipelineFactory.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ChangeStreamPipelineFactory.java
@@ -56,8 +56,7 @@ class ChangeStreamPipelineFactory {
         var filters = Stream
                 .of(
                         createCollectionFilter(filterConfig),
-                        createOperationTypeFilter(connectorConfig),
-                        createClusterTimeFilter(rsOffsetContext))
+                        createOperationTypeFilter(connectorConfig))
                 .flatMap(Optional::stream)
                 .collect(toList());
 
@@ -162,16 +161,6 @@ class ChangeStreamPipelineFactory {
         return Optional.of(Filters.in("operationType", includedOperations.stream()
                 .map(OperationType::getValue)
                 .collect(toList())));
-    }
-
-    private static Optional<Bson> createClusterTimeFilter(ReplicaSetOffsetContext rsOffsetContext) {
-        if (rsOffsetContext.lastResumeToken() != null) {
-            return Optional.empty();
-        }
-
-        // After snapshot the oplogStart points to the last change snapshotted, so it must filtered-out to
-        // prevent duplicates
-        return Optional.of(Filters.ne("clusterTime", rsOffsetContext.lastOffsetTimestamp()));
     }
 
     @SafeVarargs

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbOffsetContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbOffsetContext.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.kafka.connect.data.Schema;
-import org.bson.BsonDocument;
 
 import io.debezium.connector.SnapshotRecord;
 import io.debezium.connector.mongodb.connection.ReplicaSet;
@@ -38,12 +37,6 @@ public class MongoDbOffsetContext extends CommonOffsetContext<SourceInfo> {
         super(sourceInfo);
         this.transactionContext = transactionContext;
         this.incrementalSnapshotContext = incrementalSnapshotContext;
-    }
-
-    public MongoDbOffsetContext(SourceInfo sourceInfo, TransactionContext transactionContext,
-                                IncrementalSnapshotContext<CollectionId> incrementalSnapshotContext, Map<ReplicaSet, BsonDocument> offsets) {
-        this(sourceInfo, transactionContext, incrementalSnapshotContext);
-        offsets.forEach((replicaSet, document) -> sourceInfo.initialPosition(replicaSet.replicaSetName(), document));
     }
 
     void startReplicaSetSnapshot(String replicaSetName) {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbStreamingChangeEventSource.java
@@ -168,7 +168,6 @@ public class MongoDbStreamingChangeEventSource implements StreamingChangeEventSo
                     LOGGER.trace("Arrived Change Stream event: {}", event);
 
                     rsOffsetContext.changeStreamEvent(event);
-                    rsOffsetContext.getOffset();
                     CollectionId collectionId = new CollectionId(
                             replicaSet.replicaSetName(),
                             event.getNamespace().getDatabaseName(),

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoUtil.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoUtil.java
@@ -16,9 +16,7 @@ import java.util.regex.Pattern;
 
 import org.bson.BsonDocument;
 import org.bson.Document;
-import org.slf4j.Logger;
 
-import com.mongodb.MongoQueryException;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
@@ -225,22 +223,6 @@ public class MongoUtil {
             }
         }
         return null;
-    }
-
-    public static BsonDocument getOplogEntry(MongoClient client, int sortOrder, Logger logger) throws MongoQueryException {
-        try {
-            MongoCollection<BsonDocument> oplog = client.getDatabase("local").getCollection("oplog.rs", BsonDocument.class);
-            return oplog.find().sort(new Document("$natural", sortOrder)).limit(1).first();
-        }
-        catch (MongoQueryException e) {
-            if (e.getMessage().contains("$natural:") && e.getMessage().contains("is not supported")) {
-                final String sortOrderType = sortOrder == -1 ? "descending" : "ascending";
-                // Amazon DocumentDB does not support $natural, assume no oplog entries when this occurs
-                logger.info("Natural {} sort is not supported on oplog, treating situation as no oplog entry exists.", sortOrderType);
-                return null;
-            }
-            throw e;
-        }
     }
 
     /**

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSetOffsetContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSetOffsetContext.java
@@ -10,7 +10,6 @@ import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
 import org.bson.BsonDocument;
-import org.bson.BsonTimestamp;
 
 import com.mongodb.client.MongoChangeStreamCursor;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
@@ -103,6 +102,10 @@ public class ReplicaSetOffsetContext extends CommonOffsetContext<SourceInfo> {
         sourceInfo.lastOffset(replicaSetName);
     }
 
+    public void initEvent(MongoChangeStreamCursor<ChangeStreamDocument<BsonDocument>> cursor) {
+        sourceInfo.initEvent(replicaSetName, cursor);
+    }
+
     public void noEvent(MongoChangeStreamCursor<?> cursor) {
         sourceInfo.noEvent(replicaSetName, cursor);
     }
@@ -111,12 +114,13 @@ public class ReplicaSetOffsetContext extends CommonOffsetContext<SourceInfo> {
         sourceInfo.changeStreamEvent(replicaSetName, changeStreamEvent);
     }
 
-    public BsonTimestamp lastOffsetTimestamp() {
-        return sourceInfo.lastOffsetTimestamp(replicaSetName);
-    }
-
     public String lastResumeToken() {
         return sourceInfo.lastResumeToken(replicaSetName);
+    }
+
+    public BsonDocument lastResumeTokenDoc() {
+        final String data = sourceInfo.lastResumeToken(replicaSetName);
+        return (data == null) ? null : ResumeTokens.fromData(data);
     }
 
     @Override

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ResumeTokens.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ResumeTokens.java
@@ -9,6 +9,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import org.bson.BsonDocument;
+import org.bson.BsonString;
 import org.bson.BsonTimestamp;
 import org.bson.BsonValue;
 
@@ -42,6 +43,14 @@ public final class ResumeTokens {
         }
 
         return resumeToken.get("_data");
+    }
+
+    public static String getDataString(BsonDocument resumeToken) {
+        return getData(resumeToken).asString().getValue();
+    }
+
+    public static BsonDocument fromData(String data) {
+        return (data == null) ? null : new BsonDocument("_data", new BsonString(data));
     }
 
     private static byte[] getDataBytes(BsonValue data) {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/SourceInfo.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/SourceInfo.java
@@ -294,8 +294,9 @@ public final class SourceInfo extends BaseSourceInfo {
         String namespace = "";
         long wallTime = 0L;
         if (changeStreamEvent != null) {
-            BsonTimestamp ts = changeStreamEvent.getClusterTime();
             String resumeToken = ResumeTokens.getDataString(changeStreamEvent.getResumeToken());
+            // > Decode timestamp from resume token to be consistent with other events
+            BsonTimestamp ts = ResumeTokens.getTimestamp(changeStreamEvent.getResumeToken());
             position = Position.changeStreamPosition(ts, resumeToken, MongoUtil.getChangeStreamSessionTransactionId(changeStreamEvent));
             namespace = changeStreamEvent.getNamespace().getFullName();
             if (changeStreamEvent.getWallTime() != null) {

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/connection/MongoDbConnection.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/connection/MongoDbConnection.java
@@ -20,6 +20,7 @@ import com.mongodb.client.MongoClient;
 import io.debezium.DebeziumException;
 import io.debezium.connector.mongodb.CollectionId;
 import io.debezium.connector.mongodb.Filters;
+import io.debezium.connector.mongodb.MongoDbPartition;
 import io.debezium.connector.mongodb.MongoUtil;
 import io.debezium.function.BlockingConsumer;
 import io.debezium.function.BlockingFunction;
@@ -32,6 +33,8 @@ import io.debezium.util.Metronome;
  */
 public final class MongoDbConnection implements AutoCloseable {
 
+    public static final String AUTHORIZATION_FAILURE_MESSAGE = "Command failed with error 13";
+
     @FunctionalInterface
     public interface ErrorHandler {
         /**
@@ -40,6 +43,18 @@ public final class MongoDbConnection implements AutoCloseable {
          * @param error     the error which triggered this call
          */
         void onError(String desc, Throwable error);
+    }
+
+    @FunctionalInterface
+    public interface ChangeEventSourceConnectionFactory {
+        /**
+         * Create connection for given replica set and partition
+         *
+         * @param replicaSet    the replica set information; may not be null
+         * @param partition      database partition
+         * @return connection based on given parameters
+         */
+        MongoDbConnection get(ReplicaSet replicaSet, MongoDbPartition partition);
     }
 
     /**

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ChangeStreamPipelineFactoryTest.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ChangeStreamPipelineFactoryTest.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
 
-import org.bson.BsonTimestamp;
 import org.bson.conversions.Bson;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,8 +31,6 @@ public class ChangeStreamPipelineFactoryTest {
     private ChangeStreamPipelineFactory sut;
 
     @Mock
-    private ReplicaSetOffsetContext rsOffsetContext;
-    @Mock
     private MongoDbConnectorConfig connectorConfig;
     @Mock
     private FilterConfig filterConfig;
@@ -47,10 +44,6 @@ public class ChangeStreamPipelineFactoryTest {
                 .willReturn("dbit.*");
         given(filterConfig.getUserPipeline())
                 .willReturn(new ChangeStreamPipeline("[{\"$match\": { \"$and\": [{\"operationType\": \"insert\"}, {\"fullDocument.eventId\": 1404 }] } }]"));
-        given(rsOffsetContext.lastResumeToken())
-                .willReturn(null);
-        given(rsOffsetContext.lastOffsetTimestamp())
-                .willReturn(new BsonTimestamp(0L));
 
         // When:
         var pipeline = sut.create();
@@ -78,15 +71,6 @@ public class ChangeStreamPipelineFactoryTest {
                         "    }, {\n" +
                         "      \"operationType\" : {\n" +
                         "        \"$in\" : [ \"insert\", \"update\", \"replace\", \"delete\" ]\n" +
-                        "      }\n" +
-                        "    }, {\n" +
-                        "      \"clusterTime\" : {\n" +
-                        "        \"$ne\" : {\n" +
-                        "          \"$timestamp\" : {\n" +
-                        "            \"t\" : 0,\n" +
-                        "            \"i\" : 0\n" +
-                        "          }\n" +
-                        "        }\n" +
                         "      }\n" +
                         "    } ]\n" +
                         "  }\n" +


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5987


This is just a draft for now -- although tests seem to be passing just fine, I still have some doubts.

Depending on our timeline for 2.2 release I would also like to follow up on this and finished some long overdue clean ups in `ReplicaSetOffsetContext` / `SourceInfo` classes (dates way back when the connector was ported to the common framework).