### PR TITLE
DBZ-6204 Avoid skipping record when determining resume LSN

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
@@ -75,8 +75,9 @@ public class WalPositionLocator {
             // We can resume streaming from it
             if (currentLsn.equals(lastEventStoredLsn)) {
                 // BEGIN and first message after change have the same LSN
-                if (txStartLsn != null && (lastProcessedMessageType == null || lastProcessedMessageType == Operation.BEGIN)) {
-                    // start from the BEGIN tx; prevent skipping of unprocessed event after BEGIN
+                if (txStartLsn != null
+                        && (lastProcessedMessageType == null || lastProcessedMessageType == Operation.BEGIN || lastProcessedMessageType == Operation.COMMIT)) {
+                    // start from the BEGIN tx; prevent skipping of unprocessed event after BEGIN or previsou tx COMMIT
                     LOGGER.info("Will restart from LSN '{}' corresponding to the event following the BEGIN event", txStartLsn);
                     startStreamingLsn = txStartLsn;
                     return Optional.of(startStreamingLsn);

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/WalPositionLocator.java
@@ -77,7 +77,7 @@ public class WalPositionLocator {
                 // BEGIN and first message after change have the same LSN
                 if (txStartLsn != null
                         && (lastProcessedMessageType == null || lastProcessedMessageType == Operation.BEGIN || lastProcessedMessageType == Operation.COMMIT)) {
-                    // start from the BEGIN tx; prevent skipping of unprocessed event after BEGIN or previsou tx COMMIT
+                    // start from the BEGIN tx; prevent skipping of unprocessed event after BEGIN or previous tx COMMIT
                     LOGGER.info("Will restart from LSN '{}' corresponding to the event following the BEGIN event", txStartLsn);
                     startStreamingLsn = txStartLsn;
                     return Optional.of(startStreamingLsn);


### PR DESCRIPTION
When the last operation before connector stop was tx BEGIN, subsequent INSERT done after connector stop can have same LSN as BEGIN and thus it was possible to skip this INSERT when we search for the resume LSN, This issue was described and fixed in DBZ-5915. However, the same LSN can have also previous tx, so the WAL can look like this:

    LSN | operation
    ------------------
    123 | COMMIT
    123 | BEGIN
    123 | INSERT
    124 | COMMIT

When last stored LSN is 123 for COMMIT operation, we skip also BEGIN and INSERT operations with LSN 123 and resume from COMMIT with LSN 124.

Adjust condition introduced in DBZ-5915 to consider also the case when the last processed operation is COMMIT.

https://issues.redhat.com/browse/DBZ-6204