### PR TITLE
DBZ-6470 Refer correctly to the source database

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -36,6 +36,7 @@ Andrey Pustovetov
 Andrey Savchuk
 Andrey Yegorov
 Andy Teijelo
+Angshuman Dey
 Anil Dasari
 Animesh Kumar
 Anisha Mohanty

--- a/documentation/modules/ROOT/pages/configuration/signalling.adoc
+++ b/documentation/modules/ROOT/pages/configuration/signalling.adoc
@@ -120,7 +120,7 @@ You create a signaling table by submitting a standard SQL DDL query to the sourc
 
 .Prerequisites
 
-* You have sufficient access privileges to create a table on the target database.
+* You have sufficient access privileges to create a table on the source database.
 
 .Procedure
 


### PR DESCRIPTION
While creating signaling table we need to have privileges to create table in source database not target
