### PR TITLE
DBZ-6438 Add config to reset mysql binlog offset

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorOffset.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorOffset.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mysql;
+
+import java.time.Instant;
+
+import io.debezium.document.Document;
+
+public class MySqlConnectorOffset {
+
+    private final Document doc;
+
+    public MySqlConnectorOffset(Document document) {
+        this.doc = document;
+    }
+
+    public MySqlConnectorOffset(String gtidSet, String binlogFilename, long binlogPosition, int serverId, long tsSec) {
+        this.doc = Document.create();
+        doc.setString(MySqlOffsetContext.GTID_SET_KEY, gtidSet);
+        doc.setString(SourceInfo.BINLOG_FILENAME_OFFSET_KEY, binlogFilename);
+        doc.setNumber(SourceInfo.BINLOG_POSITION_OFFSET_KEY, binlogPosition);
+        doc.setNumber(SourceInfo.SERVER_ID_KEY, serverId);
+        doc.setNumber(MySqlOffsetContext.TIMESTAMP_KEY, tsSec);
+    }
+
+    public Document document() {
+        return this.doc;
+    }
+
+    protected Instant timestamp() {
+        return Instant.ofEpochSecond(doc.getLong(MySqlOffsetContext.TIMESTAMP_KEY, 0));
+    }
+
+    protected String file() {
+        return doc.getString(SourceInfo.BINLOG_FILENAME_OFFSET_KEY);
+    }
+
+    protected Long position() {
+        return doc.getLong(SourceInfo.BINLOG_POSITION_OFFSET_KEY, 0);
+    }
+
+    protected String gtids() {
+        return doc.getString(MySqlOffsetContext.GTID_SET_KEY);
+    }
+
+    protected Integer row() {
+        return doc.getInteger(SourceInfo.BINLOG_ROW_IN_EVENT_OFFSET_KEY, 0);
+    }
+
+    protected Long serverId() {
+        return doc.getLong(SourceInfo.SERVER_ID_KEY, 0);
+    }
+
+    protected Long event() {
+        return doc.getLong(MySqlOffsetContext.EVENTS_TO_SKIP_OFFSET_KEY, 0);
+    }
+
+    @Override
+    public String toString() {
+        return doc.toString();
+    }
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlConnectorTask.java
@@ -105,7 +105,10 @@ public class MySqlConnectorTask extends BaseSourceTask<MySqlPartition, MySqlOffs
 
         MySqlPartition partition = previousOffsets.getTheOnlyPartition();
         MySqlOffsetContext previousOffset = previousOffsets.getTheOnlyOffset();
-
+        if (previousOffset != null && connectorConfig.getForceResetOffset() != null) {
+            MySqlConnectorOffset resetOffset = new MySqlConnectorOffset(connectorConfig.getForceResetOffset());
+            previousOffset.reset(resetOffset);
+        }
         validateAndLoadSchemaHistory(connectorConfig, partition, previousOffset, schema);
 
         LOGGER.info("Reconnecting after finishing schema recovery");

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlHistoryRecordComparator.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlHistoryRecordComparator.java
@@ -88,12 +88,12 @@ final class MySqlHistoryRecordComparator extends HistoryRecordComparator {
 
         // Both positions are missing GTIDs. Look at the servers ...
         int recordedServerId = recorded.getInteger(SourceInfo.SERVER_ID_KEY, 0);
-        int desiredServerId = recorded.getInteger(SourceInfo.SERVER_ID_KEY, 0);
+        int desiredServerId = desired.getInteger(SourceInfo.SERVER_ID_KEY, 0);
         if (recordedServerId != desiredServerId) {
             // These are from different servers, and their binlog coordinates are not related. So the only thing we can do
             // is compare timestamps, and we have to assume that the server timestamps can be compared ...
-            long recordedTimestamp = recorded.getLong(SourceInfo.TIMESTAMP_KEY, 0);
-            long desiredTimestamp = recorded.getLong(SourceInfo.TIMESTAMP_KEY, 0);
+            long recordedTimestamp = recorded.getLong(MySqlOffsetContext.TIMESTAMP_KEY, 0);
+            long desiredTimestamp = desired.getLong(MySqlOffsetContext.TIMESTAMP_KEY, 0);
             return recordedTimestamp <= desiredTimestamp;
         }
 
@@ -179,7 +179,7 @@ final class MySqlHistoryRecordComparator extends HistoryRecordComparator {
         @Override
         public int compareTo(BinlogFilename other) {
             if (!baseName.equals(other.baseName)) {
-                throw new IllegalArgumentException("Can't compare binlog filenames with different base names");
+                throw new IllegalArgumentException(String.format("Can't compare binlog filenames with different base names: %s != %s", baseName, other.baseName));
             }
             return Long.compare(extension, other.extension);
         }

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/StreamingSourceIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/StreamingSourceIT.java
@@ -582,9 +582,6 @@ public class StreamingSourceIT extends AbstractConnectorTest {
                 JdbcConnection connection = db.connect();
                 Connection jdbc = connection.connection();
                 Statement statement = jdbc.createStatement()) {
-            if (mode == null) {
-                waitForStreamingRunning("mysql", DATABASE.getServerName(), "streaming");
-            }
             statement.executeUpdate("INSERT INTO customers VALUES (default,'John','Lazy','john.lazy@acme.com')");
         }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6438

Allow reseting MySQL connector's offset

### Which use case/requirement will be addressed by the proposed feature?
Add a config to MySQL connector that allows overriding committed offset. Replaying binlog is useful in case of a data corruption incident or data loss incidents. For example an SMT could have an issue in filtering or transformation logic when events get lost or corrupted.

### Implementation
Add an optional config that takes an offset to force reset to. The format is the same as for committed offsets, so that the desired offset could be copied from the connector's offsets topic.
The previous offset gets overridden with the value from config if config is provided.
The schema history will be recovered up to the provided offset, because there could be schema changes between provided and the latest committed offset. 

