### PR TITLE
DBZ-6216 Enable publishing to Docker Hub again

### DIFF
--- a/jenkins-jobs/job-dsl/release_debezium_nightly_image.groovy
+++ b/jenkins-jobs/job-dsl/release_debezium_nightly_image.groovy
@@ -20,6 +20,9 @@ freeStyleJob('release-debezium-nightly-image') {
             noActivity(600)
         }
         credentialsBinding {
+            usernamePassword('DOCKER_USERNAME', 'DOCKER_PASSWORD', 'debezium-dockerhub')
+        }
+        credentialsBinding {
             string('QUAYIO_CREDENTIALS', 'debezium-quay')
         }
     }

--- a/jenkins-jobs/pipelines/build_debezium_images_pipeline.groovy
+++ b/jenkins-jobs/pipelines/build_debezium_images_pipeline.groovy
@@ -7,6 +7,7 @@ TAG_REST_ENDPOINT = "https://api.github.com/repos/${params.DEBEZIUM_REPOSITORY}/
 STREAMS_TO_BUILD_COUNT = params.STREAMS_TO_BUILD_COUNT.toInteger()
 TAGS_PER_STREAM_COUNT = params.TAGS_PER_STREAM_COUNT.toInteger()
 GIT_CREDENTIALS_ID = 'debezium-github'
+DOCKER_CREDENTIALS_ID = 'debezium-dockerhub'
 QUAYIO_CREDENTIALS_ID = 'debezium-quay'
 
 class Version implements Comparable {
@@ -152,6 +153,11 @@ node('Slave') {
             )
             withCredentials([usernamePassword(credentialsId: GIT_CREDENTIALS_ID, passwordVariable: 'GIT_PASSWORD', usernameVariable: 'GIT_USERNAME')]) {
                 initVersions(GIT_USERNAME, GIT_PASSWORD)
+            }
+            withCredentials([usernamePassword(credentialsId: DOCKER_CREDENTIALS_ID, passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USERNAME')]) {
+                sh """
+                    docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+                """
             }
             withCredentials([string(credentialsId: QUAYIO_CREDENTIALS_ID, variable: 'USERNAME_PASSWORD')]) {
                 def credentials = USERNAME_PASSWORD.split(':')

--- a/jenkins-jobs/pipelines/build_debezium_tool_images_pipeline.groovy
+++ b/jenkins-jobs/pipelines/build_debezium_tool_images_pipeline.groovy
@@ -3,6 +3,7 @@ import java.util.*
 
 IMAGES_DIR = 'images'
 GIT_CREDENTIALS_ID = 'debezium-github'
+DOCKER_CREDENTIALS_ID = 'debezium-dockerhub'
 QUAYIO_CREDENTIALS_ID = 'debezium-quay'
 
 node('Slave') {
@@ -19,6 +20,11 @@ node('Slave') {
                       userRemoteConfigs                : [[url: "https://$params.IMAGES_REPOSITORY", credentialsId: GIT_CREDENTIALS_ID]]
             ]
             )
+            withCredentials([usernamePassword(credentialsId: DOCKER_CREDENTIALS_ID, passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USERNAME')]) {
+                sh """
+                    docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+                """
+            }
             withCredentials([string(credentialsId: QUAYIO_CREDENTIALS_ID, variable: 'USERNAME_PASSWORD')]) {
                 def credentials = USERNAME_PASSWORD.split(':')
                 sh """

--- a/jenkins-jobs/pipelines/release-pipeline.groovy
+++ b/jenkins-jobs/pipelines/release-pipeline.groovy
@@ -553,7 +553,8 @@ node('Slave') {
             }
             dir(IMAGES_DIR) {
                 script {
-                    env.DEBEZIUM_DOCKER_REGISTRY_PRIMARY_NAME='localhost:5500/debezium'
+                    env.DEBEZIUM_DOCKER_REGISTRY_PRIMARY_NAME='localhost:5500/debeziumquay'
+                    env.DEBEZIUM_DOCKER_REGISTRY_SECONDARY_NAME='localhost:5500/debezium'
                 }
                 sh """
                     docker run --privileged --rm tonistiigi/binfmt --install all

--- a/jenkins-jobs/scripts/trigger-nightly-docker.sh
+++ b/jenkins-jobs/scripts/trigger-nightly-docker.sh
@@ -9,3 +9,5 @@ docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
 docker login -u ${QUAYIO_CREDENTIALS%:*} -p ${QUAYIO_CREDENTIALS#*:} quay.io
 docker build --build-arg DEBEZIUM_VERSION=$SNAPSHOT_VERSION -t quay.io/debezium/connect:nightly connect/snapshot
 docker push quay.io/debezium/connect:nightly
+docker tag quay.io/debezium/connect:nightly debezium/connect:nightly
+docker push debezium/connect:nightly

--- a/jenkins-jobs/scripts/trigger-nightly-docker.sh
+++ b/jenkins-jobs/scripts/trigger-nightly-docker.sh
@@ -5,6 +5,7 @@ DEBEZIUM_BRANCH=main
 
 SNAPSHOT_VERSION=$(curl -s https://raw.githubusercontent.com/$DEBEZIUM_REPOSITORY/$DEBEZIUM_BRANCH/pom.xml | grep -o '<version>.*-SNAPSHOT</version>' | awk -F '[<>]' '{print $3}')
 
+docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
 docker login -u ${QUAYIO_CREDENTIALS%:*} -p ${QUAYIO_CREDENTIALS#*:} quay.io
 docker build --build-arg DEBEZIUM_VERSION=$SNAPSHOT_VERSION -t quay.io/debezium/connect:nightly connect/snapshot
 docker push quay.io/debezium/connect:nightly


### PR DESCRIPTION
Partially revert commits which related to stop publishing images to Docker Hub:
* revert removing Docker credentials
* publish nightly images again on Docker Hub

https://issues.redhat.com/browse/DBZ-6216