### PR TITLE
Dbz 823 conditionalize incubation note as tp for downstream

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2435,9 +2435,15 @@ For example, if the topic prefix is `fulfillment`, the default topic name is `fu
 
 |[[db2-property-snapshot-max-threads]]<<db2-property-snapshot-max-threads, `snapshot.max.threads`>>
 |`1`
-|Controls the number of threads used for the initial snapshot. A value _greater than 1_ will enable parallel initial snapshot, meaning that the tables will be processed in parallel.
+|Specifies the number of threads that the connector uses when performing an initial snapshot.
+To enable parallel initial snapshots, set the property to a value greater than 1.
+In a parallel initial snapshot, the connector processes multiple tables concurrently.
+ifdef::community[]
 This feature is incubating.
-
+endif::community[]
+ifdef::product[]
+The use of parallel initial snapshots is a Technology Preview feature.
+endif::product[]
 |===
 
 [id="debezium-db2-connector-database-history-configuration-properties"]

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -2442,7 +2442,14 @@ ifdef::community[]
 This feature is incubating.
 endif::community[]
 ifdef::product[]
-The use of parallel initial snapshots is a Technology Preview feature.
+[IMPORTANT]
+====
+Parallel initial snapshots is a Technology Preview feature only.
+Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete.
+Red Hat does not recommend using them in production.
+These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
 endif::product[]
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -3185,8 +3185,22 @@ For example, if the topic prefix is `fulfillment`, the default topic name is `fu
 
 |[[mysql-property-snapshot-max-threads]]<<mysql-property-snapshot-max-threads, `snapshot.max.threads`>>
 |`1`
-|Controls the number of threads used for the initial snapshot. A value _greater than 1_ will enable parallel initial snapshot, meaning that the tables will be processed in parallel.
+|Specifies the number of threads that the connector uses when performing an initial snapshot.
+To enable parallel initial snapshots, set the property to a value greater than 1.
+In a parallel initial snapshot, the connector processes multiple tables concurrently.
+ifdef::community[]
 This feature is incubating.
+endif::community[]
+ifdef::product[]
+[IMPORTANT]
+====
+Parallel initial snapshots is a Technology Preview feature only.
+Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete.
+Red Hat does not recommend using them in production.
+These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::product[]
 
 |[[mysql-property-snapshot-tables-order-by-row-count]]<<mysql-property-snapshot-tables-order-by-row-count, `snapshot.tables.order.by.row.count`>>
 |`disabled`

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -3204,7 +3204,12 @@ endif::product[]
 
 |[[mysql-property-snapshot-tables-order-by-row-count]]<<mysql-property-snapshot-tables-order-by-row-count, `snapshot.tables.order.by.row.count`>>
 |`disabled`
-|Controls the order in which tables are processed in the initial snapshot. The `descending` value will order the tables by row count descending. The `ascending` value will order the tables by row count ascending. The value of `disabled` will disable ordering by row count.
+|Controls the order in which the connector processes tables when it performs an initial snapshot.
+Specify one of the following options:
+
+`descending`:: The connector snapshots tables in order, based on the number of rows from the highest to the lowest.
+`ascending`:: The connector snapshots tables in order, based on the number of rows, from lowest to highest.
+`disabled`:: The connector disregards row count when performing an initial snapshot.
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3335,8 +3335,22 @@ For example, if the topic prefix is `fulfillment`, the default topic name is `fu
 
 |[[oracle-property-snapshot-max-threads]]<<oracle-property-snapshot-max-threads, `snapshot.max.threads`>>
 |`1`
-|Controls the number of threads used for the initial snapshot. A value _greater than 1_ will enable parallel initial snapshot, meaning that the tables will be processed in parallel.
+|Specifies the number of threads that the connector uses when performing an initial snapshot.
+To enable parallel initial snapshots, set the property to a value greater than 1.
+In a parallel initial snapshot, the connector processes multiple tables concurrently.
+ifdef::community[]
 This feature is incubating.
+endif::community[]
+ifdef::product[]
+[IMPORTANT]
+====
+Parallel initial snapshots is a Technology Preview feature only.
+Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete.
+Red Hat does not recommend using them in production.
+These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::product[]
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -3298,8 +3298,22 @@ For example, if the topic prefix is `fulfillment`, the default topic name is `fu
 
 |[[postgresql-property-snapshot-max-threads]]<<postgresql-property-snapshot-max-threads, `snapshot.max.threads`>>
 |`1`
-|Controls the number of threads used for the initial snapshot. A value _greater than 1_ will enable parallel initial snapshot, meaning that the tables will be processed in parallel.
+|Specifies the number of threads that the connector uses when performing an initial snapshot.
+To enable parallel initial snapshots, set the property to a value greater than 1.
+In a parallel initial snapshot, the connector processes multiple tables concurrently.
+ifdef::community[]
 This feature is incubating.
+endif::community[]
+ifdef::product[]
+[IMPORTANT]
+====
+Parallel initial snapshots is a Technology Preview feature only.
+Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete.
+Red Hat does not recommend using them in production.
+These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::product[]
 
 |===
 

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2668,8 +2668,22 @@ For more information, see xref:sqlserver-transaction-metadata[Transaction Metada
 
 |[[sqlserver-property-snapshot-max-threads]]<<sqlserver-property-snapshot-max-threads, `snapshot.max.threads`>>
 |`1`
-|Controls the number of threads used for the initial snapshot. A value _greater than 1_ will enable parallel initial snapshot, meaning that the tables will be processed in parallel.
+|Specifies the number of threads that the connector uses when performing an initial snapshot.
+To enable parallel initial snapshots, set the property to a value greater than 1.
+In a parallel initial snapshot, the connector processes multiple tables concurrently.
+ifdef::community[]
 This feature is incubating.
+endif::community[]
+ifdef::product[]
+[IMPORTANT]
+====
+Parallel initial snapshots is a Technology Preview feature only.
+Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete.
+Red Hat does not recommend using them in production.
+These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+endif::product[]
 
 |===
 


### PR DESCRIPTION
[DBZ-823](https://issues.redhat.com/browse/DBZ-823)

This change updates the description for `snapshot.max.threads` that was modified in DBZ-823, by conditionalizing the existing note about parallel snapshots being in an incubating state so that it renders only in the community version of the docs. 
It also adds an equivalent Tech Preview statement for the product version.

At present, in the MongoDB documentation, the property description does not include any caveats. If that is ok, then this can be merged as-is. Let me know if I need to add a similar note for the MongoDB connector.