### PR TITLE
DBZ-6265 skip the wal level check if no cdc is to occur

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
@@ -141,7 +141,7 @@ public class PostgresConnector extends RelationalBaseSourceConnector {
                     "SHOW wal_level",
                     connection.singleResultMapper(rs -> rs.getString("wal_level"), "Could not fetch wal_level"));
             if (!"logical".equals(walLevel)) {
-                throw new SQLException("Postgres server wal_level property must be \\\"logical\\\" but is: \" + walLevel");
+                throw new SQLException("Postgres server wal_level property must be 'logical' but is: '" + walLevel + "'");
             }
         }
         else {

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -265,6 +265,19 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     }
 
     @Test
+    public void shouldSkipWalLevelCheckIfNoCdc() throws Exception {
+        final LogInterceptor logInterceptor = new LogInterceptor(PostgresConnector.class);
+
+        Configuration config = TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_ONLY.getValue())
+                .build();
+        PostgresConnector connector = new PostgresConnector();
+        connector.validate(config.asMap());
+
+        assertThat(logInterceptor.containsMessage("Skipped WAL_LEVEL check as CDC was not requested")).isTrue();
+    }
+
+    @Test
     public void shouldSupportSSLParameters() throws Exception {
         // the default docker image we're testing against doesn't use SSL, so check that the connector fails to start when
         // SSL is enabled

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -274,7 +274,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         PostgresConnector connector = new PostgresConnector();
         connector.validate(config.asMap());
 
-        assertThat(logInterceptor.containsMessage("Skipped WAL_LEVEL check as CDC was not requested")).isTrue();
+        assertThat(logInterceptor.containsWarnMessage("Skipped WAL_LEVEL check as CDC was not requested")).isTrue();
     }
 
     @Test


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6265 
Refactored the Postgres connector class to extract the individual connection check methods, changed the WAL_LEVEL test to only run if the snapshot mode involves streaming.