### PR TITLE
make it support temporal slot

### DIFF
--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -168,12 +168,7 @@ public class PostgresStreamingChangeEventSource implements StreamingChangeEventS
                 catch (Exception e) {
                     LOGGER.info("Commit failed while preparing for reconnect", e);
                 }
-                walPosition.enableFiltering();
-                stream.stopKeepAlive();
-                replicationConnection.reconnect();
-                replicationStream.set(replicationConnection.startStreaming(walPosition.getLastEventStoredLsn(), walPosition));
-                stream = this.replicationStream.get();
-                stream.startKeepAlive(Threads.newSingleThreadExecutor(PostgresConnector.class, connectorConfig.getLogicalName(), KEEP_ALIVE_THREAD_NAME));
+
             }
             processMessages(context, partition, offsetContext, stream);
         }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -285,7 +285,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     private boolean useTemporarySlot() throws SQLException {
         // Temporary replication slots cannot be used due to connection restart
         // when finding WAL position
-         return dropSlotOnClose && pgConnection().haveMinimumServerVersion(ServerVersion.v10);
+        return dropSlotOnClose && pgConnection().haveMinimumServerVersion(ServerVersion.v10);
     }
 
     /**

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/connection/PostgresReplicationConnection.java
@@ -285,8 +285,7 @@ public class PostgresReplicationConnection extends JdbcConnection implements Rep
     private boolean useTemporarySlot() throws SQLException {
         // Temporary replication slots cannot be used due to connection restart
         // when finding WAL position
-        // return dropSlotOnClose && pgConnection().haveMinimumServerVersion(ServerVersion.v10);
-        return false;
+         return dropSlotOnClose && pgConnection().haveMinimumServerVersion(ServerVersion.v10);
     }
 
     /**


### PR DESCRIPTION
1. After specifying the parameter dropSlotOnClose should create a temporal slot in PG
2. After reconnecting, the startStreamingLsn in WalPosition Locator changed, it won't get subsequent changes
So, after getting the position, just keep the same connection