### PR TITLE
DBZ-1973: Enable Debezium to send notifications about it's status

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeEventSourceFactory.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbChangeEventSourceFactory.java
@@ -20,6 +20,7 @@ import io.debezium.connector.mongodb.connection.MongoDbConnection;
 import io.debezium.connector.mongodb.connection.ReplicaSet;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.ChangeEventSource;
 import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
@@ -90,7 +91,8 @@ public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory
     public Optional<IncrementalSnapshotChangeEventSource<MongoDbPartition, ? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(
                                                                                                                                                 MongoDbOffsetContext offsetContext,
                                                                                                                                                 SnapshotProgressListener<MongoDbPartition> snapshotProgressListener,
-                                                                                                                                                DataChangeEventListener<MongoDbPartition> dataChangeEventListener) {
+                                                                                                                                                DataChangeEventListener<MongoDbPartition> dataChangeEventListener,
+                                                                                                                                                NotificationService<MongoDbPartition, MongoDbOffsetContext> notificationService) {
         if (replicaSets.size() > 1) {
             LOGGER.info("Only ReplicaSet deployments and Sharded Cluster with connection.mode=sharded are supported by incremental snapshot");
             return Optional.empty();
@@ -104,7 +106,8 @@ public class MongoDbChangeEventSourceFactory implements ChangeEventSourceFactory
                 schema,
                 clock,
                 snapshotProgressListener,
-                dataChangeEventListener);
+                dataChangeEventListener,
+                notificationService);
         return Optional.of(incrementalSnapshotChangeEventSource);
     }
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbConnectorTask.java
@@ -29,8 +29,10 @@ import io.debezium.pipeline.ChangeEventSourceCoordinator;
 import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.signal.SignalProcessor;
 import io.debezium.pipeline.spi.Offsets;
+import io.debezium.schema.SchemaFactory;
 import io.debezium.schema.SchemaNameAdjuster;
 import io.debezium.util.Clock;
 import io.debezium.util.LoggingContext.PreviousContext;
@@ -118,6 +120,9 @@ public final class MongoDbConnectorTask extends BaseSourceTask<MongoDbPartition,
 
             dispatcher.getSignalingActions().forEach(signalProcessor::registerSignalAction);
 
+            NotificationService<MongoDbPartition, MongoDbOffsetContext> notificationService = new NotificationService<>(getNotificationChannels(),
+                    connectorConfig, SchemaFactory.get(), dispatcher::enqueueNotification);
+
             ChangeEventSourceCoordinator<MongoDbPartition, MongoDbOffsetContext> coordinator = new ChangeEventSourceCoordinator<>(
                     // TODO pass offsets from all the partitions
                     Offsets.of(Collections.singletonMap(new MongoDbPartition(), previousOffset)),
@@ -135,7 +140,8 @@ public final class MongoDbConnectorTask extends BaseSourceTask<MongoDbPartition,
                     new MongoDbChangeEventSourceMetricsFactory(),
                     dispatcher,
                     schema,
-                    signalProcessor);
+                    signalProcessor,
+                    notificationService);
 
             coordinator.start(taskContext, this.queue, metadataProvider);
 

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbIncrementalSnapshotChangeEventSource.java
@@ -28,6 +28,7 @@ import io.debezium.connector.mongodb.connection.MongoDbConnection;
 import io.debezium.connector.mongodb.connection.ReplicaSet;
 import io.debezium.connector.mongodb.recordemitter.MongoDbSnapshotRecordEmitter;
 import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.signal.actions.snapshotting.CloseIncrementalSnapshotWindow;
 import io.debezium.pipeline.signal.actions.snapshotting.OpenIncrementalSnapshotWindow;
 import io.debezium.pipeline.source.AbstractSnapshotChangeEventSource;
@@ -72,13 +73,16 @@ public class MongoDbIncrementalSnapshotChangeEventSource
 
     private final CollectionId signallingCollectionId;
 
+    protected final NotificationService<MongoDbPartition, ? extends OffsetContext> notificationService;
+
     public MongoDbIncrementalSnapshotChangeEventSource(MongoDbConnectorConfig config,
                                                        MongoDbConnection.ChangeEventSourceConnectionFactory connections, ReplicaSets replicaSets,
                                                        EventDispatcher<MongoDbPartition, CollectionId> dispatcher,
                                                        MongoDbSchema collectionSchema,
                                                        Clock clock,
                                                        SnapshotProgressListener<MongoDbPartition> progressListener,
-                                                       DataChangeEventListener<MongoDbPartition> dataChangeEventListener) {
+                                                       DataChangeEventListener<MongoDbPartition> dataChangeEventListener,
+                                                       NotificationService<MongoDbPartition, ? extends OffsetContext> notificationService) {
         this.connectorConfig = config;
         this.replicaSets = replicaSets;
         this.connections = connections;
@@ -89,6 +93,7 @@ public class MongoDbIncrementalSnapshotChangeEventSource
         this.dataListener = dataChangeEventListener;
         this.signallingCollectionId = connectorConfig.getSignalingDataCollectionId() == null ? null
                 : CollectionId.parse("UNUSED", connectorConfig.getSignalingDataCollectionId());
+        this.notificationService = notificationService;
     }
 
     @Override

--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbIncrementalSnapshotContext.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/MongoDbIncrementalSnapshotContext.java
@@ -10,6 +10,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -244,6 +245,11 @@ public class MongoDbIncrementalSnapshotContext<T> implements IncrementalSnapshot
     public boolean removeDataCollectionFromSnapshot(String dataCollectionId) {
         final T collectionId = (T) CollectionId.parse(dataCollectionId);
         return dataCollectionsToSnapshot.remove(new DataCollection<T>(collectionId));
+    }
+
+    @Override
+    public List<DataCollection<T>> getDataCollections() {
+        return new ArrayList<>(dataCollectionsToSnapshot);
     }
 
     protected static <U> IncrementalSnapshotContext<U> init(MongoDbIncrementalSnapshotContext<U> context, Map<String, ?> offsets) {

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceFactory.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlChangeEventSourceFactory.java
@@ -15,6 +15,7 @@ import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
 import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
@@ -86,7 +87,9 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<M
     public Optional<IncrementalSnapshotChangeEventSource<MySqlPartition, ? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(
                                                                                                                                               MySqlOffsetContext offsetContext,
                                                                                                                                               SnapshotProgressListener<MySqlPartition> snapshotProgressListener,
-                                                                                                                                              DataChangeEventListener<MySqlPartition> dataChangeEventListener) {
+                                                                                                                                              DataChangeEventListener<MySqlPartition> dataChangeEventListener,
+                                                                                                                                              NotificationService<MySqlPartition, MySqlOffsetContext> notificationService) {
+
         if (configuration.isReadOnlyConnection()) {
             if (connectionFactory.mainConnection().isGtidModeEnabled()) {
                 return Optional.of(new MySqlReadOnlyIncrementalSnapshotChangeEventSource<>(
@@ -96,7 +99,8 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<M
                         schema,
                         clock,
                         snapshotProgressListener,
-                        dataChangeEventListener));
+                        dataChangeEventListener,
+                        notificationService));
             }
             throw new UnsupportedOperationException("Read only connection requires GTID_MODE to be ON");
         }
@@ -112,6 +116,6 @@ public class MySqlChangeEventSourceFactory implements ChangeEventSourceFactory<M
                 schema,
                 clock,
                 snapshotProgressListener,
-                dataChangeEventListener));
+                dataChangeEventListener, notificationService));
     }
 }

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlSnapshotChangeEventSource.java
@@ -238,7 +238,7 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
 
                     final TableId tableId = event.getTables().isEmpty() ? null : event.getTables().iterator().next().id();
                     snapshotContext.offset.event(tableId, getClock().currentTime());
-                    dispatcher.dispatchSchemaChangeEvent(snapshotContext.partition, tableId, (receiver) -> receiver.schemaChangeEvent(event));
+                    dispatcher.dispatchSchemaChangeEvent(snapshotContext.partition, snapshotContext.offset, tableId, (receiver) -> receiver.schemaChangeEvent(event));
                 }
 
                 // Make schema available for snapshot source
@@ -541,7 +541,7 @@ public class MySqlSnapshotChangeEventSource extends RelationalSnapshotChangeEven
 
             final TableId tableId = event.getTables().isEmpty() ? null : event.getTables().iterator().next().id();
             snapshotContext.offset.event(tableId, getClock().currentTime());
-            dispatcher.dispatchSchemaChangeEvent(snapshotContext.partition, tableId, (receiver) -> receiver.schemaChangeEvent(event));
+            dispatcher.dispatchSchemaChangeEvent(snapshotContext.partition, snapshotContext.offset, tableId, (receiver) -> receiver.schemaChangeEvent(event));
         }
 
         // Make schema available for snapshot source

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -602,7 +602,7 @@ public class MySqlStreamingChangeEventSource implements StreamingChangeEventSour
                     eventDispatcher.dispatchDataChangeEvent(partition, tableId,
                             new MySqlChangeRecordEmitter(partition, offsetContext, clock, Operation.TRUNCATE, null, null, connectorConfig.skipMessagesWithoutChange()));
                 }
-                eventDispatcher.dispatchSchemaChangeEvent(partition, tableId, (receiver) -> {
+                eventDispatcher.dispatchSchemaChangeEvent(partition, offsetContext, tableId, (receiver) -> {
                     try {
                         receiver.schemaChangeEvent(schemaChangeEvent);
                     }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/NotificationsIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/NotificationsIT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.mysql;
+
+import java.nio.file.Path;
+import java.sql.SQLException;
+
+import org.junit.After;
+import org.junit.Before;
+
+import io.debezium.config.Configuration;
+import io.debezium.pipeline.notification.AbstractNotificationsIT;
+import io.debezium.util.Testing;
+
+public class NotificationsIT extends AbstractNotificationsIT<MySqlConnector> {
+
+    protected static final String SERVER_NAME = "is_test";
+    protected final UniqueDatabase DATABASE = new UniqueDatabase(SERVER_NAME, "incremental_snapshot-test").withDbHistoryPath(SCHEMA_HISTORY_PATH);
+    protected static final Path SCHEMA_HISTORY_PATH = Testing.Files.createTestingPath("file-schema-history-is.txt")
+            .toAbsolutePath();
+
+    @Before
+    public void before() throws SQLException {
+        stopConnector();
+        DATABASE.createAndInitialize();
+        initializeConnectorTestFramework();
+        Testing.Files.delete(SCHEMA_HISTORY_PATH);
+    }
+
+    @After
+    public void after() {
+        try {
+            stopConnector();
+        }
+        finally {
+            Testing.Files.delete(SCHEMA_HISTORY_PATH);
+        }
+    }
+
+    @Override
+    protected Class<MySqlConnector> connectorClass() {
+        return MySqlConnector.class;
+    }
+
+    @Override
+    protected Configuration.Builder config() {
+        return DATABASE.defaultConfig()
+                .with(MySqlConnectorConfig.SNAPSHOT_MODE, MySqlConnectorConfig.SnapshotMode.NEVER.getValue());
+    }
+
+    @Override
+    protected String snapshotStatusResult() {
+        return "SKIPPED";
+    }
+}

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleChangeEventSourceFactory.java
@@ -11,6 +11,7 @@ import io.debezium.config.Configuration;
 import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
@@ -71,7 +72,8 @@ public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory<
     public Optional<IncrementalSnapshotChangeEventSource<OraclePartition, ? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(
                                                                                                                                                OracleOffsetContext offsetContext,
                                                                                                                                                SnapshotProgressListener<OraclePartition> snapshotProgressListener,
-                                                                                                                                               DataChangeEventListener<OraclePartition> dataChangeEventListener) {
+                                                                                                                                               DataChangeEventListener<OraclePartition> dataChangeEventListener,
+                                                                                                                                               NotificationService<OraclePartition, OracleOffsetContext> notificationService) {
         // If no data collection id is provided, don't return an instance as the implementation requires
         // that a signal data collection id be provided to work.
         if (Strings.isNullOrEmpty(configuration.getSignalingDataCollectionId())) {
@@ -89,6 +91,7 @@ public class OracleChangeEventSourceFactory implements ChangeEventSourceFactory<
                 schema,
                 clock,
                 snapshotProgressListener,
-                dataChangeEventListener));
+                dataChangeEventListener,
+                notificationService));
     }
 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
@@ -29,9 +29,11 @@ import io.debezium.pipeline.ChangeEventSourceCoordinator;
 import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.signal.SignalProcessor;
 import io.debezium.pipeline.spi.Offsets;
 import io.debezium.relational.TableId;
+import io.debezium.schema.SchemaFactory;
 import io.debezium.schema.SchemaNameAdjuster;
 import io.debezium.spi.topic.TopicNamingStrategy;
 import io.debezium.util.Clock;
@@ -127,6 +129,9 @@ public class OracleConnectorTask extends BaseSourceTask<OraclePartition, OracleO
 
         dispatcher.getSignalingActions().forEach(signalProcessor::registerSignalAction);
 
+        NotificationService<OraclePartition, OracleOffsetContext> notificationService = new NotificationService<>(getNotificationChannels(),
+                connectorConfig, SchemaFactory.get(), dispatcher::enqueueNotification);
+
         ChangeEventSourceCoordinator<OraclePartition, OracleOffsetContext> coordinator = new ChangeEventSourceCoordinator<>(
                 previousOffsets,
                 errorHandler,
@@ -136,7 +141,8 @@ public class OracleConnectorTask extends BaseSourceTask<OraclePartition, OracleO
                         streamingMetrics),
                 new OracleChangeEventSourceMetricsFactory(streamingMetrics),
                 dispatcher,
-                schema, signalProcessor);
+                schema, signalProcessor,
+                notificationService);
 
         coordinator.start(taskContext, this.queue, metadataProvider);
 

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import io.debezium.DebeziumException;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
 import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
@@ -33,8 +34,9 @@ public class OracleSignalBasedIncrementalSnapshotChangeEventSource extends Signa
                                                                  DatabaseSchema<?> databaseSchema,
                                                                  Clock clock,
                                                                  SnapshotProgressListener<OraclePartition> progressListener,
-                                                                 DataChangeEventListener<OraclePartition> dataChangeEventListener) {
-        super(config, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener);
+                                                                 DataChangeEventListener<OraclePartition> dataChangeEventListener,
+                                                                 NotificationService<OraclePartition, OracleOffsetContext> notificationService) {
+        super(config, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener, notificationService);
         this.pdbName = ((OracleConnectorConfig) config).getPdbName();
         this.connection = (OracleConnection) jdbcConnection;
     }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/processor/AbstractLogMinerEventProcessor.java
@@ -687,7 +687,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
             offsetContext.setEventScn(row.getScn());
             offsetContext.setRedoThread(row.getThread());
             offsetContext.setRsId(row.getRsId());
-            dispatcher.dispatchSchemaChangeEvent(partition,
+            dispatcher.dispatchSchemaChangeEvent(partition, offsetContext,
                     tableId,
                     new OracleSchemaChangeEventEmitter(
                             getConfig(),
@@ -1020,7 +1020,7 @@ public abstract class AbstractLogMinerEventProcessor<T extends AbstractTransacti
 
         LOGGER.info("Table '{}' is new and will now be captured.", tableId);
         offsetContext.event(tableId, Instant.now());
-        dispatcher.dispatchSchemaChangeEvent(partition,
+        dispatcher.dispatchSchemaChangeEvent(partition, offsetContext,
                 tableId,
                 new OracleSchemaChangeEventEmitter(connectorConfig,
                         partition,

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -182,6 +182,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
             LOGGER.info("Table {} will be captured.", tableId);
             dispatcher.dispatchSchemaChangeEvent(
                     partition,
+                    offsetContext,
                     tableId,
                     new OracleSchemaChangeEventEmitter(
                             connectorConfig,
@@ -255,6 +256,7 @@ class LcrEventHandler implements XStreamLCRCallbackHandler {
 
         dispatcher.dispatchSchemaChangeEvent(
                 partition,
+                offsetContext,
                 tableId,
                 new OracleSchemaChangeEventEmitter(
                         connectorConfig,

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/NotificationsIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/NotificationsIT.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.oracle;
+
+import java.sql.SQLException;
+
+import org.junit.After;
+import org.junit.Before;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.util.TestHelper;
+import io.debezium.pipeline.notification.AbstractNotificationsIT;
+import io.debezium.util.Testing;
+
+public class NotificationsIT extends AbstractNotificationsIT<OracleConnector> {
+
+    private OracleConnection connection;
+
+    @Before
+    public void before() throws SQLException {
+        connection = TestHelper.testConnection();
+
+        TestHelper.dropTable(connection, "a");
+        connection.execute("CREATE TABLE a (pk numeric(9,0) primary key, aa numeric(9,0))");
+        TestHelper.streamTable(connection, "a");
+
+        initializeConnectorTestFramework();
+        Testing.Files.delete(TestHelper.SCHEMA_HISTORY_PATH);
+    }
+
+    @After
+    public void after() {
+        stopConnector();
+    }
+
+    @Override
+    protected Class<OracleConnector> connectorClass() {
+        return OracleConnector.class;
+    }
+
+    @Override
+    protected Configuration.Builder config() {
+        return TestHelper.defaultConfig()
+                .with(OracleConnectorConfig.SNAPSHOT_MODE, OracleConnectorConfig.SnapshotMode.INITIAL);
+    }
+
+    @Override
+    protected String snapshotStatusResult() {
+        return "COMPLETED";
+    }
+}

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceCoordinator.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceCoordinator.java
@@ -19,6 +19,7 @@ import io.debezium.pipeline.ChangeEventSourceCoordinator;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.metrics.spi.ChangeEventSourceMetricsFactory;
+import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.signal.SignalProcessor;
 import io.debezium.pipeline.source.spi.ChangeEventSource;
 import io.debezium.pipeline.source.spi.ChangeEventSource.ChangeEventSourceContext;
@@ -45,9 +46,10 @@ public class PostgresChangeEventSourceCoordinator extends ChangeEventSourceCoord
                                                 ChangeEventSourceMetricsFactory<PostgresPartition> changeEventSourceMetricsFactory,
                                                 EventDispatcher<PostgresPartition, ?> eventDispatcher, DatabaseSchema<?> schema,
                                                 Snapshotter snapshotter, SlotState slotInfo,
-                                                SignalProcessor<PostgresPartition, PostgresOffsetContext> signalProcessor) {
+                                                SignalProcessor<PostgresPartition, PostgresOffsetContext> signalProcessor,
+                                                NotificationService<PostgresPartition, PostgresOffsetContext> notificationService) {
         super(previousOffsets, errorHandler, connectorType, connectorConfig, changeEventSourceFactory,
-                changeEventSourceMetricsFactory, eventDispatcher, schema, signalProcessor);
+                changeEventSourceMetricsFactory, eventDispatcher, schema, signalProcessor, notificationService);
         this.snapshotter = snapshotter;
         this.slotInfo = slotInfo;
     }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFactory.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresChangeEventSourceFactory.java
@@ -14,6 +14,7 @@ import io.debezium.connector.postgresql.spi.SlotState;
 import io.debezium.connector.postgresql.spi.Snapshotter;
 import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
 import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
@@ -89,7 +90,8 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
     public Optional<IncrementalSnapshotChangeEventSource<PostgresPartition, ? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(
                                                                                                                                                  PostgresOffsetContext offsetContext,
                                                                                                                                                  SnapshotProgressListener<PostgresPartition> snapshotProgressListener,
-                                                                                                                                                 DataChangeEventListener<PostgresPartition> dataChangeEventListener) {
+                                                                                                                                                 DataChangeEventListener<PostgresPartition> dataChangeEventListener,
+                                                                                                                                                 NotificationService<PostgresPartition, PostgresOffsetContext> notificationService) {
         // If no data collection id is provided, don't return an instance as the implementation requires
         // that a signal data collection id be provided to work.
         if (Strings.isNullOrEmpty(configuration.getSignalingDataCollectionId())) {
@@ -102,7 +104,8 @@ public class PostgresChangeEventSourceFactory implements ChangeEventSourceFactor
                 schema,
                 clock,
                 snapshotProgressListener,
-                dataChangeEventListener);
+                dataChangeEventListener,
+                notificationService);
         return Optional.of(incrementalSnapshotChangeEventSource);
     }
 }

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresConnectorTask.java
@@ -39,9 +39,11 @@ import io.debezium.pipeline.ChangeEventSourceCoordinator;
 import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.metrics.DefaultChangeEventSourceMetricsFactory;
+import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.signal.SignalProcessor;
 import io.debezium.pipeline.spi.Offsets;
 import io.debezium.relational.TableId;
+import io.debezium.schema.SchemaFactory;
 import io.debezium.schema.SchemaNameAdjuster;
 import io.debezium.spi.topic.TopicNamingStrategy;
 import io.debezium.util.Clock;
@@ -211,6 +213,9 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
 
             dispatcher.getSignalingActions().forEach(signalProcessor::registerSignalAction);
 
+            NotificationService<PostgresPartition, PostgresOffsetContext> notificationService = new NotificationService<>(getNotificationChannels(),
+                    connectorConfig, SchemaFactory.get(), dispatcher::enqueueNotification);
+
             ChangeEventSourceCoordinator<PostgresPartition, PostgresOffsetContext> coordinator = new PostgresChangeEventSourceCoordinator(
                     previousOffsets,
                     errorHandler,
@@ -233,7 +238,8 @@ public class PostgresConnectorTask extends BaseSourceTask<PostgresPartition, Pos
                     schema,
                     snapshotter,
                     slotInfo,
-                    signalProcessor);
+                    signalProcessor,
+                    notificationService);
 
             coordinator.start(taskContext, this.queue, metadataProvider);
 

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSignalBasedIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresSignalBasedIncrementalSnapshotChangeEventSource.java
@@ -13,9 +13,11 @@ import org.slf4j.LoggerFactory;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
@@ -42,8 +44,9 @@ public class PostgresSignalBasedIncrementalSnapshotChangeEventSource
                                                                    DatabaseSchema<?> databaseSchema,
                                                                    Clock clock,
                                                                    SnapshotProgressListener<PostgresPartition> progressListener,
-                                                                   DataChangeEventListener<PostgresPartition> dataChangeEventListener) {
-        super(config, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener);
+                                                                   DataChangeEventListener<PostgresPartition> dataChangeEventListener,
+                                                                   NotificationService<PostgresPartition, ? extends OffsetContext> notificationService) {
+        super(config, jdbcConnection, dispatcher, databaseSchema, clock, progressListener, dataChangeEventListener, notificationService);
         this.jdbcConnection = (PostgresConnection) jdbcConnection;
         this.schema = (PostgresSchema) databaseSchema;
     }

--- a/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/NotificationsIT.java
+++ b/debezium-connector-postgres/src/test/java/io/debezium/connector/postgresql/NotificationsIT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.postgresql;
+
+import java.sql.SQLException;
+
+import org.junit.After;
+import org.junit.Before;
+
+import io.debezium.config.Configuration;
+import io.debezium.pipeline.notification.AbstractNotificationsIT;
+
+public class NotificationsIT extends AbstractNotificationsIT<PostgresConnector> {
+
+    @Before
+    public void before() throws SQLException {
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.dropAllSchemas();
+        initializeConnectorTestFramework();
+    }
+
+    @After
+    public void after() {
+        stopConnector();
+        TestHelper.dropDefaultReplicationSlot();
+        TestHelper.dropPublication();
+    }
+
+    @Override
+    protected Class<PostgresConnector> connectorClass() {
+        return PostgresConnector.class;
+    }
+
+    @Override
+    protected Configuration.Builder config() {
+        return TestHelper.defaultConfig()
+                .with(PostgresConnectorConfig.SNAPSHOT_MODE, PostgresConnectorConfig.SnapshotMode.NEVER.getValue())
+                .with(PostgresConnectorConfig.DROP_SLOT_ON_STOP, Boolean.TRUE);
+    }
+
+    @Override
+    protected String snapshotStatusResult() {
+        return "SKIPPED";
+    }
+}

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerChangeEventSourceFactory.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.snapshot.incremental.SignalBasedIncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.ChangeEventSourceFactory;
@@ -65,7 +66,8 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
     public Optional<IncrementalSnapshotChangeEventSource<SqlServerPartition, ? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(
                                                                                                                                                   SqlServerOffsetContext offsetContext,
                                                                                                                                                   SnapshotProgressListener<SqlServerPartition> snapshotProgressListener,
-                                                                                                                                                  DataChangeEventListener<SqlServerPartition> dataChangeEventListener) {
+                                                                                                                                                  DataChangeEventListener<SqlServerPartition> dataChangeEventListener,
+                                                                                                                                                  NotificationService<SqlServerPartition, SqlServerOffsetContext> notificationService) {
         // If no data collection id is provided, don't return an instance as the implementation requires
         // that a signal data collection id be provided to work.
         if (Strings.isNullOrEmpty(configuration.getSignalingDataCollectionId())) {
@@ -78,7 +80,8 @@ public class SqlServerChangeEventSourceFactory implements ChangeEventSourceFacto
                 schema,
                 clock,
                 snapshotProgressListener,
-                dataChangeEventListener);
+                dataChangeEventListener,
+                notificationService);
         return Optional.of(incrementalSnapshotChangeEventSource);
     }
 }

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerConnectorTask.java
@@ -26,9 +26,11 @@ import io.debezium.jdbc.MainConnectionProvidingConnectionFactory;
 import io.debezium.pipeline.ChangeEventSourceCoordinator;
 import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.signal.SignalProcessor;
 import io.debezium.pipeline.spi.Offsets;
 import io.debezium.relational.TableId;
+import io.debezium.schema.SchemaFactory;
 import io.debezium.schema.SchemaNameAdjuster;
 import io.debezium.spi.topic.TopicNamingStrategy;
 import io.debezium.util.Clock;
@@ -129,6 +131,9 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
 
         dispatcher.getSignalingActions().forEach(signalProcessor::registerSignalAction);
 
+        NotificationService<SqlServerPartition, SqlServerOffsetContext> notificationService = new NotificationService<>(getNotificationChannels(),
+                connectorConfig, SchemaFactory.get(), dispatcher::enqueueNotification);
+
         ChangeEventSourceCoordinator<SqlServerPartition, SqlServerOffsetContext> coordinator = new SqlServerChangeEventSourceCoordinator(
                 offsets,
                 errorHandler,
@@ -139,7 +144,8 @@ public class SqlServerConnectorTask extends BaseSourceTask<SqlServerPartition, S
                 dispatcher,
                 schema,
                 clock,
-                signalProcessor);
+                signalProcessor,
+                notificationService);
 
         coordinator.start(taskContext, this.queue, metadataProvider);
 

--- a/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
+++ b/debezium-connector-sqlserver/src/main/java/io/debezium/connector/sqlserver/SqlServerStreamingChangeEventSource.java
@@ -371,7 +371,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
             LOGGER.info("Migration skipped, no table schema changes detected.");
             return;
         }
-        dispatcher.dispatchSchemaChangeEvent(partition, newTable.getSourceTableId(),
+        dispatcher.dispatchSchemaChangeEvent(partition, offsetContext, newTable.getSourceTableId(),
                 new SqlServerSchemaChangeEventEmitter(partition, offsetContext, newTable, tableSchema, schema,
                         SchemaChangeEventType.ALTER));
         newTable.setSourceTable(tableSchema);
@@ -443,6 +443,7 @@ public class SqlServerStreamingChangeEventSource implements StreamingChangeEvent
                         Instant.now());
                 dispatcher.dispatchSchemaChangeEvent(
                         partition,
+                        offsetContext,
                         currentTable.getSourceTableId(),
                         new SqlServerSchemaChangeEventEmitter(
                                 partition,

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/NotificationsIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/NotificationsIT.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.sqlserver;
+
+import java.sql.SQLException;
+
+import org.junit.After;
+import org.junit.Before;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.sqlserver.util.TestHelper;
+import io.debezium.pipeline.notification.AbstractNotificationsIT;
+import io.debezium.util.Testing;
+
+public class NotificationsIT extends AbstractNotificationsIT<SqlServerConnector> {
+
+    @Before
+    public void before() throws SQLException {
+
+        TestHelper.createTestDatabase();
+        SqlServerConnection sqlServerConnection = TestHelper.testConnection();
+        sqlServerConnection.execute(
+                "CREATE TABLE tablea (id int primary key, cola varchar(30))",
+                "CREATE TABLE tableb (id int primary key, colb varchar(30))",
+                "INSERT INTO tablea VALUES(1, 'a')");
+        TestHelper.enableTableCdc(sqlServerConnection, "tablea");
+
+        initializeConnectorTestFramework();
+
+        Testing.Files.delete(TestHelper.SCHEMA_HISTORY_PATH);
+    }
+
+    @After
+    public void after() {
+        stopConnector();
+        TestHelper.dropTestDatabase();
+    }
+
+    @Override
+    protected Class<SqlServerConnector> connectorClass() {
+        return SqlServerConnector.class;
+    }
+
+    @Override
+    protected Configuration.Builder config() {
+        return TestHelper.defaultConfig()
+                .with(SqlServerConnectorConfig.SNAPSHOT_MODE, SqlServerConnectorConfig.SnapshotMode.SCHEMA_ONLY);
+    }
+
+    @Override
+    protected String snapshotStatusResult() {
+        return "COMPLETED";
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/config/Configuration.java
+++ b/debezium-core/src/main/java/io/debezium/config/Configuration.java
@@ -1038,10 +1038,11 @@ public interface Configuration {
 
     default <T> List<T> getList(String key, String separator, Function<String, T> converter) {
         var value = getString(key);
-        return Arrays.stream(value.split(separator))
-                .map(String::trim)
-                .map(converter)
-                .collect(Collectors.toList());
+        return value == null ? List.of()
+                : Arrays.stream(value.split(separator))
+                        .map(String::trim)
+                        .map(converter)
+                        .collect(Collectors.toList());
     }
 
     /**

--- a/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
+++ b/debezium-core/src/main/java/io/debezium/connector/base/ChangeEventQueue.java
@@ -85,7 +85,7 @@ public class ChangeEventQueue<T extends Sizeable> implements ChangeEventQueueMet
     @SingleThreadAccess("producer thread")
     private boolean buffering;
 
-    private AtomicReference<T> bufferedEvent = new AtomicReference<>();
+    private final AtomicReference<T> bufferedEvent = new AtomicReference<>();
 
     private volatile RuntimeException producerException;
 
@@ -330,5 +330,9 @@ public class ChangeEventQueue<T extends Sizeable> implements ChangeEventQueueMet
     @Override
     public long currentQueueSizeInBytes() {
         return currentQueueSizeInBytes;
+    }
+
+    public boolean isBuffered() {
+        return buffering;
     }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -216,7 +216,7 @@ public class ChangeEventSourceCoordinator<P extends Partition, O extends OffsetC
         getSignalProcessor(previousOffsets).ifPresent(s -> s.setContext(streamingSource.getOffsetContext()));
 
         final Optional<IncrementalSnapshotChangeEventSource<P, ? extends DataCollectionId>> incrementalSnapshotChangeEventSource = changeEventSourceFactory
-                .getIncrementalSnapshotChangeEventSource(offsetContext, snapshotMetrics, snapshotMetrics);
+                .getIncrementalSnapshotChangeEventSource(offsetContext, snapshotMetrics, snapshotMetrics, notificationService);
         eventDispatcher.setIncrementalSnapshotChangeEventSource(incrementalSnapshotChangeEventSource);
         incrementalSnapshotChangeEventSource.ifPresent(x -> x.init(partition, offsetContext));
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/EventDispatcher.java
@@ -381,7 +381,8 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> im
         return Optional.empty();
     }
 
-    public void dispatchSchemaChangeEvent(P partition, T dataCollectionId, SchemaChangeEventEmitter schemaChangeEventEmitter) throws InterruptedException {
+    public void dispatchSchemaChangeEvent(P partition, OffsetContext offsetContext, T dataCollectionId, SchemaChangeEventEmitter schemaChangeEventEmitter)
+            throws InterruptedException {
         if (dataCollectionId != null && !filter.isIncluded(dataCollectionId)) {
             if (historizedSchema == null || historizedSchema.storeOnlyCapturedTables()) {
                 LOGGER.trace("Filtering schema change event for {}", dataCollectionId);
@@ -389,8 +390,9 @@ public class EventDispatcher<P extends Partition, T extends DataCollectionId> im
             }
         }
         schemaChangeEventEmitter.emitSchemaChangeEvent(new SchemaChangeEventReceiver());
+
         if (incrementalSnapshotChangeEventSource != null) {
-            incrementalSnapshotChangeEventSource.processSchemaChange(partition, dataCollectionId);
+            incrementalSnapshotChangeEventSource.processSchemaChange(partition, offsetContext, dataCollectionId);
         }
     }
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/notification/Notification.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/notification/Notification.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.notification;
+
+import java.util.Map;
+
+public class Notification {
+
+    public static final String ID_KEY = "id";
+    public static final String TYPE = "type";
+    public static final String AGGREGATE_TYPE = "aggregate_type";
+    public static final String ADDITIONAL_DATA = "additional_data";
+
+    private final String id;
+    private final String aggregateType;
+    private final String type;
+    private final Map<String, String> additionalData;
+
+    public Notification(String id, String aggregateType, String type, Map<String, String> additionalData) {
+        this.id = id;
+        this.aggregateType = aggregateType;
+        this.type = type;
+        this.additionalData = additionalData;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getAggregateType() {
+        return aggregateType;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public Map<String, String> getAdditionalData() {
+        return additionalData;
+    }
+
+    @Override
+    public String toString() {
+        return "{" +
+                "aggregateType='" + aggregateType + '\'' +
+                ", type='" + type + '\'' +
+                ", additionalData=" + additionalData +
+                '}';
+    }
+
+    public static final class Builder {
+        private String id;
+        private String aggregateType;
+        private String type;
+        private Map<String, String> additionalData;
+
+        private Builder() {
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public Builder withId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withAggregateType(String aggregateType) {
+            this.aggregateType = aggregateType;
+            return this;
+        }
+
+        public Builder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder withAdditionalData(Map<String, String> additionalData) {
+            this.additionalData = additionalData;
+            return this;
+        }
+
+        public Notification build() {
+            return new Notification(id, aggregateType, type, additionalData);
+        }
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/notification/NotificationService.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/notification/NotificationService.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.notification;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.function.BlockingConsumer;
+import io.debezium.pipeline.notification.channels.ConnectChannel;
+import io.debezium.pipeline.notification.channels.NotificationChannel;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.schema.SchemaFactory;
+
+/**
+ * This service can be used to send notification to available and enabled channels
+ */
+public class NotificationService<P extends Partition, O extends OffsetContext> {
+
+    private final List<NotificationChannel> notificationChannels;
+    private final List<String> enabledChannels;
+
+    public NotificationService(List<NotificationChannel> notificationChannels,
+                               CommonConnectorConfig config,
+                               SchemaFactory schemaFactory, BlockingConsumer<SourceRecord> consumer) {
+
+        this.notificationChannels = notificationChannels;
+
+        this.enabledChannels = config.getEnabledNotificationChannels();
+
+        this.notificationChannels.stream()
+                .filter(isEnabled())
+                .forEach(channel -> channel.init(config));
+
+        this.notificationChannels.stream()
+                .filter(isConnectChannel())
+                .forEach(channel -> ((ConnectChannel) channel).initConnectChannel(schemaFactory, consumer));
+    }
+
+    /**
+     * This method permits to just send a notification.
+     * For the channels that implements For {@link ConnectChannel} an empty Partition and Offset will be sent with the {@link SourceRecord}
+     * @param notification the notification to send
+     */
+    public void notify(Notification notification) {
+
+        notificationChannels.stream()
+                .filter(isEnabled())
+                .forEach(channel -> channel.send(notification));
+    }
+
+    /**
+     * This method permits to send a notification together with offsets.
+     * This make sense only for channels that implements For {@link ConnectChannel}
+     * @param notification the notification to send
+     * @param offsets the offset to send together with Kafka {@link SourceRecord}
+     */
+    public void notify(Notification notification, Offsets<P, O> offsets) {
+
+        this.notificationChannels.stream()
+                .filter(isEnabled())
+                .filter(isConnectChannel())
+                .forEach(channel -> ((ConnectChannel) channel).send(notification, offsets));
+    }
+
+    private Predicate<? super NotificationChannel> isEnabled() {
+        return channel -> enabledChannels.contains(channel.name());
+    }
+
+    private Predicate<? super NotificationChannel> isConnectChannel() {
+        return channel -> channel instanceof ConnectChannel;
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/notification/NotificationService.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/notification/NotificationService.java
@@ -62,7 +62,7 @@ public class NotificationService<P extends Partition, O extends OffsetContext> {
      * @param notification the notification to send
      * @param offsets the offset to send together with Kafka {@link SourceRecord}
      */
-    public void notify(Notification notification, Offsets<P, O> offsets) {
+    public void notify(Notification notification, Offsets<P, ? extends OffsetContext> offsets) {
 
         this.notificationChannels.stream()
                 .filter(isEnabled())

--- a/debezium-core/src/main/java/io/debezium/pipeline/notification/channels/ConnectChannel.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/notification/channels/ConnectChannel.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.notification.channels;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+import io.debezium.function.BlockingConsumer;
+import io.debezium.pipeline.notification.Notification;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.schema.SchemaFactory;
+
+/**
+ * A special channel that is strictly connected to Kafka Connect API
+ */
+public interface ConnectChannel {
+
+    void initConnectChannel(SchemaFactory schemaFactory, BlockingConsumer<SourceRecord> consumer);
+
+    <P extends Partition, O extends OffsetContext> void send(Notification notification, Offsets<P, O> offsets);
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/notification/channels/LogNotificationChannel.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/notification/channels/LogNotificationChannel.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.notification.channels;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.pipeline.notification.Notification;
+
+public class LogNotificationChannel implements NotificationChannel {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LogNotificationChannel.class);
+    private static final String LOG_PREFIX = "[Notification Service] ";
+    public static final String CHANNEL_NAME = "log";
+
+    @Override
+    public void init(CommonConnectorConfig config) {
+    }
+
+    @Override
+    public String name() {
+        return CHANNEL_NAME;
+    }
+
+    @Override
+    public void send(Notification notification) {
+
+        LOGGER.info("{} {}", LOG_PREFIX, notification);
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/notification/channels/NotificationChannel.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/notification/channels/NotificationChannel.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.notification.channels;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.pipeline.notification.Notification;
+
+/**
+ * This interface is used to provide custom write channels for the Debezium notification feature:
+ *
+ * Implementations must:
+ * define the name of the channel in {@link #name()},
+ * initialize specific configuration/variables/connections in the {@link #init(CommonConnectorConfig connectorConfig)} method,
+ * implement send of the notification on the channel in the {@link #send(Notification notification)} method.
+ * Close all allocated resources int the {@link #close()} method.
+ *
+ * @author Mario Fiore Vitale
+ */
+public interface NotificationChannel {
+
+    void init(CommonConnectorConfig config);
+
+    String name();
+
+    void send(Notification notification);
+
+    void close();
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/notification/channels/SinkNotificationChannel.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/notification/channels/SinkNotificationChannel.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.notification.channels;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.config.Field;
+import io.debezium.connector.SnapshotRecord;
+import io.debezium.function.BlockingConsumer;
+import io.debezium.pipeline.notification.Notification;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.pipeline.txmetadata.TransactionContext;
+import io.debezium.schema.SchemaFactory;
+import io.debezium.schema.SchemaNameAdjuster;
+import io.debezium.spi.schema.DataCollectionId;
+
+public class SinkNotificationChannel implements NotificationChannel, ConnectChannel {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SinkNotificationChannel.class);
+
+    public static final Field NOTIFICATION_TOPIC = Field.create(CommonConnectorConfig.NOTIFICATION_CONFIGURATION_FIELD_PREFIX_STRING + "sink.topic.name")
+            .withDisplayName("Notification topic name")
+            .withType(ConfigDef.Type.STRING)
+            .withWidth(ConfigDef.Width.LONG)
+            .withImportance(ConfigDef.Importance.HIGH)
+            .withDescription("The name of the topic for the notifications. This is required in case 'sink' is in the list of enabled channels")
+            .withValidation(SinkNotificationChannel::validateNotificationTopicName);
+
+    public static final String CHANNEL_NAME = "sink";
+    private BlockingConsumer<SourceRecord> consumer;
+    private Schema keySchema;
+    private Schema valueSchema;
+    private String topicName;
+
+    private static int validateNotificationTopicName(Configuration config, Field field, Field.ValidationOutput problems) {
+
+        String topicName = config.getString(field);
+        boolean isKafkaChannelEnabled = config.getList(CommonConnectorConfig.NOTIFICATION_ENABLED_CHANNELS).contains(CHANNEL_NAME);
+        int count = 0;
+        if (isKafkaChannelEnabled && topicName == null) {
+            problems.accept(field, topicName, "Notification topic name must be provided when kafka notification channel is enabled");
+            ++count;
+        }
+
+        return count;
+    }
+
+    @Override
+    public void init(CommonConnectorConfig config) {
+
+        this.topicName = config.getNotificationTopic();
+    }
+
+    @Override
+    public void initConnectChannel(SchemaFactory schemaFactory, BlockingConsumer<SourceRecord> consumer) {
+
+        this.consumer = consumer;
+        this.keySchema = schemaFactory.notificationKeySchema(SchemaNameAdjuster.NO_OP);
+        this.valueSchema = schemaFactory.notificationValueSchema(SchemaNameAdjuster.NO_OP);
+    }
+
+    @Override
+    public String name() {
+        return CHANNEL_NAME;
+    }
+
+    @Override
+    public void send(Notification notification) {
+
+        send(notification, Offsets.of(Collections.singletonMap(Map::of, new EmptyOffsetContext())));
+    }
+
+    @Override
+    public <P extends Partition, O extends OffsetContext> void send(Notification notification, Offsets<P, O> offsets) {
+
+        Struct keyValue = new Struct(keySchema).put(Notification.ID_KEY, notification.getId());
+        Struct value = new Struct(valueSchema)
+                .put(Notification.ID_KEY, notification.getId())
+                .put(Notification.TYPE, notification.getType())
+                .put(Notification.AGGREGATE_TYPE, notification.getAggregateType())
+                .put(Notification.ADDITIONAL_DATA, notification.getAdditionalData());
+
+        // When connector is started for the first time and SnapshotMode.NEVER
+        Map<String, ?> offset = offsets.getTheOnlyOffset() == null ? Map.of() : offsets.getTheOnlyOffset().getOffset();
+
+        SourceRecord sourceRecord = new SourceRecord(offsets.getTheOnlyPartition().getSourcePartition(), offset, topicName,
+                keySchema, keyValue,
+                valueSchema, value);
+
+        try {
+            consumer.accept(sourceRecord); // This sends the record to the ChangeEventQueue
+        }
+        catch (InterruptedException e) {
+            LOGGER.error("Notification {} not sent due to interrupt", notification);
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+
+    private static class EmptyOffsetContext implements OffsetContext {
+
+        @Override
+        public Map<String, ?> getOffset() {
+            return Map.of();
+        }
+
+        @Override
+        public Schema getSourceInfoSchema() {
+            return null;
+        }
+
+        @Override
+        public Struct getSourceInfo() {
+            return null;
+        }
+
+        @Override
+        public boolean isSnapshotRunning() {
+            return false;
+        }
+
+        @Override
+        public void markSnapshotRecord(SnapshotRecord record) {
+
+        }
+
+        @Override
+        public void preSnapshotStart() {
+
+        }
+
+        @Override
+        public void preSnapshotCompletion() {
+
+        }
+
+        @Override
+        public void postSnapshotCompletion() {
+
+        }
+
+        @Override
+        public void event(DataCollectionId collectionId, Instant timestamp) {
+
+        }
+
+        @Override
+        public TransactionContext getTransactionContext() {
+            return null;
+        }
+    }
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/SchemaChanges.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/SchemaChanges.java
@@ -58,7 +58,7 @@ public class SchemaChanges<P extends Partition> implements SignalAction<P> {
         for (TableChanges.TableChange tableChange : serializer.deserialize(changes, useCatalogBeforeSchema)) {
             if (dispatcher.getHistorizedSchema() != null) {
                 LOGGER.info("Executing schema change for table '{}' requested by signal '{}'", tableChange.getId(), signalPayload.id);
-                dispatcher.dispatchSchemaChangeEvent(signalPayload.partition, tableChange.getId(), emitter -> {
+                dispatcher.dispatchSchemaChangeEvent(signalPayload.partition, signalPayload.offsetContext, tableChange.getId(), emitter -> {
                     emitter.schemaChangeEvent(SchemaChangeEvent.ofTableChange(
                             tableChange,
                             signalPayload.partition.getSourcePartition(),

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotContext.java
@@ -10,6 +10,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -250,6 +251,11 @@ public class AbstractIncrementalSnapshotContext<T> implements IncrementalSnapsho
     public boolean removeDataCollectionFromSnapshot(String dataCollectionId) {
         final T collectionId = (T) TableId.parse(dataCollectionId, useCatalogBeforeSchema);
         return dataCollectionsToSnapshot.removeAll(Arrays.asList(new DataCollection<T>(collectionId)));
+    }
+
+    @Override
+    public List<DataCollection<T>> getDataCollections() {
+        return new ArrayList<>(dataCollectionsToSnapshot);
     }
 
     protected static <U> IncrementalSnapshotContext<U> init(AbstractIncrementalSnapshotContext<U> context, Map<String, ?> offsets) {

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
@@ -50,6 +50,6 @@ public interface IncrementalSnapshotChangeEventSource<P extends Partition, T ext
     default void processTransactionCommittedEvent(P partition, OffsetContext offsetContext) throws InterruptedException {
     }
 
-    default void processSchemaChange(P partition, DataCollectionId dataCollectionId) throws InterruptedException {
+    default void processSchemaChange(P partition, OffsetContext offsetContext, DataCollectionId dataCollectionId) throws InterruptedException {
     }
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
@@ -66,4 +66,7 @@ public interface IncrementalSnapshotContext<T> {
     void stopSnapshot();
 
     boolean removeDataCollectionFromSnapshot(String dataCollectionId);
+
+    List<DataCollection<T>> getDataCollections();
+
 }

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeEventSourceFactory.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/spi/ChangeEventSourceFactory.java
@@ -7,6 +7,7 @@ package io.debezium.pipeline.source.spi;
 
 import java.util.Optional;
 
+import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
@@ -51,7 +52,8 @@ public interface ChangeEventSourceFactory<P extends Partition, O extends OffsetC
      */
     default Optional<IncrementalSnapshotChangeEventSource<P, ? extends DataCollectionId>> getIncrementalSnapshotChangeEventSource(O offsetContext,
                                                                                                                                   SnapshotProgressListener<P> snapshotProgressListener,
-                                                                                                                                  DataChangeEventListener<P> dataChangeEventListener) {
+                                                                                                                                  DataChangeEventListener<P> dataChangeEventListener,
+                                                                                                                                  NotificationService<P, O> notificationService) {
         return Optional.empty();
     }
 }

--- a/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/relational/RelationalSnapshotChangeEventSource.java
@@ -355,7 +355,7 @@ public abstract class RelationalSnapshotChangeEventSource<P extends Partition, O
                 continue;
             }
 
-            dispatcher.dispatchSchemaChangeEvent(snapshotContext.partition, tableId, (receiver) -> {
+            dispatcher.dispatchSchemaChangeEvent(snapshotContext.partition, snapshotContext.offset, tableId, (receiver) -> {
                 try {
                     receiver.schemaChangeEvent(event);
                 }

--- a/debezium-core/src/main/java/io/debezium/schema/SchemaFactory.java
+++ b/debezium-core/src/main/java/io/debezium/schema/SchemaFactory.java
@@ -22,6 +22,7 @@ import io.debezium.data.Uuid;
 import io.debezium.data.VariableScaleDecimal;
 import io.debezium.data.Xml;
 import io.debezium.heartbeat.HeartbeatImpl;
+import io.debezium.pipeline.notification.Notification;
 import io.debezium.pipeline.txmetadata.TransactionMonitor;
 import io.debezium.relational.history.ConnectTableChangeSerializer;
 import io.debezium.relational.history.HistoryRecord;
@@ -77,6 +78,10 @@ public class SchemaFactory {
 
     private static final String SCHEMA_HISTORY_CHANGE_SCHEMA_NAME = "io.debezium.connector.schema.Change";
     private static final int SCHEMA_HISTORY_CHANGE_SCHEMA_VERSION = 1;
+    private static final String NOTIFICATION_KEY_SCHEMA_NAME = "io.debezium.connector.common.NotificationKey";
+    private static final Integer NOTIFICATION_KEY_SCHEMA_VERSION = 1;
+    private static final String NOTIFICATION_VALUE_SCHEMA_NAME = "io.debezium.connector.common.Notification";
+    private static final Integer NOTIFICATION_VALUE_SCHEMA_VERSION = 1;
 
     private static final SchemaFactory schemaFactoryObject = new SchemaFactory();
 
@@ -206,6 +211,25 @@ public class SchemaFactory {
                 .field(HistoryRecord.Fields.SCHEMA_NAME, Schema.OPTIONAL_STRING_SCHEMA)
                 .field(HistoryRecord.Fields.DDL_STATEMENTS, Schema.OPTIONAL_STRING_SCHEMA)
                 .field(HistoryRecord.Fields.TABLE_CHANGES, SchemaBuilder.array(serializer.getChangeSchema()).build())
+                .build();
+    }
+
+    public Schema notificationKeySchema(SchemaNameAdjuster adjuster) {
+        return SchemaBuilder.struct()
+                .name(adjuster.adjust(NOTIFICATION_KEY_SCHEMA_NAME))
+                .version(NOTIFICATION_KEY_SCHEMA_VERSION)
+                .field(Notification.ID_KEY, Schema.STRING_SCHEMA)
+                .build();
+    }
+
+    public Schema notificationValueSchema(SchemaNameAdjuster adjuster) {
+        return SchemaBuilder.struct()
+                .name(adjuster.adjust(NOTIFICATION_VALUE_SCHEMA_NAME))
+                .version(NOTIFICATION_VALUE_SCHEMA_VERSION)
+                .field(Notification.ID_KEY, SchemaBuilder.STRING_SCHEMA)
+                .field(Notification.TYPE, Schema.STRING_SCHEMA)
+                .field(Notification.AGGREGATE_TYPE, Schema.STRING_SCHEMA)
+                .field(Notification.ADDITIONAL_DATA, SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).optional().build())
                 .build();
     }
 

--- a/debezium-core/src/main/resources/META-INF/services/io.debezium.pipeline.notification.channels.NotificationChannel
+++ b/debezium-core/src/main/resources/META-INF/services/io.debezium.pipeline.notification.channels.NotificationChannel
@@ -1,0 +1,2 @@
+io.debezium.pipeline.notification.channels.SinkNotificationChannel
+io.debezium.pipeline.notification.channels.LogNotificationChannel

--- a/debezium-core/src/test/java/io/debezium/pipeline/notification/NotificationServiceTest.java
+++ b/debezium-core/src/test/java/io/debezium/pipeline/notification/NotificationServiceTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.junit.logging.LogInterceptor;
+import io.debezium.pipeline.notification.channels.LogNotificationChannel;
+import io.debezium.pipeline.notification.channels.SinkNotificationChannel;
+import io.debezium.schema.SchemaFactory;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NotificationServiceTest {
+
+    public static final String NOTIFICATION_ID = UUID.fromString("a5dc3ab8-933d-4aae-a994-2e5f9d47acd2").toString();
+    private final SourceRecord expectedRecord = buildRecord();
+    private boolean isConsumerCalled = false;
+
+    @Mock
+    private CommonConnectorConfig connectorConfig;
+
+    private SourceRecord buildRecord() {
+
+        Schema keySchema = SchemaBuilder.struct()
+                .name("io.debezium.connector.common.NotificationKey")
+                .field("id", SchemaBuilder.STRING_SCHEMA)
+                .build();
+
+        Schema valueSchema = SchemaBuilder.struct()
+                .name("io.debezium.connector.common.Notification")
+                .field("id", SchemaBuilder.STRING_SCHEMA)
+                .field("type", SchemaBuilder.STRING_SCHEMA)
+                .field("aggregate_type", SchemaBuilder.STRING_SCHEMA)
+                .field("additional_data", SchemaBuilder.map(SchemaBuilder.STRING_SCHEMA, SchemaBuilder.STRING_SCHEMA))
+                .build();
+
+        Struct key = new Struct(keySchema).put("id", NOTIFICATION_ID);
+        Struct value = new Struct(valueSchema)
+                .put("id", NOTIFICATION_ID)
+                .put("type", "Test")
+                .put("aggregate_type", "Test")
+                .put("additional_data", Map.of("k1", "v1"));
+
+        return new SourceRecord(Map.of(), Map.of(), "notificationTopic", null, keySchema, key, valueSchema, value);
+    }
+
+    @Test
+    public void testNotificationWithLogNotificationChannel() {
+
+        when(connectorConfig.getEnabledNotificationChannels()).thenReturn(List.of("log"));
+
+        LogInterceptor logInterceptor = new LogInterceptor(LogNotificationChannel.class);
+
+        NotificationService<?, ?> notificationService = new NotificationService<>(List.of(new LogNotificationChannel()), connectorConfig,
+                new SchemaFactory(),
+                this::consume);
+
+        notificationService.notify(Notification.Builder.builder()
+                .withId(NOTIFICATION_ID)
+                .withType("Test")
+                .withAggregateType("Test")
+                .withAdditionalData(Map.of("Key1", "Value1"))
+                .build());
+
+        assertThat(logInterceptor.containsMessage("[Notification Service]  {aggregateType='Test', type='Test', additionalData={Key1=Value1}}")).isTrue();
+    }
+
+    @Test
+    public void notificationSentOnKafkaChannelWillBeCorrectlyProcessed() {
+
+        when(connectorConfig.getNotificationTopic()).thenReturn("io.debezium.notification");
+        when(connectorConfig.getEnabledNotificationChannels()).thenReturn(List.of("sink"));
+
+        NotificationService<?, ?> notificationService = new NotificationService<>(List.of(new SinkNotificationChannel()), connectorConfig,
+                new SchemaFactory(), this::consume);
+
+        notificationService.notify(Notification.Builder.builder()
+                .withId(NOTIFICATION_ID)
+                .withType("Test")
+                .withAggregateType("Test")
+                .withAdditionalData(Map.of("k1", "v1"))
+                .build());
+
+        assertThat(isConsumerCalled).isTrue();
+    }
+
+    private void consume(SourceRecord sourceRecord) {
+        Struct value = (Struct) sourceRecord.value();
+        Struct expectedValue = (Struct) expectedRecord.value();
+        assertThat(value.toString()).isEqualTo(expectedValue.toString());
+        Struct key = (Struct) sourceRecord.key();
+        Struct expectedKey = (Struct) expectedRecord.key();
+        assertThat(key.toString()).isEqualTo(expectedKey.toString());
+        assertThat(sourceRecord.topic()).isEqualTo("io.debezium.notification");
+        isConsumerCalled = true;
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedSnapshotChangeEventSourceTest.java
+++ b/debezium-core/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedSnapshotChangeEventSourceTest.java
@@ -11,11 +11,15 @@ import java.util.List;
 import java.util.Optional;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.SourceInfoStructMaker;
 import io.debezium.doc.FixFor;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.pipeline.notification.NotificationService;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.spi.Partition;
@@ -25,7 +29,11 @@ import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 
+@RunWith(MockitoJUnitRunner.class)
 public class SignalBasedSnapshotChangeEventSourceTest {
+
+    @Mock
+    private NotificationService notificationService;
 
     protected RelationalDatabaseConnectorConfig config() {
         return buildConfig(Configuration.create()
@@ -57,7 +65,7 @@ public class SignalBasedSnapshotChangeEventSourceTest {
     public void testBuildQueryOnePkColumn() {
         final SignalBasedIncrementalSnapshotChangeEventSource<? extends Partition, TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
                 config(), new JdbcConnection(config().getJdbcConfig(), config -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP(),
-                DataChangeEventListener.NO_OP());
+                DataChangeEventListener.NO_OP(), notificationService);
         final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
         source.setContext(context);
         final Column pk1 = Column.editor().name("pk1").create();
@@ -79,7 +87,7 @@ public class SignalBasedSnapshotChangeEventSourceTest {
     public void testBuildQueryOnePkColumnWithAdditionalCondition() {
         final SignalBasedIncrementalSnapshotChangeEventSource<? extends Partition, TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
                 config(), new JdbcConnection(config().getJdbcConfig(), config -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP(),
-                DataChangeEventListener.NO_OP());
+                DataChangeEventListener.NO_OP(), notificationService);
         final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
         source.setContext(context);
         final Column pk1 = Column.editor().name("pk1").create();
@@ -102,7 +110,7 @@ public class SignalBasedSnapshotChangeEventSourceTest {
     public void testBuildQueryTwoPkColumnsWithAdditionalConditionWithSurrogateKey() {
         final SignalBasedIncrementalSnapshotChangeEventSource<? extends Partition, TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
                 config(), new JdbcConnection(config().getJdbcConfig(), config -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP(),
-                DataChangeEventListener.NO_OP());
+                DataChangeEventListener.NO_OP(), notificationService);
         final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
         source.setContext(context);
         final Column pk1 = Column.editor().name("pk1").create();
@@ -128,7 +136,7 @@ public class SignalBasedSnapshotChangeEventSourceTest {
     public void testBuildQueryThreePkColumns() {
         final SignalBasedIncrementalSnapshotChangeEventSource<? extends Partition, TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
                 config(), new JdbcConnection(config().getJdbcConfig(), config -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP(),
-                DataChangeEventListener.NO_OP());
+                DataChangeEventListener.NO_OP(), notificationService);
         final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
         source.setContext(context);
         final Column pk1 = Column.editor().name("pk1").create();
@@ -154,7 +162,7 @@ public class SignalBasedSnapshotChangeEventSourceTest {
     public void testBuildQueryThreePkColumnsWithAdditionalCondition() {
         final SignalBasedIncrementalSnapshotChangeEventSource<? extends Partition, TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
                 config(), new JdbcConnection(config().getJdbcConfig(), config -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP(),
-                DataChangeEventListener.NO_OP());
+                DataChangeEventListener.NO_OP(), notificationService);
         final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
         source.setContext(context);
         final Column pk1 = Column.editor().name("pk1").create();
@@ -181,7 +189,7 @@ public class SignalBasedSnapshotChangeEventSourceTest {
     public void testBuildQueryTwoPkColumnsWithSurrogateKey() {
         final SignalBasedIncrementalSnapshotChangeEventSource<? extends Partition, TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
                 config(), new JdbcConnection(config().getJdbcConfig(), config -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP(),
-                DataChangeEventListener.NO_OP());
+                DataChangeEventListener.NO_OP(), notificationService);
         final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
         source.setContext(context);
         final Column pk1 = Column.editor().name("pk1").create();
@@ -203,7 +211,7 @@ public class SignalBasedSnapshotChangeEventSourceTest {
     public void testMaxQuery() {
         final SignalBasedIncrementalSnapshotChangeEventSource<? extends Partition, TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
                 config(), new JdbcConnection(config().getJdbcConfig(), config -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP(),
-                DataChangeEventListener.NO_OP());
+                DataChangeEventListener.NO_OP(), notificationService);
         final Column pk1 = Column.editor().name("pk1").create();
         final Column pk2 = Column.editor().name("pk2").create();
         final Column val1 = Column.editor().name("val1").create();
@@ -218,7 +226,7 @@ public class SignalBasedSnapshotChangeEventSourceTest {
     public void testMaxQueryWithAdditionalCondition() {
         final SignalBasedIncrementalSnapshotChangeEventSource<? extends Partition, TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
                 config(), new JdbcConnection(config().getJdbcConfig(), config -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP(),
-                DataChangeEventListener.NO_OP());
+                DataChangeEventListener.NO_OP(), notificationService);
         final Column pk1 = Column.editor().name("pk1").create();
         final Column pk2 = Column.editor().name("pk2").create();
         final Column val1 = Column.editor().name("val1").create();
@@ -233,7 +241,7 @@ public class SignalBasedSnapshotChangeEventSourceTest {
     public void testMaxQueryWithSurrogateKey() {
         final SignalBasedIncrementalSnapshotChangeEventSource<? extends Partition, TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
                 config(), new JdbcConnection(config().getJdbcConfig(), config -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP(),
-                DataChangeEventListener.NO_OP());
+                DataChangeEventListener.NO_OP(), notificationService);
         final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
         source.setContext(context);
         final Column pk1 = Column.editor().name("pk1").create();
@@ -254,7 +262,7 @@ public class SignalBasedSnapshotChangeEventSourceTest {
                 .with(RelationalDatabaseConnectorConfig.COLUMN_INCLUDE_LIST, ".*\\.(pk1|pk2|val1|val2)$").build());
         final SignalBasedIncrementalSnapshotChangeEventSource<? extends Partition, TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
                 config, new JdbcConnection(config.getJdbcConfig(), c -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP(),
-                DataChangeEventListener.NO_OP());
+                DataChangeEventListener.NO_OP(), notificationService);
         final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
         source.setContext(context);
         String actualProjection = source.buildChunkQuery(createTwoPrimaryKeysTable(), Optional.empty());
@@ -269,7 +277,7 @@ public class SignalBasedSnapshotChangeEventSourceTest {
                 .with(RelationalDatabaseConnectorConfig.COLUMN_EXCLUDE_LIST, ".*\\.(pk2|val3)$").build());
         final SignalBasedIncrementalSnapshotChangeEventSource<? extends Partition, TableId> source = new SignalBasedIncrementalSnapshotChangeEventSource<>(
                 config, new JdbcConnection(config.getJdbcConfig(), c -> null, "\"", "\""), null, null, null, SnapshotProgressListener.NO_OP(),
-                DataChangeEventListener.NO_OP());
+                DataChangeEventListener.NO_OP(), notificationService);
         final IncrementalSnapshotContext<TableId> context = new SignalBasedIncrementalSnapshotContext<>();
         source.setContext(context);
         String actualProjection = source.buildChunkQuery(createTwoPrimaryKeysTable(), Optional.empty());

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/notification/AbstractNotificationsIT.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/notification/AbstractNotificationsIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.embedded.AbstractConnectorTest;
+import io.debezium.junit.logging.LogInterceptor;
+import io.debezium.pipeline.notification.channels.SinkNotificationChannel;
+
+public abstract class AbstractNotificationsIT<T extends SourceConnector> extends AbstractConnectorTest {
+
+    protected abstract Class<T> connectorClass();
+
+    protected abstract Configuration.Builder config();
+
+    protected void startConnector(Function<Configuration.Builder, Configuration.Builder> custConfig) {
+
+        final Configuration config = custConfig.apply(config()).build();
+
+        start(connectorClass(), config);
+    }
+
+    protected abstract String snapshotStatusResult();
+
+    @Test
+    public void notificationCorrectlySentOnItsTopic() throws InterruptedException {
+        // Testing.Print.enable();
+
+        startConnector(config -> config
+                .with(SinkNotificationChannel.NOTIFICATION_TOPIC, "io.debezium.notification")
+                .with(CommonConnectorConfig.NOTIFICATION_ENABLED_CHANNELS, "sink"));
+
+        assertConnectorIsRunning();
+
+        waitForAvailableRecords(100, TimeUnit.MILLISECONDS);
+
+        final SourceRecords records = consumeRecordsByTopic(1);
+        assertThat(records.allRecordsInOrder()).hasSize(1);
+        SourceRecord sourceRecord = records.allRecordsInOrder().get(0);
+        Assertions.assertThat(sourceRecord.topic()).isEqualTo("io.debezium.notification");
+        Assertions.assertThat(((Struct) sourceRecord.value()).getString("aggregate_type")).isEqualTo("Initial Snapshot");
+        Assertions.assertThat(((Struct) sourceRecord.value()).getString("type")).isEqualTo("Status " + snapshotStatusResult());
+    }
+
+    @Test
+    public void notificationNotSentIfNoChannelIsConfigured() {
+        // Testing.Print.enable();
+
+        startConnector(config -> config.with(SinkNotificationChannel.NOTIFICATION_TOPIC, "io.debezium.notification"));
+        assertConnectorIsRunning();
+
+        waitForAvailableRecords(100, TimeUnit.MILLISECONDS);
+
+        // there shouldn't be any snapshot records
+        assertNoRecordsToConsume();
+    }
+
+    @Test
+    public void reportErrorWhenSinkChannelIsEnabledAndNoTopicConfigurationProvided() {
+        // Testing.Print.enable();
+
+        LogInterceptor logInterceptor = new LogInterceptor("io.debezium.connector");
+        startConnector(config -> config
+                .with(CommonConnectorConfig.NOTIFICATION_ENABLED_CHANNELS, "sink"));
+
+        Assertions.assertThat(logInterceptor.containsErrorMessage(
+                "Connector configuration is not valid. The 'notification.sink.topic.name' value is invalid: Notification topic name must be provided when kafka notification channel is enabled"))
+                .isTrue();
+    }
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1973

This is an example of the notification sent to Kafka topic

```json
{
  "schema": {
    "type": "struct",
    "fields": [
      {
        "type": "string",
        "optional": false,
        "field": "id"
      },
      {
        "type": "string",
        "optional": false,
        "field": "type"
      },
      {
        "type": "string",
        "optional": false,
        "field": "aggregate_type"
      },
      {
        "type": "map",
        "keys": {
          "type": "string",
          "optional": false
        },
        "values": {
          "type": "string",
          "optional": false
        },
        "optional": true,
        "field": "additional_data"
      }
    ],
    "optional": false,
    "name": "io.debezium.connector.common.Notification",
    "version": 1
  },
  "payload": {
    "id": "1a8a17d7-276f-4a16-9365-98178ec0e6e4",
    "type": "Status COMPLETED",
    "aggregate_type": "Initial Snapshot",
    "additional_data": {
      "name": "dbserver1"
    }
  }
}
```