### PR TITLE
DBZ-6246 Bumping minimal MongoDB version to 4.2 in GH actions

### DIFF
--- a/.github/workflows/debezium-workflow.yml
+++ b/.github/workflows/debezium-workflow.yml
@@ -280,7 +280,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version-mongo-server: ["4.0", "4.4", "5.0", "6.0"]
+        version-mongo-server: ["4.2", "4.4", "5.0", "6.0"]
       fail-fast: false
     steps:
       - name: Checkout Action


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6246