### PR TITLE
DBZ-6459 [MariaDB] Add support for userstat plugin keywords

### DIFF
--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlLexer.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlLexer.g4
@@ -763,6 +763,14 @@ SECOND:                              'SECOND';
 MICROSECOND:                         'MICROSECOND';
 
 
+// MariaDB: userstat plugin Keywords
+
+USER_STATISTICS:                     'USER_STATISTICS';
+CLIENT_STATISTICS:                   'CLIENT_STATISTICS';
+INDEX_STATISTICS:                    'INDEX_STATISTICS';
+TABLE_STATISTICS:                    'TABLE_STATISTICS';
+
+
 // PRIVILEGES
 
 ADMIN:                               'ADMIN';

--- a/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
+++ b/debezium-ddl-parser/src/main/antlr4/io/debezium/ddl/parser/mysql/generated/MySqlParser.g4
@@ -1935,6 +1935,8 @@ showStatement
           rowCount=decimalLiteral
         )                                                           #showProfile
     | SHOW SLAVE STATUS (FOR CHANNEL STRING_LITERAL)?               #showSlaveStatus
+    // MariaDB userstat plugin
+    | SHOW (USER_STATISTICS | CLIENT_STATISTICS | INDEX_STATISTICS | TABLE_STATISTICS) # showUserstatPlugin
     ;
 
 // details
@@ -1985,6 +1987,8 @@ cacheIndexStatement
 flushStatement
     : FLUSH flushFormat=(NO_WRITE_TO_BINLOG | LOCAL)?
       flushOption (',' flushOption)*
+    // MariaDB userstat plugin
+    | FLUSH (USER_STATISTICS | CLIENT_STATISTICS | INDEX_STATISTICS | TABLE_STATISTICS)
     ;
 
 killStatement
@@ -2809,7 +2813,7 @@ keywordsCanBeId
     | BINLOG_MONITOR | BINLOG_REPLAY | CURRENT_ROLE | CYCLE | ENCRYPTED | ENCRYPTION_KEY_ID | FEDERATED_ADMIN
     | INCREMENT | LASTVAL | LOCKED | MAXVALUE | MINVALUE | NEXTVAL | NOCACHE | NOCYCLE | NOMAXVALUE | NOMINVALUE
     | PERSISTENT | PREVIOUS | READ_ONLY_ADMIN | REPLICA | REPLICATION_MASTER_ADMIN | RESTART | SEQUENCE | SETVAL
-    | SKIP_ | STATEMENT | UUID | VIA | MONITOR | READ_ONLY| REPLAY
+    | SKIP_ | STATEMENT | UUID | VIA | MONITOR | READ_ONLY| REPLAY | USER_STATISTICS | CLIENT_STATISTICS | INDEX_STATISTICS | TABLE_STATISTICS
     ;
 
 functionNameBase

--- a/debezium-ddl-parser/src/test/resources/mysql/examples/userstat.sql
+++ b/debezium-ddl-parser/src/test/resources/mysql/examples/userstat.sql
@@ -1,0 +1,13 @@
+-- Special statements from the MariaDB userstat plugin: https://mariadb.com/kb/en/user-statistics/
+
+-- SHOW statements: https://mariadb.com/kb/en/user-statistics/#using-the-show-statements
+SHOW USER_STATISTICS;
+SHOW CLIENT_STATISTICS;
+SHOW INDEX_STATISTICS;
+SHOW TABLE_STATISTICS;
+
+-- FLUSH statements: https://mariadb.com/kb/en/user-statistics/#flushing-plugin-data
+FLUSH USER_STATISTICS;
+FLUSH CLIENT_STATISTICS;
+FLUSH INDEX_STATISTICS;
+FLUSH TABLE_STATISTICS;


### PR DESCRIPTION
The MariaDB User Statistics (userstat) plugin adds 4 new keywords:

`USER_STATISTICS`, `CLIENT_STATISTICS`, `INDEX_STATISTICS`, and `TABLE_STATISTICS`

Additionally, it adds unusual variants of the `SHOW` and `FLUSH` statements which aren't covered by the MariaDB SQL grammar yet, for example

```
SHOW TABLE_STATISTICS;
FLUSH USER_STATISTICS;
```

See also:

- https://mariadb.com/kb/en/user-statistics/
- https://mariadb.com/kb/en/show-client-statistics/
- https://mariadb.com/kb/en/show-index-statistics/
- https://mariadb.com/kb/en/show-table-statistics/
- https://mariadb.com/kb/en/show-user-statistics/

Refs https://github.com/antlr/grammars-v4/pull/3400