### PR TITLE
DBZ-6265 always check the WAL_LEVEL but fail if streaming is required

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnector.java
@@ -135,17 +135,17 @@ public class PostgresConnector extends RelationalBaseSourceConnector {
     }
 
     private static void checkWalLevel(PostgresConnection connection, PostgresConnectorConfig config) throws SQLException {
-        // Logical WAL_LEVEL is only necessary for CDC snapshotting
-        if (config.getSnapshotter() != null && config.getSnapshotter().shouldStream()) {
-            final String walLevel = connection.queryAndMap(
-                    "SHOW wal_level",
-                    connection.singleResultMapper(rs -> rs.getString("wal_level"), "Could not fetch wal_level"));
-            if (!"logical".equals(walLevel)) {
+        final String walLevel = connection.queryAndMap(
+                "SHOW wal_level",
+                connection.singleResultMapper(rs -> rs.getString("wal_level"), "Could not fetch wal_level"));
+        if (!"logical".equals(walLevel)) {
+            if (config.getSnapshotter() != null && config.getSnapshotter().shouldStream()) {
+                // Logical WAL_LEVEL is only necessary for CDC snapshotting
                 throw new SQLException("Postgres server wal_level property must be 'logical' but is: '" + walLevel + "'");
             }
-        }
-        else {
-            LOGGER.warn("Skipped WAL_LEVEL check as CDC was not requested");
+            else {
+                LOGGER.warn("WAL_LEVEL check failed but this is ignored as CDC was not requested");
+            }
         }
     }
 

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -265,19 +265,6 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
     }
 
     @Test
-    public void shouldSkipWalLevelCheckIfNoCdc() throws Exception {
-        final LogInterceptor logInterceptor = new LogInterceptor(PostgresConnector.class);
-
-        Configuration config = TestHelper.defaultConfig()
-                .with(PostgresConnectorConfig.SNAPSHOT_MODE, SnapshotMode.INITIAL_ONLY.getValue())
-                .build();
-        PostgresConnector connector = new PostgresConnector();
-        connector.validate(config.asMap());
-
-        assertThat(logInterceptor.containsWarnMessage("Skipped WAL_LEVEL check as CDC was not requested")).isTrue();
-    }
-
-    @Test
     public void shouldSupportSSLParameters() throws Exception {
         // the default docker image we're testing against doesn't use SSL, so check that the connector fails to start when
         // SSL is enabled


### PR DESCRIPTION
This is to address this comment: https://github.com/debezium/debezium/pull/4425#issuecomment-1501691602
This means that the WAL_LEVEL check always happens and an appropriate warning message will be given if it's not configured properly but the connector can function without it (initial_only mode).

Note: [Oracle](https://github.com/debezium/debezium/pull/4425/files) and MySQL have the desired behaviour already.