### PR TITLE
DBZ-6225 Treat BOOLEAN as TINYINT(1) consistently

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/MySqlAntlrDdlParser.java
@@ -192,8 +192,8 @@ public class MySqlAntlrDdlParser extends AntlrDdlParser<MySqlLexer, MySqlParser>
                 new DataTypeEntry(Types.BLOB, MySqlParser.TINYBLOB),
                 new DataTypeEntry(Types.BLOB, MySqlParser.MEDIUMBLOB),
                 new DataTypeEntry(Types.BLOB, MySqlParser.LONGBLOB),
-                new DataTypeEntry(Types.BOOLEAN, MySqlParser.BOOL),
-                new DataTypeEntry(Types.BOOLEAN, MySqlParser.BOOLEAN),
+                new DataTypeEntry(Types.SMALLINT, MySqlParser.BOOL),
+                new DataTypeEntry(Types.SMALLINT, MySqlParser.BOOLEAN),
                 new DataTypeEntry(Types.BIGINT, MySqlParser.SERIAL)));
         dataTypeResolverBuilder.registerDataTypes(MySqlParser.CollectionDataTypeContext.class.getCanonicalName(), Arrays.asList(
                 new DataTypeEntry(Types.CHAR, MySqlParser.ENUM).setSuffixTokens(MySqlParser.BINARY),

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/ColumnDefinitionParserListener.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/antlr/listener/ColumnDefinitionParserListener.java
@@ -255,6 +255,11 @@ public class ColumnDefinitionParserListener extends MySqlParserBaseListener {
             columnEditor.type("BIGINT UNSIGNED");
             serialColumn();
         }
+        else if (dataTypeName.equalsIgnoreCase("BOOLEAN")) {
+            // BOOLEAN is an alias for TINYINT(1)
+            columnEditor.type("TINYINT");
+            columnEditor.length(1);
+        }
         else {
             columnEditor.type(dataTypeName);
         }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlBooleanIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlBooleanIT.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.util.Testing;
+
+/**
+ * Tests for the MySQL {@code BOOLEAN} data type synonym.
+ *
+ * @author Chris Cranford
+ */
+public class MySqlBooleanIT extends AbstractConnectorTest {
+
+    private static final String TABLE_NAME = "BOOLEAN_TEST";
+    private static final Path SCHEMA_HISTORY_PATH = Testing.Files.createTestingPath("file-schema-history-boolean.text").toAbsolutePath();
+    private final UniqueDatabase DATABASE = new UniqueDatabase("booleanit", "boolean_test").withDbHistoryPath(SCHEMA_HISTORY_PATH);
+
+    private Configuration config;
+
+    @Before
+    public void beforeEach() {
+        stopConnector();
+        DATABASE.createAndInitialize();
+        initializeConnectorTestFramework();
+        Testing.Files.delete(SCHEMA_HISTORY_PATH);
+    }
+
+    @After
+    public void afterEach() {
+        try {
+            stopConnector();
+        }
+        finally {
+            Testing.Files.delete(SCHEMA_HISTORY_PATH);
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-6225")
+    public void testBooleanDataTypeMappedConsistentlyBetweenSnapshotAndStreamingAfterTheFact() throws Exception {
+        config = DATABASE.defaultConfig()
+                .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.INITIAL)
+                .with(MySqlConnectorConfig.TABLE_INCLUDE_LIST, DATABASE.qualifiedTableName(TABLE_NAME) + "," + DATABASE.qualifiedTableName("BOOlEAN_TEST2"))
+                .with(MySqlConnectorConfig.PROPAGATE_COLUMN_SOURCE_TYPE, ".*")
+                .build();
+
+        start(MySqlConnector.class, config);
+
+        SourceRecords records = consumeRecordsByTopic(2 + 4 + 1);
+        assertThat(records).isNotNull();
+
+        List<SourceRecord> tableRecords = records.recordsForTopic(DATABASE.topicForTable(TABLE_NAME));
+        assertThat(tableRecords).hasSize(1);
+
+        SourceRecord record = tableRecords.get(0);
+        System.out.println(record);
+
+        Schema after = record.valueSchema().field("after").schema();
+
+        // Assert how the BOOLEAN data type is mapped during the snapshot phase.
+        assertThat(after.field("b1").schema().type()).isEqualTo(Schema.Type.INT16);
+        assertThat(after.field("b1").schema().parameters().get("__debezium.source.column.type")).isEqualTo("TINYINT");
+        assertThat(after.field("b1").schema().parameters().get("__debezium.source.column.length")).isEqualTo("1");
+        assertThat(after.field("b2").schema().type()).isEqualTo(Schema.Type.INT16);
+        assertThat(after.field("b2").schema().parameters().get("__debezium.source.column.type")).isEqualTo("TINYINT");
+        assertThat(after.field("b2").schema().parameters().get("__debezium.source.column.length")).isEqualTo("1");
+
+        // Create the table after-the-fact
+        try (MySqlTestConnection db = MySqlTestConnection.forTestDatabase(DATABASE.getDatabaseName())) {
+            try (JdbcConnection conn = db.connect()) {
+                conn.execute("CREATE TABLE BOOLEAN_TEST2 (`id` INT NOT NULL AUTO_INCREMENT, " +
+                        "`b1` boolean default true, `b2` boolean default false, " +
+                        "primary key (`ID`)) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;");
+                conn.execute("INSERT INTO BOOLEAN_TEST2 (b1,b2) VALUES (true, false)");
+            }
+        }
+
+        records = consumeRecordsByTopic(2);
+        assertThat(records).isNotNull();
+
+        tableRecords = records.recordsForTopic(DATABASE.topicForTable(TABLE_NAME + "2"));
+        assertThat(tableRecords).hasSize(1);
+
+        record = tableRecords.get(0);
+        System.out.println(record);
+
+        after = record.valueSchema().field("after").schema();
+
+        // Assert the created table after-the-fact record is identical to the snapshot
+        assertThat(after.field("b1").schema().type()).isEqualTo(Schema.Type.INT16);
+        assertThat(after.field("b1").schema().parameters().get("__debezium.source.column.type")).isEqualTo("TINYINT");
+        assertThat(after.field("b1").schema().parameters().get("__debezium.source.column.length")).isEqualTo("1");
+        assertThat(after.field("b2").schema().type()).isEqualTo(Schema.Type.INT16);
+        assertThat(after.field("b2").schema().parameters().get("__debezium.source.column.type")).isEqualTo("TINYINT");
+        assertThat(after.field("b2").schema().parameters().get("__debezium.source.column.length")).isEqualTo("1");
+
+        stopConnector();
+    }
+}

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDefaultValueTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDefaultValueTest.java
@@ -290,10 +290,10 @@ public class MySqlDefaultValueTest {
                 ");";
         parser.parse(sql, tables);
         Table table = tables.forTable(new TableId(null, null, "BOOLEAN_TABLE"));
-        assertThat(getColumnSchema(table, "A").defaultValue()).isEqualTo(false);
-        assertThat(getColumnSchema(table, "B").defaultValue()).isEqualTo(true);
-        assertThat(getColumnSchema(table, "C").defaultValue()).isEqualTo(true);
-        assertThat(getColumnSchema(table, "D").defaultValue()).isEqualTo(true);
+        assertThat(getColumnSchema(table, "A").defaultValue()).isEqualTo((short) 0);
+        assertThat(getColumnSchema(table, "B").defaultValue()).isEqualTo((short) 1);
+        assertThat(getColumnSchema(table, "C").defaultValue()).isEqualTo((short) 9);
+        assertThat(getColumnSchema(table, "D").defaultValue()).isEqualTo((short) 1);
         assertThat(getColumnSchema(table, "E").defaultValue()).isEqualTo(null);
     }
 
@@ -491,7 +491,7 @@ public class MySqlDefaultValueTest {
 
         Table table = tables.forTable(new TableId(null, null, "data"));
 
-        assertThat((Boolean) getColumnSchema(table, "bval").defaultValue()).isTrue();
+        assertThat((Short) getColumnSchema(table, "bval").defaultValue()).isEqualTo((short) 1);
         assertThat((Short) getColumnSchema(table, "tival1").defaultValue()).isZero();
         assertThat((Short) getColumnSchema(table, "tival2").defaultValue()).isEqualTo((short) 3);
         assertThat((Short) getColumnSchema(table, "tival3").defaultValue()).isEqualTo((short) 1);
@@ -513,7 +513,7 @@ public class MySqlDefaultValueTest {
 
         Table table = tables.forTable(new TableId(null, null, "data"));
 
-        assertThat((Boolean) getColumnSchema(table, "bval").defaultValue()).isTrue();
+        assertThat((Short) getColumnSchema(table, "bval").defaultValue()).isEqualTo((short) 1);
         assertThat((Integer) getColumnSchema(table, "ival1").defaultValue()).isZero();
         assertThat((Integer) getColumnSchema(table, "ival2").defaultValue()).isEqualTo(3);
         assertThat((Integer) getColumnSchema(table, "ival3").defaultValue()).isEqualTo(1);

--- a/debezium-connector-mysql/src/test/resources/ddl/boolean_test.sql
+++ b/debezium-connector-mysql/src/test/resources/ddl/boolean_test.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `BOOLEAN_TEST` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `b1` boolean default true,
+  `b2` boolean default false,
+  PRIMARY KEY (`ID`)
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
+INSERT INTO BOOLEAN_TEST(b1, b2) VALUE (false, true);


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6225

The snapshot phase uses the JDBC driver metadata to resolve the column mappings; however, during streaming, if a CREATE TABLE ddl statement is used, the column mapping is based on that of the DDL, which was not treating a BOOLEAN column as TINYINT(1); instead, it treated the column as BOOLEAN, which is incorrect for MySQL.