### PR TITLE
DBZ-6440 Init Kafka signal channel

### DIFF
--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -96,6 +96,7 @@ public class MySqlReadOnlyIncrementalSnapshotChangeEventSource<T extends DataCol
     public void init(MySqlPartition partition, OffsetContext offsetContext) {
         super.init(partition, offsetContext);
 
+        kafkaSignal.init(connectorConfig);
         Long signalOffset = getContext().getSignalOffset();
         if (signalOffset != null) {
             kafkaSignal.seek(signalOffset);


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-6440

Fixes 

`
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.kafka.clients.consumer.KafkaConsumer.seek(org.apache.kafka.common.TopicPartition, long)" because "this.signalsConsumer" is null
`