### PR TITLE
DBZ-6436 Improve Oracle LogMiner failure logging

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -584,12 +584,14 @@ public class LogMinerStreamingChangeEventSource implements StreamingChangeEventS
             return true;
         }
         catch (SQLException e) {
+            LogMinerDatabaseStateWriter.writeLogMinerStartParameters(connection);
             if (e.getErrorCode() == 1291 || e.getMessage().startsWith("ORA-01291")) {
                 if (attempts <= MINING_START_RETRIES) {
                     LOGGER.warn("Failed to start Oracle LogMiner session, retrying...");
                     return false;
                 }
                 LOGGER.error("Failed to start Oracle LogMiner after '{}' attempts.", MINING_START_RETRIES, e);
+                LogMinerDatabaseStateWriter.writeLogMinerLogFailures(connection);
             }
             LOGGER.error("Got exception when starting mining session.", e);
             // Capture the database state before throwing the exception up


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6436

This change explicitly captures the state of two critical tables when the connector fails to start a LogMiner session, namely V$LOGMNR_LOGS and V$LOGMNR_PARAMETERS. While these were previously captured by the LogMinerDatabaseStateWriter, the old code required DEBUG log level and that isn't always feasible, so this change will capture these in ERROR log level regardless moving forward.

@jpechane I'd prefer we backport this as far back as you're comfortable, preferably 2.1, as it shouldn't be an intrusive change.