### PR TITLE
DBZ-6340 Make "preferred" the new default SSL mode for the MySQL connector

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorConfig.java
@@ -562,13 +562,13 @@ public class MySqlConnectorConfig extends HistorizedRelationalDatabaseConnectorC
 
     public static final Field SSL_MODE = Field.create("database.ssl.mode")
             .withDisplayName("SSL mode")
-            .withEnum(SecureConnectionMode.class, SecureConnectionMode.DISABLED)
+            .withEnum(SecureConnectionMode.class, SecureConnectionMode.PREFERRED)
             .withGroup(Field.createGroupEntry(Field.Group.CONNECTION_ADVANCED_SSL, 0))
             .withWidth(Width.MEDIUM)
             .withImportance(Importance.MEDIUM)
             .withDescription("Whether to use an encrypted connection to MySQL. Options include: "
-                    + "'disabled' (the default) to use an unencrypted connection; "
-                    + "'preferred' to establish a secure (encrypted) connection if the server supports secure connections, "
+                    + "'disabled' to use an unencrypted connection; "
+                    + "'preferred' (the default) to establish a secure (encrypted) connection if the server supports secure connections, "
                     + "but fall back to an unencrypted connection otherwise; "
                     + "'required' to use a secure (encrypted) connection, and fail if one cannot be established; "
                     + "'verify_ca' like 'required' but additionally verify the server TLS certificate against the configured Certificate Authority "

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/UniqueDatabase.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/UniqueDatabase.java
@@ -196,7 +196,7 @@ public class UniqueDatabase {
                 .with(MySqlConnectorConfig.USER, "snapper")
                 .with(MySqlConnectorConfig.PASSWORD, "snapperpass");
 
-        String sslMode = System.getProperty("database.ssl.mode", "disabled");
+        String sslMode = System.getProperty("database.ssl.mode", "preferred");
 
         if (sslMode.equals("disabled")) {
             builder.with(MySqlConnectorConfig.SSL_MODE, MySqlConnectorConfig.SecureConnectionMode.DISABLED);

--- a/documentation/modules/ROOT/pages/connectors/mysql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/mysql.adoc
@@ -2979,7 +2979,7 @@ For example, to define a `selector` parameter that specifies the subset of colum
 |A Boolean value that specifies whether built-in system tables should be ignored. This applies regardless of the table include and exclude lists. By default, system tables are excluded from having their changes captured, and no events are generated when changes are made to any system tables.
 
 |[[mysql-property-database-ssl-mode]]<<mysql-property-database-ssl-mode, `+database.ssl.mode+`>>
-|`disabled`
+|`preferred`
 |Specifies whether to use an encrypted connection. Possible settings are: +
  +
 `disabled` specifies the use of an unencrypted connection. +


### PR DESCRIPTION
https://github.com/debezium/debezium/pull/4460 made "prefer" the default SSL mode for the Postgres connector. This [comment](https://issues.redhat.com/browse/DBZ-6340?focusedId=22110644&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22110644) suggested doing similar work for other connectors. This PR makes a similar change for MySQL.


