### PR TITLE
[2.2] DBZ-6402 Using MongoCommandException to detect invalid change stream

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbSnapshotChangeEventSource.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.mongodb.MongoChangeStreamException;
+import com.mongodb.MongoCommandException;
 import com.mongodb.client.ChangeStreamIterable;
 import com.mongodb.client.MongoChangeStreamCursor;
 import com.mongodb.client.MongoCollection;
@@ -207,7 +208,7 @@ public class MongoDbSnapshotChangeEventSource extends AbstractSnapshotChangeEven
                         LOGGER.info("Valid resume token present for replica set '{}, so no snapshot will be performed'", replicaSet.replicaSetName());
                         return false;
                     }
-                    catch (MongoChangeStreamException e) {
+                    catch (MongoCommandException | MongoChangeStreamException e) {
                         LOGGER.info("Invalid resume token present for replica set '{}, snapshot will be performed'", replicaSet.replicaSetName());
                         return true;
                     }


### PR DESCRIPTION
…resume token in order to perform snapshot properly

https://issues.redhat.com/browse/DBZ-6402


Backport for #4506 