### PR TITLE
DBZ-6256 Add `log.mining.flush.table.name` Oracle config option

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorConfig.java
@@ -473,6 +473,15 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             .withValidation(OracleConnectorConfig::validateLogMiningReadOnly)
             .withDescription("When set to 'true', the connector will not attempt to flush the LGWR buffer to disk, allowing connecting to read-only databases.");
 
+    public static final Field LOG_MINING_FLUSH_TABLE_NAME = Field.create("log.mining.flush.table.name")
+            .withDisplayName("Specifies the name of the flush table used by the connector")
+            .withType(Type.STRING)
+            .withWidth(Width.MEDIUM)
+            .withImportance(Importance.LOW)
+            .withDefault("LOG_MINING_FLUSH")
+            .withValidation(OracleConnectorConfig::validateLogMiningFlushTableName)
+            .withDescription("The name of the flush table used by the connector, defaults to LOG_MINING_FLUSH.");
+
     public static final Field QUERY_FETCH_SIZE = CommonConnectorConfig.QUERY_FETCH_SIZE
             .withDescription(
                     "The maximum number of records that should be loaded into memory while streaming. A value of '0' uses the default JDBC fetch size, defaults to '2000'.")
@@ -534,7 +543,8 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
                     LOG_MINING_LOG_BACKOFF_MAX_DELAY_MS,
                     LOG_MINING_SESSION_MAX_MS,
                     LOG_MINING_TRANSACTION_SNAPSHOT_BOUNDARY_MODE,
-                    LOG_MINING_READ_ONLY)
+                    LOG_MINING_READ_ONLY,
+                    LOG_MINING_FLUSH_TABLE_NAME)
             .create();
 
     /**
@@ -593,6 +603,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
     private final Duration logMiningMaximumSession;
     private final TransactionSnapshotBoundaryMode logMiningTransactionSnapshotBoundaryMode;
     private final Boolean logMiningReadOnly;
+    private final String logMiningFlushTableName;
 
     public OracleConnectorConfig(Configuration config) {
         super(
@@ -648,6 +659,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         this.logMiningMaximumSession = Duration.ofMillis(config.getLong(LOG_MINING_SESSION_MAX_MS));
         this.logMiningTransactionSnapshotBoundaryMode = TransactionSnapshotBoundaryMode.parse(config.getString(LOG_MINING_TRANSACTION_SNAPSHOT_BOUNDARY_MODE));
         this.logMiningReadOnly = config.getBoolean(LOG_MINING_READ_ONLY);
+        this.logMiningFlushTableName = config.getString(LOG_MINING_FLUSH_TABLE_NAME);
     }
 
     private static String toUpperCase(String property) {
@@ -1266,7 +1278,7 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         }
 
         private boolean isFlushTable(TableId id) {
-            return LogWriterFlushStrategy.isFlushTable(id, config.getString(USER));
+            return LogWriterFlushStrategy.isFlushTable(id, config.getString(USER), config.getString(LOG_MINING_FLUSH_TABLE_NAME));
         }
 
         private boolean isCompressionAdvisorTable(TableId id) {
@@ -1510,6 +1522,13 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
         return logMiningReadOnly;
     }
 
+    /**
+     * @return the log mining flush table name
+     */
+    public String getLogMiningFlushTableName() {
+        return logMiningFlushTableName;
+    }
+
     @Override
     public String getConnectorName() {
         return Module.name();
@@ -1610,5 +1629,17 @@ public class OracleConnectorConfig extends HistorizedRelationalDatabaseConnector
             }
         }
         return 0;
+    }
+
+    public static int validateLogMiningFlushTableName(Configuration config, Field field, ValidationOutput problems) {
+        if (config.getBoolean(LOG_MINING_READ_ONLY)) {
+            // This option is not required when using read-only mode
+            return 0;
+        }
+        else if (ConnectorAdapter.XSTREAM.equals(ConnectorAdapter.parse(config.getString(CONNECTOR_ADAPTER)))) {
+            // This option is not required when using XStream
+            return 0;
+        }
+        return Field.isRequired(config, field, problems);
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -858,7 +858,7 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
         if (connectorConfig.isRacSystem()) {
             return new RacCommitLogWriterFlushStrategy(connectorConfig, jdbcConfiguration, streamingMetrics);
         }
-        return new CommitLogWriterFlushStrategy(jdbcConnection);
+        return new CommitLogWriterFlushStrategy(connectorConfig, jdbcConnection);
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/logwriter/LogWriterFlushStrategy.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/logwriter/LogWriterFlushStrategy.java
@@ -14,10 +14,6 @@ import io.debezium.relational.TableId;
  * @author Chris Cranford
  */
 public interface LogWriterFlushStrategy extends AutoCloseable {
-    /**
-     * The LogMiner implemenation's flush table name.
-     */
-    String LOGMNR_FLUSH_TABLE = "LOG_MINING_FLUSH";
 
     /**
      * @return the host or ip address that will be flushed by the strategy
@@ -36,10 +32,11 @@ public interface LogWriterFlushStrategy extends AutoCloseable {
      *
      * @param id the table id
      * @param schemaName the schema name
+     * @param flushTableName configured flush table name
      * @return true if the table is the flush table, false otherwise
      */
-    static boolean isFlushTable(TableId id, String schemaName) {
-        return id.table().equalsIgnoreCase(LOGMNR_FLUSH_TABLE) && id.schema().equalsIgnoreCase(schemaName);
+    static boolean isFlushTable(TableId id, String schemaName, String flushTableName) {
+        return id.table().equalsIgnoreCase(flushTableName) && id.schema().equalsIgnoreCase(schemaName);
     }
 
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/logwriter/RacCommitLogWriterFlushStrategy.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/logwriter/RacCommitLogWriterFlushStrategy.java
@@ -42,6 +42,7 @@ public class RacCommitLogWriterFlushStrategy implements LogWriterFlushStrategy {
     private final Map<String, CommitLogWriterFlushStrategy> flushStrategies = new HashMap<>();
     private final OracleStreamingChangeEventSourceMetrics streamingMetrics;
     private final JdbcConfiguration jdbcConfiguration;
+    private final OracleConnectorConfig connectorConfig;
     private final Set<String> hosts;
 
     /**
@@ -55,6 +56,7 @@ public class RacCommitLogWriterFlushStrategy implements LogWriterFlushStrategy {
                                            OracleStreamingChangeEventSourceMetrics streamingMetrics) {
         this.jdbcConfiguration = jdbcConfig;
         this.streamingMetrics = streamingMetrics;
+        this.connectorConfig = connectorConfig;
         this.hosts = connectorConfig.getRacNodes().stream().map(String::toUpperCase).collect(Collectors.toSet());
         recreateRacNodeFlushStrategies();
     }
@@ -134,7 +136,7 @@ public class RacCommitLogWriterFlushStrategy implements LogWriterFlushStrategy {
                 .with(JdbcConfiguration.PORT, port).build());
 
         LOGGER.debug("Creating flush connection to RAC node '{}'", hostName);
-        return new CommitLogWriterFlushStrategy(jdbcHostConfig);
+        return new CommitLogWriterFlushStrategy(connectorConfig, jdbcHostConfig);
     }
 
     /**

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
@@ -279,7 +279,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
         // Check whether the row has a table reference and if so, is the reference included by the filter.
         // If the reference isn't included, the row will be skipped entirely.
         if (row.getTableId() != null) {
-            if (LogWriterFlushStrategy.isFlushTable(row.getTableId(), connectorConfig.getJdbcConfig().getUser())) {
+            if (LogWriterFlushStrategy.isFlushTable(row.getTableId(), connectorConfig.getJdbcConfig().getUser(), connectorConfig.getLogMiningFlushTableName())) {
                 LOGGER.trace("Skipped change associated with flush table '{}'", row.getTableId());
                 return;
             }

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/FlushStrategyIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/logminer/FlushStrategyIT.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.oracle.logminer;
 
-import static io.debezium.connector.oracle.logminer.logwriter.LogWriterFlushStrategy.LOGMNR_FLUSH_TABLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.sql.SQLException;
@@ -50,10 +49,12 @@ public class FlushStrategyIT extends AbstractConnectorTest {
     public final TestRule skipReadOnly = new SkipTestDependingOnReadOnly();
 
     private static OracleConnection connection;
+    private static String flushTableName;
 
     @BeforeClass
     public static void beforeClass() throws SQLException {
         connection = TestHelper.testConnection();
+        flushTableName = TestHelper.defaultConfig().build().getString(OracleConnectorConfig.LOG_MINING_FLUSH_TABLE_NAME);
     }
 
     @AfterClass
@@ -112,7 +113,7 @@ public class FlushStrategyIT extends AbstractConnectorTest {
 
             // Verify that the connector logged multiple rows detected and fixed
             Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> logInterceptor.containsWarnMessage(
-                    "DBZ-4118: The flush table, " + LOGMNR_FLUSH_TABLE + ", has multiple rows"));
+                    "DBZ-4118: The flush table, " + flushTableName + ", has multiple rows"));
 
             // Verify that no additional rows get inserted on restart
             // Log entry will occur before the SQL has fired in the strategy, so delay checking to allow
@@ -152,6 +153,6 @@ public class FlushStrategyIT extends AbstractConnectorTest {
     }
 
     private static String getFlushTableName() {
-        return TestHelper.getConnectorUserName() + "." + LOGMNR_FLUSH_TABLE;
+        return TestHelper.getConnectorUserName() + "." + flushTableName;
     }
 }

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3247,8 +3247,9 @@ If the difference between the timestamps is less than the specified value, and t
 
 |[[oracle-property-log-mining-flush-table-name]]<<oracle-property-log-mining-flush-table-name, `+log.mining.flush.table.name+`>>
 |`LOG_MINING_FLUSH`
-|Specifies the table name of the flush table used to coordinate flushing the Oracle LogWriter Buffer (LGWR) to the redo logs.
-Normally, multiple connectors will operate fine when using the same flush table; however, if you experience any type of table lock contention, this allows you to configure different tables for each connector deployment.
+|Specifies the name of the flush table that coordinates flushing the Oracle LogWriter Buffer (LGWR) to the redo logs.
+Typically, multiple connectors can use the same flush table.
+However, if connectors encounter table lock contention errors, use this property to specify a dedicated table for each connector deployment.
 
 |[[oracle-property-lob-enabled]]<<oracle-property-lob-enabled, `+lob.enabled+`>>
 |`false`

--- a/documentation/modules/ROOT/pages/connectors/oracle.adoc
+++ b/documentation/modules/ROOT/pages/connectors/oracle.adoc
@@ -3245,6 +3245,11 @@ If the difference between the SCN values is greater than the specified value, an
 |Specifies a value,  in milliseconds, that the connector compares to the difference between the current and previous SCN timestamps  to determine whether an SCN gap exists.
 If the difference between the timestamps is less than the specified value, and the SCN delta is greater than xref:oracle-property-log-mining-scn-gap-detection-gap-size-min[`log.mining.scn.gap.detection.gap.size.min`], then an SCN gap is detected and the connector uses a mining window larger than the configured maximum batch.
 
+|[[oracle-property-log-mining-flush-table-name]]<<oracle-property-log-mining-flush-table-name, `+log.mining.flush.table.name+`>>
+|`LOG_MINING_FLUSH`
+|Specifies the table name of the flush table used to coordinate flushing the Oracle LogWriter Buffer (LGWR) to the redo logs.
+Normally, multiple connectors will operate fine when using the same flush table; however, if you experience any type of table lock contention, this allows you to configure different tables for each connector deployment.
+
 |[[oracle-property-lob-enabled]]<<oracle-property-lob-enabled, `+lob.enabled+`>>
 |`false`
 |Controls whether or not large object (CLOB or BLOB) column values are emitted in change events. +


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6256

_Premise:_
There is the potential when using multiple connector deployments on Oracle that there could be some level of lock contention with all connectors using the same table. This allows users to configure the flush table name themselves, reducing the lock contention across multiple connector deployments.

@jpechane its safe to back-port this to Debezium 2.2 at least, the code is completely backward compatible.