### PR TITLE
DBZ-6340 Add support to the Postgres connector for allow and prefer SSL modes  (with prefer as the new default value)

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorConfig.java
@@ -277,6 +277,22 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
         DISABLED("disable"),
 
         /**
+         * Establish an unencrypted connection first.
+         * Establish a secure connection next if an unencrypted connection cannot be established
+         *
+         * see the {@code sslmode} Postgres JDBC driver option
+         */
+        ALLOW("allow"),
+
+        /**
+        * Establish a secure connection first.
+        * Establish an unencrypted connection next if a secure connection cannot be established
+        *
+        * see the {@code sslmode} Postgres JDBC driver option
+        */
+        PREFER("prefer"),
+
+        /**
          * Establish a secure connection if the server supports secure connections.
          * The connection attempt fails if a secure connection cannot be established
          *
@@ -638,11 +654,13 @@ public class PostgresConnectorConfig extends RelationalDatabaseConnectorConfig {
     public static final Field SSL_MODE = Field.create(DATABASE_CONFIG_PREFIX + "sslmode")
             .withDisplayName("SSL mode")
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED_SSL, 0))
-            .withEnum(SecureConnectionMode.class, SecureConnectionMode.DISABLED)
+            .withEnum(SecureConnectionMode.class, SecureConnectionMode.PREFER)
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.MEDIUM)
             .withDescription("Whether to use an encrypted connection to Postgres. Options include: "
                     + "'disable' (the default) to use an unencrypted connection; "
+                    + "'allow' to try and use an unencrypted connection first and, failing that, a secure (encrypted) connection; "
+                    + "'prefer' (the default) to try and use a secure (encrypted) connection first and, failing that, an unencrypted connection; "
                     + "'require' to use a secure (encrypted) connection, and fail if one cannot be established; "
                     + "'verify-ca' like 'required' but additionally verify the server TLS certificate against the configured Certificate Authority "
                     + "(CA) certificates, or fail if no valid matching CA certificates are found; or "

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/PostgresConnectorIT.java
@@ -230,7 +230,7 @@ public class PostgresConnectorIT extends AbstractConnectorTest {
         validateConfigField(validatedConfig, PostgresConnectorConfig.MAX_BATCH_SIZE, PostgresConnectorConfig.DEFAULT_MAX_BATCH_SIZE);
         validateConfigField(validatedConfig, PostgresConnectorConfig.SNAPSHOT_FETCH_SIZE, null);
         validateConfigField(validatedConfig, PostgresConnectorConfig.POLL_INTERVAL_MS, PostgresConnectorConfig.DEFAULT_POLL_INTERVAL_MILLIS);
-        validateConfigField(validatedConfig, PostgresConnectorConfig.SSL_MODE, PostgresConnectorConfig.SecureConnectionMode.DISABLED);
+        validateConfigField(validatedConfig, PostgresConnectorConfig.SSL_MODE, PostgresConnectorConfig.SecureConnectionMode.PREFER);
         validateConfigField(validatedConfig, PostgresConnectorConfig.SSL_CLIENT_CERT, null);
         validateConfigField(validatedConfig, PostgresConnectorConfig.SSL_CLIENT_KEY, null);
         validateConfigField(validatedConfig, PostgresConnectorConfig.SSL_CLIENT_KEY_PASSWORD, null);

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2788,10 +2788,14 @@ For example: `P1Y2M3DT4H5M6.78S`.
 For more information, see xref:postgresql-basic-types[PostgreSQL basic types].
 
 |[[postgresql-property-database-sslmode]]<<postgresql-property-database-sslmode, `+database.sslmode+`>>
-|`disable`
+|`prefer`
 |Whether to use an encrypted connection to the PostgreSQL server. Options include: +
  +
 `disable` uses an unencrypted connection. +
+ +
+`allow` attempts to use an unencrypted connection first and, failing that, a secure (encrypted) connection. +
+ +
+`prefer` attempts to use a secure (encrypted) connection first and, failing that, an unencrypted connection. +
  +
 `require` uses a secure (encrypted) connection, and fails if one cannot be established. +
  +


### PR DESCRIPTION
The supported values for database.sslmode are disable, require, verify-ca and verify-full. In In addition to those values, the Postgres JDBC [driver](https://jdbc.postgresql.org/documentation/publicapi/org/postgresql/jdbc/SslMode.html) supports 2 more values:
* allow: try to connect to Postgres without encryption and, failing that, try encrypted 
* prefer: try to connect to Postgres with encryption and, failing that, try unencrypted

Let's add support for both of those modes and then make the prefer value the default mode.  

[DBZ-6340](https://issues.redhat.com/browse/DBZ-6340)