### PR TITLE
DBZ-6271 allow binlog to be absent when doing a snapshot only

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
@@ -289,7 +289,7 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
                 }
             }
             else if (!connectorConfig.getSnapshotMode().shouldStream()) {
-                LOGGER.info("Failed retrieving binlog position, continuing as streaming CDC wasn't requested");
+                LOGGER.warn("Failed retrieving binlog position, continuing as streaming CDC wasn't requested");
             }
             else {
                 throw new DebeziumException("Cannot read the binlog filename and position via '" + showMasterStmt


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6271
If we're in the initial_only mode of the snapshotter and don't require streaming CDC, we don't need the bin log position to be retrieved and can safely skip it and start the snapshot from scratch.