### PR TITLE
DBZ-6361 KafkaSignalThread#SIGNAL_POLL_TIMEOUT_MS option duplicate signal prefix

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/signal/KafkaSignalThread.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/signal/KafkaSignalThread.java
@@ -81,7 +81,7 @@ public class KafkaSignalThread<T extends DataCollectionId> {
             .withValidation(Field::isRequired);
 
     public static final Field SIGNAL_POLL_TIMEOUT_MS = Field.create(CONFIGURATION_FIELD_PREFIX_STRING
-            + "signal.kafka.poll.timeout.ms")
+            + "kafka.poll.timeout.ms")
             .withDisplayName("Poll timeout for kafka signals (ms)")
             .withType(ConfigDef.Type.INT)
             .withWidth(ConfigDef.Width.SHORT)


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6361

KafkaSignalThread#SIGNAL_POLL_TIMEOUT_MS option duplicate signal prefix. need remove one.

