### PR TITLE
DBZ-6447 Correlate incremental snapshot notifications ids with execute signal

### DIFF
--- a/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSetNotifier.java
+++ b/debezium-connector-mongodb/src/main/java/io/debezium/connector/mongodb/ReplicaSetNotifier.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.mongodb;
+
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
+import io.debezium.pipeline.spi.OffsetContext;
+
+@FunctionalInterface
+interface ReplicaSetNotifier<T> {
+
+    void apply(IncrementalSnapshotContext<T> a, MongoDbPartition b, OffsetContext c);
+
+}

--- a/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
+++ b/debezium-connector-mysql/src/main/java/io/debezium/connector/mysql/MySqlReadOnlyIncrementalSnapshotChangeEventSource.java
@@ -18,6 +18,7 @@ import io.debezium.DebeziumException;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.notification.NotificationService;
+import io.debezium.pipeline.signal.SignalPayload;
 import io.debezium.pipeline.signal.channels.KafkaSignalChannel;
 import io.debezium.pipeline.source.snapshot.incremental.AbstractIncrementalSnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
@@ -232,11 +233,14 @@ public class MySqlReadOnlyIncrementalSnapshotChangeEventSource<T extends DataCol
     }
 
     @Override
-    public void addDataCollectionNamesToSnapshot(MySqlPartition partition, OffsetContext offsetContext, Map<String, Object> additionalData,
+    public void addDataCollectionNamesToSnapshot(SignalPayload<MySqlPartition> signalPayload,
                                                  List<String> dataCollectionIds,
                                                  Optional<String> additionalCondition, Optional<String> surrogateKey)
             throws InterruptedException {
-        super.addDataCollectionNamesToSnapshot(partition, offsetContext, additionalData, dataCollectionIds, additionalCondition, surrogateKey);
+
+        final Map<String, Object> additionalData = signalPayload.additionalData;
+
+        super.addDataCollectionNamesToSnapshot(signalPayload, dataCollectionIds, additionalCondition, surrogateKey);
 
         getContext().setSignalOffset((Long) additionalData.get(KafkaSignalChannel.CHANNEL_OFFSET));
     }

--- a/debezium-core/src/main/java/io/debezium/pipeline/notification/IncrementalSnapshotNotificationService.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/notification/IncrementalSnapshotNotificationService.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.notification;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.connect.errors.DataException;
+
+import io.debezium.connector.common.BaseSourceInfo;
+import io.debezium.pipeline.source.snapshot.incremental.DataCollection;
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.spi.schema.DataCollectionId;
+
+public class IncrementalSnapshotNotificationService<P extends Partition, O extends OffsetContext> {
+
+    public static final String INCREMENTAL_SNAPSHOT = "Incremental Snapshot";
+    public static final String DATA_COLLECTIONS = "data_collections";
+    public static final String CURRENT_COLLECTION_IN_PROGRESS = "current_collection_in_progress";
+    public static final String MAXIMUM_KEY = "maximum_key";
+    public static final String LAST_PROCESSED_KEY = "last_processed_key";
+    public static final String NONE = "<none>";
+    public static final String CONNECTOR_NAME = "connector_name";
+    public static final String TOTAL_ROWS_SCANNED = "total_rows_scanned";
+    public static final String LIST_DELIMITER = ",";
+
+    private final NotificationService<P, O> notificationService;
+
+    public enum SnapshotStatus {
+        STARTED,
+        PAUSED,
+        RESUMED,
+        ABORTED,
+        IN_PROGRESS,
+        TABLE_SCAN_COMPLETED,
+        COMPLETED
+    }
+
+    public IncrementalSnapshotNotificationService(NotificationService<P, O> notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    public <T extends DataCollectionId> void notifyStarted(IncrementalSnapshotContext<T> incrementalSnapshotContext, P partition, OffsetContext offsetContext) {
+
+        String dataCollections = incrementalSnapshotContext.getDataCollections().stream().map(DataCollection::getId)
+                .map(DataCollectionId::identifier)
+                .collect(Collectors.joining(LIST_DELIMITER));
+
+        notificationService.notify(buildNotificationWith(incrementalSnapshotContext, SnapshotStatus.STARTED,
+                Map.of(DATA_COLLECTIONS, dataCollections), offsetContext), Offsets.of(partition, offsetContext));
+    }
+
+    public <T extends DataCollectionId> void notifyPaused(IncrementalSnapshotContext<T> incrementalSnapshotContext, P partition, OffsetContext offsetContext) {
+
+        String dataCollections = incrementalSnapshotContext.getDataCollections().stream().map(DataCollection::getId)
+                .map(DataCollectionId::identifier)
+                .collect(Collectors.joining(LIST_DELIMITER));
+
+        notificationService.notify(buildNotificationWith(incrementalSnapshotContext, SnapshotStatus.PAUSED,
+                Map.of(DATA_COLLECTIONS, dataCollections), offsetContext),
+                Offsets.of(partition, offsetContext));
+    }
+
+    public <T extends DataCollectionId> void notifyResumed(IncrementalSnapshotContext<T> incrementalSnapshotContext, P partition, OffsetContext offsetContext) {
+
+        String dataCollections = incrementalSnapshotContext.getDataCollections().stream().map(DataCollection::getId)
+                .map(DataCollectionId::identifier)
+                .collect(Collectors.joining(LIST_DELIMITER));
+
+        notificationService.notify(buildNotificationWith(incrementalSnapshotContext, SnapshotStatus.RESUMED,
+                Map.of(DATA_COLLECTIONS, dataCollections), offsetContext),
+                Offsets.of(partition, offsetContext));
+    }
+
+    public <T extends DataCollectionId> void notifyAborted(IncrementalSnapshotContext<T> incrementalSnapshotContext, P partition, OffsetContext offsetContext) {
+
+        notificationService.notify(buildNotificationWith(incrementalSnapshotContext, SnapshotStatus.ABORTED,
+                Map.of(), offsetContext), Offsets.of(partition, offsetContext));
+    }
+
+    public <T extends DataCollectionId> void notifyAborted(IncrementalSnapshotContext<T> incrementalSnapshotContext, P partition, OffsetContext offsetContext,
+                                                           List<String> dataCollectionIds) {
+
+        notificationService.notify(buildNotificationWith(incrementalSnapshotContext, SnapshotStatus.ABORTED,
+                Map.of(DATA_COLLECTIONS, String.join(LIST_DELIMITER, dataCollectionIds)), offsetContext),
+                Offsets.of(partition, offsetContext));
+    }
+
+    public <T extends DataCollectionId> void notifyTableScanCompleted(IncrementalSnapshotContext<T> incrementalSnapshotContext, P partition, OffsetContext offsetContext,
+                                                                      long totalRowsScanned) {
+
+        String dataCollections = incrementalSnapshotContext.getDataCollections().stream().map(DataCollection::getId)
+                .map(DataCollectionId::identifier)
+                .collect(Collectors.joining(LIST_DELIMITER));
+
+        notificationService.notify(buildNotificationWith(incrementalSnapshotContext, SnapshotStatus.TABLE_SCAN_COMPLETED,
+                Map.of(
+                        DATA_COLLECTIONS, dataCollections,
+                        TOTAL_ROWS_SCANNED, String.valueOf(totalRowsScanned)),
+                offsetContext),
+                Offsets.of(partition, offsetContext));
+    }
+
+    public <T extends DataCollectionId> void notifyInProgress(IncrementalSnapshotContext<T> incrementalSnapshotContext, P partition, OffsetContext offsetContext) {
+
+        String dataCollections = incrementalSnapshotContext.getDataCollections().stream().map(DataCollection::getId)
+                .map(DataCollectionId::identifier)
+                .collect(Collectors.joining(LIST_DELIMITER));
+
+        notificationService.notify(buildNotificationWith(incrementalSnapshotContext, SnapshotStatus.IN_PROGRESS,
+                Map.of(
+                        DATA_COLLECTIONS, dataCollections,
+                        CURRENT_COLLECTION_IN_PROGRESS, incrementalSnapshotContext.currentDataCollectionId().getId().identifier(),
+                        MAXIMUM_KEY, incrementalSnapshotContext.maximumKey().orElse(new Object[0])[0].toString(),
+                        LAST_PROCESSED_KEY, incrementalSnapshotContext.chunkEndPosititon()[0].toString()),
+                offsetContext),
+                Offsets.of(partition, offsetContext));
+    }
+
+    public <T extends DataCollectionId> void notifyCompleted(IncrementalSnapshotContext<T> incrementalSnapshotContext, P partition, OffsetContext offsetContext) {
+
+        notificationService.notify(buildNotificationWith(incrementalSnapshotContext, SnapshotStatus.COMPLETED,
+                Map.of(), offsetContext),
+                Offsets.of(partition, offsetContext));
+    }
+
+    private <T extends DataCollectionId> Notification buildNotificationWith(IncrementalSnapshotContext<T> incrementalSnapshotContext, SnapshotStatus type,
+                                                                            Map<String, String> additionalData, OffsetContext offsetContext) {
+
+        Map<String, String> fullMap = new HashMap<>(additionalData);
+
+        String connectorName;
+        try {
+            connectorName = offsetContext.getSourceInfo().getString(BaseSourceInfo.SERVER_NAME_KEY);
+        }
+        catch (DataException e) {
+            connectorName = NONE;
+        }
+        fullMap.put(CONNECTOR_NAME, connectorName);
+
+        String id = incrementalSnapshotContext.getCorrelationId() != null ? incrementalSnapshotContext.getCorrelationId() : UUID.randomUUID().toString();
+        return Notification.Builder.builder()
+                .withId(id)
+                .withAggregateType(INCREMENTAL_SNAPSHOT)
+                .withType(type.name())
+                .withAdditionalData(fullMap)
+                .build();
+    }
+
+}

--- a/debezium-core/src/main/java/io/debezium/pipeline/notification/Notification.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/notification/Notification.java
@@ -6,6 +6,7 @@
 package io.debezium.pipeline.notification;
 
 import java.util.Map;
+import java.util.Objects;
 
 public class Notification {
 
@@ -49,6 +50,25 @@ public class Notification {
                 ", type='" + type + '\'' +
                 ", additionalData=" + additionalData +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Notification that = (Notification) o;
+        return Objects.equals(id, that.id) && Objects.equals(aggregateType, that.aggregateType) && Objects.equals(type,
+                that.type) && Objects.equals(additionalData, that.additionalData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, aggregateType, type, additionalData);
     }
 
     public static final class Builder {

--- a/debezium-core/src/main/java/io/debezium/pipeline/notification/NotificationService.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/notification/NotificationService.java
@@ -27,6 +27,8 @@ public class NotificationService<P extends Partition, O extends OffsetContext> {
     private final List<NotificationChannel> notificationChannels;
     private final List<String> enabledChannels;
 
+    private final IncrementalSnapshotNotificationService<P, O> incrementalSnapshotNotificationService;
+
     public NotificationService(List<NotificationChannel> notificationChannels,
                                CommonConnectorConfig config,
                                SchemaFactory schemaFactory, BlockingConsumer<SourceRecord> consumer) {
@@ -42,6 +44,8 @@ public class NotificationService<P extends Partition, O extends OffsetContext> {
         this.notificationChannels.stream()
                 .filter(isConnectChannel())
                 .forEach(channel -> ((ConnectChannel) channel).initConnectChannel(schemaFactory, consumer));
+
+        incrementalSnapshotNotificationService = new IncrementalSnapshotNotificationService<>(this);
     }
 
     /**
@@ -68,6 +72,10 @@ public class NotificationService<P extends Partition, O extends OffsetContext> {
                 .filter(isEnabled())
                 .filter(isConnectChannel())
                 .forEach(channel -> ((ConnectChannel) channel).send(notification, offsets));
+    }
+
+    public IncrementalSnapshotNotificationService<P, O> incrementalSnapshotNotificationService() {
+        return incrementalSnapshotNotificationService;
     }
 
     private Predicate<? super NotificationChannel> isEnabled() {

--- a/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/ExecuteSnapshot.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/signal/actions/snapshotting/ExecuteSnapshot.java
@@ -55,7 +55,7 @@ public class ExecuteSnapshot<P extends Partition> extends AbstractSnapshotSignal
         switch (type) {
             case INCREMENTAL:
                 dispatcher.getIncrementalSnapshotChangeEventSource().addDataCollectionNamesToSnapshot(
-                        signalPayload.partition, signalPayload.offsetContext, signalPayload.additionalData, dataCollections, additionalCondition, surrogateKey);
+                        signalPayload, dataCollections, additionalCondition, surrogateKey);
                 break;
         }
         return true;

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotChangeEventSource.java
@@ -11,36 +11,31 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
-import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.errors.DataException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.DebeziumException;
 import io.debezium.annotation.NotThreadSafe;
-import io.debezium.connector.common.BaseSourceInfo;
 import io.debezium.data.ValueWrapper;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.pipeline.EventDispatcher;
-import io.debezium.pipeline.notification.Notification;
 import io.debezium.pipeline.notification.NotificationService;
+import io.debezium.pipeline.signal.SignalPayload;
 import io.debezium.pipeline.source.spi.DataChangeEventListener;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.spi.ChangeRecordEmitter;
 import io.debezium.pipeline.spi.OffsetContext;
-import io.debezium.pipeline.spi.Offsets;
 import io.debezium.pipeline.spi.Partition;
 import io.debezium.relational.Column;
 import io.debezium.relational.Key.KeyMapper;
@@ -68,17 +63,6 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         implements IncrementalSnapshotChangeEventSource<P, T> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractIncrementalSnapshotChangeEventSource.class);
-    public static final String INCREMENTAL_SNAPSHOT = "Incremental Snapshot";
-
-    public enum SnapshotStatus {
-        STARTED,
-        PAUSED,
-        RESUMED,
-        ABORTED,
-        IN_PROGRESS,
-        TABLE_SCAN_COMPLETED,
-        COMPLETED
-    }
 
     protected final RelationalDatabaseConnectorConfig connectorConfig;
     private final Clock clock;
@@ -133,9 +117,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         if (context.snapshotRunning() && !context.isSnapshotPaused()) {
             context.pauseSnapshot();
             progressListener.snapshotPaused(partition);
-            String dataCollections = context.getDataCollections().stream().map(DataCollection::getId).map(DataCollectionId::identifier).collect(Collectors.joining(","));
-            notificationService.notify(buildNotificationWith(SnapshotStatus.PAUSED, Map.of("data_collections", dataCollections), offsetContext),
-                    Offsets.of(partition, offsetContext));
+            notificationService.incrementalSnapshotNotificationService().notifyPaused(context, partition, offsetContext);
         }
     }
 
@@ -145,9 +127,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         if (context.snapshotRunning() && context.isSnapshotPaused()) {
             context.resumeSnapshot();
             progressListener.snapshotResumed(partition);
-            String dataCollections = context.getDataCollections().stream().map(DataCollection::getId).map(DataCollectionId::identifier).collect(Collectors.joining(","));
-            notificationService.notify(buildNotificationWith(SnapshotStatus.RESUMED, Map.of("data_collections", dataCollections), offsetContext),
-                    Offsets.of(partition, offsetContext));
+            notificationService.incrementalSnapshotNotificationService().notifyResumed(context, partition, offsetContext);
             readChunk(partition, offsetContext);
         }
     }
@@ -393,35 +373,18 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
                 }
                 if (createDataEventsForTable(partition)) {
 
-                    String dataCollections = context.getDataCollections().stream()
-                            .map(DataCollection::getId)
-                            .map(DataCollectionId::identifier).collect(
-                                    Collectors.joining(","));
-
                     if (window.isEmpty()) {
                         LOGGER.info("No data returned by the query, incremental snapshotting of table '{}' finished",
                                 currentTableId);
 
-                        notificationService.notify(buildNotificationWith(SnapshotStatus.TABLE_SCAN_COMPLETED,
-                                Map.of(
-                                        "data_collections", dataCollections,
-                                        "total_rows_scanned", String.valueOf(totalRowsScanned)),
-                                offsetContext),
-                                Offsets.of(partition, offsetContext));
+                        notificationService.incrementalSnapshotNotificationService().notifyTableScanCompleted(context, partition, offsetContext, totalRowsScanned);
 
                         tableScanCompleted(partition);
                         nextDataCollection(partition, offsetContext);
                     }
                     else {
 
-                        notificationService.notify(buildNotificationWith(SnapshotStatus.IN_PROGRESS,
-                                Map.of(
-                                        "data_collections", dataCollections,
-                                        "current_collection_in_progress", context.currentDataCollectionId().getId().identifier(),
-                                        "maximum_key", context.maximumKey().orElse(new Object[0])[0].toString(),
-                                        "last_processed_key", context.chunkEndPosititon()[0].toString()),
-                                offsetContext),
-                                Offsets.of(partition, offsetContext));
+                        notificationService.incrementalSnapshotNotificationService().notifyInProgress(context, partition, offsetContext);
                         break;
                     }
                 }
@@ -507,17 +470,21 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
         context.nextDataCollection();
         if (!context.snapshotRunning()) {
             progressListener.snapshotCompleted(partition);
-            notificationService.notify(buildNotificationWith(SnapshotStatus.COMPLETED,
-                    Map.of(), offsetContext),
-                    Offsets.of(partition, offsetContext));
+            notificationService.incrementalSnapshotNotificationService().notifyCompleted(context, partition, offsetContext);
+            context.unsetCorrelationId();
         }
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public void addDataCollectionNamesToSnapshot(P partition, OffsetContext offsetContext, Map<String, Object> additionalData, List<String> dataCollectionIds,
+    public void addDataCollectionNamesToSnapshot(SignalPayload<P> signalPayload, List<String> dataCollectionIds,
                                                  Optional<String> additionalCondition, Optional<String> surrogateKey)
             throws InterruptedException {
+
+        final OffsetContext offsetContext = signalPayload.offsetContext;
+        final P partition = signalPayload.partition;
+        final String correlationId = signalPayload.id;
+
         context = (IncrementalSnapshotContext<T>) offsetContext.getIncrementalSnapshotContext();
         boolean shouldReadChunk = !context.snapshotRunning();
 
@@ -526,14 +493,15 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
             LOGGER.info("Data-collections to snapshot have been expanded from {} to {}", dataCollectionIds, expandedDataCollectionIds);
         }
 
-        final List<DataCollection<T>> newDataCollectionIds = context.addDataCollectionNamesToSnapshot(expandedDataCollectionIds, additionalCondition, surrogateKey);
+        final List<DataCollection<T>> newDataCollectionIds = context.addDataCollectionNamesToSnapshot(correlationId, expandedDataCollectionIds, additionalCondition,
+                surrogateKey);
         if (shouldReadChunk) {
+
             List<T> monitoredDataCollections = newDataCollectionIds.stream()
                     .map(DataCollection::getId).collect(Collectors.toList());
             progressListener.snapshotStarted(partition);
 
-            notificationService.notify(buildNotificationWith(SnapshotStatus.STARTED, Map.of("data_collections", monitoredDataCollections.stream()
-                    .map(DataCollectionId::identifier).collect(Collectors.joining(","))), offsetContext), Offsets.of(partition, offsetContext));
+            notificationService.incrementalSnapshotNotificationService().notifyStarted(context, partition, offsetContext);
 
             progressListener.monitoredDataCollectionsDetermined(partition, monitoredDataCollections);
             readChunk(partition, offsetContext);
@@ -559,7 +527,7 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
 
                     progressListener.snapshotAborted(partition);
 
-                    notificationService.notify(buildNotificationWith(SnapshotStatus.ABORTED, Map.of(), offsetContext), Offsets.of(partition, offsetContext));
+                    notificationService.incrementalSnapshotNotificationService().notifyAborted(context, partition, offsetContext);
                 }
                 catch (InterruptedException e) {
                     LOGGER.warn("Failed to stop snapshot successfully.", e);
@@ -601,35 +569,12 @@ public abstract class AbstractIncrementalSnapshotChangeEventSource<P extends Par
                     }
                 }
 
-                notificationService.notify(buildNotificationWith(SnapshotStatus.ABORTED,
-                        Map.of("data_collections", String.join(",", expandedDataCollectionIds)), offsetContext),
-                        Offsets.of(partition, offsetContext));
+                notificationService.incrementalSnapshotNotificationService().notifyAborted(context, partition, offsetContext, expandedDataCollectionIds);
             }
         }
         else {
             LOGGER.warn("No active incremental snapshot, stop ignored");
         }
-    }
-
-    private static Notification buildNotificationWith(SnapshotStatus type, Map<String, String> additionalData, OffsetContext offsetContext) {
-
-        Map<String, String> fullMap = new HashMap<>(additionalData);
-
-        String connectorName;
-        try {
-            connectorName = offsetContext.getSourceInfo().getString(BaseSourceInfo.SERVER_NAME_KEY);
-        }
-        catch (DataException e) {
-            connectorName = "<none>";
-        }
-        fullMap.put("connector_name", connectorName);
-
-        return Notification.Builder.builder()
-                .withId(UUID.randomUUID().toString())
-                .withAggregateType(INCREMENTAL_SNAPSHOT)
-                .withType(type.name())
-                .withAdditionalData(fullMap)
-                .build();
     }
 
     protected void addKeyColumnsToCondition(Table table, StringBuilder sql, String predicate) {

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotChangeEventSource.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import io.debezium.pipeline.signal.SignalPayload;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
 import io.debezium.spi.schema.DataCollectionId;
@@ -32,7 +33,7 @@ public interface IncrementalSnapshotChangeEventSource<P extends Partition, T ext
 
     void init(P partition, OffsetContext offsetContext);
 
-    void addDataCollectionNamesToSnapshot(P partition, OffsetContext offsetContext, Map<String, Object> additionalData, List<String> dataCollectionIds,
+    void addDataCollectionNamesToSnapshot(SignalPayload<P> signalPayload, List<String> dataCollectionIds,
                                           Optional<String> additionalCondition, Optional<String> surrogateKey)
             throws InterruptedException;
 

--- a/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/source/snapshot/incremental/IncrementalSnapshotContext.java
@@ -17,7 +17,8 @@ public interface IncrementalSnapshotContext<T> {
 
     DataCollection<T> nextDataCollection();
 
-    List<DataCollection<T>> addDataCollectionNamesToSnapshot(List<String> dataCollectionIds, Optional<String> additionalCondition, Optional<String> surrogateKey);
+    List<DataCollection<T>> addDataCollectionNamesToSnapshot(String correlationId, List<String> dataCollectionIds, Optional<String> additionalCondition,
+                                                             Optional<String> surrogateKey);
 
     int dataCollectionsToBeSnapshottedCount();
 
@@ -68,5 +69,9 @@ public interface IncrementalSnapshotContext<T> {
     boolean removeDataCollectionFromSnapshot(String dataCollectionId);
 
     List<DataCollection<T>> getDataCollections();
+
+    void unsetCorrelationId();
+
+    String getCorrelationId();
 
 }

--- a/debezium-core/src/test/java/io/debezium/pipeline/notification/IncrementalSnapshotNotificationServiceTest.java
+++ b/debezium-core/src/test/java/io/debezium/pipeline/notification/IncrementalSnapshotNotificationServiceTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.pipeline.notification;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import io.debezium.pipeline.source.snapshot.incremental.DataCollection;
+import io.debezium.pipeline.source.snapshot.incremental.IncrementalSnapshotContext;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.pipeline.spi.Partition;
+import io.debezium.relational.TableId;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IncrementalSnapshotNotificationServiceTest {
+
+    @Mock
+    private Partition partition;
+    @Mock
+    private OffsetContext offsetContext;
+    @Mock
+    private NotificationService<Partition, OffsetContext> notificationService;
+    @Mock
+    private IncrementalSnapshotContext<TableId> incrementalSnapshotContext;
+    @InjectMocks
+    private IncrementalSnapshotNotificationService<Partition, OffsetContext> incrementalSnapshotNotificationService;
+
+    @Before
+    public void setUp() {
+        Struct mockedSourceStruct = mock(Struct.class);
+        when(mockedSourceStruct.getString("name")).thenReturn("connector-test");
+        when(offsetContext.getSourceInfo()).thenReturn(mockedSourceStruct);
+        when(incrementalSnapshotContext.getCorrelationId()).thenReturn("12345");
+        when(incrementalSnapshotContext.getDataCollections()).thenReturn(List.of(
+                new DataCollection<>(new TableId("db", "inventory", "product")),
+                new DataCollection<>(new TableId("db", "inventory", "customer"))));
+        when(incrementalSnapshotContext.currentDataCollectionId()).thenReturn(new DataCollection<>(new TableId("db", "inventory", "product")));
+        when(incrementalSnapshotContext.maximumKey()).thenReturn(Optional.of(new Object[]{ 100, 0, 0 }));
+        when(incrementalSnapshotContext.chunkEndPosititon()).thenReturn(new Object[]{ 50, 0, 0 });
+    }
+
+    @Test
+    public void notifyStarted() {
+
+        incrementalSnapshotNotificationService.notifyStarted(incrementalSnapshotContext, partition, offsetContext);
+
+        Notification expectedNotification = new Notification("12345", "Incremental Snapshot", "STARTED", Map.of(
+                "connector_name", "connector-test",
+                "data_collections", "db.inventory.product,db.inventory.customer"));
+
+        verify(notificationService).notify(eq(expectedNotification), any(Offsets.class));
+    }
+
+    @Test
+    public void notifyPaused() {
+
+        incrementalSnapshotNotificationService.notifyPaused(incrementalSnapshotContext, partition, offsetContext);
+
+        Notification expectedNotification = new Notification("12345", "Incremental Snapshot", "PAUSED", Map.of(
+                "connector_name", "connector-test",
+                "data_collections", "db.inventory.product,db.inventory.customer"));
+
+        verify(notificationService).notify(eq(expectedNotification), any(Offsets.class));
+    }
+
+    @Test
+    public void notifyResumed() {
+
+        incrementalSnapshotNotificationService.notifyResumed(incrementalSnapshotContext, partition, offsetContext);
+
+        Notification expectedNotification = new Notification("12345", "Incremental Snapshot", "RESUMED", Map.of(
+                "connector_name", "connector-test",
+                "data_collections", "db.inventory.product,db.inventory.customer"));
+
+        verify(notificationService).notify(eq(expectedNotification), any(Offsets.class));
+    }
+
+    @Test
+    public void notifyAborted() {
+
+        incrementalSnapshotNotificationService.notifyAborted(incrementalSnapshotContext, partition, offsetContext);
+
+        Notification expectedNotification = new Notification("12345", "Incremental Snapshot", "ABORTED", Map.of(
+                "connector_name", "connector-test"));
+
+        verify(notificationService).notify(eq(expectedNotification), any(Offsets.class));
+    }
+
+    @Test
+    public void testNotifyAborted() {
+
+        incrementalSnapshotNotificationService.notifyAborted(incrementalSnapshotContext, partition, offsetContext, List.of("db.inventory.product"));
+
+        Notification expectedNotification = new Notification("12345", "Incremental Snapshot", "ABORTED", Map.of(
+                "connector_name", "connector-test",
+                "data_collections", "db.inventory.product"));
+
+        verify(notificationService).notify(eq(expectedNotification), any(Offsets.class));
+    }
+
+    @Test
+    public void notifyTableScanCompleted() {
+
+        incrementalSnapshotNotificationService.notifyTableScanCompleted(incrementalSnapshotContext, partition, offsetContext, 100L);
+
+        Notification expectedNotification = new Notification("12345", "Incremental Snapshot", "TABLE_SCAN_COMPLETED", Map.of(
+                "connector_name", "connector-test",
+                "data_collections", "db.inventory.product,db.inventory.customer",
+                "total_rows_scanned", "100"));
+
+        verify(notificationService).notify(eq(expectedNotification), any(Offsets.class));
+    }
+
+    @Test
+    public void notifyInProgress() {
+
+        incrementalSnapshotNotificationService.notifyInProgress(incrementalSnapshotContext, partition, offsetContext);
+
+        Notification expectedNotification = new Notification("12345", "Incremental Snapshot", "IN_PROGRESS", Map.of(
+                "connector_name", "connector-test",
+                "data_collections", "db.inventory.product,db.inventory.customer",
+                "current_collection_in_progress", "db.inventory.product",
+                "maximum_key", "100",
+                "last_processed_key", "50"));
+
+        verify(notificationService).notify(eq(expectedNotification), any(Offsets.class));
+    }
+
+    @Test
+    public void notifyCompleted() {
+
+        incrementalSnapshotNotificationService.notifyCompleted(incrementalSnapshotContext, partition, offsetContext);
+
+        Notification expectedNotification = new Notification("12345", "Incremental Snapshot", "COMPLETED", Map.of(
+                "connector_name", "connector-test"));
+
+        verify(notificationService).notify(eq(expectedNotification), any(Offsets.class));
+
+    }
+}

--- a/debezium-core/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedSnapshotChangeEventSourceTest.java
+++ b/debezium-core/src/test/java/io/debezium/pipeline/source/snapshot/incremental/SignalBasedSnapshotChangeEventSourceTest.java
@@ -123,7 +123,7 @@ public class SignalBasedSnapshotChangeEventSourceTest {
                 .addColumn(val1)
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1", "pk2").create();
-        context.addDataCollectionNamesToSnapshot(List.of(table.id().toString()), Optional.empty(), Optional.of("pk2"));
+        context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), Optional.empty(), Optional.of("pk2"));
         assertThat(source.buildChunkQuery(table, Optional.of("\"val1\"=foo")))
                 .isEqualTo("SELECT * FROM \"s1\".\"table1\" WHERE \"val1\"=foo ORDER BY \"pk2\" LIMIT 1024");
         context.nextChunkPosition(new Object[]{ 1, 5 });
@@ -202,7 +202,7 @@ public class SignalBasedSnapshotChangeEventSourceTest {
                 .addColumn(val1)
                 .addColumn(val2)
                 .setPrimaryKeyNames("pk1", "pk2").create();
-        context.addDataCollectionNamesToSnapshot(List.of(table.id().toString()), Optional.empty(), Optional.of("pk2"));
+        context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), Optional.empty(), Optional.of("pk2"));
         assertThat(source.buildChunkQuery(table, Optional.empty()))
                 .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk2\" LIMIT 1024");
     }
@@ -250,7 +250,7 @@ public class SignalBasedSnapshotChangeEventSourceTest {
         final Column val2 = Column.editor().name("val2").create();
         final Table table = Table.editor().tableId(new TableId(null, "s1", "table1")).addColumn(pk1).addColumn(pk2)
                 .addColumn(val1).addColumn(val2).setPrimaryKeyNames("pk1", "pk2").create();
-        context.addDataCollectionNamesToSnapshot(List.of(table.id().toString()), Optional.empty(), Optional.of("pk2"));
+        context.addDataCollectionNamesToSnapshot("12345", List.of(table.id().toString()), Optional.empty(), Optional.of("pk2"));
         assertThat(source.buildMaxPrimaryKeyQuery(table, Optional.empty()))
                 .isEqualTo("SELECT * FROM \"s1\".\"table1\" ORDER BY \"pk2\" DESC LIMIT 1");
     }

--- a/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/pipeline/source/snapshot/incremental/AbstractIncrementalSnapshotTest.java
@@ -1164,6 +1164,10 @@ public abstract class AbstractIncrementalSnapshotTest<T extends SourceConnector>
         assertThat(incrementalSnapshotNotification.stream().anyMatch(s -> s.getString("type").equals("TABLE_SCAN_COMPLETED"))).isTrue();
         assertThat(incrementalSnapshotNotification.stream().anyMatch(s -> s.getString("type").equals("COMPLETED"))).isTrue();
 
+        assertThat(incrementalSnapshotNotification.stream().map(s -> s.getString("id"))
+                .distinct()
+                .collect(Collectors.toList())).contains("ad-hoc");
+
         Struct inProgress = incrementalSnapshotNotification.stream().filter(s -> s.getString("type").equals("IN_PROGRESS")).findFirst().get();
         assertThat(inProgress.getMap("additional_data"))
                 .containsEntry("current_collection_in_progress", tableDataCollectionId())


### PR DESCRIPTION
Incremental snapshot notification ids are now equal to the id sent in the `execute-snapshot` signal.

closes: https://issues.redhat.com/browse/DBZ-6447