### PR TITLE
DBZ-6496 Fix `signal.poll.interval.ms` default value

### DIFF
--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/IncrementalSnapshotCaseSensitiveIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/IncrementalSnapshotCaseSensitiveIT.java
@@ -180,6 +180,11 @@ public class IncrementalSnapshotCaseSensitiveIT extends AbstractIncrementalSnaps
         return "ALTER TABLE " + tableName + " ADD col3 INTEGER DEFAULT 0";
     }
 
+    @Override
+    protected int defaultIncrementalSnapshotChunkSize() {
+        return 250;
+    }
+
     @Test
     public void snapshotPreceededBySchemaChange() throws Exception {
         // TODO: remove once https://github.com/Apicurio/apicurio-registry/issues/2980 is fixed

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/IncrementalSnapshotIT.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/IncrementalSnapshotIT.java
@@ -175,6 +175,11 @@ public class IncrementalSnapshotIT extends AbstractIncrementalSnapshotTest<Oracl
         return "ALTER TABLE " + tableName + " ADD col3 INTEGER DEFAULT 0";
     }
 
+    @Override
+    protected int defaultIncrementalSnapshotChunkSize() {
+        return 250;
+    }
+
     @Test
     public void snapshotPreceededBySchemaChange() throws Exception {
         // TODO: remove once https://github.com/Apicurio/apicurio-registry/issues/2980 is fixed

--- a/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/IncrementalSnapshotWithRecompileIT.java
+++ b/debezium-connector-sqlserver/src/test/java/io/debezium/connector/sqlserver/IncrementalSnapshotWithRecompileIT.java
@@ -126,4 +126,9 @@ public class IncrementalSnapshotWithRecompileIT extends AbstractIncrementalSnaps
     protected void waitForCdcTransactionPropagation(int expectedTransactions) throws Exception {
         TestHelper.waitForCdcTransactionPropagation(connection, TestHelper.TEST_DATABASE_1, expectedTransactions);
     }
+
+    @Override
+    protected int defaultIncrementalSnapshotChunkSize() {
+        return 250;
+    }
 }

--- a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
+++ b/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java
@@ -627,7 +627,7 @@ public abstract class CommonConnectorConfig {
             .withType(Type.LONG)
             .withWidth(Width.SHORT)
             .withImportance(Importance.MEDIUM)
-            .withDefault(5L)
+            .withDefault(5000L)
             .withValidation(Field::isPositiveInteger)
             .withDescription("Interval for looking for new signals in registered channels, given in milliseconds. Defaults to 5 seconds.");
 


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/DBZ-6496