### PR TITLE
DBZ-6351 Fixes broken links in deployment instructions

### DIFF
--- a/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/con-connector-streams-deployment.adoc
@@ -22,5 +22,5 @@ You can still use the REST API to retrieve information.
 
 .Additional resources
 
-* link:{LinkStreamsOpenShift}#proc-kafka-connect-config-str[Configuring Kafka Connect] in {NameStreamsOpenShift}.
+* link:{LinkConfiguringStreamsOpenShift}#proc-kafka-connect-config-str[Configuring Kafka Connect] in {NameStreamsOpenShift}.
 * link:{LinkDeployStreamsOpenShift}#creating-new-image-using-kafka-connect-build-str[Creating a new container image automatically using {StreamsName} in {NameDeployStreamsOpenShift}].

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-db2-ora-pg-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-db2-ora-pg-connector.adoc
@@ -20,9 +20,10 @@ To store the build image in an image registry, such as Red Hat Quay.io or Docker
 ** An account and permissions to create and manage images in the registry.
 
 To store the build image as a native OpenShift ImageStream::
-** An link:https://docs.openshift.com/container-platform/latest/openshift_images/images-understand.html#images-imagestream-use_images-understand[ImageStream] resource is deployed to the cluster.
+** An link:{LinkConfiguringStreamsOpenShift}#literal_output_literal[ImageStream] resource is deployed to the cluster for storing new container images.
 You must explicitly create an ImageStream for the cluster.
 ImageStreams are not available by default.
+For more information about ImageStreams, see link:{LinkCreatingManagingOpenShiftImages}#managing-image-streams[Managing image streams on OpenShift Container Platform].
 
 .Procedure
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mongodb-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mongodb-connector.adoc
@@ -20,9 +20,10 @@ To store the build image in an image registry, such as Red Hat Quay.io or Docker
 ** An account and permissions to create and manage images in the registry.
 
 To store the build image as a native OpenShift ImageStream::
-** An link:https://docs.openshift.com/container-platform/latest/openshift_images/images-understand.html#images-imagestream-use_images-understand[ImageStream] resource is deployed to the cluster.
+** An link:{LinkConfiguringStreamsOpenShift}#literal_output_literal[ImageStream] resource is deployed to the cluster for storing new container images.
 You must explicitly create an ImageStream for the cluster.
 ImageStreams are not available by default.
+For more information about ImageStreams, see link:{LinkCreatingManagingOpenShiftImages}#managing-image-streams[Managing image streams on OpenShift Container Platform].
 
 .Procedure
 

--- a/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mysql-sqlserver-connector.adoc
+++ b/documentation/modules/ROOT/partials/modules/all-connectors/proc-using-streams-to-deploy-a-debezium-mysql-sqlserver-connector.adoc
@@ -20,9 +20,10 @@ To store the build image in an image registry, such as Red Hat Quay.io or Docker
 ** An account and permissions to create and manage images in the registry.
 
 To store the build image as a native OpenShift ImageStream::
-** An link:https://docs.openshift.com/container-platform/latest/openshift_images/images-understand.html#images-imagestream-use_images-understand[ImageStream] resource is deployed to the cluster.
+** An link:{LinkConfiguringStreamsOpenShift}#literal_output_literal[ImageStream] resource is deployed to the cluster for storing new container images.
 You must explicitly create an ImageStream for the cluster.
 ImageStreams are not available by default.
+For more information about ImageStreams, see link:{LinkCreatingManagingOpenShiftImages}#managing-image-streams[Managing image streams on OpenShift Container Platform].
 
 .Procedure
 


### PR DESCRIPTION
[DBZ-6351](https://issues.redhat.com/browse/DBZ-6351)

Updates shared modules to fix broken links in downstream OCP install and User guides. Tested in a local downstream build.
