### PR TITLE
DBZ-6462 Schedule SignalProcessor task with a more relaxed scheduling

### DIFF
--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/SignalProcessor.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/SignalProcessor.java
@@ -92,7 +92,7 @@ public class SignalProcessor<P extends Partition, O extends OffsetContext> {
     public void start() {
 
         LOGGER.info("SignalProcessor started. Scheduling it every {}ms", connectorConfig.getSignalPollInterval().toMillis());
-        signalProcessorExecutor.scheduleAtFixedRate(this::process, 0, 1, TimeUnit.NANOSECONDS);
+        signalProcessorExecutor.scheduleAtFixedRate(this::process, 0, connectorConfig.getSignalPollInterval().toMillis(), TimeUnit.MILLISECONDS);
     }
 
     public void stop() throws InterruptedException {
@@ -127,7 +127,7 @@ public class SignalProcessor<P extends Partition, O extends OffsetContext> {
 
         executeWithSemaphore(() -> {
             LOGGER.trace("SignalProcessor processing");
-            signalChannelReaders.parallelStream()
+            signalChannelReaders.stream()
                     .filter(isEnabled())
                     .map(SignalChannelReader::read)
                     .flatMap(Collection::stream)

--- a/debezium-core/src/test/java/io/debezium/pipeline/signal/SignalProcessorTest.java
+++ b/debezium-core/src/test/java/io/debezium/pipeline/signal/SignalProcessorTest.java
@@ -147,7 +147,7 @@ public class SignalProcessorTest {
     }
 
     @Test
-    public void shouldIgnoreUnparseableData() {
+    public void shouldIgnoreUnparseableData() throws InterruptedException {
 
         final SignalChannelReader genericChannel = mock(SignalChannelReader.class);
 
@@ -166,10 +166,12 @@ public class SignalProcessorTest {
                 .atMost(40, TimeUnit.SECONDS)
                 .untilAsserted(
                         () -> assertThat(log.containsMessage("Signal 'log1' has been received but the data '{\"message: \"signallog\"}' cannot be parsed")).isTrue());
+
+        signalProcess.stop();
     }
 
     @Test
-    public void shouldRegisterAdditionalAction() {
+    public void shouldRegisterAdditionalAction() throws InterruptedException {
 
         final SignalChannelReader genericChannel = mock(SignalChannelReader.class);
 
@@ -193,6 +195,8 @@ public class SignalProcessorTest {
         Awaitility.await()
                 .atMost(40, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertThat(called.intValue()).isEqualTo(5));
+
+        signalProcess.stop();
     }
 
     protected CommonConnectorConfig baseConfig() {


### PR DESCRIPTION
Removes parallelStreams while processing signalChannelReaders