### PR TITLE
DBZ-6395 Restore debezium-server artifact Sonatype

### DIFF
--- a/jenkins-jobs/job-dsl/release/release_deploy_snapshots.groovy
+++ b/jenkins-jobs/job-dsl/release/release_deploy_snapshots.groovy
@@ -27,7 +27,7 @@ pipelineJob('release/release-deploy_snapshots_pipeline') {
         stringParam('DEBEZIUM_BRANCH', 'main', 'A branch from which Debezium is built')
         stringParam(
                 'DEBEZIUM_ADDITIONAL_REPOSITORIES',
-                'db2#github.com/debezium/debezium-connector-db2.git#main vitess#github.com/debezium/debezium-connector-vitess.git#main cassandra#github.com/debezium/debezium-connector-cassandra.git#main spanner#github.com/debezium/debezium-connector-spanner.git#main jdbc#github.com/debezium/debezium-connector-jdbc.git#main',
+                'db2#github.com/debezium/debezium-connector-db2.git#main vitess#github.com/debezium/debezium-connector-vitess.git#main cassandra#github.com/debezium/debezium-connector-cassandra.git#main spanner#github.com/debezium/debezium-connector-spanner.git#main jdbc#github.com/debezium/debezium-connector-jdbc.git#main server#github.com/debezium/debezium-server.git#main',
                 'A space separated list of additional repositories from which Debezium connectors are built (id#repo#branch)'
         )
     }


### PR DESCRIPTION
After debezium-server repo has been moved out the main repo it was no more deployed on Sonatype.

https://issues.redhat.com/browse/DBZ-6395