### PR TITLE
Keep timezone information

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
@@ -176,7 +176,8 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter<P
 
             int position = getPosition(columnName, table, values);
             if (position != -1) {
-                Object value = column.getValue(() -> (BaseConnection) connection.connection(), connectorConfig.includeUnknownDatatypes());
+                Object value = column.getValue(() -> (BaseConnection) connection.connection(), connectorConfig.includeUnknownDatatypes(),
+                        connectorConfig.timezoneHandlingMode());
                 if (sourceOfToasted) {
                     cachedOldToastedValues.put(columnName, value);
                 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/UnchangedToastedReplicationMessageColumn.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/UnchangedToastedReplicationMessageColumn.java
@@ -39,7 +39,8 @@ public class UnchangedToastedReplicationMessageColumn extends AbstractReplicatio
     }
 
     @Override
-    public Object getValue(PostgresStreamingChangeEventSource.PgConnectionSupplier connection, boolean includeUnknownDatatypes) {
+    public Object getValue(PostgresStreamingChangeEventSource.PgConnectionSupplier connection, boolean includeUnknownDatatypes,
+                           PostgresConnectorConfig.TimezoneHandlingMode timezoneHandlingMode) {
         return unchangedToastValue;
     }
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractColumnValue.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/AbstractColumnValue.java
@@ -60,14 +60,20 @@ public abstract class AbstractColumnValue<T> implements ReplicationMessage.Colum
     }
 
     @Override
-    public OffsetDateTime asOffsetDateTimeAtUtc() {
+    public OffsetDateTime asOffsetDateTimePreservingTimezone() {
         if ("infinity".equals(asString())) {
             return PostgresValueConverter.POSITIVE_INFINITY_OFFSET_DATE_TIME;
         }
         else if ("-infinity".equals(asString())) {
             return PostgresValueConverter.NEGATIVE_INFINITY_OFFSET_DATE_TIME;
         }
-        return DateTimeFormat.get().timestampWithTimeZoneToOffsetDateTime(asString()).withOffsetSameInstant(ZoneOffset.UTC);
+
+        return DateTimeFormat.get().timestampWithTimeZoneToOffsetDateTime(asString());
+    }
+
+    @Override
+    public OffsetDateTime asOffsetDateTimeAtUtc() {
+        return asOffsetDateTimePreservingTimezone().withOffsetSameInstant(ZoneOffset.UTC);
     }
 
     @Override

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/ReplicationMessage.java
@@ -20,6 +20,7 @@ import org.postgresql.geometric.PGpath;
 import org.postgresql.geometric.PGpoint;
 import org.postgresql.geometric.PGpolygon;
 
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.postgresql.PostgresStreamingChangeEventSource;
 import io.debezium.connector.postgresql.PostgresStreamingChangeEventSource.PgConnectionSupplier;
 import io.debezium.connector.postgresql.PostgresType;
@@ -63,7 +64,7 @@ public interface ReplicationMessage {
          */
         ColumnTypeMetadata getTypeMetadata();
 
-        Object getValue(PgConnectionSupplier connection, boolean includeUnknownDatatypes);
+        Object getValue(PgConnectionSupplier connection, boolean includeUnknownDatatypes, PostgresConnectorConfig.TimezoneHandlingMode timezoneHandlingMode);
 
         boolean isOptional();
 
@@ -98,6 +99,8 @@ public interface ReplicationMessage {
         Object asDecimal();
 
         LocalDate asLocalDate();
+
+        OffsetDateTime asOffsetDateTimePreservingTimezone();
 
         OffsetDateTime asOffsetDateTimeAtUtc();
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgoutput/PgOutputReplicationMessage.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.OptionalLong;
 
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.postgresql.PostgresStreamingChangeEventSource.PgConnectionSupplier;
 import io.debezium.connector.postgresql.PostgresType;
 import io.debezium.connector.postgresql.TypeRegistry;
@@ -87,8 +88,9 @@ public class PgOutputReplicationMessage implements ReplicationMessage {
      * @return the value; may be null
      */
     public static Object getValue(String columnName, PostgresType type, String fullType, String rawValue, final PgConnectionSupplier connection,
-                                  boolean includeUnknownDataTypes, TypeRegistry typeRegistry) {
+                                  boolean includeUnknownDataTypes, TypeRegistry typeRegistry, PostgresConnectorConfig.TimezoneHandlingMode timezoneHandlingMode) {
         final PgOutputColumnValue columnValue = new PgOutputColumnValue(rawValue);
-        return ReplicationMessageColumnValueResolver.resolveValue(columnName, type, fullType, columnValue, connection, includeUnknownDataTypes, typeRegistry);
+        return ReplicationMessageColumnValueResolver.resolveValue(columnName, type, fullType, columnValue, connection, includeUnknownDataTypes, typeRegistry,
+                timezoneHandlingMode);
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/pgproto/PgProtoReplicationMessage.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import io.debezium.DebeziumException;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.postgresql.PostgresStreamingChangeEventSource.PgConnectionSupplier;
 import io.debezium.connector.postgresql.PostgresType;
 import io.debezium.connector.postgresql.TypeRegistry;
@@ -112,8 +113,9 @@ class PgProtoReplicationMessage implements ReplicationMessage {
                             typeInfo.map(PgProto.TypeInfo::getValueOptional).orElse(Boolean.FALSE)) {
 
                         @Override
-                        public Object getValue(PgConnectionSupplier connection, boolean includeUnknownDatatypes) {
-                            return PgProtoReplicationMessage.this.getValue(columnName, type, fullType, datum, connection, includeUnknownDatatypes);
+                        public Object getValue(PgConnectionSupplier connection, boolean includeUnknownDatatypes,
+                                               PostgresConnectorConfig.TimezoneHandlingMode timezoneHandlingMode) {
+                            return PgProtoReplicationMessage.this.getValue(columnName, type, fullType, datum, connection, includeUnknownDatatypes, timezoneHandlingMode);
                         }
 
                         @Override
@@ -131,9 +133,10 @@ class PgProtoReplicationMessage implements ReplicationMessage {
     }
 
     public Object getValue(String columnName, PostgresType type, String fullType, PgProto.DatumMessage datumMessage, final PgConnectionSupplier connection,
-                           boolean includeUnknownDatatypes) {
+                           boolean includeUnknownDatatypes, PostgresConnectorConfig.TimezoneHandlingMode timezoneHandlingMode) {
         final PgProtoColumnValue columnValue = new PgProtoColumnValue(datumMessage);
-        return ReplicationMessageColumnValueResolver.resolveValue(columnName, type, fullType, columnValue, connection, includeUnknownDatatypes, typeRegistry);
+        return ReplicationMessageColumnValueResolver.resolveValue(columnName, type, fullType, columnValue, connection, includeUnknownDatatypes, typeRegistry,
+                timezoneHandlingMode);
     }
 
     @Override


### PR DESCRIPTION
Instead of converting everything to UTC, which effectively drop the timezone information, continue to use the timezone which is read from the socket.

pgjdbc will set the timezone of the connection to the VMs timezone by default, therefore this has the negative side effect that the output result depends on the VMs timezone.