### PR TITLE
DBZ-6368 Align version of Antlr runtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
 
         <!-- ANTLR -->
         <!-- Align with Antlr runtime version pulled in via Quarkus -->
-        <version.antlr>4.8</version.antlr>
+        <version.antlr>4.10.1</version.antlr>
         <version.antlr4test.plugin>1.18</version.antlr4test.plugin>
 
         <!-- Quarkus -->


### PR DESCRIPTION
Ensure all modules use antlr-runtime version 4.10.1. There is a breaking change in [Antlr 4.10 ](https://github.com/antlr/antlr4/releases/tag/4.10) that makes parsers from older versions incompatible.

Link: https://issues.redhat.com/browse/DBZ-6368