### PR TITLE
DBZ-5182 Fetch Postgres types by ascending order

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/TypeRegistry.java
@@ -131,7 +131,12 @@ public class TypeRegistry {
 
     private void addType(PostgresType type) {
         oidToType.put(type.getOid(), type);
-        nameToType.put(type.getName(), type);
+        if (!nameToType.containsKey(type.getName())) {
+            nameToType.put(type.getName(), type);
+        }
+        else {
+            LOGGER.warn("Type [oid:{}, name:{}] is already mapped", type.getOid(), type.getName());
+        }
 
         if (TYPE_NAME_GEOMETRY.equals(type.getName())) {
             geometryOid = type.getOid();


### PR DESCRIPTION
…ostgres types first. Does not override types that are already registered (e.g does not allow orafce module types to be registered and override default postgres types)