### PR TITLE
DBZ-6246: Removing MongoDB 4.0 and adding 4.2 to Jenkins job

### DIFF
--- a/jenkins-jobs/job-dsl/connector_mongodb_matrix_test.groovy
+++ b/jenkins-jobs/job-dsl/connector_mongodb_matrix_test.groovy
@@ -7,7 +7,7 @@ matrixJob('connector-debezium-mongodb-matrix-test') {
     label('Slave')
 
     axes {
-        text('MONGODB_VERSION', '4.0', '4.2', '4.4', '5.0')
+        text('MONGODB_VERSION', '4.2', '4.4', '5.0', '6.0')
         label("Node", "Slave")
 
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6246