### PR TITLE
DBZ-6336 MySql in debezium-parser-ddl does not support with keyword p…

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -508,3 +508,4 @@ Phạm Ngọc Thắng
 Moustapha Mahfoud
 Đỗ Ngọc Sơn
 RJ Nowling
+蔡灿材

--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -74,7 +74,7 @@ dmlStatement
     : selectStatement | insertStatement | updateStatement
     | deleteStatement | replaceStatement | callStatement
     | loadDataStatement | loadXmlStatement | doStatement
-    | handlerStatement | valuesStatement
+    | handlerStatement | valuesStatement | withStatement
     ;
 
 transactionStatement
@@ -959,6 +959,10 @@ valuesStatement
     '(' expressionsWithDefaults? ')'
     (',' '(' expressionsWithDefaults? ')')*
     ;
+
+withStatement
+  : WITH RECURSIVE? commonTableExpressions (',' commonTableExpressions)*
+  ;
 
 updateStatement
     : singleUpdateStatement | multipleUpdateStatement

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/dml_select.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/dml_select.sql
@@ -256,3 +256,46 @@ SELECT *
          )
         ) AS tt;
 
+#begin
+---- From MySQL 5.7, withStatement are supported
+--https://dev.mysql.com/doc/refman/8.0/en/with.html
+-- Recursive CTE
+WITH RECURSIVE cte (n) AS (
+  SELECT 1
+  UNION ALL
+  SELECT n + 1 FROM cte WHERE n < 10
+)
+SELECT n FROM cte;
+
+WITH RECURSIVE cte AS (
+    SELECT id, name, manager_id
+    FROM employees
+    WHERE id = 1
+    UNION ALL
+    SELECT e.id, e.name, e.manager_id
+    FROM employees e
+             JOIN cte ON e.manager_id = cte.id
+)
+SELECT * FROM cte;
+
+WITH RECURSIVE cte AS (
+    SELECT id, name, parent_id
+    FROM departments
+    WHERE id = 1
+    UNION ALL
+    SELECT d.id, d.name, d.parent_id
+    FROM departments d
+             JOIN cte ON d.parent_id = cte.id
+)
+SELECT * FROM cte;
+#end
+#begin
+--Non-recursive Ctes
+WITH cte1 AS (
+  SELECT * FROM table1 WHERE col1 = 'value'
+),
+cte2 AS (
+  SELECT * FROM table2 WHERE col2 = 'value'
+)
+SELECT cte1.col1, cte2.col2 FROM cte1 JOIN cte2 ON cte1.id = cte2.id;
+#end

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -196,3 +196,4 @@ Fiore Mario Vitale,Mario Fiore Vitale
 smallYellowCat,Dou Pengwei
 ShuranZhang,Shuran Zhang
 Henko,Henrik Schnell
+HangC


### PR DESCRIPTION
After mysql5.7, with cte analysis is supported, but MySqlParser.g4 does not currently support with keyword analysis.
Now improve MySqlParser.g4 to support with cte parsing