### PR TITLE
DBZ-6435 MySql in debezium-parser-ddl does not support table keyword parsing

### DIFF
--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -965,6 +965,11 @@ withStatement
   : WITH RECURSIVE? commonTableExpressions (',' commonTableExpressions)*
   ;
 
+tableStatement
+  :TABLE tableName orderByClause? limitClause?
+  ;
+  
+
 updateStatement
     : singleUpdateStatement | multipleUpdateStatement
     ;

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/dml_table.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/dml_table.sql
@@ -1,0 +1,15 @@
+###https://dev.mysql.com/doc/refman/8.0/en/table.html
+#begin
+TABLE t;
+#end
+
+#begin
+TABLE t LIMIT 3;
+#end
+
+#begin
+TABLE t ORDER BY b LIMIT 3;
+#end
+
+
+


### PR DESCRIPTION
Support table keyword parsing in mysql8.0：https://dev.mysql.com/doc/refman/8.0/en/table.html