### PR TITLE
DBZ-6267 2.1 correct Kafka YAML examples

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -10,7 +10,7 @@
 :connector-file: {context}
 :connector-class: MySql
 :connector-name: MySQL
-:include-list-example: inventory
+:include-list-example: inventory.*
 ifdef::community[]
 :toc:
 :toc-placement: macro

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mysql-sqlserver-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mysql-sqlserver-connector.adoc
@@ -69,8 +69,9 @@ For example, create the following `KafkaConnector` CR, and save it as `{context}
         database.port: {database-port}   // <6>
         database.user: debezium  // <7>
         database.password: dbz  // <8>
-        topic.prefix: inventory-connector-{context} // <9>
-        table.include.list: {include-list-example}  // <10>
+        database.server.id: 184054 // <9>
+        topic.prefix: inventory-connector-{context} // <10>
+        table.include.list: {include-list-example}  // <11>
 ----
 =====================================================================
 +
@@ -104,12 +105,15 @@ For example, create the following `KafkaConnector` CR, and save it as `{context}
 |The password that {prodname} uses to connect to the database user account.
 
 |9
+|Unique numeric ID of the connector.
+
+|10
 |The topic prefix for the database instance or cluster. +
 The specified name must be formed only from alphanumeric characters or underscores. +
 Because the topic prefix is used as the prefix for any Kafka topics that receive change events from this connector, the name must be unique among the connectors in the cluster. +
 This namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the xref:{link-avro-serialization}#avro-serialization[Avro connector].
 
-|10
+|11
 |The list of tables from which the connector captures change events.
 
 |===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mysql-sqlserver-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mysql-sqlserver-connector.adoc
@@ -51,73 +51,7 @@ For example, create the following `KafkaConnector` CR, and save it as `{context}
 +
 .`{context}-inventory-connector.yaml` file that defines the `KafkaConnector` custom resource for a {prodname} connector
 =====================================================================
-[source,yaml,subs="+attributes"]
-----
-    apiVersion: {KafkaConnectApiVersion}
-    kind: KafkaConnector
-    metadata:
-      labels:
-        strimzi.io/cluster: debezium-kafka-connect-cluster
-      name: inventory-connector-{context} // <1>
-    spec:
-      class: io.debezium.connector.{context}.{connector-class}Connector // <2>
-      tasksMax: 1  // <3>
-      config:  // <4>
-        schema.history.internal.kafka.bootstrap.servers: debezium-kafka-cluster-kafka-bootstrap.debezium.svc.cluster.local:9092
-        schema.history.internal.kafka.topic: schema-changes.inventory
-        database.hostname: {context}.debezium-{context}.svc.cluster.local // <5>
-        database.port: {database-port}   // <6>
-        database.user: debezium  // <7>
-        database.password: dbz  // <8>
-        database.server.id: 184054 // <9>
-        topic.prefix: inventory-connector-{context} // <10>
-        table.include.list: {include-list-example}  // <11>
-----
-=====================================================================
-+
-.Descriptions of connector configuration settings
-[cols="1,7",options="header",subs="+attributes"]
-|===
-|Item |Description
-
-|1
-|The name of the connector to register with the Kafka Connect cluster.
-
-|2
-|The name of the connector class.
-
-|3
-|The number of tasks that can operate concurrently.
-
-|4
-|The connector’s configuration.
-
-|5
-|The address of the host database instance.
-
-|6
-|The port number of the database instance.
-
-|7
-|The name of the account that {prodname} uses to connect to the database.
-
-|8
-|The password that {prodname} uses to connect to the database user account.
-
-|9
-|Unique numeric ID of the connector.
-
-|10
-|The topic prefix for the database instance or cluster. +
-The specified name must be formed only from alphanumeric characters or underscores. +
-Because the topic prefix is used as the prefix for any Kafka topics that receive change events from this connector, the name must be unique among the connectors in the cluster. +
-This namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the xref:{link-avro-serialization}#avro-serialization[Avro connector].
-
-|11
-|The list of tables from which the connector captures change events.
-
-|===
-
+include::../{partialsdir}/modules/all-connectors/ref-deploy-{context}-connector-yaml.adoc[]
 
 . Create the connector resource by running the following command:
 +

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-kafka-connect-yaml.adoc
@@ -17,7 +17,7 @@ metadata:
   annotations:
     strimzi.io/use-connector-resources: "true" // <1>
 spec:
-  version: 3.00
+  version: {debezium-kafka-version}
   build: // <2>
     output: // <3>
       type: imagestream  // <4>

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-mysql-connector-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-mysql-connector-yaml.adoc
@@ -1,0 +1,66 @@
+[source,yaml,subs="+attributes"]
+----
+    apiVersion: {KafkaConnectApiVersion}
+    kind: KafkaConnector
+    metadata:
+      labels:
+        strimzi.io/cluster: debezium-kafka-connect-cluster
+      name: inventory-connector-{context} // <1>
+    spec:
+      class: io.debezium.connector.{context}.{connector-class}Connector // <2>
+      tasksMax: 1  // <3>
+      config:  // <4>
+        schema.history.internal.kafka.bootstrap.servers: debezium-kafka-cluster-kafka-bootstrap.debezium.svc.cluster.local:9092
+        schema.history.internal.kafka.topic: schema-changes.inventory
+        database.hostname: {context}.debezium-{context}.svc.cluster.local // <5>
+        database.port: {database-port}   // <6>
+        database.user: debezium  // <7>
+        database.password: dbz  // <8>
+        database.server.id: 184054 // <9>
+        topic.prefix: inventory-connector-{context} // <10>
+        table.include.list: {include-list-example}  // <11>
+----
+=====================================================================
++
+.Descriptions of connector configuration settings
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|The name of the connector to register with the Kafka Connect cluster.
+
+|2
+|The name of the connector class.
+
+|3
+|The number of tasks that can operate concurrently.
+
+|4
+|The connector’s configuration.
+
+|5
+|The address of the host database instance.
+
+|6
+|The port number of the database instance.
+
+|7
+|The name of the account that {prodname} uses to connect to the database.
+
+|8
+|The password that {prodname} uses to connect to the database user account.
+
+|9
+|Unique numeric ID of the connector.
+
+|10
+|The topic prefix for the database instance or cluster. +
+The specified name must be formed only from alphanumeric characters or underscores. +
+Because the topic prefix is used as the prefix for any Kafka topics that receive change events from this connector, the name must be unique among the connectors in the cluster. +
+This namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the xref:{link-avro-serialization}#avro-serialization[Avro connector].
+
+|11
+|The list of tables from which the connector captures change events.
+
+|===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-oracle-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-oracle-kafka-connect-yaml.adoc
@@ -17,7 +17,7 @@ metadata:
   annotations:
     strimzi.io/use-connector-resources: "true" // <1>
 spec:
-  version: 3.00
+  version: {debezium-kafka-version}
   build: // <2>
     output: // <3>
       type: imagestream  // <4>

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-sqlserver-connector-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-sqlserver-connector-yaml.adoc
@@ -1,0 +1,62 @@
+[source,yaml,subs="+attributes"]
+----
+    apiVersion: {KafkaConnectApiVersion}
+    kind: KafkaConnector
+    metadata:
+      labels:
+        strimzi.io/cluster: debezium-kafka-connect-cluster
+      name: inventory-connector-{context} // <1>
+    spec:
+      class: io.debezium.connector.{context}.{connector-class}Connector // <2>
+      tasksMax: 1  // <3>
+      config:  // <4>
+        schema.history.internal.kafka.bootstrap.servers: debezium-kafka-cluster-kafka-bootstrap.debezium.svc.cluster.local:9092
+        schema.history.internal.kafka.topic: schema-changes.inventory
+        database.hostname: {context}.debezium-{context}.svc.cluster.local // <5>
+        database.port: {database-port}   // <6>
+        database.user: debezium  // <7>
+        database.password: dbz  // <8>
+        topic.prefix: inventory-connector-{context} // <9>
+        table.include.list: {include-list-example}  // <10>
+----
+=====================================================================
++
+.Descriptions of connector configuration settings
+[cols="1,7",options="header",subs="+attributes"]
+|===
+|Item |Description
+
+|1
+|The name of the connector to register with the Kafka Connect cluster.
+
+|2
+|The name of the connector class.
+
+|3
+|The number of tasks that can operate concurrently.
+
+|4
+|The connector’s configuration.
+
+|5
+|The address of the host database instance.
+
+|6
+|The port number of the database instance.
+
+|7
+|The name of the account that {prodname} uses to connect to the database.
+
+|8
+|The password that {prodname} uses to connect to the database user account.
+
+|9
+|The topic prefix for the database instance or cluster. +
+The specified name must be formed only from alphanumeric characters or underscores. +
+Because the topic prefix is used as the prefix for any Kafka topics that receive change events from this connector, the name must be unique among the connectors in the cluster. +
+This namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the xref:{link-avro-serialization}#avro-serialization[Avro connector].
+
+|10
+|The list of tables from which the connector captures change events.
+
+|===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-deploy-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-deploy-kafka-connect-yaml.adoc
@@ -16,7 +16,7 @@ metadata:
   annotations:
     strimzi.io/use-connector-resources: "true" // <1>
 spec:
-  version: 3.00
+  version: {debezium-kafka-version}
   build: // <2>
     output: // <3>
       type: imagestream  // <4>


### PR DESCRIPTION
[DBZ-6267](https://issues.redhat.com/browse/DBZ-6267)

Cherry-pick of PR #4416 into 2.1 to correct errors in YAML examples.
This content is rendered in the downstream documenation build only.