### PR TITLE
DBZ-6330 Address review feedback and fix links

### DIFF
--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -229,14 +229,14 @@ For more information about ad hoc snapshots, see the _Snapshots_ topic in the do
 
 .Additional resources
 
-* xref:{link-db2-connector}#db2-ad-hoc-snapshots[Db2 connector ad hoc snapshots]
+* {link-prefix}:{link-db2-connector}#db2-ad-hoc-snapshots[Db2 connector ad hoc snapshots]
 ifdef::community[]
-* xref:{link-mongodb-connector}#mongodb-ad-hoc-snapshots[MongoDB connector ad hoc snapshots]
+* {link-prefix}:{link-mongodb-connector}#mongodb-ad-hoc-snapshots[MongoDB connector ad hoc snapshots]
 endif::community[]
-* xref:{link-mysql-connector}#mysql-ad-hoc-snapshots[MySQL connector ad hoc snapshots]
-* xref:{link-oracle-connector}#oracle-ad-hoc-snapshots[Oracle connector ad hoc snapshots]
-* xref:{link-postgresql-connector}#postgresql-ad-hoc-snapshots[PostgreSQL connector ad hoc snapshots]
-* xref:{link-sqlserver-connector}#sqlserver-ad-hoc-snapshots[SQL Server connector ad hoc snapshots]
+* {link-prefix}:{link-mysql-connector}#mysql-ad-hoc-snapshots[MySQL connector ad hoc snapshots]
+* {link-prefix}:{link-oracle-connector}#oracle-ad-hoc-snapshots[Oracle connector ad hoc snapshots]
+* {link-prefix}:{link-postgresql-connector}#postgresql-ad-hoc-snapshots[PostgreSQL connector ad hoc snapshots]
+* {link-prefix}:{link-sqlserver-connector}#sqlserver-ad-hoc-snapshots[SQL Server connector ad hoc snapshots]
 
 [id="debezium-signaling-stop-ad-hoc-snapshots"]
 === Ad hoc snapshot stop signals
@@ -366,11 +366,11 @@ For more information about incremental snapshots, see the _Snapshots_ topic in t
 
 .Additional resources
 
-* xref:{link-db2-connector}#db2-incremental-snapshots[Db2 connector incremental snapshots]
+* {link-prefix}:{link-db2-connector}#db2-incremental-snapshots[Db2 connector incremental snapshots]
 ifdef::community[]
-* xref:{link-mongodb-connector}#mongodb-incremental-snapshots[MongoDB connector incremental snapshots]
+* {link-prefix}:{link-mongodb-connector}#mongodb-incremental-snapshots[MongoDB connector incremental snapshots]
 endif::community[]
-* xref:{link-mysql-connector}#mysql-incremental-snapshots[MySQL connector incremental snapshots]
-* xref:{link-oracle-connector}#oracle-incremental-snapshots[Oracle connector incremental snapshots]
-* xref:{link-postgresql-connector}#postgresql-incremental-snapshots[PostgreSQL connector incremental snapshots]
-* xref:{link-sqlserver-connector}#sqlserver-incremental-snapshots[SQL Server connector incremental snapshots]
+* {link-prefix}:{link-mysql-connector}#mysql-incremental-snapshots[MySQL connector incremental snapshots]
+* {link-prefix}:{link-oracle-connector}#oracle-incremental-snapshots[Oracle connector incremental snapshots]
+* {link-prefix}:{link-postgresql-connector}#postgresql-incremental-snapshots[PostgreSQL connector incremental snapshots]
+* {link-prefix}:{link-sqlserver-connector}#sqlserver-incremental-snapshots[SQL Server connector incremental snapshots]

--- a/documentation/modules/ROOT/pages/configuration/topic-auto-create-config.adoc
+++ b/documentation/modules/ROOT/pages/configuration/topic-auto-create-config.adoc
@@ -83,8 +83,8 @@ You specify topic configuration properties in the {prodname} connector configura
 The connector configuration defines a default topic creation group, and, optionally, one or more custom topic creation groups.
 Custom topic creation groups use lists of topic name patterns to specify the topics to which the group's settings apply.
 
-For details about how Kafka Connect matches topics to topic creation groups, see xref:{link-topic-auto-creation}#topic-creation-groups[Topic creation groups].
-For more information about how configuration properties are assigned to groups, see xref:{link-topic-auto-creation}#topic-creation-group-configuration-properties[Topic creation group configuration properties].
+For details about how Kafka Connect matches topics to topic creation groups, see xref:topic-creation-groups[Topic creation groups].
+For more information about how configuration properties are assigned to groups, see xref:topic-creation-group-configuration-properties[Topic creation group configuration properties].
 
 By default, topics that Kafka Connect creates are named based on the pattern `server.schema.table`, for example, `dbserver.myschema.inventory`.
 
@@ -169,12 +169,12 @@ If no custom groups are registered, or if the `include` patterns for any registe
 then Kafka Connect uses the configuration of the `default` group to create topics.
 
 ifdef::community[]
-See xref:{link-install-debezium}#configuring-debezium-topics[Configuring {prodname} topics] in the
+See {link-prefix}:{link-install-debezium}#configuring-debezium-topics[Configuring {prodname} topics] in the
 {prodname} installation guide on generic topic configuration considerations.
 endif::community[]
 
 ifdef::product[]
-For general information about configuring topics, see xref:{LinkDebeziumInstallOpenShift}#kafka-topic-creation-recommendations[Kafka topic creation recommendations] in {NameDebeziumInstallOpenShift}.
+For general information about configuring topics, see link:{LinkDebeziumInstallOpenShift}#kafka-topic-creation-recommendations[Kafka topic creation recommendations] in {NameDebeziumInstallOpenShift}.
 endif::product[]
 
 // Type: procedure

--- a/documentation/modules/ROOT/pages/connectors/db2.adoc
+++ b/documentation/modules/ROOT/pages/connectors/db2.adoc
@@ -81,7 +81,8 @@ that enable SQL Replication in Db2. A capture agent:
 
 The {prodname} connector uses a SQL interface to query change-data tables for  change events.
 
-The database administrator must put the tables for which you want to capture changes into capture mode. For convenience and for automating testing, there are xref:{link-db2-connector}#db2-management[{prodname} user-defined functions (UDFs)] in C that you can compile and then use to do the following management tasks:
+The database administrator must put the tables for which you want to capture changes into capture mode.
+For convenience and for automating testing, there are xref:db2-management[{prodname} management user-defined functions (UDFs)] in C that you can compile and then use to do the following management tasks:
 
 * Start, stop, and reinitialize the ASN agent
 * Put tables into capture mode
@@ -214,7 +215,7 @@ The connector applies similar naming conventions to label its internal database 
 
 If the default topic name do not meet your requirements, you can configure custom topic names.
 To configure custom topic names, you specify regular expressions in the logical topic routing SMT.
-For more information about using the logical topic routing SMT to customize topic naming, see xref:{link-topic-routing}#topic-routing[Topic routing].
+For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].
 
 // Type: concept
 // Title: About the {prodname} Db2 connector schema change topic
@@ -227,7 +228,7 @@ You can configure a {prodname} Db2 connector to produce schema change events tha
 
 * A new table goes into capture mode.
 * A table is removed from capture mode.
-* During a xref:{link-db2-connector}#db2-schema-evolution[database schema update], there is a change in the schema for a table that is in capture mode.
+* During a xref:db2-schema-evolution[database schema update], there is a change in the schema for a table that is in capture mode.
 
 The connector writes schema change events to a Kafka schema change topic that has the name `_<topicPrefix>_` where `_<topicPrefix>_` is the topic prefix that is specified in the xref:db2-property-topic-prefix[`topic.prefix`] connector configuration property.
 Messages that the connector sends to the schema change topic contain a payload that includes the following elements:
@@ -579,7 +580,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 |`schema`
 |The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed. +
  +
-It is possible to override the table's primary key by setting the xref:{link-db2-connector}#db2-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
+It is possible to override the table's primary key by setting the xref:db2-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
 
 |2
 |`payload`
@@ -595,7 +596,7 @@ It is possible to override the table's primary key by setting the xref:{link-db2
 
 |===
 
-By default, the connector streams change event records to topics with names that are the same as the event's originating table. See xref:{link-db2-connector}#db2-topic-names[topic names].
+By default, the connector streams change event records to topics with names that are the same as the event's originating table. For more information, see xref:db2-topic-names[topic names].
 
 [WARNING]
 ====
@@ -911,7 +912,7 @@ a|In the `schema` section, each `name` field specifies the schema for a field in
 `mydatabase.MYSCHEMA.CUSTOMERS.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table. The connector uses this schema for all rows in the `MYSCHEMA.CUSTOMERS` table. +
  +
 Names of schemas for `before` and `after` fields are of the form `_logicalName_._schemaName_._tableName_.Value`, which ensures that the schema name is unique in the database.
-This means that when using the xref:{link-avro-serialization}#avro-serialization[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
+This means that when using the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
 
 |3
 |`name`
@@ -926,7 +927,7 @@ a|`mydatabase.MYSCHEMA.CUSTOMERS.Envelope` is the schema for the overall structu
 |The value's actual data. This is the information that the change event is providing. +
  +
 It may appear that JSON representations of events are much larger than the rows they describe. This is because a JSON representation must include the schema portion and the payload portion of the message.
-However, by using the xref:{link-avro-serialization}#avro-serialization[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
+However, by using the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
 
 |6
 |`before`
@@ -1043,7 +1044,7 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 
 [NOTE]
 ====
-Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a xref:{link-db2-connector}#db2-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row.
+Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a xref:db2-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row.
 ====
 
 [[db2-delete-events]]
@@ -1255,7 +1256,7 @@ String representation of an XML document
 
 If present, a column's default value is propagated to the corresponding field's Kafka Connect schema. Change events contain the field's default value unless an explicit column value had been given. Consequently, there is rarely a need to obtain the default value from the schema.
 ifdef::community[]
-Passing the default value helps satisfy compatibility rules when xref:{link-avro-serialization}[using Avro] as the serialization format together with the Confluent schema registry.
+Passing the default value helps satisfy compatibility rules when {link-prefix}:{link-avro-serialization}[using Avro] as the serialization format together with the Confluent schema registry.
 endif::community[]
 
 [[db2-temporal-types]]
@@ -1532,7 +1533,7 @@ VALUES ASNCDC.ASNCDCSERVICES('reinit','asncdc');
 
 .Additional resource
 
-xref:{link-db2-connector}#db2-management[Reference table for {prodname} Db2 management UDFs]
+xref:db2-management[Reference table for {prodname} Db2 management UDFs]
 
 // Type: concept
 // ModuleID: effect-of-db2-capture-agent-configuration-on-server-load-and-latency
@@ -1593,7 +1594,7 @@ To deploy a {prodname} Db2 connector, you install the {prodname} Db2 connector a
 .Prerequisites
 
 * link:https://zookeeper.apache.org/[Apache ZooKeeper], link:http://kafka.apache.org/[Apache Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
-* Db2 is installed and xref:{link-db2-connector}#setting-up-db2[capture mode is enabled for tables] to prepare the database to be used with the {prodname} connector.
+* Db2 is installed and xref:setting-up-db2[capture mode is enabled for tables] to prepare the database to be used with the {prodname} connector.
 
 .Procedure
 
@@ -1760,7 +1761,8 @@ docker push _<myregistry.io>_/debezium-container-for-db2:latest
 ----
 
 .. Create a new {prodname} Db2 `KafkaConnect` custom resource (CR).
-For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties as shown in the following example:
+For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties.
+The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource. +
 +
 =====================================================================
 [source,yaml,subs="+attributes"]
@@ -1774,6 +1776,8 @@ metadata:
 spec:
   #...
   image: debezium-container-for-db2  // <2>
+
+  ...
 ----
 =====================================================================
 +
@@ -1805,7 +1809,7 @@ You configure a {prodname} Db2 connector in a `.yaml` file that specifies the co
 The connector configuration might instruct {prodname} to produce events for a subset of the schemas and tables, or it might set properties so that {prodname} ignores, masks, or truncates values in specified columns that are sensitive, too large, or not needed.
 +
 The following example configures a {prodname} connector that connects to a Db2 server host, `192.168.99.100`, on port `50000`.
-This host has a database named `mydatabase`, a table with the name `inventory`, and `fulfillment` is the server's logical name.
+This host has a database named `mydatabase`, a table with the name `inventory`, and `inventory-connector-{context}` is the server's logical name.
 +
 .Db2 `inventory-connector.yaml`
 [source,yaml,options="nowrap",subs="+attributes"]
@@ -1813,7 +1817,7 @@ This host has a database named `mydatabase`, a table with the name `inventory`, 
 apiVersion: {KafkaConnectApiVersion}
   kind: KafkaConnector
   metadata:
-    name: inventory-connector  // <1>
+    name: inventory-connector-{context}  // <1>
     labels:
       strimzi.io/cluster: my-connect-cluster
     annotations:
@@ -1827,8 +1831,10 @@ apiVersion: {KafkaConnectApiVersion}
       database.user: db2inst1 // <7>
       database.password: Password! // <8>
       database.dbname: mydatabase // <9>
-      topic.prefix: fullfillment   // <10>
+      topic.prefix: inventory-connector-{context}   // <10>
       table.include.list: public.inventory   // <11>
+
+      ...
 ----
 +
 .Descriptions of connector configuration settings
@@ -1864,7 +1870,7 @@ apiVersion: {KafkaConnectApiVersion}
 |The name of the database to capture changes from.
 
 |10
-|The logical name of the Db2 instance/cluster, which forms a namespace and is used in the names of the Kafka topics to which the connector writes, the names of Kafka Connect schemas, and the namespaces of the corresponding Avro schema when the xref:{link-avro-serialization}#avro-serialization[Avro Connector] is used.
+|The logical name of the Db2 instance/cluster, which forms a namespace and is used in the names of the Kafka topics to which the connector writes, the names of Kafka Connect schemas, and the namespaces of the corresponding Avro schema when the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro Connector] is used.
 
 |11
 |The connector captures changes from the `public.inventory` table only.
@@ -1919,14 +1925,14 @@ Optionally, you can ignore, mask, or truncate columns that contain sensitive dat
 <5> The name of the Db2 user.
 <6> The password for the Db2 user.
 <7> The name of the database to capture changes from.
-<8> The logical name of the Db2 instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the xref:{link-avro-serialization}[Avro Connector] is used.
+<8> The logical name of the Db2 instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the {link-prefix}:{link-avro-serialization}[Avro Connector] is used.
 <9> A list of all tables whose changes {prodname} should capture.
 <10> The list of Kafka brokers that this connector uses to write and recover DDL statements to the database schema history topic.
 <11> The name of the database schema history topic where the connector writes and recovers DDL statements. This topic is for internal use only and should not be used by consumers.
 
 endif::community[]
 
-For the complete list of the configuration properties that you can set for the {prodname} Db2 connector, see xref:{link-db2-connector}#db2-connector-properties[Db2 connector properties].
+For the complete list of the configuration properties that you can set for the {prodname} Db2 connector, see xref:db2-connector-properties[Db2 connector properties].
 
 ifdef::community[]
 
@@ -1944,7 +1950,7 @@ To start running a Db2 connector, create a connector configuration and add the c
 
 .Prerequisites
 
-* xref:{link-db2-connector}#setting-up-db2[Db2 replication is enabled] to expose change data for tables that are in capture mode.
+* xref:setting-up-db2[Db2 replication is enabled] to expose change data for tables that are in capture mode.
 * The Db2 connector is installed.
 
 .Procedure
@@ -1956,7 +1962,7 @@ endif::community[]
 
 .Results
 
-After the connector starts, it xref:{link-db2-connector}#db2-snapshots[performs a consistent snapshot] of the Db2 database tables that the connector is configured to capture changes for.
+After the connector starts, it xref:db2-snapshots[performs a consistent snapshot] of the Db2 database tables that the connector is configured to capture changes for.
 The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
 
 ifdef::product[]
@@ -2106,7 +2112,8 @@ Depending on the _hashAlgorithm_ used, the _salt_ selected, and the actual data 
  +
 `adaptive` captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type. +
  +
-`connect` always represents time and timestamp values by using Kafka Connect's built-in representations for `Time`, `Date`, and `Timestamp`, which uses millisecond precision regardless of the database columns' precision. See xref:{link-db2-connector}#db2-temporal-values[temporal values].
+`connect` always represents time and timestamp values by using Kafka Connect's built-in representations for `Time`, `Date`, and `Timestamp`, which uses millisecond precision regardless of the database columns' precision.
+For more information, see xref:db2-temporal-types[temporal types].
 
 |[[db2-property-tombstones-on-delete]]<<db2-property-tombstones-on-delete, `+tombstones.on.delete+`>>
 |`true`
@@ -2224,7 +2231,7 @@ For `purchaseorders` tables in any schema, the columns `pk3` and `pk4` serve as 
 * `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
 * `avro_unicode` replaces the underscore or characters that cannot be used in the Avro type name with corresponding unicode like _uxxxx. Note: _ is an escape sequence like backslash in Java +
 
-See xref:{link-avro-serialization}#avro-naming[Avro naming] for more details.
+See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 |===
 
 [id="db2-advanced-configuration-properties"]
@@ -2345,7 +2352,7 @@ That is, the specified expression is matched against the entire name string of t
 
 |[[db2-property-snapshot-lock-timeout-ms]]<<db2-property-snapshot-lock-timeout-ms, `+snapshot.lock.timeout.ms+`>>
 |`10000`
-|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this interval, the snapshot fails. xref:{link-db2-connector}#db2-snapshots[How the connector performs snapshots] provides details. Other possible settings are: +
+|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this interval, the snapshot fails. xref:db2-snapshots[How the connector performs snapshots] provides details. Other possible settings are: +
  +
 `0` -  The connector immediately fails when it cannot obtain a lock. +
  +
@@ -2383,7 +2390,7 @@ In the resulting snapshot, the connector includes only the records for which `de
 
 |[[db2-property-provide-transaction-metadata]]<<db2-property-provide-transaction-metadata, `+provide.transaction.metadata+`>>
 |`false`
-|Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See xref:{link-db2-connector}#db2-transaction-metadata[Transaction metadata] for details.
+|Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See xref:db2-transaction-metadata[Transaction metadata] for details.
 
 |[[db2-property-skipped-operations]]<<db2-property-skipped-operations, `+skipped.operations+`>>
 |`t`
@@ -2393,7 +2400,7 @@ By default, truncate operations are skipped (not emitted by this connector).
 
 |[[db2-property-signal-data-collection]]<<db2-property-signal-data-collection, `+signal.data.collection+`>>
 |No default
-| Fully-qualified name of the data collection that is used to send xref:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector.
+| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector.
 Use the following format to specify the collection name: +
 `_<schemaName>_._<tableName>_`
 
@@ -2471,9 +2478,9 @@ include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-databas
 
 The {prodname} Db2 connector provides three types of metrics that are in addition to the built-in support for JMX metrics that Apache ZooKeeper, Apache Kafka, and Kafka Connect provide.
 
-* xref:{link-db2-connector}#db2-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
-* xref:{link-db2-connector}#db2-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
-* xref:{link-db2-connector}#db2-schema-history-metrics[Schema history metrics] provide information about the status of the connector's schema history.
+* xref:db2-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
+* xref:db2-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
+* xref:db2-schema-history-metrics[Schema history metrics] provide information about the status of the connector's schema history.
 
 {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
 
@@ -2561,8 +2568,8 @@ It is vital to execute a schema update procedure completely before there is a ne
 
 There are generally two procedures for updating table schemas:
 
-* xref:{link-db2-connector}#db2-offline-schema-update[Offline - executed while {prodname} is stopped]
-* xref:{link-db2-connector}#db2-online-schema-update[Online - executed while {prodname} is running]
+* xref:db2-offline-schema-update[Offline - executed while {prodname} is stopped]
+* xref:db2-hot-schema-update[Online - executed while {prodname} is running]
 
 Each approach has advantages and disadvantages.
 
@@ -2585,11 +2592,11 @@ You stop the {prodname} Db2 connector before you perform an offline schema updat
 . Stop the {prodname} connector.
 . Apply all changes to the source table schema.
 . In the ASN register table, mark the tables with updated schemas as `INACTIVE`.
-. xref:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service].
-. Remove the source table with the old schema from capture mode by xref:{link-db2-connector}#debezium-db2-remove-capture-mode[running the {prodname} UDF for removing tables from capture mode].
-. Add the source table with the new schema to capture mode by xref:{link-db2-connector}#debezium-db2-put-capture-mode[running the {prodname} UDF for adding tables to capture mode].
+. xref:debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service].
+. Remove the source table with the old schema from capture mode by xref:debezium-db2-remove-capture-mode[running the {prodname} UDF for removing tables from capture mode].
+. Add the source table with the new schema to capture mode by xref:debezium-db2-put-capture-mode[running the {prodname} UDF for adding tables to capture mode].
 . In the ASN register table, mark the updated source tables as `ACTIVE`.
-. xref:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
+. xref:debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
 . Resume the application that updates the database.
 . Restart the {prodname} connector.
 
@@ -2611,18 +2618,18 @@ However, when a table is in capture mode, after a change to a column name, the D
 
 . Lock the source tables whose schema you want to change.
 . In the ASN register table, mark the locked tables as `INACTIVE`.
-. xref:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
+. xref:debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
 . Apply all changes to the schemas for the source tables.
 . Apply all changes to the schemas for the corresponding change-data tables.
 . In the ASN register table, mark the source tables as `ACTIVE`.
-. xref:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
+. xref:debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
 . Optional. Restart the connector to see updated column names in change events.
 
 .Procedure when adding a column to the middle of a table
 
 . Lock the source table(s) to be changed.
 . In the ASN register table, mark the locked tables as `INACTIVE`.
-. xref:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
+. xref:debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
 . For each source table to be changed:
 .. Export the data in the source table.
 .. Truncate the source table.
@@ -2633,5 +2640,5 @@ However, when a table is in capture mode, after a change to a column name, the D
 .. Alter the change-data table and add the column.
 .. Load the exported data into the altered change-data table.
 . In the ASN register table, mark the tables as `INACTIVE`. This marks the old change-data tables as inactive, which allows the data in them to remain but they are no longer updated.
-. xref:{link-db2-connector}#debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
+. xref:debezium-db2-reinitialize-asn-service[Reinitialize the ASN capture service.]
 . Optional. Restart the connector to see updated column names in change events.

--- a/documentation/modules/ROOT/pages/connectors/mongodb.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mongodb.adoc
@@ -200,7 +200,7 @@ We recommend logical names begin with an alphabetic or underscore character, and
 === Performing a snapshot
 
 When a task starts up using a replica set, it uses the connector's logical name and the replica set name to find an _offset_ that describes the position where the connector previously stopped reading changes.
-If an offset can be found and it still exists in the oplog, then the task immediately proceeds with xref:{link-mongodb-connector}#mongodb-streaming-changes[streaming changes], starting at the recorded offset position.
+If an offset can be found and it still exists in the oplog, then the task immediately proceeds with xref:mongodb-streaming-changes[streaming changes], starting at the recorded offset position.
 
 However, if no offset is found or if the oplog no longer contains that position, the task must first obtain the current state of the replica set contents by performing a _snapshot_.
 This process starts by recording the current position of the oplog and recording that as the offset (along with a flag that denotes a snapshot has been started).
@@ -286,7 +286,7 @@ include::{partialsdir}/modules/all-connectors/proc-stopping-an-incremental-snaps
 
 After the connector task for a replica set records an offset, it uses the offset to determine the position in the oplog where it should start streaming changes.
 The task then (depending on the configuration) either connects to the replica set's primary node or connects to a replica-set-wide change stream and starts streaming changes from that position.
-It processes all of create, insert, and delete operations, and converts them into {prodname} xref:{link-mongodb-connector}#mongodb-events[change events].
+It processes all of create, insert, and delete operations, and converts them into {prodname} xref:mongodb-events[change events].
 Each change event includes the position in the oplog where the operation was found, and the connector periodically records this as its most recent offset.
 The interval at which the offset is recorded is governed by link:https://kafka.apache.org/documentation/#offset.flush.interval.ms[`offset.flush.interval.ms`], which is a Kafka Connect worker configuration property.
 
@@ -331,7 +331,7 @@ For information about how to avoid exceeding the change stream limit, see the ht
 === Topic names
 
 The MongoDB connector writes events for all insert, update, and delete operations to documents in each collection to a single Kafka topic.
-The name of the Kafka topics always takes the form _logicalName_._databaseName_._collectionName_, where _logicalName_ is the xref:{link-mongodb-connector}#mongodb-logical-connector-name[logical name] of the connector as specified with the `topic.prefix` configuration property, _databaseName_ is the name of the database where the operation occurred, and _collectionName_ is the name of the MongoDB collection in which the affected document existed.
+The name of the Kafka topics always takes the form _logicalName_._databaseName_._collectionName_, where _logicalName_ is the xref:mongodb-logical-connector-name[logical name] of the connector as specified with the `topic.prefix` configuration property, _databaseName_ is the name of the database where the operation occurred, and _collectionName_ is the name of the MongoDB collection in which the affected document existed.
 
 For example, consider a MongoDB replica set with an `inventory` database that contains four collections: `products`, `products_on_hand`, `customers`, and `orders`.
 If the connector monitoring this database were given a logical name of `fulfillment`, then the connector would produce events on these four Kafka topics:
@@ -412,7 +412,7 @@ The following example shows a typical message:
 }
 ----
 
-Unless overridden via the xref:{link-mongodb-connector}#mongodb-property-topic-transaction[`topic.transaction`] option,
+Unless overridden via the xref:mongodb-property-topic-transaction[`topic.transaction`] option,
 transaction events are written to the topic named xref:mongodb-property-topic-prefix[`_<topic.prefix>_`]`.transaction`.
 
 .Change data event enrichment
@@ -495,7 +495,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 
 |===
 
-By default, the connector streams change event records to topics with names that are the same as the event's originating collection. See xref:{link-mongodb-connector}#mongodb-topic-names[topic names].
+By default, the connector streams change event records to topics with names that are the same as the event's originating collection. See xref:mongodb-topic-names[topic names].
 
 [WARNING]
 ====
@@ -779,7 +779,7 @@ a|`dbserver1.inventory.customers.Envelope` is the schema for the overall structu
 |The value's actual data. This is the information that the change event is providing. +
  +
 It may appear that the JSON representations of the events are much larger than the documents they describe. This is because the JSON representation must include the schema and the payload portions of the message.
-However, by using the xref:{link-avro-serialization}#avro-serialization[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
+However, by using the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
 
 |6
 |`after`
@@ -1033,7 +1033,7 @@ To deploy a {prodname} MongoDB connector, you install the {prodname} MongoDB con
 
 .Prerequisites
 * link:https://zookeeper.apache.org/[Apache Zookeeper], link:http://kafka.apache.org/[Apache Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
-* MongoDB is installed and is xref:{link-mongodb-connector}#setting-up-mongodb[set up to work with the {prodname} connector].
+* MongoDB is installed and is xref:setting-up-mongodb[set up to work with the {prodname} connector].
 
 .Procedure
 . Download the
@@ -1173,7 +1173,8 @@ docker push _<myregistry.io>_/debezium-container-for-mongodb:latest
 ----
 
 .. Create a new {prodname} MongoDB `KafkaConnect` custom resource (CR).
-For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties as shown in the following example:
+For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties.
+The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource. +
 +
 =====================================================================
 [source,yaml,subs="+attributes"]
@@ -1187,6 +1188,8 @@ metadata:
 spec:
   #...
   image: debezium-container-for-mongodb  // <2>
+
+  ...
 ----
 =====================================================================
 +
@@ -1220,7 +1223,7 @@ Optionally, you can set properties that filter out collections that are not need
 +
 The following example configures a {prodname} connector that connects to a MongoDB replica set `rs0` at port `27017` on `192.168.99.100`,
 and captures changes that occur in the `inventory` collection.
-`fullfillment` is the logical name of the replica set.
+`inventory-connector-{context}` is the logical name of the replica set.
 +
 .MongoDB `inventory-connector.yaml`
 [source,yaml,options="nowrap",subs="+attributes"]
@@ -1228,13 +1231,13 @@ and captures changes that occur in the `inventory` collection.
 apiVersion: {KafkaConnectApiVersion}
   kind: KafkaConnector
   metadata:
-    name: inventory-connector // <1>
+    name: inventory-connector-{context} // <1>
     labels: strimzi.io/cluster: my-connect-cluster
   spec:
     class: io.debezium.connector.mongodb.MongoDbConnector // <2>
     config:
      mongodb.connection.string: mongodb://192.168.99.100:27017/?replicaSet=rs0 // <3>
-     topic.prefix: fulfillment // <4>
+     topic.prefix: inventory-connector-{context} // <4>
      collection.include.list: inventory[.]* // <5>
 ----
 <1> The name that is used to register the connector with Kafka Connect.
@@ -1285,7 +1288,7 @@ Optionally, you can filter out collections that are not needed.
 endif::community[]
 
 For the complete list of the configuration properties that you can set for the {prodname} MongoDB connector,
-see xref:{link-mongodb-connector}#mongodb-connector-properties[MongoDB connector configuration properties].
+see xref:mongodb-connector-properties[MongoDB connector configuration properties].
 
 ifdef::community[]
 You can send this configuration with a `POST` command to a running Kafka Connect service.
@@ -1304,7 +1307,7 @@ To start running a {prodname} MongoDB connector, create a connector configuratio
 
 .Prerequisites
 
-* xref:{link-mongodb-connector}#setting-up-mongodb[MongoDB is set up to work with a {prodname} connector].
+* xref:setting-up-mongodb[MongoDB is set up to work with a {prodname} connector].
 * The {prodname} MongoDB connector is installed.
 
 .Procedure
@@ -1317,7 +1320,7 @@ endif::community[]
 .Results
 After the connector starts, it completes the following actions:
 
-* xref:{link-mongodb-connector}#mongodb-performing-a-snapshot[Performs a consistent snapshot] of the collections in your MongoDB replica sets.
+* xref:mongodb-performing-a-snapshot[Performs a consistent snapshot] of the collections in your MongoDB replica sets.
 * Reads the change streams for the replica sets.
 * Produces change events for every inserted, updated, and deleted document.
 * Streams change event records to Kafka topics.
@@ -1578,7 +1581,7 @@ Defaults to 0, which indicates that the server chooses an appropriate fetch size
 * `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
 * `avro_unicode` replaces the underscore or characters that cannot be used in the Avro type name with corresponding unicode like _uxxxx. Note: _ is an escape sequence like backslash in Java +
 
-See xref:{link-avro-serialization}#avro-naming[Avro naming] for more details.
+See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 
 |[[mongodb-property-mongodb-hosts]]<<mongodb-property-mongodb-hosts, `+mongodb.hosts+`>>
 |No default
@@ -1677,7 +1680,7 @@ For each collection that you specify, also specify another configuration propert
 |`false`
 |When set to `true` {prodname} generates events with transaction boundaries and enriches data events envelope with transaction metadata.
 
-See xref:{link-mongodb-connector}#mongodb-transaction-metadata[Transaction Metadata] for additional details.
+See xref:mongodb-transaction-metadata[Transaction Metadata] for additional details.
 
 |[[mongodb-property-retriable-restart-connector-wait-ms]]<<mongodb-property-retriable-restart-connector-wait-ms, `+retriable.restart.connector.wait.ms+`>>
 |10000 (10 seconds)
@@ -1772,10 +1775,10 @@ For example, if the topic prefix is `fulfillment`, the default topic name is `fu
 
 The {prodname} MongoDB connector has two metric types in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect have.
 
-* xref:{link-mongodb-connector}#mongodb-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
-* xref:{link-mongodb-connector}#mongodb-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
+* xref:mongodb-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
+* xref:mongodb-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
 
-The xref:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details about how to expose these metrics by using JMX.
+The {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details about how to expose these metrics by using JMX.
 
 // Type: reference
 // ModuleID: monitoring-debezium-during-mongodb-snapshots

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -129,7 +129,7 @@ When the MySQL connector captures changes in a table to which a schema change to
 The connector needs to be configured to capture change to these helper tables.
 If consumers do not need the records generated for helper tables, then a single message transform can be applied to filter them out.
 
-See xref:{link-mysql-connector}#mysql-topic-names[default names for topics] that receive {prodname} event records.
+For more information, see xref:mysql-topic-names[default names for topics] that receive {prodname} event records.
 
 // Type: concept
 // ModuleID: how-debezium-mysql-connectors-expose-database-schema-changes
@@ -365,7 +365,7 @@ In the case of a table rename, this identifier is a concatenation of `_<old>_,_<
 
 |===
 
-See also: xref:{link-mysql-connector}#mysql-schema-history-topic[schema history topic].
+For more information, see xref:mysql-schema-history-topic[schema history topic].
 
 // Type: concept
 // Title: How {prodname} MySQL connectors perform database snapshots
@@ -373,7 +373,8 @@ See also: xref:{link-mysql-connector}#mysql-schema-history-topic[schema history 
 [[mysql-snapshots]]
 === Snapshots
 
-When a {prodname} MySQL connector is first started, it performs an initial _consistent snapshot_ of your database. The following flow describes how the connector creates this snapshot. This flow is for the default snapshot mode, which is `initial`. For information about other snapshot modes, see the xref:{link-mysql-connector}#mysql-property-snapshot-mode[MySQL connector `snapshot.mode` configuration property].
+When a {prodname} MySQL connector is first started, it performs an initial _consistent snapshot_ of your database. The following flow describes how the connector creates this snapshot. This flow is for the default snapshot mode, which is `initial`.
+For information about other snapshot modes, see the xref:mysql-property-snapshot-mode[MySQL connector `snapshot.mode` configuration property].
 
 .Workflow for performing an initial snapshot with a global read lock
 [cols="1,9",options="header",subs="+attributes"]
@@ -414,7 +415,7 @@ a|Records the completed snapshot in the connector offsets.
 Connector restarts::
 If the connector fails, stops, or is rebalanced while performing the _initial snapshot_, then after the connector restarts, it performs a new snapshot. After that _intial snapshot_ is completed, the {prodname} MySQL connector restarts from the same position in the binlog so it does not miss any updates.
 +
-If the connector stops for long enough, MySQL could purge old binlog files and the connector's position would be lost. If the position is lost, the connector reverts to the _initial snapshot_ for its starting position. For more tips on troubleshooting the {prodname} MySQL connector, see xref:{link-mysql-connector}#mysql-when-things-go-wrong[behavior when things go wrong].
+If the connector stops for long enough, MySQL could purge old binlog files and the connector's position would be lost. If the position is lost, the connector reverts to the _initial snapshot_ for its starting position. For more tips on troubleshooting the {prodname} MySQL connector, see xref:mysql-when-things-go-wrong[behavior when things go wrong].
 
 Global read locks not allowed::
 Some environments do not allow global read locks. If the {prodname} MySQL connector detects that global read locks are not permitted, the connector uses table-level locks instead and performs a snapshot with this method. This requires the database user for the {prodname} connector to have `LOCK TABLES` privileges.
@@ -489,7 +490,7 @@ The MySQL connector allows for running incremental snapshots with a read-only co
 To run an incremental snapshot with read-only access, the connector uses the executed global transaction IDs (GTID) set as high and low watermarks.
 The state of a chunk's window is updated by comparing the GTIDs of binary log (binlog) events or the server's heartbeats against low and high watermarks.
 
-To switch to a read-only implementation, set the value of the xref:{link-mysql-connector}#mysql-property-read-only[`read.only`] property to `true`.
+To switch to a read-only implementation, set the value of the xref:mysql-property-read-only[`read.only`] property to `true`.
 
 .Prerequisites
 
@@ -502,8 +503,8 @@ you must set one of the following options:
 
 ==== Ad hoc read-only incremental snapshots
 
-When the MySQL connection is read-only, the xref:{link-signalling}[signaling table] mechanism can also run a snapshot by sending a message to the Kafka topic that is specified in
-the xref:{link-mysql-connector}#mysql-property-signal-kafka-topic[signal.kafka.topic] property.
+When the MySQL connection is read-only, the {link-prefix}:{link-signalling}[signaling table] mechanism can also run a snapshot by sending a message to the Kafka topic that is specified in
+the xref:mysql-property-signal-kafka-topic[signal.kafka.topic] property.
 
 The key of the Kafka message must match the value of the `topic.prefix` connector configuration option.
 
@@ -575,8 +576,8 @@ Value = `{"type":"execute-snapshot","data": {"data-collections": ["schema1.produ
 
 ==== Stopping an Ad hoc read-only incremental snapshot
 
-When the MySQL connection is read-only, the xref:{link-signalling}[signaling table] mechanism can also stop a snapshot by sending a message to the Kafka topic that is specified in
-the xref:{link-mysql-connector}#mysql-property-signal-kafka-topic[signal.kafka.topic] property.
+When the MySQL connection is read-only, the {link-prefix}:{link-signalling}[signaling table] mechanism can also stop a snapshot by sending a message to the Kafka topic that is specified in
+the xref:mysql-property-signal-kafka-topic[signal.kafka.topic] property.
 
 The key of the Kafka message must match the value of the `topic.prefix` connector configuration option.
 
@@ -658,7 +659,7 @@ The connector applies similar naming conventions to label its internal database 
 
 If the default topic name do not meet your requirements, you can configure custom topic names.
 To configure custom topic names, you specify regular expressions in the logical topic routing SMT.
-For more information about using the logical topic routing SMT to customize topic naming, see xref:{link-topic-routing}#topic-routing[Topic routing].
+For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].
 
 [[mysql-transaction-metadata]]
 === Transaction metadata
@@ -788,7 +789,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 |`schema`
 |The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed. +
  +
-It is possible to override the table's primary key by setting the xref:{link-mysql-connector}#mysql-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
+It is possible to override the table's primary key by setting the xref:mysql-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
 
 |2
 |`payload`
@@ -804,7 +805,7 @@ It is possible to override the table's primary key by setting the xref:{link-mys
 
 |===
 
-By default, the connector streams change event records to topics with names that are the same as the event's originating table. See xref:{link-mysql-connector}#mysql-topic-names[topic names].
+By default, the connector streams change event records to topics with names that are the same as the event's originating table. See xref:mysql-topic-names[topic names].
 
 [WARNING]
 ====
@@ -1130,7 +1131,7 @@ a|In the `schema` section, each `name` field specifies the schema for a field in
 `mysql-server-1.inventory.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table. +
  +
 Names of schemas for `before` and `after` fields are of the form `_logicalName_._tableName_.Value`, which ensures that the schema name is unique in the database.
-This means that when using the xref:{link-avro-serialization}#avro-serialization[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
+This means that when using the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
 
 |3
 |`name`
@@ -1145,7 +1146,7 @@ This means that when using the xref:{link-avro-serialization}#avro-serialization
 |The value's actual data. This is the information that the change event is providing. +
  +
 It may appear that the JSON representations of the events are much larger than the rows they describe. This is because the JSON representation must include the schema and the payload portions of the message.
-However, by using the xref:{link-avro-serialization}#avro-serialization[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
+However, by using the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
 
 |6
 |`op`
@@ -1185,7 +1186,7 @@ a| Mandatory field that describes the source metadata for the event. This field 
 * MySQL server ID (if available)
 * Timestamp for when the change was made in the database
 
-If the xref:{link-mysql-connector}#enable-query-log-events[`binlog_rows_query_log_events`] MySQL configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
+If the xref:enable-query-log-events[`binlog_rows_query_log_events`] MySQL configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
 
 |===
 
@@ -1263,7 +1264,7 @@ a|Mandatory field that describes the source metadata for the event. The `source`
 * MySQL server ID (if available)
 * Timestamp for when the change was made in the database
 
-If the xref:{link-mysql-connector}#enable-query-log-events[`binlog_rows_query_log_events`] MySQL configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
+If the xref:enable-query-log-events[`binlog_rows_query_log_events`] MySQL configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
 
 |4
 |`op`
@@ -1279,7 +1280,7 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 
 [NOTE]
 ====
-Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a xref:{link-mysql-connector}#mysql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row. Details are in the next section.
+Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a xref:mysql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row. Details are in the next section.
 ====
 
 // Type: continue
@@ -1361,7 +1362,7 @@ a|Mandatory field that describes the source metadata for the event. In a _delete
 * MySQL server ID (if available)
 * Timestamp for when the change was made in the database
 
-If the xref:{link-mysql-connector}#enable-query-log-events[`binlog_rows_query_log_events`] MySQL configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
+If the xref:enable-query-log-events[`binlog_rows_query_log_events`] MySQL configuration option is enabled and the connector configuration `include.query` property is enabled, the `source` field also provides the `query` field, which contains the original SQL statement that caused the change event.
 
 |4
 |`op`
@@ -1560,17 +1561,17 @@ a|_n/a_
 |`BINARY(M)]`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
+Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`VARBINARY(M)]`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
+Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`TINYBLOB`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
+Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`TINYTEXT`
 |`STRING`
@@ -1579,7 +1580,7 @@ a|_n/a_
 |`BLOB`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting. +
+Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting. +
 Only values with a size of up to 2GB are supported. It is recommended to externalize large column values, using the claim check pattern.
 
 |`TEXT`
@@ -1590,7 +1591,7 @@ Only values with a size of up to 2GB are supported. It is recommended to externa
 |`MEDIUMBLOB`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
+Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting.
 
 |`MEDIUMTEXT`
 |`STRING`
@@ -1599,7 +1600,7 @@ a|_n/a_
 |`LONGBLOB`
 |`BYTES` or `STRING`
 a|_n/a_ +
-Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:{link-mysql-connector}#mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting. +
+Either the raw bytes (the default), a base64-encoded String, or a base64-url-safe-encoded String, or a hex-encoded String, based on the xref:mysql-property-binary-handling-mode[`binary.handling.mode`] connector configuration property setting. +
 Only values with a size of up to 2GB are supported. It is recommended to externalize large column values, using the claim check pattern.
 
 |`LONGTEXT`
@@ -1650,7 +1651,7 @@ Such columns are converted into an equivalent `io.debezium.time.ZonedTimestamp` 
 
 The time zone of the JVM running Kafka Connect and Debezium does not affect these conversions.
 
-More details about properties related to temporal values are in the documentation for xref:{link-mysql-connector}#mysql-connector-properties[MySQL connector configuration properties].
+More details about properties related to temporal values are in the documentation for xref:mysql-connector-properties[MySQL connector configuration properties].
 
 time.precision.mode=adaptive_time_microseconds(default)::
 The MySQL connector determines the literal type and semantic type based on the column's data type definition so that events represent exactly the values in the database. All time fields are in microseconds. Only positive `TIME` field values in the range of `00:00:00.000000` to `23:59:59.999999` can be captured correctly.
@@ -1710,7 +1711,7 @@ Represents the number of milliseconds since the epoch, and does not include time
 [id="mysql-decimal-types"]
 === Decimal types
 
-{prodname} connectors handle decimals according to the setting of the xref:{link-mysql-connector}#mysql-property-decimal-handling-mode[`decimal.handling.mode` connector configuration property].
+{prodname} connectors handle decimals according to the setting of the xref:mysql-property-decimal-handling-mode[`decimal.handling.mode` connector configuration property].
 
 decimal.handling.mode=precise::
 +
@@ -1871,7 +1872,7 @@ mysql> GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIE
 +
 The table below describes the permissions.
 +
-IMPORTANT: If using a hosted option such as Amazon RDS or Amazon Aurora that does not allow a global read lock, table-level locks are used to create the _consistent snapshot_. In this case, you need to also grant `LOCK TABLES` permissions to the user that you create. See xref:{link-mysql-connector}#mysql-snapshots[snapshots] for more details.
+IMPORTANT: If using a hosted option such as Amazon RDS or Amazon Aurora that does not allow a global read lock, table-level locks are used to create the _consistent snapshot_. In this case, you need to also grant `LOCK TABLES` permissions to the user that you create. See xref:mysql-snapshots[snapshots] for more details.
 
 . Finalize the user's permissions:
 +
@@ -1988,7 +1989,7 @@ FROM performance_schema.global_variables WHERE variable_name='log_bin';
 |The `binlog_row_image` must be set to `FULL` or `full`.
 
 |`expire_logs_days`
-|This is the number of days for automatic binlog file removal. The default is `0`, which means no automatic removal. Set the value to match the needs of your environment. See xref:{link-mysql-connector}#mysql-purges-binlog-files-used-by-debezium[MySQL purges binlog files].
+|This is the number of days for automatic binlog file removal. The default is `0`, which means no automatic removal. Set the value to match the needs of your environment. See xref:mysql-purges-binlog-files-used-by-debezium[MySQL purges binlog files].
 
 |===
 
@@ -2187,7 +2188,7 @@ To deploy a {prodname} MySQL connector, you install the {prodname} MySQL connect
 
 .Prerequisites
 * link:https://zookeeper.apache.org/[Apache Zookeeper], link:http://kafka.apache.org/[Apache Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
-* MySQL Server is installed and is xref:{link-mysql-connector}#setting-up-mysql[set up to work with the {prodname} connector].
+* MySQL Server is installed and is xref:setting-up-mysql[set up to work with the {prodname} connector].
 
 .Procedure
 
@@ -2199,7 +2200,7 @@ ifeval::['{page-version}' != 'master']
 endif::[]
 . Extract the files into your Kafka Connect environment.
 . Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
-. xref:{link-mysql-connector}#mysql-example-configuration[Configure the connector] and xref:{link-mysql-connector}#mysql-adding-configuration[add the configuration to your Kafka Connect cluster.]
+. xref:mysql-example-configuration[Configure the connector] and xref:mysql-adding-configuration[add the configuration to your Kafka Connect cluster.]
 . Restart your Kafka Connect process to pick up the new JAR files.
 
 If you are working with immutable containers, see link:https://quay.io/organization/debezium[{prodname}'s Container images] for Apache Zookeeper, Apache Kafka, MySQL, and Kafka Connect with the MySQL connector already installed and ready to run.
@@ -2324,7 +2325,8 @@ docker push _<myregistry.io>_/debezium-container-for-mysql:latest
 ----
 
 .. Create a new {prodname} MySQL `KafkaConnect` custom resource (CR).
-For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties as shown in the following example:
+For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties.
+The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource. +
 +
 =====================================================================
 [source,yaml,subs="+attributes"]
@@ -2338,6 +2340,8 @@ metadata:
 spec:
   #...
   image: debezium-container-for-mysql  // <2>
+
+  ...
 ----
 =====================================================================
 +
@@ -2378,7 +2382,7 @@ and captures changes to the `inventory` database.
   apiVersion: {KafkaConnectApiVersion}
   kind: KafkaConnector
   metadata:
-    name: inventory-connector  // <1>
+    name: inventory-connector-{context}  // <1>
     labels:
       strimzi.io/cluster: my-connect-cluster
   spec:
@@ -2390,7 +2394,7 @@ and captures changes to the `inventory` database.
       database.user: debezium
       database.password: dbz
       database.server.id: 184054  // <5>
-      topic.prefix: dbserver1 // <6>
+      topic.prefix: inventory-connector-{context} // <6>
       table.include.list: inventory  // <7>
       schema.history.internal.kafka.bootstrap.servers: my-cluster-kafka-bootstrap:9092  // <8>
       schema.history.internal.kafka.topic: schema-changes.inventory  // <9>
@@ -2494,7 +2498,7 @@ Optionally, you can ignore, mask, or truncate columns that contain sensitive dat
 endif::community[]
 
 For the complete list of the configuration properties that you can set for the {prodname} MySQL connector,
-see xref:{link-mysql-connector}#mysql-connector-properties[MySQL connector configuration properties].
+see xref:mysql-connector-properties[MySQL connector configuration properties].
 
 ifdef::community[]
 You can send this configuration with a `POST` command to a running Kafka Connect service.
@@ -2511,7 +2515,7 @@ To start running a MySQL connector, configure a connector configuration, and add
 
 .Prerequisites
 
-* xref:{link-mysql-connector}#setting-up-mysql[MySQL is set up to work with a {prodname} connector].
+* xref:setting-up-mysql[MySQL is set up to work with a {prodname} connector].
 * The {prodname} MySQL connector is installed.
 
 .Procedure
@@ -2522,7 +2526,7 @@ To start running a MySQL connector, configure a connector configuration, and add
 endif::community[]
 
 .Results
-After the connector starts, it xref:{link-mysql-connector}#mysql-snapshots[performs a consistent snapshot] of the MySQL databases that the connector is configured for.
+After the connector starts, it xref:mysql-snapshots[performs a consistent snapshot] of the MySQL databases that the connector is configured for.
 The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
 
 ifdef::product[]
@@ -2925,13 +2929,13 @@ However, it's best to use the minimum number that are required to specify a uniq
 * `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
 * `avro_unicode` replaces the underscore or characters that cannot be used in the Avro type name with corresponding unicode like _uxxxx. Note: _ is an escape sequence like backslash in Java +
 
-See xref:{link-avro-serialization}#avro-naming[Avro naming] for more details.
+See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 |===
 
 [id="mysql-advanced-connector-configuration-properties"]
 ==== Advanced MySQL connector configuration properties
 
-The following table describes xref:{link-mysql-connector}#mysql-advanced-connector-configuration-properties[advanced MySQL connector properties]. The default values for these properties rarely need to be changed. Therefore, you do not need to specify them in the connector configuration.
+The following table describes xref:mysql-advanced-connector-configuration-properties[advanced MySQL connector properties]. The default values for these properties rarely need to be changed. Therefore, you do not need to specify them in the connector configuration.
 
 .Descriptions of MySQL connector advanced configuration properties
 [cols="30%a,20%a,50%a",options="header",subs="+attributes"]
@@ -3100,7 +3104,7 @@ The connector might establish JDBC connections at its own discretion, so this pr
 
 |[[mysql-property-snapshot-lock-timeout-ms]]<<mysql-property-snapshot-lock-timeout-ms, `+snapshot.lock.timeout.ms+`>>
 |`10000`
-|Positive integer that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. See xref:{link-mysql-connector}#mysql-snapshots[how MySQL connectors perform database snapshots].
+|Positive integer that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. See xref:mysql-snapshots[how MySQL connectors perform database snapshots].
 
 |[[mysql-property-enable-time-adjuster]]<<mysql-property-enable-time-adjuster, `+enable.time.adjuster+`>>
 |`true`
@@ -3124,7 +3128,7 @@ By default, truncate operations are skipped.
 
 |[[mysql-property-signal-data-collection]]<<mysql-property-signal-data-collection,`+signal.data.collection+`>>
 |No default value
-|Fully-qualified name of the data collection that is used to send xref:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector. +
+|Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector. +
 Use the following format to specify the collection name: +
 `_<databaseName>_._<tableName>_`
 
@@ -3149,7 +3153,7 @@ endif::community[]
 
 |[[mysql-property-provide-transaction-metadata]]<<mysql-property-provide-transaction-metadata, `provide.transaction.metadata`>>
 |`false`
-|Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See xref:{link-mysql-connector}#mysql-transaction-metadata[Transaction metadata] for details.
+|Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See xref:mysql-transaction-metadata[Transaction metadata] for details.
 
 |[[mysql-property-event-processing-failure-handling-mode]]<<mysql-property-event-processing-failure-handling-mode, `event.processing.failure.handling.mode`>>
 |`fail`
@@ -3267,9 +3271,9 @@ include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-databas
 
 The {prodname} MySQL connector provides three types of metrics that are in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect provide.
 
-* xref:{link-mysql-connector}#mysql-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
-* xref:{link-mysql-connector}#mysql-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is reading the binlog.
-* xref:{link-mysql-connector}#mysql-schema-history-metrics[Schema history metrics] provide information about the status of the connector's schema history.
+* xref:mysql-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
+* xref:mysql-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is reading the binlog.
+* xref:mysql-schema-history-metrics[Schema history metrics] provide information about the status of the connector's schema history.
 
 {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
 
@@ -3295,7 +3299,7 @@ The {prodname} MySQL connector also provides the `HoldingGlobalLock` custom snap
 
 Transaction-related attributes are available only if binlog event buffering is enabled.
 ifdef::community[]
-See xref:{link-mysql-connector}#mysql-property-binlog-buffer-size[`binlog.buffer.size`] in the advanced connector configuration properties for more details.
+See xref:mysql-property-binlog-buffer-size[`binlog.buffer.size`] in the advanced connector configuration properties for more details.
 endif::community[]
 include::{partialsdir}/modules/all-connectors/frag-common-mbean-name.adoc[leveloffset=+1,tags=common-streaming]
 
@@ -3427,4 +3431,4 @@ The Kafka Connect framework records {prodname} change events in Kafka by using t
 
 If the {prodname} MySQL connector stops for too long, the MySQL server purges older binlog files and the connector's last position may be lost. When the connector is restarted, the MySQL server no longer has the starting point and the connector performs another initial snapshot. If the snapshot is disabled, the connector fails with an error.
 
-See xref:{link-mysql-connector}#mysql-snapshots[snapshots] for details about how MySQL connectors perform initial snapshots.
+See xref:mysql-snapshots[snapshots] for details about how MySQL connectors perform initial snapshots.

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -192,7 +192,7 @@ The connector applies similar naming conventions to label its internal database 
 
 If the default topic name do not meet your requirements, you can configure custom topic names.
 To configure custom topic names, you specify regular expressions in the logical topic routing SMT.
-For more information about using the logical topic routing SMT to customize topic naming, see xref:{link-topic-routing}#topic-routing[Topic routing].
+For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].
 
 // Type: concept
 // ModuleID: how-debezium-oracle-connectors-expose-database-schema-changes
@@ -257,7 +257,7 @@ ifdef::community[]
 
 [NOTE]
 ====
-Following a change in table structure, you must follow (the xref:{link-oracle-connector}#surrogate-schema-evolution[schema evolution procedure]).
+Following a change in table structure, you must follow (the xref:surrogate-schema-evolution[schema evolution procedure]).
 ====
 endif::community[]
 
@@ -1042,7 +1042,7 @@ In the preceding example, notice how the event defines the following schema:
 [TIP]
 ====
 The names of the schemas for the `before` and `after` fields are of the form `_<logicalName>_._<schemaName>_._<tableName>_.Value`, and thus are entirely independent from the schemas for all other tables.
-As a result, when you use the xref:{link-avro-serialization}#avro-serialization[Avro converter], the Avro schemas for tables in each logical source have their own evolution and history.
+As a result, when you use the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], the Avro schemas for tables in each logical source have their own evolution and history.
 ====
 
 The `payload` portion of this event's _value_, provides information about the event.
@@ -1052,7 +1052,7 @@ It describes that a row was created (`op=c`), and shows that the `after` field v
 ====
 By default, the JSON representations of events are much larger than the rows that they describe.
 The larger size is due to the JSON representation including both the schema and payload portions of a message.
-You can use the xref:{link-avro-serialization}#avro-serialization[Avro Converter] to decrease the size of messages that the connector writes to Kafka topics.
+You can use the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro Converter] to decrease the size of messages that the connector writes to Kafka topics.
 ====
 
 // Type: continue
@@ -1117,7 +1117,7 @@ When the columns for a row's primary/unique key are updated, the value of the ro
 As a result, {prodname} emits _three_ events after such an update:
 
 * A `DELETE` event.
-* A xref:{link-oracle-connector}#oracle-tombstone-events[tombstone event] with the old key for the row.
+* A xref:oracle-tombstone-events[tombstone event] with the old key for the row.
 * An `INSERT` event that provides the new key for the row.
 ====
 
@@ -2077,7 +2077,7 @@ To deploy a {prodname} Oracle connector, you install the {prodname} Oracle conne
 
 .Prerequisites
 * link:https://zookeeper.apache.org/[Apache ZooKeeper], link:http://kafka.apache.org/[Apache Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
-* Oracle Database is installed, and is xref:{link-oracle-connector}#setting-up-oracle[configured to work with the {prodname} connector].
+* Oracle Database is installed, and is xref:setting-up-oracle[configured to work with the {prodname} connector].
 
 .Procedure
 
@@ -2092,7 +2092,7 @@ For more information, see xref:obtaining-oracle-jdbc-driver-and-xstreams-api-fil
 
 .Next steps
 
-* xref:{link-oracle-connector}#oracle-example-configuration[Configure the connector] and xref:{link-oracle-connector}#oracle-adding-connector-configuration[add the configuration to your Kafka Connect cluster.]
+* xref:oracle-example-configuration[Configure the connector] and xref:oracle-adding-connector-configuration[add the configuration to your Kafka Connect cluster.]
 
 endif::community[]
 
@@ -2167,7 +2167,7 @@ You then need to create the following custom resources (CRs):
 * The Kafka Connect server has access to Maven Central to download the required JDBC driver for Oracle.
   You can also use a local copy of the driver, or one that is available from a local Maven repository or other HTTP server.
 +
-For more information, see xref:{link-oracle-connector}#obtaining-the-oracle-jdbc-driver[Obtaining the Oracle JDBC driver].
+For more information, see xref:obtaining-the-oracle-jdbc-driver[Obtaining the Oracle JDBC driver].
 
 .Procedure
 
@@ -2239,7 +2239,8 @@ docker push _<myregistry.io>_/debezium-container-for-oracle:latest
 ----
 
 .. Create a new {prodname} Oracle KafkaConnect custom resource (CR).
-For example, create a KafkaConnect CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties as shown in the following example:
+For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties.
+The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource. +
 +
 =====================================================================
 [source,yaml,subs="+attributes"]
@@ -2252,6 +2253,8 @@ metadata:
     strimzi.io/use-connector-resources: "true" // <1>
 spec:
   image: debezium-container-for-oracle // <2>
+
+  ...
 ----
 =====================================================================
 +
@@ -2291,7 +2294,7 @@ This host has a database named `ORCLCDB`, and `server1` is the server's logical 
 apiVersion: {KafkaConnectorApiVersion}
 kind: KafkaConnector
 metadata:
-  name: inventory-connector // <1>
+  name: inventory-connector-{context} // <1>
   labels:
     strimzi.io/cluster: my-connect-cluster
   annotations:
@@ -2305,7 +2308,7 @@ spec:
     database.password: dbz // <6>
     database.dbname: ORCLCDB // <7>
     database.pdb.name : ORCLPDB1, <8>
-    topic.prefix: server1 // <9>
+    topic.prefix: inventory-connector-{context} // <9>
     schema.history.internal.kafka.bootstrap.servers: kafka:9092 // <10>
     schema.history.internal.kafka.topic: schema-changes.inventory // <11>
 ----
@@ -2328,10 +2331,10 @@ spec:
 |The port number of the Oracle instance.
 
 |5
-|The name of the Oracle user, as specified in xref:{link-oracle-connector}#creating-users-for-the-connector[Creating users for the connector].
+|The name of the Oracle user, as specified in xref:creating-users-for-the-connector[Creating users for the connector].
 
 |6
-|The password for the Oracle user, as specified in xref:{link-oracle-connector}#creating-users-for-the-connector[Creating users for the connector].
+|The password for the Oracle user, as specified in xref:creating-users-for-the-connector[Creating users for the connector].
 
 |7
 |The name of the database to capture changes from.
@@ -2395,8 +2398,8 @@ Optionally, you can ignore, mask, or truncate columns that contain sensitive dat
 <2> The name of this Oracle connector class.
 <3> The address of the Oracle instance.
 <4> The port number of the Oracle instance.
-<5> The name of the Oracle user, as specified in xref:{link-oracle-connector}#creating-users-for-the-connector[Creating users for the connector].
-<6> The password for the Oracle user, as specified in xref:{link-oracle-connector}#creating-users-for-the-connector[Creating users for the connector].
+<5> The name of the Oracle user, as specified in xref:creating-users-for-the-connector[Creating users for the connector].
+<6> The password for the Oracle user, as specified in xref:creating-users-for-the-connector[Creating users for the connector].
 <7> The name of the database to capture changes from.
 <8> Topic prefix that identifies and provides a namespace for the Oracle database server from which the connector captures changes.
 <9> The maximum number of tasks to create for this connector.
@@ -2430,7 +2433,7 @@ The following JSON example shows the same configuration as in the preceding exam
 ----
 endif::community[]
 
-For the complete list of the configuration properties that you can set for the {prodname} Oracle connector, see xref:{link-oracle-connector}#oracle-connector-properties[Oracle connector properties].
+For the complete list of the configuration properties that you can set for the {prodname} Oracle connector, see xref:oracle-connector-properties[Oracle connector properties].
 
 ifdef::community[]
 You can send this configuration with a `POST` command to a running Kafka Connect service.
@@ -2447,19 +2450,19 @@ To start running a {prodname} Oracle connector, create a connector configuration
 
 .Prerequisites
 
-* xref:{link-oracle-connector}#setting-up-oracle[Oracle is configured for use with {prodname}].
+* xref:setting-up-oracle[Oracle is configured for use with {prodname}].
 * The {prodname} Oracle connector is installed.
 
 .Procedure
 
-. Create a xref:{link-oracle-connector}#oracle-example-configuration[configuration] for the Oracle connector.
+. Create a xref:oracle-example-configuration[configuration] for the Oracle connector.
 
 . Use the link:{link-kafka-docs}/#connect_rest[Kafka Connect REST API] to add that connector configuration to your Kafka Connect cluster.
 endif::community[]
 
 .Results
 
-After the connector starts, it xref:{link-oracle-connector}#oracle-snapshots[performs a consistent snapshot] of the Oracle databases that the connector is configured for.
+After the connector starts, it xref:oracle-snapshots[performs a consistent snapshot] of the Oracle databases that the connector is configured for.
 The connector then starts generating data change events for row-level operations and streaming the change event records to Kafka topics.
 
 // Type: concept
@@ -2890,7 +2893,7 @@ Hashing strategy version 2 should be used to ensure fidelity if the value is bei
 * `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
 * `avro_unicode` replaces the underscore or characters that cannot be used in the Avro type name with corresponding unicode like _uxxxx. Note: _ is an escape sequence like backslash in Java +
 
-See xref:{link-avro-serialization}#avro-naming[Avro naming] for more details.
+See {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming] for more details.
 
 |[[oracle-property-decimal-handling-mode]]<<oracle-property-decimal-handling-mode, `+decimal.handling.mode+`>>
 |`precise`
@@ -3082,7 +3085,7 @@ Using a value of `0` will use the JDBC driver's default fetch size.
 |`false`
 |Set the property to `true` if you want {prodname} to generate events with transaction boundaries and enriches data events envelope with transaction metadata.
 
-See xref:{link-oracle-connector}#oracle-transaction-metadata[Transaction Metadata] for additional details.
+See xref:oracle-transaction-metadata[Transaction Metadata] for additional details.
 
 |[[oracle-property-log-mining-strategy]]<<oracle-property-log-mining-strategy, `+log.mining.strategy+`>>
 |`redo_log_catalog`
@@ -3297,7 +3300,7 @@ By default, only truncate operations are skipped.
 
 |[[oracle-property-signal-data-collection]]<<oracle-property-signal-data-collection,`+signal.data.collection+`>>
 |No default value
-a|Fully-qualified name of the data collection that is used to send xref:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector.
+a|Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector.
 When you use this property with an Oracle pluggable database (PDB), set its value to the name of the root database. +
 Use the following format to specify the collection name: +
 `_<databaseName>_._<schemaName>_._<tableName>_`
@@ -3375,11 +3378,11 @@ include::{partialsdir}/modules/all-connectors/ref-connector-pass-through-databas
 
 The {prodname} Oracle connector provides three metric types in addition to the built-in support for JMX metrics that Apache Zookeeper, Apache Kafka, and Kafka Connect have.
 
-* xref:{link-oracle-connector}#oracle-snapshot-metrics[snapshot metrics]; for monitoring the connector when performing snapshots
-* xref:{link-oracle-connector}#oracle-streaming-metrics[streaming metrics]; for monitoring the connector when processing change events
-* xref:{link-oracle-connector}#oracle-schema-history-metrics[schema history metrics]; for monitoring the status of the connector's schema history
+* xref:oracle-snapshot-metrics[snapshot metrics]; for monitoring the connector when performing snapshots
+* xref:oracle-streaming-metrics[streaming metrics]; for monitoring the connector when processing change events
+* xref:oracle-schema-history-metrics[schema history metrics]; for monitoring the status of the connector's schema history
 
-Please refer to the xref:{link-debezium-monitoring}#monitoring-debezium[monitoring documentation] for details of how to expose these metrics via JMX.
+Please refer to the {link-prefix}:{link-debezium-monitoring}#monitoring-debezium[monitoring documentation] for details of how to expose these metrics via JMX.
 
 // Type: reference
 // ModuleID: debezium-oracle-connector-snapshot-metrics

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -85,7 +85,7 @@ The connector relies on and reflects the PostgreSQL logical decoding feature, wh
 * Logical decoding does not support DDL changes. This means that the connector is unable to report DDL change events back to consumers.
 * Logical decoding replication slots are supported on only `primary` servers. When there is a cluster of PostgreSQL servers, the connector can run on only the active `primary` server. It cannot run on `hot` or `warm` standby replicas. If the `primary` server fails or is demoted, the connector stops. After the `primary` server has recovered, you can restart the connector. If a different PostgreSQL server has been promoted to `primary`, adjust the connector configuration before restarting the connector.
 
-xref:{link-postgresql-connector}#postgresql-when-things-go-wrong[ Behavior when things go wrong] describes what the connector does when there is a problem.
+xref:postgresql-when-things-go-wrong[Behavior when things go wrong] describes how the connector responds if there is a problem.
 ====
 
 [IMPORTANT]
@@ -122,7 +122,7 @@ To use the {prodname} connector to stream changes from a PostgreSQL database, th
 Although one way to grant the necessary privileges is to provide the user with `superuser` privileges, doing so potentially exposes your PostgreSQL data to unauthorized access.
 Rather than granting excessive privileges to the {prodname} user, it is best to create a dedicated {prodname} replication user to which you grant specific privileges.
 
-For more information about configuring privileges for the {prodname} PostgreSQL user, see xref:{link-postgresql-connector}#postgresql-permissions[Setting up permissions].
+For more information about configuring privileges for the {prodname} PostgreSQL user, see xref:postgresql-permissions[Setting up permissions].
 For more information about PostgreSQL logical replication security, see the link:https://www.postgresql.org/docs/current/logical-replication-security.html[PostgreSQL documentation].
 
 // Type: concept
@@ -131,7 +131,11 @@ For more information about PostgreSQL logical replication security, see the link
 [[postgresql-snapshots]]
 === Snapshots
 
-Most PostgreSQL servers are configured to not retain the complete history of the database in the WAL segments. This means that the PostgreSQL connector would be unable to see the entire history of the database by reading only the WAL. Consequently, the first time that the connector starts, it performs an initial _consistent snapshot_ of the database. The default behavior for performing a snapshot consists of the following steps. You can change this behavior by setting the xref:{link-postgresql-connector}#postgresql-property-snapshot-mode[`snapshot.mode` connector configuration property] to a value other than `initial`.
+Most PostgreSQL servers are configured to not retain the complete history of the database in the WAL segments.
+This means that the PostgreSQL connector would be unable to see the entire history of the database by reading only the WAL.
+Consequently, the first time that the connector starts, it performs an initial _consistent snapshot_ of the database.
+The default behavior for performing a snapshot consists of the following steps.
+You can change this behavior by setting the xref:postgresql-property-snapshot-mode[`snapshot.mode` connector configuration property] to a value other than `initial`.
 
 . Start a transaction with a link:https://www.postgresql.org/docs/current/static/sql-set-transaction.html[SERIALIZABLE, READ ONLY, DEFERRABLE] isolation level to ensure that subsequent reads in this transaction are against a single consistent version of the data. Any changes to the data due to subsequent `INSERT`, `UPDATE`, and `DELETE` operations by other clients are not visible to this transaction.
 . Read the current position in the server's transaction log.
@@ -165,7 +169,7 @@ If the connector fails, is rebalanced, or stops after Step 1 begins but before S
 
 ifdef::community[]
 |`custom`
-|The `custom` snapshot mode lets you inject your own implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. Set the `snapshot.custom.class` configuration property to the class on the classpath of your Kafka Connect cluster or included in the JAR if using the `EmbeddedEngine`. For more details, see xref:{link-postgresql-connector}#postgresql-custom-snapshot[custom snapshotter SPI].
+|The `custom` snapshot mode lets you inject your own implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. Set the `snapshot.custom.class` configuration property to the class on the classpath of your Kafka Connect cluster or included in the JAR if using the `EmbeddedEngine`. For more details, see xref:postgresql-custom-snapshot[custom snapshotter SPI].
 endif::community[]
 
 |===
@@ -308,7 +312,7 @@ endif::community[]
 
 The PostgreSQL connector typically spends the vast majority of its time streaming changes from the PostgreSQL server to which it is connected. This mechanism relies on link:https://www.postgresql.org/docs/current/static/protocol-replication.html[_PostgreSQL's replication protocol_]. This protocol enables clients to receive changes from the server as they are committed in the server's transaction log at certain positions, which are referred to as Log Sequence Numbers (LSNs).
 
-Whenever the server commits a transaction, a separate server process invokes a callback function from the xref:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in]. This function processes the changes from the transaction, converts them to a specific format (Protobuf or JSON in the case of {prodname} plug-in) and writes them on an output stream, which can then be consumed by clients.
+Whenever the server commits a transaction, a separate server process invokes a callback function from the xref:postgresql-output-plugin[logical decoding plug-in]. This function processes the changes from the transaction, converts them to a specific format (Protobuf or JSON in the case of {prodname} plug-in) and writes them on an output stream, which can then be consumed by clients.
 
 The {prodname} PostgreSQL connector acts as a PostgreSQL client. When the connector receives changes it transforms the events into {prodname} _create_, _update_, or _delete_ events that include the LSN of the event. The PostgreSQL connector forwards these change events in records to the Kafka Connect framework, which is running in the same process. The Kafka Connect process asynchronously writes the change event records in the same order in which they were generated to the appropriate Kafka topic.
 
@@ -335,7 +339,7 @@ As of PostgreSQL 10+, there is a logical replication stream mode, called `pgoutp
 without the need for additional plug-ins.
 This is particularly valuable for environments where installation of plug-ins is not supported or not allowed.
 
-See xref:{link-postgresql-connector}#setting-up-postgresql[Setting up PostgreSQL] for more details.
+For more information, see xref:setting-up-postgresql[Setting up PostgreSQL].
 
 // Type: concept
 // ModuleID: default-names-of-kafka-topics-that-receive-debezium-postgresql-change-event-records
@@ -372,7 +376,7 @@ The connector applies similar naming conventions to label its xref:postgresql-tr
 
 If the default topic name do not meet your requirements, you can configure custom topic names.
 To configure custom topic names, you specify regular expressions in the logical topic routing SMT.
-For more information about using the logical topic routing SMT to customize topic naming, see xref:{link-topic-routing}#topic-routing[Topic routing].
+For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].
 
 // Type: concept
 // ModuleID: debezium-postgresql-connector-generated-events-that-represent-transaction-boundaries
@@ -502,7 +506,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 |`schema`
 |The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed. +
  +
-It is possible to override the table's primary key by setting the xref:{link-postgresql-connector}#postgresql-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
+It is possible to override the table's primary key by setting the xref:postgresql-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
 
 |2
 |`payload`
@@ -519,7 +523,7 @@ It is possible to override the table's primary key by setting the xref:{link-pos
 |===
 
 
-By default behavior is that the connector streams change event records to xref:{link-postgresql-connector}#postgresql-topic-names[topics with names that are the same as the event's originating table].
+By default behavior is that the connector streams change event records to xref:postgresql-topic-names[topics with names that are the same as the event's originating table].
 
 [NOTE]
 ====
@@ -871,7 +875,7 @@ a|In the `schema` section, each `name` field specifies the schema for a field in
 `PostgreSQL_server.inventory.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table. +
  +
 Names of schemas for `before` and `after` fields are of the form `_logicalName_._tableName_.Value`, which ensures that the schema name is unique in the database.
-This means that when using the xref:{link-avro-serialization}#avro-serialization[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
+This means that when using the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
 
 |3
 |`name`
@@ -886,7 +890,7 @@ a|`PostgreSQL_server.inventory.customers.Envelope` is the schema for the overall
 |The value's actual data. This is the information that the change event is providing. +
  +
 It may appear that the JSON representations of the events are much larger than the rows they describe. This is because the JSON representation must include the schema and the payload portions of the message.
-However, by using the xref:{link-avro-serialization}#avro-serialization[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
+However, by using the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
 
 |6
 |`before`
@@ -894,7 +898,7 @@ a|An optional field that specifies the state of the row before the event occurre
  +
 [NOTE]
 ====
-Whether or not this field is available is dependent on the xref:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting for each table.
+Whether or not this field is available is dependent on the xref:postgresql-replica-identity[`REPLICA IDENTITY`] setting for each table.
 ====
 
 |7
@@ -980,7 +984,7 @@ The value of a change event for an update in the sample `customers` table has th
 
 |1
 |`before`
-|An optional field that contains values that were in the row before the database commit. In this example, only the primary key column, `id`, is present because the table's xref:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting is, by default, `DEFAULT`.
+|An optional field that contains values that were in the row before the database commit. In this example, only the primary key column, `id`, is present because the table's xref:postgresql-replica-identity[`REPLICA IDENTITY`] setting is, by default, `DEFAULT`.
 +
 For an _update_ event to contain the previous values of all columns in the row, you would have to change the `customers` table by running `ALTER TABLE customers REPLICA IDENTITY FULL`.
 
@@ -1015,7 +1019,7 @@ In the `source` object, `ts_ms` indicates the time that the change was made in t
 
 [NOTE]
 ====
-Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a xref:{link-postgresql-connector}#postgresql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row. Details are in the next section.
+Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a `DELETE` event and a xref:postgresql-tombstone-events[tombstone event] with the old key for the row, followed by an event with the new key for the row. Details are in the next section.
 ====
 
 // Type: continue
@@ -1072,7 +1076,7 @@ The value in a _delete_ change event has the same `schema` portion as _create_ a
 |`before`
 |Optional field that specifies the state of the row before the event occurred. In a _delete_ event value, the `before` field contains the values that were in the row before it was deleted with the database commit. +
  +
-In this example, the `before` field contains only the primary key column because the table's xref:{link-postgresql-connector}#postgresql-replica-identity[`REPLICA IDENTITY`] setting is `DEFAULT`.
+In this example, the `before` field contains only the primary key column because the table's xref:postgresql-replica-identity[`REPLICA IDENTITY`] setting is `DEFAULT`.
 
 |2
 |`after`
@@ -1294,7 +1298,7 @@ For non-transactional _message_ events, the `source` object's `ts_ms` indicates 
 a|Field that contains the message metadata
 
 * Prefix (text)
-* Content (byte array that is encoded based on the xref:{link-postgresql-connector}#postgresql-property-binary-handling-mode[binary handling mode] setting)
+* Content (byte array that is encoded based on the xref:postgresql-property-binary-handling-mode[binary handling mode] setting)
 
 |===
 
@@ -1427,7 +1431,8 @@ The string representation of the interval value that follows the pattern `P<year
  +
 Either the raw bytes (the default), a base64-encoded string, or a base64-url-safe-encoded String, or a hex-encoded string, based on the connector's xref:postgresql-property-binary-handling-mode[binary handling mode] setting. +
  +
-Debezium only supports Postgres `bytea_output` configuration of value `hex`. See this link:https://www.postgresql.org/docs/current/datatype-binary.html[documentation on Postgres binary data types].
+Debezium only supports Postgres `bytea_output` configuration of value `hex`.
+For more information about PostgreSQL binary data types, see the link:https://www.postgresql.org/docs/current/datatype-binary.html[PostgreSQL documentation].
 
 |`JSON`, `JSONB`
 |`STRING`
@@ -1641,7 +1646,8 @@ The timezone of the JVM running Kafka Connect and {prodname} does not affect thi
 
 PostgreSQL supports using `+/-infinite` values in `TIMESTAMP` columns.
 These special values are converted to timestamps with value `9223372036825200000` in case of positive infinity or `-9223372036832400000` in case of negative infinity.
-This behaviour mimics the standard behaviour of PostgreSQL JDBC driver - see `org.postgresql.PGStatement` interface for reference.
+This behavior mimics the standard behavior of the PostgreSQL JDBC driver.
+For reference, see the https://jdbc.postgresql.org/documentation/publicapi/org/postgresql/PGStatement.html[`org.postgresql.PGStatement`] interface.
 
 [id="postgresql-decimal-types"]
 === Decimal types
@@ -2020,7 +2026,7 @@ It is possible to use {prodname} with link:https://crunchybridge.com/[CrunchyBri
 
 [IMPORTANT]
 ====
-While using the `pgoutput` plug-in, it is recommended that you configure `filtered` as the xref:{link-postgresql-connector}#postgresql-publication-autocreate-mode[`publication.autocreate.mode`]. If you use `all_tables`, which is the default value for `publication.autocreate.mode`, and the publication is not found, the connector tries to create one by using `CREATE PUBLICATION <publication_name> FOR ALL TABLES;`, but this fails due to lack of permissions.
+While using the `pgoutput` plug-in, it is recommended that you configure `filtered` as the xref:postgresql-publication-autocreate-mode[`publication.autocreate.mode`]. If you use `all_tables`, which is the default value for `publication.autocreate.mode`, and the publication is not found, the connector tries to create one by using `CREATE PUBLICATION <publication_name> FOR ALL TABLES;`, but this fails due to lack of permissions.
 ====
 
 [[installing-postgresql-output-plugin]]
@@ -2028,7 +2034,7 @@ While using the `pgoutput` plug-in, it is recommended that you configure `filter
 
 [TIP]
 ====
-See xref:{link-postgresql-plugins}[Logical Decoding Output Plug-in Installation for PostgreSQL] for more detailed instructions for setting up and testing logical decoding plug-ins.
+For more detailed instructions about setting up and testing logical decoding plug-ins, see xref:{link-postgresql-plugins}[Logical Decoding Output Plug-in Installation for PostgreSQL] .
 ====
 
 As of PostgreSQL 9.4, the only way to read changes to the write-ahead-log is to install a logical decoding output plug-in. Plug-ins are written in C, compiled, and installed on the machine that runs the PostgreSQL server. Plug-ins use  a number of PostgreSQL specific APIs, as described by the link:https://www.postgresql.org/docs/current/static/logicaldecoding-output-plugin.html[PostgreSQL documentation].
@@ -2057,7 +2063,7 @@ All up-to-date differences are tracked in a test suite link:https://github.com/d
 [[postgresql-server-configuration]]
 === Configuring the PostgreSQL server
 
-If you are using a xref:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] other than pgoutput, after installing it, configure the PostgreSQL server as follows:
+If you are using a xref:postgresql-output-plugin[logical decoding plug-in] other than pgoutput, after installing it, configure the PostgreSQL server as follows:
 
 . To load the plug-in at startup, add the following to the `postgresql.conf` file::
 +
@@ -2104,7 +2110,7 @@ endif::community[]
 Setting up a PostgreSQL server to run a {prodname} connector requires a database user that can perform replications.
 Replication can be performed only by a database user that has appropriate permissions and only for a configured number of hosts.
 
-Although, by default, superusers have the necessary `REPLICATION` and `LOGIN` roles, as mentioned in xref:{link-postgresql-connector}#postgresql-security[Security], it is best not to provide the {prodname} replication user with elevated privileges.
+Although, by default, superusers have the necessary `REPLICATION` and `LOGIN` roles, as mentioned in xref:postgresql-security[Security], it is best not to provide the {prodname} replication user with elevated privileges.
 Instead, create a {prodname} user that has the minimum required privileges.
 
 .Prerequisites
@@ -2142,7 +2148,7 @@ In general, it is best to manually create publications for the tables that you w
 However, you can configure your environment in a way that permits {prodname} to create publications automatically, and to specify the data that is added to them.
 
 {prodname} uses include list and exclude list properties to specify how data is inserted in the publication.
-For more information about the options for enabling {prodname} to create publications, see xref:{link-postgresql-connector}#postgresql-publication-autocreate-mode[`publication.autocreate.mode`].
+For more information about the options for enabling {prodname} to create publications, see xref:postgresql-publication-autocreate-mode[`publication.autocreate.mode`].
 
 For {prodname} to create a PostgreSQL publication, it must run as a user that has the following privileges:
 
@@ -2181,7 +2187,7 @@ GRANT REPLICATION_GROUP TO __<replication_user>__;
 ALTER TABLE __<table_name>__ OWNER TO REPLICATION_GROUP;
 ----
 
-For {prodname} to specify the capture configuration, the value of xref:{link-postgresql-connector}#postgresql-publication-autocreate-mode[`publication.autocreate.mode`] must be set to `filtered`.
+For {prodname} to specify the capture configuration, the value of xref:postgresql-publication-autocreate-mode[`publication.autocreate.mode`] must be set to `filtered`.
 
 // Type: procedure
 // ModuleID: configuring-postgresql-to-allow-replication-with-the-connector-host
@@ -2219,7 +2225,7 @@ ifdef::community[]
 
 The PostgreSQL connector can be used with a standalone PostgreSQL server or with a cluster of PostgreSQL servers.
 
-As mentioned xref:{link-postgresql-connector}#postgresql-limitations[in the beginning], PostgreSQL (for all versions <= 12) supports logical replication slots on only `primary` servers. This means that a replica in a PostgreSQL cluster cannot be configured for logical replication, and consequently that the {prodname} PostgreSQL connector can connect and communicate with only the primary server. Should this server fail, the connector stops. When the cluster is repaired, if the original primary server is once again promoted to `primary`, you can restart the connector. However, if a different PostgreSQL server _with the plug-in and proper configuration_ is promoted to `primary`, you must change the connector configuration to point to the new `primary` server and then you can restart the connector.
+As mentioned xref:postgresql-limitations[in the beginning], PostgreSQL (for all versions <= 12) supports logical replication slots on only `primary` servers. This means that a replica in a PostgreSQL cluster cannot be configured for logical replication, and consequently that the {prodname} PostgreSQL connector can connect and communicate with only the primary server. Should this server fail, the connector stops. When the cluster is repaired, if the original primary server is once again promoted to `primary`, you can restart the connector. However, if a different PostgreSQL server _with the plug-in and proper configuration_ is promoted to `primary`, you must change the connector configuration to point to the new `primary` server and then you can restart the connector.
 endif::community[]
 
 // Type: concept
@@ -2236,7 +2242,7 @@ Also in the `pg_replication_slots` view, the `restart_lsn` column contains the L
 +
 The database typically reclaims disk space in batch blocks. This is expected behavior and no action by a user is necessary.
 
-* There are many updates in a database that is being tracked but only a tiny number of updates are related to the table(s) and schema(s) for which the connector is capturing changes. This situation can be easily solved with periodic heartbeat events. Set the xref:{link-postgresql-connector}#postgresql-property-heartbeat-interval-ms[`heartbeat.interval.ms`] connector configuration property.
+* There are many updates in a database that is being tracked but only a tiny number of updates are related to the table(s) and schema(s) for which the connector is capturing changes. This situation can be easily solved with periodic heartbeat events. Set the xref:postgresql-property-heartbeat-interval-ms[`heartbeat.interval.ms`] connector configuration property.
 
 * The PostgreSQL instance contains multiple databases and one of them is a high-traffic database. {prodname} captures changes in another database that is low-traffic in comparison to the other database. {prodname} then cannot confirm the LSN as replication slots work per-database and {prodname} is not invoked. As WAL is shared by all databases, the amount used tends to grow until an event is emitted by the database for which {prodname} is capturing changes. To overcome this, it is necessary to:
 
@@ -2246,7 +2252,7 @@ The database typically reclaims disk space in batch blocks. This is expected beh
 +
 A separate process would then periodically update the table by either inserting a new row or repeatedly updating the same row.
 PostgreSQL then invokes {prodname}, which confirms the latest LSN and allows the database to reclaim the WAL space.
-This task can be automated by means of the xref:{link-postgresql-connector}#postgresql-property-heartbeat-action-query[`heartbeat.action.query`] connector configuration property.
+This task can be automated by means of the xref:postgresql-property-heartbeat-action-query[`heartbeat.action.query`] connector configuration property.
 
 ifdef::community[]
 [TIP]
@@ -2268,7 +2274,7 @@ To deploy a {prodname} PostgreSQL connector, you install the {prodname} PostgreS
 .Prerequisites
 
 * link:https://zookeeper.apache.org/[Zookeeper], link:http://kafka.apache.org/[Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
-* PostgreSQL is installed and is xref:{link-postgresql-connector}#setting-up-postgresql[set up to run the {prodname} connector].
+* PostgreSQL is installed and is xref:setting-up-postgresql[set up to run the {prodname} connector].
 
 .Procedure
 
@@ -2399,7 +2405,8 @@ docker push _<myregistry.io>_/debezium-container-for-postgresql:latest
 ----
 
 .. Create a new {prodname} PostgreSQL `KafkaConnect` custom resource (CR).
-For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties as shown in the following example:
+For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties.
+The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource. +
 +
 =====================================================================
 [source,yaml,subs="+attributes"]
@@ -2412,6 +2419,8 @@ metadata:
     strimzi.io/use-connector-resources: "true" // <1>
 spec:
   image: debezium-container-for-postgresql // <2>
+
+  ...
 ----
 =====================================================================
 +
@@ -2441,17 +2450,18 @@ This updates your Kafka Connect environment in OpenShift to add a Kafka Connecto
 +
 You configure a {prodname} PostgreSQL connector in a `.yaml` file that specifies the configuration properties for the connector.
 The connector configuration might instruct {prodname} to produce events for a subset of the schemas and tables, or it might set properties so that {prodname} ignores, masks, or truncates values in specified columns that are sensitive, too large, or not needed.
-For the complete list of the configuration properties that you can set for the {prodname} PostgreSQL connector, see xref:{link-postgresql-connector}#descriptions-of-debezium-sql-server-connector-configuration-properties[PostgreSQL connector properties].
+For the complete list of the configuration properties that you can set for the {prodname} PostgreSQL connector, see xref:descriptions-of-debezium-postgresql-connector-configuration-properties[PostgreSQL connector properties].
 +
-The following example configures a {prodname} connector that connects to a PostgreSQL server host, `192.168.99.100`, on port `5432`. This host has a database named `sampledb`, a schema named `public`, and `fulfillment` is the server's logical name.
+The following example shows an excerpt from a custom resource that configures a {prodname} connector that connects to a PostgreSQL server host, `192.168.99.100`, on port `5432`.
+This host has a database named `sampledb`, a schema named `public`, and `inventory-connector-{context}` is the server's logical name.
 +
-.`fulfillment-connector.yaml`
+.`inventory-connector.yaml`
 [source,yaml,options="nowrap",subs="+attributes"]
 ----
 apiVersion: {KafkaConnectorApiVersion}
   kind: KafkaConnector
   metadata:
-    name: fulfillment-connector  // <1>
+    name: inventory-connector-{context}  // <1>
     labels:
       strimzi.io/cluster: my-connect-cluster
   spec:
@@ -2463,9 +2473,11 @@ apiVersion: {KafkaConnectorApiVersion}
       database.user: debezium
       database.password: dbz
       database.dbname: sampledb
-      topic.prefix: fulfillment   // <5>
+      topic.prefix: inventory-connector-{context}   // <5>
       schema.include.list: public   // <6>
       plugin.name: pgoutput    // <7>
+
+      ...
 ----
 <1> The name of the connector.
 <2> Only one task should operate at any one time.
@@ -2480,25 +2492,23 @@ those tasks will be redistributed to running services.
 <5> A unique topic prefix.
 The server name is the logical identifier for the PostgreSQL server or cluster of servers.
 This name is used as the prefix for all Kafka topics that receive change event records.
-<6> The connector captures changes in only the `public` schema. It is possible to configure the connector to capture changes in only the tables that you choose. See xref:{link-postgresql-connector}#postgresql-property-table-include-list[`table.include.list` connector configuration property].
-<7> The name of the PostgreSQL xref:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed on the PostgreSQL server. While the only supported value for PostgreSQL 10 and later is `pgoutput`, you must explicitly set `plugin.name` to `pgoutput`.
+<6> The connector captures changes in only the `public` schema. It is possible to configure the connector to capture changes in only the tables that you choose.
+For more information, see xref:postgresql-property-table-include-list[`table.include.list`].
+<7> The name of the PostgreSQL xref:postgresql-output-plugin[logical decoding plug-in] installed on the PostgreSQL server. While the only supported value for PostgreSQL 10 and later is `pgoutput`, you must explicitly set `plugin.name` to `pgoutput`.
 
-. Create your connector instance with Kafka Connect. For example, if you saved your `KafkaConnector` resource in the `fulfillment-connector.yaml` file, you would run the following command:
+. Create your connector instance with Kafka Connect. For example, if you saved your `KafkaConnector` resource in the `inventory-connector.yaml` file, you would run the following command:
 +
 [source,shell,options="nowrap"]
 ----
-oc apply -f fulfillment-connector.yaml
+oc apply -f inventory-connector.yaml
 ----
 +
-This registers `fulfillment-connector` and the connector starts to run against the `sampledb` database as defined in the `KafkaConnector` CR.
+This registers `inventory-connector` and the connector starts to run against the `sampledb` database as defined in the `KafkaConnector` CR.
 
 endif::product[]
 
 ifdef::community[]
 
-// Type: concept
-// ModuleID:debezium-postgresql-connector-configuration-example
-// Title: {prodname} PostgreSQL connector configuration example
 [[postgresql-example-configuration]]
 === Connector configuration example
 
@@ -2529,13 +2539,13 @@ Optionally, you can ignore, mask, or truncate columns that contain sensitive dat
 <2> The name of this PostgreSQL connector class.
 <3> The address of the PostgreSQL server.
 <4> The port number of the PostgreSQL server.
-<5> The name of the PostgreSQL user that has the xref:{link-postgresql-connector}#postgresql-permissions[required privileges].
-<6> The password for the PostgreSQL user that has the xref:{link-postgresql-connector}#postgresql-permissions[required privileges].
+<5> The name of the PostgreSQL user that has the xref:postgresql-permissions[required privileges].
+<6> The password for the PostgreSQL user that has the xref:postgresql-permissions[required privileges].
 <7> The name of the PostgreSQL database to connect to
 <8> The topic prefix for the PostgreSQL server/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the Avro converter is used.
 <9> A list of all tables hosted by this server that this connector will monitor. This is optional, and there are other properties for listing the schemas and tables to include or exclude from monitoring.
 
-See the xref:{link-postgresql-connector}#postgresql-connector-properties[complete list of PostgreSQL connector properties] that can be specified in these configurations.
+See the xref:postgresql-connector-properties[complete list of PostgreSQL connector properties] that can be specified in these configurations.
 
 You can send this configuration with a `POST` command to a running Kafka Connect service.
 The service records the configuration and starts one connector task that performs the following actions:
@@ -2551,9 +2561,9 @@ To run a {prodname} PostgreSQL connector, create a connector configuration and a
 
 .Prerequisites
 
-* xref:{link-postgresql-connector}#postgresql-server-configuration[PostgreSQL is configured to support logical replication].
+* xref:postgresql-server-configuration[PostgreSQL is configured to support logical replication].
 
-* The xref:{link-postgresql-connector}#installing-postgresql-output-plugin[logical decoding plug-in] is installed.
+* The xref:installing-postgresql-output-plugin[logical decoding plug-in] is installed.
 
 * The PostgreSQL connector is installed.
 
@@ -2567,7 +2577,7 @@ endif::community[]
 
 .Results
 
-After the connector starts, it xref:{link-postgresql-connector}#postgresql-snapshots[performs a consistent snapshot] of the PostgreSQL server databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
+After the connector starts, it xref:postgresql-snapshots[performs a consistent snapshot] of the PostgreSQL server databases that the connector is configured for. The connector then starts generating data change events for row-level operations and streaming change event records to Kafka topics.
 
 ifdef::product[]
 // Type: procedure
@@ -2613,7 +2623,7 @@ The following configuration properties are _required_ unless a default value is 
 
 |[[postgresql-property-plugin-name]]<<postgresql-property-plugin-name, `+plugin.name+`>>
 |`decoderbufs`
-|The name of the PostgreSQL xref:{link-postgresql-connector}#postgresql-output-plugin[logical decoding plug-in] installed on the PostgreSQL server.
+|The name of the PostgreSQL xref:postgresql-output-plugin[logical decoding plug-in] installed on the PostgreSQL server.
 
 ifdef::community[]
 Supported values are `decoderbufs`, and `pgoutput`.
@@ -2741,9 +2751,11 @@ If you include this property in the configuration, do not set the `column.includ
  +
 `adaptive` captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type. +
  +
-`adaptive_time_microseconds` captures the date, datetime and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type. An exception is `TIME` type fields, which are always captured as microseconds. +
+`adaptive_time_microseconds` captures the date, datetime and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type.
+An exception is `TIME` type fields, which are always captured as microseconds. +
  +
-`connect` always represents time and timestamp values by using Kafka Connect's built-in representations for `Time`, `Date`, and `Timestamp`, which use millisecond precision regardless of the database columns' precision. See xref:{link-postgresql-connector}#postgresql-temporal-values[temporal values].
+`connect` always represents time and timestamp values by using Kafka Connect's built-in representations for `Time`, `Date`, and `Timestamp`, which use millisecond precision regardless of the database columns' precision.
+For more information, see xref:postgresql-temporal-types[temporal values].
 
 |[[postgresql-property-decimal-handling-mode]]<<postgresql-property-decimal-handling-mode, `+decimal.handling.mode+`>>
 |`precise`
@@ -2753,7 +2765,8 @@ If you include this property in the configuration, do not set the `column.includ
  +
 `double` represents values by using `double` values, which might result in a loss of precision but which is easier to use. +
  +
-`string` encodes values as formatted strings, which are easy to consume but semantic information about the real type is lost. See xref:{link-postgresql-connector}#postgresql-decimal-types[Decimal types].
+`string` encodes values as formatted strings, which are easy to consume but semantic information about the real type is lost.
+For more information, see xref:postgresql-decimal-types[Decimal types].
 
 |[[postgresql-property-hstore-handling-mode]]<<postgresql-property-hstore-handling-mode, `+hstore.handling.mode+`>>
 |`map`
@@ -2761,7 +2774,8 @@ If you include this property in the configuration, do not set the `column.includ
  +
 `map` represents values by using `MAP`. +
  +
-`json` represents values by using `json string`. This setting encodes values as formatted strings such as `{"key" : "val"}`. See xref:{link-postgresql-connector}#postgresql-hstore-type[PostgreSQL `HSTORE` type].
+`json` represents values by using `json string`. This setting encodes values as formatted strings such as `{"key" : "val"}`.
+For more information, see xref:postgresql-hstore-type[PostgreSQL `HSTORE` type].
 
 |[[postgresql-property-interval-handling-mode]]<<postgresql-property-interval-handling-mode, `+interval.handling.mode+`>>
 |`numeric`
@@ -2769,7 +2783,9 @@ If you include this property in the configuration, do not set the `column.includ
  +
 `numeric` represents intervals using approximate number of microseconds. +
  +
-`string` represents intervals exactly by using the string pattern representation `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`. For example: `P1Y2M3DT4H5M6.78S`. See xref:{link-postgresql-connector}#postgresql-basic-types[PostgreSQL basic types].
+`string` represents intervals exactly by using the string pattern representation `P<years>Y<months>M<days>DT<hours>H<minutes>M<seconds>S`.
+For example: `P1Y2M3DT4H5M6.78S`.
+For more information, see xref:postgresql-basic-types[PostgreSQL basic types].
 
 |[[postgresql-property-database-sslmode]]<<postgresql-property-database-sslmode, `+database.sslmode+`>>
 |`disable`
@@ -2781,27 +2797,33 @@ If you include this property in the configuration, do not set the `column.includ
  +
 `verify-ca` behaves like `require` but also verifies the server TLS certificate against the configured Certificate Authority (CA) certificates, or fails if no valid matching CA certificates are found. +
  +
-`verify-full` behaves like `verify-ca` but also verifies that the server certificate matches the host to which the connector is trying to connect. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
+`verify-full` behaves like `verify-ca` but also verifies that the server certificate matches the host to which the connector is trying to connect.
+For more information, see link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation].
 
 |[[postgresql-property-database-sslcert]]<<postgresql-property-database-sslcert, `+database.sslcert+`>>
 |No default
-|The path to the file that contains the SSL certificate for the client. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
+|The path to the file that contains the SSL certificate for the client.
+For more information, see link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation].
 
 |[[postgresql-property-database-sslkey]]<<postgresql-property-database-sslkey, `+database.sslkey+`>>
 |No default
-|The path to the file that contains the SSL private key of the client. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
+|The path to the file that contains the SSL private key of the client.
+For more information, see link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation].
 
 |[[postgresql-property-database-sslpassword]]<<postgresql-property-database-sslpassword, `+database.sslpassword+`>>
 |No default
-|The password to access the client private key from the file specified by `database.sslkey`. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
+|The password to access the client private key from the file specified by `database.sslkey`.
+For more information, see link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation].
 
 |[[postgresql-property-database-sslrootcert]]<<postgresql-property-database-sslrootcert, `+database.sslrootcert+`>>
 |No default
-|The path to the file that contains the root certificate(s) against which the server is validated. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
+|The path to the file that contains the root certificate(s) against which the server is validated.
+For more information, see link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation].
 
 |[[postgresql-property-database-tcpkeepalive]]<<postgresql-property-database-tcpkeepalive, `+database.tcpKeepAlive+`>>
 |`true`
-|Enable TCP keep-alive probe to verify that the database connection is still alive. See link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation] for more information.
+|Enable TCP keep-alive probe to verify that the database connection is still alive.
+For more information, see link:https://www.postgresql.org/docs/current/static/libpq-connect.html[the PostgreSQL documentation].
 
 |[[postgresql-property-tombstones-on-delete]]<<postgresql-property-tombstones-on-delete, `+tombstones.on.delete+`>>
 |`true`
@@ -2980,7 +3002,7 @@ For example: `ALTER PUBLICATION <publication_name> SET TABLE <tbl1, tbl2, tbl3>`
 * `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
 * `avro_unicode` replaces the underscore or characters that cannot be used in the Avro type name with corresponding unicode like _uxxxx. Note: _ is an escape sequence like backslash in Java +
 
-See xref:{link-avro-serialization}#avro-naming[Avro naming] for more details.
+For more information, see {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming].
 
 |[[postgresql-property-money-fraction-digits]]<<postgresql-property-money-fraction-digits, `+money.fraction.digits+`>>
 |`2`
@@ -3074,7 +3096,7 @@ For more information, see the xref:#postgresql-connector-snapshot-mode-options[t
 ifdef::community[]
 |[[postgresql-property-snapshot-custom-class]]<<postgresql-property-snapshot-custom-class, `+snapshot.custom.class+`>>
 |No default
-| A full Java class name that is an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. Required when the `snapshot.mode` property is set to `custom`. See xref:{link-postgresql-connector}#postgresql-custom-snapshot[custom snapshotter SPI].
+| A full Java class name that is an implementation of the `io.debezium.connector.postgresql.spi.Snapshotter` interface. Required when the `snapshot.mode` property is set to `custom`. See xref:postgresql-custom-snapshot[custom snapshotter SPI].
 endif::community[]
 
 |[[postgresql-property-snapshot-include-collection-list]]<<postgresql-property-snapshot-include-collection-list, `+snapshot.include.collection.list+`>>
@@ -3089,7 +3111,7 @@ That is, the specified expression is matched against the entire name string of t
 
 |[[postgresql-property-snapshot-lock-timeout-ms]]<<postgresql-property-snapshot-lock-timeout-ms, `+snapshot.lock.timeout.ms+`>>
 |`10000`
-|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. xref:{link-postgresql-connector}#postgresql-snapshots[How the connector performs snapshots] provides details.
+|Positive integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If the connector cannot acquire table locks in this time interval, the snapshot fails. xref:postgresql-snapshots[How the connector performs snapshots] provides details.
 
 |[[postgresql-property-snapshot-select-statement-overrides]]<<postgresql-property-snapshot-select-statement-overrides, `+snapshot.select.statement.overrides+`>>
 |No default
@@ -3159,7 +3181,7 @@ For example, if you set `max.queue.size=1000`, and `max.queue.size.in.bytes=5000
 |`false`
 |Specifies connector behavior when the connector encounters a field whose data type is unknown. The default behavior is that the connector omits the field from the change event and logs a warning. +
  +
-Set this property to `true` if you want the change event to contain an opaque binary representation of the field. This lets consumers decode the field. You can control the exact representation by setting the xref:{link-postgresql-connector}#postgresql-property-binary-handling-mode[`binary handling mode`] property.
+Set this property to `true` if you want the change event to contain an opaque binary representation of the field. This lets consumers decode the field. You can control the exact representation by setting the xref:postgresql-property-binary-handling-mode[`binary handling mode`] property.
 
 NOTE: Consumers risk backward compatibility issues when `include.unknown.datatypes` is set to `true`. Not only may the database-specific binary representation change between releases, but if the data type is eventually supported by {prodname}, the data type will be sent downstream in a logical type, which would require adjustments by consumers. In general, when encountering unsupported data types, create a feature request so that support can be added.
 
@@ -3189,7 +3211,7 @@ Heartbeat messages are needed when there are many updates in a database that is 
 |No default
 |Specifies a query that the connector executes on the source database when the connector sends a heartbeat message. +
  +
-This is useful for resolving the situation described in xref:{link-postgresql-connector}#postgresql-wal-disk-space[WAL disk space consumption], where capturing changes from a low-traffic database on the same host as a high-traffic database prevents {prodname} from processing WAL records and thus acknowledging WAL positions with the database. To address this situation, create a heartbeat table in the low-traffic database, and set this property to a statement that inserts records into that table, for example:  +
+This is useful for resolving the situation described in xref:postgresql-wal-disk-space[WAL disk space consumption], where capturing changes from a low-traffic database on the same host as a high-traffic database prevents {prodname} from processing WAL records and thus acknowledging WAL positions with the database. To address this situation, create a heartbeat table in the low-traffic database, and set this property to a statement that inserts records into that table, for example:  +
  +
 `INSERT INTO test_heartbeat_table (text) VALUES ('test_heartbeat')` +
  +
@@ -3229,11 +3251,13 @@ become outdated if TOASTable columns are dropped from the table.
 |[[postgresql-property-unavailable-value-placeholder]]<<postgresql-property-unavailable-value-placeholder, `+unavailable.value.placeholder+`>>
 |`__debezium_unavailable_value`
 |Specifies the constant that the connector provides to indicate that the original value is a toasted value that is not provided by the database.
-If the setting of `unavailable.value.placeholder` starts with the `hex:` prefix it is expected that the rest of the string represents hexadecimally encoded octets. See xref:postgresql-toasted-values[toasted values] for additional details.
+If the setting of `unavailable.value.placeholder` starts with the `hex:` prefix it is expected that the rest of the string represents hexadecimally encoded octets.
+For more information, see xref:postgresql-toasted-values[toasted values].
 
 |[[postgresql-property-provide-transaction-metadata]]<<postgresql-property-provide-transaction-metadata, `+provide.transaction.metadata+`>>
 |`false`
-|Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this. See xref:{link-postgresql-connector}#postgresql-transaction-metadata[Transaction metadata] for details.
+|Determines whether the connector generates events with transaction boundaries and enriches change event envelopes with transaction metadata. Specify `true` if you want the connector to do this.
+For more information, see xref:postgresql-transaction-metadata[Transaction metadata].
 
 |[[postgresql-property-flush-lsn-source]]<<postgresql-property-flush-lsn-source, `+flush.lsn.source+`>>
 |`true`
@@ -3332,10 +3356,10 @@ Be sure to consult the {link-kafka-docs}.html[Kafka documentation] for all of th
 
 The {prodname} PostgreSQL connector provides two types of metrics that are in addition to the built-in support for JMX metrics that Zookeeper, Kafka, and Kafka Connect provide.
 
-* xref:{link-postgresql-connector}#postgresql-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
-* xref:{link-postgresql-connector}#postgresql-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
+* xref:postgresql-snapshot-metrics[Snapshot metrics] provide information about connector operation while performing a snapshot.
+* xref:postgresql-streaming-metrics[Streaming metrics] provide information about connector operation when the connector is capturing changes and streaming change event records.
 
-xref:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
+{link-prefix}:{link-debezium-monitoring}#monitoring-debezium[{prodname} monitoring documentation] provides details for how to expose these metrics by using JMX.
 
 // Type: reference
 // ModuleID: monitoring-debezium-during-snapshots-of-postgresql-databases
@@ -3403,7 +3427,8 @@ In these cases, the error message has details about the problem and possibly a s
 
 When the connector is running, the PostgreSQL server that it is connected to could become unavailable for any number of reasons. If this happens, the connector fails with an error and stops. When the server is available again, restart the connector.
 
-The PostgreSQL connector externally stores the last processed offset in the form of a PostgreSQL LSN. After a connector restarts and connects to a server instance, the connector communicates with the server to continue streaming from that particular offset. This offset is available as long as the {prodname} replication slot remains intact.  Never drop a replication slot on the primary server or you will lose data. See the next section for failure cases in which a slot has been removed.
+The PostgreSQL connector externally stores the last processed offset in the form of a PostgreSQL LSN. After a connector restarts and connects to a server instance, the connector communicates with the server to continue streaming from that particular offset. This offset is available as long as the {prodname} replication slot remains intact.  Never drop a replication slot on the primary server or you will lose data.
+For information about failure cases in which a slot has been removed, see the next section.
 
 [id="postgresql-cluster-failures"]
 === Cluster failures
@@ -3418,7 +3443,7 @@ Some managed PostgresSQL services (AWS RDS and GCP CloudSQL for example) impleme
 ====
 
 ifdef::community[]
-The new primary must have the xref:{link-postgresql-connector}#installing-postgresql-output-plugin[logical decoding plug-in] installed and a replication slot that is configured for use by the plug-in and the database for which you want to capture changes. Only then can you point the connector to the new server and restart the connector.
+The new primary must have the xref:installing-postgresql-output-plugin[logical decoding plug-in] installed and a replication slot that is configured for use by the plug-in and the database for which you want to capture changes. Only then can you point the connector to the new server and restart the connector.
 endif::community[]
 
 ifdef::product[]

--- a/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
+++ b/documentation/modules/ROOT/pages/connectors/sqlserver.adoc
@@ -241,7 +241,7 @@ _topicPrefix_:: The logical name of the server, as specified by the xref:sqlserv
 _schemaName_:: The name of the database schema in which the change event occurred.
 _tableName_:: The name of the database table in which the change event occurred.
 
-For example, if `fulfillment` is the server name, and `dbo` is the schema name, and the database contains tables with the names `products`, `products_on_hand`, `customers`, and `orders`,
+For example, if `fulfillment` is the logical server name, and `dbo` is the schema name, and the database contains tables with the names `products`, `products_on_hand`, `customers`, and `orders`,
 the connector would stream change event records to the following Kafka topics:
 
 * `fulfillment.testDB.dbo.products`
@@ -253,7 +253,7 @@ The connector applies similar naming conventions to label its internal database 
 
 If the default topic name do not meet your requirements, you can configure custom topic names.
 To configure custom topic names, you specify regular expressions in the logical topic routing SMT.
-For more information about using the logical topic routing SMT to customize topic naming, see xref:{link-topic-routing}#topic-routing[Topic routing].
+For more information about using the logical topic routing SMT to customize topic naming, see {link-prefix}:{link-topic-routing}#topic-routing[Topic routing].
 
 
 // Type: concept
@@ -290,7 +290,7 @@ The format of the messages that a connector emits to its schema change topic is 
 
 * You enable CDC for a table.
 * You disable CDC for a table.
-* You alter the structure of a table for which CDC is enabled by following the xref:{link-sqlserver-connector}#sqlserver-schema-evolution[schema evolution procedure].
+* You alter the structure of a table for which CDC is enabled by following the xref:sqlserver-schema-evolution[schema evolution procedure].
 
 .Example: Message emitted to the SQL Server connector schema change topic
 The following example shows a message in the schema change topic.
@@ -517,7 +517,7 @@ The following skeleton JSON shows the basic four parts of a change event. Howeve
 |`schema`
 |The first `schema` field is part of the event key. It specifies a Kafka Connect schema that describes what is in the event key's `payload` portion. In other words, the first `schema` field describes the structure of the primary key, or the unique key if the table does not have a primary key, for the table that was changed. +
  +
-It is possible to override the table's primary key by setting the xref:{link-sqlserver-connector}#sqlserver-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
+It is possible to override the table's primary key by setting the xref:sqlserver-property-message-key-columns[`message.key.columns` connector configuration property]. In this case, the first schema field describes the structure of the key identified by that property.
 
 |2
 |`payload`
@@ -533,7 +533,8 @@ It is possible to override the table's primary key by setting the xref:{link-sql
 
 |===
 
-By default, the connector streams change event records to topics with names that are the same as the event's originating table. See xref:{link-sqlserver-connector}#sqlserver-topic-names[topic names].
+By default, the connector streams change event records to topics with names that are the same as the event's originating table.
+For more information, see xref:sqlserver-topic-names[topic names].
 
 [WARNING]
 ====
@@ -859,7 +860,7 @@ a|In the `schema` section, each `name` field specifies the schema for a field in
 `server1.dbo.testDB.customers.Value` is the schema for the payload's `before` and `after` fields. This schema is specific to the `customers` table. +
  +
  Names of schemas for `before` and `after` fields are of the form `_logicalName_._database-schemaName_._tableName_.Value`, which ensures that the schema name is unique in the database.
- This means that when using the xref:{link-avro-serialization}#avro-serialization[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
+ This means that when using the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], the resulting Avro schema for each table in each logical source has its own evolution and history.
 
 |3
 |`name`
@@ -874,7 +875,7 @@ a|`server1.dbo.testDB.customers.Envelope` is the schema for the overall structur
 |The value's actual data. This is the information that the change event is providing. +
  +
 It may appear that the JSON representations of the events are much larger than the rows they describe. This is because the JSON representation must include the schema and the payload portions of the message.
-However, by using the xref:{link-avro-serialization}#avro-serialization[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
+However, by using the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter], you can significantly decrease the size of the messages that the connector streams to Kafka topics.
 
 |6
 |`before`
@@ -1005,7 +1006,7 @@ By comparing the value for `payload.source.ts_ms` with the value for `payload.ts
 
 [NOTE]
 ====
-Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a _delete_ event and a xref:{link-sqlserver-connector}#sqlserver-tombstone-events[tombstone event] with the old key for the row, followed by a _create_ event with the new key for the row.
+Updating the columns for a row's primary/unique key changes the value of the row's key. When a key changes, {prodname} outputs _three_ events: a _delete_ event and a xref:sqlserver-tombstone-events[tombstone event] with the old key for the row, followed by a _create_ event with the new key for the row.
 ====
 
 [[sqlserver-delete-events]]
@@ -1304,7 +1305,7 @@ If present, a column's default value is propagated to the corresponding field's 
 Change messages will contain the field's default value
 (unless an explicit column value had been given), so there should rarely be the need to obtain the default value from the schema.
 ifdef::community[]
-Passing the default value helps though with satisfying the compatibility rules when xref:{link-avro-serialization}[using Avro] as serialization format together with the Confluent schema registry.
+Passing the default value helps though with satisfying the compatibility rules when {link-prefix}:{link-avro-serialization}[using Avro] as serialization format together with the Confluent schema registry.
 endif::community[]
 
 [[sql-server-temporal-values]]
@@ -1426,7 +1427,7 @@ Note that the timezone of the JVM running Kafka Connect and {prodname} does not 
 [id="sql-server-decimal-values"]
 ==== Decimal values
 
-{prodname} connectors handle decimals according to the setting of the xref:{link-sqlserver-connector}#sqlserver-property-decimal-handling-mode[`decimal.handling.mode` connector configuration property].
+{prodname} connectors handle decimals according to the setting of the xref:sqlserver-property-decimal-handling-mode[`decimal.handling.mode` connector configuration property].
 
 decimal.handling.mode=precise::
 +
@@ -1750,13 +1751,13 @@ To deploy a {prodname} SQL Server connector, you install the {prodname} SQL Serv
 
 .Prerequisites
 * link:https://zookeeper.apache.org/[Apache ZooKeeper], link:http://kafka.apache.org/[Apache Kafka], and link:{link-kafka-docs}.html#connect[Kafka Connect] are installed.
-* SQL Server is installed, is xref:{link-sqlserver-connector}#setting-up-sqlserver[configured for CDC], and is ready to be used with the {prodname} connector.
+* SQL Server is installed, is xref:setting-up-sqlserver[configured for CDC], and is ready to be used with the {prodname} connector.
 
 .Procedure
 . Download the {prodname} https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/{debezium-version}/debezium-connector-sqlserver-{debezium-version}-plugin.tar.gz[SQL Server connector plug-in archive]
 . Extract the files into your Kafka Connect environment.
 . Add the directory with the JAR files to {link-kafka-docs}/#connectconfigs[Kafka Connect's `plugin.path`].
-. xref:{link-sqlserver-connector}#sqlserver-example-configuration[Configure the connector] and xref:{link-sqlserver-connector}#sqlserver-adding-connector-configuration[add the configuration to your Kafka Connect cluster.]
+. xref:sqlserver-example-configuration[Configure the connector] and xref:sqlserver-adding-connector-configuration[add the configuration to your Kafka Connect cluster.]
 . Restart your Kafka Connect process to pick up the new JAR files.
 
 If you are working with immutable containers, see link:https://quay.io/organization/debezium[{prodname}'s container images] for Åpache ZooKeeper, Apache Kafka, and Kafka Connect.
@@ -1884,7 +1885,8 @@ docker push _<myregistry.io>_/debezium-container-for-sqlserver:latest
 ----
 
 .. Create a new {prodname} SQL Server KafkaConnect custom resource (CR).
-For example, create a KafkaConnect CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties as shown in the following example:
+For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies `annotations` and `image` properties.
+The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource. +
 +
 =====================================================================
 [source,yaml,subs="+attributes"]
@@ -1898,6 +1900,8 @@ metadata:
 spec:
   #...
   image: debezium-container-for-sqlserver  // <2>
+
+  ...
 ----
 =====================================================================
 +
@@ -1929,15 +1933,15 @@ You configure a {prodname} SQL Server connector in a `.yaml` file that specifies
 The connector configuration might instruct {prodname} to produce events for a subset of the schemas and tables, or it might set properties so that {prodname} ignores, masks, or truncates values in specified columns that are sensitive, too large, or not needed.
 +
 The following example configures a {prodname} connector that connects to a SQL server host, `192.168.99.100`, on port `1433`.
-This host has a database named `testDB`, a table with the name `customers`, and `fulfillment` is the server's logical name.
+This host has a database named `testDB`, a table with the name `customers`, and `inventory-connector-{context}` is the server's logical name.
 +
-.SQL Server `fulfillment-connector.yaml`
+.SQL Server `inventory-connector.yaml`
 [source,yaml,subs="+attributes",options="nowrap"]
 ----
 apiVersion: {KafkaConnectorApiVersion}
 kind: KafkaConnector
 metadata:
-  name: fulfillment-connector // <1>
+  name: inventory-connector-{context} // <1>
   labels:
     strimzi.io/cluster: my-connect-cluster
   annotations:
@@ -1950,7 +1954,7 @@ spec:
     database.user: debezium // <5>
     database.password: dbz // <6>
     database.names: testDB1,testDB2 // <7>
-    topic.prefix: fullfullment // <8>
+    topic.prefix: inventory-connector-{context} // <8>
     table.include.list: dbo.customers // <9>
     schema.history.internal.kafka.bootstrap.servers: my-cluster-kafka-bootstrap:9092 // <10>
     schema.history.internal.kafka.topic: schemahistory.fullfillment // <11>
@@ -1985,7 +1989,7 @@ spec:
 |The name of the database to capture changes from.
 
 |8
-|The topic prefix for the SQL Server instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the xref:{link-avro-serialization}#avro-serialization[Avro converter] is used.
+|The topic prefix for the SQL Server instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter] is used.
 
 |9
 |The connector captures changes from the `dbo.customers` table only.
@@ -2007,14 +2011,14 @@ This property is required unless database encryption is disabled (`database.encr
 |===
 
 . Create your connector instance with Kafka Connect.
-  For example, if you saved your `KafkaConnector` resource in the `fulfillment-connector.yaml` file, you would run the following command:
+  For example, if you saved your `KafkaConnector` resource in the `inventory-connector.yaml` file, you would run the following command:
 +
 [source,shell,options="nowrap"]
 ----
-oc apply -f fulfillment-connector.yaml
+oc apply -f inventory-connector.yaml
 ----
 +
-The preceding command registers `fulfillment-connector` and the connector starts to run against the `testDB` database as defined in the `KafkaConnector` CR.
+The preceding command registers `inventory-connector` and the connector starts to run against the `testDB` database as defined in the `KafkaConnector` CR.
 
 [id="verifying-that-the-debezium-sqlserver-connector-is-running"]
 === Verifying that the {prodname} SQL Server connector is running
@@ -2060,7 +2064,7 @@ Optionally, you can ignore, mask, or truncate columns that contain sensitive dat
 <5> The name of the SQL Server user
 <6> The password for the SQL Server user
 <7> The name of the database to capture changes from.
-<8> The topic prefix for the SQL Server instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the xref:{link-avro-serialization}#avro-serialization[Avro converter] is used.
+<8> The topic prefix for the SQL Server instance/cluster, which forms a namespace and is used in all the names of the Kafka topics to which the connector writes, the Kafka Connect schema names, and the namespaces of the corresponding Avro schema when the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro converter] is used.
 <9> A list of all tables whose changes {prodname} should capture.
 <10> The list of Kafka brokers that this connector will use to write and recover DDL statements to the database schema history topic.
 <11> The name of the database schema history topic where the connector will write and recover DDL statements. This topic is for internal use only and should not be used by consumers.
@@ -2070,7 +2074,7 @@ This property is required unless database encryption is disabled (`database.encr
 This property is required unless database encryption is disabled (`database.encrypt=false`).
 endif::community[]
 
-For the complete list of the configuration properties that you can set for the {prodname} SQL Server connector, see xref:{link-sqlserver-connector}#sqlserver-connector-properties[SQL Server connector properties].
+For the complete list of the configuration properties that you can set for the {prodname} SQL Server connector, see xref:sqlserver-connector-properties[SQL Server connector properties].
 
 ifdef::community[]
 You can send this configuration with a `POST` command to a running Kafka Connect service.
@@ -2087,7 +2091,7 @@ To start running a {prodname} SQL Server connector, create a connector configura
 
 .Prerequisites
 
-* xref:{link-sqlserver-connector}#setting-up-sqlserver[CDC is enabled on SQL Server].
+* xref:setting-up-sqlserver[CDC is enabled on SQL Server].
 * The {prodname} SQL Server connector is installed.
 
 .Procedure
@@ -2099,7 +2103,7 @@ endif::community[]
 
 .Results
 
-When the connector starts, it xref:{link-sqlserver-connector}#sqlserver-snapshots[performs a consistent snapshot] of the SQL Server databases that the connector is configured for.
+When the connector starts, it xref:sqlserver-snapshots[performs a consistent snapshot] of the SQL Server databases that the connector is configured for.
 The connector then starts generating data change events for row-level operations and streaming the change event records to Kafka topics.
 
 // Type: reference
@@ -2271,7 +2275,8 @@ Hashing strategy version 2 should be used to ensure fidelity if the value is bei
 
 |[[sqlserver-property-time-precision-mode]]<<sqlserver-property-time-precision-mode, `+time.precision.mode+`>>
 |`adaptive`
-| Time, date, and timestamps can be represented with different kinds of precision, including: `adaptive` (the default) captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type; or `connect` always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which uses millisecond precision regardless of the database columns' precision. See xref:{link-sqlserver-connector}#sqlserver-temporal-values[temporal values].
+| Time, date, and timestamps can be represented with different kinds of precision, including: `adaptive` (the default) captures the time and timestamp values exactly as in the database using either millisecond, microsecond, or nanosecond precision values based on the database column's type; or `connect` always represents time and timestamp values using Kafka Connect's built-in representations for Time, Date, and Timestamp, which uses millisecond precision regardless of the database columns' precision.
+For more information, see xref:sql-server-temporal-values[temporal values].
 
 |[[sqlserver-property-decimal-handling-mode]]<<sqlserver-property-decimal-handling-mode,`+decimal.handling.mode+`>>
 |`precise`
@@ -2408,7 +2413,7 @@ However, it's best to use the minimum number that are required to specify a uniq
 * `avro` replaces the characters that cannot be used in the Avro type name with underscore. +
 * `avro_unicode` replaces the underscore or characters that cannot be used in the Avro type name with corresponding unicode like _uxxxx. Note: _ is an escape sequence like backslash in Java +
 
-See xref:{link-avro-serialization}#avro-naming[Avro naming] for more details.
+For more information, see {link-prefix}:{link-avro-serialization}#avro-naming[Avro naming].
 
 |===
 
@@ -2551,7 +2556,7 @@ Defaults to the JDBC driver's default fetch size.
 
 |[[sqlserver-property-snapshot-lock-timeout-ms]]<<sqlserver-property-snapshot-lock-timeout-ms, `+snapshot.lock.timeout.ms+`>>
 |`10000`
-|An integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If table locks cannot be acquired in this time interval, the snapshot will fail (also see xref:{link-sqlserver-connector}#sqlserver-snapshots[snapshots]). +
+|An integer value that specifies the maximum amount of time (in milliseconds) to wait to obtain table locks when performing a snapshot. If table locks cannot be acquired in this time interval, the snapshot will fail (also see xref:sqlserver-snapshots[snapshots]). +
 When set to `0` the connector will fail immediately when it cannot obtain the lock. Value `-1` indicates infinite waiting.
 
 |[[sqlserver-property-snapshot-select-statement-overrides]]<<sqlserver-property-snapshot-select-statement-overrides, `+snapshot.select.statement.overrides+`>>
@@ -2609,7 +2614,7 @@ By default, truncate operations are skipped (not emitted by this connector).
 
 |[[sqlserver-property-signal-data-collection]]<<sqlserver-property-signal-data-collection,`+signal.data.collection+`>>
 |No default value
-| Fully-qualified name of the data collection that is used to send xref:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector. +
+| Fully-qualified name of the data collection that is used to send {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[signals] to the connector. +
 Use the following format to specify the collection name: +
 `_<databaseName>_._<schemaName>_._<tableName>_`
 
@@ -2715,8 +2720,8 @@ As a {prodname} user, you must coordinate tasks with the SQL Server database ope
 
 You can use one of the following methods to update capture tables after a schema change:
 
-* xref:{link-sqlserver-connector}#offline-schema-updates[Offline schema updates] require you to stop the {prodname} connector before you can update capture tables.
-* xref:{link-sqlserver-connector}#online-schema-updates[Online schema updates] can update capture tables while the {prodname} connector is running.
+* xref:offline-schema-updates[Offline schema updates] require you to stop the {prodname} connector before you can update capture tables.
+* xref:online-schema-updates[Online schema updates] can update capture tables while the {prodname} connector is running.
 
 There are advantages and disadvantages to using each type of procedure.
 

--- a/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
+++ b/documentation/modules/ROOT/pages/integrations/cloudevents.adoc
@@ -51,7 +51,7 @@ endif::product[]
 
 For information about using Avro, see:
 
-* xref:{link-avro-serialization}#avro-serialization[Avro serialization]
+* {link-prefix}:{link-avro-serialization}#avro-serialization[Avro serialization]
 
 * link:https://github.com/Apicurio/apicurio-registry[Apicurio Registry]
 

--- a/documentation/modules/ROOT/pages/operations/monitoring.adoc
+++ b/documentation/modules/ROOT/pages/operations/monitoring.adoc
@@ -35,14 +35,14 @@ be sure to use distinct JMX ports for each service.
 In addition to the built-in support for JMX metrics in Kafka, Zookeeper, and Kafka Connect,
 each connector provides additional metrics that you can use to monitor their activities.
 
-* xref:{link-mysql-connector}#mysql-monitoring[MySQL connector metrics]
-* xref:{link-mongodb-connector}#mongodb-monitoring[MongoDB connector metrics]
-* xref:{link-postgresql-connector}#postgresql-monitoring[PostgreSQL connector metrics]
-* xref:{link-sqlserver-connector}#sqlserver-monitoring[SQL Server connector metrics]
-* xref:{link-db2-connector}#db2-monitoring[Db2 connector metrics]
+* {link-prefix}:{link-db2-connector}#db2-monitoring[Db2 connector metrics]
+* {link-prefix}:{link-mongodb-connector}#mongodb-monitoring[MongoDB connector metrics]
+* {link-prefix}:{link-mysql-connector}#mysql-monitoring[MySQL connector metrics]
+* {link-prefix}:{link-oracle-connector}#oracle-monitoring[Oracle connector metrics]
+* {link-prefix}:{link-postgresql-connector}#postgresql-monitoring[PostgreSQL connector metrics]
+* {link-prefix}:{link-sqlserver-connector}#sqlserver-monitoring[SQL Server connector metrics]
 ifdef::community[]
-* xref:{link-oracle-connector}#oracle-monitoring[Oracle connector metrics]
-* xref:{link-cassandra-connector}#cassandra-monitoring[Cassandra connector metrics]
+* {link-prefix}:{link-cassandra-connector}#cassandra-monitoring[Cassandra connector metrics]
 endif::community[]
 
 

--- a/documentation/modules/ROOT/pages/transformations/content-based-routing.adoc
+++ b/documentation/modules/ROOT/pages/transformations/content-based-routing.adoc
@@ -188,7 +188,7 @@ In addition to the change event messages that a {prodname} connector emits when 
 Because the structure of these other messages differs from the structure of the change event messages that the SMT is designed to process, it's best to configure the connector to selectively apply the SMT, so that it processes only the intended data change messages.
 You can use one of the following methods to configure the connector to apply the SMT selectively:
 
-* xref:{link-smt-predicates}#applying-transformations-selectively[Configure an SMT predicate for the transformation].
+* {link-prefix}:{link-smt-predicates}#applying-transformations-selectively[Configure an SMT predicate for the transformation].
 * Use the xref:content-based-router-topic-regex[topic.regex] configuration option for the SMT.
 
 // Type: reference
@@ -197,7 +197,7 @@ You can use one of the following methods to configure the connector to apply the
 == Language specifics
 
 The way that you express content-based routing conditions depends on the scripting language that you use.
-For example, as shown in the xref:{link-content-based-routing}#example-basic-content-based-routing-configuration[basic configuration example], when you use `Groovy` as the expression language,
+For example, as shown in the xref:example-basic-content-based-routing-configuration[basic configuration example], when you use `Groovy` as the expression language,
 the following expression reroutes all update (`u`) records to the `updates` topic, while routing other records to the default topic:
 
 [source,groovy]

--- a/documentation/modules/ROOT/pages/transformations/event-changes.adoc
+++ b/documentation/modules/ROOT/pages/transformations/event-changes.adoc
@@ -124,7 +124,7 @@ To apply the transformation to a subset of events, you can define xref:options-f
 In addition to the change event messages that a {prodname} connector emits when a database change occurs, the connector also emits other types of messages, including heartbeat messages, and metadata messages about schema changes and transactions.
 Because the structure of these other messages differs from the structure of the change event messages that the SMT is designed to process, it's best to configure the connector to selectively apply the SMT, so that it processes only the intended data change messages.
 
-For more information about how to apply the SMT selectively, see xref:{link-smt-predicates}#applying-transformations-selectively[Configure an SMT predicate for the transformation].
+For more information about how to apply the SMT selectively, see {link-prefix}:{link-smt-predicates}#applying-transformations-selectively[Configure an SMT predicate for the transformation].
 
 [id="configuration-options"]
 

--- a/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/event-flattening.adoc
@@ -235,7 +235,7 @@ To add metadata to a simplified Kafka record that is for a `DELETE` operation, y
 In addition to the change event messages that a {prodname} connector emits when a database change occurs, the connector also emits other types of messages, including heartbeat messages, and metadata messages about schema changes and transactions.
 Because the structure of these other messages differs from the structure of the change event messages that the SMT is designed to process, it's best to configure the connector to selectively apply the SMT, so that it processes only the intended data change messages.
 
-For more information about how to apply the SMT selectively, see xref:{link-smt-predicates}#applying-transformations-selectively[Configure an SMT predicate for the transformation].
+For more information about how to apply the SMT selectively, see {link-prefix}:{link-smt-predicates}#applying-transformations-selectively[Configure an SMT predicate for the transformation].
 
 ifdef::community[]
 [id="configuration-options"]
@@ -255,12 +255,11 @@ The following table describes the options that you can specify to configure the 
 |Default
 |Description
 
-|[[extract-new-record-state-drop-tombstones]]xref:{link-event-flattening}#extract-new-record-state-drop-tombstones[`drop.tombstones`]
+|[[extract-new-record-state-drop-tombstones]]xref:extract-new-record-state-drop-tombstones[`drop.tombstones`]
 |`true`
 |{prodname} generates a tombstone record for each `DELETE` operation. The default behavior is that event flattening SMT removes tombstone records from the stream. To keep tombstone records in the stream, specify `drop.tombstones=false`.
 
-[id="extract-new-record-state-delete-handling-mode"]
-|xref:{link-event-flattening}#extract-new-record-state-delete-handling-mode[`delete.handling{zwsp}.mode`]
+|[[extract-new-record-state-delete-handling-mode]]xref:extract-new-record-state-delete-handling-mode[`delete.handling{zwsp}.mode`]
 |`drop`
 |{prodname} generates a change event record for each `DELETE` operation. The default behavior is that event flattening SMT removes these records from the stream. To keep Kafka records for `DELETE` operations in the stream, set `delete.handling.mode` to `none` or `rewrite`. +
  +
@@ -270,8 +269,7 @@ Specify `rewrite` to keep the change event record in the stream and edit the rec
  +
 When you  specify `rewrite`, the updated simplified records for `DELETE` operations might be all you need to track deleted records. You can consider accepting the default behavior of dropping the tombstone records that the {prodname} connector creates.
 
-[id="extract-new-record-state-route-by-field"]
-|xref:{link-event-flattening}#extract-new-record-state-route-by-field[`route.by.field`]
+|[[extract-new-record-state-route-by-field]]xref:extract-new-record-state-route-by-field[`route.by.field`]
 |
 |To use row data to determine the topic to route the record to, set this option to an `after` field attribute. The SMT routes the record to the topic whose name matches the value of the specified `after` field attribute. For a `DELETE` operation, set this option to a `before` field attribute. +
  +
@@ -279,13 +277,11 @@ For example, configuration of `route.by.field=destination` routes records to the
  +
 If you are configuring the event flattening SMT on a sink connector, setting this option might be useful when the destination topic name dictates the name of the database table that will be updated with the simplified change event record. If the topic name is not correct for your use case, you can configure `route.by.field` to re-route the event.
 
-[id="extract-new-record-state-add-fields-prefix"]
-|xref:{link-event-flattening}#extract-new-record-state-add-fields-prefix[`add.fields.prefix`]
+|[[extract-new-record-state-add-fields-prefix]]xref:extract-new-record-state-add-fields-prefix[`add.fields.prefix`]
 | __ (double-underscore)
 |Set this optional string to prefix a field.
 
-[id="extract-new-record-state-add-fields"]
-|xref:{link-event-flattening}#extract-new-record-state-add-fields[`add.fields`]
+|[[extract-new-record-state-add-fields]]xref:extract-new-record-state-add-fields[`add.fields`]
 |
 |Set this option to a comma-separated list, with no spaces, of metadata fields to add to the simplified Kafka record's value. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
  +
@@ -295,13 +291,11 @@ When the SMT adds metadata fields to the simplified record's value, it prefixes 
  +
 If you specify a field that is not in the change event record, the SMT still adds the field to the record's value.
 
-[id="extract-new-record-state-add-headers-prefix"]
-|xref:{link-event-flattening}#extract-new-record-state-add-headers-prefix[`add.headers.prefix`]
+|[[extract-new-record-state-add-headers-prefix]]xref:extract-new-record-state-add-headers-prefix[`add.headers.prefix`]
 | __ (double-underscore)
 |Set this optional string to prefix a header.
 
-[id="extract-new-record-state-add-headers"]
-|xref:{link-event-flattening}#extract-new-record-state-add-headers[`add.headers`]
+|[[extract-new-record-state-add-headers]]xref:extract-new-record-state-add-headers[`add.headers`]
 |
 |Set this option to a comma-separated list, with no spaces, of metadata fields to add to the header of the simplified Kafka record. When there are duplicate field names, to add metadata for one of those fields, specify the struct as well as the field, for example `source.ts_ms`. +
  +
@@ -311,18 +305,16 @@ When the SMT adds metadata fields to the simplified record's header, it prefixes
  +
 If you specify a field that is not in the change event record, the SMT does not add the field to the header.
 
-[id="extract-new-record-state-drop-fields-header-name"]
-|xref:extract-new-record-state-drop-fields-header-name[`drop.fields.header.name`]
+|[[extract-new-record-state-drop-fields-header-name]]xref:extract-new-record-state-drop-fields-header-name[`drop.fields.header.name`]
 |
 |The Kafka message header name to use for listing field names in the source message that you want to drop from the output message.
 
-[id="extract-new-record-state-drop-fields-from-key"]
-|xref:extract-new-record-state-drop-fields-from-key[`drop.fields.from.key`]
+|[[extract-new-record-state-drop-fields-from-key]]xref:extract-new-record-state-drop-fields-from-key[`drop.fields.from.key`]
 |`false`
 |Specifies whether you want the SMT to remove fields that are listed in `drop.fields.header.name` from the event's key.
 
-[id="extract-new-record-state-drop-fields-keep-schema-compatible"]
-|xref:extract-new-record-state-drop-fields-keep-schema-compatible[`drop.fields.keep.schema.compatible`]
+
+|[[extract-new-record-state-drop-fields-keep-schema-compatible]]xref:extract-new-record-state-drop-fields-keep-schema-compatible[`drop.fields.keep.schema.compatible`]
 |`true`
 |Specifies whether you want the SMT to remove non-optional fields that are included in the xref:extract-new-record-state-drop-fields-header-name[`drop.fields.header.name`] configuration property. +
  +

--- a/documentation/modules/ROOT/pages/transformations/filtering.adoc
+++ b/documentation/modules/ROOT/pages/transformations/filtering.adoc
@@ -183,7 +183,7 @@ In addition to the change event messages that a {prodname} connector emits when 
 Because the structure of these other messages differs from the structure of the change event messages that the SMT is designed to process, it's best to configure the connector to selectively apply the SMT, so that it processes only the intended data change messages.
 You can use one of the following methods to configure the connector to apply the SMT selectively:
 
-* xref:{link-smt-predicates}#applying-transformations-selectively[Configure an SMT predicate for the transformation].
+* {link-prefix}:{link-smt-predicates}#applying-transformations-selectively[Configure an SMT predicate for the transformation].
 * Use the xref:filter-topic-regex[topic.regex] configuration option for the SMT.
 
 // Type: reference
@@ -193,7 +193,7 @@ You can use one of the following methods to configure the connector to apply the
 
 The way that you express filtering conditions depends on the scripting language that you use.
 
-For example, as shown in the xref:{link-filtering}#example-basic-filter-configuration-example[basic configuration example], when you use `Groovy` as the expression language,
+For example, as shown in the xref:example-basic-filter-configuration-example[basic configuration example], when you use `Groovy` as the expression language,
 the following expression removes all messages, except for update records that have `id` values set to `2`:
 
 [source,groovy]

--- a/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
@@ -443,7 +443,7 @@ If you want the SMT to add metadata fields to `delete` events, set the value of 
 In addition to the change event messages that a {prodname} connector emits when a database change occurs, the connector also emits other types of messages, including heartbeat messages, and metadata messages about schema changes and transactions.
 Because the structure of these other messages differs from the structure of the change event messages that the SMT is designed to process, it's best to configure the connector to selectively apply the SMT, so that it processes only the intended data change messages.
 
-For more information about how to apply the SMT selectively, see xref:{link-smt-predicates}#applying-transformations-selectively[Configure an SMT predicate for the transformation].
+For more information about how to apply the SMT selectively, see {link-prefix}:{link-smt-predicates}#applying-transformations-selectively[Configure an SMT predicate for the transformation].
 
 // Type: reference
 // ModuleID: configuration-options-for-the-debezium-mongodb-event-flattening-transformation

--- a/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
+++ b/documentation/modules/ROOT/pages/transformations/mongodb-event-flattening.adoc
@@ -130,7 +130,7 @@ When you use the event flattening SMT to process a message emitted from a MongoD
 For example, the SMT converts the JSON strings that represent the `after` information in the original message into schema structures that any consumer can process.
 
 Optionally, you can configure the event flattening SMT for MongoDB to modify messages in other ways during processing.
-For more information, see xref:mongodb-event-flattening-configuration[].
+For more information, see the xref:mongodb-event-flattening-configuration[configuration topic].
 
 // Type: concept
 // ModuleID: configuration-of-the-debezium-mongodb-event-flattening-transformation
@@ -182,7 +182,7 @@ transforms.unwrap.delete.handling.mode=drop
 transforms.unwrap.add.headers=op
 ----
 
-For more information about the configuration options in the preceding example, see xref:mongodb-extract-new-record-state-configuration-options[]
+For more information about the configuration options in the preceding example, see the xref:mongodb-extract-new-record-state-configuration-options[configuration topic].
 
 .Customizing the configuration
 The connector might emit many types of event messages (for example, heartbeat messages, tombstone messages, or metadata messages about transactions).

--- a/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
+++ b/documentation/modules/ROOT/pages/transformations/outbox-event-router.adoc
@@ -202,7 +202,7 @@ In addition to the change event messages that a {prodname} connector emits when 
 Because the structure of these other messages differs from the structure of the change event messages that the SMT is designed to process, it's best to configure the connector to selectively apply the SMT, so that it processes only the intended data change messages.
 You can use one of the following methods to configure the connector to apply the SMT selectively:
 
-* xref:{link-smt-predicates}#applying-transformations-selectively[Configure an SMT predicate for the transformation].
+* {link-prefix}:{link-smt-predicates}#applying-transformations-selectively[Configure an SMT predicate for the transformation].
 * Use the xref:outbox-event-router-property-route-topic-regex[`route.topic.regex`] configuration option for the SMT.
 
 // Type: concept

--- a/documentation/modules/ROOT/pages/transformations/topic-routing.adoc
+++ b/documentation/modules/ROOT/pages/transformations/topic-routing.adoc
@@ -49,7 +49,7 @@ You can re-route change event records for tables in any of the shards to the sam
 
 .Partitioned PostgreSQL tables
 
-When the {prodname} PostgreSQL connector captures changes in a partitioned table, the default behavior is that change event records are routed to a different topic for each partition. To emit records from all partitions to one topic, configure the topic routing SMT. Because each key in a partitioned table is guaranteed to be unique, configure xref:{link-topic-routing}#by-logical-table-router-key-enforce-uniqueness[`key.enforce.uniqueness=false`] so that the SMT does not add a key field to ensure unique keys. The addition of a key field is default behavior.
+When the {prodname} PostgreSQL connector captures changes in a partitioned table, the default behavior is that change event records are routed to a different topic for each partition. To emit records from all partitions to one topic, configure the topic routing SMT. Because each key in a partitioned table is guaranteed to be unique, configure xref:by-logical-table-router-key-enforce-uniqueness[`key.enforce.uniqueness=false`] so that the SMT does not add a key field to ensure unique keys. The addition of a key field is default behavior.
 
 // Type: concept
 // ModuleID: example-of-routing-debezium-records-for-multiple-tables-to-one-topic
@@ -151,7 +151,7 @@ Because the structure of these other messages differs from the structure of the 
 
 You can use one of the following methods to configure the connector to apply the SMT selectively:
 
-* xref:{link-smt-predicates}#applying-transformations-selectively[Configure an SMT predicate for the transformation].
+* {link-prefix}:{link-smt-predicates}#applying-transformations-selectively[Configure an SMT predicate for the transformation].
 * Use the xref:by-logical-table-router-topic-regex[topic.regex] configuration option for the SMT.
 
 ifdef::community[]

--- a/documentation/modules/ROOT/partials/assemblies/tutorial/assembly-viewing-change-events.adoc
+++ b/documentation/modules/ROOT/partials/assemblies/tutorial/assembly-viewing-change-events.adoc
@@ -13,7 +13,7 @@ When you watched the connector start up,
 you saw that events were written to the following topics with the `dbserver1` prefix (the name of the connector):
 
 `dbserver1`::
-The xref:{link-mysql-connector}#mysql-schema-change-topic[schema change topic] to which all of the DDL statements are written.
+The {link-prefix}:{link-mysql-connector}#mysql-schema-change-topic[schema change topic] to which all of the DDL statements are written.
 
 `dbserver1.inventory.products`::
 Captures change events for the `products` table in the `inventory` database.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-ad-hoc-snapshots.adoc
@@ -11,11 +11,11 @@ The following changes in a database might be cause for performing an ad hoc snap
 * Data corruption occurs due to a configuration error or some other problem.
 
 You can re-run a snapshot for a {data-collection} for which you previously captured a snapshot by initiating a so-called _ad-hoc snapshot_.
-Ad hoc snapshots require the use of xref:{link-signalling}#sending-signals-to-a-debezium-connector[signaling {data-collection}s].
+Ad hoc snapshots require the use of {link-prefix}:{link-signalling}#sending-signals-to-a-debezium-connector[signaling {data-collection}s].
 You initiate an ad hoc snapshot by sending a signal request to the {prodname} signaling {data-collection}.
 
 When you initiate an ad hoc snapshot of an existing {data-collection}, the connector appends content to the topic that already exists for the {data-collection}.
-If a previously existing topic was removed, {prodname} can create a topic automatically if xref:{link-topic-auto-creation}#customizing-debezium-automatically-created-topics[automatic topic creation] is enabled.
+If a previously existing topic was removed, {prodname} can create a topic automatically if {link-prefix}:{link-topic-auto-creation}#customizing-debezium-automatically-created-topics[automatic topic creation] is enabled.
 
 Ad hoc snapshot signals specify the {data-collection}s to include in the snapshot.
 The snapshot can capture the entire contents of the database, or capture only a subset of the {data-collection}s in the database.
@@ -65,7 +65,7 @@ After the connector processes the message, it begins the snapshot operation.
 The snapshot process reads the first and last primary key values and uses those values as the start and end point for each {data-collection}.
 Based on the number of entries in the {data-collection}, and the configured chunk size, {prodname} divides the {data-collection} into chunks, and proceeds to snapshot each chunk, in succession, one at a time.
 
-Currently, the `execute-snapshot` action type triggers xref:{link-signalling}#debezium-signaling-incremental-snapshots[incremental snapshots] only.
+Currently, the `execute-snapshot` action type triggers {link-prefix}:{link-signalling}#debezium-signaling-incremental-snapshots[incremental snapshots] only.
 For more information, see xref:#{context}-incremental-snapshots[Incremental snapshots].
 ////
 .Prerequisites

--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-incremental-snapshot.adoc
@@ -1,5 +1,5 @@
 To provide flexibility in managing snapshots, {prodname} includes a supplementary snapshot mechanism, known as _incremental snapshotting_.
-Incremental snapshots rely on the {prodname} mechanism for xref:{link-signalling}#sending-signals-to-a-debezium-connector[sending signals to a {prodname} connector].
+Incremental snapshots rely on the {prodname} mechanism for {link-prefix}:{link-signalling}#sending-signals-to-a-debezium-connector[sending signals to a {prodname} connector].
 ifdef::community[]
 Incremental snapshots are based on the link:https://github.com/debezium/debezium-design-documents/blob/main/DDD-3.md[DDD-3] design document.
 endif::community[]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot-sql.adoc
@@ -7,7 +7,7 @@ The query that you submit specifies the snapshot operation of `incremental`, and
 
 .Prerequisites
 
-* xref:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled]. +
+* {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled]. +
 ** A signaling data collection exists on the source database.
 ** The signaling data collection is specified in the xref:{context}-property-signal-data-collection[`signal.data.collection`] property.
 
@@ -31,7 +31,7 @@ values ('ad-hoc-1',   // <2>
     "type":"incremental"}'); // <5>
 ----
 +
-The values of the `id`, `type`, and `data` parameters in the signal command correspond to the xref:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
+The values of the `id`, `type`, and `data` parameters in the signal command correspond to the {link-prefix}:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
 +
 The following table describes the parameters in the example:
 +

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-stopping-an-incremental-snapshot.adoc
@@ -11,7 +11,7 @@ The query that you submit specifies the snapshot operation of `incremental`, and
 
 .Prerequisites
 
-* xref:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled]. +
+* {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled]. +
 ** A signaling data collection exists on the source database.
 ** The signaling data collection is specified in the xref:{context}-property-signal-data-collection[`signal.data.collection`] property.
 
@@ -57,7 +57,7 @@ db.debeziumSignal.insert({ // <1>
 ----
 end::nosql-based-snapshot[]
 +
-The values of the `id`, `type`, and `data` parameters in the signal command correspond to the xref:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
+The values of the `id`, `type`, and `data` parameters in the signal command correspond to the {link-prefix}:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
 +
 The following table describes the parameters in the example:
 +

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-triggering-an-incremental-snapshot.adoc
@@ -1,4 +1,4 @@
-Currently, the only way to initiate an incremental snapshot is to send an xref:{link-signalling}#debezium-signaling-ad-hoc-snapshots[ad hoc snapshot signal] to the signaling {data-collection} on the source database.
+Currently, the only way to initiate an incremental snapshot is to send an {link-prefix}:{link-signalling}#debezium-signaling-ad-hoc-snapshots[ad hoc snapshot signal] to the signaling {data-collection} on the source database.
 tag::sql-based-snapshot[]
 You submit a signal to the signaling {data-collection} as SQL `INSERT` queries.
 end::sql-based-snapshot[]
@@ -36,7 +36,7 @@ end::nosql-based-snapshot[]
 
 .Prerequisites
 
-* xref:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled]. +
+* {link-prefix}:{link-signalling}#debezium-signaling-enabling-signaling[Signaling is enabled]. +
 ** A signaling data collection exists on the source database.
 ** The signaling data collection is specified in the xref:{context}-property-signal-data-collection[`signal.data.collection`] property.
 
@@ -87,7 +87,7 @@ db.debeziumSignal.insert({ // <1>
 ----
 end::nosql-based-snapshot[]
 +
-The values of the `id`,`type`, and `data` parameters in the command correspond to the xref:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
+The values of the `id`,`type`, and `data` parameters in the command correspond to the {link-prefix}:{link-signalling}#debezium-signaling-description-of-required-structure-of-a-signaling-data-collection[fields of the signaling {data-collection}].
 +
 The following table describes the parameters in the example:
 +

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-db2-ora-pg-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-db2-ora-pg-connector.adoc
@@ -28,8 +28,8 @@ ImageStreams are not available by default.
 
 . Log in to the OpenShift cluster.
 . Create a {prodname} `KafkaConnect` custom resource (CR) for the connector, or modify an existing one.
-For example, create a `KafkaConnect` CR that specifies the `metadata.annotations` and `spec.build` properties, as shown in the following example.
-Save the file with a name such as `dbz-connect.yaml`.
+For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies the `metadata.annotations` and `spec.build` properties.
+The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource. +
 +
 .A `dbz-connect.yaml` file that defines a `KafkaConnect` custom resource that includes a {prodname} connector
 =====================================================================
@@ -89,7 +89,7 @@ include::../{partialsdir}/modules/all-connectors/ref-deploy-{context}-connector-
 |The topic prefix for the database instance or cluster. +
 The specified name must be formed only from alphanumeric characters or underscores. +
 Because the topic prefix is used as the prefix for any Kafka topics that receive change events from this connector, the name must be unique among the connectors in the cluster. +
-This namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the xref:{link-avro-serialization}#avro-serialization[Avro connector].
+This namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro connector].
 
 |11
 |The list of tables from which the connector captures change events.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mongodb-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mongodb-connector.adoc
@@ -28,8 +28,8 @@ ImageStreams are not available by default.
 
 . Log in to the OpenShift cluster.
 . Create a {prodname} `KafkaConnect` custom resource (CR) for the connector, or modify an existing one.
-For example, create a `KafkaConnect` CR that specifies the `metadata.annotations` and `spec.build` properties, as shown in the following example.
-Save the file with a name such as `dbz-connect.yaml`.
+For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies the `metadata.annotations` and `spec.build` properties.
+The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource. +
 +
 .A `dbz-connect.yaml` file that defines a `KafkaConnect` custom resource that includes a {prodname} connector
 =====================================================================

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mysql-sqlserver-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mysql-sqlserver-connector.adoc
@@ -28,8 +28,8 @@ ImageStreams are not available by default.
 
 . Log in to the OpenShift cluster.
 . Create a {prodname} `KafkaConnect` custom resource (CR) for the connector, or modify an existing one.
-For example, create a `KafkaConnect` CR that specifies the `metadata.annotations` and `spec.build` properties, as shown in the following example.
-Save the file with a name such as `dbz-connect.yaml`.
+For example, create a `KafkaConnect` CR with the name `dbz-connect.yaml` that specifies the `metadata.annotations` and `spec.build` properties.
+The following example shows an excerpt from a `dbz-connect.yaml` file that describes a `KafkaConnect` custom resource. +
 +
 .A `dbz-connect.yaml` file that defines a `KafkaConnect` custom resource that includes a {prodname} connector
 =====================================================================

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-kafka-connect-yaml.adoc
@@ -41,6 +41,8 @@ spec:
             url: https://repo1.maven.org/maven2/com/ibm/db2/jcc/{db2-version}/jcc-{db2-version}.jar
 
   bootstrapServers: debezium-kafka-cluster-kafka-bootstrap:9093
+
+  ...
 ----
 .Descriptions of Kafka Connect configuration settings
 [cols="1,7",options="header",subs="+attributes"]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-ora-connector-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-db2-ora-connector-yaml.adoc
@@ -19,5 +19,7 @@ spec:
     database.dbname: mydatabase // <9>
     topic.prefix: inventory-connector-{context} // <10>
     table.include.list: {include-list-example}  // <11>
+
+    ...
 ----
 =====================================================================

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-mysql-connector-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-mysql-connector-yaml.adoc
@@ -19,6 +19,8 @@
         database.server.id: 184054 // <9>
         topic.prefix: inventory-connector-{context} // <10>
         table.include.list: {include-list-example}  // <11>
+
+        ...
 ----
 =====================================================================
 +
@@ -58,7 +60,7 @@
 |The topic prefix for the database instance or cluster. +
 The specified name must be formed only from alphanumeric characters or underscores. +
 Because the topic prefix is used as the prefix for any Kafka topics that receive change events from this connector, the name must be unique among the connectors in the cluster. +
-This namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the xref:{link-avro-serialization}#avro-serialization[Avro connector].
+This namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro connector].
 
 |11
 |The list of tables from which the connector captures change events.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-oracle-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-oracle-kafka-connect-yaml.adoc
@@ -41,6 +41,8 @@ spec:
             url: https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/{ojdbc8-version}/ojdbc8-{ojdbc8-version}.jar
 
   bootstrapServers: debezium-kafka-cluster-kafka-bootstrap:9093
+
+  ...
 ----
 .Descriptions of Kafka Connect configuration settings
 [cols="1,7",options="header",subs="+attributes"]

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-postgresql-connector-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-postgresql-connector-yaml.adoc
@@ -17,5 +17,7 @@ spec:
     database.dbname: mydatabase // <9>
     topic.prefix: inventory-connector-{context} // <10>
     table.include.list: {include-list-example}  // <11>
+
+    ...
 ----
 =====================================================================

--- a/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-sqlserver-connector-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/ref-deploy-sqlserver-connector-yaml.adoc
@@ -18,6 +18,8 @@
         database.password: dbz  // <8>
         topic.prefix: inventory-connector-{context} // <9>
         table.include.list: {include-list-example}  // <10>
+
+        ...
 ----
 =====================================================================
 +
@@ -54,7 +56,7 @@
 |The topic prefix for the database instance or cluster. +
 The specified name must be formed only from alphanumeric characters or underscores. +
 Because the topic prefix is used as the prefix for any Kafka topics that receive change events from this connector, the name must be unique among the connectors in the cluster. +
-This namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the xref:{link-avro-serialization}#avro-serialization[Avro connector].
+This namespace is also used in the names of related Kafka Connect schemas, and the namespaces of a corresponding Avro schema if you integrate the connector with the {link-prefix}:{link-avro-serialization}#avro-serialization[Avro connector].
 
 |10
 |The list of tables from which the connector captures change events.

--- a/documentation/modules/ROOT/partials/modules/all-connectors/shared-deploy-kafka-connect-yaml.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/shared-deploy-kafka-connect-yaml.adoc
@@ -38,6 +38,8 @@ spec:
             url: https://repo1.maven.org/maven2/org/codehaus/groovy/groovy-json{groovy-version}/groovy-json-{groovy-version}.jar
 
   bootstrapServers: debezium-kafka-cluster-kafka-bootstrap:9093
+
+  ...
 ----
 .Descriptions of Kafka Connect configuration settings
 [cols="1,7",options="header",subs="+attributes"]


### PR DESCRIPTION
[DBZ-6330](https://issues.redhat.com/browse/DBZ-6330)

This change addresses feedback from the review of the downstream 2.1 documentation, including a pass to reformat links that failed to resolve.

Tested in local Antora and downstream builds.

To apply these changes to the `2.1` branch, I opened a separate PR. 