### PR TITLE
DBZ-6215 Adds missing annotation comments for Oracle connector FAQ topic

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -51,7 +51,7 @@ Information and procedures for using a {prodname} Oracle connector are organized
   * xref:deployment-of-debezium-oracle-connectors[]
   * xref:descriptions-of-debezium-oracle-connector-configuration-properties[]
   * xref:monitoring-debezium-oracle-connector-performance[]
-  * xref:oracle-frequently-asked-questions[]
+  * xref:debezium-oracle-connector-frequently-asked-questions[]
 endif::product[]
 
 // Type: assembly
@@ -4059,6 +4059,9 @@ This diverged behavior is captured in https://issues.redhat.com/browse/DBZ-4741[
 
 endif::community[]
 
+// Type: concept
+// ModuleID: debezium-oracle-connector-frequently-asked-questions
+// Title: Oracle connector frequently asked questions
 [[oracle-frequently-asked-questions]]
 == Frequently Asked Questions
 


### PR DESCRIPTION
[DBZ-6215](https://issues.redhat.com/browse/DBZ-6215)

Restores Nebel annotation comments that are used by the script that fetches and splits content for downstream use.

Tested in a local Antora build and local downstream build. This change has no effect on the community version of the documentation.

Please backport this change to 2.1/2.2.