### PR TITLE
DBZ-6170 Connect and stream from sharded clusters through mongos instances

### DIFF
--- a/debezium-connector-mongodb/pom.xml
+++ b/debezium-connector-mongodb/pom.xml
@@ -114,8 +114,12 @@
         <apicurio.port>8080</apicurio.port>
         <apicurio.init.timeout>60000</apicurio.init.timeout> <!-- 60 seconds -->
         <!-- Mongo test containers -->
-        <mongodb.docker.desktop.ports>27017,27018,27019</mongodb.docker.desktop.ports>
+        <!-- port range used to allocate ports -->
+        <mongodb.docker.desktop.ports>27017:27117</mongodb.docker.desktop.ports>
         <mongodb.replica.size>1</mongodb.replica.size>
+        <mongodb.shard.size>2</mongodb.shard.size>
+        <mongodb.shard.replica.size>${mongodb.replica.size}</mongodb.shard.replica.size>
+
     </properties>
     <build>
         <plugins>
@@ -200,6 +204,8 @@
                         <version.mongo.server>${version.mongo.server}</version.mongo.server>
                         <mongodb.docker.desktop.ports>${mongodb.docker.desktop.ports}</mongodb.docker.desktop.ports>
                         <mongodb.replica.size>${mongodb.replica.size}</mongodb.replica.size>
+                        <mongodb.shard.size>${mongodb.shard.size}</mongodb.shard.size>
+                        <mongodb.shard.replica.size>${mongodb.shard.replica.size}</mongodb.shard.replica.size>
                         <skipLongRunningTests>${skipLongRunningTests}</skipLongRunningTests>
                     </systemPropertyVariables>
                     <runOrder>${runOrder}</runOrder>

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
@@ -23,7 +23,6 @@ import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.connector.common.BaseSourceTask;
-import io.debezium.connector.mongodb.connection.ReplicaSet;
 import io.debezium.connector.mongodb.metrics.MongoDbChangeEventSourceMetricsFactory;
 import io.debezium.pipeline.ChangeEventSourceCoordinator;
 import io.debezium.pipeline.DataChangeEvent;
@@ -78,7 +77,7 @@ public final class MongoDbConnectorTask extends BaseSourceTask<MongoDbPartition,
         final Schema structSchema = connectorConfig.getSourceInfoStructMaker().schema();
         this.schema = new MongoDbSchema(taskContext.filters(), taskContext.topicNamingStrategy(), structSchema, schemaNameAdjuster);
 
-        final ReplicaSets replicaSets = getReplicaSets(config);
+        final ReplicaSets replicaSets = getReplicaSets(connectorConfig);
         final MongoDbOffsetContext previousOffset = getPreviousOffset(connectorConfig, replicaSets);
         final Clock clock = Clock.system();
 
@@ -174,10 +173,8 @@ public final class MongoDbConnectorTask extends BaseSourceTask<MongoDbPartition,
         }
     }
 
-    private ReplicaSets getReplicaSets(Configuration config) {
-        var replicas = config.getList(MongoDbConnectorConfig.REPLICA_SETS, ";", ReplicaSet::new);
-
-        final ReplicaSets replicaSets = new ReplicaSets(replicas);
+    private ReplicaSets getReplicaSets(MongoDbConnectorConfig connectorConfig) {
+        final ReplicaSets replicaSets = connectorConfig.getReplicaSets();
         if (replicaSets.size() == 0) {
             throw new DebeziumException("Unable to start MongoDB connector task since no replica sets were found");
         }

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/connection/ReplicaSet.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/connection/ReplicaSet.java
@@ -14,6 +14,8 @@ import io.debezium.annotation.Immutable;
 @Immutable
 public final class ReplicaSet implements Comparable<ReplicaSet> {
 
+    public static final String CLUSTER_RS_NAME = "cluster";
+
     private final String replicaSetName;
     private final ConnectionString connectionString;
     private final int hc;
@@ -30,6 +32,23 @@ public final class ReplicaSet implements Comparable<ReplicaSet> {
         this.connectionString = Objects.requireNonNull(connectionString, "Connection string cannot be null");
         this.replicaSetName = Objects.requireNonNull(replicaSetName, "Replica set name cannot be null");
         this.hc = Objects.hash(connectionString);
+    }
+
+    /**
+     * Creates a fake replica set representing entire sharded cluster
+     *
+     * @param connectionString connection string for sharded cluster
+     * @return sharded cluster as fake replica set
+     */
+    public static ReplicaSet forCluster(ConnectionString connectionString) {
+        return new ReplicaSet(CLUSTER_RS_NAME, connectionString);
+    }
+
+    /**
+     * Same as {@link #forCluster(ConnectionString)}
+     */
+    public static ReplicaSet forCluster(String connectionString) {
+        return new ReplicaSet(CLUSTER_RS_NAME, new ConnectionString(connectionString));
     }
 
     /**

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/MongoDbConnectorIT.java
@@ -229,7 +229,7 @@ public class MongoDbConnectorIT extends AbstractMongoConnectorIT {
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.SSL_ENABLED);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.SSL_ALLOW_INVALID_HOSTNAMES);
         assertNoConfigurationErrors(result, CommonConnectorConfig.TOMBSTONES_ON_DELETE);
-
+        assertNoConfigurationErrors(result, MongoDbConnectorConfig.CONNECTION_MODE);
         assertNoConfigurationErrors(result, MongoDbConnectorConfig.CAPTURE_MODE);
     }
 

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ShardedMongoConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ShardedMongoConnectorIT.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.bson.Document;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.model.Updates;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.connector.mongodb.MongoDbConnectorConfig.ConnectionMode;
+import io.debezium.connector.mongodb.junit.MongoDbDatabaseProvider;
+import io.debezium.data.Envelope;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.testing.testcontainers.MongoDbShardedCluster;
+import io.debezium.testing.testcontainers.util.DockerUtils;
+
+public class ShardedMongoConnectorIT extends AbstractConnectorTest {
+
+    public static final String TOPIC_PREFIX = "mongo";
+    private static final String DATABASE = "dbit";
+    public static final String COLLECTION = "items";
+    private static final int INIT_DOCUMENT_COUNT = 1000;
+    private static final int NEW_DOCUMENT_COUNT = 4;
+    private static final int STOPPED_NEW_DOCUMENT_COUNT = 5;
+
+    protected static MongoDbShardedCluster mongo;
+
+    @BeforeClass
+    public static void beforeAll() {
+        DockerUtils.enableFakeDnsIfRequired();
+        mongo = MongoDbDatabaseProvider.mongoDbShardedCluster();
+        mongo.start();
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        DockerUtils.disableFakeDns();
+        if (mongo != null) {
+            mongo.stop();
+        }
+    }
+
+    @Before
+    public void beforeEach() {
+        stopConnector();
+        initializeConnectorTestFramework();
+
+        TestHelper.cleanDatabase(mongo, DATABASE);
+        mongo.enableSharding(DATABASE);
+        mongo.shardCollection(DATABASE, COLLECTION, "_id");
+    }
+
+    @After
+    public void afterEach() {
+        stopConnector();
+    }
+
+    protected static void populateCollection(String dbName, String colName, int count) {
+        populateCollection(dbName, colName, 0, count);
+    }
+
+    protected static void populateCollection(String dbName, String colName, int startId, int count) {
+        try (var client = connect()) {
+            var db = client.getDatabase(dbName);
+            var collection = db.getCollection(colName);
+
+            var items = IntStream.range(startId, startId + count)
+                    .mapToObj(i -> new Document("_id", i).append("name", "name_" + i))
+                    .collect(Collectors.toList());
+            collection.insertMany(items);
+        }
+    }
+
+    @Test
+    public void shouldConsumeAllEventsFromDatabaseWithShardedConnectionMode() throws InterruptedException {
+        shouldConsumeAllEventsFromDatabase(ConnectionMode.SHARDED);
+    }
+
+    @Test
+    public void shouldConsumeAllEventsFromDatabaseWithReplicaSetConnectionMode() throws InterruptedException {
+        shouldConsumeAllEventsFromDatabase(ConnectionMode.REPLICA_SET);
+    }
+
+    public void shouldConsumeAllEventsFromDatabase(ConnectionMode connectionMode) throws InterruptedException {
+        var documentCount = 0;
+        var topic = String.format("%s.%s.%s", TOPIC_PREFIX, DATABASE, COLLECTION);
+
+        // Populate collection
+        populateCollection(DATABASE, COLLECTION, INIT_DOCUMENT_COUNT);
+        documentCount += INIT_DOCUMENT_COUNT;
+
+        // Use the DB configuration to define the connector's configuration ...
+        Configuration config = TestHelper.getConfiguration(mongo).edit()
+                .with(MongoDbConnectorConfig.POLL_INTERVAL_MS, 10)
+                .with(MongoDbConnectorConfig.CONNECTION_MODE, connectionMode)
+                .with(CommonConnectorConfig.TOPIC_PREFIX, TOPIC_PREFIX)
+                .build();
+
+        // Start the connector ...
+        start(MongoDbConnector.class, config);
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Consume all of the events due to startup and initialization of the database
+        // ---------------------------------------------------------------------------------------------------------------
+        consumeAndVerifyFromInitialSync(connectionMode, topic, INIT_DOCUMENT_COUNT);
+
+        // At this point, the connector has performed the initial sync and awaits changes ...
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Store more documents while the connector is still running
+        // ---------------------------------------------------------------------------------------------------------------
+        populateCollection(DATABASE, COLLECTION, documentCount, NEW_DOCUMENT_COUNT);
+        documentCount += NEW_DOCUMENT_COUNT;
+
+        // Wait until we can consume the documents we just added ...
+        consumeAndVerifyNotFromInitialSync(topic, NEW_DOCUMENT_COUNT);
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Stop the connector
+        // ---------------------------------------------------------------------------------------------------------------
+        stopConnector();
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Store more documents while the connector is NOT running
+        // ---------------------------------------------------------------------------------------------------------------
+        populateCollection(DATABASE, COLLECTION, documentCount, STOPPED_NEW_DOCUMENT_COUNT);
+        documentCount += STOPPED_NEW_DOCUMENT_COUNT;
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Start the connector and we should only see the documents added since it was stopped
+        // ---------------------------------------------------------------------------------------------------------------
+        start(MongoDbConnector.class, config);
+        consumeAndVerifyNotFromInitialSync(topic, STOPPED_NEW_DOCUMENT_COUNT);
+
+        // ---------------------------------------------------------------------------------------------------------------
+        // Update a document
+        // ---------------------------------------------------------------------------------------------------------------
+        try (var client = connect()) {
+            var db = client.getDatabase(DATABASE);
+            var collection = db.getCollection(COLLECTION);
+            collection.updateOne(new Document("_id", 0), Updates.set("name", "Tom"));
+        }
+        consumeAndVerifyNotFromInitialSync(topic, 1, Envelope.Operation.UPDATE);
+    }
+
+    protected static MongoClient connect() {
+        return MongoClients.create(mongo.getConnectionString());
+    }
+
+    protected void consumeAndVerifyFromInitialSync(ConnectionMode connectionMode, String topic, int expectedRecords) throws InterruptedException {
+        var records = consumeRecordsByTopic(expectedRecords);
+        assertThat(records.topics().size()).isEqualTo(1);
+        assertThat(records.recordsForTopic(topic).size()).isEqualTo(expectedRecords);
+
+        AtomicInteger lastCount = new AtomicInteger();
+        var expectedLastCount = connectionMode == ConnectionMode.SHARDED ? 1 : mongo.size();
+        records.forEach(record -> {
+            // Check that all records are valid, and can be serialized and deserialized ...
+            validate(record);
+            verifyFromInitialSync(record, expectedLastCount, lastCount);
+            verifyOperation(record, Envelope.Operation.READ);
+        });
+        assertThat(lastCount.get()).isEqualTo(expectedLastCount);
+    }
+
+    protected void verifyFromInitialSync(SourceRecord record, int numOfShards, AtomicInteger lastCounter) {
+        if (record.sourceOffset().containsKey(SourceInfo.INITIAL_SYNC)) {
+            assertThat(record.sourceOffset().containsKey(SourceInfo.INITIAL_SYNC)).isTrue();
+            Struct value = (Struct) record.value();
+            assertThat(value.getStruct(Envelope.FieldName.SOURCE).getString(SourceInfo.SNAPSHOT_KEY)).isEqualTo("true");
+        }
+        else {
+            // Only the last record in the initial sync should be marked as not being part of the initial sync ...
+            assertThat(lastCounter.getAndIncrement()).isLessThanOrEqualTo(numOfShards);
+            Struct value = (Struct) record.value();
+            assertThat(value.getStruct(Envelope.FieldName.SOURCE).getString(SourceInfo.SNAPSHOT_KEY)).isEqualTo("last");
+        }
+    }
+
+    protected void consumeAndVerifyNotFromInitialSync(String topic, int expectedRecords) throws InterruptedException {
+        consumeAndVerifyNotFromInitialSync(topic, expectedRecords, Envelope.Operation.CREATE);
+    }
+
+    protected void consumeAndVerifyNotFromInitialSync(String topic, int expectedRecords, Envelope.Operation op) throws InterruptedException {
+        var records = consumeRecordsByTopic(expectedRecords);
+        assertThat(records.recordsForTopic(topic).size()).isEqualTo(expectedRecords);
+        assertThat(records.topics().size()).isEqualTo(1);
+        records.forEach(record -> {
+            // Check that all records are valid, and can be serialized and deserialized ...
+            validate(record);
+            verifyNotFromInitialSync(record);
+            verifyOperation(record, op);
+        });
+    }
+
+    protected void verifyNotFromInitialSync(SourceRecord record) {
+        assertThat(record.sourceOffset().containsKey(SourceInfo.INITIAL_SYNC)).isFalse();
+        Struct value = (Struct) record.value();
+        assertThat(value.getStruct(Envelope.FieldName.SOURCE).getString(SourceInfo.SNAPSHOT_KEY)).isNull();
+    }
+
+    protected void verifyOperation(SourceRecord record, Envelope.Operation expected) {
+        Struct value = (Struct) record.value();
+        assertThat(value.getString(Envelope.FieldName.OPERATION)).isEqualTo(expected.code());
+    }
+}

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/TestHelper.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/TestHelper.java
@@ -30,7 +30,7 @@ import io.debezium.config.CommonConnectorConfig;
 import io.debezium.config.Configuration;
 import io.debezium.config.Configuration.Builder;
 import io.debezium.connector.mongodb.connection.MongoDbConnection;
-import io.debezium.testing.testcontainers.MongoDbReplicaSet;
+import io.debezium.testing.testcontainers.MongoDbDeployment;
 
 /**
  * A common test configuration options
@@ -59,7 +59,7 @@ public class TestHelper {
         return getConfiguration("mongodb://dummy:27017");
     }
 
-    public static Configuration getConfiguration(MongoDbReplicaSet mongo) {
+    public static Configuration getConfiguration(MongoDbDeployment mongo) {
         return getConfiguration(mongo.getConnectionString());
     }
 
@@ -80,11 +80,11 @@ public class TestHelper {
         };
     }
 
-    public static MongoClient connect(MongoDbReplicaSet mongo) {
+    public static MongoClient connect(MongoDbDeployment mongo) {
         return MongoClients.create(mongo.getConnectionString());
     }
 
-    public static void cleanDatabase(MongoDbReplicaSet mongo, String dbName) {
+    public static void cleanDatabase(MongoDbDeployment mongo, String dbName) {
         try (var client = connect(mongo)) {
             MongoDatabase db1 = client.getDatabase(dbName);
             db1.listCollectionNames().forEach((String x) -> {

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/junit/MongoDbDatabaseProvider.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/junit/MongoDbDatabaseProvider.java
@@ -6,15 +6,18 @@
 package io.debezium.connector.mongodb.junit;
 
 import io.debezium.testing.testcontainers.MongoDbReplicaSet;
+import io.debezium.testing.testcontainers.MongoDbShardedCluster;
 import io.debezium.testing.testcontainers.util.ParsingPortResolver;
 
 public final class MongoDbDatabaseProvider {
 
     public static final String MONGO_REPLICA_SIZE = "mongodb.replica.size";
+    public static final String MONGO_SHARD_SIZE = "mongodb.shard.size";
+    public static final String MONGO_SHARD_REPLICA_SIZE = "mongodb.shard.replica.size";
     public static final String MONGO_DOCKER_DESKTOP_PORT_PROPERTY = "mongodb.docker.desktop.ports";
 
     // Should be aligned with definition in pom.xm
-    public static final String MONGO_DOCKER_DESKTOP_PORT_DEFAULT = "27017,27018,27019";
+    public static final String MONGO_DOCKER_DESKTOP_PORT_DEFAULT = "27017:27117";
 
     /**
      * Constructs the default testing MongoDB replica set
@@ -28,6 +31,25 @@ public final class MongoDbDatabaseProvider {
 
         return MongoDbReplicaSet.replicaSet()
                 .memberCount(replicaSize)
+                .portResolver(portResolver)
+                .build();
+    }
+
+    /**
+     * Constructs the default testing MongoDB sharded cluster
+     *
+     * @return MongoDb Replica set
+     */
+    public static MongoDbShardedCluster mongoDbShardedCluster() {
+        // will be used only in environment with docker desktop
+        var portResolver = ParsingPortResolver.parseProperty(MONGO_DOCKER_DESKTOP_PORT_PROPERTY, MONGO_DOCKER_DESKTOP_PORT_DEFAULT);
+        var shardSize = Integer.parseInt(System.getProperty(MONGO_SHARD_SIZE, "2"));
+        var replicaSize = Integer.parseInt(System.getProperty(MONGO_SHARD_REPLICA_SIZE, "1"));
+
+        return MongoDbShardedCluster.shardedCluster()
+                .shardCount(shardSize)
+                .replicaCount(replicaSize)
+                .routerCount(1)
                 .portResolver(portResolver)
                 .build();
     }

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbDeployment.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbDeployment.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.testing.testcontainers;
+
+import org.testcontainers.lifecycle.Startable;
+
+/**
+ *  A MongoDB deployment with arbitrary topology
+ */
+public interface MongoDbDeployment extends Startable {
+
+    /**
+     * @return the <a href="https://www.mongodb.com/docs/manual/reference/connection-string/#standard-connection-string-format">standard connection string</a>
+     * for this MongoDB deployment.
+     */
+    String getConnectionString();
+
+}

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbReplicaSet.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbReplicaSet.java
@@ -36,7 +36,7 @@ import io.debezium.testing.testcontainers.util.RandomPortResolver;
 /**
  * A MongoDB replica set.
  */
-public class MongoDbReplicaSet implements Startable {
+public class MongoDbReplicaSet implements MongoDbDeployment {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbReplicaSet.class);
 

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbShardedCluster.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbShardedCluster.java
@@ -33,7 +33,7 @@ import io.debezium.testing.testcontainers.util.RandomPortResolver;
 /**
  * A MongoDB sharded cluster.
  */
-public class MongoDbShardedCluster implements Startable {
+public class MongoDbShardedCluster implements MongoDbDeployment {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoDbShardedCluster.class);
 
@@ -139,6 +139,10 @@ public class MongoDbShardedCluster implements Startable {
         LOGGER.info("Stopping {} shard cluster...", shards.size());
         MoreStartables.deepStopSync(stream());
         network.close();
+    }
+
+    public int size() {
+        return shards.size();
     }
 
     /**


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6170

This PR brings support for connecting to sharded clusters as a single connection via monos instance(s). 

In order to remain backwards compatible a new config property `mongodb.connection.mode` is introduced. This property defaults to `replica_set` which keeps the current behaviour when the connector processes each shard as individual replica set. 

When the value is set to `sharded` then the connector will internally create a single instance of `ReplicaSet` with artificial name `cluster` which results in single connector where all connections are processed via the initially supplied connection string. 

Testing is not done yet -- I will have to introduce the very first tests for sharded cluster which is unlikely to work in GH actions. Additionally when this feature is enabled then incremental snapshotting should work also for sharded clusters and thus the incremental snapshot tests will have to be adapted as well. 