### PR TITLE
DBZ-4427 basic test for incremental snapshot support with sharded MongoDB deployments

### DIFF
--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/AbstractShardedMongoConnectorIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/AbstractShardedMongoConnectorIT.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import static io.debezium.connector.mongodb.TestHelper.cleanDatabase;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.bson.Document;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.MongoIterable;
+import com.mongodb.client.model.InsertOneOptions;
+
+import io.debezium.connector.mongodb.junit.MongoDbDatabaseProvider;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.testing.testcontainers.MongoDbShardedCluster;
+import io.debezium.testing.testcontainers.util.DockerUtils;
+import io.debezium.util.Testing;
+
+public class AbstractShardedMongoConnectorIT extends AbstractConnectorTest {
+    protected static final String DEFAULT_DATABASE = "dbit";
+
+    protected static final String DEFAULT_COLLECTION = "items";
+    protected static final String DEFAULT_SHARDING_KEY = "_id";
+
+    protected static MongoDbShardedCluster mongo;
+
+    protected static MongoClient connect() {
+        return MongoClients.create(mongo.getConnectionString());
+    }
+
+    @BeforeClass
+    public static void beforeAll() {
+        DockerUtils.enableFakeDnsIfRequired();
+        mongo = MongoDbDatabaseProvider.mongoDbShardedCluster();
+        mongo.start();
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        DockerUtils.disableFakeDns();
+        if (mongo != null) {
+            mongo.stop();
+        }
+    }
+
+    @Before
+    public void beforeEach() {
+        stopConnector();
+        initializeConnectorTestFramework();
+
+        var database = shardedDatabase();
+        cleanDatabase(mongo, database);
+        mongo.enableSharding(database);
+
+        shardedCollections().forEach((collection, key) -> {
+            mongo.shardCollection(database, collection, key);
+        });
+    }
+
+    @After
+    public void afterEach() {
+        stopConnector();
+    }
+
+    protected String shardedDatabase() {
+        return DEFAULT_DATABASE;
+    }
+
+    protected Map<String, String> shardedCollections() {
+        return Map.of(DEFAULT_COLLECTION, DEFAULT_SHARDING_KEY);
+    }
+
+    protected String shardedCollection() {
+        return shardedCollections().keySet().stream().findFirst().orElseThrow();
+    }
+
+    /**
+     * Inserts all documents in the specified collection.
+     *
+     * @param dbName the database name
+     * @param collectionName the collection name
+     * @param documents the documents to be inserted, can be empty
+     */
+    protected void insertDocuments(String dbName, String collectionName, Document... documents) {
+        // Do nothing if no documents are provided
+        if (documents.length == 0) {
+            return;
+        }
+
+        try (var client = TestHelper.connect(mongo)) {
+            Testing.debug("Storing in '" + dbName + "." + collectionName + "' document");
+
+            MongoDatabase db = client.getDatabase(dbName);
+
+            MongoCollection<Document> collection = db.getCollection(collectionName);
+
+            for (Document document : documents) {
+                InsertOneOptions options = new InsertOneOptions().bypassDocumentValidation(true);
+                assertThat(document).isNotNull();
+                assertThat(document.size()).isGreaterThan(0);
+                collection.insertOne(document, options);
+            }
+        }
+    }
+
+    /**
+     * Inserts all documents in the specified collection within a transaction.
+     *
+     * @param dbName the database name
+     * @param collectionName the collection name
+     * @param documents the documents to be inserted, can be empty
+     */
+    protected void insertDocumentsInTx(String dbName, String collectionName, Document... documents) {
+        assertThat(TestHelper.transactionsSupported()).isTrue();
+
+        try (var client = TestHelper.connect(mongo)) {
+            Testing.debug("Storing documents in '" + dbName + "." + collectionName + "'");
+            // If the collection does not exist, be sure to create it
+            final MongoDatabase db = client.getDatabase(dbName);
+            if (!collectionExists(db, collectionName)) {
+                db.createCollection(collectionName);
+            }
+
+            final MongoCollection<Document> collection = db.getCollection(collectionName);
+
+            final ClientSession session = client.startSession();
+            try {
+                session.startTransaction();
+
+                final InsertOneOptions insertOptions = new InsertOneOptions().bypassDocumentValidation(true);
+                for (Document document : documents) {
+                    assertThat(document).isNotNull();
+                    assertThat(document.size()).isGreaterThan(0);
+                    collection.insertOne(session, document, insertOptions);
+                }
+
+                session.commitTransaction();
+            }
+            finally {
+                session.close();
+            }
+        }
+    }
+
+    private static boolean collectionExists(MongoDatabase database, String collectionName) {
+        final MongoIterable<String> collections = database.listCollectionNames();
+        final MongoCursor<String> cursor = collections.cursor();
+        while (cursor.hasNext()) {
+            if (collectionName.equalsIgnoreCase(cursor.next())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ShardedIncrementalSnapshotIT.java
+++ b/debezium-connector-mongodb/src/test/java/io/debezium/connector/mongodb/ShardedIncrementalSnapshotIT.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.bson.Document;
+import org.junit.Test;
+
+import io.debezium.config.Configuration;
+import io.debezium.engine.DebeziumEngine;
+
+public class ShardedIncrementalSnapshotIT extends AbstractShardedMongoConnectorIT {
+    protected static final int ROW_COUNT = 1_000;
+    private static final int MAXIMUM_NO_RECORDS_CONSUMES = 3;
+    private static final String DATABASE_NAME = "dbA";
+    private static final String COLLECTION_NAME = "c1";
+    private static final String SIGNAL_COLLECTION_NAME = DATABASE_NAME + ".signals";
+    private static final String FULL_COLLECTION_NAME = DATABASE_NAME + "." + COLLECTION_NAME;
+    private static final String DOCUMENT_ID = "_id";
+    private static final int CHUNK_SIZE = 100;
+
+    @Override
+    protected String shardedDatabase() {
+        return DATABASE_NAME;
+    }
+
+    @Override
+    protected Map<String, String> shardedCollections() {
+        return Map.of(COLLECTION_NAME, DOCUMENT_ID);
+    }
+
+    protected String fullDataCollectionName() {
+        return FULL_COLLECTION_NAME;
+    }
+
+    protected String topicName() {
+        return "mongo1" + "." + fullDataCollectionName();
+    }
+
+    protected Configuration.Builder config() {
+        return TestHelper.getConfiguration(mongo)
+                .edit()
+                .with(MongoDbConnectorConfig.DATABASE_INCLUDE_LIST, shardedDatabase())
+                .with(MongoDbConnectorConfig.COLLECTION_INCLUDE_LIST, fullDataCollectionName() + ",dbA.c1,dbA.c2")
+                .with(MongoDbConnectorConfig.SIGNAL_DATA_COLLECTION, SIGNAL_COLLECTION_NAME)
+                .with(MongoDbConnectorConfig.INCREMENTAL_SNAPSHOT_CHUNK_SIZE, CHUNK_SIZE)
+                .with(MongoDbConnectorConfig.SNAPSHOT_MODE, MongoDbConnectorConfig.SnapshotMode.NEVER)
+                .with(MongoDbConnectorConfig.CONNECTION_MODE, MongoDbConnectorConfig.ConnectionMode.SHARDED);
+    }
+
+    @Test
+    public void snapshotOnlyWithInt64() throws Exception {
+        long firstKey = Integer.MAX_VALUE + 1L;
+        snapshotOnly(firstKey, k -> k + 1);
+    }
+
+    private <K> void snapshotOnly(K initialId, Function<K, K> idGenerator) throws Exception {
+        final Map<K, Document> documents = new LinkedHashMap<>();
+
+        K key = initialId;
+        for (int i = 0; i < ROW_COUNT; i++) {
+            final Document doc = new Document();
+            doc.append(DOCUMENT_ID, key).append(valueFieldName(), i);
+            documents.put(key, doc);
+            key = idGenerator.apply(key);
+        }
+        insertDocumentsInTx(DATABASE_NAME, COLLECTION_NAME, documents.values().toArray(Document[]::new));
+
+        startConnector();
+        sendAdHocSnapshotSignal();
+
+        final var dbChanges = consumeMixedWithIncrementalSnapshot(
+                ROW_COUNT,
+                x -> true,
+                k -> k.getString(pkFieldName()),
+                this::extractFieldValue,
+                topicName(), null);
+
+        var serialization = new JsonSerialization();
+
+        var expected = documents.values()
+                .stream()
+                .map(d -> d.toBsonDocument())
+                .collect(toMap(
+                        d -> serialization.getDocumentIdSnapshot(d),
+                        d -> d.getInt32(valueFieldName()).getValue()));
+
+        assertThat(dbChanges).containsAllEntriesOf(expected);
+    }
+
+    protected String valueFieldName() {
+        return "aa";
+    }
+
+    protected String pkFieldName() {
+        return "id";
+    }
+
+    protected Class<MongoDbConnector> connectorClass() {
+        return MongoDbConnector.class;
+    }
+
+    protected void startConnector(Function<Configuration.Builder, Configuration.Builder> custConfig, DebeziumEngine.CompletionCallback callback) {
+        final Configuration config = custConfig.apply(config()).build();
+        start(connectorClass(), config, callback);
+        waitForConnectorToStart();
+
+        waitForAvailableRecords(5, TimeUnit.SECONDS);
+        // there shouldn't be any snapshot records
+        assertNoRecordsToConsume();
+    }
+
+    protected void startConnector() {
+        startConnector(Function.identity(), loggingCompletion());
+    }
+
+    protected void waitForConnectorToStart() {
+        assertConnectorIsRunning();
+    }
+
+    protected void sendAdHocSnapshotSignal() throws SQLException {
+        sendAdHocSnapshotSignal(fullDataCollectionName());
+    }
+
+    protected void sendAdHocSnapshotSignal(String... dataCollectionIds) throws SQLException {
+        final String dataCollectionIdsList = Arrays.stream(dataCollectionIds)
+                .map(x -> "\\\"" + x + "\\\"")
+                .collect(Collectors.joining(", "));
+        insertDocuments("dbA", "signals",
+                new Document[]{ Document.parse("{\"type\": \"execute-snapshot\", \"payload\": \"{\\\"data-collections\\\": [" + dataCollectionIdsList + "]}\"}") });
+    }
+
+    protected Map<Integer, Integer> consumeMixedWithIncrementalSnapshot(int recordCount, String topicName) throws InterruptedException {
+        return consumeMixedWithIncrementalSnapshot(recordCount, this::extractFieldValue, x -> true, null, topicName);
+    }
+
+    protected Integer extractFieldValue(SourceRecord record) {
+        final String after = ((Struct) record.value()).getString("after");
+        final Pattern p = Pattern.compile("\"" + valueFieldName() + "\": (\\d+)");
+        final Matcher m = p.matcher(after);
+        m.find();
+        return Integer.parseInt(m.group(1));
+    }
+
+    protected <V> Map<Integer, V> consumeMixedWithIncrementalSnapshot(int recordCount, Function<SourceRecord, V> valueConverter,
+                                                                      Predicate<Map.Entry<Integer, V>> dataCompleted,
+                                                                      Consumer<List<SourceRecord>> recordConsumer,
+                                                                      String topicName)
+            throws InterruptedException {
+        return consumeMixedWithIncrementalSnapshot(recordCount, dataCompleted,
+                k -> Integer.parseInt(k.getString(pkFieldName())), valueConverter, topicName, recordConsumer);
+    }
+
+    protected <V, K> Map<K, V> consumeMixedWithIncrementalSnapshot(int recordCount,
+                                                                   Predicate<Map.Entry<K, V>> dataCompleted,
+                                                                   Function<Struct, K> idCalculator,
+                                                                   Function<SourceRecord, V> valueConverter,
+                                                                   String topicName,
+                                                                   Consumer<List<SourceRecord>> recordConsumer)
+            throws InterruptedException {
+        final Map<K, V> dbChanges = new HashMap<>();
+        int noRecords = 0;
+        for (;;) {
+            final SourceRecords records = consumeRecordsByTopic(1);
+            final List<SourceRecord> dataRecords = records.recordsForTopic(topicName);
+            if (records.allRecordsInOrder().isEmpty()) {
+                noRecords++;
+                assertThat(noRecords).describedAs(String.format("Too many no data record results, %d < %d", dbChanges.size(), recordCount))
+                        .isLessThanOrEqualTo(MAXIMUM_NO_RECORDS_CONSUMES);
+                continue;
+            }
+            noRecords = 0;
+            if (dataRecords == null || dataRecords.isEmpty()) {
+                continue;
+            }
+            dataRecords.forEach(record -> {
+                final K id = idCalculator.apply((Struct) record.key());
+                final V value = valueConverter.apply(record);
+                dbChanges.put(id, value);
+            });
+            if (recordConsumer != null) {
+                recordConsumer.accept(dataRecords);
+            }
+            if (dbChanges.size() >= recordCount) {
+                if (!dbChanges.entrySet().stream().anyMatch(dataCompleted.negate())) {
+                    break;
+                }
+            }
+        }
+
+        assertThat(dbChanges).hasSize(recordCount);
+        return dbChanges;
+    }
+}

--- a/debezium-connector-mongodb/src/test/resources/logback-test.xml
+++ b/debezium-connector-mongodb/src/test/resources/logback-test.xml
@@ -22,6 +22,31 @@
         <appender-ref ref="CONSOLE" />
     </logger>
     <logger
+            name="io.debezium.connector.mongodb.ReplicaSetDiscovery"
+            level="warn" additivity="false">
+        <appender-ref ref="CONSOLE" />
+    </logger>
+    <logger
+            name="io.debezium.connector.mongodb.MongoDbIncrementalSnapshotChangeEventSource"
+            level="TRACE" additivity="false">
+        <appender-ref ref="CONSOLE" />
+    </logger>
+    <logger
+            name="io.debezium.connector.mongodb.MongoDbStreamingChangeEventSource"
+            level="TRACE" additivity="false">
+        <appender-ref ref="CONSOLE" />
+    </logger>
+    <logger
+            name="io.debezium.connector.mongodb.MongoDbIncrementalSnapshotContext"
+            level="TRACE" additivity="false">
+        <appender-ref ref="CONSOLE" />
+    </logger>
+    <logger
+            name="io.debezium.pipeline.EventDispatcher$IncrementalSnapshotChangeRecordReceiver"
+            level="TRACE" additivity="false">
+        <appender-ref ref="CONSOLE" />
+    </logger>
+    <logger
         name="org.mongodb.driver"
         level="warn" additivity="false">
         <appender-ref ref="CONSOLE" />

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbContainer.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbContainer.java
@@ -237,7 +237,7 @@ public class MongoDbContainer extends GenericContainer<MongoDbContainer> {
                     "--host " + name + " " +
                     "--port " + port + " " +
                     "--eval \"JSON.stringify(" + command + ")\"";
-
+            LOGGER.debug("Running command inside container: {}", mongoCommand);
             // Support newer and older MongoDB versions respectively
             var result = execInContainer("sh", "-c", isLegacy() ? mongoCommand : "mongosh " + mongoCommand);
             checkExitCode(result);

--- a/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbShardedCluster.java
+++ b/debezium-testing/debezium-testing-testcontainers/src/main/java/io/debezium/testing/testcontainers/MongoDbShardedCluster.java
@@ -165,6 +165,7 @@ public class MongoDbShardedCluster implements MongoDbDeployment {
 
     public void shardCollection(String databaseName, String collectionName, String keyField) {
         // See https://www.mongodb.com/docs/v6.0/tutorial/deploy-shard-cluster/#shard-a-collection
+        LOGGER.info("Enabling sharding for {}.{} using '{}' filed as key", databaseName, collectionName, keyField);
         var arbitraryRouter = routers.get(0);
         arbitraryRouter.eval("sh.shardCollection(" +
                 "'" + databaseName + "." + collectionName + "'," +


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-4427

Few noteworthy comments 

1) At this point tests in MongoDB module would benefit from some cleanup and code deduplication 
2) currently the test uses a chunk size of 100. This is a change compared to non sharded variant of the tests due to yet unknown performance issue. When running the tests against sharded MongoDB incremental snapshot is almost 100x slower when the chunk size is extremely low (e.g. chunk size 10 for 10000 entries). This will be documented for the next release and the support marked as incubating. I will continue with the investigation in the meantime. 



