### PR TITLE
DBZ-2979 -  Feat: Add Config skip.messages.without.change to skip updates where there is no change in whitelisted columns

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeRecordEmitter.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeRecordEmitter.java
@@ -27,14 +27,16 @@ public class MySqlChangeRecordEmitter extends RelationalChangeRecordEmitter<MySq
     private final OffsetContext offset;
     private final Object[] before;
     private final Object[] after;
+    private final boolean skipMessagesWithoutChange;
 
-    public MySqlChangeRecordEmitter(MySqlPartition partition, OffsetContext offset, Clock clock, Envelope.Operation operation, Serializable[] before,
-                                    Serializable[] after) {
+    public MySqlChangeRecordEmitter(MySqlPartition partition, OffsetContext offset, Clock clock, Operation operation, Serializable[] before,
+                                    Serializable[] after, boolean skipMessagesWithoutChange) {
         super(partition, offset, clock);
         this.offset = offset;
         this.operation = operation;
         this.before = before;
         this.after = after;
+        this.skipMessagesWithoutChange = skipMessagesWithoutChange;
     }
 
     @Override
@@ -61,5 +63,10 @@ public class MySqlChangeRecordEmitter extends RelationalChangeRecordEmitter<MySq
     protected void emitTruncateRecord(Receiver receiver, TableSchema tableSchema) throws InterruptedException {
         Struct envelope = tableSchema.getEnvelopeSchema().truncate(getOffset().getSourceInfo(), getClock().currentTimeAsInstant());
         receiver.changeRecord(getPartition(), tableSchema, Operation.TRUNCATE, null, envelope, getOffset(), null);
+    }
+
+    @Override
+    public boolean skipMessagesWithoutChange() {
+        return skipMessagesWithoutChange;
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -599,7 +599,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
                 if (tableId != null && !connectorConfig.getSkippedOperations().contains(Operation.TRUNCATE)
                         && schemaChangeEvent.getType().equals(SchemaChangeEventType.TRUNCATE)) {
                     eventDispatcher.dispatchDataChangeEvent(partition, tableId,
-                            new MySqlChangeRecordEmitter(partition, offsetContext, clock, Operation.TRUNCATE, null, null));
+                            new MySqlChangeRecordEmitter(partition, offsetContext, clock, Operation.TRUNCATE, null, null, connectorConfig.skipMessagesWithoutChange()));
                 }
                 eventDispatcher.dispatchSchemaChangeEvent(partition, tableId, (receiver) -> {
                     try {
@@ -749,7 +749,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
         handleChange(partition, offsetContext, event, Operation.CREATE, WriteRowsEventData.class, x -> taskContext.getSchema().getTableId(x.getTableId()),
                 WriteRowsEventData::getRows,
                 (tableId, row) -> eventDispatcher.dispatchDataChangeEvent(partition, tableId,
-                        new MySqlChangeRecordEmitter(partition, offsetContext, clock, Operation.CREATE, null, row)));
+                        new MySqlChangeRecordEmitter(partition, offsetContext, clock, Operation.CREATE, null, row, connectorConfig.skipMessagesWithoutChange())));
     }
 
     /**
@@ -763,7 +763,8 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
         handleChange(partition, offsetContext, event, Operation.UPDATE, UpdateRowsEventData.class, x -> taskContext.getSchema().getTableId(x.getTableId()),
                 UpdateRowsEventData::getRows,
                 (tableId, row) -> eventDispatcher.dispatchDataChangeEvent(partition, tableId,
-                        new MySqlChangeRecordEmitter(partition, offsetContext, clock, Operation.UPDATE, row.getKey(), row.getValue())));
+                        new MySqlChangeRecordEmitter(partition, offsetContext, clock, Operation.UPDATE, row.getKey(), row.getValue(),
+                                connectorConfig.skipMessagesWithoutChange())));
     }
 
     /**
@@ -777,7 +778,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
         handleChange(partition, offsetContext, event, Operation.DELETE, DeleteRowsEventData.class, x -> taskContext.getSchema().getTableId(x.getTableId()),
                 DeleteRowsEventData::getRows,
                 (tableId, row) -> eventDispatcher.dispatchDataChangeEvent(partition, tableId,
-                        new MySqlChangeRecordEmitter(partition, offsetContext, clock, Operation.DELETE, row, null)));
+                        new MySqlChangeRecordEmitter(partition, offsetContext, clock, Operation.DELETE, row, null, connectorConfig.skipMessagesWithoutChange())));
     }
 
     private <T extends EventData, U> void handleChange(MySqlPartition partition, MySqlOffsetContext offsetContext, Event event, Operation operation,

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSkipMessagesWithoutChangeConfigIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSkipMessagesWithoutChangeConfigIT.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.data.Envelope;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.jdbc.JdbcConnection;
+
+/**
+ * Integration Tests for config skip.messages.without.change
+ *
+ * @author Ronak Jain
+ */
+public class MySqlSkipMessagesWithoutChangeConfigIT extends AbstractConnectorTest {
+
+    private static final Path SCHEMA_HISTORY_PATH = Files.createTestingPath("file-schema-history-decimal.txt")
+            .toAbsolutePath();
+    private final UniqueDatabase DATABASE = new UniqueDatabase("skip_messages_db", "skip_messages_test")
+            .withDbHistoryPath(SCHEMA_HISTORY_PATH);
+
+    private Configuration config;
+
+    @Before
+    public void beforeEach() {
+        stopConnector();
+        DATABASE.createAndInitialize();
+        initializeConnectorTestFramework();
+        Files.delete(SCHEMA_HISTORY_PATH);
+    }
+
+    @After
+    public void afterEach() {
+        try {
+            stopConnector();
+        }
+        finally {
+            Files.delete(SCHEMA_HISTORY_PATH);
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-2979")
+    public void shouldSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipEnabled() throws SQLException, InterruptedException {
+        config = DATABASE.defaultConfig()
+                .with(MySqlConnectorConfig.COLUMN_INCLUDE_LIST, getQualifiedColumnName("id") + "," + getQualifiedColumnName("white"))
+                .with(MySqlConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, true)
+                .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.NEVER)
+                .build();
+
+        start(MySqlConnector.class, config);
+        waitForStreamingRunning("mysql", DATABASE.getServerName());
+
+        try (MySqlTestConnection db = MySqlTestConnection.forTestDatabase(DATABASE.getDatabaseName())) {
+            try (JdbcConnection connection = db.connect()) {
+                connection.execute("insert into debezium_test(id, black, white) values(1, 1, 1)");
+                connection.execute("UPDATE debezium_test SET black=2 where id = 1");
+                connection.execute("UPDATE debezium_test SET white=2 where id = 1");
+            }
+        }
+
+        SourceRecords records = consumeRecordsByTopic(6);
+
+        List<SourceRecord> recordsForTopic = records.recordsForTopic(DATABASE.topicForTable("debezium_test"));
+        /*
+         * Total Events:
+         * Create Database
+         * Create Table
+         * 0,0,0 (I)
+         * 1,1,1 (I)
+         * 1,1,2 (U) (Skipped)
+         * 1,2,2 (U)
+         */
+        assertThat(recordsForTopic).hasSize(3);
+        Struct thirdMessage = ((Struct) recordsForTopic.get(2).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(thirdMessage.get("white")).isEqualTo(2);
+    }
+
+    @Test
+    @FixFor("DBZ-2979")
+    public void shouldSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipEnabledWithExcludeConfig() throws Exception {
+        config = DATABASE.defaultConfig()
+                .with(MySqlConnectorConfig.COLUMN_EXCLUDE_LIST, getQualifiedColumnName("black"))
+                .with(MySqlConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, true)
+                .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.NEVER)
+                .build();
+
+        start(MySqlConnector.class, config);
+        waitForStreamingRunning("mysql", DATABASE.getServerName());
+
+        try (MySqlTestConnection db = MySqlTestConnection.forTestDatabase(DATABASE.getDatabaseName())) {
+            try (JdbcConnection connection = db.connect()) {
+                connection.execute("insert into debezium_test(id, black, white) values(1, 1, 1)");
+                connection.execute("UPDATE debezium_test SET black=2 where id = 1");
+                connection.execute("UPDATE debezium_test SET white=2 where id = 1");
+            }
+        }
+
+        SourceRecords records = consumeRecordsByTopic(6);
+        List<SourceRecord> recordsForTopic = records.recordsForTopic(DATABASE.topicForTable("debezium_test"));
+        /*
+         * Total Events:
+         * Create Database
+         * Create Table
+         * 0,0,0 (I)
+         * 1,1,1 (I)
+         * 1,1,2 (U) (Skipped)
+         * 1,2,2 (U)
+         */
+        assertThat(recordsForTopic).hasSize(3);
+        Struct thirdMessage = ((Struct) recordsForTopic.get(2).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(thirdMessage.get("white")).isEqualTo(2);
+    }
+
+    @Test
+    @FixFor("DBZ-2979")
+    public void shouldNotSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipDisabled() throws Exception {
+        config = DATABASE.defaultConfig()
+                .with(MySqlConnectorConfig.COLUMN_INCLUDE_LIST, getQualifiedColumnName("id") + "," + getQualifiedColumnName("white"))
+                .with(MySqlConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, false)
+                .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.NEVER)
+                .build();
+
+        start(MySqlConnector.class, config);
+        waitForStreamingRunning("mysql", DATABASE.getServerName());
+
+        try (MySqlTestConnection db = MySqlTestConnection.forTestDatabase(DATABASE.getDatabaseName())) {
+            try (JdbcConnection connection = db.connect()) {
+                connection.execute("insert into debezium_test(id, black, white) values(1, 1, 1)");
+                connection.execute("UPDATE debezium_test SET black=2 where id = 1");
+                connection.execute("UPDATE debezium_test SET white=2 where id = 1");
+            }
+        }
+
+        SourceRecords records = consumeRecordsByTopic(6);
+        /*
+         * Total Events:
+         * Create Database
+         * Create Table
+         * 0,0,0 (I)
+         * 1,1,1 (I)
+         * 1,1,2 (U)
+         * 1,2,2 (U)
+         */
+        List<SourceRecord> recordsForTopic = records.recordsForTopic(DATABASE.topicForTable("debezium_test"));
+        assertThat(recordsForTopic).hasSize(4);
+        Struct thirdMessage = ((Struct) recordsForTopic.get(2).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(thirdMessage.get("white")).isEqualTo(1);
+    }
+
+    String getQualifiedColumnName(String column) {
+        return String.format("%s.%s", DATABASE.qualifiedTableName("debezium_test"), column);
+    }
+
+}

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSkipMessagesWithoutChangeConfigIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSkipMessagesWithoutChangeConfigIT.java
@@ -72,10 +72,11 @@ public class MySqlSkipMessagesWithoutChangeConfigIT extends AbstractConnectorTes
                 connection.execute("insert into debezium_test(id, black, white) values(1, 1, 1)");
                 connection.execute("UPDATE debezium_test SET black=2 where id = 1");
                 connection.execute("UPDATE debezium_test SET white=2 where id = 1");
+                connection.execute("UPDATE debezium_test SET white=3, black=3 where id = 1");
             }
         }
 
-        SourceRecords records = consumeRecordsByTopic(6);
+        SourceRecords records = consumeRecordsByTopic(7);
 
         List<SourceRecord> recordsForTopic = records.recordsForTopic(DATABASE.topicForTable("debezium_test"));
         /*
@@ -86,10 +87,13 @@ public class MySqlSkipMessagesWithoutChangeConfigIT extends AbstractConnectorTes
          * 1,1,1 (I)
          * 1,1,2 (U) (Skipped)
          * 1,2,2 (U)
+         * 1,3,3 (U)
          */
-        assertThat(recordsForTopic).hasSize(3);
+        assertThat(recordsForTopic).hasSize(4);
         Struct thirdMessage = ((Struct) recordsForTopic.get(2).value()).getStruct(Envelope.FieldName.AFTER);
         assertThat(thirdMessage.get("white")).isEqualTo(2);
+        Struct forthMessage = ((Struct) recordsForTopic.get(3).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(forthMessage.get("white")).isEqualTo(3);
     }
 
     @Test
@@ -109,10 +113,11 @@ public class MySqlSkipMessagesWithoutChangeConfigIT extends AbstractConnectorTes
                 connection.execute("insert into debezium_test(id, black, white) values(1, 1, 1)");
                 connection.execute("UPDATE debezium_test SET black=2 where id = 1");
                 connection.execute("UPDATE debezium_test SET white=2 where id = 1");
+                connection.execute("UPDATE debezium_test SET white=3, black=3 where id = 1");
             }
         }
 
-        SourceRecords records = consumeRecordsByTopic(6);
+        SourceRecords records = consumeRecordsByTopic(7);
         List<SourceRecord> recordsForTopic = records.recordsForTopic(DATABASE.topicForTable("debezium_test"));
         /*
          * Total Events:
@@ -122,10 +127,13 @@ public class MySqlSkipMessagesWithoutChangeConfigIT extends AbstractConnectorTes
          * 1,1,1 (I)
          * 1,1,2 (U) (Skipped)
          * 1,2,2 (U)
+         * 1,3,3 (U)
          */
-        assertThat(recordsForTopic).hasSize(3);
+        assertThat(recordsForTopic).hasSize(4);
         Struct thirdMessage = ((Struct) recordsForTopic.get(2).value()).getStruct(Envelope.FieldName.AFTER);
         assertThat(thirdMessage.get("white")).isEqualTo(2);
+        Struct forthMessage = ((Struct) recordsForTopic.get(3).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(forthMessage.get("white")).isEqualTo(3);
     }
 
     @Test
@@ -145,10 +153,11 @@ public class MySqlSkipMessagesWithoutChangeConfigIT extends AbstractConnectorTes
                 connection.execute("insert into debezium_test(id, black, white) values(1, 1, 1)");
                 connection.execute("UPDATE debezium_test SET black=2 where id = 1");
                 connection.execute("UPDATE debezium_test SET white=2 where id = 1");
+                connection.execute("UPDATE debezium_test SET white=3, black=3 where id = 1");
             }
         }
 
-        SourceRecords records = consumeRecordsByTopic(6);
+        SourceRecords records = consumeRecordsByTopic(7);
         /*
          * Total Events:
          * Create Database
@@ -157,11 +166,16 @@ public class MySqlSkipMessagesWithoutChangeConfigIT extends AbstractConnectorTes
          * 1,1,1 (I)
          * 1,1,2 (U)
          * 1,2,2 (U)
+         * 1,3,3 (U)
          */
         List<SourceRecord> recordsForTopic = records.recordsForTopic(DATABASE.topicForTable("debezium_test"));
-        assertThat(recordsForTopic).hasSize(4);
+        assertThat(recordsForTopic).hasSize(5);
         Struct thirdMessage = ((Struct) recordsForTopic.get(2).value()).getStruct(Envelope.FieldName.AFTER);
         assertThat(thirdMessage.get("white")).isEqualTo(1);
+        Struct forthMessage = ((Struct) recordsForTopic.get(3).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(forthMessage.get("white")).isEqualTo(2);
+        Struct fifthMessage = ((Struct) recordsForTopic.get(4).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(fifthMessage.get("white")).isEqualTo(3);
     }
 
     String getQualifiedColumnName(String column) {

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSkipMessagesWithoutChangeConfigIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlSkipMessagesWithoutChangeConfigIT.java
@@ -57,7 +57,7 @@ public class MySqlSkipMessagesWithoutChangeConfigIT extends AbstractConnectorTes
 
     @Test
     @FixFor("DBZ-2979")
-    public void shouldSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipEnabled() throws SQLException, InterruptedException {
+    public void shouldSkipEventsWithNoChangeInIncludedColumnsWhenSkipEnabled() throws SQLException, InterruptedException {
         config = DATABASE.defaultConfig()
                 .with(MySqlConnectorConfig.COLUMN_INCLUDE_LIST, getQualifiedColumnName("id") + "," + getQualifiedColumnName("white"))
                 .with(MySqlConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, true)
@@ -76,7 +76,7 @@ public class MySqlSkipMessagesWithoutChangeConfigIT extends AbstractConnectorTes
             }
         }
 
-        SourceRecords records = consumeRecordsByTopic(7);
+        SourceRecords records = consumeRecordsByTopic(6);
 
         List<SourceRecord> recordsForTopic = records.recordsForTopic(DATABASE.topicForTable("debezium_test"));
         /*
@@ -98,7 +98,7 @@ public class MySqlSkipMessagesWithoutChangeConfigIT extends AbstractConnectorTes
 
     @Test
     @FixFor("DBZ-2979")
-    public void shouldSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipEnabledWithExcludeConfig() throws Exception {
+    public void shouldSkipEventsWithNoChangeInIncludedColumnsWhenSkipEnabledWithExcludeConfig() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(MySqlConnectorConfig.COLUMN_EXCLUDE_LIST, getQualifiedColumnName("black"))
                 .with(MySqlConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, true)
@@ -117,7 +117,7 @@ public class MySqlSkipMessagesWithoutChangeConfigIT extends AbstractConnectorTes
             }
         }
 
-        SourceRecords records = consumeRecordsByTopic(7);
+        SourceRecords records = consumeRecordsByTopic(6);
         List<SourceRecord> recordsForTopic = records.recordsForTopic(DATABASE.topicForTable("debezium_test"));
         /*
          * Total Events:
@@ -138,7 +138,7 @@ public class MySqlSkipMessagesWithoutChangeConfigIT extends AbstractConnectorTes
 
     @Test
     @FixFor("DBZ-2979")
-    public void shouldNotSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipDisabled() throws Exception {
+    public void shouldNotSkipEventsWithNoChangeInIncludedColumnsWhenSkipDisabled() throws Exception {
         config = DATABASE.defaultConfig()
                 .with(MySqlConnectorConfig.COLUMN_INCLUDE_LIST, getQualifiedColumnName("id") + "," + getQualifiedColumnName("white"))
                 .with(MySqlConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, false)

--- a/debezium-connector-mysql/src/test/resources/ddl/skip_messages_test.sql
+++ b/debezium-connector-mysql/src/test/resources/ddl/skip_messages_test.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `debezium_test` (
+  id INT NOT NULL PRIMARY KEY,
+  black INT,
+  white INT
+) ENGINE=InnoDB AUTO_INCREMENT=15851 DEFAULT CHARSET=utf8;
+INSERT INTO `debezium_test`(id, black, white) VALUES (0,0,0);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/BaseChangeRecordEmitter.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/BaseChangeRecordEmitter.java
@@ -54,6 +54,11 @@ public abstract class BaseChangeRecordEmitter<T> extends RelationalChangeRecordE
     }
 
     @Override
+    protected boolean skipMessagesWithoutChange() {
+        return connectorConfig.skipMessagesWithoutChange();
+    }
+
+    @Override
     protected Object[] getOldColumnValues() {
         return oldColumnValues;
     }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleSkipMessagesWithoutChangeConfigIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleSkipMessagesWithoutChangeConfigIT.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.junit.SkipTestDependingOnAdapterNameRule;
+import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.data.Envelope;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.AbstractConnectorTest;
+
+/**
+ * Integration tests for config skip.messages.without.change
+ *
+ * @author Ronak Jain
+ */
+public class OracleSkipMessagesWithoutChangeConfigIT extends AbstractConnectorTest {
+
+    @Rule
+    public final TestRule skipAdapterRule = new SkipTestDependingOnAdapterNameRule();
+
+    private OracleConnection connection;
+
+    @Before
+    public void before() {
+        connection = TestHelper.testConnection();
+        TestHelper.dropTable(connection, "debezium.test");
+        setConsumeTimeout(TestHelper.defaultMessageConsumerPollTimeout(), TimeUnit.SECONDS);
+        initializeConnectorTestFramework();
+        Files.delete(TestHelper.SCHEMA_HISTORY_PATH);
+    }
+
+    @After
+    public void after() throws Exception {
+        if (connection != null) {
+            TestHelper.dropTable(connection, "debezium.test");
+            connection.close();
+        }
+    }
+
+    @Test
+    @FixFor("DBZ-2979")
+    public void shouldSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipEnabled() throws Exception {
+        String ddl = "CREATE TABLE debezium.test (" +
+                "  id INT NOT NULL, white INT, black INT PRIMARY KEY (id))";
+
+        connection.execute(ddl);
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "debezium\\.test")
+                .with(OracleConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, true)
+                .with(OracleConnectorConfig.COLUMN_INCLUDE_LIST, "debezium\\.test\\.id, debezium\\.test\\.white")
+                .with(OracleConnectorConfig.SNAPSHOT_MODE, OracleConnectorConfig.SnapshotMode.SCHEMA_ONLY)
+                .build();
+
+        start(OracleConnector.class, config);
+        waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+        connection.execute("INSERT INTO debezium.test VALUES (1, 1, 1)");
+        connection.execute("UPDATE debezium.test SET black=2 where id = 1");
+        connection.execute("UPDATE debezium.test SET white=2 where id = 1");
+        connection.execute("UPDATE debezium.test SET white=3, black=3 where id = 1");
+
+        /*
+         * Total Events
+         * 1,1,1 (I)
+         * 1,1,2 (U) (Skipped)
+         * 1,2,2 (U)
+         * 1,3,3 (U)
+         */
+        SourceRecords records = consumeRecordsByTopic(5);
+        List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("test"));
+        assertThat(recordsForTopic).hasSize(3);
+
+        Struct secondMessage = ((Struct) recordsForTopic.get(1).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(secondMessage.get("white")).isEqualTo(2);
+        Struct thirdMessage = ((Struct) recordsForTopic.get(2).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(thirdMessage.get("white")).isEqualTo(3);
+    }
+
+    @Test
+    @FixFor("DBZ-2979")
+    public void shouldSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipEnabledWithExcludeConfig() throws Exception {
+        String ddl = "CREATE TABLE debezium.test (" +
+                "  id INT NOT NULL, white INT, black INT PRIMARY KEY (id))";
+
+        connection.execute(ddl);
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "debezium\\.test")
+                .with(OracleConnectorConfig.COLUMN_EXCLUDE_LIST, "debezium\\.test\\.black")
+                .with(OracleConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, true)
+                .with(OracleConnectorConfig.SNAPSHOT_MODE, OracleConnectorConfig.SnapshotMode.SCHEMA_ONLY)
+                .build();
+
+        start(OracleConnector.class, config);
+        waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+        connection.execute("INSERT INTO debezium.test VALUES (1, 1, 1)");
+        connection.execute("UPDATE debezium.test SET black=2 where id = 1");
+        connection.execute("UPDATE debezium.test SET white=2 where id = 1");
+        connection.execute("UPDATE debezium.test SET white=3, black=3 where id = 1");
+
+        /*
+         * Total Events
+         * 1,1,1 (I)
+         * 1,1,2 (U) (Skipped)
+         * 1,2,2 (U)
+         * 1,3,3 (U)
+         */
+        SourceRecords records = consumeRecordsByTopic(5);
+        List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("test"));
+        assertThat(recordsForTopic).hasSize(3);
+
+        Struct secondMessage = ((Struct) recordsForTopic.get(1).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(secondMessage.get("white")).isEqualTo(2);
+        Struct thirdMessage = ((Struct) recordsForTopic.get(2).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(thirdMessage.get("white")).isEqualTo(3);
+    }
+
+    @Test
+    @FixFor("DBZ-2979")
+    public void shouldNotSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipDisabled() throws Exception {
+        String ddl = "CREATE TABLE debezium.test (" +
+                "  id INT NOT NULL, white INT, black INT PRIMARY KEY (id))";
+
+        connection.execute(ddl);
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.TABLE_INCLUDE_LIST, "debezium\\.test")
+                .with(OracleConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, false)
+                .with(OracleConnectorConfig.COLUMN_INCLUDE_LIST, "debezium\\.test\\.id, debezium\\.test\\.white")
+                .with(OracleConnectorConfig.SNAPSHOT_MODE, OracleConnectorConfig.SnapshotMode.SCHEMA_ONLY)
+                .build();
+
+        start(OracleConnector.class, config);
+        waitForStreamingRunning(TestHelper.CONNECTOR_NAME, TestHelper.SERVER_NAME);
+
+        connection.execute("INSERT INTO debezium.test VALUES (1, 1, 1)");
+        connection.execute("UPDATE debezium.test SET black=2 where id = 1");
+        connection.execute("UPDATE debezium.test SET white=2 where id = 1");
+        connection.execute("UPDATE debezium.test SET white=3, black=3 where id = 1");
+
+        /*
+         * Total Events
+         * 1,1,1 (I)
+         * 1,1,2 (U)
+         * 1,2,2 (U)
+         * 1,3,3 (U)
+         */
+        SourceRecords records = consumeRecordsByTopic(5);
+        List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("test"));
+        assertThat(recordsForTopic).hasSize(3);
+
+        Struct secondMessage = ((Struct) recordsForTopic.get(1).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(secondMessage.get("white")).isEqualTo(1);
+        Struct thirdMessage = ((Struct) recordsForTopic.get(2).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(thirdMessage.get("white")).isEqualTo(2);
+        Struct forthMessage = ((Struct) recordsForTopic.get(3).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(forthMessage.get("white")).isEqualTo(3);
+    }
+
+    private static String topicName(String tableName) {
+        return TestHelper.SERVER_NAME + ".DEBEZIUM." + tableName;
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeRecordEmitter.java
@@ -377,4 +377,9 @@ public class PostgresChangeRecordEmitter extends RelationalChangeRecordEmitter<P
     protected boolean skipEmptyMessages() {
         return true;
     }
+
+    @Override
+    protected boolean skipMessagesWithoutChange() {
+        return connectorConfig.skipMessagesWithoutChange();
+    }
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSkipMessagesWithoutChangeConfigIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSkipMessagesWithoutChangeConfigIT.java
@@ -64,12 +64,22 @@ public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnector
         TestHelper.execute("INSERT INTO updates_test.debezium_test (id,white,black) VALUES (1,1,1);");
         TestHelper.execute("UPDATE updates_test.debezium_test SET black=2 where id = 1;");
         TestHelper.execute("UPDATE updates_test.debezium_test SET white=2 where id = 1;");
+        TestHelper.execute("UPDATE updates_test.debezium_test SET white=3, black=3 where id = 1;");
 
-        final SourceRecords records = consumeRecordsByTopic(10);
+        final SourceRecords records = consumeRecordsByTopic(4);
+        /*
+         * Total Events
+         * 1,1,1 (I)
+         * 1,1,2 (U) (Skipped)
+         * 1,2,2 (U)
+         * 1,3,3 (U)
+         */
         final List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("updates_test.debezium_test"));
-        assertThat(recordsForTopic).hasSize(2);
-        Struct after = ((Struct) recordsForTopic.get(1).value()).getStruct(Envelope.FieldName.AFTER);
-        assertThat(after.get("white")).isEqualTo(2);
+        assertThat(recordsForTopic).hasSize(3);
+        Struct secondMessage = ((Struct) recordsForTopic.get(1).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(secondMessage.get("white")).isEqualTo(2);
+        Struct thirdMessage = ((Struct) recordsForTopic.get(2).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(thirdMessage.get("white")).isEqualTo(3);
     }
 
     @Test
@@ -94,12 +104,22 @@ public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnector
         TestHelper.execute("INSERT INTO updates_test.debezium_test (id,white,black) VALUES (1,1,1);");
         TestHelper.execute("UPDATE updates_test.debezium_test SET black=2 where id = 1;");
         TestHelper.execute("UPDATE updates_test.debezium_test SET white=2 where id = 1;");
+        TestHelper.execute("UPDATE updates_test.debezium_test SET white=3, black=3 where id = 1;");
 
-        final SourceRecords records = consumeRecordsByTopic(3);
+        final SourceRecords records = consumeRecordsByTopic(4);
+        /*
+         * Total Events
+         * 1,1,1 (I)
+         * 1,1,2 (U) (Skipped)
+         * 1,2,2 (U)
+         * 1,3,3 (U)
+         */
         final List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("updates_test.debezium_test"));
-        assertThat(recordsForTopic).hasSize(2);
-        Struct after = ((Struct) recordsForTopic.get(1).value()).getStruct(Envelope.FieldName.AFTER);
-        assertThat(after.get("white")).isEqualTo(2);
+        assertThat(recordsForTopic).hasSize(3);
+        Struct secondMessage = ((Struct) recordsForTopic.get(1).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(secondMessage.get("white")).isEqualTo(2);
+        Struct thirdMessage = ((Struct) recordsForTopic.get(2).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(thirdMessage.get("white")).isEqualTo(3);
     }
 
     @Test
@@ -122,11 +142,23 @@ public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnector
         TestHelper.execute("INSERT INTO updates_test.debezium_test (id,white,black) VALUES (1,1,1);");
         TestHelper.execute("UPDATE updates_test.debezium_test SET black=2 where id = 1;");
         TestHelper.execute("UPDATE updates_test.debezium_test SET white=2 where id = 1;");
-        final SourceRecords records = consumeRecordsByTopic(3);
+        TestHelper.execute("UPDATE updates_test.debezium_test SET white=3, black=3 where id = 1;");
+        final SourceRecords records = consumeRecordsByTopic(5);
+        /*
+         * Total Events
+         * 1,1,1 (I)
+         * 1,1,2 (U)
+         * 1,2,2 (U)
+         * 1,3,3 (U)
+         */
         final List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("updates_test.debezium_test"));
-        assertThat(recordsForTopic).hasSize(3);
-        Struct after = ((Struct) recordsForTopic.get(1).value()).getStruct(Envelope.FieldName.AFTER);
-        assertThat(after.get("white")).isEqualTo(1);
+        assertThat(recordsForTopic).hasSize(4);
+        Struct secondMessage = ((Struct) recordsForTopic.get(1).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(secondMessage.get("white")).isEqualTo(1);
+        Struct thirdMessage = ((Struct) recordsForTopic.get(2).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(thirdMessage.get("white")).isEqualTo(2);
+        Struct forthMessage = ((Struct) recordsForTopic.get(3).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(forthMessage.get("white")).isEqualTo(3);
     }
 
     @Test
@@ -151,12 +183,24 @@ public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnector
         TestHelper.execute("INSERT INTO updates_test.debezium_test (id,white,black) VALUES (1,1,1);");
         TestHelper.execute("UPDATE updates_test.debezium_test SET black=2 where id = 1;");
         TestHelper.execute("UPDATE updates_test.debezium_test SET white=2 where id = 1;");
-        final SourceRecords records = consumeRecordsByTopic(3);
+        TestHelper.execute("UPDATE updates_test.debezium_test SET white=3, black=3 where id = 1;");
+        /*
+         * Total Events
+         * 1,1,1 (I)
+         * 1,1,2 (U)
+         * 1,2,2 (U)
+         * 1,3,3 (U)
+         */
+        final SourceRecords records = consumeRecordsByTopic(5);
         final List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("updates_test.debezium_test"));
 
-        assertThat(recordsForTopic).hasSize(3);
-        Struct after = ((Struct) recordsForTopic.get(1).value()).getStruct(Envelope.FieldName.AFTER);
-        assertThat(after.get("white")).isEqualTo(1);
+        assertThat(recordsForTopic).hasSize(4);
+        Struct secondMessage = ((Struct) recordsForTopic.get(1).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(secondMessage.get("white")).isEqualTo(1);
+        Struct thirdMessage = ((Struct) recordsForTopic.get(2).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(thirdMessage.get("white")).isEqualTo(2);
+        Struct forthMessage = ((Struct) recordsForTopic.get(3).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(forthMessage.get("white")).isEqualTo(3);
     }
 
 }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSkipMessagesWithoutChangeConfigIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSkipMessagesWithoutChangeConfigIT.java
@@ -44,7 +44,7 @@ public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnector
 
     @Test
     @FixFor("DBZ-2979")
-    public void shouldSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipEnabled() throws Exception {
+    public void shouldSkipEventsWithNoChangeInIncludedColumnsWhenSkipEnabled() throws Exception {
 
         TestHelper.execute(
                 "DROP SCHEMA IF EXISTS updates_test CASCADE;",
@@ -66,7 +66,7 @@ public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnector
         TestHelper.execute("UPDATE updates_test.debezium_test SET white=2 where id = 1;");
         TestHelper.execute("UPDATE updates_test.debezium_test SET white=3, black=3 where id = 1;");
 
-        final SourceRecords records = consumeRecordsByTopic(4);
+        final SourceRecords records = consumeRecordsByTopic(3);
         /*
          * Total Events
          * 1,1,1 (I)
@@ -84,7 +84,7 @@ public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnector
 
     @Test
     @FixFor("DBZ-2979")
-    public void shouldSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipEnabledWithExcludeConfig() throws Exception {
+    public void shouldSkipEventsWithNoChangeInIncludedColumnsWhenSkipEnabledWithExcludeConfig() throws Exception {
 
         TestHelper.execute(
                 "DROP SCHEMA IF EXISTS updates_test CASCADE;",
@@ -106,7 +106,7 @@ public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnector
         TestHelper.execute("UPDATE updates_test.debezium_test SET white=2 where id = 1;");
         TestHelper.execute("UPDATE updates_test.debezium_test SET white=3, black=3 where id = 1;");
 
-        final SourceRecords records = consumeRecordsByTopic(4);
+        final SourceRecords records = consumeRecordsByTopic(3);
         /*
          * Total Events
          * 1,1,1 (I)
@@ -124,7 +124,7 @@ public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnector
 
     @Test
     @FixFor("DBZ-2979")
-    public void shouldNotSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipEnabledButTableReplicaIdentityNotFull() throws Exception {
+    public void shouldNotSkipEventsWithNoChangeInIncludedColumnsWhenSkipEnabledButTableReplicaIdentityNotFull() throws Exception {
 
         TestHelper.execute("DROP SCHEMA IF EXISTS updates_test CASCADE;",
                 "CREATE SCHEMA updates_test;",
@@ -143,7 +143,7 @@ public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnector
         TestHelper.execute("UPDATE updates_test.debezium_test SET black=2 where id = 1;");
         TestHelper.execute("UPDATE updates_test.debezium_test SET white=2 where id = 1;");
         TestHelper.execute("UPDATE updates_test.debezium_test SET white=3, black=3 where id = 1;");
-        final SourceRecords records = consumeRecordsByTopic(5);
+        final SourceRecords records = consumeRecordsByTopic(4);
         /*
          * Total Events
          * 1,1,1 (I)
@@ -163,7 +163,7 @@ public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnector
 
     @Test
     @FixFor("DBZ-2979")
-    public void shouldNotSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipDisabled() throws Exception {
+    public void shouldNotSkipEventsWithNoChangeInIncludedColumnsWhenSkipDisabled() throws Exception {
 
         TestHelper.execute(
                 "DROP SCHEMA IF EXISTS updates_test CASCADE;",
@@ -191,7 +191,7 @@ public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnector
          * 1,2,2 (U)
          * 1,3,3 (U)
          */
-        final SourceRecords records = consumeRecordsByTopic(5);
+        final SourceRecords records = consumeRecordsByTopic(4);
         final List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("updates_test.debezium_test"));
 
         assertThat(recordsForTopic).hasSize(4);

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSkipMessagesWithoutChangeConfigIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresSkipMessagesWithoutChangeConfigIT.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.postgresql;
+
+import static io.debezium.connector.postgresql.TestHelper.topicName;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.data.Envelope;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.AbstractConnectorTest;
+
+/**
+ * Integration Tests for config skip.messages.without.change
+ *
+ * @author Ronak Jain
+ */
+public class PostgresSkipMessagesWithoutChangeConfigIT extends AbstractConnectorTest {
+
+    @Before
+    public void before() throws Exception {
+        initializeConnectorTestFramework();
+        TestHelper.dropAllSchemas();
+    }
+
+    @After
+    public void after() {
+        stopConnector();
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.dropPublication();
+    }
+
+    @Test
+    @FixFor("DBZ-2979")
+    public void shouldSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipEnabled() throws Exception {
+
+        TestHelper.execute(
+                "DROP SCHEMA IF EXISTS updates_test CASCADE;",
+                "CREATE SCHEMA updates_test;",
+                "CREATE TABLE updates_test.debezium_test (id int4 NOT NULL, white int, black int, PRIMARY KEY(id));",
+                "ALTER TABLE updates_test.debezium_test REPLICA IDENTITY FULL;");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.COLUMN_INCLUDE_LIST, "updates_test.debezium_test.id, updates_test.debezium_test.white")
+                .with(PostgresConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, true)
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER)
+                .build();
+
+        start(PostgresConnector.class, config);
+        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
+
+        TestHelper.execute("INSERT INTO updates_test.debezium_test (id,white,black) VALUES (1,1,1);");
+        TestHelper.execute("UPDATE updates_test.debezium_test SET black=2 where id = 1;");
+        TestHelper.execute("UPDATE updates_test.debezium_test SET white=2 where id = 1;");
+
+        final SourceRecords records = consumeRecordsByTopic(10);
+        final List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("updates_test.debezium_test"));
+        assertThat(recordsForTopic).hasSize(2);
+        Struct after = ((Struct) recordsForTopic.get(1).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(after.get("white")).isEqualTo(2);
+    }
+
+    @Test
+    @FixFor("DBZ-2979")
+    public void shouldSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipEnabledWithExcludeConfig() throws Exception {
+
+        TestHelper.execute(
+                "DROP SCHEMA IF EXISTS updates_test CASCADE;",
+                "CREATE SCHEMA updates_test;",
+                "CREATE TABLE updates_test.debezium_test (id int4 NOT NULL, white int, black int, PRIMARY KEY(id));",
+                "ALTER TABLE updates_test.debezium_test REPLICA IDENTITY FULL;");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.COLUMN_EXCLUDE_LIST, "updates_test.debezium_test.black")
+                .with(PostgresConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, true)
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER)
+                .build();
+
+        start(PostgresConnector.class, config);
+        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
+
+        TestHelper.execute("INSERT INTO updates_test.debezium_test (id,white,black) VALUES (1,1,1);");
+        TestHelper.execute("UPDATE updates_test.debezium_test SET black=2 where id = 1;");
+        TestHelper.execute("UPDATE updates_test.debezium_test SET white=2 where id = 1;");
+
+        final SourceRecords records = consumeRecordsByTopic(3);
+        final List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("updates_test.debezium_test"));
+        assertThat(recordsForTopic).hasSize(2);
+        Struct after = ((Struct) recordsForTopic.get(1).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(after.get("white")).isEqualTo(2);
+    }
+
+    @Test
+    @FixFor("DBZ-2979")
+    public void shouldNotSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipEnabledButTableReplicaIdentityNotFull() throws Exception {
+
+        TestHelper.execute("DROP SCHEMA IF EXISTS updates_test CASCADE;",
+                "CREATE SCHEMA updates_test;",
+                "CREATE TABLE updates_test.debezium_test (id int4 NOT NULL, white int, black int, PRIMARY KEY(id));");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.COLUMN_INCLUDE_LIST, "updates_test.debezium_test.id, updates_test.debezium_test.white")
+                .with(PostgresConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, true)
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER)
+                .build();
+
+        start(PostgresConnector.class, config);
+        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
+
+        TestHelper.execute("INSERT INTO updates_test.debezium_test (id,white,black) VALUES (1,1,1);");
+        TestHelper.execute("UPDATE updates_test.debezium_test SET black=2 where id = 1;");
+        TestHelper.execute("UPDATE updates_test.debezium_test SET white=2 where id = 1;");
+        final SourceRecords records = consumeRecordsByTopic(3);
+        final List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("updates_test.debezium_test"));
+        assertThat(recordsForTopic).hasSize(3);
+        Struct after = ((Struct) recordsForTopic.get(1).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(after.get("white")).isEqualTo(1);
+    }
+
+    @Test
+    @FixFor("DBZ-2979")
+    public void shouldNotSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipDisabled() throws Exception {
+
+        TestHelper.execute(
+                "DROP SCHEMA IF EXISTS updates_test CASCADE;",
+                "CREATE SCHEMA updates_test;",
+                "CREATE TABLE updates_test.debezium_test (id int4 NOT NULL, white int, black int, PRIMARY KEY(id));",
+                "ALTER TABLE updates_test.debezium_test REPLICA IDENTITY FULL;");
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.COLUMN_INCLUDE_LIST, "updates_test.debezium_test.id, updates_test.debezium_test.white")
+                .with(PostgresConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, false)
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER)
+                .build();
+
+        start(PostgresConnector.class, config);
+        waitForStreamingRunning("postgres", TestHelper.TEST_SERVER);
+
+        TestHelper.execute("INSERT INTO updates_test.debezium_test (id,white,black) VALUES (1,1,1);");
+        TestHelper.execute("UPDATE updates_test.debezium_test SET black=2 where id = 1;");
+        TestHelper.execute("UPDATE updates_test.debezium_test SET white=2 where id = 1;");
+        final SourceRecords records = consumeRecordsByTopic(3);
+        final List<SourceRecord> recordsForTopic = records.recordsForTopic(topicName("updates_test.debezium_test"));
+
+        assertThat(recordsForTopic).hasSize(3);
+        Struct after = ((Struct) recordsForTopic.get(1).value()).getStruct(Envelope.FieldName.AFTER);
+        assertThat(after.get("white")).isEqualTo(1);
+    }
+
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeRecordEmitter.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeRecordEmitter.java
@@ -27,12 +27,16 @@ public class SqlServerChangeRecordEmitter extends RelationalChangeRecordEmitter 
     private final Object[] data;
     private final Object[] dataNext;
 
-    public SqlServerChangeRecordEmitter(Partition partition, OffsetContext offset, int operation, Object[] data, Object[] dataNext, Clock clock) {
+    private final boolean skipMessagesWithoutChange;
+
+    public SqlServerChangeRecordEmitter(Partition partition, OffsetContext offset, int operation, Object[] data, Object[] dataNext, Clock clock,
+                                        boolean skipMessagesWithoutChange) {
         super(partition, offset, clock);
 
         this.operation = operation;
         this.data = data;
         this.dataNext = dataNext;
+        this.skipMessagesWithoutChange = skipMessagesWithoutChange;
     }
 
     @Override
@@ -71,5 +75,10 @@ public class SqlServerChangeRecordEmitter extends RelationalChangeRecordEmitter 
             default:
                 return null;
         }
+    }
+
+    @Override
+    protected boolean skipMessagesWithoutChange() {
+        return skipMessagesWithoutChange;
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -316,7 +316,8 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                                                     operation,
                                                     data,
                                                     dataNext,
-                                                    clock));
+                                                    clock,
+                                                    connectorConfig.skipMessagesWithoutChange()));
                             tableWithSmallestLsn.next();
                         }
                     });

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SQLServerSkipMessagesWithNoUpdateConfigIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SQLServerSkipMessagesWithNoUpdateConfigIT.java
@@ -67,17 +67,21 @@ public class SQLServerSkipMessagesWithNoUpdateConfigIT extends AbstractConnector
         connection.execute("INSERT INTO skip_messages_test VALUES (1, 1, 1);");
         connection.execute("UPDATE skip_messages_test SET black=2 where id=1");
         connection.execute("UPDATE skip_messages_test SET white=2 where id=1");
-        final SourceRecords records = consumeRecordsByTopic(3);
+        connection.execute("UPDATE skip_messages_test SET white=3,black=3 where id=1");
+        final SourceRecords records = consumeRecordsByTopic(4);
         final List<SourceRecord> tableMessages = records.recordsForTopic("server1.testDB1.dbo.skip_messages_test");
         /*
          * Total events:
          * 1,1,1 (I)
          * 1,1,2 (U) (Skipped)
          * 1,2,2 (U)
+         * 1,3,3 (U)
          */
-        assertThat(tableMessages).hasSize(2);
-        final Struct secondRecord = (Struct) tableMessages.get(1).value();
-        assertThat(((Struct) secondRecord.get("after")).get("white")).isEqualTo(2);
+        assertThat(tableMessages).hasSize(3);
+        final Struct secondMessage = (Struct) tableMessages.get(1).value();
+        assertThat(((Struct) secondMessage.get("after")).get("white")).isEqualTo(2);
+        final Struct thirdMessage = (Struct) tableMessages.get(2).value();
+        assertThat(((Struct) thirdMessage.get("after")).get("white")).isEqualTo(3);
         stopConnector();
     }
 
@@ -97,17 +101,21 @@ public class SQLServerSkipMessagesWithNoUpdateConfigIT extends AbstractConnector
         connection.execute("INSERT INTO skip_messages_test VALUES (1, 1, 1);");
         connection.execute("UPDATE skip_messages_test SET black=2 where id=1");
         connection.execute("UPDATE skip_messages_test SET white=2 where id=1");
-        final SourceRecords records = consumeRecordsByTopic(3);
-        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.skip_messages_test");
+        connection.execute("UPDATE skip_messages_test SET white=3,black=3 where id=1");
+        final SourceRecords records = consumeRecordsByTopic(4);
+        final List<SourceRecord> tableMessages = records.recordsForTopic("server1.testDB1.dbo.skip_messages_test");
         /*
          * Total events:
          * 1,1,1 (I)
          * 1,1,2 (U) (Skipped)
          * 1,2,2 (U)
+         * 1,3,3 (U)
          */
-        assertThat(tableA).hasSize(2);
-        final Struct valueA = (Struct) tableA.get(1).value();
-        assertThat(((Struct) valueA.get("after")).get("white")).isEqualTo(2);
+        assertThat(tableMessages).hasSize(3);
+        final Struct secondMessage = (Struct) tableMessages.get(1).value();
+        assertThat(((Struct) secondMessage.get("after")).get("white")).isEqualTo(2);
+        final Struct thirdMessage = (Struct) tableMessages.get(2).value();
+        assertThat(((Struct) thirdMessage.get("after")).get("white")).isEqualTo(3);
         stopConnector();
     }
 
@@ -124,17 +132,23 @@ public class SQLServerSkipMessagesWithNoUpdateConfigIT extends AbstractConnector
         connection.execute("INSERT INTO skip_messages_test VALUES (1, 1, 1);");
         connection.execute("UPDATE skip_messages_test SET black=2 where id=1");
         connection.execute("UPDATE skip_messages_test SET white=2 where id=1");
-        final SourceRecords records = consumeRecordsByTopic(3);
+        connection.execute("UPDATE skip_messages_test SET white=3,black=3 where id=1");
+        final SourceRecords records = consumeRecordsByTopic(5);
         final List<SourceRecord> tableMessages = records.recordsForTopic("server1.testDB1.dbo.skip_messages_test");
         /*
          * Total events:
          * 1,1,1 (I)
          * 1,1,2 (U)
          * 1,2,2 (U)
+         * 1,3,3 (U)
          */
-        assertThat(tableMessages).hasSize(3);
+        assertThat(tableMessages).hasSize(4);
         final Struct secondMessage = (Struct) tableMessages.get(1).value();
         assertThat(((Struct) secondMessage.get("after")).get("white")).isEqualTo(1);
+        final Struct thirdMessage = (Struct) tableMessages.get(2).value();
+        assertThat(((Struct) thirdMessage.get("after")).get("white")).isEqualTo(2);
+        final Struct forthMessage = (Struct) tableMessages.get(3).value();
+        assertThat(((Struct) forthMessage.get("after")).get("white")).isEqualTo(3);
         stopConnector();
     }
 

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SQLServerSkipMessagesWithNoUpdateConfigIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SQLServerSkipMessagesWithNoUpdateConfigIT.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.sqlserver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.sqlserver.SqlServerConnectorConfig.SnapshotMode;
+import io.debezium.connector.sqlserver.util.TestHelper;
+import io.debezium.doc.FixFor;
+import io.debezium.embedded.AbstractConnectorTest;
+
+/**
+ * Integration Tests for config skip.messages.without.change
+ *
+ * @author Ronak Jain
+ *
+ */
+public class SQLServerSkipMessagesWithNoUpdateConfigIT extends AbstractConnectorTest {
+    private SqlServerConnection connection;
+
+    private final Configuration.Builder configBuilder = TestHelper.defaultConfig()
+            .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
+            .with(SqlServerConnectorConfig.TABLE_INCLUDE_LIST, "dbo.skip_messages_test")
+            .with(SqlServerConnectorConfig.COLUMN_INCLUDE_LIST, "dbo.skip_messages_test.id, dbo.skip_messages_test.white");
+
+    @Before
+    public void before() throws SQLException {
+        TestHelper.createTestDatabase();
+        connection = TestHelper.testConnection();
+        connection.execute(
+                "CREATE TABLE skip_messages_test (id int primary key, white int, black int)");
+        TestHelper.enableTableCdc(connection, "skip_messages_test");
+
+        initializeConnectorTestFramework();
+        Files.delete(TestHelper.SCHEMA_HISTORY_PATH);
+    }
+
+    @After
+    public void after() throws SQLException {
+        if (connection != null) {
+            connection.close();
+        }
+    }
+
+    @Test
+    public void shouldSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipEnabled() throws Exception {
+        Configuration config = configBuilder
+                .with(SqlServerConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, true)
+                .build();
+
+        start(SqlServerConnector.class, config);
+        TestHelper.waitForStreamingStarted();
+
+        connection.execute("INSERT INTO skip_messages_test VALUES (1, 1, 1);");
+        connection.execute("UPDATE skip_messages_test SET black=2 where id=1");
+        connection.execute("UPDATE skip_messages_test SET white=2 where id=1");
+        final SourceRecords records = consumeRecordsByTopic(3);
+        final List<SourceRecord> tableMessages = records.recordsForTopic("server1.testDB1.dbo.skip_messages_test");
+        /*
+         * Total events:
+         * 1,1,1 (I)
+         * 1,1,2 (U) (Skipped)
+         * 1,2,2 (U)
+         */
+        assertThat(tableMessages).hasSize(2);
+        final Struct secondRecord = (Struct) tableMessages.get(1).value();
+        assertThat(((Struct) secondRecord.get("after")).get("white")).isEqualTo(2);
+        stopConnector();
+    }
+
+    @Test
+    @FixFor("DBZ-2979")
+    public void shouldSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipEnabledWithExcludeConfig() throws Exception {
+        Configuration config = TestHelper.defaultConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
+                .with(SqlServerConnectorConfig.TABLE_INCLUDE_LIST, "dbo.skip_messages_test")
+                .with(SqlServerConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, true)
+                .with(SqlServerConnectorConfig.COLUMN_EXCLUDE_LIST, "dbo.skip_messages_test.black")
+                .build();
+
+        start(SqlServerConnector.class, config);
+        TestHelper.waitForStreamingStarted();
+
+        connection.execute("INSERT INTO skip_messages_test VALUES (1, 1, 1);");
+        connection.execute("UPDATE skip_messages_test SET black=2 where id=1");
+        connection.execute("UPDATE skip_messages_test SET white=2 where id=1");
+        final SourceRecords records = consumeRecordsByTopic(3);
+        final List<SourceRecord> tableA = records.recordsForTopic("server1.testDB1.dbo.skip_messages_test");
+        /*
+         * Total events:
+         * 1,1,1 (I)
+         * 1,1,2 (U) (Skipped)
+         * 1,2,2 (U)
+         */
+        assertThat(tableA).hasSize(2);
+        final Struct valueA = (Struct) tableA.get(1).value();
+        assertThat(((Struct) valueA.get("after")).get("white")).isEqualTo(2);
+        stopConnector();
+    }
+
+    @Test
+    @FixFor("DBZ-2979")
+    public void shouldNotSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipDisabled() throws Exception {
+        Configuration config = configBuilder
+                .with(SqlServerConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, false)
+                .build();
+
+        start(SqlServerConnector.class, config);
+        TestHelper.waitForStreamingStarted();
+
+        connection.execute("INSERT INTO skip_messages_test VALUES (1, 1, 1);");
+        connection.execute("UPDATE skip_messages_test SET black=2 where id=1");
+        connection.execute("UPDATE skip_messages_test SET white=2 where id=1");
+        final SourceRecords records = consumeRecordsByTopic(3);
+        final List<SourceRecord> tableMessages = records.recordsForTopic("server1.testDB1.dbo.skip_messages_test");
+        /*
+         * Total events:
+         * 1,1,1 (I)
+         * 1,1,2 (U)
+         * 1,2,2 (U)
+         */
+        assertThat(tableMessages).hasSize(3);
+        final Struct secondMessage = (Struct) tableMessages.get(1).value();
+        assertThat(((Struct) secondMessage.get("after")).get("white")).isEqualTo(1);
+        stopConnector();
+    }
+
+}

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerSkipMessagesWithNoUpdateConfigIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/SqlServerSkipMessagesWithNoUpdateConfigIT.java
@@ -28,7 +28,7 @@ import io.debezium.embedded.AbstractConnectorTest;
  * @author Ronak Jain
  *
  */
-public class SQLServerSkipMessagesWithNoUpdateConfigIT extends AbstractConnectorTest {
+public class SqlServerSkipMessagesWithNoUpdateConfigIT extends AbstractConnectorTest {
     private SqlServerConnection connection;
 
     private final Configuration.Builder configBuilder = TestHelper.defaultConfig()
@@ -56,7 +56,7 @@ public class SQLServerSkipMessagesWithNoUpdateConfigIT extends AbstractConnector
     }
 
     @Test
-    public void shouldSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipEnabled() throws Exception {
+    public void shouldSkipEventsWithNoChangeInIncludedColumnsWhenSkipEnabled() throws Exception {
         Configuration config = configBuilder
                 .with(SqlServerConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, true)
                 .build();
@@ -68,7 +68,7 @@ public class SQLServerSkipMessagesWithNoUpdateConfigIT extends AbstractConnector
         connection.execute("UPDATE skip_messages_test SET black=2 where id=1");
         connection.execute("UPDATE skip_messages_test SET white=2 where id=1");
         connection.execute("UPDATE skip_messages_test SET white=3,black=3 where id=1");
-        final SourceRecords records = consumeRecordsByTopic(4);
+        final SourceRecords records = consumeRecordsByTopic(3);
         final List<SourceRecord> tableMessages = records.recordsForTopic("server1.testDB1.dbo.skip_messages_test");
         /*
          * Total events:
@@ -87,7 +87,7 @@ public class SQLServerSkipMessagesWithNoUpdateConfigIT extends AbstractConnector
 
     @Test
     @FixFor("DBZ-2979")
-    public void shouldSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipEnabledWithExcludeConfig() throws Exception {
+    public void shouldSkipEventsWithNoChangeInIncludedColumnsWhenSkipEnabledWithExcludeConfig() throws Exception {
         Configuration config = TestHelper.defaultConfig()
                 .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SnapshotMode.SCHEMA_ONLY)
                 .with(SqlServerConnectorConfig.TABLE_INCLUDE_LIST, "dbo.skip_messages_test")
@@ -102,7 +102,7 @@ public class SQLServerSkipMessagesWithNoUpdateConfigIT extends AbstractConnector
         connection.execute("UPDATE skip_messages_test SET black=2 where id=1");
         connection.execute("UPDATE skip_messages_test SET white=2 where id=1");
         connection.execute("UPDATE skip_messages_test SET white=3,black=3 where id=1");
-        final SourceRecords records = consumeRecordsByTopic(4);
+        final SourceRecords records = consumeRecordsByTopic(3);
         final List<SourceRecord> tableMessages = records.recordsForTopic("server1.testDB1.dbo.skip_messages_test");
         /*
          * Total events:
@@ -121,7 +121,7 @@ public class SQLServerSkipMessagesWithNoUpdateConfigIT extends AbstractConnector
 
     @Test
     @FixFor("DBZ-2979")
-    public void shouldNotSkipEventsWithNoChangeInWhitelistedColumnsWhenSkipDisabled() throws Exception {
+    public void shouldNotSkipEventsWithNoChangeInIncludedColumnsWhenSkipDisabled() throws Exception {
         Configuration config = configBuilder
                 .with(SqlServerConnectorConfig.SKIP_MESSAGES_WITHOUT_CHANGE, false)
                 .build();

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalDatabaseConnectorConfig.java
@@ -313,6 +313,21 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
             .withValidation(Field::isListOfRegex)
             .withDescription("Regular expressions matching columns to include in change events");
 
+    /**
+     *  Specifies whether to skip messages containing no updates in included columns
+     */
+    public static final Field SKIP_MESSAGES_WITHOUT_CHANGE = Field.create("skip.messages.without.change")
+            .withDisplayName("Enable skipping messages without change")
+            .withType(Type.BOOLEAN)
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED, 0))
+            .withDefault(false)
+            .withWidth(Width.SHORT)
+            .withImportance(Importance.MEDIUM)
+            .withDescription(("Enable to skip publishing messages when there is no change in whitelisted columns."
+                    + "This would essentially filter messages to be sent when there is no change in columns included as per column.include.list/column.exclude.list."
+                    + "For Postgres - this would require REPLICA IDENTITY of table to be FULL."))
+            .withValidation(Field::isBoolean);
+
     public static final Field MSG_KEY_COLUMNS = Field.create("message.key.columns")
             .withDisplayName("Columns PK mapping")
             .withType(Type.STRING)
@@ -568,6 +583,8 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
     private final FieldNamer<Column> fieldNamer;
     private final SnapshotTablesRowCountOrder snapshotOrderByRowCount;
 
+    private final boolean skipMessagesWithoutChange;
+
     protected RelationalDatabaseConnectorConfig(Configuration config, TableFilter systemTablesFilter,
                                                 TableIdToStringMapper tableIdMapper, int defaultSnapshotFetchSize,
                                                 ColumnFilterMode columnFilterMode, boolean useCatalogBeforeSchema) {
@@ -599,6 +616,8 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
         else {
             this.columnFilter = ColumnNameFilterFactory.createExcludeListFilter(columnExcludeList, columnFilterMode);
         }
+
+        this.skipMessagesWithoutChange = config.getBoolean(SKIP_MESSAGES_WITHOUT_CHANGE);
 
         this.heartbeatActionQuery = config.getString(DatabaseHeartbeatImpl.HEARTBEAT_ACTION_QUERY_PROPERTY_NAME, "");
         this.fieldNamer = FieldNameSelector.defaultSelector(fieldNameAdjuster());
@@ -642,6 +661,10 @@ public abstract class RelationalDatabaseConnectorConfig extends CommonConnectorC
 
     public String getHeartbeatActionQuery() {
         return heartbeatActionQuery;
+    }
+
+    public boolean skipMessagesWithoutChange() {
+        return skipMessagesWithoutChange;
     }
 
     public byte[] getUnavailableValuePlaceholder() {

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2659,6 +2659,11 @@ To match the name of a column, {prodname} applies the regular expression that yo
 That is, the specified expression is matched against the entire name string of the column; it does not match substrings that might be present in a column name. +
 If you include this property in the configuration, do not set the `column.exclude.list` property.
 
+|[[mysql-property-skip-messages-without-change]]<<mysql-property-skip-messages-without-change, `+skip.messages.without.change+`>>
+|`false`
+| Specifies whether to skip publishing messages when there is no change in whitelisted columns. This would essentially filter messages if there is no change in columns included as per `column.include.list` or `column.exclude.list` properties. 
+
+
 |[[mysql-property-column-truncate-to-length-chars]]<<mysql-property-column-truncate-to-length-chars, `column.truncate.to._length_.chars`>>
 |_n/a_
 |An optional, comma-separated list of regular expressions that match the fully-qualified names of character-based columns.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -2843,6 +2843,10 @@ To match the name of a column, {prodname} applies the regular expression that yo
 That is, the specified expression is matched against the entire name string of the column it does not match substrings that might be present in a column name. +
 If you include this property in the configuration, do not set the `column.include.list` property.
 
+|[[oracle-property-skip-messages-without-change]]<<oracle-property-skip-messages-without-change, `+skip.messages.without.change+`>>
+|`false`
+| Specifies whether to skip publishing messages when there is no change in whitelisted columns. This would essentially filter messages if there is no change in columns included as per `column.include.list` or `column.exclude.list` properties.
+
 |[[oracle-property-column-mask-hash]]<<oracle-property-column-mask-hash, `column.mask.hash._hashAlgorithm_.with.salt._salt_`>>;
 [[oracle-property-column-mask-hash-v2]]<<oracle-property-column-mask-hash-v2, `column.mask.hash.v2._hashAlgorithm_.with.salt._salt_`>>
 |_n/a_

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2735,6 +2735,13 @@ To match the name of a column, {prodname} applies the regular expression that yo
 That is, the expression is used to match the entire name string of the column; it does not match substrings that might be present in a column name. +
 If you include this property in the configuration, do not set the `column.include.list` property.
 
+|[[postgresql-property-skip-messages-without-change]]<<postgresql-property-skip-messages-without-change, `+skip.messages.without.change+`>>
+|`false`
+| Specifies whether to skip publishing messages when there is no change in whitelisted columns. This would essentially filter messages if there is no change in columns included as per `column.include.list` or `column.exclude.list` properties. 
+
+Note: Only works when REPLICA IDENTITY of the table to is FULL
+
+
 |[[postgresql-property-time-precision-mode]]<<postgresql-property-time-precision-mode, `+time.precision.mode+`>>
 |`adaptive`
 |Time, date, and timestamps can be represented with different kinds of precision: +

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -2243,6 +2243,10 @@ To match the name of a column, {prodname} applies the regular expression that yo
 That is, the specified expression is matched against the entire name string of the column; it does not match substrings that might be present in a column name. +
 If you include this property in the configuration, do not also set the `column.include.list` property.
 
+|[[sqlserver-property-skip-messages-without-change]]<<sqlserver-property-skip-messages-without-change, `+skip.messages.without.change+`>>
+|`false`
+| Specifies whether to skip publishing messages when there is no change in whitelisted columns. This would essentially filter messages if there is no change in columns included as per `column.include.list` or `column.exclude.list` properties. 
+
 |[[sqlserver-property-column-mask-hash]]<<sqlserver-property-column-mask-hash, `column.mask.hash._hashAlgorithm_.with.salt._salt_`>>;
 [[sqlserver-property-column-mask-hash-v2]]<<sqlserver-property-column-mask-hash-v2, `column.mask.hash.v2._hashAlgorithm_.with.salt._salt_`>>
 |_n/a_


### PR DESCRIPTION
If config is enabled and If `column.include.list/column.exclude.list` is used and the target table receives an update for the excluded (or not included) column - such events should be ignored

Addresses/Closes DBZ-2979
https://issues.redhat.com/browse/DBZ-2979