### PR TITLE
[docs] resolve grammatical error with note

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -519,3 +519,4 @@ RJ Nowling
 ddsr-ops
 Ben White
 Miguel Angel Sotomayor
+Stephen Clarkson

--- a/documentation/modules/ROOT/pages/connectors/postgresql.adoc
+++ b/documentation/modules/ROOT/pages/connectors/postgresql.adoc
@@ -2862,7 +2862,7 @@ If you include this property in the configuration, do not set the `column.includ
 |`false`
 | Specifies whether to skip publishing messages when there is no change in included columns. This would essentially filter messages if there is no change in columns included as per `column.include.list` or `column.exclude.list` properties.
 
-Note: Only works when REPLICA IDENTITY of the table to is FULL
+Note: Only works when REPLICA IDENTITY of the table is set to FULL
 
 
 |[[postgresql-property-time-precision-mode]]<<postgresql-property-time-precision-mode, `+time.precision.mode+`>>

--- a/jenkins-jobs/scripts/config/Aliases.txt
+++ b/jenkins-jobs/scripts/config/Aliases.txt
@@ -207,3 +207,4 @@ subkanthi,Kanthi Subramanian
 benw-at-birdie,Ben White
 miguelbirdie,Miguel Angel Sotomayor
 umachi,Hidetomi Umaki
+sclarkson-zoomcare,Stephen Clarkson


### PR DESCRIPTION
Property `skip.messages.without.change` in Postgresql Connector documentation has a note with a grammatical error.