### PR TITLE
DBZ-6327 Refactor incr. snapshot files (cherry-pick 34cfb36 from main)

### DIFF
--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -159,13 +159,13 @@ The {prodname} connector for Db2 does not support schema changes while an increm
 [id="db2-triggering-an-incremental-snapshot"]
 ==== Triggering an incremental snapshot
 
-include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot.adoc[leveloffset=+3,tags=!nosql-based-snapshot]
+include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+3]
 
 // Type: procedure
 [id="db2-stopping-an-incremental-snapshot"]
 ==== Stopping an incremental snapshot
 
-include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot.adoc[leveloffset=+3,tags=!nosql-based-snapshot]
+include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc[leveloffset=+3]
 
 // Type: concept
 // Title: How {prodname} Db2 connectors read change-data tables

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -260,13 +260,13 @@ endif::community[]
 [id="mongodb-triggering-an-incremental-snapshot"]
 ==== Triggering an incremental snapshot
 
-include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot.adoc[leveloffset=+3,tags=!sql-based-snapshot]
+include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-nosql.adoc[leveloffset=+3]
 
 // Type: procedure
 [id="mongodb-stopping-an-incremental-snapshot"]
 ==== Stopping an incremental snapshot
 
-include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot.adoc[leveloffset=+3,tags=!sql-based-snapshot]
+include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot-nosql.adoc[leveloffset=+3]
 
 // Type: concept
 // ModuleID: how-the-debezium-mongodb-connector-streams-change-event-records

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -473,13 +473,13 @@ include::{partialsdir}/modules/all-connectors/con-connector-incremental-snapshot
 [id="mysql-triggering-an-incremental-snapshot"]
 ==== Triggering an incremental snapshot
 
-include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot.adoc[leveloffset=+3,tags=!nosql-based-snapshot]
+include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+3]
 
 // Type: procedure
 [id="mysql-stopping-an-incremental-snapshot"]
 ==== Stopping an incremental snapshot
 
-include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot.adoc[leveloffset=+3,tags=!nosql-based-snapshot]
+include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc[leveloffset=+3]
 
 ifdef::community[]
 [id="mysql-read-only-incremental-snapshots"]
@@ -3256,7 +3256,7 @@ The {prodname} MySQL connector also provides the `HoldingGlobalLock` custom snap
 [[mysql-streaming-metrics]]
 === Streaming metrics
 
-Transaction-related attributes are available only if binlog event buffering is enabled. 
+Transaction-related attributes are available only if binlog event buffering is enabled.
 ifdef::community[]
 See xref:{link-mysql-connector}#mysql-property-binlog-buffer-size[`binlog.buffer.size`] in the advanced connector configuration properties for more details.
 endif::community[]

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -152,13 +152,13 @@ The {prodname} connector for Oracle does not support schema changes while an inc
 [id="oracle-triggering-an-incremental-snapshot"]
 ==== Triggering an incremental snapshot
 
-include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot.adoc[leveloffset=+3,tags=!nosql-based-snapshot]
+include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+3]
 
 // Type: procedure
 [id="oracle-stopping-an-incremental-snapshot"]
 ==== Stopping an incremental snapshot
 
-include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot.adoc[leveloffset=+3,tags=!nosql-based-snapshot]
+include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc[leveloffset=+3]
 
 // Type: concept
 // ModuleID: default-names-of-kafka-topics-that-receive-debezium-oracle-change-event-records

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -191,13 +191,13 @@ If a schema change is performed _before_ the incremental snapshot start but _aft
 [id="postgresql-triggering-an-incremental-snapshot"]
 ==== Triggering an incremental snapshot
 
-include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot.adoc[leveloffset=+3,tags=!nosql-based-snapshot]
+include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+3]
 
 // Type: procedure
 [id="postgresql-stopping-an-incremental-snapshot"]
 ==== Stopping an incremental snapshot
 
-include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot.adoc[leveloffset=+3,tags=!nosql-based-snapshot]
+include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc[leveloffset=+3]
 
 ifdef::community[]
 [[postgresql-custom-snapshot]]

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -164,13 +164,13 @@ The {prodname} connector for SQL Server does not support schema changes while an
 [id="sqlserver-triggering-an-incremental-snapshot"]
 ==== Triggering an incremental snapshot
 
-include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot.adoc[leveloffset=+3,tags=!nosql-based-snapshot]
+include::{partialsdir}/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc[leveloffset=+3]
 
 // Type: procedure
 [id="sqlserver-stopping-an-incremental-snapshot"]
 ==== Stopping an incremental snapshot
 
-include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot.adoc[leveloffset=+3,tags=!nosql-based-snapshot]
+include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc[leveloffset=+3]
 
 // Type: concept
 // ModuleID: how-the-debezium-sql-server-connector-reads-change-data-tables

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-nosql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-nosql.adoc
@@ -1,0 +1,69 @@
+You can also stop an incremental snapshot by sending a signal to the {data-collection} on the source database.
+You submit a stop snapshot signal by inserting a document into the to the signaling {data-collection}.
+After {prodname} detects the change in the signaling {data-collection}, it reads the signal, and stops the incremental snapshot operation if it's in progress.
+
+The query that you submit specifies the snapshot operation of `incremental`, and, optionally, the {data-collection}s of the current running snapshot to be removed.
+
+.Prerequisites
+
+* xref:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled]. +
+** A signaling data collection exists on the source database.
+** The signaling data collection is specified in the xref:{context}-property-signal-data-collection[`signal.data.collection`] property.
+
+.Procedure
+
+. Insert a stop snapshot signal document into the signaling {data-collection}:
++
+[source,bash,indent=0,subs="+attributes,+quotes"]
+----
+_<signalDataCollection>_.insert({"_id" : _<idNumber>_,"type" : "stop-snapshot", "data" : {"data-collections" ["_<collectionName>_", "_<collectionName>_"],"type": "incremental"}});
+----
++
+For example,
++
+[source,bash,indent=0,subs="+attributes"]
+----
+db.debeziumSignal.insert({ // <1>
+"type" : "stop-snapshot", // <2> <3>
+"data" : {
+"data-collections" ["\"public\".\"Collection1\"", "\"public\".\"Collection2\""], // <4>
+"type": "incremental"} // <5>
+});
+----
++
+The values of the `id`, `type`, and `data` parameters in the signal command correspond to the xref:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
++
+The following table describes the parameters in the example:
++
+.Descriptions of fields in an insert command for sending a stop incremental snapshot document to the signaling {data-collection}
+[cols="1,2,6",options="header"]
+|===
+|Item|Value |Description
+
+|1
+|`db.debeziumSignal`
+|Specifies the fully-qualified name of the signaling {data-collection} on the source database.
+
+|2
+|null
+|The insert method in the preceding example omits use of the optional `_id` parameter.
+Because the document does not explicitly assign a value for the parameter, the arbitrary id that MongoDB automatically assigns to the document becomes the `id` identifier for the signal request. +
+Use this string to identify logging messages to entries in the signaling {data-collection}.
+{prodname} does not use this identifier string.
+
+|3
+|`stop-snapshot`
+| The `type` parameter specifies the operation that the signal is intended to trigger. +
+
+|4
+|`data-collections`
+|An optional component of the `data` field of a signal that specifies an array of {data-collection} names or regular expressions to match {data-collection} names to remove from the snapshot. +
+The array lists regular expressions which match {data-collection}s by their fully-qualified names, using the same format as you use to specify the name of the connector's signaling {data-collection} in the xref:{context}-property-signal-data-collection[`signal.data.collection`] configuration property.
+If this component of the `data` field is omitted, the signal stops the entire incremental snapshot that is in progress.
+
+|5
+|`incremental`
+|A required component of the `data` field of a signal that specifies the kind of snapshot operation that is to be stopped. +
+Currently, the only valid option is `incremental`. +
+If you do not specify a `type` value, the signal fails to stop the incremental snapshot.
+|===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-nosql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-nosql.adoc
@@ -6,7 +6,7 @@ The query that you submit specifies the snapshot operation of `incremental`, and
 
 .Prerequisites
 
-* xref:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled]. +
+* {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled]. +
 ** A signaling data collection exists on the source database.
 ** The signaling data collection is specified in the xref:{context}-property-signal-data-collection[`signal.data.collection`] property.
 
@@ -31,7 +31,7 @@ db.debeziumSignal.insert({ // <1>
 });
 ----
 +
-The values of the `id`, `type`, and `data` parameters in the signal command correspond to the xref:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
+The values of the `id`, `type`, and `data` parameters in the signal command correspond to the {link-prefix}:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
 +
 The following table describes the parameters in the example:
 +

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc
@@ -1,0 +1,68 @@
+You can also stop an incremental snapshot by sending a signal to the {data-collection} on the source database.
+You submit a stop snapshot signal to the {data-collection} by sending a SQL `INSERT` query.
+
+After {prodname} detects the change in the signaling {data-collection}, it reads the signal, and stops the incremental snapshot operation if it's in progress.
+
+The query that you submit specifies the snapshot operation of `incremental`, and, optionally, the {data-collection}s of the current running snapshot to be removed.
+
+.Prerequisites
+
+* xref:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled]. +
+** A signaling data collection exists on the source database.
+** The signaling data collection is specified in the xref:{context}-property-signal-data-collection[`signal.data.collection`] property.
+
+.Procedure
+
+. Send a SQL query to stop the ad hoc incremental snapshot to the signaling {data-collection}:
++
+[source,sql,indent=0,subs="+attributes,+quotes"]
+----
+INSERT INTO _<signalTable>_ (id, type, data) values (_'<id>'_, 'stop-snapshot', '{"data-collections": ["_<tableName>_","_<tableName>_"],"type":"incremental"}');
+----
++
+For example,
++
+[source,sql,indent=0,subs="+attributes"]
+----
+INSERT INTO myschema.debezium_signal (id, type, data) // <1>
+values ('ad-hoc-1',   // <2>
+    'stop-snapshot',  // <3>
+    '{"data-collections": ["schema1.table1", "schema2.table2"], // <4>
+    "type":"incremental"}'); // <5>
+----
++
+The values of the `id`, `type`, and `data` parameters in the signal command correspond to the xref:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
++
+The following table describes the parameters in the example:
++
+.Descriptions of fields in a SQL command for sending a stop incremental snapshot signal to the signaling {data-collection}
+[cols="1,2,6",options="header"]
+|===
+|Item|Value |Description
+
+|1
+|`myschema.debezium_signal`
+|Specifies the fully-qualified name of the signaling {data-collection} on the source database.
+
+|2
+|`ad-hoc-1`
+| The `id` parameter specifies an arbitrary string that is assigned as the `id` identifier for the signal request. +
+Use this string to identify logging messages to entries in the signaling {data-collection}.
+{prodname} does not use this string.
+
+|3
+|`stop-snapshot`
+| Specifies `type` parameter specifies the operation that the signal is intended to trigger. +
+
+|4
+|`data-collections`
+|An optional component of the `data` field of a signal that specifies an array of {data-collection} names or regular expressions to match {data-collection} names to remove from the snapshot. +
+The array lists regular expressions which match {data-collection}s by their fully-qualified names, using the same format as you use to specify the name of the connector's signaling {data-collection} in the xref:{context}-property-signal-data-collection[`signal.data.collection`] configuration property.
+If this component of the `data` field is omitted, the signal stops the entire incremental snapshot that is in progress.
+
+|5
+|`incremental`
+|A required component of the `data` field of a signal that specifies the kind of snapshot operation that is to be stopped. +
+Currently, the only valid option is `incremental`. +
+If you do not specify a `type` value, the signal fails to stop the incremental snapshot.
+|===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-nosql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-nosql.adoc
@@ -1,4 +1,4 @@
-Currently, the only way to initiate an incremental snapshot is to send an xref:{link-signalling}#debezium-signaling-ad-hoc-snapshots[ad hoc snapshot signal] to the signaling {data-collection} on the source database.
+Currently, the only way to initiate an incremental snapshot is to send an {link-prefix}:{link-signalling}#debezium-signaling-ad-hoc-snapshots[ad hoc snapshot signal] to the signaling {data-collection} on the source database.
 
 You submit a signal to the signaling {data-collection} by using the MongoDB `insert()` method.
 
@@ -22,7 +22,7 @@ For example, to include a data collection that exists in the `*public*` database
 
 .Prerequisites
 
-* xref:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled]. +
+* {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled]. +
 ** A signaling data collection exists on the source database.
 ** The signaling data collection is specified in the xref:{context}-property-signal-data-collection[`signal.data.collection`] property.
 
@@ -47,7 +47,7 @@ db.debeziumSignal.insert({ // <1>
 });
 ----
 +
-The values of the `id`,`type`, and `data` parameters in the command correspond to the xref:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
+The values of the `id`,`type`, and `data` parameters in the command correspond to the {link-prefix}:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
 +
 The following table describes the parameters in the example:
 +

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-nosql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-nosql.adoc
@@ -1,0 +1,123 @@
+Currently, the only way to initiate an incremental snapshot is to send an xref:{link-signalling}#debezium-signaling-ad-hoc-snapshots[ad hoc snapshot signal] to the signaling {data-collection} on the source database.
+
+You submit a signal to the signaling {data-collection} by using the MongoDB `insert()` method.
+
+After {prodname} detects the change in the signaling {data-collection}, it reads the signal, and runs the requested snapshot operation.
+
+The query that you submit specifies the {data-collection}s to include in the snapshot, and, optionally, specifies the kind of snapshot operation.
+Currently, the only valid option for snapshots operations is the default value, `incremental`.
+
+To specify the {data-collection}s to include in the snapshot, provide a `data-collections` array that lists the {data-collection}s or an array of regular expressions used to match {data-collection}s, for example, +
+`{"data-collections": ["public.Collection1", "public.Collection2"]}` +
+
+The `data-collections` array for an incremental snapshot signal has no default value.
+If the `data-collections` array is empty, {prodname} detects that no action is required and does not perform a snapshot.
+
+[NOTE]
+====
+If the name of a {data-collection} that you want to include in a snapshot contains a dot (`.`) in the name of the database, schema, or table, to add the {data-collection} to the `data-collections` array, you must escape each part of the name in double quotes. +
+ +
+For example, to include a data collection that exists in the `*public*` database, and that has the name `*MyCollection*`, use the following format: `*"public"."MyCollection"*`.
+====
+
+.Prerequisites
+
+* xref:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled]. +
+** A signaling data collection exists on the source database.
+** The signaling data collection is specified in the xref:{context}-property-signal-data-collection[`signal.data.collection`] property.
+
+.Procedure
+
+. Insert a snapshot signal document into the signaling {data-collection}:
++
+[source,bash,indent=0,subs="+attributes,+quotes"]
+----
+_<signalDataCollection>_.insert({"_id" : _<idNumber>_,"type" : _<snapshotType>_, "data" : {"data-collections" ["_<collectionName>_", "_<collectionName>_"],"type": _<snapshotType>_}});
+----
++
+For example,
++
+[source,bash,indent=0,subs="+attributes,+quotes"]
+----
+db.debeziumSignal.insert({ // <1>
+"type" : "execute-snapshot", // <2> <3>
+"data" : {
+"data-collections" ["\"public\".\"Collection1\"", "\"public\".\"Collection2\""], // <4>
+"type": "incremental"} // <5>
+});
+----
++
+The values of the `id`,`type`, and `data` parameters in the command correspond to the xref:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
++
+The following table describes the parameters in the example:
++
+.Descriptions of fields in a MongoDB insert() command for sending an incremental snapshot signal to the signaling {data-collection}
+[cols="1,2,6",options="header"]
+|===
+|Item |Value |Description
+
+|1
+|`db.debeziumSignal`
+|Specifies the fully-qualified name of the signaling {data-collection} on the source database.
+
+|2
+|null
+|The `_id` parameter specifies an arbitrary string that is assigned as the `id` identifier for the signal request. +
+The insert method in the preceding example omits use of the optional `_id` parameter.
+Because the document does not explicitly assign a value for the parameter, the arbitrary id that MongoDB automatically assigns to the document becomes the `id` identifier for the signal request. +
+Use this string to identify logging messages to entries in the signaling {data-collection}.
+{prodname} does not use this identifier string.
+Rather, during the snapshot, {prodname} generates its own `id` string as a watermarking signal.
+
+|3
+|`execute-snapshot`
+|Specifies `type` parameter specifies the operation that the signal is intended to trigger. +
+
+|4
+|`data-collections`
+|A required component of the `data` field of a signal that specifies an array of {data-collection} names or regular expressions to match {data-collection} names to include in the snapshot. +
+The array lists regular expressions which match {data-collection}s by their fully-qualified names, using the same format as you use to specify the name of the connector's signaling {data-collection} in the xref:{context}-property-signal-data-collection[`signal.data.collection`] configuration property.
+
+|5
+|`incremental`
+|An optional `type` component of the `data` field of a signal that specifies the kind of snapshot operation to run. +
+Currently, the only valid option is the default value, `incremental`. +
+If you do not specify a value, the connector runs an incremental snapshot.
+|===
+
+The following example, shows the JSON for an incremental snapshot event that is captured by a connector.
+
+.Example: Incremental snapshot event message
+[source,json,index=0]
+----
+{
+    "before":null,
+    "after": {
+        "pk":"1",
+        "value":"New data"
+    },
+    "source": {
+        ...
+        "snapshot":"incremental" <1>
+    },
+    "op":"r", <2>
+    "ts_ms":"1620393591654",
+    "transaction":null
+}
+----
+[cols="1,1,4",options="header"]
+|===
+|Item |Field name |Description
+|1
+|`snapshot`
+|Specifies the type of snapshot operation to run. +
+Currently, the only valid option is the default value, `incremental`. +
+Specifying a `type` value in the SQL query that you submit to the signaling {data-collection} is optional. +
+If you do not specify a value, the connector runs an incremental snapshot.
+
+|2
+|`op`
+|Specifies the event type. +
+The value for snapshot events is `r`, signifying a `READ` operation.
+
+|===

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc
@@ -1,4 +1,4 @@
-Currently, the only way to initiate an incremental snapshot is to send an xref:{link-signalling}#debezium-signaling-ad-hoc-snapshots[ad hoc snapshot signal] to the signaling {data-collection} on the source database.
+Currently, the only way to initiate an incremental snapshot is to send an {link-prefix}:{link-signalling}#debezium-signaling-ad-hoc-snapshots[ad hoc snapshot signal] to the signaling {data-collection} on the source database.
 
 You submit a signal to the signaling {data-collection} as SQL `INSERT` queries.
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot-sql.adoc
@@ -1,0 +1,174 @@
+Currently, the only way to initiate an incremental snapshot is to send an xref:{link-signalling}#debezium-signaling-ad-hoc-snapshots[ad hoc snapshot signal] to the signaling {data-collection} on the source database.
+
+You submit a signal to the signaling {data-collection} as SQL `INSERT` queries.
+
+After {prodname} detects the change in the signaling {data-collection}, it reads the signal, and runs the requested snapshot operation.
+
+The query that you submit specifies the {data-collection}s to include in the snapshot, and, optionally, specifies the kind of snapshot operation.
+Currently, the only valid option for snapshots operations is the default value, `incremental`.
+
+To specify the {data-collection}s to include in the snapshot, provide a `data-collections` array that lists the {data-collection}s or an array of regular expressions used to match {data-collection}s, for example, +
+
+`{"data-collections": ["public.MyFirstTable", "public.MySecondTable"]}` +
+
+The `data-collections` array for an incremental snapshot signal has no default value.
+If the `data-collections` array is empty, {prodname} detects that no action is required and does not perform a snapshot.
+
+[NOTE]
+====
+If the name of a {data-collection} that you want to include in a snapshot contains a dot (`.`) in the name of the database, schema, or table, to add the {data-collection} to the `data-collections` array, you must escape each part of the name in double quotes. +
+ +
+For example, to include a table that exists in the `*public*` schema and that has the name `*My.Table*`, use the following format: `*"public"."My.Table"*`.
+====
+
+.Prerequisites
+
+* xref:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled]. +
+** A signaling data collection exists on the source database.
+** The signaling data collection is specified in the xref:{context}-property-signal-data-collection[`signal.data.collection`] property.
+
+.Procedure
+
+. Send a SQL query to add the ad hoc incremental snapshot request to the signaling {data-collection}:
++
+[source,sql,indent=0,subs="+attributes,+quotes"]
+----
+INSERT INTO _<signalTable>_ (id, type, data) VALUES (_'<id>'_, _'<snapshotType>'_, '{"data-collections": ["_<tableName>_","_<tableName>_"],"type":"_<snapshotType>_","additional-condition":"_<additional-condition>_"}');
+----
++
+For example,
++
+[source,sql,indent=0,subs="+attributes"]
+----
+INSERT INTO myschema.debezium_signal (id, type, data) // <1>
+values ('ad-hoc-1',   // <2>
+    'execute-snapshot',  // <3>
+    '{"data-collections": ["schema1.table1", "schema2.table2"], // <4>
+    "type":"incremental"}, // <5>
+    "additional-condition":"color=blue"}'); // <6>
+----
++
+The values of the `id`,`type`, and `data` parameters in the command correspond to the xref:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
++
+The following table describes the parameters in the example:
++
+.Descriptions of fields in a SQL command for sending an incremental snapshot signal to the signaling {data-collection}
+[cols="1,2,6",options="header"]
+|===
+|Item |Value |Description
+
+|1
+|`myschema.debezium_signal`
+|Specifies the fully-qualified name of the signaling {data-collection} on the source database.
+
+|2
+|`ad-hoc-1`
+|The `id` parameter specifies an arbitrary string that is assigned as the `id` identifier for the signal request. +
+Use this string to identify logging messages to entries in the signaling {data-collection}.
+{prodname} does not use this string.
+Rather, during the snapshot, {prodname} generates its own `id` string as a watermarking signal.
+
+|3
+|`execute-snapshot`
+|The `type` parameter specifies the operation that the signal is intended to trigger. +
+
+|4
+|`data-collections`
+|A required component of the `data` field of a signal that specifies an array of {data-collection} names or regular expressions to match {data-collection} names to include in the snapshot. +
+The array lists regular expressions which match {data-collection}s by their fully-qualified names, using the same format as you use to specify the name of the connector's signaling {data-collection} in the xref:{context}-property-signal-data-collection[`signal.data.collection`] configuration property.
+
+|5
+|`incremental`
+|An optional `type` component of the `data` field of a signal that specifies the kind of snapshot operation to run. +
+Currently, the only valid option is the default value, `incremental`. +
+If you do not specify a value, the connector runs an incremental snapshot.
+
+|6
+|`additional-condition`
+|An optional string, which specifies a condition based on the column(s) of the {data-collection}(s), to capture a
+subset of the contents of the {data-collection}s.
+For more information about the `additional-condition` parameter, see xref:{context}-incremental-snapshots-additional-condition[].
+|===
+
+[id="{context}-incremental-snapshots-additional-condition"]
+.Ad hoc incremental snapshots with `additional-condition`
+
+If you want a snapshot to include only a subset of the content in a {data-collection}, you can modify the signal request by appending an `additional-condition` parameter to the snapshot signal.
+
+The SQL query for a typical snapshot takes the following form:
+
+[source,sql,subs="+attributes,+quotes"]
+----
+SELECT * FROM _<tableName>_ ....
+----
+
+By adding an `additional-condition` parameter, you append a `WHERE` condition to the SQL query, as in the following example:
+
+[source,sql,subs="+attributes,+quotes"]
+----
+SELECT * FROM _<tableName>_ WHERE _<additional-condition>_ ....
+----
+
+The following example shows a SQL query to send an ad hoc incremental snapshot request with an additional condition to the signaling {data-collection}:
+[source,sql,indent=0,subs="+attributes,+quotes"]
+----
+INSERT INTO _<signalTable>_ (id, type, data) VALUES (_'<id>'_, _'<snapshotType>'_, '{"data-collections": ["_<tableName>_","_<tableName>_"],"type":"_<snapshotType>_","additional-condition":"_<additional-condition>_"}');
+----
+
+For example, suppose you have a `products` {data-collection} that contains the following columns:
+
+* `id` (primary key)
+* `color`
+* `quantity`
+
+If you want an incremental snapshot of the `products` {data-collection} to include only the data items where `color=blue`, you can use the following SQL statement to trigger the snapshot:
+
+[source,sql,indent=0,subs="+attributes"]
+----
+INSERT INTO myschema.debezium_signal (id, type, data) VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.products"],"type":"incremental", "additional-condition":"color=blue"}');
+----
+
+The `additional-condition` parameter also enables you to pass conditions that are based on more than on column.
+For example, using the `products` {data-collection} from the previous example, you can submit a query that triggers an incremental snapshot that includes the data of only those items for which `color=blue` and `quantity>10`:
+
+[source,sql,indent=0,subs="+attributes"]
+----
+INSERT INTO myschema.debezium_signal (id, type, data) VALUES('ad-hoc-1', 'execute-snapshot', '{"data-collections": ["schema1.products"],"type":"incremental", "additional-condition":"color=blue AND quantity>10"}');
+----
+
+The following example, shows the JSON for an incremental snapshot event that is captured by a connector.
+
+.Example: Incremental snapshot event message
+[source,json,index=0]
+----
+{
+    "before":null,
+    "after": {
+        "pk":"1",
+        "value":"New data"
+    },
+    "source": {
+        ...
+        "snapshot":"incremental" <1>
+    },
+    "op":"r", <2>
+    "ts_ms":"1620393591654",
+    "transaction":null
+}
+----
+[cols="1,1,4",options="header"]
+|===
+|Item |Field name |Description
+|1
+|`snapshot`
+|Specifies the type of snapshot operation to run. +
+Currently, the only valid option is the default value, `incremental`. +
+Specifying a `type` value in the SQL query that you submit to the signaling {data-collection} is optional. +
+If you do not specify a value, the connector runs an incremental snapshot.
+
+|2
+|`op`
+|Specifies the event type. +
+The value for snapshot events is `r`, signifying a `READ` operation.
+
+|===


### PR DESCRIPTION
[DBZ-6327](https://issues.redhat.com/browse/DBZ-6327)

2.1 version of #4446 to separate the topics for triggering and stopping incremental snapshots into separate files for the SQL-based and MongoDB connectors.

Tested in local Antora and downstream builds.
 