### PR TITLE
DBZ-6439 Don't scan all the tables when loading schema

### DIFF
--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -177,7 +177,7 @@ public class OracleSnapshotChangeEventSource extends RelationalSnapshotChangeEve
                     snapshotContext.tables,
                     null,
                     schema,
-                    null,
+                    connectorConfig.getTableFilters().dataCollectionFilter(),
                     null,
                     false);
         }

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -1175,6 +1175,7 @@ public class JdbcConnection implements AutoCloseable {
                 }
             }
         }
+        LOGGER.debug("{} table(s) will be scanned", tableIds.size());
 
         Map<TableId, List<Column>> columnsByTable = new HashMap<>();
 

--- a/debezium-core/src/test/java/io/debezium/junit/logging/LogInterceptor.java
+++ b/debezium-core/src/test/java/io/debezium/junit/logging/LogInterceptor.java
@@ -69,8 +69,9 @@ public class LogInterceptor extends AppenderBase<ILoggingEvent> {
         this.events.add(loggingEvent);
     }
 
-    public void setLoggerLevel(Class<?> loggerClass, String level) {
-        // TODO LogManager.getLogger(loggerClass).setLevel(Level.toLevel(level));
+    public void setLoggerLevel(Class<?> loggerClass, Level level) {
+        Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(loggerClass.getName());
+        logger.setLevel(level);
     }
 
     public long countOccurrences(String text) {


### PR DESCRIPTION
* Enable set log level in tests (https://issues.redhat.com/browse/DBZ-6460)
* Don't scan all the tables when loading schema (https://issues.redhat.com/browse/DBZ-6439)