### PR TITLE
DBZ-6470 Signaling data collection document update

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -516,3 +516,4 @@ Moustapha Mahfoud
 RJ Nowling
 蔡灿材
 ddsr-ops
+Angshuman Dey

--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -120,7 +120,7 @@ You create a signaling table by submitting a standard SQL DDL query to the sourc
 
 .Prerequisites
 
-* You have sufficient access privileges to create a table on the target database.
+* You have sufficient access privileges to create a table on the source database.
 
 .Procedure
 


### PR DESCRIPTION
 DBZ-6470 While creating signaling table we need to have privileges to create table in source database not target